### PR TITLE
Clarify multi-buildpack link and strip whitespace

### DIFF
--- a/docs/additional_reading/heroku_deployment.md
+++ b/docs/additional_reading/heroku_deployment.md
@@ -18,9 +18,9 @@ Assuming you have downloaded and installed the Heroku command-line utility and h
 heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
 ```
 
-Heroku will now be able to use the multiple buildpacks specified in `.buildpacks`. 
+Heroku will now be able to use the multiple buildpacks specified in `.buildpacks`.
 
-Note, an alternative approach is to use the [Heroku Toolbelt to set buildpacks](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
+For more information, see [Using Multiple Buildpacks for an App](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app)
 
 ## Fresh Rails Install
 


### PR DESCRIPTION
Was just reading through the docs about setting up the recommended buildpack, and felt like the existing multiple buildpack link was not really an alternative approach. It contains the same approach specified above, but also some extra information.

A little picky, maybe, but I thought it might clarify things a bit and it gives me the opportunity for my first contribution :tada:

Thoughts?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/306)
<!-- Reviewable:end -->
