### PR TITLE
Raise if versions differ and fix performance regression for string props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Change Log
-All notable changes to this project's source code will be documented in this file. Items under `Unreleased` is upcoming features that will be out in next version.
+All notable changes to this project's source code will be documented in this file. Items under `Unreleased` is upcoming features that will be out in next version. NOTE: major versions of the npm module and the gem must be kept in sync.
 
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
+## [7.0.0] - 2017-04-25
+### Changed
+- Any version differences in gem and node package for React on Rails throw an error [#821](https://github.com/shakacode/react_on_rails/pull/821) by [justin808](https://github.com/justin808)
+
+### Fixed
+- Fixes serious performance regression when using String props for rendering. [#821](https://github.com/shakacode/react_on_rails/pull/821) by [justin808](https://github.com/justin808)
+
 ## [6.10.1] - 2017-04-23
 ### Fixed
 - Improve json conversion with tests and support for older Rails 3.x. [#787](https://github.com/shakacode/react_on_rails/pull/787) by [cheremukhin23](https://github.com/cheremukhin23) and [Ynote](https://github.com/Ynote).
@@ -534,7 +541,8 @@ Best done with Object destructing:
 ##### Fixed
 - Fix several generator related issues.
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/6.10.1...master
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/7.0.0...master
+[7.0.0]: https://github.com/shakacode/react_on_rails/compare/6.10.1...7.0.0
 [6.10.1]: https://github.com/shakacode/react_on_rails/compare/6.10.0...6.10.1
 [6.10.0]: https://github.com/shakacode/react_on_rails/compare/6.9.3...6.10.0
 [6.9.3]: https://github.com/shakacode/react_on_rails/compare/6.9.1...6.9.3

--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -107,12 +107,17 @@ module ReactOnRailsHelper
     # Setup the page_loaded_js, which is the same regardless of prerendering or not!
     # The reason is that React is smart about not doing extra work if the server rendering did its job.
     component_specification_tag = content_tag(:script,
-                                              json_safe_and_pretty(options.data).html_safe,
+                                              json_safe_and_pretty(options.props).html_safe,
                                               type: "application/json",
-                                              class: "js-react-on-rails-component")
+                                              class: "js-react-on-rails-component",
+                                              "data-component-name" => options.name,
+                                              "data-trace" => options.trace,
+                                              "data-dom-id" => options.dom_id)
 
     # Create the HTML rendering part
-    result = server_rendered_react_component_html(options.props, options.name, options.dom_id,
+    result = server_rendered_react_component_html(options.props,
+                                                  options.name,
+                                                  options.dom_id,
                                                   prerender: options.prerender,
                                                   trace: options.trace,
                                                   raise_on_prerender_error: options.raise_on_prerender_error)

--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -2,7 +2,7 @@ module ReactOnRails
   class Engine < ::Rails::Engine
     config.to_prepare do
       if File.exist?(VersionChecker::NodePackageVersion.package_json_path)
-        VersionChecker.build.warn_if_gem_and_node_package_versions_differ
+        VersionChecker.build.raise_if_gem_and_node_package_versions_differ
       end
       ReactOnRails::ServerRenderingPool.reset_pool
     end

--- a/lib/react_on_rails/react_component/options.rb
+++ b/lib/react_on_rails/react_component/options.rb
@@ -13,8 +13,7 @@ module ReactOnRails
       end
 
       def props
-        props = options.fetch(:props) { NO_PROPS }
-        props.is_a?(String) ? JSON.parse(ERB::Util.json_escape(props)) : props
+        options.fetch(:props) { NO_PROPS }
       end
 
       def name
@@ -43,15 +42,6 @@ module ReactOnRails
 
       def raise_on_prerender_error
         retrieve_key(:raise_on_prerender_error)
-      end
-
-      def data
-        {
-          component_name: name,
-          props: props,
-          trace: trace,
-          dom_id: dom_id
-        }
       end
 
       private

--- a/spec/dummy/client/yarn.lock
+++ b/spec/dummy/client/yarn.lock
@@ -4146,7 +4146,7 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-helmet@5.0.3:
+react-helmet@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.0.3.tgz#c6da63ee96e83aa7c8fe6d041f28dd288b1b006d"
   dependencies:
@@ -4156,7 +4156,7 @@ react-helmet@5.0.3:
     react-side-effect "^1.1.0"
 
 "react-on-rails@file:../../..":
-  version "6.9.3"
+  version "6.10.1"
 
 react-proptypes@^0.0.1:
   version "0.0.1"

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -18,12 +18,12 @@ describe ReactOnRailsHelper, type: :helper do
     }
   end
 
-  let(:hash_sanitized) do
+  let(:json_string_sanitized) do
     '{"hello":"world","free":"of charge","x":"\\u003c/script\\u003e\\u003cscrip'\
       "t\\u003ealert('foo')\\u003c/script\\u003e\"}"
   end
 
-  let(:hash_unsanitized) do
+  let(:json_string_unsanitized) do
     "{\"hello\":\"world\",\"free\":\"of charge\",\"x\":\"</script><script>alert('foo')</script>\"}"
   end
 
@@ -34,29 +34,29 @@ describe ReactOnRailsHelper, type: :helper do
 
     it "converts a hash to escaped JSON" do
       escaped_json = helper.json_safe_and_pretty(hash)
-      expect(escaped_json).to eq(hash_sanitized)
+      expect(escaped_json).to eq(json_string_sanitized)
     end
 
     it "converts a string to escaped JSON" do
-      escaped_json = helper.json_safe_and_pretty(hash_unsanitized)
-      expect(escaped_json).to eq(hash_sanitized)
+      escaped_json = helper.json_safe_and_pretty(json_string_unsanitized)
+      expect(escaped_json).to eq(json_string_sanitized)
     end
   end
 
   describe "#sanitized_props_string(props)" do
     it "converts a hash to JSON and escapes </script>" do
       sanitized = helper.sanitized_props_string(hash)
-      expect(sanitized).to eq(hash_sanitized)
+      expect(sanitized).to eq(json_string_sanitized)
     end
 
     it "leaves a string alone that does not contain xss tags" do
-      sanitized = helper.sanitized_props_string(hash_sanitized)
-      expect(sanitized).to eq(hash_sanitized)
+      sanitized = helper.sanitized_props_string(json_string_sanitized)
+      expect(sanitized).to eq(json_string_sanitized)
     end
 
     it "fixes a string alone that contain xss tags" do
-      sanitized = helper.sanitized_props_string(hash_unsanitized)
-      expect(sanitized).to eq(hash_sanitized)
+      sanitized = helper.sanitized_props_string(json_string_unsanitized)
+      expect(sanitized).to eq(json_string_sanitized)
     end
   end
 
@@ -76,15 +76,17 @@ describe ReactOnRailsHelper, type: :helper do
     let(:id) { "App-react-component-0" }
 
     let(:react_definition_script) do
-      '<script type="application/json" class="js-react-on-rails-component">'\
-        '{"component_name":"App","props":{"name":"My Test Name"},"trace":false,"dom_id":"App-react-component-0"}'\
-      "</script>"
+      <<-SCRIPT
+<script type="application/json" class="js-react-on-rails-component" data-component-name="App" \
+data-trace="false" data-dom-id="App-react-component-0">{"name":"My Test Name"}</script>
+      SCRIPT
     end
 
     let(:react_definition_script_no_params) do
-      '<script type="application/json" class="js-react-on-rails-component">'\
-        '{"component_name":"App","props":{},"trace":false,"dom_id":"App-react-component-0"}'\
-      "</script>"
+      <<-SCRIPT
+<script type="application/json" class="js-react-on-rails-component" data-component-name="App" \
+data-trace="false" data-dom-id="App-react-component-0">{}</script>
+      SCRIPT
     end
 
     context "with json string props" do
@@ -92,13 +94,13 @@ describe ReactOnRailsHelper, type: :helper do
         "{\"hello\":\"world\",\"free\":\"of charge\",\"x\":\"</script><script>alert('foo')</script>\"}"
       end
 
-      let(:props_sanitized) do
+      let(:json_props_sanitized) do
         '{"hello":"world","free":"of charge","x":"\\u003c/script\\u003e\\u003cscrip'\
           "t\\u003ealert('foo')\\u003c/script\\u003e\"}"
       end
 
       subject { react_component("App", props: json_props) }
-      it { is_expected.to include props_sanitized }
+      it { is_expected.to include json_props_sanitized }
     end
 
     describe "API with component name only" do
@@ -122,9 +124,10 @@ describe ReactOnRailsHelper, type: :helper do
       let(:id) { "shaka_div" }
 
       let(:react_definition_script) do
-        '<script type="application/json" class="js-react-on-rails-component">'\
-          '{"component_name":"App","props":{"name":"My Test Name"},"trace":false,"dom_id":"shaka_div"}'\
-        "</script>"
+        <<-SCRIPT
+<script type="application/json" class="js-react-on-rails-component" data-component-name="App" \
+data-trace="false" data-dom-id="shaka_div">{"name":"My Test Name"}</script>
+        SCRIPT
       end
 
       it { is_expected.to include id }

--- a/spec/react_on_rails/react_component/options_spec.rb
+++ b/spec/react_on_rails/react_component/options_spec.rb
@@ -110,22 +110,6 @@ describe ReactOnRails::ReactComponent::Options do
     end
   end
 
-  describe "#data" do
-    it "returns data for component" do
-      attrs = the_attrs(name: "app", options: { trace: false, id: 2 })
-      expected_data = {
-        component_name: "App",
-        props: {},
-        trace: false,
-        dom_id: 2
-      }
-
-      opts = described_class.new(attrs)
-
-      expect(opts.data).to eq expected_data
-    end
-  end
-
   CONFIGURABLE_OPTIONS.each do |option|
     describe "##{option}" do
       context "with #{option} option" do


### PR DESCRIPTION
## Raise on Gem and Node Version Mismatch

Because many installations did not notice issues when versions differed, we're now going to force upgrading both the gem and node package at the same time.


## Fix Performance Issue on String Props

6.9 introduced code that would parse the props into a Hash
unnecessarily. Any customers with significant String props took a huge
performance hit from this on page rendering.

Fix is to remove the unnecessary parsing.

I believe the parsing was done so that pretty printing of the JSON could
be done. If we introduce that feature in the future, it will:

* Be configurable on whether or not to use it.
* Possibly never run in production.

See #819.

CC: @cheremukhin23 @robwise @dylangrafmyre @squadette 

Thanks @dzirtusss for finding this! AWESOME!!!

See https://github.com/shakacode/react_on_rails/commit/7ccd603683af377880d4e16f56752ac7587c38b7#diff-ab00ff0a0648717a06431522f7eb6861R16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/821)
<!-- Reviewable:end -->
