### PR TITLE
Add missing listen gem

### DIFF
--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
   gem "rubocop", require: false
   gem "ruby-lint", require: false
   gem "scss_lint", require: false
+  gem "listen"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -116,6 +116,10 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (5.3.332.38.3)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -191,6 +195,9 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.1)
     rake (12.0.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
+      ffi (>= 0.5.0)
     rdoc (4.3.0)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
@@ -221,6 +228,7 @@ GEM
       parser (~> 2.2)
       slop (~> 3.4, >= 3.4.7)
     ruby-progressbar (1.8.1)
+    ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -291,6 +299,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy
+  listen
   mini_racer
   poltergeist
   pry
@@ -317,4 +326,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.14.5
+   1.14.6


### PR DESCRIPTION
The `listen` gem is needed for rails 5 apps when using the file watcher [here.](https://github.com/shakacode/react_on_rails/blob/f42e8f47af7a6b7e0f7b55d4563b236a86aba4a3/spec/dummy/config/environments/development.rb#L53)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/761)
<!-- Reviewable:end -->
