### PR TITLE
Customizable DOM prefix for react components, stores, and contexts

### DIFF
--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -107,7 +107,7 @@ module ReactOnRailsHelper
     component_specification_tag =
       content_tag(:div,
                   "",
-                  class: "js-react-on-rails-component",
+                  class: "#{ReactOnRails.configuration.dom_prefix}-component",
                   style: options.style,
                   data: options.data)
 
@@ -237,7 +237,7 @@ module ReactOnRailsHelper
 
     rails_context_content = content_tag(:div,
                                         "",
-                                        id: "js-react-on-rails-context",
+                                        id: "#{ReactOnRails.configuration.dom_prefix}-context",
                                         style: ReactOnRails.configuration.skip_display_none ? nil : "display:none",
                                         data: data)
     "#{rails_context_content}\n#{render_value}".html_safe
@@ -246,7 +246,7 @@ module ReactOnRailsHelper
   def render_redux_store_data(redux_store_data)
     result = content_tag(:div,
                          "",
-                         class: "js-react-on-rails-store",
+                         class: "#{ReactOnRails.configuration.dom_prefix}-store",
                          style: ReactOnRails.configuration.skip_display_none ? nil : "display:none",
                          data: redux_store_data)
     prepend_render_rails_context(result)

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -56,7 +56,8 @@ module ReactOnRails
       server_renderer_timeout: 20,
       skip_display_none: false,
       webpack_generated_files: [],
-      rendering_extension: nil
+      rendering_extension: nil,
+      dom_prefix: "js-react-on-rails"
     )
   end
 
@@ -66,7 +67,7 @@ module ReactOnRails
                   :logging_on_server, :server_renderer_pool_size,
                   :server_renderer_timeout, :raise_on_prerender_error,
                   :skip_display_none, :generated_assets_dirs, :generated_assets_dir,
-                  :webpack_generated_files, :rendering_extension
+                  :webpack_generated_files, :rendering_extension, :dom_prefix
 
     def initialize(server_bundle_js_file: nil, prerender: nil, replay_console: nil,
                    trace: nil, development_mode: nil,
@@ -74,7 +75,7 @@ module ReactOnRails
                    server_renderer_timeout: nil, raise_on_prerender_error: nil,
                    skip_display_none: nil, generated_assets_dirs: nil,
                    generated_assets_dir: nil, webpack_generated_files: nil,
-                   rendering_extension: nil)
+                   rendering_extension: nil, dom_prefix: nil)
       self.server_bundle_js_file = server_bundle_js_file
       self.generated_assets_dirs = generated_assets_dirs
       self.generated_assets_dir = generated_assets_dir
@@ -97,6 +98,7 @@ module ReactOnRails
 
       self.webpack_generated_files = webpack_generated_files
       self.rendering_extension = rendering_extension
+      self.dom_prefix = dom_prefix
     end
   end
 end

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -12,6 +12,7 @@ const ctx = context();
 
 const DEFAULT_OPTIONS = {
   traceTurbolinks: false,
+  domPrefix: 'js-react-on-rails'
 };
 
 ctx.ReactOnRails = {
@@ -51,11 +52,17 @@ ctx.ReactOnRails = {
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events
+   * `domPrefix: string If specified must match ReactOnRails.config.dom_prefix in the Rails project
    */
   setOptions(options) {
     if (options.hasOwnProperty('traceTurbolinks')) {
       this._options.traceTurbolinks = options.traceTurbolinks;
       delete options.traceTurbolinks;
+    }
+
+    if (options.hasOwnProperty('domPrefix')) {
+      this._options.domPrefix = options.domPrefix;
+      delete options.domPrefix;
     }
 
     if (Object.keys(options).length > 0) {

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -4,9 +4,6 @@ import createReactElement from './createReactElement';
 import handleError from './handleError';
 import isRouterResult from './isRouterResult';
 
-const REACT_ON_RAILS_COMPONENT_CLASS_NAME = 'js-react-on-rails-component';
-const REACT_ON_RAILS_STORE_CLASS_NAME = 'js-react-on-rails-store';
-
 function debugTurbolinks(...msg) {
   if (!window) {
     return;
@@ -22,11 +19,13 @@ function turbolinksInstalled() {
 }
 
 function forEachComponent(fn, railsContext) {
-  forEach(fn, REACT_ON_RAILS_COMPONENT_CLASS_NAME, railsContext);
+  const reactOnRailsComponentClassName = `${ReactOnRails.option('domPrefix')}-component`;
+  forEach(fn, reactOnRailsComponentClassName, railsContext);
 }
 
 function forEachStore(railsContext) {
-  forEach(initializeStore, REACT_ON_RAILS_STORE_CLASS_NAME, railsContext);
+  const reactOnRailsStoreClassName = `${ReactOnRails.option('domPrefix')}-store`;
+  forEach(initializeStore, reactOnRailsStoreClassName, railsContext);
 }
 
 function forEach(fn, className, railsContext) {
@@ -87,7 +86,8 @@ You should return a React.Component always for the client side entry point.`);
 }
 
 function parseRailsContext() {
-  const el = document.getElementById('js-react-on-rails-context');
+  const contextId = `${ReactOnRails.option('domPrefix')}-context`;
+  const el = document.getElementById(contextId);
   if (el) {
     return JSON.parse(el.getAttribute('data-rails-context'));
   } else {

--- a/node_package/tests/ReactOnRails.test.js
+++ b/node_package/tests/ReactOnRails.test.js
@@ -50,6 +50,22 @@ test('ReactOnRails not specified has traceTurbolinks as false', (assert) => {
   assert.equal(actual, false);
 });
 
+test('ReactOnRails accepts domPrefix as an option string', (assert) => {
+  ReactOnRails.resetOptions();
+  assert.plan(1);
+  ReactOnRails.setOptions({ domPrefix: 'js-foobar' });
+  const actual = ReactOnRails.option('domPrefix');
+  assert.equal(actual, 'js-foobar');
+});
+
+test('ReactOnRails not specified has domPrefix as js-react-on-rails', (assert) => {
+  ReactOnRails.resetOptions();
+  assert.plan(1);
+  ReactOnRails.setOptions({ });
+  const actual = ReactOnRails.option('domPrefix');
+  assert.equal(actual, 'js-react-on-rails');
+});
+
 test('serverRenderReactComponent throws error for invalid options', (assert) => {
   ReactOnRails.resetOptions();
   assert.plan(1);

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -128,6 +128,13 @@ describe ReactOnRailsHelper, type: :helper do
 
       it { is_expected.to include react_definition_div_skip_display_none_false }
     end
+
+    context "with custom dom_prefix string" do
+      before { ReactOnRails.configuration.dom_prefix = "js-foobar" }
+      after { ReactOnRails.configuration.dom_prefix = "js-react-on-rails" }
+
+      it { is_expected.to include 'id="js-foobar-context"' }
+    end
   end
 
   describe "#redux_store" do
@@ -166,6 +173,13 @@ describe ReactOnRailsHelper, type: :helper do
     context "with skip_display_none option false" do
       before { ReactOnRails.configuration.skip_display_none = false }
       it { is_expected.to include react_store_div }
+    end
+
+    context "with custom dom_prefix string" do
+      before { ReactOnRails.configuration.dom_prefix = "js-foobar" }
+      after { ReactOnRails.configuration.dom_prefix = "js-react-on-rails" }
+
+      it { is_expected.to include 'class="js-foobar-store"' }
     end
   end
 


### PR DESCRIPTION
Requested in https://github.com/shakacode/react_on_rails/issues/381.

If there was a vulnerability, I suppose this could help stop attackers from fingerprinting what libraries are being used on a site. Some people also like to have control over their markup. If you think this is useful I could improve the documentation and add some tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/387)
<!-- Reviewable:end -->
