### PR TITLE
Fixes Generator Warning Messages #138

### DIFF
--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -1,7 +1,9 @@
 require "rails/generators"
 require File.expand_path("../generator_helper", __FILE__)
+require File.expand_path("../generator_errors", __FILE__)
 
 include GeneratorHelper
+include GeneratorErrors
 
 module ReactOnRails
   module Generators
@@ -62,7 +64,11 @@ module ReactOnRails
           /app/assets/javascripts/generated/*
         DATA
 
-        dest_file_exists?(".gitignore") ? append_to_file(".gitignore", data) : puts_setup_file_error(".gitignore", data)
+        if dest_file_exists?(".gitignore")
+          append_to_file(".gitignore", data)
+        else
+          GeneratorErrors.add_error(return_setup_file_error(".gitignore", data))
+        end
       end
 
       def update_application_js

--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -1,6 +1,8 @@
 require "rails/generators"
 require File.expand_path("../generator_helper", __FILE__)
+require File.expand_path("../generator_errors", __FILE__)
 include GeneratorHelper
+include GeneratorErrors
 
 module ReactOnRails
   module Generators
@@ -54,7 +56,7 @@ module ReactOnRails
         if File.exist?(application_scss)
           append_to_file(application_scss, data)
         else
-          puts_setup_file_error(application_scss, data)
+          GeneratorErrors.add_error(return_setup_file_error(application_scss, data))
         end
       end
 

--- a/lib/generators/react_on_rails/generator_errors.rb
+++ b/lib/generators/react_on_rails/generator_errors.rb
@@ -1,0 +1,15 @@
+module GeneratorErrors
+  class << self
+    def output
+      @output ||= []
+    end
+
+    def add_error(message)
+      output << message
+    end
+
+    def errors
+      output
+    end
+  end
+end

--- a/lib/generators/react_on_rails/generator_helper.rb
+++ b/lib/generators/react_on_rails/generator_helper.rb
@@ -17,6 +17,14 @@ module GeneratorHelper
     puts "\n#{data}\n"
   end
 
+  def return_setup_file_error(file, data)
+    error = ""
+    error << "** #{file} was not found.\n"
+    error << "Please add the following content to your #{file} file:\n"
+    error << "\n#{data}\n"
+    error
+  end
+
   def empty_directory_with_keep_file(destination, config = {})
     empty_directory(destination, config)
     keep_file(destination)

--- a/lib/generators/react_on_rails/install_generator.rb
+++ b/lib/generators/react_on_rails/install_generator.rb
@@ -1,4 +1,8 @@
 require "rails/generators"
+require File.expand_path("../generator_helper", __FILE__)
+require File.expand_path("../generator_errors", __FILE__)
+include GeneratorHelper
+include GeneratorErrors
 
 module ReactOnRails
   module Generators
@@ -44,12 +48,20 @@ module ReactOnRails
                    aliases: "-b"
 
       def run_generators # rubocop:disable Metrics/CyclomaticComplexity
-        return unless installation_prerequisites_met?
+        unless installation_prerequisites_met?
+          print_errors
+          return
+        end
         warn_if_nvm_is_not_installed
         invoke_generators
+        print_errors
       end
 
       private
+
+      def print_errors
+        GeneratorErrors.errors.each { |errors| puts errors }
+      end
 
       def invoke_generators # rubocop:disable Metrics/CyclomaticComplexity
         invoke "react_on_rails:base"
@@ -72,14 +84,14 @@ module ReactOnRails
         return false unless `which npm`.blank?
         error = "** npm is required. Please install it before continuing."
         error << "https://www.npmjs.com/"
-        puts error
+        GeneratorErrors.add_error(error)
       end
 
       def missing_node?
         return false unless `which node`.blank?
         error = "** nodejs is required. Please install it before continuing."
         error << "https://nodejs.org/en/"
-        puts error
+        GeneratorErrors.add_error(error)
       end
 
       def uncommitted_changes?
@@ -87,12 +99,12 @@ module ReactOnRails
         status = `git status`
         return false if status.include?("nothing to commit, working directory clean")
         error = "** You have uncommitted code. Please commit or stash your changes before continuing"
-        puts error
+        GeneratorErrors.add_error(error)
       end
 
       def warn_if_nvm_is_not_installed
         return true unless `which nvm`.blank?
-        puts "** nvm is advised. Please consider installing it. https://github.com/creationix/nvm"
+        GeneratorErrors.add_error("** nvm is advised. Please consider installing it. https://github.com/creationix/nvm")
       end
     end
   end

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -190,4 +190,9 @@ describe InstallGenerator, type: :generator do
     before(:all) { run_generator_test_with_args([], assets_rb: true) }
     include_examples "base_generator:base", assets_rb: true
   end
+
+  context "with missing files to trigger errors" do
+    before(:all) { run_generator_test_with_args([], gitignore: false) }
+    include_examples "generator_errors"
+  end
 end

--- a/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/spec/react_on_rails/support/generator_spec_helper.rb
@@ -8,7 +8,7 @@ include ReactOnRails::Generators
 # Expects an array of strings, such as "--redux"
 def run_generator_test_with_args(args, options = {})
   prepare_destination # this completely wipes the `destination` directory
-  simulate_existing_file(".gitignore")
+  simulate_existing_file(".gitignore") if options.fetch(:gitignore, true)
   simulate_existing_file("Gemfile", "")
   simulate_existing_file("config/routes.rb", "Rails.application.routes.draw do\nend\n")
   simulate_existing_file("config/application.rb", "module Gentest\nclass Application < Rails::Application\nend\nend)")

--- a/spec/react_on_rails/support/shared_examples/generator_errors_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/generator_errors_examples.rb
@@ -1,0 +1,45 @@
+shared_examples "generator_errors" do
+  it "initializes GeneratorErrors singleton" do
+    assert_equal GeneratorErrors, GeneratorErrors
+  end
+
+  it "has an errors method that returns an array" do
+    assert_instance_of Array, GeneratorErrors.errors
+  end
+
+  it "has a method that can add errors" do
+    GeneratorErrors.add_error "Test error"
+    assert_instance_of Array, GeneratorErrors.errors
+    assert_includes GeneratorErrors.errors, "Test error"
+  end
+
+  it "adds setup file error to errors" do
+    file = "test_file"
+    data = <<-DATA.strip_heredoc
+      test data
+    DATA
+    GeneratorErrors.add_error(return_setup_file_error(file, data))
+    error = ""
+    error << "** #{file} was not found.\n"
+    error << "Please add the following content to your #{file} file:\n"
+    error << "\n#{data}\n"
+    assert_includes GeneratorErrors.errors, error
+  end
+
+  it "shows gitignore error if gitignore does not exist" do
+    file = ".gitignore"
+    data = <<-DATA.strip_heredoc
+      # React on Rails
+      npm-debug.log
+      node_modules
+
+      # Generated js bundles
+      /app/assets/javascripts/generated/*
+    DATA
+    error = ""
+    error << "** #{file} was not found.\n"
+    error << "Please add the following content to your #{file} file:\n"
+    error << "\n#{data}\n"
+    assert_includes GeneratorErrors.errors, error
+  end
+end


### PR DESCRIPTION
Added an ‘errors’ attribute to the install generator class which gets passed, as an option, to the generators that output errors.

Errors outputted get pushed into the errors attr array. At the end of the install any errors in the attr array get printed to the terminal.