### PR TITLE
i18n_yml_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
+*Please add entries here for your pull requests.*
 Add option to specify i18n_yml_dir in order to include only subset of locale files when generating translations.js & default.js for react-intl
 
 ## [6.8.2] - 2017-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ### Added
 - Add option to specify i18n_yml_dir in order to include only subset of locale files when generating translations.js & default.js for react-intl
-[#777](https://github.com/shakacode/react_on_rails/pull/777) by [danijel](https://github.com/danijel)
+[#777](https://github.com/shakacode/react_on_rails/pull/777) by [danijel](https://github.com/danijel).
 
 ## [6.8.2] - 2017-03-24
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ### Added
 - Add option to specify i18n_yml_dir in order to include only subset of locale files when generating translations.js & default.js for react-intl
+[#777](https://github.com/shakacode/react_on_rails/pull/777) by [danijel](https://github.com/danijel)
 
 ## [6.8.2] - 2017-03-24
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 
 ## [Unreleased]
 *Please add entries here for your pull requests.*
-Add option to specify i18n_yml_dir in order to include only subset of locale files when generating translations.js & default.js for react-intl
+
+### Added
+- Add option to specify i18n_yml_dir in order to include only subset of locale files when generating translations.js & default.js for react-intl
 
 ## [6.8.2] - 2017-03-24
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
-*Please add entries here for your pull requests.*
+Add option to specify i18n_yml_dir in order to include only subset of locale files when generating translations.js & default.js for react-intl
 
 ## [6.8.2] - 2017-03-24
 ## Fixed

--- a/docs/basics/i18n.md
+++ b/docs/basics/i18n.md
@@ -27,7 +27,7 @@ You can refer to [react-webpack-rails-tutorial](https://github.com/shakacode/rea
   Optionally you can also set `config.i18n_yml_dir` if you do not what to use all the locale files from rails.
   ```ruby
   # Replace the following line to the location where you keep your client i18n yml files
-  config.i18n_dir = Rails.root.join("PATH_TO", "YOUR_YAML_I18N_FOLDER")
+  config.i18n_yml_dir = Rails.root.join("PATH_TO", "YOUR_YAML_I18N_FOLDER")
   ```
 
   `translations.js`: All your locales in json format.

--- a/docs/basics/i18n.md
+++ b/docs/basics/i18n.md
@@ -16,7 +16,7 @@ You can refer to [react-webpack-rails-tutorial](https://github.com/shakacode/rea
   ```
 
 2. Add `config.i18n_dir` in `config/initializers/react_on_rails.rb`
-  
+
   `react-intl` requires locale files in json format. React on Rails will generate `translations.js` & `default.js` automatically after you configured your `config.i18n_dir` in `config/initializers/react_on_rails.rb`.
 
   ```ruby
@@ -27,6 +27,7 @@ You can refer to [react-webpack-rails-tutorial](https://github.com/shakacode/rea
   Optionally you can also set `config.i18n_yml_dir` if you do not what to use all the locale files from rails.
   ```ruby
   # Replace the following line to the location where you keep your client i18n yml files
+  # By default(without this option), all yaml files from Rails.root.join("config", "locales") and installed gems are loaded
   config.i18n_yml_dir = Rails.root.join("PATH_TO", "YOUR_YAML_I18N_FOLDER")
   ```
 
@@ -34,9 +35,9 @@ You can refer to [react-webpack-rails-tutorial](https://github.com/shakacode/rea
   `default.js`: Default settings in json format.
 
 3. Add `translations.js` and `default.js` to your `.gitignore` and `.eslintignore`.
-  
-4. Javascript locale files must be generated before `yarn build`. 
-  
+
+4. Javascript locale files must be generated before `yarn build`.
+
   Once you setup `config.i18n_dir` as in the previous step, react_on_rails will automatically do this for testing (if using the `ReactOnRails::TestHelper.configure_rspec_to_compile_assets` and for production deployments if using the [default precompile rake hook](../additional-reading/heroku-deployment.md). For development, you should adjust your startup scripts (Procfiles) so that they run `bundle exec rake react_on_rails:locale` before running any webpack watch process (`yarn run build:development`).
 
 5. In React, you need to initialize `react-intl`, and set parameters for it.

--- a/docs/basics/i18n.md
+++ b/docs/basics/i18n.md
@@ -23,7 +23,13 @@ You can refer to [react-webpack-rails-tutorial](https://github.com/shakacode/rea
   # Replace the following line to the location where you keep translation.js & default.js.
   config.i18n_dir = Rails.root.join("PATH_TO", "YOUR_JS_I18N_FOLDER")
   ```
-  
+
+  Optionally you can also set `config.i18n_yml_dir` if you do not what to use all the locale files from rails.
+  ```ruby
+  # Replace the following line to the location where you keep your client i18n yml files
+  config.i18n_dir = Rails.root.join("PATH_TO", "YOUR_YAML_I18N_FOLDER")
+  ```
+
   `translations.js`: All your locales in json format.
   `default.js`: Default settings in json format.
 

--- a/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
+++ b/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
@@ -65,6 +65,10 @@ ReactOnRails.configure do |config|
   # Replace the following line to the location where you keep translation.js & default.js for use
   # by the npm packages react-intl. Be sure this directory exists!
   # config.i18n_dir = Rails.root.join("client", "app", "libs", "i18n")
+  #
+  # Replace the following line to the location where you keep your client i18n yml files
+  # that will source for automatic generation on translations.js & default.js
+  # config.i18n_yml_dir = Rails.root.join("config", "locales", "client")
 
   ################################################################################
   # MISCELLANEOUS OPTIONS

--- a/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
+++ b/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
@@ -68,6 +68,7 @@ ReactOnRails.configure do |config|
   #
   # Replace the following line to the location where you keep your client i18n yml files
   # that will source for automatic generation on translations.js & default.js
+  # By default(without this option) all yaml files from Rails.root.join("config", "locales") and installed gems are loaded
   # config.i18n_yml_dir = Rails.root.join("config", "locales", "client")
 
   ################################################################################

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -12,6 +12,7 @@ module ReactOnRails
     ensure_generated_assets_dir_present
     ensure_server_bundle_js_file_has_no_path
     check_i18n_directory_exists
+    check_i18n_yml_directory_exists
   end
 
   def self.check_i18n_directory_exists
@@ -21,6 +22,15 @@ module ReactOnRails
     raise "Error configuring /config/react_on_rails.rb: invalid value for `config.i18n_dir`. "\
         "Directory does not exist: #{@configuration.i18n_dir}. Set to value to nil or comment it "\
         "out if not using this i18n with React on Rails."
+  end
+
+  def self.check_i18n_yml_directory_exists
+    return unless @configuration.i18n_yml_dir.present?
+    return if Dir.exist?(@configuration.i18n_yml_dir)
+
+    raise "Error configuring /config/react_on_rails.rb: invalid value for `config.i18n_yml_dir`. "\
+        "Directory does not exist: #{@configuration.i18n_yml_dir}. Set to value to nil or comment it "\
+        "out if not using this i18n with React on Rails, or if you want to use all translation files."
   end
 
   def self.ensure_generated_assets_dir_present
@@ -83,6 +93,7 @@ module ReactOnRails
       symlink_non_digested_assets_regex: /\.(png|jpg|jpeg|gif|tiff|woff|ttf|eot|svg|map)/,
       npm_build_test_command: "",
       i18n_dir: "",
+      i18n_yml_dir: "",
       npm_build_production_command: ""
     )
   end
@@ -95,7 +106,7 @@ module ReactOnRails
                   :skip_display_none, :generated_assets_dirs, :generated_assets_dir,
                   :webpack_generated_files, :rendering_extension, :npm_build_test_command,
                   :npm_build_production_command,
-                  :i18n_dir,
+                  :i18n_dir, :i18n_yml_dir,
                   :server_render_method, :symlink_non_digested_assets_regex
 
     def initialize(server_bundle_js_file: nil, prerender: nil, replay_console: nil,
@@ -106,7 +117,7 @@ module ReactOnRails
                    generated_assets_dir: nil, webpack_generated_files: nil,
                    rendering_extension: nil, npm_build_test_command: nil,
                    npm_build_production_command: nil,
-                   i18n_dir: nil,
+                   i18n_dir: nil, i18n_yml_dir: nil,
                    server_render_method: nil, symlink_non_digested_assets_regex: nil)
       self.server_bundle_js_file = server_bundle_js_file
       self.generated_assets_dirs = generated_assets_dirs
@@ -114,6 +125,7 @@ module ReactOnRails
       self.npm_build_test_command = npm_build_test_command
       self.npm_build_production_command = npm_build_production_command
       self.i18n_dir = i18n_dir
+      self.i18n_yml_dir = i18n_yml_dir
 
       self.prerender = prerender
       self.replay_console = replay_console

--- a/lib/react_on_rails/locales_to_js.rb
+++ b/lib/react_on_rails/locales_to_js.rb
@@ -39,12 +39,21 @@ module ReactOnRails
     end
 
     def locale_files
-      @locale_files ||=
-        (Rails.application && Rails.application.config.i18n.load_path).presence
+      @locale_files ||= begin
+        if i18n_yml_dir.present?
+          Dir["#{i18n_yml_dir}/**/*.yml"]
+        else
+          (Rails.application && Rails.application.config.i18n.load_path).presence
+        end
+      end
     end
 
     def i18n_dir
       @i18n_dir ||= ReactOnRails.configuration.i18n_dir
+    end
+
+    def i18n_yml_dir
+      @i18n_yml_dir ||= ReactOnRails.configuration.i18n_yml_dir
     end
 
     def default_locale

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -77,6 +77,10 @@ ReactOnRails.configure do |config|
   # Replace the following line to the location where you keep translation.js & default.js for use
   # by the npm packages react-intl. Be sure this directory exists!
   # config.i18n_dir = Rails.root.join("client", "app", "libs", "i18n")
+  #
+  # Replace the following line to the location where you keep your client i18n yml files
+  # that will source for automatic generation on translations.js & default.js
+  # config.i18n_yml_dir = Rails.root.join("config", "locales", "client")
 
   ################################################################################
   # MISCELLANEOUS OPTIONS

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -21,6 +21,25 @@ module ReactOnRails
       expect(ReactOnRails.configuration.i18n_dir).to eq(dir)
     end
 
+    it "raises if the i18n yaml directory does not exist" do
+      junk_name = "/YYYY/junkYYYY"
+      expect do
+        ReactOnRails.configure do |config|
+          config.i18n_yml_dir = junk_name
+        end
+      end.to raise_error(/#{junk_name}/)
+    end
+
+    it "does not raises if the i18n yaml directory does exist" do
+      dir = File.expand_path(File.dirname(__FILE__))
+      expect do
+        ReactOnRails.configure do |config|
+          config.i18n_yml_dir = dir
+        end
+      end.to_not raise_error
+      expect(ReactOnRails.configuration.i18n_yml_dir).to eq(dir)
+    end
+
     it "be able to config default configuration of the gem" do
       ReactOnRails.configure do |config|
         config.server_bundle_js_file = "server.js"

--- a/spec/react_on_rails/locales_to_js_spec.rb
+++ b/spec/react_on_rails/locales_to_js_spec.rb
@@ -4,57 +4,88 @@ require "tmpdir"
 module ReactOnRails
   RSpec.describe LocalesToJs do
     let(:i18n_dir) { Pathname.new(Dir.mktmpdir) }
-    let(:locale_dir) { File.expand_path("../fixtures/i18n/locales", __FILE__) }
     let(:translations_path) { "#{i18n_dir}/translations.js" }
     let(:default_path) { "#{i18n_dir}/default.js" }
-    let(:en_path) { "#{locale_dir}/en.yml" }
 
-    before do
-      allow_any_instance_of(ReactOnRails::LocalesToJs).to receive(:locale_files).and_return(Dir["#{locale_dir}/*"])
-      ReactOnRails.configure do |config|
-        config.i18n_dir = i18n_dir
+    shared_examples "locale to js" do
+      context "with obsolete js files" do
+        before do
+          FileUtils.touch(translations_path, mtime: Time.now - 1.year)
+          FileUtils.touch(en_path, mtime: Time.now - 1.month)
+        end
+
+        it "updates files" do
+          ReactOnRails::LocalesToJs.new
+
+          translations = File.read(translations_path)
+          default = File.read(default_path)
+          expect(translations).to include('{"hello":"Hello world"')
+          expect(translations).to include('{"hello":"Hallo welt"')
+          expect(default).to include("const defaultLocale = 'en';")
+          expect(default).to include('{"hello":{"id":"hello","defaultMessage":"Hello world"}}')
+
+          expect(File.mtime(translations_path)).to be >= File.mtime(en_path)
+        end
+      end
+
+      context "with up-to-date js files" do
+        before do
+          ReactOnRails::LocalesToJs.new
+        end
+
+        it "doesn't update files" do
+          ref_time = Time.now - 1.minute
+          FileUtils.touch(translations_path, mtime: ref_time)
+
+          update_time = Time.now
+          ReactOnRails::LocalesToJs.new
+          expect(update_time).to be > File.mtime(translations_path)
+        end
       end
     end
 
-    after do
-      ReactOnRails.configure do |config|
-        config.i18n_dir = nil
-      end
-    end
+    describe "without i18n_yml_dir" do
+      let(:locale_dir) { File.expand_path("../fixtures/i18n/locales", __FILE__) }
+      let(:en_path) { "#{locale_dir}/en.yml" }
 
-    context "with obsolete js files" do
       before do
-        FileUtils.touch(translations_path, mtime: Time.now - 1.year)
-        FileUtils.touch(en_path, mtime: Time.now - 1.month)
+        allow_any_instance_of(ReactOnRails::LocalesToJs).to receive(:locale_files).and_return(Dir["#{locale_dir}/*"])
+        ReactOnRails.configure do |config|
+          config.i18n_dir = i18n_dir
+        end
       end
 
-      it "updates files" do
-        ReactOnRails::LocalesToJs.new
-
-        translations = File.read(translations_path)
-        default = File.read(default_path)
-        expect(translations).to include('{"hello":"Hello world"')
-        expect(translations).to include('{"hello":"Hallo welt"')
-        expect(default).to include("const defaultLocale = 'en';")
-        expect(default).to include('{"hello":{"id":"hello","defaultMessage":"Hello world"}}')
-
-        expect(File.mtime(translations_path)).to be >= File.mtime(en_path)
+      after do
+        ReactOnRails.configure do |config|
+          config.i18n_dir = nil
+        end
       end
+
+      it_behaves_like "locale to js"
+
     end
 
-    context "with up-to-date js files" do
+    describe "with i18n_yml_dir" do
+      let(:locale_dir) { File.expand_path("../fixtures/i18n/locales", __FILE__) }
+      let(:en_path) { "#{locale_dir}/en.yml" }
+
       before do
-        ReactOnRails::LocalesToJs.new
+        ReactOnRails.configure do |config|
+          config.i18n_dir = i18n_dir
+          config.i18n_yml_dir = locale_dir
+        end
       end
 
-      it "doesn't update files" do
-        ref_time = Time.now - 1.minute
-        FileUtils.touch(translations_path, mtime: ref_time)
-
-        update_time = Time.now
-        ReactOnRails::LocalesToJs.new
-        expect(update_time).to be > File.mtime(translations_path)
+      after do
+        ReactOnRails.configure do |config|
+          config.i18n_dir = nil
+          config.i18n_yml_dir = nil
+        end
       end
+
+      it_behaves_like "locale to js"
+
     end
+
   end
 end

--- a/spec/react_on_rails/locales_to_js_spec.rb
+++ b/spec/react_on_rails/locales_to_js_spec.rb
@@ -62,7 +62,6 @@ module ReactOnRails
       end
 
       it_behaves_like "locale to js"
-
     end
 
     describe "with i18n_yml_dir" do
@@ -84,8 +83,6 @@ module ReactOnRails
       end
 
       it_behaves_like "locale to js"
-
     end
-
   end
 end


### PR DESCRIPTION
The purpose of this PR is to add option to specify directory from where to load locale files for auto generating translations.js and default.js.

I have a rather big rails app and I don't want all the locales from rails i18n load path in my translations.js, for example I don't want rails_admin or kaminari, or other rails views stuff in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/777)
<!-- Reviewable:end -->
