### PR TITLE
Report error in parsing version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Improved error reporting on version mismatches between Javascript and Ruby packages.
+
 ### [10.1.2] - 2018-02-27
 #### Fixed
 - Use ReactDOM.hydrate() for hydrating a SSR component if available. ReactDOM.render() has been deprecated for use on SSR components in React 16 and this addresses the warning. [PR 1028](https://github.com/shakacode/react_on_rails/pull/1028) by [theJoeBiz](https://github.com/theJoeBiz).

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -82,6 +82,9 @@ module ReactOnRails
       def major_minor_patch
         return if relative_path?
         match = raw.match(MAJOR_MINOR_PATCH_VERSION_REGEX)
+        unless match
+          raise "Cannot parse version number '#{raw}' (wildcard versions are not supported)"
+        end
         [match[1], match[2], match[3]]
       end
 


### PR DESCRIPTION
If you accidentally put "react-on-rails": "9.0.x" in your `package.json`, you will get a stack trace.

This commit helps you during upgrade and reports error in a readable way.

Closes #489.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1025)
<!-- Reviewable:end -->
