### PR TITLE
no camelize react component name

### DIFF
--- a/lib/react_on_rails/react_component/options.rb
+++ b/lib/react_on_rails/react_component/options.rb
@@ -7,6 +7,8 @@ module ReactOnRails
     class Options
       include Utils::Required
 
+      attr_reader :name
+
       NO_PROPS = {}.freeze
 
       def initialize(name: required("name"), options: required("options"))
@@ -16,10 +18,6 @@ module ReactOnRails
 
       def props
         options.fetch(:props) { NO_PROPS }
-      end
-
-      def name
-        @name.camelize
       end
 
       def dom_id

--- a/spec/react_on_rails/react_component/options_spec.rb
+++ b/spec/react_on_rails/react_component/options_spec.rb
@@ -55,7 +55,7 @@ describe ReactOnRails::ReactComponent::Options do
 
       opts = described_class.new(attrs)
 
-      expect(opts.name).to eq "SomeApp"
+      expect(opts.name).to eq "some_app"
     end
   end
 


### PR DESCRIPTION
I do not understand why I can not register a component with the name you want

Example:
I want to register HelloWorld component with the name "hello_world/index"
```js
import ReactOnRails from 'react-on-rails'
import HelloWorld from '../../views/hello_world/index'
ReactOnRails.register({
  "hello_world/index": HelloWorld,
})
```

```html
hello_world/index.html.erb
<%= react_component("hello_world/index", props: @hello_world_props, prerender: false) %>
```

When render the page react on rails say
```
ComponentRegistry.js:65 Uncaught Error: ReactOnRails encountered an error while rendering component: HelloWorld::Index.
Original message: Could not find component registered with name HelloWorld::Index. Registered
```

this error it's because react on rails camelize my component name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1001)
<!-- Reviewable:end -->
