### PR TITLE
Fix Bootstrap Sass Append to Gemfile

### DIFF
--- a/lib/generators/react_on_rails/bootstrap_generator.rb
+++ b/lib/generators/react_on_rails/bootstrap_generator.rb
@@ -62,7 +62,7 @@ module ReactOnRails
       end
 
       def add_bootstrap_sprockets_to_gemfile
-        append_to_file("Gemfile", "gem 'bootstrap-sass'\n")
+        append_to_file("Gemfile", "\ngem 'bootstrap-sass'\n")
       end
 
       def add_bootstrap_sprockets_to_application_js


### PR DESCRIPTION
Fixes #256 

If the gemfile does not have an empty line at the end, append_to_file will append ‘gem bootstrap-sass’ to the last line.

- Added a line break to the beginning of ‘gem bootstrap-sass’ to ensure it’s on a new line.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/262)
<!-- Reviewable:end -->
