### PR TITLE
Update CONTRIBUTING.md and related files

### DIFF
--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -73,7 +73,7 @@
     "build:dev:server": "webpack -w --config webpack.server.rails.build.config.js",
     "build:server": "webpack --config webpack.server.rails.build.config.js",
     "hot-assets": "babel-node server-rails-hot.js",
-    "install-react-on-rails": "yarn add 'file:../../..'"
+    "install-react-on-rails": "npm i --save 'file:../../..'"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
- Explicitly lists the locations to run commands when setting up the gem for local development.
- Fixes an issue where `yarn install-react-on-rails` command used `yarn` instead of `yarn add` and failed to exectute.

Closes #736

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/737)
<!-- Reviewable:end -->
