### PR TITLE
A proposal to update the "rubocop"

### DIFF
--- a/lib/react_on_rails/server_rendering_pool.rb
+++ b/lib/react_on_rails/server_rendering_pool.rb
@@ -16,6 +16,7 @@ module ReactOnRails
         end
       end
 
+      # rubocop:disable Style/MethodMissing
       def method_missing(sym, *args, &block)
         pool.send sym, *args, &block
       end

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -11,6 +11,7 @@ module ReactOnRails
     end
 
     def self.last_process_completed_successfully?
+      # rubocop:disable Style/NumericPredicate
       $CHILD_STATUS.exitstatus == 0
     end
 

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.40.0)
+    rubocop (0.42.0)
       parser (>= 2.3.1.0, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)


### PR DESCRIPTION
```
lib/react_on_rails/server_rendering_pool.rb:19:7: C: Style/MethodMissing: When using method_missing, define respond_to_missing? and fall back on super.
  def method_missing(sym, *args, &block) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

lib/react_on_rails/utils.rb:14:7: C: Style/NumericPredicate: Use $CHILD_STATUS.exitstatus.zero? instead of $CHILD_STATUS.exitstatus == 0.
  $CHILD_STATUS.exitstatus == 0
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

--
`TravisCI` fails but it is not connected to this PR.
Maybe I can figure it out where is the offender.

Local `rake` command show all green now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/515)
<!-- Reviewable:end -->
