### PR TITLE
Generated client/package.json creates production builds using webpack by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
+### [8.0.6]
+#### fixed
+- The package.json file created by the generator now creates minified javascript production builds by default. This was done by adding the -p flag to webpack on the build:production script.
+
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests.*

--- a/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
+++ b/lib/generators/react_on_rails/templates/base/base/client/package.json.tt
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build:test": "NODE_ENV=test webpack --config webpack.config.js",
-    "build:production": "NODE_ENV=production webpack --config webpack.config.js",
+    "build:production": "NODE_ENV=production webpack -p --config webpack.config.js",
     "build:development": "NODE_ENV=development webpack -w --config webpack.config.js"
   },
   "cacheDirectories": ["node_modules", "client/node_modules"],

--- a/spec/react_on_rails/support/shared_examples/base_generator_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/base_generator_examples.rb
@@ -46,4 +46,11 @@ shared_examples "base_generator" do
       assert_match("registration", contents)
     end
   end
+
+  it "creates a client/package.json file configured to create production builds" do
+    production_script = "NODE_ENV=production webpack -p --config webpack.config.js"
+    assert_file("client/package.json") do |contents|
+      assert_match(production_script, contents)
+    end
+  end
 end


### PR DESCRIPTION
**WORK DONE**
1. The package.json file created by the generator now creates minified javascript production builds by default. This was done by adding the -p flag to webpack on the build:production script.
2. A test was added to verify that the build:production script includes the -p flag.

**NOTES**
1. I deleted the previous PR and created a new one because I squashed and rebased to keep the project history clean.
2. Sorry for the delay, it took me a while to wrap my head around the development setup and the codebase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/895)
<!-- Reviewable:end -->
