### PR TITLE
fixed ReferenceError: navigator is not defined during server_rendering

### DIFF
--- a/lib/react_on_rails/server_rendering_pool/exec.rb
+++ b/lib/react_on_rails/server_rendering_pool/exec.rb
@@ -136,6 +136,9 @@ function setTimeout() {
 function clearTimeout() {
   #{undefined_for_exec_js_logging('clearTimeout')}
 }
+
+navigator = {};
+
           JS
         end
 


### PR DESCRIPTION
I've got this error using react-check package and it's components. It uses [navigator Object](http://www.w3schools.com/jsref/obj_navigator.asp) inside

Here is related issue https://github.com/luqin/react-icheck/issues/25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/464)
<!-- Reviewable:end -->
