### PR TITLE
Allow rendering of React components without using a generator function (just direct React Component)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Contributions and pull requests welcome!
 3. The default for rendering right now is `prerender: false`. **NOTE:**  Server side rendering does
    not work for some components, namely react-router, that use an async setup for server rendering.
    You can configure the default for prerender in your config.
-4. You can expose either a React component or a function that returns a React component.
+4. You can expose either a React component or a function that returns a React component. If you wish to create a React component via a function, rather than simply props, then you need to set the property "generator" on that function to true. When that is done, the function is invoked with a single parameter of "props", and that function should return a React element.
 
 # Example Configuration, config/react_on_rails.rb
 ```ruby

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Contributions and pull requests welcome!
   cd spec/dummy
   bundle
   npm i
-  foreman start 
-  ``` 
+  foreman start
+  ```
 2. Caching is turned for development mode. Open the console and run `Rails.cache.clear` to clear
   the cache. Note, even if you stop the server, you'll still have the cache entries around.
 3. Visit http://localhost:3000
@@ -53,23 +53,22 @@ Contributions and pull requests welcome!
    See `spec/dummy/app/views/pages/index.html.erb:17` for the generation of that message.
 5. Open up the browser console and see some tracing.
 6. Open up the source for the page and see the server rendered code.
-7. If you want to turn off server caching, run the server like: 
+7. If you want to turn off server caching, run the server like:
    `export RAILS_USE_CACHE=N && foreman start`
 8. If you click back and forth between the about and react page links, you can see the rails console
    log as well as the browser console to see what's going on with regards to server rendering and
    caching.
 
 # Key Tips
-1. See sample app in `spec/dummy` for how to set this up. 
+1. See sample app in `spec/dummy` for how to set this up.
 2. The file used for server rendering is hard coded as `generated/server.js`
    (assets/javascripts/generated/server.js).
 3. If you're only doing client rendering, you still *MUST* create an empty version of this file. This
    will soon change so that this is not necessary.
-3. The default for rendering right now is `prerender: false`. **NOTE:**  Server side rendering does 
-   not work for some components, namely react-router, that use an async setup for server rendering. 
-   You can configure the default for prerender in your config. 
-4. The API for objects exposed differs from the react-rails gem in that you expose a function that
-   returns a react component. We'll be changing that to take either a function or a React component.
+3. The default for rendering right now is `prerender: false`. **NOTE:**  Server side rendering does
+   not work for some components, namely react-router, that use an async setup for server rendering.
+   You can configure the default for prerender in your config.
+4. You can expose either a React component or a function that returns a React component.
 
 # Example Configuration, config/react_on_rails.rb
 ```ruby
@@ -104,7 +103,7 @@ Or install it yourself as:
 
 ## Usage
 
-PENDING. See `spec/dummy` for the sample app. 
+PENDING. See `spec/dummy` for the sample app.
 
 ## Development
 

--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -49,7 +49,7 @@ module ReactOnRailsHelper
     # Create the HTML rendering part
     if prerender
       render_js_expression = <<-JS
-          renderReactComponent(this.#{reactComponent}, #{props.to_json})
+        renderReactComponent(this.#{reactComponent}, #{props.to_json})
       JS
       server_rendered_react_component_html = render_js(render_js_expression)
     else
@@ -90,10 +90,18 @@ module ReactOnRailsHelper
     <<-JS.strip_heredoc
       var renderIfDomNodePresent = function() {
         var domNode = document.getElementById('#{dom_id}');
+
         if (domNode) {
           #{debug_js(react_component, data_variable, dom_id, trace)}
-          var reactComponent = #{react_component}(#{data_variable});
-          React.render(reactComponent, domNode);
+          var element;
+
+          if (Object.getPrototypeOf(#{react_component}) === React.Component) {
+            element = React.createElement(#{react_component}, #{data_variable});
+          } else {
+            // when using Redux, we need to pull the component off the wrapper function
+            element = #{react_component}(#{data_variable});
+          }
+          React.render(element, domNode);
         }
       }
     JS

--- a/lib/react_on_rails/react_renderer.rb
+++ b/lib/react_on_rails/react_renderer.rb
@@ -2,13 +2,19 @@ module ReactOnRails
   class ReactRenderer
 
     # "this" does not need a closure as it refers to the "this" defined by the
-    # calling the calling context which is the "this" in the execJs environment.
+    # calling context which is the "this" in the execJs environment.
     def render_js_react_component
       <<-JS.strip_heredoc
-      function renderReactComponent(componentClass, props) {
-        return this.React.renderToString(
-         componentClass(props)
-        );
+      function renderReactComponent(reactComponent, props) {
+        var element;
+
+        if (Object.getPrototypeOf(reactComponent) === this.React.Component) {
+          element = this.React.createElement(reactComponent, props);
+        } else {
+          // when using Redux, we need to pull the component off the wrapper function
+          element = reactComponent(props);
+        }
+        return this.React.renderToString(element);
       }
       JS
     end

--- a/lib/react_on_rails/react_renderer.rb
+++ b/lib/react_on_rails/react_renderer.rb
@@ -1,26 +1,17 @@
 module ReactOnRails
   class ReactRenderer
 
-    # "this" does not need a closure as it refers to the "this" defined by the
-    # calling context which is the "this" in the execJs environment.
-    def render_js_react_component
-      <<-JS.strip_heredoc
-      function renderReactComponent(reactComponent, props) {
-        var element;
-
-        if (Object.getPrototypeOf(reactComponent) === this.React.Component) {
-          element = this.React.createElement(reactComponent, props);
-        } else {
-          // when using Redux, we need to pull the component off the wrapper function
-          element = reactComponent(props);
-        }
-        return this.React.renderToString(element);
-      }
+    # Returns a React element, unwrapping it if the component is a generator function
+    def render_js_react_element(react_component, props)
+      <<-JS
+        #{react_component}.generator ?
+          #{react_component}(#{props}) :
+          this.React.createElement(#{react_component}, #{props})
       JS
     end
 
     def initialize
-      js_code = "#{bundle_js_code};\n#{render_js_react_component}"
+      js_code = "#{bundle_js_code};"
       @context = ExecJS.compile(js_code)
     end
 

--- a/lib/react_on_rails/react_renderer.rb
+++ b/lib/react_on_rails/react_renderer.rb
@@ -4,7 +4,8 @@ module ReactOnRails
     # Returns the JavaScript code to generate a React element.
     # The parameter react_component_name can be a React component or a generator function
     # that returns a React component. To be invoked as a function, react_component_name
-    # must have the property "generator" set to true
+    # must have the property "generator" set to true and be a function that
+    # takes one parameter, props, that is used to construct the React component.
     def self.render_js_react_element(react_component_name, props_name)
       <<-JS.strip_heredoc
         #{react_component_name}.generator ?

--- a/lib/react_on_rails/react_renderer.rb
+++ b/lib/react_on_rails/react_renderer.rb
@@ -1,12 +1,15 @@
 module ReactOnRails
   class ReactRenderer
 
-    # Returns a React element, unwrapping it if the component is a generator function
-    def render_js_react_element(react_component, props)
-      <<-JS
-        #{react_component}.generator ?
-          #{react_component}(#{props}) :
-          this.React.createElement(#{react_component}, #{props})
+    # Returns the JavaScript code to generate a React element.
+    # The parameter react_component_name can be a React component or a generator function
+    # that returns a React component. To be invoked as a function, react_component_name
+    # must have the property "generator" set to true
+    def self.render_js_react_element(react_component_name, props_name)
+      <<-JS.strip_heredoc
+        #{react_component_name}.generator ?
+          #{react_component_name}(#{props_name}) :
+          this.React.createElement(#{react_component_name}, #{props_name})
       JS
     end
 

--- a/spec/dummy/app/views/pages/index.html.erb
+++ b/spec/dummy/app/views/pages/index.html.erb
@@ -60,8 +60,10 @@
 <h1>Simple Component Without Redux</h1>
 <code>
   <%%= react_component("HelloWorld", @app_props_hello, prerender: false, trace: true) %>
+  <%%= react_component("HelloES5", @app_props_hello, prerender: false, trace: true) %>
 </code>
 <%= react_component("HelloWorld", @app_props_hello, prerender: false, trace: true) %>
+<%= react_component("HelloES5", @app_props_hello, prerender: false, trace: true) %>
 <hr/>
 
 <h1>Non-React Component</h1>

--- a/spec/dummy/app/views/pages/index.html.erb
+++ b/spec/dummy/app/views/pages/index.html.erb
@@ -35,7 +35,7 @@
     <%% end %>
   </code>
   <p>
-    And this is an example of the server rendering a React component without Redux
+    And this is an example of a server rendered React component without Redux
   </p>
 
   <%= react_component("HelloWorld", @app_props_server_render, trace: true) %>
@@ -45,16 +45,16 @@
 <h1>Simple Client Rendered Component</h1>
 <!-- Passing prerender: false to not render on server -->
 <code>
-  <%%= react_component("HelloWorldComponent", @app_props_hello, prerender: false, trace: true) %>
+  <%%= react_component("HelloWorldApp", @app_props_hello, prerender: false, trace: true) %>
 </code>
-<%= react_component("HelloWorldComponent", @app_props_hello, prerender: false, trace: true) %>
+<%= react_component("HelloWorldApp", @app_props_hello, prerender: false, trace: true) %>
 <hr/>
 
 <h1>Showing you can put the same component twice on a page with different props</h1>
 <code>
-  <%%= react_component("HelloWorldComponent", @app_props_hello_again, prerender: false, trace: true) %>
+  <%%= react_component("HelloWorldApp", @app_props_hello_again, prerender: false, trace: true) %>
 </code>
-<%= react_component("HelloWorldComponent", @app_props_hello_again, prerender: false, trace: true) %>
+<%= react_component("HelloWorldApp", @app_props_hello_again, prerender: false, trace: true) %>
 <hr/>
 
 <h1>Simple Component Without Redux</h1>

--- a/spec/dummy/app/views/pages/index.html.erb
+++ b/spec/dummy/app/views/pages/index.html.erb
@@ -1,7 +1,45 @@
 <%= render "header" %>
 
 <h1>React Rails Server Rendering</h1>
+<hr/>
 
+<h1>Server Rendered/Cached React/Redux Component</h1>
+<p>
+  Server Caching (Rails.application.config.perform_caching) is <%= $rails_perform_caching %>
+  <% if $rails_perform_caching %>
+    <br/><b>WARNING: be sure to clear the cache by opening a console and running Rails.cache.clear</b>
+  <% end %>
+</p>
+
+<code>
+  <%% cache @app_props_server_render do %><br/>
+  <%%    = react_component("App", @app_props_server_render, trace: true) %><br/>
+  <%% end %>
+</code>
+<p>
+  That will generate this, which is done only once on the server side:
+</p>
+
+<% cache @app_props_server_render do %>
+  <% puts "=" * 80 %>
+  <% puts "server rendering react components" %>
+  <% puts "=" * 80 %>
+  <!-- Default for prerender is true for the app, set in config/react_on_rails.rb -->
+  <%= react_component("App", @app_props_server_render, trace: true) %>
+  <hr/>
+
+  <h1>Server Rendered/Cached React Component Without Redux</h1>
+  <code>
+    <%% cache @app_props_server_render do %><br/>
+    <%%    = react_component("HelloWorld", @app_props_server_render, trace: true) %><br/>
+    <%% end %>
+  </code>
+  <p>
+    And this is an example of the server rendering a React component without Redux
+  </p>
+
+  <%= react_component("HelloWorld", @app_props_server_render, trace: true) %>
+<% end %>
 <hr/>
 
 <h1>Simple Client Rendered Component</h1>
@@ -16,39 +54,18 @@
 <code>
   <%%= react_component("HelloWorldComponent", @app_props_hello_again, prerender: false, trace: true) %>
 </code>
-
 <%= react_component("HelloWorldComponent", @app_props_hello_again, prerender: false, trace: true) %>
-
 <hr/>
 
-<h1>Server Rendered/Cached React/Redux Component</h1>
-<p>
-  Server Caching (Rails.application.config.perform_caching) is <%= $rails_perform_caching %>
-  <% if $rails_perform_caching %>
-    <br/><b>WARNING: be sure to clear the cache by opening a console and running Rails.cache.clear</b>
-  <% end %>
-</p>
+<h1>Simple Component Without Redux</h1>
 <code>
-  <%% cache @app_props_server_render do %><br/>
-  <%%    = react_component("App", @app_props_server_render, trace: true) %><br/>
-  <%% end %>
+  <%%= react_component("HelloWorld", @app_props_hello, prerender: false, trace: true) %>
 </code>
-<p>
-  That will generate this, which is done only once on the server side:
-</p>
-
-<% cache @app_props_server_render do %>
-  <% puts "=" * 80 %>
-  <% puts "server rendering react component" %>
-  <% puts "=" * 80 %>
-  <!-- Default for prerender is true for the app, set in config/react_on_rails.rb -->
-  <%= react_component("App", @app_props_server_render, trace: true) %>
-<% end %>
-
+<%= react_component("HelloWorld", @app_props_hello, prerender: false, trace: true) %>
 <hr/>
+
 <h1>Non-React Component</h1>
-For example, Suppose you have some JavaScript that generates a string of HTML:
-<br/>
+<p>For example, Suppose you have some JavaScript that generates a string of HTML:</p>
 <code>
   this.HelloString.world()
 </code>

--- a/spec/dummy/client/app/components/HelloES5.jsx
+++ b/spec/dummy/client/app/components/HelloES5.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+// Super simple example of React component using React.createClass
+const HelloES5 = React.createClass({
+
+  getInitialState() {
+    return this.props.helloWorldData;
+  },
+
+  _handleChange() {
+    const name = React.findDOMNode(this.refs.name).value;
+    this.setState({name});
+  },
+
+  render() {
+    const { name } = this.state;
+
+    return (
+      <div>
+        <h3>
+          Hello ES5, {name}!
+        </h3>
+        <p>
+          Say hello to:
+          <input type="text" ref="name" defaultValue={name} onChange={this._handleChange} />
+        </p>
+      </div>
+    );
+  },
+});
+
+export default HelloES5;

--- a/spec/dummy/client/app/startup/ClientApp.jsx
+++ b/spec/dummy/client/app/startup/ClientApp.jsx
@@ -10,6 +10,7 @@ import middleware from 'redux-thunk';
 
 import reducers from '../reducers/reducersIndex';
 import HelloWorldContainer from '../components/HelloWorldContainer';
+import HelloWorld from '../components/HelloWorld';
 
 /*
  *  Export a function that takes the props and returns a ReactComponent.
@@ -28,3 +29,6 @@ window.App = props => {
   );
   return reactComponent;
 };
+
+// This is an example of how to render a React component directly, without using Redux
+window.HelloWorld = HelloWorld;

--- a/spec/dummy/client/app/startup/ClientApp.jsx
+++ b/spec/dummy/client/app/startup/ClientApp.jsx
@@ -11,6 +11,7 @@ import middleware from 'redux-thunk';
 import reducers from '../reducers/reducersIndex';
 import HelloWorldContainer from '../components/HelloWorldContainer';
 import HelloWorld from '../components/HelloWorld';
+import HelloES5 from '../components/HelloES5';
 
 /*
  *  Export a function that takes the props and returns a ReactComponent.
@@ -30,5 +31,14 @@ window.App = props => {
   return reactComponent;
 };
 
+/*
+ * If you wish to create a React component via a function, rather than simply props,
+ * then you need to set the property "generator" on that function to true.
+ * When that is done, the function is invoked with a single parameter of "props",
+ * and that function should return a react element.
+ */
+window.App.generator = true;
+
 // This is an example of how to render a React component directly, without using Redux
 window.HelloWorld = HelloWorld;
+window.HelloES5 = HelloES5;

--- a/spec/dummy/client/app/startup/ClientHelloWorldApp.jsx
+++ b/spec/dummy/client/app/startup/ClientHelloWorldApp.jsx
@@ -1,7 +1,5 @@
 // Top level component for simple client side only rendering
-
 import React from 'react';
-
 import HelloWorld from '../components/HelloWorld';
 
 /*
@@ -9,6 +7,6 @@ import HelloWorld from '../components/HelloWorld';
  *  This is used for the client rendering hook after the page html is rendered.
  *  React will see that the state is the same and not do anything.
  */
-window.HelloWorldComponent = props => {
+window.HelloWorldApp = props => {
   return <HelloWorld {...props}/>;
 };

--- a/spec/dummy/client/app/startup/ClientHelloWorldApp.jsx
+++ b/spec/dummy/client/app/startup/ClientHelloWorldApp.jsx
@@ -10,3 +10,11 @@ import HelloWorld from '../components/HelloWorld';
 window.HelloWorldApp = props => {
   return <HelloWorld {...props}/>;
 };
+
+/*
+ * If you wish to create a React component via a function, rather than simply props,
+ * then you need to set the property "generator" on that function to true.
+ * When that is done, the function is invoked with a single parameter of "props",
+ * and that function should return a react element.
+ */
+window.HelloWorldApp.generator = true;

--- a/spec/dummy/client/app/startup/ServerApp.jsx
+++ b/spec/dummy/client/app/startup/ServerApp.jsx
@@ -12,7 +12,9 @@ import middleware from 'redux-thunk';
 
 // Uses the index
 import reducers from '../reducers/reducersIndex';
+
 import HelloWorldContainer from '../components/HelloWorldContainer';
+import HelloWorld from '../components/HelloWorld';
 
 export default props => {
   const combinedReducer = combineReducers(reducers);
@@ -29,3 +31,6 @@ export default props => {
     </Provider>
   );
 };
+
+// This is an example of how to render a React component directly, without using Redux
+export { HelloWorld };

--- a/spec/dummy/client/app/startup/ServerApp.jsx
+++ b/spec/dummy/client/app/startup/ServerApp.jsx
@@ -15,6 +15,7 @@ import reducers from '../reducers/reducersIndex';
 
 import HelloWorldContainer from '../components/HelloWorldContainer';
 import HelloWorld from '../components/HelloWorld';
+import HelloES5 from '../components/HelloES5';
 
 export default props => {
   const combinedReducer = combineReducers(reducers);
@@ -33,4 +34,4 @@ export default props => {
 };
 
 // This is an example of how to render a React component directly, without using Redux
-export { HelloWorld };
+export { HelloWorld, HelloES5 };

--- a/spec/dummy/client/app/startup/serverGlobals.jsx
+++ b/spec/dummy/client/app/startup/serverGlobals.jsx
@@ -3,14 +3,17 @@
 // Shows the mapping from the exported object to the name used by the server rendering.
 import App from './ServerApp';
 
+// Example of server rendering without using Redux
+import { HelloWorld } from './ServerApp';
+
 // Example of server rendering with no React
 import HelloString from '../non_react/HelloString';
 
 // We can use the node global object for exposing.
 // NodeJs: https://nodejs.org/api/globals.html#globals_global
-// Uncomment next 4 lines to use global
-global.HelloString = HelloString;
 global.App = App;
+global.HelloWorld = HelloWorld;
+global.HelloString = HelloString;
 
 // Alternative syntax for exposing Vars
 // require("expose?HelloString!./non_react/HelloString.js");

--- a/spec/dummy/client/app/startup/serverGlobals.jsx
+++ b/spec/dummy/client/app/startup/serverGlobals.jsx
@@ -4,15 +4,24 @@
 import App from './ServerApp';
 
 // Example of server rendering without using Redux
-import { HelloWorld } from './ServerApp';
+import { HelloWorld, HelloES5 } from './ServerApp';
 
 // Example of server rendering with no React
 import HelloString from '../non_react/HelloString';
+
+/*
+ * If you wish to create a React component via a function, rather than simply props,
+ * then you need to set the property "generator" on that function to true.
+ * When that is done, the function is invoked with a single parameter of "props",
+ * and that function should return a react element.
+ */
+App.generator = true;
 
 // We can use the node global object for exposing.
 // NodeJs: https://nodejs.org/api/globals.html#globals_global
 global.App = App;
 global.HelloWorld = HelloWorld;
+global.HelloES5 = HelloES5;
 global.HelloString = HelloString;
 
 // Alternative syntax for exposing Vars

--- a/spec/dummy/client/webpack.client.js
+++ b/spec/dummy/client/webpack.client.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   entry: [
     'startup/ClientApp',
-    'startup/ClientHelloWorldComponent',
+    'startup/ClientHelloWorldApp',
   ],
   output: {
     path: '../app/assets/javascripts/generated',


### PR DESCRIPTION
When using Redux, the main component exposed to the API is a function that returns a React component. This PR allows rendering of simple React components. The more advanced functionality of using a generator function is essential for tools like redux and react-router.

In the dummy app, along with App component (that uses Redux), `ServerApp` and `ClientApp` now also export a simple React component, HelloWorld. The component can be rendered by the client or using server side rendering, as demonstrated in the index page.

To test, run the dummy app and export some components with and without Redux, in both client an server apps.