### PR TITLE
Fix rendering in non-Turbolink apps and improve Turbolink docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. Items under
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
+##### Fixed
+- Fixed regression where apps that were not using Turbolinks would not render components on page load.
+
+##### Added
+- `debug_turbolinks` helper for debugging turbolinks issues. See [turbolinks](docs/additional_reading/turbolinks.md).
+- Enhanced regression testing for non-turbolinks apps. Runs all tests for dummy app with turbolinks both disabled and enabled.
 
 ## [2.1.0] - 2016-01-26
 ##### Added

--- a/app/assets/javascripts/debug_turbolinks.js
+++ b/app/assets/javascripts/debug_turbolinks.js
@@ -1,0 +1,4 @@
+window.DEBUG_TURBOLINKS = true;
+console.log('window.DEBUG_TURBOLINKS = true;');
+console.log('To disable Turbolinks debugging, remove the debug_turbolinks require' +
+            ' from app/assets/javascripts/application.js');

--- a/docs/additional_reading/turbolinks.md
+++ b/docs/additional_reading/turbolinks.md
@@ -4,8 +4,8 @@
 * Currently support 2.5.x of Turbolinks. We plan to update to Turbolinks 5 soon.
 
 ## Why Turbolinks?
-As you switch between Rails HTML controller requests, you will only load the HTML and you will 
-not reload JavaScript and stylesheets. This definitely can make an app perform better, even if 
+As you switch between Rails HTML controller requests, you will only load the HTML and you will
+not reload JavaScript and stylesheets. This definitely can make an app perform better, even if
 the JavaScript and stylesheets are cached by the browser, as they will still require parsing.
 
 ### Install Checklist
@@ -19,21 +19,8 @@ the JavaScript and stylesheets are cached by the browser, as they will still req
    ```javascript
    //= require turbolinks
    ```
-   
+
 ## Troubleshooting
+To turn on tracing of Turbolinks events, require `debug_turbolinks` (provided by ReactOnRails) inside of `app/assets/javascripts/application.js` **at the beginning of the file**. This will print out events related to the initialization of the components created with the view helper `react_component`.
 
-You cans set a global debug flag in your `application.js` to turn on tracing of Turbolinks events
-as they pertain to React on Rails.
-
-1. Add this line to your `application.js`:
-   ```javascript
-   //= require testGlobals
-   ```
-2. Initialie the global debug value of `DEBUG_TURBOLINKS` like this:
-   ```javascript
-   window.DEBUG_TURBOLINKS = true;
-   console.log('window.DEBUG_TURBOLINKS = true;');
-   ```
-   
-This will print out events related to the initialization of the components created with the view 
-helper `react_component`.
+We've noticed that Turbolinks doesn't work if you use the ruby gem version of jQuery and jQuery ujs. Therefore we recommend using the node packages instead. See the [tutorial app](https://github.com/shakacode/react-webpack-rails-tutorial) for how to accomplish this.

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -111,7 +111,7 @@ export default function clientStartup(context) {
 
     if (!turbolinksInstalled()) {
       debugTurbolinks('WITHOUT TURBOLINKS: DOMContentLoaded handler installed.');
-      document.addEventListener('DOMContentLoaded', reactOnRailsPageLoaded);
+      reactOnRailsPageLoaded();
     } else {
       debugTurbolinks('WITH TURBOLINKS: document page:before-unload and page:change handlers' +
         ' installed.');

--- a/rakelib/run_rspec.rake
+++ b/rakelib/run_rspec.rake
@@ -16,6 +16,12 @@ namespace :run_rspec do
     run_tests_in(File.join("spec", "dummy"), env_vars: "DRIVER=selenium_firefox")
   end
 
+  task dummy_no_turbolinks: ["dummy_apps:dummy_app"] do
+    run_tests_in(File.join("spec", "dummy"),
+                 env_vars: "DRIVER=selenium_firefox DISABLE_TURBOLINKS=TRUE",
+                 command_name: "dummy_no_turbolinks")
+  end
+
   # Dynamically define Rake tasks for each example app found in the examples directory
   ExampleType.all.each do |example_type|
     desc "Runs RSpec for #{example_type.name_pretty} only"
@@ -37,7 +43,7 @@ namespace :run_rspec do
   Coveralls::RakeTask.new
 
   desc "run all tests"
-  task run_rspec: [:gem, :dummy, :examples, :empty, :js_tests] do
+  task run_rspec: [:gem, :dummy, :dummy_no_turbolinks, :examples, :empty, :js_tests] do
     puts "Completed all RSpec tests"
   end
 end
@@ -69,6 +75,6 @@ def run_tests_in(dir, options = {})
 
   command_name = options.fetch(:command_name, path.basename)
   rspec_args = options.fetch(:rspec_args, "")
-  env_vars = %(#{options.fetch(env_vars, '')} COVERAGE=true TEST_ENV_COMMAND_NAME="#{command_name}")
+  env_vars = %(#{options.fetch(:env_vars, '')} COVERAGE=true TEST_ENV_COMMAND_NAME="#{command_name}")
   sh_in_dir(path.realpath, "#{env_vars} bundle exec rspec #{rspec_args}")
 end

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -18,7 +18,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+gem 'turbolinks' if ENV["DISABLE_TURBOLINKS"].nil?
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -269,8 +269,6 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.2)
     tins (1.6.0)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -327,7 +325,6 @@ DEPENDENCIES
   spring
   sqlite3
   therubyracer
-  turbolinks
   uglifier (>= 2.7.2)
   web-console (~> 2.0)
 

--- a/spec/dummy/Procfile.dev.no.turbolinks
+++ b/spec/dummy/Procfile.dev.no.turbolinks
@@ -1,0 +1,3 @@
+client: sh -c 'rm app/assets/javascripts/generated/* || true && cd client && npm run build:dev:client'
+server: sh -c 'cd client && npm run build:dev:server'
+web: DISABLE_TURBOLINKS=TRUE bin/rails s

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,7 +10,4 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require testGlobals
 //= require generated/client
-
-//= require turbolinks

--- a/spec/dummy/app/assets/javascripts/application_with_turbolinks.js
+++ b/spec/dummy/app/assets/javascripts/application_with_turbolinks.js
@@ -1,0 +1,9 @@
+// This file is so that we can test the dummy app with turbolinks both enabled
+// and disabled via an environment variable (see also:
+//           Gemfile, layout/application.html.erb, and config/initializers/assets.rb
+
+//= require debug_turbolinks
+
+//= require application
+
+//= require turbolinks

--- a/spec/dummy/app/assets/javascripts/testGlobals.js
+++ b/spec/dummy/app/assets/javascripts/testGlobals.js
@@ -1,2 +1,0 @@
-window.DEBUG_TURBOLINKS = true;
-console.log('window.DEBUG_TURBOLINKS = true;');

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,12 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= ENV["DISABLE_TURBOLINKS"] ?
+      stylesheet_link_tag('application', media: 'all') :
+      stylesheet_link_tag('application', media: 'all', 'data-turbolinks-track' => true) %>
+  <%= ENV["DISABLE_TURBOLINKS"] ?
+      javascript_include_tag('application') :
+      javascript_include_tag('application_with_turbolinks', 'data-turbolinks-track' => true) %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -9,3 +9,5 @@ Rails.application.config.assets.version = "1.0"
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+
+Rails.application.config.assets.precompile += %w( application_with_turbolinks.js ) unless ENV["DISABLE_TURBOLINKS"]

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -48,13 +48,13 @@ describe ReactOnRailsHelper, type: :helper do
     let(:id) { "App-react-component-0" }
 
     let(:react_definition_div) do
-      "<div class=\"js-react-on-rails-component\"
+      %(<div class=\"js-react-on-rails-component\"
             style=\"display:none\"
             data-component-name=\"App\"
             data-props=\"{&quot;name&quot;:&quot;My Test Name&quot;}\"
             data-trace=\"false\"
-            data-expect-turbolinks=\"true\"
-            data-dom-id=\"#{id}\"></div>".squish
+            #{turbolinks_line}
+            data-dom-id=\"#{id}\"></div>).squish
     end
 
     it { expect(self).to respond_to :react_component }
@@ -83,7 +83,7 @@ describe ReactOnRailsHelper, type: :helper do
               data-component-name=\"App\"
               data-props=\"{&quot;name&quot;:&quot;My Test Name&quot;}\"
               data-trace=\"false\"
-              data-expect-turbolinks=\"true\"
+              #{turbolinks_line}
               data-dom-id=\"#{id}\"></div>".squish
       end
 
@@ -99,7 +99,7 @@ describe ReactOnRailsHelper, type: :helper do
               data-component-name=\"App\"
               data-props=\"{&quot;name&quot;:&quot;My Test Name&quot;}\"
               data-trace=\"false\"
-              data-expect-turbolinks=\"true\"
+              #{turbolinks_line}
               data-dom-id=\"#{id}\"></div>".squish
       end
 
@@ -118,5 +118,9 @@ describe ReactOnRailsHelper, type: :helper do
 
     it { is_expected.to be_an_instance_of ActiveSupport::SafeBuffer }
     it { is_expected.to eq hello_world }
+  end
+
+  def turbolinks_line
+    %(data-expect-turbolinks="#{ENV['DISABLE_TURBOLINKS'] ? 'false' : 'true'}")
   end
 end


### PR DESCRIPTION
- React components were not being rendered because of a double
nesting of event handlers when React on Rails did not detect
that Turbolinks was installed. This has been fixed.
- Add `debug_turbolinks` helper file so that the user can simply
require their file in their application.js file to debug turbolinks.
Documentation has been improved to show how to do this.
- Add section to turbolinks troubleshooting documentation recommending
that users use the node package versions of jQuery and jQuery-ujs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/241)
<!-- Reviewable:end -->
