### PR TITLE
Fix coverage to include dummy app specs

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,1 @@
+SimpleCov.start if ENV["COVERAGE"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,34 @@
 require "fileutils"
-require 'coveralls/rake/task'
+require "coveralls/rake/task"
 
 namespace :run_rspec do
   desc "Run RSpec for top level only"
   task :gem do
-    sh %( rspec spec/react_on_rails_spec.rb )
+    sh %( COVERAGE=true rspec spec/react_on_rails_spec.rb )
   end
 
   desc "Run RSpec for spec/dummy only"
   task :dummy do
-    sh %( cd spec/dummy && DRIVER=selenium_firefox rspec )
+    # TEST_ENV_NUMBER is used to make SimpleCov.command_name unique in order to
+    # prevent a name collision
+    sh %( cd spec/dummy && DRIVER=selenium_firefox COVERAGE=true TEST_ENV_NUMBER=1 rspec )
   end
 
   desc "Run RSpec for spec/dummy only"
   task :dummy_react_013 do
-    sh %( cd spec/dummy-react-013 && DRIVER=selenium_firefox rspec )
+    # TEST_ENV_NUMBER is used to make SimpleCov.command_name unique in order to
+    # prevent a name collision
+    sh %( cd spec/dummy-react-013 && DRIVER=selenium_firefox COVERAGE=true TEST_ENV_NUMBER=2 rspec )
+  end
+
+  desc "Run RSpec on spec/empty_spec in order to have SimpleCov generate a coverage report from cache"
+  task :empty do
+    sh %( COVERAGE=true rspec spec/empty_spec.rb )
   end
 
   Coveralls::RakeTask.new
 
-  task run_rspec: [:gem, :dummy, :dummy_react_013, "coveralls:push"] do
+  task run_rspec: [:gem, :dummy, :dummy_react_013, :empty, "coveralls:push"] do
     puts "Completed all RSpec tests"
   end
 end

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -27,6 +27,8 @@ Run `rake` for testing the gem and `spec/dummy` and `spec/dummy-react-013`. Othe
 
 If you run `rspec` at the top level, you'll see this message: `require': cannot load such file -- rails_helper (LoadError)`
 
+After running a test, you can view the coverage results SimpleCov reports by opening `coverage/index.html`.
+
 ### Debugging
 Start the sample app like this for some debug printing:
 ```bash

--- a/spec/dummy/spec/rails_helper.rb
+++ b/spec/dummy/spec/rails_helper.rb
@@ -1,7 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= "test"
-require "coveralls"
-Coveralls.wear_merged!("rails")
+require "simplecov"
+# Using a command name along with the test_env_number prevents results from
+# getting clobbered by other test suites
+SimpleCov.command_name "dummy-specs" + (ENV["TEST_ENV_NUMBER"] || "")
+SimpleCov.start do
+  coverage_dir("../../coverage")
+end
 require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/empty_spec.rb
+++ b/spec/empty_spec.rb
@@ -1,0 +1,4 @@
+# This file is used to compel SimpleCov to output a new report based on its
+# cached data. Simply run rspec on this file to do so.
+require "simplecov"
+SimpleCov.command_name "empty_spec"

--- a/spec/react_on_rails_spec.rb
+++ b/spec/react_on_rails_spec.rb
@@ -1,5 +1,9 @@
-require "coveralls"
-Coveralls.wear!("rails") # must occur before any of your application code is required
+require "simplecov"
+# Not necessary to explicitly start SimpleCov here because of presence of
+# the .simplecov file
+# Using a command name prevents results from getting clobbered by other test
+# suites
+SimpleCov.command_name "gem-specs"
 require "spec_helper"
 
 describe ReactOnRails do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,2 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "coveralls"
-Coveralls.wear_merged!
 require "react_on_rails"


### PR DESCRIPTION
- switch from Coveralls `wear_merged!` to SimpleCov in order to specify the correct output coverage folder
- employ `TEST_ENV_NUMBER` environment variables in rake task to ensure dummy apps are uniquely named via `SimpleCov.command_name`
- add `.simplecov` file to start the coverage process and avoid covering anything that doesn't have `COVERAGE=true` environment variable (prevents error messages when running "coveralls:push"
- employ `COVERAGE=true` environment variables in rake tasks
- use `run_rspec:empty` rake task on `empty_spec.rb` to compel SimpleCov to generate a new, all-inclusive report after running tests
- update `docs/Contributing.md` to include information on how to view a coverage report locally