### PR TITLE
Fix broken link to 8.x -> 9.x upgrade instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Updated React on Rails to depend on [rails/webpacker](https://github.com/rails/w
 
 
 #### 9.0 from 8.x. Upgrade Instructions
-Moved to [our additional reading documentation](https://github.com/shakacode/react_on_rails/blob/master/docs/additional-reading/upgrading-react-on-rails#from-version-8).
+Moved to [our documentation](docs/basics/upgrading-react-on-rails.md#upgrading-to-version-9).
 
 ### [8.0.7] - 2017-08-16
 #### Fixed


### PR DESCRIPTION
Docs link provided in relative form, per instructions in `CONTRIBUTING.md`. Let me know if I overlooked anything!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1003)
<!-- Reviewable:end -->
