### PR TITLE
Fix requires

### DIFF
--- a/lib/react_on_rails.rb
+++ b/lib/react_on_rails.rb
@@ -1,9 +1,11 @@
 require "rails"
 
 require "react_on_rails/version"
+require "react_on_rails/version_checker"
 require "react_on_rails/configuration"
 require "react_on_rails/server_rendering_pool"
 require "react_on_rails/engine"
+require "react_on_rails/version_syntax_converter"
 require "react_on_rails/ensure_assets_compiled"
 
 module ReactOnRails

--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -1,5 +1,3 @@
-require_relative "version_checker"
-
 module ReactOnRails
   class Engine < ::Rails::Engine
     config.to_prepare do

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -1,6 +1,3 @@
-require_relative "version"
-require_relative "version_syntax_converter"
-
 module ReactOnRails
   # Responsible for checking versions of rubygem versus npm node package
   # against each otherat runtime.


### PR DESCRIPTION
Put require statements all in one place. This will address an issue 
where the user is warned that React on Rails
is attempting to set a constant twice. This was happening because
the version.rb file was being required from multiple locations.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/226)
<!-- Reviewable:end -->
