### PR TITLE
Fix typo in React Rails 9.x upgrade instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ For an example of upgrading, see [react-webpack-rails-tutorial/pull/416](https:/
   1. Added `config.node_modules_location` which defaults to `""` if Webpacker is installed. You may want to set this to 'client'` to `config/initializers/react_on_rails.rb` to keep your node_modules inside of `/client`
   2. Renamed
    * config.npm_build_test_command ==> config.build_test_command
-   * config.build_production_command ==> config.build_production_command
+   * config.npm_build_production_command ==> config.build_production_command
 
 - Update the gemfile. Switch over to using the webpacker gem.
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/944)
<!-- Reviewable:end -->
