### PR TITLE
Support multi-bundle component registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+- ComponentRegistry now uses a Map on the global context so multiple webpack bundles can call `ReactOnRails.registerComponents()` multiple times prior to rendering.
+
 ### [10.1.3] - 2018-02-28
 #### Fixed
 - Improved error reporting on version mismatches between Javascript and Ruby packages. [PR 1025](https://github.com/shakacode/react_on_rails/pull/1025) by [theJoeBiz](https://github.com/squadette).

--- a/node_package/src/ComponentRegistry.js
+++ b/node_package/src/ComponentRegistry.js
@@ -5,11 +5,10 @@ import context from './context';
 
 const ctx = context();
 
-let registeredComponents;
-if(!ctx.reactOnRailsRegisteredComponents) {
+if (!ctx.reactOnRailsRegisteredComponents) {
   ctx.reactOnRailsRegisteredComponents = new Map();
 }
-registeredComponents = ctx.reactOnRailsRegisteredComponents;
+const registeredComponents = ctx.reactOnRailsRegisteredComponents;
 
 export default {
   /**

--- a/node_package/src/ComponentRegistry.js
+++ b/node_package/src/ComponentRegistry.js
@@ -1,8 +1,15 @@
 // key = name used by react_on_rails
 // value = { name, component, generatorFunction: boolean, isRenderer: boolean }
 import generatorFunction from './generatorFunction';
+import context from './context';
 
-const registeredComponents = new Map();
+const ctx = context();
+
+let registeredComponents;
+if(!ctx.reactOnRailsRegisteredComponents) {
+  ctx.reactOnRailsRegisteredComponents = new Map();
+}
+registeredComponents = ctx.reactOnRailsRegisteredComponents;
 
 export default {
   /**


### PR DESCRIPTION
This change moves the `registeredComponents` onto the global context so when your project is using multiple webpack bundles, and thus calling `ReactOnRails.registerComponents()` multiple times prior to rendering, the components are accumulated in the same `Map` instance. Without this change, the last webpack bundle to register components overwrites all the previous registrations. I'm open to suggestions to solve this problem a different way. I've searched through the docs _and_ the code and this is the only way I got it to work. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1043)
<!-- Reviewable:end -->
