### PR TITLE
Use 'phantomjs-prebuilt'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ After checking out the repo, making sure you have rvm and nvm setup (setup ruby 
 Additionally, our RSpec tests use the poltergeist web driver. You will need to install the phantomjs node module:
 
 ```sh
-yarn global add phantomjs
+yarn global add phantomjs-prebuilt
 ```
 
 Note this *must* be installed globally for the dummy test project rspec runner to see it properly.


### PR DESCRIPTION
    $ yarn add phatomjs

says

    warning phantomjs@2.1.7: Package renamed to phantomjs-prebuilt. Please update 'phantomjs' package references to 'phantomjs-prebuilt'

So do like it says.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/930)
<!-- Reviewable:end -->
