### PR TITLE
Expanded .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,13 @@ spec/dummy/client/npm-debug.log*
 
 /gen-examples
 
+# OS Files
 .DS_Store
+._.DS_Store
+.directory
+
+# Text-editor/IDE generated files
+*.sublime-workspace
+*.sublime-project
+/.idea
+*.iml


### PR DESCRIPTION
* Expanded `.gitignore` to include more OS Files and various IDE files. In detail, these have been added:
  * `._.DS_Store` - an additional HFS+ file that OS X could potentially generate
  * `.directory` - custom folder settings in KDE's Dolphin file browser
  * `.sublime-workspace` - stores the state of a Sublime window (open files, modifications, etc)
  * `.sublime-project` - folders added to an open Sublime window/project
  * `/.idea` - IntelliJ IDEA/RubyMine project settings
  * `.iml`- module information for IntelliJ IDEA/RubyMine projects

I figured this might be helpful in keeping bogus artifacts out of folk's PRs, as the open source community uses a wide variety of desktops, IDEs and configurations..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/719)
<!-- Reviewable:end -->
