### PR TITLE
Foreman dependency issue (remove foreman)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
 
 6. Start your Rails server:
 
+  Install foreman
+
+  ```bash
+  gem install foreman
+  ```
+
   ```bash
   foreman start -f Procfile.dev
   ```

--- a/README.md
+++ b/README.md
@@ -120,11 +120,7 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
 
 6. Start your Rails server:
 
-  Install foreman
-
-  ```bash
-  gem install foreman
-  ```
+  with foreman installed (`gem install foreman`)
 
   ```bash
   foreman start -f Procfile.dev

--- a/docs/additional-reading/foreman-issues.md
+++ b/docs/additional-reading/foreman-issues.md
@@ -1,0 +1,15 @@
+# Foreman Issues
+
+## It is not recomended to include foreman into Gemfile
+
+See: https://github.com/ddollar/foreman
+
+> Ruby users should take care not to install foreman in their project's Gemfile.
+
+## Known issues
+
+ * With `foreman 0.82.0` npm `react-s3-uploader` was failing to finish upload file to S3 when server was started by `foreman -f Procfile.dev`, 
+   at the same time the same code works fine when ruby server started by `bundle exec rails s`.
+
+ * The same Procfile with different versions of `foreman` in combination with different versions of `bundler` may produce different output of `ps aux`.
+   This may brake bash tools which rely on `ps` output.

--- a/react_on_rails.gemspec
+++ b/react_on_rails.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency "execjs", "~> 2.5"
   s.add_dependency "rainbow", "~> 2.1"
   s.add_dependency "rails", ">= 3.2"
-  s.add_dependency "foreman"
   s.add_dependency "addressable"
 
   s.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
According https://github.com/ddollar/foreman

> Ruby users should take care not to install foreman in their project's Gemfile.

and known issues with `foreman` I suggest to remove `foreman` from gem dependencies and install it manually.

This PR is related to discussion https://github.com/shakacode/react_on_rails/issues/675

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/678)
<!-- Reviewable:end -->
