### PR TITLE
Remove contentBase deprecation warning message

### DIFF
--- a/spec/dummy/client/server-rails-hot.js
+++ b/spec/dummy/client/server-rails-hot.js
@@ -25,7 +25,9 @@ const { hotReloadingUrl, hotReloadingPort, hotReloadingHostname } = webpackConfi
 const compiler = webpack(webpackConfig);
 
 const devServer = new WebpackDevServer(compiler, {
-  contentBase: hotReloadingUrl,
+  proxy: {
+    '*': hotReloadingUrl,
+  },
   headers: {
     'Access-Control-Allow-Origin': '*',
   },


### PR DESCRIPTION
Without the change, I had the error message:

```
22:05:30 hot-assets.1 | started with pid 9115
22:05:31 hot-assets.1 | yarn run v0.24.5
22:05:31 hot-assets.1 | $ (cd client && yarn run hot-assets) 
22:05:31 hot-assets.1 | yarn run v0.24.5
22:05:31 hot-assets.1 | $ NODE_ENV=development babel-node server-rails-hot.js 
22:05:33 hot-assets.1 | Webpack HOT dev build for Rails
22:05:33 hot-assets.1 | Using a URL as contentBase is deprecated and will be removed in the next major version. Please use the proxy option instead.
22:05:33 hot-assets.1 | proxy: {
22:05:33 hot-assets.1 | 	"*": "<your current contentBase configuration>"
22:05:33 hot-assets.1 | }
22:05:33 hot-assets.1 | Using a URL as contentBase is deprecated and will be removed in the next major version. Please use the proxy option instead.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/878)
<!-- Reviewable:end -->
