### PR TITLE
Fix incorrect "this" references of Node.js SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
-*Please add entries here for your pull requests.*
+### Fixed
+- Fix incorrect "this" references of Node.js SSR [#690] by [nostophilia](https://github.com/nostophilia)
 
 ## [6.4.0] - 2017-1-12
 
 ### Possible Breaking Change
-- Since foreman is no longer a dependency of the React on Rails gem, please run `gem install foreman`. If you are using rvm, you may wish to run `rvm @global do gem install foreman` to install foreman for all your gemsets. 
+- Since foreman is no longer a dependency of the React on Rails gem, please run `gem install foreman`. If you are using rvm, you may wish to run `rvm @global do gem install foreman` to install foreman for all your gemsets.
 
 ### Fixed
 - Removed foreman as a dependency. [#678](https://github.com/shakacode/react_on_rails/pull/678) by [x2es](https://github.com/x2es).

--- a/lib/generators/react_on_rails/templates/node/base/client/node/server.js
+++ b/lib/generators/react_on_rails/templates/node/base/client/node/server.js
@@ -6,48 +6,50 @@ let bundleFileName = 'server-bundle.js';
 
 let currentArg;
 
-function Handler() {
-  this.queue = [];
-  this.initialized = false;
+class Handler {
+  constructor() {
+    this.queue = [];
+    this.initialized = false;
+  }
+
+  initialize() {
+    console.log(`Processing ${this.queue.length} pending requests`);
+    let callback;
+
+    // eslint-disable-next-line no-cond-assign
+    while (callback = this.queue.pop()) {
+      callback();
+    }
+
+    this.initialized = true;
+  }
+
+  handle(connection) {
+    const callback = () => {
+      const terminator = '\r\n\0';
+      let request = '';
+      connection.setEncoding('utf8');
+      connection.on('data', (data) => {
+        console.log(`Processing chunk: ${data}`);
+        request += data;
+        if (data.slice(-terminator.length) === terminator) {
+          request = request.slice(0, -terminator.length);
+
+          // eslint-disable-next-line no-eval
+          const response = eval(request);
+          connection.write(`${response}${terminator}`);
+          request = '';
+        }
+      });
+    };
+
+    if (this.initialized) {
+      callback();
+    } else {
+      this.queue.push(callback);
+    }
+  }
 }
-
-Handler.prototype.handle = (connection) => {
-  const callback = () => {
-    const terminator = '\r\n\0';
-    let request = '';
-    connection.setEncoding('utf8');
-    connection.on('data', (data) => {
-      console.log(`Processing chunk: ${data}`);
-      request += data;
-      if (data.slice(-terminator.length) === terminator) {
-        request = request.slice(0, -terminator.length);
-
-        // eslint-disable-next-line no-eval
-        const response = eval(request);
-        connection.write(`${response}${terminator}`);
-        request = '';
-      }
-    });
-  };
-
-  if (this.initialized) {
-    callback();
-  } else {
-    this.queue.push(callback);
-  }
-};
-
-Handler.prototype.initialize = () => {
-  console.log(`Processing ${this.queue.length} pending requests`);
-  let callback;
-
-  // eslint-disable-next-line no-cond-assign
-  while (callback = this.queue.pop()) {
-    callback();
-  }
-
-  this.initialized = true;
-};
 
 const handler = new Handler();
 


### PR DESCRIPTION
The default Node.js server file created by the generator throw errors of `undefined`. Arrow functions don't bind `this`, so it's not referencing the `handler` object as expected but the global object likely. So something like this won't work and throw an error.
```js
Handler.prototype.initialize = () => {
  console.log(`Processing ${this.queue.length} pending requests`);
  ......
}
```
We can either use ES6 class or write something like `Handler.prototype.handle = function (connection) ...`. I'd prefer the former one.
 
(BTW, I'm using Node.js as backend because I'm experimenting server-side rendering with `Relay` or `Apollo` and `ExecJS` doesn't seem to support this. But with the `Node` solution, I don't like the fact that there seems to be some unnecessary communications between `Rails` and `Node` due to the way those GraphQL client SSR works. I wish there can be a way to **hydrate** Apollo store from `Rails` like how you did with `Redux` SSR. Maybe I will update you later on another issue after some researching)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/690)
<!-- Reviewable:end -->
