### PR TITLE
Specify NODE_ENV in the production build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changes since last non-beta release.
 
 - Fixed an issue where the spec compiler check would fail if the project path contained spaces. [PR 1045](https://github.com/shakacode/react_on_rails/pull/1045) by [andrewmarkle](https://github.com/andrewmarkle)
 
+- Updated the default `build_production_command` that caused production assets to be built with development settings. [PR 1053](https://github.com/shakacode/react_on_rails/pull/1053) by [Roman Kushnir](https://github.com/RKushnir)
+
 *Please add entries here for your pull requests that are not yet released.*
 
 ### [10.1.3] - 2018-02-28

--- a/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb
+++ b/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb
@@ -5,7 +5,7 @@
 ReactOnRails.configure do |config|
   # This configures the script to run to build the production assets by webpack. Set this to nil
   # if you don't want react_on_rails building this file for you.
-  config.build_production_command = "RAILS_ENV=production bin/webpack"
+  config.build_production_command = "RAILS_ENV=production NODE_ENV=production bin/webpack"
 
   ################################################################################
   ################################################################################


### PR DESCRIPTION
Hi,
Recently webpacker gem has been updated in a way to make `NODE_ENV` not fallback to `RAILS_ENV`(https://github.com/rails/webpacker/commit/e61618465f872694775d1a39c10cf55d9df939ea).
By default react_on_rails generates this config:
```ruby
config.build_production_command = 'RAILS_ENV=production bin/webpack'
```
Before the change in webpacker, this was effectively setting both `RAILS_ENV` and `NODE_ENV` to "production", but not anymore. Now `NODE_ENV` defaults to "development". So if you don't specify it, your production assets will be compiled using dev settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1053)
<!-- Reviewable:end -->
