### PR TITLE
Disable Turbolinks support when not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 ##### Changed
 - By using the hook on `turbolinks:before-visit` to unmount the components, we can ensure that components are unmounted even when Turbolinks cache is disabled. Previously, we used `turbolinks:before-cache` event hook. [#644](https://github.com/shakacode/react_on_rails/pull/644) by [volkanunsal](https://github.com/volkanunsal).
 - Added support for Ruby 2.0 [#651](https://github.com/shakacode/react_on_rails/pull/651) by [bbonamin](https://github.com/bbonamin).
+- Disable Turbolinks support when not supported. [#650](https://github.com/shakacode/react_on_rails/pull/650) by [ka2n](https://github.com/ka2n).
 
 ## [6.3.2] - 2016-12-5
 ##### Fixed

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -63,6 +63,10 @@ function turbolinksVersion5() {
   return (typeof Turbolinks.controller !== 'undefined');
 }
 
+function turbolinksSupported() {
+  return Turbolinks.supported;
+}
+
 function delegateToRenderer(componentObj, props, railsContext, domNodeId, trace) {
   const { name, component, isRenderer } = componentObj;
 
@@ -175,23 +179,25 @@ export function clientStartup(context) {
     // We must do this check for turbolinks AFTER the document is loaded because we load the
     // Webpack bundles first.
 
-    if (!turbolinksInstalled()) {
+    if (turbolinksInstalled() && turbolinksSupported()) {
+      if (turbolinksVersion5()) {
+        debugTurbolinks(
+          'USING TURBOLINKS 5: document added event listeners ' +
+          ' turbolinks:before-visit and turbolinks:load.');
+        document.addEventListener('turbolinks:before-visit', reactOnRailsPageUnloaded);
+        document.addEventListener('turbolinks:load', reactOnRailsPageLoaded);
+      } else {
+        debugTurbolinks(
+          'USING TURBOLINKS 2: document added event listeners page:before-unload and ' +
+          'page:change.');
+        document.addEventListener('page:before-unload', reactOnRailsPageUnloaded);
+        document.addEventListener('page:change', reactOnRailsPageLoaded);
+      }
+    } else {
       debugTurbolinks(
         'NOT USING TURBOLINKS: DOMContentLoaded event, calling reactOnRailsPageLoaded',
       );
       reactOnRailsPageLoaded();
-    } else if (turbolinksVersion5()) {
-      debugTurbolinks(
-        'USING TURBOLINKS 5: document added event listeners ' +
-        ' turbolinks:before-visit and turbolinks:load.');
-      document.addEventListener('turbolinks:before-visit', reactOnRailsPageUnloaded);
-      document.addEventListener('turbolinks:load', reactOnRailsPageLoaded);
-    } else {
-      debugTurbolinks(
-        'USING TURBOLINKS 2: document added event listeners page:before-unload and ' +
-        'page:change.');
-      document.addEventListener('page:before-unload', reactOnRailsPageUnloaded);
-      document.addEventListener('page:change', reactOnRailsPageLoaded);
     }
   });
 }


### PR DESCRIPTION
By checking with Turbolinks.supported API, fallback unsupported browser to non Turbolinks mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/650)
<!-- Reviewable:end -->
