### PR TITLE
Address security alert for gem uglifier

### DIFF
--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -8,7 +8,7 @@ gem 'sqlite3'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '>= 2.7.2'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (2.7.1)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     web-console (2.2.1)
@@ -189,8 +189,8 @@ DEPENDENCIES
   spring
   sqlite3
   turbolinks
-  uglifier (>= 1.3.0)
+  uglifier (>= 2.7.2)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6


### PR DESCRIPTION
Update gem uglifier to >= 2.7.2 to address security alert for affected
versions prior to 2.7.2
Sources: https://github.com/lautis/uglifier/pull/86
https://zyan.scripts.mit.edu/blog/backdooring-js/
https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons
https://github.com/mishoo/UglifyJS2/issues/751