### PR TITLE
Use ReactDOM.hydrate() for hydrating a server-side component with Rea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Fixed `ReactDOM.render()` deprecation warning with React v16: [Issue #965](https://github.com/shakacode/react_on_rails/issues/965) by [elstgav](https://github.com/elstgav)
+
 ### [10.0.2] - 2017-11-10
 #### Fixed
 - Remove unnecessary dependencies from released NPM package: [PR 968](https://github.com/shakacode/react_on_rails/pull/968) by [tricknotes](https://github.com/tricknotes).

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -95,8 +95,8 @@ function domNodeIdForEl(el) {
 }
 
 /**
- * Used for client rendering by ReactOnRails. Either calls ReactDOM.render or delegates
- * to a renderer registered by the user.
+ * Used for client rendering by ReactOnRails. Either calls ReactDOM.hydrate, ReactDOM.render, or
+ * delegates to a renderer registered by the user.
  * @param el
  */
 function render(el, railsContext) {
@@ -128,7 +128,17 @@ function render(el, railsContext) {
 You returned a server side type of react-router error: ${JSON.stringify(reactElementOrRouterResult)}
 You should return a React.Component always for the client side entry point.`);
       } else {
-        ReactDOM.render(reactElementOrRouterResult, domNode);
+        const shouldHydrate = !!(
+          ReactDOM.hydrate &&
+          domNode &&
+          domNode.hasAttribute('data-reactroot')
+        );
+
+        if (shouldHydrate) {
+          ReactDOM.hydrate(reactElementOrRouterResult, domNode);
+        } else {
+          ReactDOM.render(reactElementOrRouterResult, domNode);
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
Fixes the `ReactDOM.render()` deprecation warning for React v16 mentioned in #965 

Calling `ReactDOM.render()` on a server-rendered component with React v16 will produce the following deprecation warning:

```
Warning: render(): Calling ReactDOM.render() to hydrate server-rendered markup will stop working in React v17. Replace the ReactDOM.render() call with ReactDOM.hydrate() if you want React to attach to the server HTML.
```

### TODO
- [ ] I’m unsure of where a test for this should go. Do we want a test? And if so, where does that go?
- [ ] Should `ReactOnRails.render()` also be updated? I’m less clear on if it’s used for server-rendered components

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1013)
<!-- Reviewable:end -->
