### PR TITLE
Add data-turbolinks-eval always to script tags

### DIFF
--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -52,6 +52,8 @@ module ReactOnRailsHelper
     # The reason is that React is smart about not doing extra work if the server rendering did its job.
     data_variable_name = "__#{component_name.camelize(:lower)}Data#{react_component_index}__"
     turbolinks_loaded = Object.const_defined?(:Turbolinks)
+    script_options = {}
+    script_options['data-turbolinks-eval'] = "always" if turbolinks_loaded
     # NOTE: props might include closing script tag that might cause XSS
     props_string = sanitized_props_string(props)
     page_loaded_js = <<-JS
@@ -69,7 +71,7 @@ module ReactOnRailsHelper
 })();
     JS
 
-    data_from_server_script_tag = javascript_tag(page_loaded_js)
+    data_from_server_script_tag = javascript_tag(page_loaded_js, script_options)
 
     # Create the HTML rendering part
     server_rendered_html, console_script =

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -19,7 +19,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+gem 'turbolinks', github: "rails/turbolinks"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/rails/turbolinks.git
+  revision: 75115a3c217f54b447b780061ae0279abae1f146
+  specs:
+    turbolinks (3.0.0)
+      coffee-rails
+
 PATH
   remote: ../..
   specs:
@@ -78,7 +85,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.10.0)
     columnize (0.9.0)
     connection_pool (2.2.0)
     coveralls (0.8.2)
@@ -253,8 +260,6 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     tins (1.6.0)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -305,7 +310,7 @@ DEPENDENCIES
   spring
   sqlite3
   therubyracer
-  turbolinks
+  turbolinks!
   uglifier (>= 2.7.2)
   web-console (~> 2.0)
 


### PR DESCRIPTION
Forward and back buttons don't re-evaluate scripts for turbolinks unless
data-turbolinks-eval is set to 'always'. However, this is a turbolinks
v3 feature which is not yet released.

The branch contains a link to turbolinks at master, and this setting
works for react_on_rails.