### PR TITLE
Handle case of existing gitignore no newline end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests.*
 
+### [8.0.7]
+#### fixed
+- Fixes generator bug by keeping blank line at top in case existing .gitignore does not end in a newline. [#916](https://github.com/shakacode/react_on_rails/pull/916) by [justin808](https://github.com/justin808).
+
+
 ### [8.0.6]
 #### fixed
 - Fixes server rendering when using a CDN. Server rendering would try to fetch a file with the "asset_host". This change updates the webpacker_lite dependency to 2.1.0 which has a new helper `pack_path`. [#901](https://github.com/shakacode/react_on_rails/pull/901) by [justin808](https://github.com/justin808). Be sure to update webpacker_lite to 2.1.0.
@@ -626,7 +631,8 @@ Best done with Object destructing:
 ##### Fixed
 - Fix several generator related issues.
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/8.0.6...master
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/8.0.7...master
+[8.0.7]: https://github.com/shakacode/react_on_rails/compare/8.0.6...8.0.7
 [8.0.6]: https://github.com/shakacode/react_on_rails/compare/8.0.5...8.0.6
 [8.0.5]: https://github.com/shakacode/react_on_rails/compare/8.0.3...8.0.5
 [8.0.3]: https://github.com/shakacode/react_on_rails/compare/8.0.2...8.0.3

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -33,7 +33,8 @@ module ReactOnRails
         DATA
 
         if dest_file_exists?(".gitignore")
-          append_to_file(".gitignore", data)
+          # NOTE: keep blank line at top in case existing .gitignore does not end in a newline
+          append_to_file(".gitignore", "\n#{data}")
         else
           GeneratorMessages.add_error(setup_file_error(".gitignore", data))
         end

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3,6 +3,7 @@
 require_relative "../support/generator_spec_helper"
 require_relative "../support/version_test_helpers"
 
+# rubocop:disable Metrics/BlockLength
 describe InstallGenerator, type: :generator do
   destination File.expand_path("../../dummy-for-generators/", __FILE__)
 
@@ -70,6 +71,34 @@ describe InstallGenerator, type: :generator do
         MSG
       expect(GeneratorMessages.output)
         .to include(GeneratorMessages.format_error(expected))
+    end
+  end
+
+  context "when gitignore already exists and has no EOF newline" do
+    before(:all) { @install_generator = InstallGenerator.new }
+
+    specify "it adds the script section if missing" do
+      data = "#lib from simplecov\ncoverage"
+
+      run_generator_test_with_args(%w[]) do
+        simulate_existing_file(".gitignore", data)
+      end
+
+      # rubocop:disable Layout/IndentHeredoc
+      expected = <<-MSG
+#{data}
+
+# React on Rails
+npm-debug.log*
+node_modules
+
+# Generated js bundles
+/public/webpack/*
+      MSG
+      assert_file(".gitignore") do |contents|
+        expect(contents).to eq(expected)
+      end
+      # rubocop:enable Layout/IndentHeredoc
     end
   end
 

--- a/spec/react_on_rails/support/shared_examples/base_generator_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/base_generator_examples.rb
@@ -13,6 +13,7 @@ shared_examples "base_generator" do
   it "updates the .gitignore file" do
     match = <<-MATCH.strip_heredoc
       some existing text
+
       # React on Rails
       npm-debug.log*
       node_modules


### PR DESCRIPTION
keep blank line at top in case existing .gitignore does not end in a
newline

If file ended with the `coverage` line below and no newline at the end, this got generated:

```
#lib genrerated from simplecov
coverage# React on Rails
npm-debug.log*
node_modules
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/916)
<!-- Reviewable:end -->
