### PR TITLE
Docker ci coveralls reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ install:
   - docker-compose up lint
 
 before_script:
-  - "export DISPLAY=:99.0"
-  - Xvfb :99 --screen 0 1600x1200x16 -ac
+  - "export DISPLAY=:99"
+  - Xvfb :99 -ac -screen scn 1600x1200x16 &
 
 script:
   - rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - sudo apt-get install -y xvfb
 
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 4.2.0
@@ -31,10 +32,15 @@ install:
   - $(npm bin)/webpack --config webpack.server.js
   - $(npm bin)/webpack --config webpack.client.js
   - cd ../../../
-  - docker-compose build ci
+  - docker-compose up lint
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - Xvfb :99 --screen 0 1600x1200x16 -ac
 
 script:
-  - docker-compose run ci
+  - rake
+  - rake docker:lint
 
 notifications:
   slack:

--- a/Dockerfile_ci
+++ b/Dockerfile_ci
@@ -3,7 +3,7 @@ FROM dylangrafmyre/docker-ci
 WORKDIR /app/
 
 COPY ["/lib/react_on_rails/version.rb", "/app/lib/react_on_rails/"]
-COPY ["Gemfile", "react_on_rails.gemspec", "/app/"]
+COPY ["Gemfile", "Gemfile.lock", "react_on_rails.gemspec", "/app/"]
 COPY ["/spec/dummy/Gemfile", "/spec/dummy/Gemfile.lock", "/app/spec/dummy/"]
 RUN  bundle install --gemfile=spec/dummy/Gemfile
 


### PR DESCRIPTION
Set travis.yml for running `rake` natively  with Xvfb headless browser testing with selenium_firefox.
This will allow proper code coverage reporting to the Coveralls API from travis-ci builds.
Set linting  within the build from docker-lint container.
Remove docker-ci build from travis.ymi since docker-ci is not configured to report Coveralls properly from travis.