### PR TITLE
Remove use of heroku-buildpack-multi

### DIFF
--- a/docs/additional_reading/heroku_deployment.md
+++ b/docs/additional_reading/heroku_deployment.md
@@ -2,7 +2,6 @@
 The generator has created the necessary files and gems for deployment to Heroku. If you have installed manually, you will need to provide these files yourself:
 
 + `Procfile`: used by Heroku and Foreman to start the Puma server
-+ `.buildpacks`: used to install Ruby and Node environments
 + `12factor` gem: required by Heroku
 + `'puma'` gem: recommended Heroku webserver
 + `config/puma.rb`: Puma webserver config file
@@ -10,17 +9,18 @@ The generator has created the necessary files and gems for deployment to Heroku.
 
 ## How to Deploy
 
-React on Rails requires both a ruby environment (for Rails) and a Node environment (for Webpack), so you will need to have Heroku use multiple buildpacks. Currently, we would suggest using [DDollar's Heroku Buildpack Multi](https://github.com/ddollar/heroku-buildpack-multi).
+React on Rails requires both a ruby environment (for Rails) and a Node environment (for Webpack), so you will need to have Heroku use multiple buildpacks.
 
-Assuming you have downloaded and installed the Heroku command-line utility and have initialized the app, you will need to tell Heroku to use Heroku Buildpack Multi via the command-line:
+Assuming you have downloaded and installed the Heroku command-line utility and have initialized the app, you will need to tell Heroku to use both buildpacks via the command-line:
 
 ```
-heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
+heroku buildpacks:set heroku/ruby
+heroku buildpacks:add --index 1 heroku/nodejs
 ```
-
-Heroku will now be able to use the multiple buildpacks specified in `.buildpacks`.
 
 For more information, see [Using Multiple Buildpacks for an App](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app)
+
+If for some reason you need custom buildpacks that are not officially supported by Heroku ([see this page](https://devcenter.heroku.com/articles/buildpacks)), we recommend checking out [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi).
 
 ## Fresh Rails Install
 

--- a/docs/tutorial-v2.md
+++ b/docs/tutorial-v2.md
@@ -146,9 +146,10 @@ Run this command that looks like this from your new heroku app
 
     heroku git:remote -a my-name-react-on-rails
 
-Set the correct buildpack for using react-on-rails:
+Set heroku to use multiple buildpacks:
 
-    heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi
+    heroku buildpacks:set heroku/ruby
+    heroku buildpacks:add --index 1 heroku/nodejs
 
 
 ### Swap out sqlite for postgres by doing the following:

--- a/lib/generators/react_on_rails/heroku_deployment_generator.rb
+++ b/lib/generators/react_on_rails/heroku_deployment_generator.rb
@@ -10,8 +10,7 @@ module ReactOnRails
 
       def copy_heroku_deployment_files
         base_path = "heroku_deployment"
-        %w(.buildpacks
-           Procfile
+        %w(Procfile
            config/puma.rb).each { |file| copy_file("#{base_path}/#{file}", file) }
       end
 

--- a/lib/generators/react_on_rails/templates/heroku_deployment/.buildpacks
+++ b/lib/generators/react_on_rails/templates/heroku_deployment/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/heroku/heroku-buildpack-ruby.git

--- a/spec/react_on_rails/support/shared_examples/heroku_deployment_generator_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/heroku_deployment_generator_examples.rb
@@ -1,7 +1,6 @@
 shared_examples "heroku_deployment" do
   it "should add heroku deployment files" do
     assert_file("Procfile")
-    assert_file(".buildpacks")
   end
 
   it "should add heroku production gems" do


### PR DESCRIPTION
I was trying to use `heroku-buildpack-multi` and was getting failures when trying to push to Heroku. This led me to realize that Heroku natively supports using multiple build packs now, so there is no need to use `heroku-buildpack-multi` or have to worry about a `.buildpack` file. I simplified the instructions and removed references to `.buildpack` in the code. Now, all you have to worry about is running this from the CLI:

```
heroku buildpacks:set heroku/ruby
heroku buildpacks:add --index 1 heroku/nodejs
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/319)
<!-- Reviewable:end -->
