### PR TITLE
Use data attrs when rendering react_components instead of script tags

### DIFF
--- a/app/assets/javascripts/react_on_rails.js
+++ b/app/assets/javascripts/react_on_rails.js
@@ -1,66 +1,10 @@
 (function() {
   this.ReactOnRails = {};
-
-  ReactOnRails.clientRenderReactComponent = function(options) {
-    var componentName = options.componentName;
-    var domId = options.domId;
-    var propsVarName = options.propsVarName;
-    var props = options.props;
-    var trace = options.trace;
-    var generatorFunction = options.generatorFunction;
-    var expectTurboLinks = options.expectTurboLinks;
-
-    this[propsVarName] = props;
-
-    var renderIfDomNodePresent = function() {
-      try {
-        var domNode = document.getElementById(domId);
-        if (domNode) {
-          var reactElement = createReactElement(componentName, propsVarName, props,
-            domId, trace, generatorFunction);
-          provideClientReact().render(reactElement, domNode);
-        }
-      }
-      catch (e) {
-        ReactOnRails.handleError({
-          e: e,
-          componentName: componentName,
-          serverSide: false,
-        });
-      }
-    };
-
-    var turbolinksInstalled = (typeof Turbolinks !== 'undefined');
-    if (!expectTurboLinks || (!turbolinksInstalled && expectTurboLinks)) {
-      if (expectTurboLinks) {
-        console.warn('WARNING: NO TurboLinks detected in JS, but it is in your Gemfile');
-      }
-
-      document.addEventListener('DOMContentLoaded', function(event) {
-        renderIfDomNodePresent();
-      });
-    } else {
-      function onPageChange(event) {
-        var removePageChangeListener = function() {
-          document.removeEventListener('page:change', onPageChange);
-          document.removeEventListener('page:before-unload', removePageChangeListener);
-          var domNode = document.getElementById(domId);
-          provideClientReact().unmountComponentAtNode(domNode);
-        };
-
-        document.addEventListener('page:before-unload', removePageChangeListener);
-
-        renderIfDomNodePresent();
-      }
-
-      document.addEventListener('page:change', onPageChange);
-    }
-  };
+  var turbolinksInstalled = (typeof Turbolinks !== 'undefined');
 
   ReactOnRails.serverRenderReactComponent = function(options) {
     var componentName = options.componentName;
     var domId = options.domId;
-    var propsVarName = options.propsVarName;
     var props = options.props;
     var trace = options.trace;
     var generatorFunction = options.generatorFunction;
@@ -69,7 +13,7 @@
     var consoleReplay = '';
 
     try {
-      var reactElement = createReactElement(componentName, propsVarName, props,
+      var reactElement = createReactElement(componentName, props,
         domId, trace, generatorFunction);
       htmlResult = provideServerReact().renderToString(reactElement);
     }
@@ -156,10 +100,59 @@
     return consoleReplay;
   };
 
-  function createReactElement(componentName, propsVarName, props, domId, trace, generatorFunction) {
+  function forEachComponent(fn) {
+    var els = document.getElementsByClassName('react-component');
+    for (var i = 0; i < els.length; i++) {
+      fn(els[i]);
+    };
+  }
+
+  function pageLoaded() {
+    forEachComponent(render);
+  }
+
+  function pageUnloaded() {
+    forEachComponent(unmount);
+  }
+
+  function unmount(el) {
+    var domId = el.getAttribute('data-dom-id');
+    var domNode = document.getElementById(domId);
+    provideClientReact().unmountComponentAtNode(domNode);
+  }
+
+  function render(el) {
+    var componentName = el.getAttribute('data-component-name');
+    var domId = el.getAttribute('data-dom-id');
+    var props = JSON.parse(el.getAttribute('data-props'));
+    var trace = JSON.parse(el.getAttribute('data-trace'));
+    var generatorFunction = JSON.parse(el.getAttribute('data-generator-function'));
+    var expectTurboLinks = JSON.parse(el.getAttribute('data-expect-turbo-links'));
+
+    if (!turbolinksInstalled && expectTurboLinks) {
+      console.warn('WARNING: NO TurboLinks detected in JS, but it is in your Gemfile');
+    }
+
+    try {
+      var domNode = document.getElementById(domId);
+      if (domNode) {
+        var reactElement = createReactElement(componentName, props,
+          domId, trace, generatorFunction);
+        provideClientReact().render(reactElement, domNode);
+      }
+    }
+    catch (e) {
+      ReactOnRails.handleError({
+        e: e,
+        componentName: componentName,
+        serverSide: false,
+      });
+    }
+  };
+
+  function createReactElement(componentName, props, domId, trace, generatorFunction) {
     if (trace) {
-      console.log('RENDERED ' + componentName + ' with data_variable ' +
-        propsVarName + ' to dom node with id: ' + domId);
+      console.log('RENDERED ' + componentName + ' to dom node with id: ' + domId);
     }
 
     if (generatorFunction) {
@@ -183,5 +176,15 @@
     }
 
     return ReactDOMServer;
+  }
+
+  // Install listeners when running on the client.
+  if (typeof document !== 'undefined') {
+    if (!turbolinksInstalled) {
+      document.addEventListener('DOMContentLoaded', pageLoaded);
+    } else {
+      document.addEventListener('page:before-unload', pageUnloaded);
+      document.addEventListener('page:change', pageLoaded);
+    }
   }
 }.call(this));

--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -50,31 +50,24 @@ module ReactOnRailsHelper
 
     # Setup the page_loaded_js, which is the same regardless of prerendering or not!
     # The reason is that React is smart about not doing extra work if the server rendering did its job.
-    data_variable_name = "__#{component_name.camelize(:lower)}Data#{react_component_index}__"
     turbolinks_loaded = Object.const_defined?(:Turbolinks)
-    # NOTE: props might include closing script tag that might cause XSS
-    props_string = sanitized_props_string(props)
-    page_loaded_js = <<-JS
-(function() {
-  window.#{data_variable_name} = #{props_string};
-  ReactOnRails.clientRenderReactComponent({
-    componentName: '#{react_component_name}',
-    domId: '#{dom_id}',
-    propsVarName: '#{data_variable_name}',
-    props: window.#{data_variable_name},
-    trace: #{trace(options)},
-    generatorFunction: #{generator_function(options)},
-    expectTurboLinks: #{turbolinks_loaded}
-  });
-})();
-    JS
 
-    data_from_server_script_tag = javascript_tag(page_loaded_js)
+    component_specification_tag =
+      content_tag(:div,
+                  "",
+                  class: "react-component",
+                  data: {
+                    component_name: react_component_name,
+                    props: props,
+                    trace: trace(options),
+                    generator_function: generator_function(options),
+                    expect_turbolinks: turbolinks_loaded,
+                    dom_id: dom_id
+                  })
 
     # Create the HTML rendering part
     server_rendered_html, console_script =
-      server_rendered_react_component_html(options, props_string, react_component_name,
-                                           data_variable_name, dom_id)
+      server_rendered_react_component_html(options, props, react_component_name, dom_id)
 
     content_tag_options = options.except(:generator_function, :prerender, :trace,
                                          :replay_console, :id, :react_component_name,
@@ -87,7 +80,7 @@ module ReactOnRailsHelper
 
     # IMPORTANT: Ensure that we mark string as html_safe to avoid escaping.
     <<-HTML.html_safe
-#{data_from_server_script_tag}
+#{component_specification_tag}
 #{rendered_output}
 #{replay_console(options) ? console_script : ''}
     HTML
@@ -136,7 +129,7 @@ module ReactOnRailsHelper
 
   # Returns Array [0]: html, [1]: script to console log
   # NOTE, these are NOT html_safe!
-  def server_rendered_react_component_html(options, props_string, react_component_name, data_variable_name, dom_id)
+  def server_rendered_react_component_html(options, props, react_component_name, dom_id)
     return ["", ""] unless prerender(options)
 
     # Make sure that we use up-to-date server-bundle
@@ -144,12 +137,10 @@ module ReactOnRailsHelper
 
     wrapper_js = <<-JS
 (function() {
-  var props = #{props_string};
   return ReactOnRails.serverRenderReactComponent({
     componentName: '#{react_component_name}',
     domId: '#{dom_id}',
-    propsVarName: '#{data_variable_name}',
-    props: props,
+    props: #{sanitized_props_string(props)},
     trace: #{trace(options)},
     generatorFunction: #{generator_function(options)}
   });
@@ -158,7 +149,11 @@ module ReactOnRailsHelper
 
     ReactOnRails::ServerRenderingPool.server_render_js_with_console_logging(wrapper_js)
   rescue ExecJS::ProgramError => err
-    raise ReactOnRails::ServerRenderingPool::PrerenderError.new(react_component_name, props_string, err)
+    raise ReactOnRails::ServerRenderingPool::PrerenderError.new(
+      react_component_name,
+      sanitized_props_string(props),
+      err
+    )
   end
 
   def trace(options)

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -35,26 +35,44 @@ describe ReactOnRailsHelper, type: :helper do
     end
   end
   describe "#react_component" do
-    subject { react_component("App") }
+    subject { react_component("App", props) }
+
+    let(:props) do
+      { name: "My Test Name" }
+    end
 
     let(:react_component_div) do
       "<div id=\"App-react-component-0\"></div>"
     end
 
+    let(:id) { "App-react-component-0" }
+
+    let(:react_definition_div) do
+      "<div class=\"react-component\"
+            data-component-name=\"App\"
+            data-props=\"{&quot;name&quot;:&quot;My Test Name&quot;}\"
+            data-trace=\"false\"
+            data-generator-function=\"false\"
+            data-expect-turbolinks=\"true\"
+            data-dom-id=\"#{id}\"></div>".squish
+    end
+
     it { expect(self).to respond_to :react_component }
 
     it { is_expected.to be_an_instance_of ActiveSupport::SafeBuffer }
-    it { is_expected.to start_with "<script>" }
+    it { is_expected.to start_with "<div" }
     it { is_expected.to end_with "</div>\n\n" }
     it { is_expected.to include react_component_div }
+    it { is_expected.to include react_definition_div }
 
     context "with 'id' option" do
-      subject { react_component("App", {}, id: id) }
+      subject { react_component("App", props, id: id) }
 
       let(:id) { "shaka_div" }
 
       it { is_expected.to include id }
       it { is_expected.not_to include react_component_div }
+      it { is_expected.to include react_definition_div }
     end
   end
 

--- a/spec/dummy/spec/requests/console_logging_spec.rb
+++ b/spec/dummy/spec/requests/console_logging_spec.rb
@@ -6,8 +6,8 @@ describe "Server Error Logging" do
     html_nodes = Nokogiri::HTML(response.body)
 
     expected = <<-JS
-console.log.apply(console, ["[SERVER] RENDERED HelloWorldWithLogAndThrow with data_variable \
-__helloWorldWithLogAndThrowData0__ to dom node with id: HelloWorldWithLogAndThrow-react-component-0"]);
+console.log.apply(console, ["[SERVER] RENDERED HelloWorldWithLogAndThrow to dom node \
+with id: HelloWorldWithLogAndThrow-react-component-0"]);
 console.log.apply(console, ["[SERVER] console.log in HelloWorld"]);
 console.warn.apply(console, ["[SERVER] console.warn in HelloWorld"]);
 console.error.apply(console, ["[SERVER] console.error in HelloWorld"]);
@@ -18,7 +18,8 @@ console.error.apply(console, ["[SERVER] stack: Error: throw in HelloWorldContain
 
     expected_lines = expected.split("\n")
 
-    script_node = html_nodes.css("script")[2]
+    script_node = html_nodes.css("script")[1]
+
     expected_lines.each do |line|
       expect(script_node.inner_text).to include(line)
     end


### PR DESCRIPTION
Client side rendering scripts do not get called when using the forward/back buttons with turbolinks, because turbolinks does not re-evaluate script tags when navigating through the history.

Instead of creating script tags throughout the page, use html elements with data attributes specifying each react component to be rendered, and iterate through all of those elements whenever the page loads.

E.g.,
```html
<div class="react-component"
     data-component-name="App"
     data-props="{&quot;name&quot;:&quot;My Test Name&quot;}"
     data-trace="false"
     data-generator-function="false"
     data-expect-turbolinks="true"
     data-dom-id="El-react-component-0"></div>
<div id="El-react-component-0"></div>
```

This has the added benefit of removing global data variables from being set on the window object and simplifying the rendering code.

(Note that it will be possible to support turbolinks navigation with the still-on-master `data-turbolinks-eval=always` feature of turbolinks.  But this solution doesn't depend on that upgrade and is a bit cleaner anyway.)