### PR TITLE
Fix reloading of dummy procfile assets

### DIFF
--- a/spec/dummy/Procfile
+++ b/spec/dummy/Procfile
@@ -1,7 +1,1 @@
-rails: REACT_ON_RAILS_ENV=HOT rails s -b 0.0.0.0
-
-# Build client assets, watching for changes.
-rails-client-assets: rm app/assets/webpack/* || true && npm run build:dev:client
-
-# Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: npm run build:dev:server
+web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
- The `spec/dummy` `Procfile` has the hot reloading environment variable set yet loads static assets.
- Webpack assets need to be recursively removed as they have folders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/762)
<!-- Reviewable:end -->
