### PR TITLE
Fix to add missing dependency to run generator spec individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes since last non-beta release.
 
 #### Fixed
 - Fixed `react_component_hash` functionality in cases of prerendering errors: [PR 960](https://github.com/shakacode/react_on_rails/pull/960) by [Judahmeek](https://github.com/Judahmeek)
+- Fix to add missing dependency to run generator spec individually: [PR 962](https://github.com/shakacode/react_on_rails/pull/962) by [tricknotes](https://github.com/tricknotes)
 
 *Please add entries here for your pull requests.*
 

--- a/spec/react_on_rails/generators/generator_messages_spec.rb
+++ b/spec/react_on_rails/generators/generator_messages_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../simplecov_helper"
+require_relative "../support/generator_spec_helper"
 
 describe GeneratorMessages do
   it "has an empty messages array" do


### PR DESCRIPTION
Without this `require` statement, the following error has thrown:

    $ bundle exec rspec spec/react_on_rails/generators/generator_messages_spec.rb
    An error occurred while loading ./spec/react_on_rails/generators/generator_messages_spec.rb.
    Failure/Error:
      describe GeneratorMessages do
        it "has an empty messages array" do
          expect(GeneratorMessages.messages).to be_empty
        end

        it "has a method that can add errors" do
          GeneratorMessages.add_error "Test error"
          expect(GeneratorMessages.messages)
            .to match_array([GeneratorMessages.format_error("Test error")])
        end

    NameError:
      uninitialized constant GeneratorMessages
    # ./spec/react_on_rails/generators/generator_messages_spec.rb:5:in `<top (required)>'
    No examples found.

    Finished in 0.00026 seconds (files took 0.12917 seconds to load)
    0 examples, 0 failures, 1 error occurred outside of examples

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/962)
<!-- Reviewable:end -->
