### PR TITLE
Change local host to match foreman port 5000 on the initial setup Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
   foreman start -f Procfile.dev
   ```
 
-7. Visit [localhost:5000/hello_world](http://localhost:5000/hello_world)
+7. foreman defaults to any PORT value set in the environment. If you have ```bash export PORT=3000 ``` in your dot file or ```bash .envrc ```, so you can set whatever port you would like to use. Otherwise, foreman will use ```bash port 5000 ```, and you would visit [localhost:5000/hello_world](http://localhost:5000/hello_world)
 
 ### Installation Summary
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
   foreman start -f Procfile.dev
   ```
 
-7. foreman defaults to any PORT value set in the environment. If you have ```bash export PORT=3000 ``` in your dot file or ```bash .envrc ```, so you can set whatever port you would like to use. Otherwise, foreman will use ```bash port 5000 ```, and you would visit [localhost:5000/hello_world](http://localhost:5000/hello_world)
+7. Foreman defaults to any PORT value set in the environment. If you have ```bash export PORT=3000 ``` in your dot file or ```bash .envrc ```, so you can set whatever port you would like to use. Otherwise, foreman will use ```bash port 5000 ```, and you would visit [localhost:5000/hello_world](http://localhost:5000/hello_world)
 
 ### Installation Summary
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **For a complete example of this gem, see our live demo at [www.reactrails.com](http://www.reactrails.com). ([Source Code](https://github.com/shakacode/react-webpack-rails-tutorial))**
 
-Aloha from Justin Gordon ([bio](http://www.railsonmaui.com/about)) and the [ShakaCode](http://www.shakacode.com) Team! We're actively looking for new projects involving React, React-Native, and Rails. Please [contact me](mailto:justin@shakacode.com) if we could potentially help you in any way. Besides consulting on bigger projects, [ShakaCode](http://www.shakacode.com) is doing ScreenHero plus Slack/Github based coaching for React on Rails. See our blog post [Can ShakaCode Help You?](https://blog.shakacode.com/can-shakacode-help-you-4a5b1e5a8a63#.jex6tg9w9) for more information. 
+Aloha from Justin Gordon ([bio](http://www.railsonmaui.com/about)) and the [ShakaCode](http://www.shakacode.com) Team! We're actively looking for new projects involving React, React-Native, and Rails. Please [contact me](mailto:justin@shakacode.com) if we could potentially help you in any way. Besides consulting on bigger projects, [ShakaCode](http://www.shakacode.com) is doing ScreenHero plus Slack/Github based coaching for React on Rails. See our blog post [Can ShakaCode Help You?](https://blog.shakacode.com/can-shakacode-help-you-4a5b1e5a8a63#.jex6tg9w9) for more information.
 
 I'm offering a free half-hour project consultation, on anything from React on Rails to any aspect of web application development for both consumer and enterprise products. In addition to React.js and Rails, we're doing React-Native iOS and Android apps!
 
@@ -22,7 +22,7 @@ Please [Subscribe](https://app.mailerlite.com/webforms/landing/l1d9x5) to keep i
 * **[@ShakaCode on Twitter](https://twitter.com/shakacode)**
 
 # Testimonials
-From Joel Hooks, Co-Founder, Chief Nerd at [egghead.io](https://egghead.io/), January 30, 2017: 
+From Joel Hooks, Co-Founder, Chief Nerd at [egghead.io](https://egghead.io/), January 30, 2017:
 ![2017-01-30_11-33-59](https://cloud.githubusercontent.com/assets/1118459/22443635/b3549fb4-e6e3-11e6-8ea2-6f589dc93ed3.png)
 
 For more testimonials, see [Live Projects](PROJECTS.md) and [Kudos](./KUDOS.md).
@@ -34,7 +34,7 @@ For more testimonials, see [Live Projects](PROJECTS.md) and [Kudos](./KUDOS.md).
 * [React on Rails, 2000+ 🌟 Stars](https://medium.com/shakacode/react-on-rails-2000-stars-32ff5cfacfbf#.6gmfb2gpy)
 * [The React on Rails Doctrine](https://medium.com/@railsonmaui/the-react-on-rails-doctrine-3c59a778c724)
 
-### Videos 
+### Videos
 
 1. [egghead.io: Creating a component with React on Rails](https://egghead.io/lessons/react-creating-a-component-with-react-on-rails)
 1. [egghead.io: Creating a redux component with React on Rails](https://egghead.io/lessons/react-add-redux-state-management-to-a-react-on-rails-project)
@@ -141,7 +141,7 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
   foreman start -f Procfile.dev
   ```
 
-7. Visit [localhost:3000/hello_world](http://localhost:3000/hello_world)
+7. Visit [localhost:5000/hello_world](http://localhost:5000/hello_world)
 
 ### Installation Summary
 
@@ -494,7 +494,7 @@ If you are using [jquery-ujs](https://github.com/rails/jquery-ujs) for AJAX call
 ## Integration with Node
 Node.js can be used as the backend for server-side rendering instead of [execJS](https://github.com/rails/execjs). Before you try this, consider the tradeoff of extra complexity with your deployments versus *potential* performance gains. We've found that using ExecJS with [mini_racer](https://github.com/discourse/mini_racer) to be "fast enough" so far. That being said, we've heard of other large websites using Node.js for better server rendering performance. See [Node.js for Server Rendering](docs/additional-reading/node-server-rendering.md) for more information.
 
-## Additional Documentation 
+## Additional Documentation
 **Try out our new [Documentation Gitbook](https://shakacode.gitbooks.io/react-on-rails/content/) for improved readability & reference!**
 + **Rails**
   + [Rails Assets](docs/additional-reading/rails-assets.md)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We're definitely not doing that. With react_on_rails, webpack is mainly generati
   foreman start -f Procfile.dev
   ```
 
-7. Foreman defaults to any PORT value set in the environment. If you have ```bash export PORT=3000 ``` in your dot file or ```bash .envrc ```, so you can set whatever port you would like to use. Otherwise, foreman will use ```bash port 5000 ```, and you would visit [localhost:5000/hello_world](http://localhost:5000/hello_world)
+8. Visit [localhost:5000/hello_world](http://localhost:5000/hello_world). Note, `foreman` defaults to PORT 5000 unless you set the value of PORT in your environment. For example, you can `export PORT=3000` to use the Rails default port of 3000.
 
 ### Installation Summary
 

--- a/docs/basics/generator.md
+++ b/docs/basics/generator.md
@@ -1,7 +1,6 @@
 - [Generator](#generator)
   - [Understanding the Organization of the Generated Client Code](#understanding-the-organization-of-the-generated-client-code)
   - [Redux](#redux)
-    - [Multiple React Components on a Page with One Store](#multiple-react-components-on-a-page-with-one-store)
   - [Using Images and Fonts](#using-images-and-fonts)
 
 The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating Webpack with Rails. Defaults for options are such that the default is for the flag to be off. For example, the default for `-R` is that `redux` is off, and the default of `-b` is that `skip-bootstrap` is off.
@@ -13,7 +12,9 @@ Usage:
   rails generate react_on_rails:install [options]
 
 Options:
-  -R, [--redux], [--no-redux]                          # Install Redux gems and Redux version of Hello World Example
+  -R, [--redux], [--no-redux]                      # Install Redux gems and Redux version of Hello World Example. Default: false
+  -N, [--node], [--no-node]                        # Sets up node as a server rendering option. Default: false
+      [--ignore-warnings], [--no-ignore-warnings]  # Skip warnings. Default: false
 
 Runtime options:
   -f, [--force]                    # Overwrite files that already exist
@@ -22,10 +23,36 @@ Runtime options:
   -s, [--skip], [--no-skip]        # Skip files that already exist
 
 Description:
-    Create react on rails files for install generator.
+
+The react_on_rails:install generator integrates webpack with rails with ease. You
+can pass the redux option if you'd like to have redux setup for you automatically.
+
+* Redux
+
+    Passing the --redux generator option causes the generated Hello World example
+    to integrate the Redux state container framework. The necessary node modules
+    will be automatically included for you.
+
+* Node
+
+    Passing the --node generator option sets up the necessary files for node to render the react_components.
+
+*******************************************************************************
+
+After running the generator, you will want to:
+
+    bundle && npm i
+
+Then you may run
+
+    foreman start -f Procfile.dev
+
+More Details:
+
+    `https://github.com/shakacode/react_on_rails/blob/master/docs/basics/generator.md`
 ```
 
-For a clear example of what each generator option will do, see our generator results repo: [Generator Results](https://github.com/shakacode/react_on_rails-generator-results/blob/master/README.md). Each pull request shows a git "diff" that highlights the changes that the generator has made. Another good option is to create a simple test app per the [Tutorial](docs/tutorial.md).
+Another good option is to create a simple test app per the [Tutorial](docs/tutorial.md).
 
 ### Understanding the Organization of the Generated Client Code
 The generated client code follows our organization scheme. Each unique set of functionality, is given its own folder inside of `client/app/bundles`. This encourages for modularity of *domains*.


### PR DESCRIPTION
Hi, the initial 8 steps for the react_on_rails installation, setup, and hello_world example, it lists localhost 3000 for the server. Foreman uses localhost 5000, and I thought it would be easier for devs that may not know this if it were included in the Readme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/713)
<!-- Reviewable:end -->
