### PR TITLE
Remove reference to heroku-buildpack-multi

### DIFF
--- a/docs/additional-reading/heroku-deployment.md
+++ b/docs/additional-reading/heroku-deployment.md
@@ -47,8 +47,6 @@ heroku buildpacks:add --index 1 heroku/nodejs
 
 For more information, see [Using Multiple Buildpacks for an App](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app)
 
-If for some reason you need custom buildpacks that are not officially supported by Heroku ([see this page](https://devcenter.heroku.com/articles/buildpacks)), we recommend checking out [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi).
-
 ## Fresh Rails Install
 
 ### Swap out sqlite for postgres by doing the following:


### PR DESCRIPTION
`heroku buildpacks:add ...` will support any custom buildpacks - there's no use case for using `heroku-buildpack-multi` unless you are relying on a `.buildpacks` file to be present in the repo (which some older projects do).

In addition, https://github.com/ddollar/heroku-buildpack-multi is deprecated and is no longer being maintained. There is a maintained fork of the project at https://github.com/heroku/heroku-buildpack-multi but it isn't necessary to point people to this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/698)
<!-- Reviewable:end -->
