### PR TITLE
Make generator recognize application.scss

### DIFF
--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -32,6 +32,7 @@ module ReactOnRails
            client/bootstrap-sass.config.js).each { |file| copy_file(base_path + file, file) }
       end
 
+      # rename to application.scss from application.css or application.css.scss
       def force_application_scss_naming_if_necessary
         base_path = "app/assets/stylesheets/"
         application_css = "#{base_path}application.css"
@@ -44,12 +45,12 @@ module ReactOnRails
         File.rename(bad_name, new_name)
       end
 
-      # def change_application_css_scss_to_scss_if_necessary
-      #   stylesheets_path = File.join(destination_root, "app/assets/stylesheets")
-      #   application_css = File.join(stylesheets_path, "application.css.scss")
-      #   return unless File.exist?(application_css)
-      #   File.rename(application_css, File.join(stylesheets_path, "application.scss"))
-      # end
+      # if there still is not application.scss, just create one
+      def create_application_scss_if_necessary
+        path = File.join(destination_root, "app/assets/stylesheets/application.scss")
+        return if File.exist?(path)
+        File.open(path, "w") { |f| f.puts "// Created by React on Rails gem\n\n" }
+      end
 
       def prepend_to_application_scss
         data = <<-DATA.strip_heredoc

--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -32,12 +32,24 @@ module ReactOnRails
            client/bootstrap-sass.config.js).each { |file| copy_file(base_path + file, file) }
       end
 
-      def change_application_css_to_scss_if_necessary
-        stylesheets_path = File.join(destination_root, "app/assets/stylesheets")
-        application_css = File.join(stylesheets_path, "application.css")
-        return unless File.exist?(application_css)
-        File.rename(application_css, File.join(stylesheets_path, "application.css.scss"))
+      def force_application_scss_naming_if_necessary
+        base_path = "app/assets/stylesheets/"
+        application_css = "#{base_path}application.css"
+        application_css_scss = "#{base_path}application.css.scss"
+
+        bad_name = dest_file_exists?(application_css) || dest_file_exists?(application_css_scss)
+        return unless bad_name
+
+        new_name = File.join(destination_root, "#{base_path}application.scss")
+        File.rename(bad_name, new_name)
       end
+
+      # def change_application_css_scss_to_scss_if_necessary
+      #   stylesheets_path = File.join(destination_root, "app/assets/stylesheets")
+      #   application_css = File.join(stylesheets_path, "application.css.scss")
+      #   return unless File.exist?(application_css)
+      #   File.rename(application_css, File.join(stylesheets_path, "application.scss"))
+      # end
 
       def prepend_to_application_scss
         data = <<-DATA.strip_heredoc
@@ -63,11 +75,18 @@ module ReactOnRails
           @import 'post-bootstrap';
 
         DATA
-        append_to_file("app/assets/stylesheets/application.css.scss", data)
+
+        application_scss = File.join(destination_root, "app/assets/stylesheets/application.scss")
+
+        if File.exist?(application_scss)
+          append_to_file(application_scss, data)
+        else
+          puts_setup_file_error(application_scss, data)
+        end
       end
 
       def strip_application_scss_of_incompatible_sprockets_statements
-        application_scss = File.join(destination_root, "app/assets/stylesheets/application.css.scss")
+        application_scss = File.join(destination_root, "app/assets/stylesheets/application.scss")
         gsub_file(application_scss, "*= require_tree .", "")
         gsub_file(application_scss, "*= require_self", "")
       end

--- a/lib/generators/react_on_rails/generator_helper.rb
+++ b/lib/generators/react_on_rails/generator_helper.rb
@@ -1,11 +1,13 @@
 module GeneratorHelper
   # Takes a relative path from the destination root, such as `.gitignore` or `app/assets/javascripts/application.js`
   def dest_file_exists?(file)
-    File.exist?(File.join(destination_root, file)) ? file : nil
+    dest_file = File.join(destination_root, file)
+    File.exist?(dest_file) ? dest_file : nil
   end
 
   def dest_dir_exists?(dir)
-    Dir.exist?(File.join(destination_root, dir)) ? dir : nil
+    dest_dir = File.join(destination_root, dir)
+    Dir.exist?(dest_dir) ? dest_dir : nil
   end
 
   # Takes the missing file and the

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -122,4 +122,11 @@ describe InstallGenerator, type: :generator do
     include_examples "heroku_deployment"
     include_examples "js_linters:enabled"
   end
+
+  context "without existing application.css/scss file" do
+    before(:all) { run_generator_test_with_args([], application_css: false) }
+    it "creates its own application.scss file" do
+      assert_file("app/assets/stylesheets/application.scss")
+    end
+  end
 end

--- a/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/spec/react_on_rails/support/generator_spec_helper.rb
@@ -5,7 +5,7 @@ require File.expand_path("../../../../lib/generators/react_on_rails/install_gene
 include ReactOnRails::Generators
 
 # Expects an array of strings, such as "--redux"
-def run_generator_test_with_args(args)
+def run_generator_test_with_args(args, options = {})
   prepare_destination # this completely wipes the `destination` directory
   simulate_existing_file(".gitignore")
   simulate_existing_file("Gemfile", "CoffeeScript\ncoffee-rails\n")
@@ -19,7 +19,10 @@ def run_generator_test_with_args(args)
     //= require_tree .
   DATA
   simulate_existing_file("app/assets/javascripts/application.js", app_js_data)
-  simulate_existing_file("app/assets/stylesheets/application.css", " *= require_tree .\n *= require_self\n")
+  application_css = "app/assets/stylesheets/application.css.scss"
+  if options.fetch(:application_css, true)
+    simulate_existing_file(application_css, " *= require_tree .\n *= require_self\n")
+  end
   run_generator(args)
 end
 

--- a/spec/react_on_rails/support/shared_examples/bootstrap_generator_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/bootstrap_generator_examples.rb
@@ -14,8 +14,8 @@ shared_examples "bootstrap" do
     assert_file("config/initializers/assets.rb") { |contents| assert_match(expected, contents) }
   end
 
-  it "removes incompatible requires in application.css.scss" do
-    assert_file("app/assets/stylesheets/application.css.scss") do |contents|
+  it "removes incompatible requires in application.scss" do
+    assert_file("app/assets/stylesheets/application.scss") do |contents|
       refute_match("*= require_tree .", contents)
       refute_match("*= require_self", contents)
     end
@@ -23,7 +23,7 @@ shared_examples "bootstrap" do
 
   it "copies bootstrap files" do
     %w(app/assets/stylesheets/_bootstrap-custom.scss
-       app/assets/stylesheets/application.css.scss
+       app/assets/stylesheets/application.scss
        client/assets/stylesheets/_post-bootstrap.scss
        client/assets/stylesheets/_pre-bootstrap.scss
        client/assets/stylesheets/_react-on-rails-sass-helper.scss


### PR DESCRIPTION
Makes the generator recognize `application.scss` files instead of only looking for `application.css.scss` by just forcing all variations to be `application.scss`.

Fixes #86

We're just forcing any version of application.css or
application.css.scss to be application.scss

This avoids a lot of headache when trying to reference the file
in multiple places, and ensures that users could have either variation without the generator failing.