### PR TITLE
Remove the babel package from the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "doc": "docs"
   },
   "devDependencies": {
-    "babel": "^6.3.26",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.4.5",
     "babel-eslint": "^5.0.0-beta8",


### PR DESCRIPTION
Starting with a freshly installed copy of this project's repo, `npm run build` fails trying to install `babel` as the package no longer exists (see http://jamesknelson.com/the-six-things-you-need-to-know-about-babel-6/). Removing it solves the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/321)
<!-- Reviewable:end -->
