### PR TITLE
Bump rainbow gem version to >= 2.1.0.

### DIFF
--- a/lib/generators/react_on_rails/generator_messages.rb
+++ b/lib/generators/react_on_rails/generator_messages.rb
@@ -25,7 +25,7 @@ module GeneratorMessages
     end
 
     def format_warning(msg)
-      Rainbow("WARNING: #{msg}").color(255, 165, 0)
+      Rainbow("WARNING: #{msg}").orange
     end
 
     def format_info(msg)

--- a/react_on_rails.gemspec
+++ b/react_on_rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "connection_pool"
   s.add_dependency "execjs", "~> 2.5"
-  s.add_dependency "rainbow", "~> 2.0"
+  s.add_dependency "rainbow", "~> 2.1"
   s.add_dependency "rails", ">= 3.2"
 
   s.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
In one of my previous PR's we had to do a 'hacky' fix to get X11 colors to output with the GeneratorMessages. https://github.com/shakacode/react_on_rails/pull/217

I was able to fix the problem with the rainbow gem and get a PR merged: https://github.com/sickill/rainbow/issues/27. The author updated the version of the gem to 2.1.0.

- New version of rainbow fixes bug with X11 colors.
- Use ‘orange’ instead of RGB color.