### PR TITLE
lodash / _ has to be excluded from the minimum 2 rule.

### DIFF
--- a/lib/generators/react_on_rails/templates/linters/client/.eslintrc
+++ b/lib/generators/react_on_rails/templates/linters/client/.eslintrc
@@ -14,4 +14,4 @@ rules:
   indent: [1, 2, { SwitchCase: 1, VariableDeclarator: 2 }]
   react/sort-comp: 0
   react/jsx-quotes: 1
-  id-length: [2, {"exceptions": ["e", "i"]}]
+  id-length: [2, {"exceptions": ["e", "i", "_"]}]


### PR DESCRIPTION
otherwise post-generation the eslintrc will flag the import _ from 'lodash'; lines in the components as bad.
