### PR TITLE
Make default rake task run docker:lint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ end
 desc "Runs all tests. Run `rake -D run_rspec` to see all available test options"
 task run_rspec: ["run_rspec:run_rspec"]
 
-task default: :run_rspec
+task default: ["run_rspec", "docker:lint"]
 
 namespace :lint do
   desc "Run Rubocop as shell"


### PR DESCRIPTION
this has been driving me nuts! It causes the CI to fail if you don't successfully get through the linters, and I forget to run it after `rake` all the time!