### PR TITLE
use json string

### DIFF
--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -306,7 +306,7 @@ module ReactOnRailsHelper
     # If to_json is called on a String, then the quotes are escaped.
     json_value = hash_or_string.is_a?(String) ? hash_or_string : hash_or_string.to_json
 
-    ERB::Util.json_escape(json_value)
+    # ERB::Util.json_escape(json_value)
     # end
   end
 

--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -304,7 +304,7 @@ module ReactOnRailsHelper
     # code to JSON.pretty_generate
 
     # If to_json is called on a String, then the quotes are escaped.
-    json_value = hash_or_string.is_a?(String) ? hash_or_string : hash_or_string.to_json
+    hash_or_string.is_a?(String) ? hash_or_string : hash_or_string.to_json
 
     # ERB::Util.json_escape(json_value)
     # end

--- a/lib/react_on_rails/version.rb
+++ b/lib/react_on_rails/version.rb
@@ -1,3 +1,3 @@
 module ReactOnRails
-  VERSION = "6.10.0".freeze
+  VERSION = "6.9.3".freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "6.10.0",
+  "version": "6.9.3",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "node_package/lib/ReactOnRails.js",
   "directories": {

--- a/react_on_rails.gemspec
+++ b/react_on_rails.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rainbow", "~> 2.1"
   s.add_dependency "rails", ">= 3.2"
   s.add_dependency "addressable"
+  s.add_dependency "activesupport", ">= 4.1.2"
 
   s.add_development_dependency "bundler", "~> 1.10"
   s.add_development_dependency "rake", "~> 10.0"

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    react_on_rails (6.10.0)
+    react_on_rails (6.9.3)
       addressable
       connection_pool
       execjs (~> 2.5)


### PR DESCRIPTION
Fix rails context funneling.

This is due to the change to use `script` tag instead of `data` attribute in the `div` node to feed rails context to react component, which result in something like this.

```HTML
<script id="js-react-on-rails-context" type="application/json">{inMailer:false,i18nLocale:en,i18nDefaultLocale:en,href:http://admin.admin.localhost:3000/orders/pos,location:/orders/pos,scheme:http,host:admin.admin.localhost,port:3000,pathname:/orders/pos,search:null,httpAcceptLanguage:en-US,en;q=0.8,zh-CN;q=0.6,zh;q=0.4,zh-TW;q=0.2,serverSide:false}</script>
```

So when `parseRailsContext` try to parse the json string, the format is invalid. In this situation, the valid string should be what we get after calling `to_json` on the string.

**FYI**

The last working version I refer to was 6.1.1, which was used by my coworker in her PR.

It funnels the rails context like this:

```HTML
<div data-rails-context="{&quot;inMailer&quot;:false,&quot;i18nLocale&quot;:&quot;en&quot;,&quot;i18nDefaultLocale&quot;:&quot;en&quot;,&quot;href&quot;:&quot;http://localhost:4000/hello_world&quot;,&quot;location&quot;:&quot;/hello_world&quot;,&quot;scheme&quot;:&quot;http&quot;,&quot;host&quot;:&quot;localhost&quot;,&quot;port&quot;:4000,&quot;pathname&quot;:&quot;/hello_world&quot;,&quot;search&quot;:null,&quot;httpAcceptLanguage&quot;:&quot;en-US,en;q=0.8,zh-CN;q=0.6,zh;q=0.4,zh-TW;q=0.2&quot;,&quot;serverSide&quot;:false}" id="js-react-on-rails-context" style="display:none"></div>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/816)
<!-- Reviewable:end -->
