### PR TITLE
Correctly check whether using `webpacker_lite`

### DIFF
--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -34,7 +34,7 @@ module ReactOnRails
     end
 
     def self.using_webpacker_lite?
-      ActionController::Base.helpers.respond_to?(:asset_pack_path)
+      defined?(WebpackerLite)
     end
 
     def self.running_on_windows?


### PR DESCRIPTION
The `asset_pack_path` is also defined in `webpacker`.
https://github.com/rails/webpacker/blob/4a11b8f91865bd174f7e9c5ad618caf38ac3241e/lib/webpacker/helper.rb#L13..L15
https://github.com/rails/webpacker/blob/4a11b8f91865bd174f7e9c5ad618caf38ac3241e/lib/webpacker/railtie.rb#L8

For that reason, even when using `webpacker`, `using_webpacker_lite?`
return true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/861)
<!-- Reviewable:end -->
