### PR TITLE
Alexey/render deferred

### DIFF
--- a/lib/react_on_rails/react_component/options.rb
+++ b/lib/react_on_rails/react_component/options.rb
@@ -33,6 +33,10 @@ module ReactOnRails
         retrieve_key(:prerender)
       end
 
+      def render_deferred
+        options[:render_deferred] || false
+      end
+
       def trace
         retrieve_key(:trace)
       end
@@ -50,7 +54,8 @@ module ReactOnRails
           component_name: name,
           props: props,
           trace: trace,
-          dom_id: dom_id
+          dom_id: dom_id,
+          render_deferred: render_deferred
         }
       end
 

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -68,7 +68,7 @@ module ReactOnRails
       end
 
       def relative_path?
-        raw.match(%r{(\.\.|\Afile:///)}).present?
+        raw.match(%r{(\.\.|\Afile:)}).present?
       end
 
       def major

--- a/node_package/src/ReactOnRails.js
+++ b/node_package/src/ReactOnRails.js
@@ -84,6 +84,16 @@ ctx.ReactOnRails = {
     ClientStartup.reactOnRailsPageLoaded();
   },
 
+
+  /**
+   * Render react_components with option data-renderdeferred: true. These components are not
+   * loaded automatically on page load event in browser, so you have to trigger rendering
+   * manually with this function
+   */
+  renderDeferredComponents() {
+    ClientStartup.renderDeferredComponents();
+  },
+
   /**
    * Returns CSRF authenticity token inserted by Rails csrf_meta_tags
    * @returns String or null

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -93,8 +93,8 @@ DELEGATING TO RENDERER ${name} for dom node with id: ${domNodeId} with props, ra
  * with data-render-deferred=true. When set to true renders only deferred components.
  */
 function render(el, railsContext, renderDeferred) {
-  const isDeferred = el.getAttribute('data-render-deferred');
-  if (isDeferred != renderDeferred) return;
+  const isDeferred = el.getAttribute('data-render-deferred') === 'true';
+  if (!!isDeferred != !!renderDeferred) return;
 
   const context = findContext();
   const name = el.getAttribute('data-component-name');

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -35,15 +35,15 @@ function turbolinksInstalled() {
   return (typeof Turbolinks !== 'undefined');
 }
 
-function forEach(fn, className, railsContext) {
+function forEach(fn, className, railsContext, ...args) {
   const els = document.getElementsByClassName(className);
   for (let i = 0; i < els.length; i += 1) {
-    fn(els[i], railsContext);
+    fn(els[i], railsContext, ...args);
   }
 }
 
-function forEachComponent(fn, railsContext) {
-  forEach(fn, REACT_ON_RAILS_COMPONENT_CLASS_NAME, railsContext);
+function forEachComponent(fn, railsContext, ...args) {
+  forEach(fn, REACT_ON_RAILS_COMPONENT_CLASS_NAME, railsContext, ...args);
 }
 
 function initializeStore(el, railsContext) {
@@ -88,8 +88,14 @@ DELEGATING TO RENDERER ${name} for dom node with id: ${domNodeId} with props, ra
  * Used for client rendering by ReactOnRails. Either calls ReactDOM.render or delegates
  * to a renderer registered by the user.
  * @param el
+ * @param railsContext
+ * @param renderDeferred - when set to false or undefined (default) skips rendering of el marked
+ * with data-render-deferred=true. When set to true renders only deferred components.
  */
-function render(el, railsContext) {
+function render(el, railsContext, renderDeferred) {
+  const isDeferred = el.getAttribute('data-render-deferred');
+  if (isDeferred != renderDeferred) return;
+
   const context = findContext();
   const name = el.getAttribute('data-component-name');
   const domNodeId = el.getAttribute('data-dom-id');
@@ -142,6 +148,11 @@ export function reactOnRailsPageLoaded() {
   const railsContext = parseRailsContext();
   forEachStore(railsContext);
   forEachComponent(render, railsContext);
+}
+
+export function renderDeferredComponents() {
+  const railsContext = parseRailsContext();
+  forEachComponent(render, railsContext, true);
 }
 
 function unmount(el) {


### PR DESCRIPTION
The purpose of this change is to allow an option on a react_component to be rendered with an explicit call rather than automatically when page loaded.

We thought this one was needed for rendering React on Rails components created on the view with react_component to be rendered by another library asynchronously, but now we're not sure this is required.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/695)
<!-- Reviewable:end -->
