### PR TITLE
Check for config/initializers/assets.rb file

### DIFF
--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -20,7 +20,12 @@ module ReactOnRails
 
           Rails.application.config.assets.precompile += %w( generated/server-bundle.js )
         DATA
-        append_to_file("config/initializers/assets.rb", data)
+        assets_intializer = "config/initializers/assets.rb"
+        if File.exist?(assets_intializer)
+          append_to_file(assets_intializer, data)
+        else
+          puts_setup_file_error(assets_intializer, data)
+        end
       end
 
       def copy_bootstrap_files


### PR DESCRIPTION
First of all thanks for an awesome gem :star: 

react_on_rails:install fails when there is no existing assets initializer file:

```
$ rails generate react_on_rails:install
# ...
# => No such file or directory @ rb_sysopen /Users/xxx../config/initializers/assets.rb
```

I added a small patch that followed the same pattern used in [`BootstrapGenerator#prepend_to_application_scss `](https://github.com/shakacode/react_on_rails/blob/213fd8049840387f32bdb626e20fbde29a5acea5/lib/generators/react_on_rails/bootstrap_generator.rb#L82).