### PR TITLE
Fix turbolinks mount event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [Unreleased]
 *Please add entries here for your pull requests.*
+
+### Fixed
+- Fixed error "The node you're attempting to unmount was rendered by another copy of React." [#706](https://github.com/shakacode/react_on_rails/issues/706) when navigating to cached page using Turbolinks  [#763](https://github.com/shakacode/react_on_rails/pull/763) by [szyablitsky](https://github.com/szyablitsky).
+
 ## [6.8.0] - 2017-03-06
 ## Added
 - Converted to Webpack v2 for generators, tests, and all example code. [#742](https://github.com/shakacode/react_on_rails/pull/742) by [justin808](https://github.com/justin808).
@@ -29,7 +33,7 @@ Commenting out this line addresses the issue:
 
 ```
 config.i18n_dir = Rails.root.join("client", "app", "libs", "i18n")
-``` 
+```
 
 ### Added
 - Allow using rake task to generate javascript locale files. The test helper automatically creates the localization files when needed. [#717](https://github.com/shakacode/react_on_rails/pull/717) by [JasonYCHuang](https://github.com/JasonYCHuang).

--- a/docs/additional-reading/turbolinks.md
+++ b/docs/additional-reading/turbolinks.md
@@ -94,7 +94,7 @@ TURBO: reactOnRailsPageLoaded
 
 Turbolinks 5:
 ```
-TURBO: WITH TURBOLINKS 5: document turbolinks:before-render and turbolinks:load handlers installed. (program)
+TURBO: WITH TURBOLINKS 5: document turbolinks:before-render and turbolinks:render handlers installed. (program)
 TURBO: reactOnRailsPageLoaded
 ```
 

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -183,9 +183,9 @@ export function clientStartup(context) {
       if (turbolinksVersion5()) {
         debugTurbolinks(
           'USING TURBOLINKS 5: document added event listeners ' +
-          'turbolinks:before-render and turbolinks:load.');
+          'turbolinks:before-render and turbolinks:render.');
         document.addEventListener('turbolinks:before-render', reactOnRailsPageUnloaded);
-        document.addEventListener('turbolinks:load', reactOnRailsPageLoaded);
+        document.addEventListener('turbolinks:render', reactOnRailsPageLoaded);
       } else {
         debugTurbolinks(
           'USING TURBOLINKS 2: document added event listeners page:before-unload and ' +
@@ -197,7 +197,7 @@ export function clientStartup(context) {
       debugTurbolinks(
         'NOT USING TURBOLINKS: DOMContentLoaded event, calling reactOnRailsPageLoaded',
       );
-      reactOnRailsPageLoaded();
     }
+    reactOnRailsPageLoaded();
   });
 }

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -186,6 +186,7 @@ export function clientStartup(context) {
           'turbolinks:before-render and turbolinks:render.');
         document.addEventListener('turbolinks:before-render', reactOnRailsPageUnloaded);
         document.addEventListener('turbolinks:render', reactOnRailsPageLoaded);
+        reactOnRailsPageLoaded();
       } else {
         debugTurbolinks(
           'USING TURBOLINKS 2: document added event listeners page:before-unload and ' +
@@ -197,7 +198,7 @@ export function clientStartup(context) {
       debugTurbolinks(
         'NOT USING TURBOLINKS: DOMContentLoaded event, calling reactOnRailsPageLoaded',
       );
+      reactOnRailsPageLoaded();
     }
-    reactOnRailsPageLoaded();
   });
 }


### PR DESCRIPTION
This change fixes "The node you're attempting to unmount was rendered by another copy of React." error when navigating to cached page using Turbolinks.

More info can be found at https://github.com/renchap/webpacker-react/pull/14#issuecomment-282500093 and https://sevos.io/2017/02/27/turbolinks-lifecycle-explained.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/764)
<!-- Reviewable:end -->
