### PR TITLE
Providing rails_context always to generator functions (store and component)

### DIFF
--- a/docs/additional-reading/react-router.md
+++ b/docs/additional-reading/react-router.md
@@ -6,12 +6,14 @@ However, when attempting to use server-rendering, it is necessary to take steps 
 If you are working with the HelloWorldApp created by the react_on_rails generator, then the code below corresponds to the module in `client/app/bundles/HelloWorld/startup/HelloWorldAppServer.jsx`.
 
 ```js
-const RouterApp = (props, location) => {
-  const store = createStore(props);
-
+const RouterApp = (props, railsContext) => {
   let error;
   let redirectLocation;
   let routeProps;
+  const { location } = railsContext;
+  
+  // create your hydrated store
+  const store = createStore(props);
 
   // See https://github.com/reactjs/react-router/blob/master/docs/guides/advanced/ServerRendering.md
   match({ routes, location }, (_error, _redirectLocation, _routeProps) => {

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -55,7 +55,8 @@ module ReactOnRails
       server_renderer_pool_size: 1,
       server_renderer_timeout: 20,
       skip_display_none: false,
-      webpack_generated_files: []
+      webpack_generated_files: [],
+      rendering_extension: nil
     )
   end
 
@@ -65,14 +66,15 @@ module ReactOnRails
                   :logging_on_server, :server_renderer_pool_size,
                   :server_renderer_timeout, :raise_on_prerender_error,
                   :skip_display_none, :generated_assets_dirs, :generated_assets_dir,
-                  :webpack_generated_files
+                  :webpack_generated_files, :rendering_extension
 
     def initialize(server_bundle_js_file: nil, prerender: nil, replay_console: nil,
                    trace: nil, development_mode: nil,
                    logging_on_server: nil, server_renderer_pool_size: nil,
                    server_renderer_timeout: nil, raise_on_prerender_error: nil,
                    skip_display_none: nil, generated_assets_dirs: nil,
-                   generated_assets_dir: nil, webpack_generated_files: nil)
+                   generated_assets_dir: nil, webpack_generated_files: nil,
+                   rendering_extension: nil)
       self.server_bundle_js_file = server_bundle_js_file
       self.generated_assets_dirs = generated_assets_dirs
       self.generated_assets_dir = generated_assets_dir
@@ -94,6 +96,7 @@ module ReactOnRails
       self.server_renderer_timeout = server_renderer_timeout # seconds
 
       self.webpack_generated_files = webpack_generated_files
+      self.rendering_extension = rendering_extension
     end
   end
 end

--- a/node_package/src/createReactElement.js
+++ b/node_package/src/createReactElement.js
@@ -15,21 +15,22 @@ import ReactOnRails from './ReactOnRails';
 export default function createReactElement({
   name,
   props,
+  railsContext,
   domNodeId,
   trace,
   location,
   }) {
   if (trace) {
-    console.log(`RENDERED ${name} to dom node with id: ${domNodeId}`);
+    console.log(`RENDERED ${name} to dom node with id: ${domNodeId} with props, railsContext:`,
+      props, railsContext);
   }
 
   const componentObj = ReactOnRails.getComponent(name);
 
-  // CONSIDER NOT RELEASING THE OPTION version
   const { component, generatorFunction } = componentObj;
 
   if (generatorFunction) {
-    return component(props, location);
+    return component(props, railsContext);
   }
 
   return React.createElement(component, props);

--- a/spec/dummy/app/controllers/pages_controller.rb
+++ b/spec/dummy/app/controllers/pages_controller.rb
@@ -1,6 +1,10 @@
 class PagesController < ApplicationController
   include ReactOnRails::Controller
 
+  before_action do
+    session[:something_useful] = "REALLY USEFUL"
+  end
+
   before_action :data
 
   before_action :initialize_shared_store, only: [:client_side_hello_world_shared_store_controller,

--- a/spec/dummy/client/app/components/HelloWorld.jsx
+++ b/spec/dummy/client/app/components/HelloWorld.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import RailsContext from './RailsContext';
 
 // Example of CSS modules.
 import css from './HelloWorld.scss';
@@ -10,6 +11,7 @@ class HelloWorld extends React.Component {
     helloWorldData: PropTypes.shape({
       name: PropTypes.string,
     }).isRequired,
+    railsContext: PropTypes.object,
 
     error: PropTypes.any,
   };
@@ -36,6 +38,7 @@ class HelloWorld extends React.Component {
 spec/dummy/client/app/components/HelloWorld.jsx:18`);
 
     const { name } = this.state;
+    const { railsContext } = this.props;
 
     return (
       <div>
@@ -51,6 +54,7 @@ spec/dummy/client/app/components/HelloWorld.jsx:18`);
             onChange={this.handleChange}
           />
         </p>
+        { railsContext && <RailsContext {...{railsContext}} /> }
       </div>
     );
   }

--- a/spec/dummy/client/app/components/HelloWorldContainer.jsx
+++ b/spec/dummy/client/app/components/HelloWorldContainer.jsx
@@ -6,17 +6,22 @@ import HelloWorldRedux from './HelloWorldRedux';
 
 import * as helloWorldActions from '../actions/HelloWorldActions';
 
-const HelloWorldContainer = ({ actions, data }) => (
-  <HelloWorldRedux {...{ actions, data }} />
-);
-
+const HelloWorldContainer = ({ actions, data, railsContext }) => {
+  return (
+    <HelloWorldRedux {...{actions, data, railsContext}} />
+  );
+}
 HelloWorldContainer.propTypes = {
   actions: PropTypes.object.isRequired,
   data: PropTypes.object.isRequired,
+  railsContext: PropTypes.object.isRequired
 };
 
 function mapStateToProps(state) {
-  return { data: state.helloWorldData };
+  return { 
+    data: state.helloWorldData,
+    railsContext: state.railsContext,
+  };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/spec/dummy/client/app/components/HelloWorldRedux.jsx
+++ b/spec/dummy/client/app/components/HelloWorldRedux.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React, {PropTypes} from 'react';
+import RailsContext from './RailsContext';
 
 // Super simple example of the simplest possible React component
 export default class HelloWorldRedux extends React.Component {
@@ -6,6 +7,7 @@ export default class HelloWorldRedux extends React.Component {
   static propTypes = {
     actions: PropTypes.object.isRequired,
     data: PropTypes.object.isRequired,
+    railsContext: PropTypes.object.isRequired,
   };
 
   // Not necessary if we only call super, but we'll need to initialize state, etc.
@@ -25,9 +27,9 @@ export default class HelloWorldRedux extends React.Component {
   }
 
   render() {
-    const { data } = this.props;
-    const { name } = data;
-
+    const {data, railsContext} = this.props;
+    const {name} = data;
+    
     return (
       <div>
         <h3>
@@ -42,6 +44,7 @@ export default class HelloWorldRedux extends React.Component {
             onChange={this.handleChange}
           />
         </p>
+        <RailsContext {...{railsContext}} />
       </div>
     );
   }

--- a/spec/dummy/client/app/components/RailsContext.jsx
+++ b/spec/dummy/client/app/components/RailsContext.jsx
@@ -1,0 +1,40 @@
+import React, { PropTypes } from 'react';
+import _ from 'lodash';
+
+function renderContextRows(railsContext) {
+  return _.transform(railsContext, (accum, value, key) => {
+    const className = `js-${key}`;
+    accum.push(
+      <tr key={className}>
+        <td><strong>
+          {key}:&nbsp;
+        </strong></td>
+        <td className={className}>{value}</td>
+      </tr>
+    );
+  }, []);
+}
+
+const RailsContext = (props) => (
+  <table>
+    <thead>
+    <tr>
+      <th><i>
+        key
+      </i></th>
+      <th><i>
+        value
+      </i></th>
+    </tr>
+    </thead>
+    <tbody>
+    {renderContextRows(props.railsContext)}
+    </tbody>
+  </table>
+);
+
+RailsContext.propTypes = {
+  railsContext: PropTypes.object.isRequired
+};
+
+export default RailsContext;

--- a/spec/dummy/client/app/reducers/RailsContextReducer.jsx
+++ b/spec/dummy/client/app/reducers/RailsContextReducer.jsx
@@ -1,0 +1,10 @@
+// This will always get set
+const initialState = {
+};
+
+// Why name function the same as the reducer?
+// https://github.com/gaearon/redux/issues/428#issuecomment-129223274
+// Naming the function will help with debugging!
+export default function railsContextReducer(state = initialState, action) {
+  return state;
+}

--- a/spec/dummy/client/app/reducers/reducersIndex.jsx
+++ b/spec/dummy/client/app/reducers/reducersIndex.jsx
@@ -1,5 +1,9 @@
 import helloWorldReducer from './HelloWorldReducer';
+import railsContextReducer from './RailsContextReducer';
 
 // This is how you do a directory of reducers.
 // The `import * as reducers` does not work for a directory, but only with a single file
-export default { helloWorldData: helloWorldReducer };
+export default { 
+  helloWorldData: helloWorldReducer,
+  railsContext: railsContextReducer,
+};

--- a/spec/dummy/client/app/startup/ClientReduxApp.jsx
+++ b/spec/dummy/client/app/startup/ClientReduxApp.jsx
@@ -1,5 +1,6 @@
 // Top level component for client side.
 // Compare this to the ./ServerApp.jsx file which is used for server side rendering.
+// NOTE: these are basically the same, but they are shown here
 
 import React from 'react';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
@@ -7,6 +8,8 @@ import { Provider } from 'react-redux';
 import middleware from 'redux-thunk';
 
 import reducers from '../reducers/reducersIndex';
+import composeInitialState from '../store/composeInitialState';
+
 import HelloWorldContainer from '../components/HelloWorldContainer';
 
 /*
@@ -15,10 +18,16 @@ import HelloWorldContainer from '../components/HelloWorldContainer';
  *  React will see that the state is the same and not do anything.
  *
  */
-export default (props) => {
+export default (props, railsContext) => {
   const combinedReducer = combineReducers(reducers);
-  const store = applyMiddleware(middleware)(createStore)(combinedReducer, props);
+  const combinedProps = composeInitialState(props, railsContext);
+  
+  // This is where we'll put in the middleware for the async function. Placeholder.
+  // store will have helloWorldData as a top level property
+  const store = applyMiddleware(middleware)(createStore)(combinedReducer, combinedProps);
 
+  // Provider uses the this.props.children, so we're not typical React syntax.
+  // This allows redux to add additional props to the HelloWorldContainer.
   return (
       <Provider store={store}>
         <HelloWorldContainer />

--- a/spec/dummy/client/app/startup/ServerReduxApp.jsx
+++ b/spec/dummy/client/app/startup/ServerReduxApp.jsx
@@ -10,22 +10,25 @@ import middleware from 'redux-thunk';
 
 // Uses the index
 import reducers from '../reducers/reducersIndex';
+import composeInitialState from '../store/composeInitialState';
 
 import HelloWorldContainer from '../components/HelloWorldContainer';
 
 /*
  *  Export a function that takes the props and returns a ReactComponent.
+ *  This is used for the server rendering.
+ *  In the client, React will see that the state is the same and not do anything.
  */
-export default (props) => {
+export default (props, railsContext) => {
   const combinedReducer = combineReducers(reducers);
+  const combinedProps = composeInitialState(props, railsContext);
 
   // This is where we'll put in the middleware for the async function. Placeholder.
   // store will have helloWorldData as a top level property
-  const store = applyMiddleware(middleware)(createStore)(combinedReducer, props);
+  const store = applyMiddleware(middleware)(createStore)(combinedReducer, combinedProps);
 
   // Provider uses the this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
-  /* eslint-disable react/no-multi-comp */
   return (
     <Provider store={store}>
       <HelloWorldContainer />

--- a/spec/dummy/client/app/startup/ServerRouterApp.jsx
+++ b/spec/dummy/client/app/startup/ServerRouterApp.jsx
@@ -3,12 +3,14 @@ import { match, RouterContext } from 'react-router';
 
 import routes from '../routes/routes';
 
-export default (props, location) => {
+export default (props, railsContext) => {
   let error;
   let redirectLocation;
   let routeProps;
 
-  // See https://github.com/reactjs/react-router/blob/master/docs/guides/advanced/ServerRendering.md
+  const { location } = railsContext;
+
+  // See https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md
   match({ routes, location }, (_error, _redirectLocation, _routeProps) => {
     error = _error;
     redirectLocation = _redirectLocation;

--- a/spec/dummy/client/app/store/composeInitialState.js
+++ b/spec/dummy/client/app/store/composeInitialState.js
@@ -1,0 +1,5 @@
+// Real world is that you'll want to do lots of manipulations of the data you get back from Rails
+// to coerce it into exactly what you want your initial redux state.
+export default (props, railsContext) => (
+  Object.assign({}, props, { railsContext })
+)

--- a/spec/dummy/client/app/stores/SharedReduxStore.jsx
+++ b/spec/dummy/client/app/stores/SharedReduxStore.jsx
@@ -7,7 +7,8 @@ import reducers from '../reducers/reducersIndex';
  *  Export a function that takes the props and returns a Redux store
  *  This is used so that 2 components can have the same store.
  */
-export default props => {
+export default (props, railsContext) => {
   const combinedReducer = combineReducers(reducers);
+  props.railsContext = railsContext;
   return applyMiddleware(middleware)(createStore)(combinedReducer, props);
 };

--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -27,6 +27,7 @@
     "jquery": "^2.2.1",
     "jquery-ujs": "^1.2.0",
     "loader-utils": "^0.2.12",
+    "lodash": "^4.6.1",
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.4.2",
     "postcss-loader": "^0.8.1",

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -1,3 +1,13 @@
+module RenderingExtension
+  # Return a Hash that contains custom values from the view context that will get passed to
+  # all calls to react_component and redux_store for rendering
+  def self.custom_context(view_context)
+    {
+      somethingUseful: view_context.session[:something_useful]
+    }
+  end
+end
+
 ReactOnRails.configure do |config|
   # Directory where your generated assets go. All generated assets must go to the same directory.
   # Configure this in your webpack config files. This relative to your Rails root directory.
@@ -34,12 +44,14 @@ ReactOnRails.configure do |config|
   # (see [discussion](https://github.com/reactjs/react-rails/pull/290))
   # On MRI, you'll get a deadlock with `pool_size` > 1
   # If you're using JRuby, you can increase `pool_size` to have real multi-threaded rendering.
-  config.server_renderer_pool_size  = 1   # increase if you're on JRuby
-  config.server_renderer_timeout    = 20  # seconds
+  config.server_renderer_pool_size = 1 # increase if you're on JRuby
+  config.server_renderer_timeout = 20 # seconds
 
   ################################################################################
   # MISCELLANEOUS OPTIONS
   ################################################################################
   # Default is false, enable if your content security policy doesn't include `style-src: 'unsafe-inline'`
   config.skip_display_none = false
+
+  config.rendering_extension = RenderingExtension
 end

--- a/spec/dummy/spec/features/rails_context_spec.rb
+++ b/spec/dummy/spec/features/rails_context_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+require "support/capybara_utils"
+
+shared_examples "railsContext" do |pathname, id_base|
+  include CapybaraUtils
+
+  let(:http_accept_language) { "en-US,en;q=0.8" }
+
+  subject { page }
+
+  background do
+    set_driver_header("ACCEPT-LANGUAGE", http_accept_language)
+    visit "/#{pathname}?ab=cd"
+  end
+
+  context pathname, :js do
+    scenario "check rails context" do
+      expect(current_path).to eq("/#{pathname}")
+      host = Capybara.current_session.server.host
+      port = Capybara.current_session.server.port
+      host_port = "#{host}:#{port}"
+      keys_to_vals = {
+        href: "http://#{host_port}/#{pathname}?ab=cd",
+        location: "/#{pathname}?ab=cd",
+        scheme: "http",
+        host: host,
+        pathname: "/#{pathname}",
+        search: "ab=cd",
+        i18nLocale: "en",
+        i18nDefaultLocale: "en",
+        httpAcceptLanguage: http_accept_language,
+        somethingUseful: "REALLY USEFUL"
+      }
+
+      top_id = "##{id_base}-react-component-0"
+
+      keys_to_vals.each do |key, val|
+        # skip checking http_accept_language if selenium
+        next if key == :httpAcceptLanguage && Capybara.javascript_driver.to_s =~ /selenium/
+
+        expect(page).to have_css("#{top_id} .js-#{key}", text: val)
+      end
+    end
+  end
+end
+
+feature "rails_context" do
+  context "client rendering" do
+    context "shared store" do
+      include_examples("railsContext",
+                       "client_side_hello_world_shared_store",
+                       "ReduxSharedStoreApp")
+    end
+  end
+
+  context "server rendering" do
+    context "shared store" do
+      include_examples("railsContext",
+                       "server_side_hello_world_shared_store",
+                       "ReduxSharedStoreApp")
+    end
+
+    context "generator function for component" do
+      include_examples("railsContext",
+                       "server_side_redux_app",
+                       "ReduxApp")
+    end
+  end
+end

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -1,6 +1,15 @@
 require "rails_helper"
 
 describe ReactOnRailsHelper, type: :helper do
+  before do
+    allow(self).to receive(:request) {
+      OpenStruct.new(
+        original_url: "http://foobar.com/development",
+        env: { "HTTP_ACCEPT_LANGUAGE" => "en" }
+      )
+    }
+  end
+
   describe "#sanitized_props_string(props)" do
     let(:hash) do
       {

--- a/spec/dummy/spec/requests/console_logging_spec.rb
+++ b/spec/dummy/spec/requests/console_logging_spec.rb
@@ -7,7 +7,7 @@ describe "Server Error Logging" do
 
     expected = <<-JS
 console.log.apply(console, ["[SERVER] RENDERED HelloWorldWithLogAndThrow to dom node \
-with id: HelloWorldWithLogAndThrow-react-component-0"]);
+with id: HelloWorldWithLogAndThrow-react-component-0 with props, railsContext:"
 console.log.apply(console, ["[SERVER] console.log in HelloWorld"]);
 console.warn.apply(console, ["[SERVER] console.warn in HelloWorld"]);
 console.error.apply(console, ["[SERVER] console.error in HelloWorld"]);

--- a/spec/dummy/spec/requests/server_render_check_spec.rb
+++ b/spec/dummy/spec/requests/server_render_check_spec.rb
@@ -31,13 +31,16 @@ describe "Server Rendering", :server_rendering do
   describe "reloading the server bundle" do
     let(:server_bundle) { File.expand_path("../../../app/assets/webpack/server-bundle.js", __FILE__) }
     let!(:original_bundle_text) { File.read(server_bundle) }
+
     before do
       ReactOnRails.configure { |config| config.development_mode = true }
     end
+
     after do
       File.open(server_bundle, "w") { |f| f.puts original_bundle_text }
       ReactOnRails.configure { |config| config.development_mode = false }
     end
+
     it "reloads the server bundle on a new request if was changed" do
       get server_side_hello_world_with_options_path
       html_nodes = Nokogiri::HTML(response.body)
@@ -52,6 +55,51 @@ describe "Server Rendering", :server_rendering do
       get server_side_hello_world_with_options_path
       new_html_nodes = Nokogiri::HTML(response.body)
       expect(new_html_nodes.css("div#my-hello-world-id p").text).to eq(replacement_text)
+    end
+  end
+
+  describe "server rendering railsContext" do
+    let(:http_accept_language) { "en-US,en;q=0.8" }
+
+    def check_match(pathname, id_base)
+      html_nodes = Nokogiri::HTML(response.body)
+      top_id = "##{id_base}-react-component-0"
+      keys_to_vals = {
+        href: "http://www.example.com/#{pathname}?ab=cd",
+        location: "/#{pathname}?ab=cd",
+        scheme: "http",
+        host: "www.example.com",
+        pathname: "/#{pathname}",
+        search: "ab=cd",
+        i18nLocale: "en",
+        i18nDefaultLocale: "en",
+        httpAcceptLanguage: http_accept_language,
+        somethingUseful: "REALLY USEFUL"
+      }
+      keys_to_vals.each do |key, val|
+        expect(html_nodes.css("#{top_id} .js-#{key}").text)
+          .to eq(val)
+      end
+    end
+
+    def do_request(path)
+      get(path,
+          { ab: :cd },
+          "HTTP_ACCEPT_LANGUAGE" => http_accept_language)
+    end
+
+    context "shared redux store" do
+      it "matches expected values" do
+        do_request(server_side_hello_world_shared_store_path)
+        check_match("server_side_hello_world_shared_store", "ReduxSharedStoreApp")
+      end
+    end
+
+    context "generator function" do
+      it "matches expected values" do
+        do_request(server_side_redux_app_path)
+        check_match("server_side_redux_app", "ReduxApp")
+      end
     end
   end
 end

--- a/spec/dummy/spec/support/capybara_utils.rb
+++ b/spec/dummy/spec/support/capybara_utils.rb
@@ -1,0 +1,13 @@
+module CapybaraUtils
+  # Sets the driver header for poltergeist and webkit.
+  # Selenium is not feasible.
+  def set_driver_header(key, value)
+    case Capybara.javascript_driver
+    when :poltergeist, :poltergeist_errors_ok
+      page.driver.headers = { key => value }
+    when :webkit
+      page.driver.header(key, value)
+      # else no possibe action for selenium
+    end
+  end
+end


### PR DESCRIPTION
## Background:
As of v4, we provide the location as a second param to component generator functions after props, and **ONLY** on the server rendering. This is not in the current API for store generator functions.

## Use Case
### Needing the current url path for server rendering
Suppose you want to display a nav bar with the current navigation link highlighted by the URL. When you server render the code, you will need to know the current URL/path if that is what you want your logic to be based on. This could be added to props, or ReactOnRails can add this automatically as another param to the generator function (or maybe an additional object, where we'll consider other additional bits of system info from Rails, like maybe the locale, later).

### Needing the I18n.locale
Suppose you want to server render your react components with a the current Rails locale. We need to pass the I18n.locale to the view rendering.

## Details
We'll do a breaking change of changing the 2nd parameter from a string to an object, but this should affect very few users, as we only passed this for server rendering.

The new api will be to pass 2 params when generating React components or hydrating redux stores:

So if you register `MyAppComponent`, it will get called like:

```js
reactComponent = MyAppComponent(props, railsContext);
```
and for a store:

```js
reduxStore = MyReduxStore(props, railsContext);
```

The `railsContext` may have:

```ruby
     {
        # URL settings
        href: request.original_url,
        location: "#{uri.path}#{uri.query.present? ? "?#{uri.query}": ""}",
        scheme: uri.scheme, # http
        host: uri.host, # foo.com
        pathname: uri.path, # /posts
        search: uri.query, # id=30&limit=5

        # Locale settings
        i18nLocale: I18n.locale,
        i18nDefaultLocale: I18n.default_locale,
        httpAcceptLanguage: request.env["HTTP_ACCEPT_LANGUAGE"]
      }
```

Additionally, you can customize the values.


Set the class for the `rendering_extension`
```ruby
  config.rendering_extension = RenderingExtension
```

Implement it like this:

```ruby
module RenderingExtension

  # Return a Hash that contains custom values from the view context that will get passed to
  # all calls to react_component and redux_store for rendering
  def self.custom_context(view_context)
     {
       somethingUseful: view_context.session[:something_useful]
     }
  end
end
```

This would put a prop of `somethingUseful` in the railsContext passed to all react_component and redux_store calls.

Since you can't access the rails session from JavaScript (or other values available in the view rendering context), this might useful.

![2016-03-26_01-07-19](https://cloud.githubusercontent.com/assets/1118459/14059711/593c9060-f2ef-11e5-9a42-72583f154b59.png)




<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/345)
<!-- Reviewable:end -->
