### PR TITLE
Have generator create application.js file if not found

### DIFF
--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -71,14 +71,15 @@ module ReactOnRails
 
           // bootstrap-sprockets depends on generated/vendor-bundle for jQuery.
           //= require bootstrap-sprockets
+
         DATA
 
-        application_js_path = "app/assets/javascripts/application.js"
-        application_js = dest_file_exists?(application_js_path) || dest_file_exists?(application_js_path + ".coffee")
-        if application_js
-          prepend_to_file(application_js, data)
+        app_js_path = "app/assets/javascripts/application.js"
+        found_app_js = dest_file_exists?(app_js_path) || dest_file_exists?(app_js_path + ".coffee")
+        if found_app_js
+          prepend_to_file(found_app_js, data)
         else
-          puts_setup_file_error("#{application_js} or #{application_js}.coffee", data)
+          create_file(app_js_path, data)
         end
       end
 

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -141,4 +141,9 @@ describe InstallGenerator, type: :generator do
     before(:all) { run_generator_test_with_args(%w(-H)) }
     include_examples "heroku_deployment"
   end
+
+  context "without existing application.js or application.js.coffee file" do
+    before(:all) { run_generator_test_with_args([], application_js: false) }
+    include_examples "base_generator:base"
+  end
 end

--- a/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/spec/react_on_rails/support/generator_spec_helper.rb
@@ -12,16 +12,20 @@ def run_generator_test_with_args(args, options = {})
   simulate_existing_file("config/routes.rb", "Rails.application.routes.draw do\nend\n")
   simulate_existing_file("config/application.rb", "module Gentest\nclass Application < Rails::Application\nend\nend)")
   simulate_existing_file("config/initializers/assets.rb")
-  app_js_data = <<-DATA.strip_heredoc
-    //= require jquery
-    //= require jquery_ujs
-    //= require turbolinks
-    //= require_tree .
-  DATA
-  simulate_existing_file("app/assets/javascripts/application.js", app_js_data)
-  application_css = "app/assets/stylesheets/application.css.scss"
+  if options.fetch(:application_js, true)
+    app_js = "app/assets/javascripts/application.js"
+    app_js_data = <<-DATA.strip_heredoc
+      //= require jquery
+      //= require jquery_ujs
+      //= require turbolinks
+      //= require_tree .
+    DATA
+    simulate_existing_file(app_js, app_js_data)
+  end
   if options.fetch(:application_css, true)
-    simulate_existing_file(application_css, " *= require_tree .\n *= require_self\n")
+    app_css = "app/assets/stylesheets/application.css.scss"
+    app_css_data = " *= require_tree .\n *= require_self\n"
+    simulate_existing_file(app_css, app_css_data)
   end
   run_generator(args)
 end

--- a/spec/react_on_rails/support/shared_examples/base_generator_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/base_generator_examples.rb
@@ -42,10 +42,10 @@ shared_examples "base_generator:base" do
       // bootstrap-sprockets depends on generated/vendor-bundle for jQuery.
       //= require bootstrap-sprockets
 
-      //= require turbolinks
-
     MATCH
-    assert_file("app/assets/javascripts/application.js", match)
+    assert_file("app/assets/javascripts/application.js") do |contents|
+      assert_match(match, contents)
+    end
   end
 
   it "removes incompatible sprockets require statements" do


### PR DESCRIPTION
Fixes #78
Generator used to put a setup error message when it did not find
application.js. Now, it will simply just create one with the
necessary data in it.