### PR TITLE
update gem version suggested in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
 1. Add the following to your Gemfile and bundle install.
 
   ```ruby
-  gem "react_on_rails", "~> 5"
+  gem "react_on_rails", "~> 6"
   ```
 
 2. Commit this to git (you cannot run the generator unless you do this).


### PR DESCRIPTION
the README instructs the user to install v5 of the the gem, but v6 is already available. When I followed the readme, I was very surprised when I ran npm upgrade and immediately got a new version of the npm package, which made me wonder if I was missing updates in the ruby gem as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/536)
<!-- Reviewable:end -->
