### PR TITLE
Check for config/initializers/assets.rb file

### DIFF
--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -24,7 +24,7 @@ module ReactOnRails
         if File.exist?(assets_intializer)
           append_to_file(assets_intializer, data)
         else
-          puts_setup_file_error(assets_intializer, data)
+          create_file(assets_intializer, data)
         end
       end
 

--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -20,7 +20,12 @@ module ReactOnRails
 
           Rails.application.config.assets.precompile += %w( generated/server-bundle.js )
         DATA
-        append_to_file("config/initializers/assets.rb", data)
+        assets_intializer = File.join(destination_root, "config/initializers/assets.rb")
+        if File.exist?(assets_intializer)
+          append_to_file(assets_intializer, data)
+        else
+          puts_setup_file_error(assets_intializer, data)
+        end
       end
 
       def copy_bootstrap_files

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -151,4 +151,14 @@ describe InstallGenerator, type: :generator do
     before(:all) { run_generator_test_with_args([], application_js: true) }
     include_examples "base_generator:base", application_js: true
   end
+
+  context "without existing assets.rb file" do
+    before(:all) { run_generator_test_with_args([], assets_rb: false) }
+    include_examples "bootstrap", assets_rb: false
+  end
+
+  context "with existing assets.rb file" do
+    before(:all) { run_generator_test_with_args([], assets_rb: true) }
+    include_examples "bootstrap", assets_rb: true
+  end
 end

--- a/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/spec/react_on_rails/support/generator_spec_helper.rb
@@ -12,7 +12,9 @@ def run_generator_test_with_args(args, options = {})
   simulate_existing_file("Gemfile", "")
   simulate_existing_file("config/routes.rb", "Rails.application.routes.draw do\nend\n")
   simulate_existing_file("config/application.rb", "module Gentest\nclass Application < Rails::Application\nend\nend)")
-  simulate_existing_file("config/initializers/assets.rb")
+  if options.fetch(:assets_rb, true)
+    simulate_existing_file("config/initializers/assets.rb")
+  end
   if options.fetch(:application_js, true)
     app_js = "app/assets/javascripts/application.js"
     app_js_data = <<-DATA.strip_heredoc


### PR DESCRIPTION
First of all thanks for an awesome gem :star: 

react_on_rails:install fails when there is no existing assets initializer file:

```
$ rails generate react_on_rails:install
# ...
# => No such file or directory @ rb_sysopen /Users/xxx../config/initializers/assets.rb
```

I added a small patch that followed the same pattern used in [`BootstrapGenerator#prepend_to_application_scss `](https://github.com/shakacode/react_on_rails/blob/213fd8049840387f32bdb626e20fbde29a5acea5/lib/generators/react_on_rails/bootstrap_generator.rb#L82).