### PR TITLE
Test in Ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   # Rails 5 requires 2.2
   - 2.3.1
   - 2.4.1
+  - 2.5.0
   - 2.2.6
 services:
   - docker
@@ -57,6 +58,8 @@ matrix:
       rvm: 2.3.1
     - gemfile: spec/dummy_no_webpacker/Gemfile.rails32
       rvm: 2.4.1
+    - gemfile: spec/dummy_no_webpacker/Gemfile.rails32
+      rvm: 2.5.0
     - gemfile: spec/dummy/Gemfile
       rvm: 2.2.6
 


### PR DESCRIPTION
This change adds Ruby 2.5.0 to Travis configuration.  Last time I worked on react_on_rails a year ago I had some issues with 2.5.0 in CI, I'm glad to see that it works nowadays.

I did not test with 2.5.0 in production, but adding to CI would be a good first step.

Please consider applying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1026)
<!-- Reviewable:end -->
