### PR TITLE
Slight improvement to the 'no hydrated stores' error

### DIFF
--- a/node_package/src/StoreRegistry.js
+++ b/node_package/src/StoreRegistry.js
@@ -40,10 +40,10 @@ export default {
 
     if (storeKeys.length === 0) {
       const msg = 'There are no stores hydrated and you are requesting the store ' +
-        `${name}. This can happen if you are server rendering and either you do not call ` +
+        `${name}. This can happen if you are server rendering and either \nyou do not call ` +
         "redux_store near the top of your controller action's view (not the layout) " +
-        'and before any call to react_component or you do not render ' +
-        '`redux_store_hydration_data` anywhere on your page';
+        'and before any call to react_component \nor you do not render ' +
+        'redux_store_hydration_data anywhere on your page';
       throw new Error(msg);
     }
 

--- a/node_package/src/StoreRegistry.js
+++ b/node_package/src/StoreRegistry.js
@@ -39,11 +39,11 @@ export default {
     const storeKeys = Array.from(hydratedStores.keys()).join(', ');
 
     if (storeKeys.length === 0) {
-      const msg = 'There are no stores hydrated and you are requesting the store ' +
-        `${name}. This can happen if you are server rendering and either \nyou do not call ` +
-        "redux_store near the top of your controller action's view (not the layout) " +
-        'and before any call to react_component \nor you do not render ' +
-        'redux_store_hydration_data anywhere on your page';
+      const msg = `There are no stores hydrated and you are requesting the store ${name}.\n` +
+        'This can happen if you are server rendering and either: \n' +
+        "1) You do not call redux_store near the top of your controller action's " +
+        'view (not the layout) and before any call to react_component \n' +
+        '2) You do not render redux_store_hydration_data anywhere on your page';
       throw new Error(msg);
     }
 

--- a/node_package/src/StoreRegistry.js
+++ b/node_package/src/StoreRegistry.js
@@ -40,9 +40,10 @@ export default {
 
     if (storeKeys.length === 0) {
       const msg = 'There are no stores hydrated and you are requesting the store ' +
-        `${name}. This can happen if you are server rendering and you do not call ` +
+        `${name}. This can happen if you are server rendering and either you do not call ` +
         "redux_store near the top of your controller action's view (not the layout) " +
-        'and before any call to react_component.';
+        'and before any call to react_component or you do not render ' +
+        '`redux_store_hydration_data` anywhere on your page';
       throw new Error(msg);
     }
 

--- a/node_package/src/StoreRegistry.js
+++ b/node_package/src/StoreRegistry.js
@@ -39,11 +39,12 @@ export default {
     const storeKeys = Array.from(hydratedStores.keys()).join(', ');
 
     if (storeKeys.length === 0) {
-      const msg = `There are no stores hydrated and you are requesting the store ${name}.\n` +
-        'This can happen if you are server rendering and either: \n' +
-        "1) You do not call redux_store near the top of your controller action's " +
-        'view (not the layout) and before any call to react_component \n' +
-        '2) You do not render redux_store_hydration_data anywhere on your page';
+      const msg =
+        `There are no stores hydrated and you are requesting the store ${name}.
+        This can happen if you are server rendering and either:
+        1) You do not call redux_store near the top of your controller action's
+        view (not the layout) and before any call to react_component
+        2) You do not render redux_store_hydration_data anywhere on your page`;
       throw new Error(msg);
     }
 

--- a/node_package/src/StoreRegistry.js
+++ b/node_package/src/StoreRegistry.js
@@ -40,11 +40,11 @@ export default {
 
     if (storeKeys.length === 0) {
       const msg =
-        `There are no stores hydrated and you are requesting the store ${name}.
-        This can happen if you are server rendering and either:
-        1) You do not call redux_store near the top of your controller action's
-        view (not the layout) and before any call to react_component
-        2) You do not render redux_store_hydration_data anywhere on your page`;
+`There are no stores hydrated and you are requesting the store ${name}.
+This can happen if you are server rendering and either:
+1. You do not call redux_store near the top of your controller action's view (not the layout)
+   and before any call to react_component.
+2. You do not render redux_store_hydration_data anywhere on your page.`;
       throw new Error(msg);
     }
 


### PR DESCRIPTION
Hi, 

When I was trying to set up server side rendering, I ran into the ['no hydrated stores' error](https://github.com/shakacode/react_on_rails/blob/master/node_package/src/StoreRegistry.js#L42-L46). After some digging, I realised I hadn't called `redux_store_hydration_data` anywhere in my view. 

This should hopefully make it more clear that rendering `redux_store_hydration_data` is required.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/605)
<!-- Reviewable:end -->
