### PR TITLE
Fix broken URL for gitbooks

### DIFF
--- a/docs/additional-reading/hot-reloading-rails-development.md
+++ b/docs/additional-reading/hot-reloading-rails-development.md
@@ -2,7 +2,7 @@
 
 This document outlines the steps to setup your React On Rails Environment so that you can experience the pleasure of hot reloading of JavaScript and Sass during your Rails development work. There are 2 examples of this setup:
 
-1. [spec/dummy](../../spec/dummy): Simpler setup used for integration testing this gem.
+1. [spec/dummy](https://github.com/shakacode/react_on_rails/tree/master/spec/dummy): Simpler setup used for integration testing this gem.
 1. [shakacode/react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial/). Full featured setup using Twitter bootstrap.
 
 ## High Level Strategy


### PR DESCRIPTION
The URL is broken on https://shakacode.gitbooks.io/react-on-rails/content/docs/additional-reading/hot-reloading-rails-development.html since it is looking relatively and not at the repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/593)
<!-- Reviewable:end -->
