### PR TITLE
added babel runtime to root package.json and removed npm-shrinkwrap from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-runtime": "^6.6.1",
     "babel-tape-runner": "^2.0.1",
     "babel-types": "^6.7.2",
     "babelify": "^7.2.0",


### PR DESCRIPTION
The npm shrinkwrap didn't do anything here since we had no dependencies besides devDependencies.

Added babel-runtime to the root since it's a peerDepenency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/399)
<!-- Reviewable:end -->
