### PR TITLE
Updated docs for libraryTarget info

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ See the next section for a aample webpack.server.rails.config.js.
    ```javascript
    entry: ['./app/startup/serverGlobals'],
    ```
-2. Ensure the name of your ouput file (shown [here](https://github.com/shakacode/react-webpack-rails-tutorial/blob/537c985dc82faee333d80509343ca32a3965f9dd/client/webpack.server.rails.config.js#L9)) of your server bundle corresponds to the configuration of the gem. The default path is `app/assets/javascripts/generated`. See below for customization of configuration variables.
-3. Set the `output.libraryTarget = 'this'` in your webpack config, like [this](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/client/webpack.server.rails.config.js#L13)
+3. Ensure the name of your ouput file (shown [here](https://github.com/shakacode/react-webpack-rails-tutorial/blob/537c985dc82faee333d80509343ca32a3965f9dd/client/webpack.server.rails.config.js#L9)) of your server bundle corresponds to the configuration of the gem. The default path is `app/assets/javascripts/generated`. See below for customization of configuration variables.
 4. Expose `React` in your webpack config, like [this](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/client/webpack.server.rails.config.js#L23)
 
 #### Sample webpack.server.rails.config.js (ONLY for server rendering)
@@ -108,8 +107,11 @@ module.exports = {
     filename: 'server-bundle.js',
     path: '../app/assets/javascripts/generated',
 
-    // CRITICAL for enabling Rails to find the globally exposed variables.
-    libaryTarget: 'this',
+    // CRITICAL to set libraryTarget: 'this' for enabling Rails to find the exposed modules IF you
+    //   use the "expose" webpackfunctionality. See startup/serverGlobals.jsx.
+    // NOTE: This is NOT necessary if you use the syntax of global.MyComponent = MyComponent syntax.
+    // See http://webpack.github.io/docs/configuration.html#externals for documentation of this option
+    //libraryTarget: 'this',
   },
   resolve: {
     extensions: ['', '.webpack.js', '.web.js', '.js', '.jsx', 'config.js'],

--- a/spec/dummy/client/app/startup/serverGlobals.jsx
+++ b/spec/dummy/client/app/startup/serverGlobals.jsx
@@ -1,24 +1,31 @@
-// Example of React + Redux
 // Shows the mapping from the exported object to the name used by the server rendering.
-import HelloWorld from '../components/HelloWorld';
-import HelloWorldWithLogAndThrow from '../components/HelloWorldWithLogAndThrow';
-import HelloWorldApp from './HelloWorldApp';
-import HelloWorldES5 from '../components/HelloWorldES5';
-import ReduxApp from './ServerReduxApp';
 
 // Example of server rendering with no React
 import HelloString from '../non_react/HelloString';
 
+// React components
+import HelloWorld from '../components/HelloWorld';
+import HelloWorldES5 from '../components/HelloWorldES5';
+import HelloWorldWithLogAndThrow from '../components/HelloWorldWithLogAndThrow';
+
+// Generator function
+import HelloWorldApp from './HelloWorldApp';
+
+// Example of React + Redux
+import ReduxApp from './ServerReduxApp';
+
+
 // We can use the node global object for exposing.
 // NodeJs: https://nodejs.org/api/globals.html#globals_global
+global.HelloString = HelloString;
 global.ReduxApp = ReduxApp;
 global.HelloWorld = HelloWorld;
 global.HelloWorldWithLogAndThrow = HelloWorldWithLogAndThrow;
 global.HelloWorldES5 = HelloWorldES5;
-global.HelloString = HelloString;
-
 global.HelloWorldApp = HelloWorldApp;
 
 // Alternative syntax for exposing Vars
-// require("expose?HelloString!./non_react/HelloString.js");
-// require("expose?HelloWorld!./HelloWorld.js");
+// NOTE: you must set exports.output.libraryTarget = 'this' in your webpack.server.js file.
+// See client/webpack.server.js:16
+// require("expose?HelloString!../non_react/HelloString");
+// require("expose?HelloWorld!../components/HelloWorld");

--- a/spec/dummy/client/webpack.server.js
+++ b/spec/dummy/client/webpack.server.js
@@ -9,8 +9,11 @@ module.exports = {
     path: '../app/assets/javascripts/generated',
     filename: 'server.js',
 
-    // CRITICAL for enabling Rails to find the globally exposed variables. See startup/serverGlobals.jsx
-    libaryTarget: 'this',
+    // CRITICAL to set libraryTarget: 'this' for enabling Rails to find the exposed modules IF you
+    //   use the "expose" webpackfunctionality. See startup/serverGlobals.jsx.
+    // NOTE: This is NOT necessary if you use the syntax of global.MyComponent = MyComponent syntax.
+    // See http://webpack.github.io/docs/configuration.html#externals for documentation of this option
+    //libraryTarget: 'this',
   },
   resolve: {
     root: [path.join(__dirname, 'app')],
@@ -18,16 +21,14 @@ module.exports = {
   },
   module: {
     loaders: [
-      { loader: 'babel-loader' },
+      {test: /\.jsx?$/, loader: 'babel-loader', exclude: /node_modules/},
 
       // require Resolve must go first
       // 1. React must be exposed (BOILERPLATE)
       { test: require.resolve('react'), loader: 'expose?React' },
 
-      // MANIFEST of what you expose for the server if you do it here in the config file.
-      // However, we recommend using the pattern in /client/app/startup/serverGlobals.jsx
-      //{ test: require.resolve('./app/HelloString.js'), loader: 'expose?HelloString' },
-      //{ test: require.resolve('./app/startup/ServerApp.jsx'), loader: 'expose?ReduxApp' },
+      // 2. See client/app/startup/serverGlobals.jsx and client/apps/startup/clientGlobals.jsx
+      // for configuration of how to expose your components for both server and client rendering.
     ],
   },
 };


### PR DESCRIPTION
We did not need to specify libraryTarget if using global.MyComponent
rather than the expose syntax for server rendering.