### PR TITLE
Babel runtime as a dependency

### DIFF
--- a/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
+++ b/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
@@ -40,6 +40,7 @@
     "autoprefixer": "^6.3.2",
     "axios": "^0.9.1",
     "babel": "^6.5.1",
+    "babel-runtime": "^6.5.1",
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.1",
     "babel-loader": "^6.2.2",


### PR DESCRIPTION
When creating new react-on-rails project according to this [tutorial](https://github.com/shakacode/react_on_rails/blob/master/docs/tutorial.md), the server logs errors about babel-runtime, e.g.

`10:10:33 server.1 | ERROR in ./~/react-on-rails/node_package/lib/clientStartup.js
10:10:33 server.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/json/stringify' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:33 server.1 |  @ ./~/react-on-rails/node_package/lib/clientStartup.js 8:17-64
10:10:33 server.1 | 
10:10:33 server.1 | ERROR in ./~/react-on-rails/node_package/lib/ComponentStore.js
10:10:33 server.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/object/keys' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:33 server.1 |  @ ./~/react-on-rails/node_package/lib/ComponentStore.js 7:12-56
10:10:33 server.1 | 
10:10:33 server.1 | ERROR in ./~/react-on-rails/node_package/lib/ComponentStore.js
10:10:33 server.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/map' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:33 server.1 |  @ ./~/react-on-rails/node_package/lib/ComponentStore.js 11:11-47
10:10:33 server.1 | 
10:10:33 server.1 | ERROR in ./~/react-on-rails/node_package/lib/buildConsoleReplay.js
10:10:33 server.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/json/stringify' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:33 server.1 |  @ ./~/react-on-rails/node_package/lib/buildConsoleReplay.js 9:17-64
10:10:33 server.1 | 
10:10:33 server.1 | ERROR in ./~/react-on-rails/node_package/lib/serverRenderReactComponent.js
10:10:33 server.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/json/stringify' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:33 server.1 |  @ ./~/react-on-rails/node_package/lib/serverRenderReactComponent.js 8:17-64
10:10:36 client.1 | Hash: fff86825b4cb1eddf6d7
10:10:36 client.1 | Version: webpack 1.12.14
10:10:36 client.1 | Time: 25030ms
10:10:36 client.1 |            Asset     Size  Chunks             Chunk Names
10:10:36 client.1 |    app-bundle.js  4.85 MB       0  [emitted]  app
10:10:36 client.1 | vendor-bundle.js   1.8 MB       1  [emitted]  vendor
10:10:36 client.1 |    [0] multi app 28 bytes {0} [built]
10:10:36 client.1 |    [0] multi vendor 76 bytes {1} [built]
10:10:36 client.1 |     + 754 hidden modules
10:10:36 client.1 | 
10:10:36 client.1 | ERROR in ./~/react-on-rails/node_package/lib/clientStartup.js
10:10:36 client.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/json/stringify' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:36 client.1 |  @ ./~/react-on-rails/node_package/lib/clientStartup.js 8:17-64
10:10:36 client.1 | 
10:10:36 client.1 | ERROR in ./~/react-on-rails/node_package/lib/ComponentStore.js
10:10:36 client.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/object/keys' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:36 client.1 |  @ ./~/react-on-rails/node_package/lib/ComponentStore.js 7:12-56
10:10:36 client.1 | 
10:10:36 client.1 | ERROR in ./~/react-on-rails/node_package/lib/ComponentStore.js
10:10:36 client.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/map' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:36 client.1 |  @ ./~/react-on-rails/node_package/lib/ComponentStore.js 11:11-47
10:10:36 client.1 | 
10:10:36 client.1 | ERROR in ./~/react-on-rails/node_package/lib/serverRenderReactComponent.js
10:10:36 client.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/json/stringify' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:36 client.1 |  @ ./~/react-on-rails/node_package/lib/serverRenderReactComponent.js 8:17-64
10:10:36 client.1 | 
10:10:36 client.1 | ERROR in ./~/react-on-rails/node_package/lib/buildConsoleReplay.js
10:10:36 client.1 | Module not found: Error: Cannot resolve module 'babel-runtime/core-js/json/stringify' in /Users/alex/Development/personal/shaka/client/node_modules/react-on-rails/node_package/lib
10:10:36 client.1 |  @ ./~/react-on-rails/node_package/lib/buildConsoleReplay.js 9:17-64`


The proposed fix adds babel-runtime to the dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/361)
<!-- Reviewable:end -->
