### PR TITLE
Fix #189 Generator Error for application.scss

### DIFF
--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -53,11 +53,7 @@ module ReactOnRails
 
         application_scss = File.join(destination_root, "app/assets/stylesheets/application.scss")
 
-        if File.exist?(application_scss)
-          append_to_file(application_scss, data)
-        else
-          GeneratorErrors.add_error(return_setup_file_error(application_scss, data))
-        end
+        append_to_file(application_scss, data)
       end
 
       def strip_application_scss_of_incompatible_sprockets_statements


### PR DESCRIPTION
Removed the File.exists? check for application.scss because it gets created if it doesn’t exist in the method before it.

(cc @robwise)