### PR TITLE
Remove unnecessary dependencies from released NPM package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,3 +18,7 @@ rules:
 
   # https://github.com/benmosher/eslint-plugin-import/issues/340
   import/no-extraneous-dependencies: 0
+
+settings:
+  import/core-modules:
+    - react-redux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
+#### Fixed
+- Remove unnecessary dependencies from released NPM package: [PR 968](https://github.com/shakacode/react_on_rails/pull/968) by [tricknotes](https://github.com/tricknotes).
 
 ### [10.0.1] - 2017-10-28
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -87,8 +87,5 @@
     "url": "https://github.com/shakacode/react_on_rails/issues"
   },
   "homepage": "https://github.com/shakacode/react_on_rails#readme",
-  "dependencies": {
-    "react-on-rails": "^10.0.0",
-    "react-redux": "^5.0.6"
-  }
+  "dependencies": {}
 }

--- a/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/spec/react_on_rails/generators/install_generator_spec.rb
@@ -8,35 +8,35 @@ describe InstallGenerator, type: :generator do
   destination File.expand_path("../../dummy-for-generators/", __FILE__)
 
   context "no args" do
-    before(:all) { run_generator_test_with_args(%w[]) }
+    before(:all) { run_generator_test_with_args(%w[], package_json: true) }
     include_examples "base_generator", application_js: true
     include_examples "no_redux_generator"
   end
 
   context "--redux" do
-    before(:all) { run_generator_test_with_args(%w[--redux]) }
+    before(:all) { run_generator_test_with_args(%w[--redux], package_json: true) }
     include_examples "base_generator", application_js: true
     include_examples "react_with_redux_generator"
   end
 
   context "-R" do
-    before(:all) { run_generator_test_with_args(%w[-R]) }
+    before(:all) { run_generator_test_with_args(%w[-R], package_json: true) }
     include_examples "base_generator", application_js: true
     include_examples "react_with_redux_generator"
   end
 
   context "without existing application.js or application.js.coffee file" do
-    before(:all) { run_generator_test_with_args([], application_js: false) }
+    before(:all) { run_generator_test_with_args([], application_js: false, package_json: true) }
     include_examples "base_generator", application_js: false
   end
 
   context "with existing application.js or application.js.coffee file" do
-    before(:all) { run_generator_test_with_args([], application_js: true) }
+    before(:all) { run_generator_test_with_args([], application_js: true, package_json: true) }
     include_examples "base_generator", application_js: true
   end
 
   context "with rails_helper" do
-    before(:all) { run_generator_test_with_args([], spec: true) }
+    before(:all) { run_generator_test_with_args([], spec: true, package_json: true) }
     it "adds ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)" do
       expected = ReactOnRails::Generators::BaseGenerator::CONFIGURE_RSPEC_TO_COMPILE_ASSETS
       assert_file("spec/rails_helper.rb") { |contents| assert_match(expected, contents) }
@@ -49,13 +49,13 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "base generator contains a helpful message" do
-      run_generator_test_with_args(%w[])
+      run_generator_test_with_args(%w[], package_json: true)
       # GeneratorMessages.output is an array with the git error being the first one
       expect(GeneratorMessages.output).to include(expected)
     end
 
     specify "react with redux generator contains a helpful message" do
-      run_generator_test_with_args(%w[--redux])
+      run_generator_test_with_args(%w[--redux], package_json: true)
       # GeneratorMessages.output is an array with the git error being the first one
       expect(GeneratorMessages.output).to include(expected)
     end

--- a/spec/react_on_rails/support/generator_spec_helper.rb
+++ b/spec/react_on_rails/support/generator_spec_helper.rb
@@ -65,8 +65,10 @@ def run_generator_test_with_args(args, options = {})
   simulate_npm_files(options)
   yield if block_given?
 
-  # WARNING: std out is swallowed from running the generator during tests
-  run_generator(args + ["--ignore-warnings"])
+  Dir.chdir(destination_root) do
+    # WARNING: std out is swallowed from running the generator during tests
+    run_generator(args + ["--ignore-warnings"])
+  end
 end
 
 # Simulate having an existing file for cases where the generator needs to modify, not create, a file

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,10 +2137,6 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2261,7 +2257,7 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
-invariant@^2.0.0, invariant@^2.2.2:
+invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -2620,7 +2616,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -2632,7 +2628,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@4.17.4, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.4, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3241,44 +3237,12 @@ react-dom@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-on-rails@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-10.0.0.tgz#afc658bf23f5dfe3fd836adc178eb4672727a89d"
-  dependencies:
-    react-on-rails "^9.0.3"
-    react-redux "^5.0.6"
-
-react-on-rails@^9.0.0-beta.12:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-9.0.1.tgz#49bf7520866214e410e6f88b298e889183d93786"
-  dependencies:
-    react-on-rails "^9.0.0-beta.12"
-    react-redux "^5.0.6"
-
-react-on-rails@^9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-9.0.3.tgz#da8a9873a94d62fe91e1f80d76716583f2be9da7"
-  dependencies:
-    react-on-rails "^9.0.0-beta.12"
-    react-redux "^5.0.6"
-
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"
   dependencies:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
-
-react-redux@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
-  dependencies:
-    hoist-non-react-statics "^2.2.1"
-    invariant "^2.0.0"
-    lodash "^4.2.0"
-    lodash-es "^4.2.0"
-    loose-envify "^1.1.0"
-    prop-types "^15.5.10"
 
 react-transform-hmr@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
These dependencies are injected by generator spec.
However they are unnecessary for released react-on-rails package.

Even if the `dependencies` section is removed, it will back after `$ rspec spec/react_on_rails/generators/install_generator_spec.rb` is run.

I think it is unexpected behavior.
So I removed these dependencies and fix specs.

@Judahmeek @justin808
Can you review this PR? It this a correct way?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/968)
<!-- Reviewable:end -->
