### PR TITLE
fixed console log spec in dummy to reflect props change

### DIFF
--- a/spec/dummy/spec/requests/console_logging_spec.rb
+++ b/spec/dummy/spec/requests/console_logging_spec.rb
@@ -7,7 +7,7 @@ describe "Server Error Logging" do
 
     expected = <<-JS
 console.log.apply(console, ["[SERVER] RENDERED HelloWorldWithLogAndThrow to dom node \
-with id: HelloWorldWithLogAndThrow-react-component-0 with railsContext:"
+with id: HelloWorldWithLogAndThrow-react-component-0 with props, railsContext:"
 console.log.apply(console, ["[SERVER] console.log in HelloWorld"]);
 console.warn.apply(console, ["[SERVER] console.warn in HelloWorld"]);
 console.error.apply(console, ["[SERVER] console.error in HelloWorld"]);


### PR DESCRIPTION
The console logging spec in dummy didn't have props added to the spec test and is failing when run locally.

This is the line https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/spec/requests/console_logging_spec.rb#L9.

It had to be changed to:

console.log.apply(console, ["[SERVER] RENDERED HelloWorldWithLogAndThrow to dom node \
with id: HelloWorldWithLogAndThrow-react-component-0 with props, railsContext:"

This makes sense with the addition of the props change. Very confused why CI is passing though. Maybe it has an outdated gem version?

Before on master
![screen shot 2016-04-23 at 4 32 21 pm](https://cloud.githubusercontent.com/assets/2458718/14764095/4188f9ac-0971-11e6-8ee3-716beeb4c87c.png)

after fix
![screen shot 2016-04-23 at 4 33 19 pm](https://cloud.githubusercontent.com/assets/2458718/14764097/4683ac36-0971-11e6-877f-df42e8fa2e9c.png)



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/397)
<!-- Reviewable:end -->