### PR TITLE
add additional steps that will allow yarn the permissions to write to…

### DIFF
--- a/docs/additional-reading/elastic-beanstalk.md
+++ b/docs/additional-reading/elastic-beanstalk.md
@@ -26,6 +26,18 @@ commands:
     cwd: /tmp
     test: '[ ! -f /usr/bin/yarn ] && echo "yarn not installed"'
     command: 'sudo yum -y install yarn'
+    
+  05_mkdir_webapp_dir:
+    command: mkdir /home/webapp
+    ignoreErrors: true
+    
+  06_chown_webapp_dir:
+    command: chown webapp:webapp /home/webapp
+    ignoreErrors: true
+    
+  07_chmod_webapp_dir:
+    command: chmod 700 /home/webapp
+    ignoreErrors: true
 
 ```
 


### PR DESCRIPTION
… /home/webapp during asset compilation

Asset compilation will still fail after adding this ebextension in the way mentioned in this blog post:

http://tech.nickserra.com/2016/11/15/npm-install-error-eacces-permission-denied-mkdir-homewebapp/

the additional .ebextensions commands create a directory with the correct permissions to allow yarn to write to it later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/794)
<!-- Reviewable:end -->
