### PR TITLE
Compatibility with Ruby 2.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: required
 language: ruby
 
 rvm:
+  - 2.0.0
+  - 2.1.10
+  - 2.2.6
   - 2.3.1
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
 install:
   - nvm install node
   - node -v
+  - npm install -g npm@3.10.7
   - npm config set spin false
   - npm install
   - bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [Unreleased]
 *Please add entries here for your pull requests.*
-##### Fixed
-- Added support for Ruby 2.0.
 
 ## [6.3.3] - 2016-12-25
+##### Changed
 - By using the hook on `turbolinks:before-visit` to unmount the components, we can ensure that components are unmounted even when Turbolinks cache is disabled. Previously, we used `turbolinks:before-cache` event hook. [#644](https://github.com/shakacode/react_on_rails/pull/644) by [volkanunsal](https://github.com/volkanunsal).
+- Added support for Ruby 2.0 [#651](https://github.com/shakacode/react_on_rails/pull/651) by [bbonamin](https://github.com/bbonamin).
 
 ## [6.3.2] - 2016-12-5
 ##### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [Unreleased]
 *Please add entries here for your pull requests.*
+##### Fixed
+- Added support for Ruby 2.0.
 
 ## [6.3.3] - 2016-12-25
 - By using the hook on `turbolinks:before-visit` to unmount the components, we can ensure that components are unmounted even when Turbolinks cache is disabled. Previously, we used `turbolinks:before-cache` event hook. [#644](https://github.com/shakacode/react_on_rails/pull/644) by [volkanunsal](https://github.com/volkanunsal).

--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -5,8 +5,11 @@
 # 2. Keep all #{some_var} fully to the left so that all indentation is done evenly in that var
 require "react_on_rails/prerender_error"
 require "addressable/uri"
+require "react_on_rails/utils"
 
 module ReactOnRailsHelper
+  include ReactOnRails::Utils::Required
+
   # The env_javascript_include_tag and env_stylesheet_link_tag support the usage of a webpack
   # dev server for providing the JS and CSS assets during development mode. See
   # https://github.com/shakacode/react-webpack-rails-tutorial/ for a working example.
@@ -255,8 +258,12 @@ module ReactOnRailsHelper
 
   # Returns Array [0]: html, [1]: script to console log
   # NOTE, these are NOT html_safe!
-  def server_rendered_react_component_html(props, react_component_name, dom_id,
-                                           prerender:, trace:, raise_on_prerender_error:)
+  def server_rendered_react_component_html(
+    props, react_component_name, dom_id,
+    prerender: required("prerender"),
+    trace: required("trace"),
+    raise_on_prerender_error: required("raise_on_prerender_error")
+  )
     return { "html" => "", "consoleReplayScript" => "" } unless prerender
 
     # On server `location` option is added (`location = request.fullpath`)
@@ -342,7 +349,7 @@ ReactOnRails.setStore('#{store_name}', store);
   # This is the definitive list of the default values used for the rails_context, which is the
   # second parameter passed to both component and store generator functions.
   # rubocop:disable Metrics/AbcSize
-  def rails_context(server_side:)
+  def rails_context(server_side: required("server_side"))
     @rails_context ||= begin
       result = {
         inMailer: in_mailer?,

--- a/lib/react_on_rails/react_component/options.rb
+++ b/lib/react_on_rails/react_component/options.rb
@@ -1,10 +1,14 @@
+require "react_on_rails/utils"
+
 module ReactOnRails
   module ReactComponent
     class Options
+      include Utils::Required
+
       NO_PROPS = {}.freeze
       HIDDEN = "display:none".freeze
 
-      def initialize(name:, options:)
+      def initialize(name: required("name"), options: required("options"))
         @name = name
         @options = options
       end

--- a/lib/react_on_rails/test_helper/webpack_assets_status_checker.rb
+++ b/lib/react_on_rails/test_helper/webpack_assets_status_checker.rb
@@ -1,15 +1,21 @@
 require "rake"
 require "fileutils"
+require "react_on_rails/utils"
 
 # You can replace this implementation with your own for use by the
 # ReactOnRails::TestHelper.ensure_assets_compiled helper
 module ReactOnRails
   module TestHelper
     class WebpackAssetsStatusChecker
+      include Utils::Required
       # client_dir is typically /client, where all client files go
       attr_reader :client_dir, :generated_assets_dir
 
-      def initialize(generated_assets_dir:, client_dir:, webpack_generated_files:)
+      def initialize(
+        generated_assets_dir: required("generated_assets_dir"),
+        client_dir: required("client_dir"),
+        webpack_generated_files: required("webpack_generated_files")
+      )
         @generated_assets_dir = generated_assets_dir
         @client_dir = client_dir
         @webpack_generated_files = webpack_generated_files

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -19,5 +19,11 @@ module ReactOnRails
       File.join(ReactOnRails.configuration.generated_assets_dir,
                 ReactOnRails.configuration.server_bundle_js_file)
     end
+
+    module Required
+      def required(arg_name)
+        raise ArgumentError, "#{arg_name} is required"
+      end
+    end
   end
 end

--- a/react_on_rails.gemspec
+++ b/react_on_rails.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.0.0'
+
   s.add_dependency "connection_pool"
   s.add_dependency "execjs", "~> 2.5"
   s.add_dependency "rainbow", "~> 2.1"

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -45,9 +45,6 @@ gem "react_on_rails", path: "../.."
 
 gem "mini_racer"
 
-# Access an IRB console on exception pages or by using <%= console %> in views
-gem 'web-console', group: :development, require: false
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "pry"

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -268,10 +268,6 @@ GEM
     uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.2)
-    web-console (3.3.0)
-      activemodel (>= 4.2)
-      debug_inspector
-      railties (>= 4.2)
     websocket (1.2.3)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
@@ -318,7 +314,6 @@ DEPENDENCIES
   sqlite3
   turbolinks (= 2.5.3)
   uglifier (>= 2.7.2)
-  web-console
 
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
First of all, let me express how grateful I am for this gem. I've recently been learning about react and webpack, and react_on_rails has made it a breeze to implement what I've learned in my Rails projects! It's allowed us to add "sprinkles" of React in certain Rails views, without commiting to rewriting everything from scratch. Thank you!

Now, for a project I'm currently working on, we need compatibility with Ruby 2.0 (yeah yeah, I know it's not receiving fixes or patches anymore, but we can't upgrade yet.)

The [rubygems page for react_on_rails](https://rubygems.org/gems/react_on_rails) doesn't specify a minimum ruby version, but if you try to use the gem with < 2.1, it breaks because of the required keyword arguments that were introduced in 2.1.

The changes in this PR do "backport" this behavior to 2.0. I couldn't find anything else other than these syntax changes that would make the gem incompatible with 2.0, and tests seem to pass.

Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/651)
<!-- Reviewable:end -->
