### PR TITLE
Place the rendered output before the spec tag

### DIFF
--- a/app/helpers/react_on_rails_helper.rb
+++ b/app/helpers/react_on_rails_helper.rb
@@ -305,9 +305,9 @@ module ReactOnRailsHelper
     # IMPORTANT: Ensure that we mark string as html_safe to avoid escaping.
     # rubocop:disable Layout/IndentHeredoc
     <<-HTML.html_safe
+#{rendered_output}
 #{component_specification_tag}
-    #{rendered_output}
-    #{console_script}
+#{console_script}
     HTML
     # rubocop:enable Layout/IndentHeredoc
   end


### PR DESCRIPTION
Many folks using the SSR features of react-on-rails are doing so in order to improve SEO while simultaneously improving user experience.

It is commonly recommended to have key content rendered into the HTML at the earliest possible point. From what I understand, there is no need for the specification tag/script to come before the rendered content and simply swapping the order can have a significant impact on the content that fits within the 100kb "SEO optimized" page size.

e.g. if I have 50kb of state data followed by 100kb of the actual rendered HTML, the bottom half of the page may not get indexed by e.g. Google.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1047)
<!-- Reviewable:end -->
