### PR TITLE
Update WebpackerLite 2.1 fixes server rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@ All notable changes to this project's source code will be documented in this fil
 Contributors: please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
 
 ## [Unreleased]
-### [8.0.6]
-#### fixed
-- The package.json file created by the generator now creates minified javascript production builds by default. This was done by adding the -p flag to webpack on the build:production script.
-
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests.*
 
-- Fixes GitUtils.uncommitted_changes? throwing an error when called in an environment without Git, and allows install generator to be run successfully with `--ignore-warnings` [#878](https://github.com/shakacode/react_on_rails/pull/878) by [jasonblalock](https://github.com/jasonblalock)
+### [8.0.6]
+#### fixed
+- Fixes server rendering when using a CDN. Server rendering would try to fetch a file with the "asset_host". This change updates the webpacker_lite dependency to 2.1.0 which has a new helper `pack_path`. [#901](https://github.com/shakacode/react_on_rails/pull/901) by [justin808](https://github.com/justin808).
+- The package.json file created by the generator now creates minified javascript production builds by default. This was done by adding the -p flag to webpack on the build:production script. [#895](https://github.com/shakacode/react_on_rails/pull/895) by [serodriguez68 ](https://github.com/serodriguez68)
+- Fixes GitUtils.uncommitted_changes? throwing an error when called in an environment without Git, and allows install generator to be run successfully with `--ignore-warnings` [#878](https://github.com/shakacode/react_on_rails/pull/878) by [jasonblalock](https://github.com/jasonblalock).
 
 ## [8.0.5]
 ### fixed
  - Corrects `devBuild` value for webpack production build from webpackConfigLoader. [#877](https://github.com/shakacode/react_on_rails/pull/877) by [chenqingspring](https://github.com/chenqingspring).
  - Remove contentBase deprecation warning message. [#878](https://github.com/shakacode/react_on_rails/pull/878) by [ened ](https://github.com/ened).
- - Removes invalid reference to _railsContext in the generated files. [#886](https://github.com/shakacode/react_on_rails/pull/8876) by [justin808](https://github.com/justin808)
+ - Removes invalid reference to _railsContext in the generated files. [#886](https://github.com/shakacode/react_on_rails/pull/886) by [justin808](https://github.com/justin808).
  - All tests run against Rails 5.1.2
 
 *Note: 8.0.4 skipped.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changes since last non-beta release.
 
 ### [8.0.6]
 #### fixed
-- Fixes server rendering when using a CDN. Server rendering would try to fetch a file with the "asset_host". This change updates the webpacker_lite dependency to 2.1.0 which has a new helper `pack_path`. [#901](https://github.com/shakacode/react_on_rails/pull/901) by [justin808](https://github.com/justin808).
+- Fixes server rendering when using a CDN. Server rendering would try to fetch a file with the "asset_host". This change updates the webpacker_lite dependency to 2.1.0 which has a new helper `pack_path`. [#901](https://github.com/shakacode/react_on_rails/pull/901) by [justin808](https://github.com/justin808). Be sure to update webpacker_lite to 2.1.0.
 - The package.json file created by the generator now creates minified javascript production builds by default. This was done by adding the -p flag to webpack on the build:production script. [#895](https://github.com/shakacode/react_on_rails/pull/895) by [serodriguez68 ](https://github.com/serodriguez68)
 - Fixes GitUtils.uncommitted_changes? throwing an error when called in an environment without Git, and allows install generator to be run successfully with `--ignore-warnings` [#878](https://github.com/shakacode/react_on_rails/pull/878) by [jasonblalock](https://github.com/jasonblalock).
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,6 @@ gem "chromedriver-helper"
 gem "launchy"
 gem "poltergeist"
 gem "selenium-webdriver"
-gem "webpacker_lite"
+gem "webpacker_lite", "~> 2.1"
 
 gem "rainbow"

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -72,7 +72,8 @@ exitstatus: #{status.exitstatus}#{stdout_msg}#{stderr_msg}
 
       if using_webpacker_lite? && WebpackerLite::Manifest.lookup(bundle_name)
         # If using webpacker_lite gem
-        public_subdir_hashed_file_name = ActionController::Base.helpers.asset_pack_path(bundle_name)
+        # Per https://github.com/rails/webpacker/issues/571, this path might
+        public_subdir_hashed_file_name = ActionController::Base.helpers.pack_path(bundle_name)
         return File.join("public", public_subdir_hashed_file_name)
       end
 

--- a/lib/react_on_rails/version.rb
+++ b/lib/react_on_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReactOnRails
-  VERSION = "8.0.5"
+  VERSION = "8.0.6.rc.0"
 end

--- a/lib/react_on_rails/version.rb
+++ b/lib/react_on_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReactOnRails
-  VERSION = "8.0.6.rc.0"
+  VERSION = "8.0.6.rc.1"
 end

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -36,7 +36,8 @@ module ReactOnRails
             "                     gem: #{gem_version}\n" \
             "            node package: #{node_package_version.raw}\n" \
             "Ensure the installed version of the gem is the same as the version of \n"\
-            "your installed node package."
+            "your installed node package.\n"\
+            "Run `cd client && yarn add react-on-rails`"
       raise msg
     end
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "8.0.6-rc.0",
+  "version": "8.0.6-rc.1",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "node_package/lib/ReactOnRails.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "8.0.5",
+  "version": "8.0.6-rc.0",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "node_package/lib/ReactOnRails.js",
   "directories": {

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -41,7 +41,7 @@ gem "sdoc", group: :doc
 
 gem "react_on_rails", path: "../.."
 
-gem "webpacker_lite", "2.0.4"
+gem "webpacker_lite", "2.1.0"
 
 gem "mini_racer"
 

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.2.1)
-    webpacker_lite (2.0.4)
+    webpacker_lite (2.1.0)
       activesupport (>= 4.2)
       multi_json (~> 1.2)
       railties (>= 4.2)
@@ -326,7 +326,7 @@ DEPENDENCIES
   sqlite3
   turbolinks (~> 5.0)
   uglifier
-  webpacker_lite (= 2.0.4)
+  webpacker_lite (= 2.1.0)
 
 BUNDLED WITH
    1.15.1

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    react_on_rails (8.0.5)
+    react_on_rails (8.0.6.rc.0)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^15.5.4",
     "react-helmet": "^5.0.3",
     "react-hot-loader": "^3.0.0-beta.6",
-    "react-on-rails": "8.0.6-rc.0",
+    "react-on-rails": "^8.0.6-rc.0",
     "react-proptypes": "^0.0.1",
     "react-redux": "^5.0.4",
     "react-router": "3.0.5",

--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^15.5.4",
     "react-helmet": "^5.0.3",
     "react-hot-loader": "^3.0.0-beta.6",
-    "react-on-rails": "8.0.5",
+    "react-on-rails": "8.0.6-rc.0",
     "react-proptypes": "^0.0.1",
     "react-redux": "^5.0.4",
     "react-router": "3.0.5",

--- a/spec/dummy/client/package.json
+++ b/spec/dummy/client/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^15.5.4",
     "react-helmet": "^5.0.3",
     "react-hot-loader": "^3.0.0-beta.6",
-    "react-on-rails": "^8.0.6-rc.0",
+    "react-on-rails": "8.0.6-rc.1",
     "react-proptypes": "^0.0.1",
     "react-redux": "^5.0.4",
     "react-router": "3.0.5",

--- a/spec/dummy/client/yarn.lock
+++ b/spec/dummy/client/yarn.lock
@@ -4281,9 +4281,9 @@ react-hot-loader@^3.0.0-beta.6:
     redbox-react "^1.3.6"
     source-map "^0.4.4"
 
-react-on-rails@8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-8.0.5.tgz#144b1c0be41df2ac810981a4876720fc0630cde7"
+react-on-rails@8.0.6-rc.0:
+  version "8.0.6-rc.0"
+  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-8.0.6-rc.0.tgz#e42f17c10ff4400ecf1bb8f7fc73445063d81289"
 
 react-proptypes@^0.0.1:
   version "0.0.1"

--- a/spec/dummy/client/yarn.lock
+++ b/spec/dummy/client/yarn.lock
@@ -4281,9 +4281,9 @@ react-hot-loader@^3.0.0-beta.6:
     redbox-react "^1.3.6"
     source-map "^0.4.4"
 
-react-on-rails@^8.0.6-rc.0:
-  version "8.0.6-rc.0"
-  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-8.0.6-rc.0.tgz#e42f17c10ff4400ecf1bb8f7fc73445063d81289"
+react-on-rails@8.0.6-rc.1:
+  version "8.0.6-rc.1"
+  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-8.0.6-rc.1.tgz#6326e2b431351f9a9976bbf6a59b5e5b2fabd91d"
 
 react-proptypes@^0.0.1:
   version "0.0.1"

--- a/spec/dummy/client/yarn.lock
+++ b/spec/dummy/client/yarn.lock
@@ -4281,7 +4281,7 @@ react-hot-loader@^3.0.0-beta.6:
     redbox-react "^1.3.6"
     source-map "^0.4.4"
 
-react-on-rails@8.0.6-rc.0:
+react-on-rails@^8.0.6-rc.0:
   version "8.0.6-rc.0"
   resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-8.0.6-rc.0.tgz#e42f17c10ff4400ecf1bb8f7fc73445063d81289"
 


### PR DESCRIPTION
Uses new helper pack_path to get the path of the server bundle without
worrying about any CDN set in the asset_host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/901)
<!-- Reviewable:end -->
