### PR TITLE
Fixed typo in install generator message

### DIFF
--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -109,7 +109,7 @@ module ReactOnRails
 
             - Include your webpack assets to your application layout.
 
-              <%= javascript_pack_tag 'main' %>
+              <%= javascript_pack_tag 'webpack-bundle' %>
 
             - Ensure your bundle and yarn installs of dependencies are up to date.
 

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -81,7 +81,7 @@ describe InstallGenerator, type: :generator do
 
           - Include your webpack assets to your application layout.
 
-            <%= javascript_pack_tag 'main' %>
+            <%= javascript_pack_tag 'webpack-bundle' %>
 
           - Ensure your bundle and yarn installs of dependencies are up to date.
 
@@ -109,7 +109,7 @@ describe InstallGenerator, type: :generator do
 
           - Include your webpack assets to your application layout.
 
-            <%= javascript_pack_tag 'main' %>
+            <%= javascript_pack_tag 'webpack-bundle' %>
 
           - Ensure your bundle and yarn installs of dependencies are up to date.
 


### PR DESCRIPTION
The name of the pack tag in the generated webpack config is webpack_bundle, not main.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/911)
<!-- Reviewable:end -->
