### PR TITLE
Lodash to default dependencies

### DIFF
--- a/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
+++ b/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
@@ -50,9 +50,9 @@
     "jquery-ujs": "^1.1.0-1",
     "loader-utils": "^0.2.11",
     <%- if options.redux? -%>
-    "lodash": "^3.10.1",
     "mirror-creator": "0.0.1",
     <%- end -%>
+    "lodash": "^3.10.1",
     "react": "^0.14.0",
     <%- unless options.skip_bootstrap? -%>
     "react-bootstrap": "^0.28.1",


### PR DESCRIPTION
It seems like we need `lodash` even for version without redux

https://github.com/shakacode/react_on_rails/blob/master/lib/generators/react_on_rails/templates/no_redux/base/client/app/bundles/HelloWorld/components/HelloWorldWidget.jsx#L2

Relate to #162 