### PR TITLE
Better to return created reactElement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ If you are using [react-rails](https://github.com/reactjs/react-rails) in your p
 
 - Remove the 'react-rails' gem from your Gemfile.
 
-- Remove the generated generated lines for react-rails in your application.js file. 
+- Remove the generated generated lines for react-rails in your application.js file.
 
 ```
 //= require react
@@ -377,6 +377,7 @@ Note: If you have components from react-rails you want to use, then you will nee
 + [React Router](docs/additional_reading/react_router.md)
 + [RSpec Configuration](docs/additional_reading/rspec_configuration.md)
 + [Server Rendering Tips](docs/additional_reading/server_rendering_tips.md)
++ [Rails View Rendering from Inline JavaScript](docs/additional_reading/rails_view_rendering_from_inline_javascript.md)
 + [Tips](docs/additional_reading/tips.md)
 + [Tutorial for v2.0](docs/tutorial-v2.md)
 + [Turbolinks](docs/additional_reading/turbolinks.md)

--- a/docs/additional_reading/rails_view_rendering_from_inline_javascript.md
+++ b/docs/additional_reading/rails_view_rendering_from_inline_javascript.md
@@ -1,0 +1,26 @@
+# Using ReactOnRails in JavaScript
+You can easily render React components in your JavaScript with `render` method that returns a [reference to the component](https://facebook.github.io/react/docs/more-about-refs.html) (virtual DOM element).
+
+```js
+// componentName - name of your registered component;
+// props - Object which contains the properties to pass to the react object;
+// elementId - id of an element where we render our React component;
+ReactOnRails.render(componentName, props, elementId)
+```
+
+## Why do we need this?
+Imagine that we have some event with jQuery, it allows us to set component state manually.
+
+```html
+<input id="input" type="range" min="0" max="100" />
+<div id="root"></div>
+
+<script>
+  var input = $("#input");
+  var component = ReactOnRails.render("componentName", { value: input.val() }, "root");
+
+  input.on("change", function(e) {
+    component.setState({ value: input.val() });
+  });
+</script>
+```

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -29,10 +29,11 @@ ctx.ReactOnRails = {
    * @param name Name of your registered component
    * @param props Props to pass to your component
    * @param domNodeId
+   * @returns {virtualDomElement} Reference to your component's backing instance
    */
   render(name, props, domNodeId) {
     const reactElement = createReactElement({ name, props, domNodeId });
-    ReactDOM.render(reactElement, document.getElementById(domNodeId));
+    return ReactDOM.render(reactElement, document.getElementById(domNodeId));
   },
 
   /**

--- a/node_package/tests/ReactOnRails.test.js
+++ b/node_package/tests/ReactOnRails.test.js
@@ -1,0 +1,26 @@
+/* eslint-disable react/no-multi-comp */
+import test from 'tape';
+import React from 'react';
+import ReactOnRails from '../src/ReactOnRails';
+import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
+import JsDom from 'jsdom';
+
+if (!canUseDOM) {
+  global.document = JsDom.jsdom('<div id="root"></div>');
+  global.window = document.defaultView;
+}
+
+test('ReactOnRails render returns a virtual DOM element for component', (assert) => {
+  assert.plan(1);
+  const R1 = React.createClass({
+    render() {
+      return (
+        <div> WORLD </div>
+      );
+    },
+  });
+  ReactOnRails.register({ R1 });
+  const actual = ReactOnRails.render('R1', {}, 'root')._reactInternalInstance._currentElement.type;
+  assert.deepEqual(actual, R1,
+    'ReactOnRails render should return a virtual DOM element for component');
+});

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-transform-hmr": "^1.0.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0",
-    "webpack": "^1.12.12"
+    "webpack": "^1.12.12",
+    "jsdom": "^8.0.0-0"
   },
   "peerDependencies": {
     "react": ">= 0.14",


### PR DESCRIPTION
If I use only React component and I want to manually set state, maybe better to return rendered reactElement?

```javascript
  render(name, props, domNodeId) {
    const reactElement = createReactElement({ name, props, domNodeId });
    return ReactDOM.render(reactElement, document.getElementById(domNodeId));
  }

// then I can
  var renderedElement = ReactOnRails.render('Element', {}, 'app');
  renderedElement.setState({ option: value });

```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/213)
<!-- Reviewable:end -->
