### PR TITLE
FormatJS i18n argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Contributors: please follow the recommendations outlined at [keepachangelog.com]
 ## [Unreleased]
 Changes since last non-beta release.
 
+#### Fixed
+- Changed i18n parsing to convert ruby i18n argument syntax into FormatJS argument syntax. by [sepehr500](https://github.com/sepehr500)  
+
 *Please add entries here for your pull requests that are not yet released.*
 
 ### [10.1.3] - 2018-02-28

--- a/lib/react_on_rails/locales_to_js.rb
+++ b/lib/react_on_rails/locales_to_js.rb
@@ -108,7 +108,7 @@ module ReactOnRails
         if v.is_a? Hash
           flatten(v).map { |hk, hv| h["#{k}.#{hk}".to_sym] = hv }
         else
-          h[k] = v
+          h[k] = v.gsub("%{", "{")
         end
       end
     end

--- a/spec/react_on_rails/fixtures/i18n/locales/en.yml
+++ b/spec/react_on_rails/fixtures/i18n/locales/en.yml
@@ -1,2 +1,3 @@
 en:
   hello: "Hello world"
+  argument: "I am %{age} years old."

--- a/spec/react_on_rails/locales_to_js_spec.rb
+++ b/spec/react_on_rails/locales_to_js_spec.rb
@@ -24,7 +24,8 @@ module ReactOnRails
           expect(translations).to include('{"hello":"Hello world"')
           expect(translations).to include('{"hello":"Hallo welt"')
           expect(default).to include("const defaultLocale = 'en';")
-          expect(default).to include('{"hello":{"id":"hello","defaultMessage":"Hello world"}}')
+          expect(default).to include('{"hello":{"id":"hello","defaultMessage":"Hello world"}')
+          expect(default).to include('"argument":{"id":"argument","defaultMessage":"I am {age} years old."}}')
 
           expect(File.mtime(translations_path)).to be >= File.mtime(en_path)
         end

--- a/spec/spec/examples.txt
+++ b/spec/spec/examples.txt
@@ -1,6 +1,0 @@
-example_id                                        | status | run_time        |
-------------------------------------------------- | ------ | --------------- |
-./react_on_rails/locales_to_js_spec.rb[1:1:1:1:1] | passed | 0.00963 seconds |
-./react_on_rails/locales_to_js_spec.rb[1:1:1:2:1] | passed | 0.00268 seconds |
-./react_on_rails/locales_to_js_spec.rb[1:2:1:1:1] | passed | 0.00256 seconds |
-./react_on_rails/locales_to_js_spec.rb[1:2:1:2:1] | passed | 0.00123 seconds |

--- a/spec/spec/examples.txt
+++ b/spec/spec/examples.txt
@@ -1,0 +1,6 @@
+example_id                                        | status | run_time        |
+------------------------------------------------- | ------ | --------------- |
+./react_on_rails/locales_to_js_spec.rb[1:1:1:1:1] | passed | 0.00963 seconds |
+./react_on_rails/locales_to_js_spec.rb[1:1:1:2:1] | passed | 0.00268 seconds |
+./react_on_rails/locales_to_js_spec.rb[1:2:1:1:1] | passed | 0.00256 seconds |
+./react_on_rails/locales_to_js_spec.rb[1:2:1:2:1] | passed | 0.00123 seconds |


### PR DESCRIPTION
Changed i18n parsing to convert ruby i18n argument syntax into FormatJS argument syntax to fix #1021

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1046)
<!-- Reviewable:end -->
