### PR TITLE
cache client/node_modules during heroku deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 ## [Unreleased]
 ##### Added
 - Non-digested version of assets in public folder [#413](https://github.com/shakacode/react_on_rails/pull/413) by [alleycat-at-git]
-
+- Cache client/node_modules directory to prevent Heroku from reinstalling all modules from scratch [#324](https://github.com/shakacode/react_on_rails/pull/324) by [modosc]
 ##### Changed
 - Replace URI with Addressable gem. See [#405](https://github.com/shakacode/react_on_rails/pull/405) by [lucke84]
 
@@ -25,7 +25,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 - [Security] Address failure to sanitize console messages when server rendering and displaying in the browser console. See [#366](https://github.com/shakacode/react_on_rails/pull/366) and [#370](https://github.com/shakacode/react_on_rails/pull/370) by [justin808](https://github.com/justin808)
 
 ##### Added
-- railsContext includes the port number and a boolean if the code is being run on the server or client. 
+- railsContext includes the port number and a boolean if the code is being run on the server or client.
 
 ## [5.1.0] - 2016-04-03
 ##### Added

--- a/docs/additional-reading/heroku-deployment.md
+++ b/docs/additional-reading/heroku-deployment.md
@@ -7,6 +7,15 @@ The generator has created the necessary files and gems for deployment to Heroku.
 + `config/puma.rb`: Puma webserver config file
 + `lib/tasks/assets.rake`: This rake task file is provided by the generator regardless of whether the user chose Heroku Deployment as an option. It is highlighted here because it is helpful to understand that this task is what generates your JavaScript bundles in production.
 
+By default Heroku will cache the root `node_modules` directory between deploys but since we're installing in `client/node_modules` you'll need to add the following line to the `package.json` in your root directory (otherwise you'll have to sit through a full `npm install` on each deploy):
+```
+"cacheDirectories": [
+  "node_modules",
+  "client/node_modules"
+],
+
+```
+
 ## How to Deploy
 
 React on Rails requires both a ruby environment (for Rails) and a Node environment (for Webpack), so you will need to have Heroku use multiple buildpacks.
@@ -94,6 +103,3 @@ namespace :assets do
   end
 end
 ```
-
-
-

--- a/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
+++ b/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
@@ -21,6 +21,7 @@
     <%- end -%>
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "cacheDirectories": ["node_modules", "client/node_modules"],
   "dependencies": {
     "autoprefixer": "^6.3.5",
     "axios": "^0.9.1",


### PR DESCRIPTION
without this heroku has to do a full npm install on every deploy - i guess this could be part of the heroku generators but it seemed like a lot more work to modify this file there than to just add this option here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/324)
<!-- Reviewable:end -->
