### PR TITLE
Update 12factor gem requirement

### DIFF
--- a/docs/additional-reading/heroku-deployment.md
+++ b/docs/additional-reading/heroku-deployment.md
@@ -2,7 +2,7 @@
 The generator has created the necessary files and gems for deployment to Heroku. If you have installed manually, you will need to provide these files yourself:
 
 + `Procfile`: used by Heroku and Foreman to start the Puma server
-+ `12factor` gem: required by Heroku if using a version before Rails 5
++ `12factor` gem: required by Heroku if using a version before Rails 5 (see their [README](https://github.com/heroku/rails_12factor#rails-5) for more information if upgrading from a lower version)
 + `'puma'` gem: recommended Heroku webserver
 + `config/puma.rb`: Puma webserver config file
 + `lib/tasks/assets.rake`: This rake task file is provided by the generator regardless of whether the user chose Heroku Deployment as an option. It is highlighted here because it is helpful to understand that this task is what generates your JavaScript bundles in production. Previously, users of this gem had to create a file `lib/tasks/assets.rake` to modify the Rails precompile task to deploy assets for production. However, we add this automatically in newer versions of React on Rails. If you need to customize this file, see [lib/tasks/assets.rake from React on Rails](https://github.com/shakacode/react_on_rails/blob/master/lib/tasks/assets.rake) as an example.

--- a/docs/additional-reading/heroku-deployment.md
+++ b/docs/additional-reading/heroku-deployment.md
@@ -2,7 +2,7 @@
 The generator has created the necessary files and gems for deployment to Heroku. If you have installed manually, you will need to provide these files yourself:
 
 + `Procfile`: used by Heroku and Foreman to start the Puma server
-+ `12factor` gem: required by Heroku
++ `12factor` gem: required by Heroku if using a version before Rails 5
 + `'puma'` gem: recommended Heroku webserver
 + `config/puma.rb`: Puma webserver config file
 + `lib/tasks/assets.rake`: This rake task file is provided by the generator regardless of whether the user chose Heroku Deployment as an option. It is highlighted here because it is helpful to understand that this task is what generates your JavaScript bundles in production. Previously, users of this gem had to create a file `lib/tasks/assets.rake` to modify the Rails precompile task to deploy assets for production. However, we add this automatically in newer versions of React on Rails. If you need to customize this file, see [lib/tasks/assets.rake from React on Rails](https://github.com/shakacode/react_on_rails/blob/master/lib/tasks/assets.rake) as an example.


### PR DESCRIPTION
The gem is no longer required in Rails 5.

https://github.com/heroku/rails_12factor#rails-5
https://devcenter.heroku.com/articles/getting-started-with-rails5#heroku-gems

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/609)
<!-- Reviewable:end -->
