### PR TITLE
Fix Utils.bundle_js_file_path for manifest.json in webpacker projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changes since last non-beta release.
 *Please add entries here for your pull requests that are not yet released.*
 
 #### Fixed
-- Fixed `Utils.bundle_js_file_path` generating the incorrect path for `manifest.json` in webpacker projects: [#1011] by [elstgav](https://github.com/elstgav)
+- Fixed `Utils.bundle_js_file_path` generating the incorrect path for `manifest.json` in webpacker projects: [Issue #1011](https://github.com/shakacode/react_on_rails/issues/1011) by [elstgav](https://github.com/elstgav)
 
 ### [10.0.2] - 2017-11-10
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Fixed `Utils.bundle_js_file_path` generating the incorrect path for `manifest.json` in webpacker projects: [#1011] by [elstgav](https://github.com/elstgav)
+
 ### [10.0.2] - 2017-11-10
 #### Fixed
 - Remove unnecessary dependencies from released NPM package: [PR 968](https://github.com/shakacode/react_on_rails/pull/968) by [tricknotes](https://github.com/tricknotes).

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -85,8 +85,7 @@ exitstatus: #{status.exitstatus}#{stdout_msg}#{stderr_msg}
     end
 
     def self.bundle_js_file_path(bundle_name)
-      if using_webpacker?
-        return bundle_name if bundle_name == "manifest.json"
+      if using_webpacker? && bundle_name != "manifest.json"
         bundle_js_file_path_from_webpacker(bundle_name)
       else
         # Default to the non-hashed name in the specified output directory, which, for legacy

--- a/spec/react_on_rails/utils_spec.rb
+++ b/spec/react_on_rails/utils_spec.rb
@@ -14,20 +14,33 @@ module ReactOnRails
         Utils.bundle_js_file_path("webpack-bundle.js")
       end
 
-      context "With Webpacker enabled and file in manifest", :webpacker do
+      context "With Webpacker enabled", :webpacker do
         before do
           allow(Rails).to receive(:root).and_return(Pathname.new("."))
           allow(Webpacker).to receive_message_chain("dev_server.running?")
             .and_return(false)
           allow(Webpacker).to receive_message_chain("config.public_output_path")
             .and_return("/webpack/development")
-          allow(Webpacker).to receive_message_chain("manifest.lookup")
-            .with("webpack-bundle.js")
-            .and_return("/webpack/development/webpack-bundle-0123456789abcdef.js")
           allow(Utils).to receive(:using_webpacker?).and_return(true)
         end
 
-        it { expect(subject).to eq("public/webpack/development/webpack-bundle-0123456789abcdef.js") }
+        context "and file in manifest", :webpacker do
+          before do
+            allow(Webpacker).to receive_message_chain("manifest.lookup")
+              .with("webpack-bundle.js")
+              .and_return("/webpack/development/webpack-bundle-0123456789abcdef.js")
+          end
+
+          it { expect(subject).to eq("public/webpack/development/webpack-bundle-0123456789abcdef.js") }
+        end
+
+        context "manifest.json" do
+          subject do
+            Utils.bundle_js_file_path("manifest.json")
+          end
+
+          it { expect(subject).to eq("public/webpack/development/manifest.json") }
+        end
       end
 
       context "Without Webpacker enabled" do


### PR DESCRIPTION
Utils.bundle_js_file_path was incorrectly returning
`'manifest.json'`
instead of, say,
`'/path/to/rails/public/packs/manifest.json'`

Fixes #1011

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1012)
<!-- Reviewable:end -->
