### PR TITLE
Fix issue with release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
-*Please add entries here for your pull requests.*
+## Fixed
+- Fixed error in the release script [#767](https://github.com/shakacode/react_on_rails/issues/767) by [isolo](https://github.com/isolo).
 
 ## [6.8.2] - 2017-03-24
 ## Fixed

--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,6 @@ task default: tasks
 
 desc "All actions but no examples, good for local developer run."
 task all_but_examples: ["run_rspec:all_but_examples", "lint"]
+
+require "bundler/gem_tasks"
+Rake::Task["release"].clear

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,3 @@ task default: tasks
 
 desc "All actions but no examples, good for local developer run."
 task all_but_examples: ["run_rspec:all_but_examples", "lint"]
-
-require "bundler/gem_tasks"
-Rake::Task["release"].clear

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -43,6 +43,8 @@ task :release, [:gem_version, :dry_run, :tools_install] do |_t, args|
 
   # Having the examples prevents publishing
   Rake::Task["examples:clobber"].invoke
+  # Delete any react_on_rails.gemspec except the root one
+  sh_in_dir(gem_root, "find . -mindepth 2 -name 'react_on_rails.gemspec' -delete")
 
   # See https://github.com/svenfuchs/gem-release
   sh_in_dir(gem_root, "git pull --rebase")

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -61,5 +61,8 @@ task :release, [:gem_version, :dry_run, :tools_install] do |_t, args|
   sh_in_dir(gem_root, release_it_command)
 
   # Release the new gem version
-  sh_in_dir(gem_root, "gem release") unless is_dry_run
+  unless is_dry_run
+    Rake::Task["build"].invoke
+    Rake::Task["release:rubygem_push"].invoke
+  end
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -61,8 +61,5 @@ task :release, [:gem_version, :dry_run, :tools_install] do |_t, args|
   sh_in_dir(gem_root, release_it_command)
 
   # Release the new gem version
-  unless is_dry_run
-    Rake::Task["build"].invoke
-    Rake::Task["release:rubygem_push"].invoke
-  end
+  sh_in_dir(gem_root, "gem release") unless is_dry_run
 end


### PR DESCRIPTION
Instead of gem-release's **release** command, I use **build** and **release:rubygems_push** from bundler/gem_tasks. 
Default release command of bundler consists of [the four following commands](https://github.com/bundler/bundler/blob/master/lib/bundler/gem_helper.rb#L55): 
- **build**
- **release:guard_clean**
- **release:source_control_push**
- **release:rubygem_push**

We already have implementation of "**release:guard_clean**" (checks if there is uncommitted changes) and "**release:source_control_push**" (pushes tags to vcs). I thought we have more flexibility with the current implementation, so I just replaced '**release**' command of gem-release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/778)
<!-- Reviewable:end -->
