### PR TITLE
Fix spec failing due to duplicate component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 ### Fixed
 - Upgrade Rails to 4.2.8 to fix security vulnerabilities in 4.2.5. [#735](https://github.com/shakacode/react_on_rails/pull/735) by [hrishimittal](https://github.com/hrishimittal).
 
+### Fixed
+- Fix spec failing due to duplicate component. [#734](https://github.com/shakacode/react_on_rails/pull/734) by [hrishimittal](https://github.com/hrishimittal).
 
 ## [6.6.0] - 2017-02-18
 ### Added

--- a/spec/dummy/app/views/pages/index.html.erb
+++ b/spec/dummy/app/views/pages/index.html.erb
@@ -79,10 +79,10 @@ This page demonstrates a few things the other pages do not show:
 
 <h1>Simple Component Without Redux</h1>
 <pre>
-  <%%= react_component("HelloWorld", props: @app_props_hello, prerender: false, trace: true, id: "HelloWorld-react-component-4") %>
+  <%%= react_component("HelloWorld", props: @app_props_hello, prerender: false, trace: true, id: "HelloWorld-react-component-5") %>
   <%%= react_component("HelloES5", props: @app_props_hello, prerender: false, trace: true, id: "HelloES5-react-component-5") %>
 </pre>
-<%= react_component("HelloWorld", props: @app_props_hello, prerender: false, trace: true, id: "HelloWorld-react-component-4") %>
+<%= react_component("HelloWorld", props: @app_props_hello, prerender: false, trace: true, id: "HelloWorld-react-component-5") %>
 <%= react_component("HelloWorldES5", props: @app_props_hello, prerender: false, trace: true, id: "HelloWorldES5-react-component-5") %>
 <hr/>
 

--- a/spec/dummy/spec/features/integration_spec.rb
+++ b/spec/dummy/spec/features/integration_spec.rb
@@ -44,7 +44,7 @@ feature "Pages/Index", :js do
     end
 
     context "Simple Component Without Redux" do
-      include_examples "React Component", "div#HelloWorld-react-component-4"
+      include_examples "React Component", "div#HelloWorld-react-component-5"
       include_examples "React Component", "div#HelloWorldES5-react-component-5"
     end
 


### PR DESCRIPTION
On running `rake`, the following spec fails:

```
  1) Pages/Index All in one page Simple Component Without Redux changes name in message according to input
     Failure/Error:
       within(dom_selector) do
         find("input").set new_text
         within("h3") do
           is_expected.to have_content new_text
         end
       end

     Capybara::Ambiguous:
       Ambiguous match, found 2 elements matching css "div#HelloWorld-react-component-4"
     Shared Example Group: "React Component" called from ./spec/features/integration_spec.rb:47
```

The reason is a duplicate component with the id `HelloWorld-react-component-4` in `pages/index.html.erb`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/734)
<!-- Reviewable:end -->
