### PR TITLE
added additional step to getting started guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,25 +113,30 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
   rails generate react_on_rails:install --help
   ```
 
-2. Run the generator with a simple "Hello World" example (more options below):
+3. Run the generator with a simple "Hello World" example (more options below):
 
   ```bash
   rails generate react_on_rails:install
   ```
 
-3. NPM install. Make sure you are on a recent version of node. Please use at least Node v5.
+4. NPM install. Make sure you are on a recent version of node. Please use at least Node v5.
 
   ```bash
   npm install
   ```
+5. After running the generator, you will want to:
+  
+  ```bash
+  bundle && npm i
+  ```
 
-4. Start your Rails server:
+6. Start your Rails server:
 
   ```bash
   foreman start -f Procfile.dev
   ```
 
-5. Visit [localhost:3000/hello_world](http://localhost:3000/hello_world)
+7. Visit [localhost:3000/hello_world](http://localhost:3000/hello_world)
 
 ### Installation Summary
 


### PR DESCRIPTION
In the getting started guide the suggestion to do a `bundle && npm i` after running the generator was missing. It can only be found in the help. My installation wasn't running without this and I got the following error messages:

```bash
➜  react_on_rails_app foreman start -f Procfile.dev
18:13:03 web.1    | started with pid 57624
18:13:03 client.1 | started with pid 57625
18:13:03 client.1 | rm: app/assets/webpack/*: No such file or directory
18:13:04 client.1 | 
18:13:04 client.1 | > react-webpack-rails-tutorial@0.0.1 build:dev:client /Users/onlinetocode/rails/test_apps/react_on_rails_app/client
18:13:04 client.1 | > webpack -w --config webpack.client.rails.config.js
18:13:04 client.1 | 
18:13:04 client.1 | sh: webpack: command not found
18:13:04 client.1 | 
18:13:04 client.1 | npm ERR! Darwin 15.4.0
18:13:04 client.1 | npm ERR! argv "/Users/onlinetocode/.nvm/versions/node/v6.1.0/bin/node" "/Users/onlinetocode/.nvm/versions/node/v6.1.0/bin/npm" "run" "build:dev:client"
18:13:04 client.1 | npm ERR! node v6.1.0
18:13:04 client.1 | npm ERR! npm  v3.8.6
18:13:04 client.1 | npm ERR! file sh
18:13:04 client.1 | npm ERR! code ELIFECYCLE
18:13:04 client.1 | npm ERR! errno ENOENT
18:13:04 client.1 | npm ERR! syscall spawn
18:13:04 client.1 | npm ERR! react-webpack-rails-tutorial@0.0.1 build:dev:client: `webpack -w --config webpack.client.rails.config.js`
18:13:04 client.1 | npm ERR! spawn ENOENT
18:13:04 client.1 | npm ERR! 
18:13:04 client.1 | npm ERR! Failed at the react-webpack-rails-tutorial@0.0.1 build:dev:client script 'webpack -w --config webpack.client.rails.config.js'.
18:13:04 client.1 | npm ERR! Make sure you have the latest version of node.js and npm installed.
18:13:04 client.1 | npm ERR! If you do, this is most likely a problem with the react-webpack-rails-tutorial package,
18:13:04 client.1 | npm ERR! not with npm itself.
18:13:04 client.1 | npm ERR! Tell the author that this fails on your system:
18:13:04 client.1 | npm ERR!     webpack -w --config webpack.client.rails.config.js
18:13:04 client.1 | npm ERR! You can get information on how to open an issue for this project with:
18:13:04 client.1 | npm ERR!     npm bugs react-webpack-rails-tutorial
18:13:04 client.1 | npm ERR! Or if that isn't available, you can get their info via:
18:13:04 client.1 | npm ERR!     npm owner ls react-webpack-rails-tutorial
18:13:04 client.1 | npm ERR! There is likely additional logging output above.
18:13:04 client.1 | npm WARN Local package.json exists, but node_modules missing, did you mean to install?
18:13:04 client.1 | 
18:13:04 client.1 | npm ERR! Please include the following file with any support request:
18:13:04 client.1 | npm ERR!     /Users/onlinetocode/rails/test_apps/react_on_rails_app/client/npm-debug.log
18:13:05 client.1 | exited with code 1
18:13:05 system   | sending SIGTERM to all processes
18:13:05 web.1    | terminated by SIGTERM
```

So I think it is a good idea to add it to the getting started guide in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/420)
<!-- Reviewable:end -->
