### PR TITLE
rewrite NODE_ENV as nodeEnv so the two mentions of the variable match up

### DIFF
--- a/lib/generators/react_on_rails/templates/base/base/client/webpack.client.base.config.js.tt
+++ b/lib/generators/react_on_rails/templates/base/base/client/webpack.client.base.config.js.tt
@@ -37,7 +37,7 @@ module.exports = {
 
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify(NODE_ENV),
+        NODE_ENV: JSON.stringify(nodeEnv),
       },
     }),
 

--- a/lib/generators/react_on_rails/templates/base/base/client/webpack.client.rails.config.js
+++ b/lib/generators/react_on_rails/templates/base/base/client/webpack.client.rails.config.js
@@ -8,7 +8,6 @@ const webpack = require('webpack');
 const config = require('./webpack.client.base.config');
 const devBuild = process.env.NODE_ENV !== 'production';
 
-
 config.output = {
   filename: '[name]-bundle.js',
   path: '../app/assets/javascripts/generated',

--- a/lib/generators/react_on_rails/templates/base/base/client/webpack.client.rails.config.js
+++ b/lib/generators/react_on_rails/templates/base/base/client/webpack.client.rails.config.js
@@ -6,6 +6,8 @@
 
 const webpack = require('webpack');
 const config = require('./webpack.client.base.config');
+const devBuild = process.env.NODE_ENV !== 'production';
+
 
 config.output = {
   filename: '[name]-bundle.js',


### PR DESCRIPTION
when trying to run `foreman start -f Procfile.dev`, I was getting the error - 
`ReferenceError: NODE_ENV is not defined`

Then when I checked in webpack.server.rails.config.js I noticed that the variable `NODE_ENV` was indeed not defined, though a variable `nodeEnv` was. My guess is that `NODE_ENV` and `nodeEnv` are intended to mean the same thing, so I rewrote `NODE_ENV` to `nodeEnv` so they match up. After doing this, I no longer received the `ReferenceError` when running `foreman`.