### PR TITLE
Adding Documentation About Deploying to Elastic Beanstalk with Yarn

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,6 +31,7 @@
   + [Generator Tips](./docs/basics/generator.md)
   + [Hot Reloading of Assets For Rails Development](./docs/additional-reading/hot-reloading-rails-development.md)
   + [Heroku Deployment](./docs/additional-reading/heroku-deployment.md)
+  + [Elastic Beanstalk Deployment](./docs/additional-reading/elastic-beanstalk.md)
   + [Updating Dependencies](./docs/additional-reading/updating-dependencies.md)
 
 ### **API**

--- a/docs/additional-reading/elastic-beanstalk.md
+++ b/docs/additional-reading/elastic-beanstalk.md
@@ -1,0 +1,33 @@
+# Deploying React on Rails to Elastic Beanstalk
+
+In order to deploy a React on Rails app to elastic beanstalk, you must install yarn on each instance.  
+If yarn is not installed, asset compilation will fail on the elastic beanstalk instance.
+
+You can install yarn by adding a `yarn.config` file to your `.ebextensions` folder which contains these commands.
+
+```
+
+commands:
+
+  01_node_get:
+    cwd: /tmp
+    command: 'sudo curl --silent --location https://rpm.nodesource.com/setup_6.x | sudo bash -'
+
+  02_node_install:
+    cwd: /tmp
+    command: 'sudo yum -y install nodejs'
+
+  03_yarn_get:
+    cwd: /tmp
+    # don't run the command if yarn is already installed (file /usr/bin/yarn exists)
+    test: '[ ! -f /usr/bin/yarn ] && echo "yarn not installed"'
+    command: 'sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo'
+
+
+  04_yarn_install:
+    cwd: /tmp
+    test: '[ ! -f /usr/bin/yarn ] && echo "yarn not installed"'
+    command: 'sudo yum -y install yarn'
+
+```
+

--- a/docs/additional-reading/elastic-beanstalk.md
+++ b/docs/additional-reading/elastic-beanstalk.md
@@ -1,12 +1,11 @@
 # Deploying React on Rails to Elastic Beanstalk
 
-In order to deploy a React on Rails app to elastic beanstalk, you must install yarn on each instance.  
+In order to deploy a React on Rails app to elastic beanstalk, you must install yarn on each instance.
 If yarn is not installed, asset compilation will fail on the elastic beanstalk instance.
 
 You can install yarn by adding a `yarn.config` file to your `.ebextensions` folder which contains these commands.
 
 ```
-
 commands:
 
   01_node_get:
@@ -22,7 +21,6 @@ commands:
     # don't run the command if yarn is already installed (file /usr/bin/yarn exists)
     test: '[ ! -f /usr/bin/yarn ] && echo "yarn not installed"'
     command: 'sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo'
-
 
   04_yarn_install:
     cwd: /tmp


### PR DESCRIPTION
When the yarn dependency was introduced, it made asset precompilation on elastic beanstalk fail, since elastic beanstalk does not have yarn installed by default.   Added a sample .ebextensions file which installs yarn and resolves the dependency issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/790)
<!-- Reviewable:end -->
