### PR TITLE
Add hook to handleError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [Unreleased]
 
+- Option to add an exceptionLogger for the ReactOnRails npm package [#485](https://github.com/shakacode/react_on_rails/pull/485) by [squaresurf](https://github.com/squaresurf)
 - React on Rails server rendering now supports contexts outside of browser rendering, such as ActionMailer templates [#486](https://github.com/shakacode/react_on_rails/pull/486) by [eacaps](https://github.com/eacaps).
 - React on Rails now correctly parses single-digit version strings from package.json [#491](https://github.com/shakacode/react_on_rails/pull/491) by [samphilipd ](https://github.com/samphilipd ).
 - Fixed assets symlinking to correctly use filenames with spaces. Begining in [#510](https://github.com/shakacode/react_on_rails/pull/510), ending in [#513](https://github.com/shakacode/react_on_rails/pull/513) by [dzirtusss](https://github.com/dzirtusss) 

--- a/docs/api/javascript-api.md
+++ b/docs/api/javascript-api.md
@@ -32,7 +32,7 @@ The best source of docs is the main [ReactOnRails.js](../../node_package/src/Rea
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events
-   * `exceptionLogger: function (optional) Any caught exception will be passed to this function as the first argument
+   * `exceptionLogger: function (optional) Caught exceptions will be passed to this function
    */
   setOptions(options)
 ```

--- a/docs/api/javascript-api.md
+++ b/docs/api/javascript-api.md
@@ -32,6 +32,7 @@ The best source of docs is the main [ReactOnRails.js](../../node_package/src/Rea
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events
+   * `exceptionLogger: function (optional) Any caught exception will be passed to this function as the first argument
    */
   setOptions(options)
 ```

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -66,6 +66,10 @@ ctx.ReactOnRails = {
     }
 
     if (options.hasOwnProperty('exceptionLogger')) {
+      if (typeof options.exceptionLogger !== 'function') {
+        throw new Error('Invalid exceptionLogger passed to ReactOnRails.options: ', JSON.stringify(options));
+      }
+
       this._options.exceptionLogger = options.exceptionLogger;
       delete options.exceptionLogger;
     }

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -57,7 +57,7 @@ ctx.ReactOnRails = {
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events
-   * `exceptionLogger: function (optional) Any caught exception will be passed to this function as the first argument
+   * `exceptionLogger: function (optional) Caught exceptions will be passed to this function
    */
   setOptions(options) {
     if (options.hasOwnProperty('traceTurbolinks')) {
@@ -67,7 +67,10 @@ ctx.ReactOnRails = {
 
     if (options.hasOwnProperty('exceptionLogger')) {
       if (typeof options.exceptionLogger !== 'function') {
-        throw new Error('Invalid exceptionLogger passed to ReactOnRails.options: ', JSON.stringify(options));
+        throw new Error(
+          'Invalid exceptionLogger passed to ReactOnRails.options: ',
+          JSON.stringify(options)
+        );
       }
 
       this._options.exceptionLogger = options.exceptionLogger;

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -12,7 +12,7 @@ const ctx = context();
 
 const DEFAULT_OPTIONS = {
   traceTurbolinks: false,
-  exceptionLogger: function(e) {}
+  exceptionLogger: function (e) {}
 };
 
 ctx.ReactOnRails = {

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -12,6 +12,7 @@ const ctx = context();
 
 const DEFAULT_OPTIONS = {
   traceTurbolinks: false,
+  exceptionLogger: function(e) {}
 };
 
 ctx.ReactOnRails = {
@@ -56,11 +57,17 @@ ctx.ReactOnRails = {
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events
+   * `exceptionLogger: function Gets passed the exception as the first argument
    */
   setOptions(options) {
     if (options.hasOwnProperty('traceTurbolinks')) {
       this._options.traceTurbolinks = options.traceTurbolinks;
       delete options.traceTurbolinks;
+    }
+
+    if (options.hasOwnProperty('exceptionLogger')) {
+      this._options.exceptionLogger = options.exceptionLogger;
+      delete options.exceptionLogger;
     }
 
     if (Object.keys(options).length > 0) {

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -57,7 +57,7 @@ ctx.ReactOnRails = {
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events
-   * `exceptionLogger: function Gets passed the exception as the first argument
+   * `exceptionLogger: function (optional) Any caught exception will be passed to this function as the first argument
    */
   setOptions(options) {
     if (options.hasOwnProperty('traceTurbolinks')) {

--- a/node_package/src/handleError.js
+++ b/node_package/src/handleError.js
@@ -63,4 +63,6 @@ ${e.stack}`;
     const reactElement = React.createElement('pre', null, msg);
     return ReactDOMServer.renderToString(reactElement);
   }
+
+  ReactOnRails.options('exceptionLogger')(e);
 };

--- a/node_package/tests/ReactOnRails.test.js
+++ b/node_package/tests/ReactOnRails.test.js
@@ -42,6 +42,15 @@ test('ReactOnRails accepts traceTurbolinks as an option false', (assert) => {
   assert.equal(actual, false);
 });
 
+test('ReactOnRails accepts exceptionLogger as an option function', (assert) => {
+  ReactOnRails.resetOptions();
+  assert.plan(1);
+  const logger = function() {};
+  ReactOnRails.setOptions({ exceptionLogger: logger });
+  const actual = ReactOnRails.option('exceptionLogger');
+  assert.equal(actual, logger);
+});
+
 test('ReactOnRails not specified has traceTurbolinks as false', (assert) => {
   ReactOnRails.resetOptions();
   assert.plan(1);

--- a/node_package/tests/ReactOnRails.test.js
+++ b/node_package/tests/ReactOnRails.test.js
@@ -52,6 +52,16 @@ test('ReactOnRails accepts exceptionLogger as an option function', (assert) => {
   assert.equal(actual, logger);
 });
 
+test('ReactOnRails throws an error for an invalid exceptionLogger', (assert) => {
+  ReactOnRails.resetOptions();
+  assert.plan(1);
+  assert.throws(
+    () => ReactOnRails.setOptions({ exceptionLogger: true }),
+    /Invalid exceptionLogger/,
+    'setOptions should throw an error for an invalid exceptionLogger'
+  );
+});
+
 test('ReactOnRails not specified has traceTurbolinks as false', (assert) => {
   ReactOnRails.resetOptions();
   assert.plan(1);

--- a/node_package/tests/ReactOnRails.test.js
+++ b/node_package/tests/ReactOnRails.test.js
@@ -45,7 +45,8 @@ test('ReactOnRails accepts traceTurbolinks as an option false', (assert) => {
 test('ReactOnRails accepts exceptionLogger as an option function', (assert) => {
   ReactOnRails.resetOptions();
   assert.plan(1);
-  const logger = function() {};
+  const logger = function () {};
+
   ReactOnRails.setOptions({ exceptionLogger: logger });
   const actual = ReactOnRails.option('exceptionLogger');
   assert.equal(actual, logger);

--- a/spec/dummy/client/app/startup/clientRegistration.jsx
+++ b/spec/dummy/client/app/startup/clientRegistration.jsx
@@ -14,7 +14,10 @@ import CssModulesImagesFontsExample from '../components/CssModulesImagesFontsExa
 import SharedReduxStore from '../stores/SharedReduxStore'
 
 ReactOnRails.setOptions({
-  traceTurbolinks: true
+  traceTurbolinks: true,
+  exceptionLogger: function(e) {
+    console.log('Log from exceptionLogger:', e);
+  }
 });
 
 ReactOnRails.register({


### PR DESCRIPTION
Why:

* It is hard to send exceptions to an exception tracker (e.g. Rollbar)
  when they're all caught and sent to console.error.

This change addresses the need by:

* Update handleError to check for the existence of a logException
  function on the window, then pass the exception to it if it exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/485)
<!-- Reviewable:end -->
