### PR TITLE
Update release version in changelog to 5.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. Items under
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 ## [Unreleased]
 
-## [5.0.0] - 2016-03-27
+## [5.0.0-rc.1] - 2016-03-27
 
 ##### Added
 - Added `railsContext`, an object which gets passed always as the second parameter to both react component and redux store generator functions, both for server and client rendering. This provides data like the current locale, the pathname, etc. The data values are customizable by a new configuration called `rendering_extension` where you can create a module with a method called `rendering_extension`. This allows you to add additional values to the Rails Context. Implement one static method called `custom_context(view_context)` and return a Hash. See [#345](https://github.com/shakacode/react_on_rails/pull/345) by [justin808](https://github.com/justin808)
@@ -247,8 +247,8 @@ Best done with Object destructing:
 
 ##### Fixed
 - Fix several generator related issues.
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/5.0.0...master
-[5.0.0]: https://github.com/shakacode/react_on_rails/compare/4.0.3...5.0.0
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/5.0.0-rc.1...master
+[5.0.0-rc.1]: https://github.com/shakacode/react_on_rails/compare/4.0.3...5.0.0-rc.1
 [4.0.3]: https://github.com/shakacode/react_on_rails/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/shakacode/react_on_rails/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/shakacode/react_on_rails/compare/4.0.0...4.0.1


### PR DESCRIPTION
Noticed the changelog displayed `5.0.0` instead of `5.0.0-rc.1`. Also the diff link was fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/359)
<!-- Reviewable:end -->
