### PR TITLE
Cache client/node_modules during heroku deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,22 @@ Here is the addition to the generated config file:
 - Fixed errors when server rendered props contain \u2028 or \u2029 characters [#375](https://github.com/shakacode/react_on_rails/pull/375) by [mariusandra]
 
 ##### Added
-- Non-digested version of assets in public folder [#413](https://github.com/shakacode/react_on_rails/pull/413) by [alleycat-at-git]
+- Non-digested version of assets in public folder [#413](https://github.com/shakacode/react_on_rails/pull/413) by [alleycat-at-git](https://github.com/alleycat-at-git)
+- Cache client/node_modules directory to prevent Heroku from reinstalling all modules from scratch [#324](https://github.com/shakacode/react_on_rails/pull/324) by [modosc](https://github.com/modosc)
 
 ##### Changed
-- Only one webpack config is generated for server and client config. Package.json files were changed to reflect this [#398](https://github.com/shakacode/react_on_rails/pull/398).
-- Added npm_build_test_command to allow developers to change what npm command is automatically run from rspec [#398](https://github.com/shakacode/react_on_rails/pull/398).
-- Replace URI with Addressable gem. See [#405](https://github.com/shakacode/react_on_rails/pull/405) by [lucke84]
+- [#398](https://github.com/shakacode/react_on_rails/pull/398) by Rob, Blaine, and Justin has:
+  - Only one webpack config is generated for server and client config. Package.json files were changed to reflect this.
+  - Added npm_build_test_command to allow developers to change what npm command is automatically run from rspec.
 
 ##### Removed
-- Server rendering is no longer an option in the generator and is always accessible [#398](https://github.com/shakacode/react_on_rails/pull/398).
-- removed lodash, jquery, and loggerMiddleware from the generated code [#398](https://github.com/shakacode/react_on_rails/pull/398).
+- [#398](https://github.com/shakacode/react_on_rails/pull/398) by Rob, Blaine, and Justin has:
+  - Server rendering is no longer an option in the generator and is always accessible.
+  - Removed lodash, jquery, and loggerMiddleware from the generated code.
+  - Removed webpack watch check for test helper automatic compilation.
+
+##### Changed
+- Replace URI with Addressable gem. See [#405](https://github.com/shakacode/react_on_rails/pull/405) by [lucke84]
 
 ## [5.2.0] - 2016-04-08
 ##### Added

--- a/docs/additional-reading/heroku-deployment.md
+++ b/docs/additional-reading/heroku-deployment.md
@@ -7,6 +7,17 @@ The generator has created the necessary files and gems for deployment to Heroku.
 + `config/puma.rb`: Puma webserver config file
 + `lib/tasks/assets.rake`: This rake task file is provided by the generator regardless of whether the user chose Heroku Deployment as an option. It is highlighted here because it is helpful to understand that this task is what generates your JavaScript bundles in production.
 
+
+By default Heroku will cache the root `node_modules` directory between deploys but since we're installing in `client/node_modules` you'll need to add the following line to the `package.json` in your root directory (otherwise you'll have to sit through a full `npm install` on each deploy):
+
+```js
+"cacheDirectories": [
+  "node_modules",
+  "client/node_modules"
+],
+
+```
+
 ## How to Deploy
 
 React on Rails requires both a ruby environment (for Rails) and a Node environment (for Webpack), so you will need to have Heroku use multiple buildpacks.

--- a/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
+++ b/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
@@ -11,6 +11,7 @@
     "build:production": "NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "webpack -w --config webpack.config.js"
   },
+  "cacheDirectories": ["node_modules", "client/node_modules"],
   "dependencies": {
     "babel": "^6.5.2",
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Without this heroku has to do a full npm install on every deploy - i
guess this could be part of the heroku generators but it seemed like a
lot more work to modify this file there than to just add this option
here.

Change by https://github.com/modosc, manually merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/415)
<!-- Reviewable:end -->
