### PR TITLE
\u2028 and \u2029 break rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. Items under
 
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 ## [Unreleased]
+##### Fixed
+- Fixed errors when server rendered props contain \u2028 or \u2029 characters [#375](https://github.com/shakacode/react_on_rails/pull/375) by [mariusandra]
+
 ##### Added
 - Non-digested version of assets in public folder [#413](https://github.com/shakacode/react_on_rails/pull/413) by [alleycat-at-git]
 


### PR DESCRIPTION
Hey,

I'm operating a website (https://www.apprentus.com) where we user react_on_rails with prerendering to server content to our users. Currently it's just the homepage, with other pages under development.

I started getting errors that our homepage wasn't loading for some users. Digging deeper I found it's because of the character "\u2028" that was being sent in the props under the "latest classes" section, that features user entered content.

Digging further I found this link:
https://bugs.chromium.org/p/v8/issues/detail?id=1907
... and learned these two are special characters in JS.

Try it out yourself by running this in your browser

```js
eval('console.log("\u2028")')
```

If you change the number to 2027 or 2030 then it works fine.

This PR is a quick fix that solved the problem for me, although there might be a more elegant solution available. 


Marius

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/375)
<!-- Reviewable:end -->
