### PR TITLE
Render server side every time in development environment

### DIFF
--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -134,7 +134,7 @@ module ReactOnRailsHelper
     return ["", ""] unless prerender(options)
 
     # Make sure that we use up-to-date server-bundle
-    ReactOnRails::ServerRenderingPool.reset_pool_if_server_bundle_was_modified
+    ReactOnRails::ServerRenderingPool.reset_pool if Rails.env.development?
 
     # Since this code is not inserted on a web page, we don't need to escape.
     props_string = props.is_a?(String) ? props : props.to_json

--- a/lib/react_on_rails/server_rendering_pool.rb
+++ b/lib/react_on_rails/server_rendering_pool.rb
@@ -11,15 +11,6 @@ module ReactOnRails
       @js_context_pool = ConnectionPool.new(options) { create_js_context }
     end
 
-    def self.reset_pool_if_server_bundle_was_modified
-      return unless ReactOnRails.configuration.development_mode
-      file_mtime = File.mtime(ReactOnRails.configuration.server_bundle_js_file)
-      first_time = @server_bundle_timestamp.nil?
-      return if first_time || @server_bundle_timestamp == file_mtime
-      ReactOnRails::ServerRenderingPool.reset_pool
-      @server_bundle_timestamp = file_mtime
-    end
-
     class PrerenderError < RuntimeError
       def initialize(component_name, props, js_message)
         message = ["Encountered error \"#{js_message}\" when prerendering #{component_name} with #{props}",


### PR DESCRIPTION
Is this sufficient to fix #114? It looks like the `ConnectionPool` is being set on startup at: https://github.com/shakacode/react_on_rails/blob/master/lib/react_on_rails/engine.rb#L4 so I don't think we have to account for the initial pool creation here.