### PR TITLE
add clearTimeout polyfill to execjs server rendering

### DIFF
--- a/lib/react_on_rails/server_rendering_pool/exec.rb
+++ b/lib/react_on_rails/server_rendering_pool/exec.rb
@@ -132,6 +132,10 @@ function setInterval() {
 function setTimeout() {
   #{undefined_for_exec_js_logging('setTimeout')}
 }
+
+function clearTimeout() {
+  #{undefined_for_exec_js_logging('clearTimeout')}
+}
           JS
         end
 


### PR DESCRIPTION
will this solve the heroku bug?

https://github.com/shakacode/react_on_rails/issues/449

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/450)
<!-- Reviewable:end -->
