### PR TITLE
RFC: Add options block so that webpack 2.6 won't complain

### DIFF
--- a/spec/dummy/client/webpack.client.rails.build.config.js
+++ b/spec/dummy/client/webpack.client.rails.build.config.js
@@ -52,7 +52,12 @@ module.exports = merge(config, {
                 localIdentName: '[name]__[local]__[hash:base64:5]',
               },
             },
-            'postcss-loader',
+            {
+              loader: 'postcss-loader',
+              options: {
+                plugins: 'autoprefixer'
+              }
+            }
           ],
         }),
       },


### PR DESCRIPTION
Also, I had to include `autoprefixer` in the list of plugins to get it working here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/873)
<!-- Reviewable:end -->
