### PR TITLE
Don't call to_json on string props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
+## [6.9.3] - 2017-04-03
+
+### Fixed
+- Removed call of to_json on strings when formatting props. [#791](https://github.com/shakacode/react_on_rails/pull/791) by [justin808](https://github.com/justin808)
 
 ## [6.9.2] - 2017-04-02
 
@@ -518,7 +522,8 @@ Best done with Object destructing:
 ##### Fixed
 - Fix several generator related issues.
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/6.9.2...master
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/6.9.3...master
+[6.9.3]: https://github.com/shakacode/react_on_rails/compare/6.9.1...6.9.3
 [6.9.2]: https://github.com/shakacode/react_on_rails/compare/6.9.1...6.9.2
 [6.9.1]: https://github.com/shakacode/react_on_rails/compare/6.8.2...6.9.1
 [6.9.0]: https://github.com/shakacode/react_on_rails/compare/6.8.2...6.9.0

--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -234,7 +234,11 @@ module ReactOnRailsHelper
     #
     # Temp fix given that a hash may contain active record objects and that crashed with the new
     # code to JSON.pretty_generate
-    ERB::Util.json_escape(hash_or_string.to_json)
+
+    # If to_json is called on a String, then the quotes are escaped.
+    json_value = hash_or_string.is_a?(String) ? hash_or_string : hash_or_string.to_json
+
+    ERB::Util.json_escape(json_value)
     # end
   end
 


### PR DESCRIPTION
This bit of debugging shows the issue.

```
[1] (pry) #<#<Class:0x007f84e5bd19f8>>: 0> puts hash_or_string.to_json
"{\"comments\":[{\"id\":9,\"author\":\"xxx\",\"text\":\"xxxxxx\",\"created_at\":\"2017-01-11T08:14:10.296Z\",

[2] (pry) #<#<Class:0x007f84e5bd19f8>>: 0> puts hash_or_string
{"comments":[{"id":9,"author":"xxx","text":"xxxxxx","created_at":"2017-01-11T08:14:10.296Z",
```

We'll get the proper tests in #787.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/791)
<!-- Reviewable:end -->
