### PR TITLE
Clarify Generator Messages

### DIFF
--- a/lib/generators/react_on_rails/generator_messages.rb
+++ b/lib/generators/react_on_rails/generator_messages.rb
@@ -16,7 +16,7 @@ module GeneratorMessages
       output << format_info(message)
     end
 
-    def errors
+    def messages
       output
     end
 

--- a/lib/generators/react_on_rails/install_generator.rb
+++ b/lib/generators/react_on_rails/install_generator.rb
@@ -62,15 +62,15 @@ module ReactOnRails
           # fail("react_on_rails generator prerequisites not met!")
         end
       ensure
-        print_errors
+        print_generator_messages
       end
 
       # Everything here is not run automatically b/c it's private
 
       private
 
-      def print_errors
-        GeneratorMessages.errors.each { |errors| puts errors }
+      def print_generator_messages
+        GeneratorMessages.messages.each { |message| puts message }
       end
 
       def invoke_generators # rubocop:disable Metrics/CyclomaticComplexity

--- a/spec/react_on_rails/generators/generator_messages_spec.rb
+++ b/spec/react_on_rails/generators/generator_messages_spec.rb
@@ -1,11 +1,11 @@
 describe GeneratorMessages do
   it "has an empty errors array" do
-    expect(GeneratorMessages.errors).to be_empty
+    expect(GeneratorMessages.messages).to be_empty
   end
 
   it "has a method that can add errors" do
     GeneratorMessages.add_error "Test error"
-    expect(GeneratorMessages.errors)
+    expect(GeneratorMessages.messages)
       .to match_array([GeneratorMessages.format_error("Test error")])
   end
 end


### PR DESCRIPTION
Updated the 'errors' wording used in GeneratorMessages to 'messages' because this singleton is also outputting warning and info messages.