### PR TITLE
Fix server rendering rescue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Fixed issue with server-rendering error handler: [PR 1020](https://github.com/shakacode/react_on_rails/pull/1020) by [jblasco3](https://github.com/jblasco3).
+
 ### [10.1.0] - 2018-01-23
 #### Added
 - Added 2 cache helpers: ReactOnRails::Utils.bundle_file_name(bundle_name) and ReactOnRails::Utils.server_bundle_file_name

--- a/lib/react_on_rails/server_rendering_pool/exec.rb
+++ b/lib/react_on_rails/server_rendering_pool/exec.rb
@@ -98,7 +98,7 @@ module ReactOnRails
           # bundle_js_code = File.read(server_js_file)
           begin
             bundle_js_code = open(server_js_file, &:read)
-          rescue StandardError
+          rescue StandardError => e
             msg = "You specified server rendering JS file: #{server_js_file}, but it cannot be "\
                 "read. You may set the server_bundle_js_file in your configuration to be \"\" to "\
                 "avoid this warning.\nError is: #{e}"
@@ -115,7 +115,7 @@ module ReactOnRails
           begin
             trace_messsage(base_js_code, file_name)
             ExecJS.compile(base_js_code)
-          rescue StandardError
+          rescue StandardError => e
             msg = "ERROR when compiling base_js_code! "\
               "See file #{file_name} to "\
               "correlate line numbers of error. Error is\n\n#{e.message}"\


### PR DESCRIPTION
Latest release does not display the actual error when server-rendering fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1020)
<!-- Reviewable:end -->
