### PR TITLE
More exact version checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Changes since last non-beta release.
 - Removed ReactOnRails::Utils.server_bundle_file_name and ReactOnRails::Utils.bundle_file_name.
 - No longer logging the `railsContext` when server logging.
 
+#### Fixes
+- More exact version checking. We keep the react_on_rails gem and the react-on-rails node package at
+the same exact versions so that we can be sure that the interaction between them is precise.
+This is so that if a bug is detected after some update, it's critical that
+both the gem and the node package get the updates. This change ensures that the package.json specification does not use a
+~ or ^ as reported in [#1062](https://github.com/shakacode/react_on_rails/issues/1062). [PR 1063](https://github.com/shakacode/react_on_rails/pull/1063) by [justin808](https://github.com/justin808).
+
 ### [10.1.4] - 2018-04-11
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -343,10 +343,10 @@ Rails will start creating the app and will skip the files you have already creat
 All JavaScript in React On Rails is loaded from npm: [react-on-rails](https://www.npmjs.com/package/react-on-rails). To manually install this (you did not use the generator), assuming you have a standard configuration, run this command (assuming you are in the directory where you have your `node_modules`):
 
 ```bash
-yarn add react-on-rails
+yarn add react-on-rails --exact
 ```
 
-That will install the latest version and update your package.json.
+That will install the latest version and update your package.json. **NOTE:** the `--exact` flag will ensure that you do not have a "~" or "^" for your react-on-rails version in your package.json.
 
 ### Webpacker Configuration
 

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -43,7 +43,7 @@ module ReactOnRails
       end
 
       def add_yarn_dependencies
-        run "yarn add react-on-rails"
+        run "yarn add react-on-rails --exact"
       end
 
       def append_to_spec_rails_helper

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -70,7 +70,7 @@ task :release, %i[gem_version dry_run tools_install] do |_t, args|
     sh_in_dir(gem_root, "gem release")
 
     # Update master with new npm version
-    sh_in_dir(File.join(gem_root, "spec", "dummy", "client"), "yarn add react-on-rails@#{npm_version}")
+    sh_in_dir(File.join(gem_root, "spec", "dummy", "client"), "yarn add react-on-rails@#{npm_version} --exact")
     sh_in_dir(gem_root, "git commit -am 'Updated spec/dummy/client/package.json latest version'")
     sh_in_dir(gem_root, "git push")
   end

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: ../..
   specs:
-    react_on_rails (10.1.4)
+    react_on_rails (11.0.0.beta.1)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/spec/react_on_rails/fixtures/semver_caret_package.json
+++ b/spec/react_on_rails/fixtures/semver_caret_package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "babel": "^6.3.26",
+    "react-on-rails": "^1.2.3",
+    "webpack": "^1.12.8"
+  },
+  "devDependencies": {
+    "babel-eslint": "^5.0.0-beta6"
+  }
+}

--- a/spec/react_on_rails/fixtures/semver_tilde_package.json
+++ b/spec/react_on_rails/fixtures/semver_tilde_package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "babel": "^6.3.26",
+    "react-on-rails": "~1.2.3",
+    "webpack": "^1.12.8"
+  },
+  "devDependencies": {
+    "babel-eslint": "^5.0.0-beta6"
+  }
+}

--- a/spec/react_on_rails/version_checker_spec.rb
+++ b/spec/react_on_rails/version_checker_spec.rb
@@ -18,12 +18,24 @@ module ReactOnRails
 
       context "when gem and node package major and minor versions are equal" do
         let(:node_package_version) do
-          double_package_version(raw: "^2.2.5-beta.2", major_minor_patch: %w[2 2 5])
+          double_package_version(raw: "2.2.5-beta.2", major_minor_patch: %w[2 2 5])
         end
         before { stub_gem_version("2.2.5.beta.2") }
 
         it "does not raise" do
           expect { check_version(node_package_version) }.not_to raise_error
+        end
+      end
+
+      context "when major and minor versions are equal BUT node uses semver wildcard" do
+        let(:node_package_version) do
+          double_package_version(raw: "^2.2.5", semver_wildcard: true, major_minor_patch: %w[2 2 5])
+        end
+        before { stub_gem_version("2.2.5") }
+
+        it "does raise" do
+          error = /ReactOnRails: Your node package version for react-on-rails contains a \^ or ~/
+          expect { check_version(node_package_version) }.to raise_error(error)
         end
       end
 
@@ -75,9 +87,11 @@ module ReactOnRails
       end
     end
 
-    def double_package_version(raw: nil, major_minor_patch: nil, relative_path: false)
+    def double_package_version(raw: nil, semver_wildcard: false,
+                               major_minor_patch: nil, relative_path: false)
       instance_double(VersionChecker::NodePackageVersion,
                       raw: raw,
+                      semver_wildcard?: semver_wildcard,
                       major_minor_patch: major_minor_patch,
                       relative_path?: relative_path)
     end
@@ -89,6 +103,26 @@ module ReactOnRails
 
     describe VersionChecker::NodePackageVersion do
       subject(:node_package_version) { VersionChecker::NodePackageVersion.new(package_json) }
+
+      describe "#semver_wildcard?" do
+        context "when package json lists an exact version of '0.0.2'" do
+          let(:package_json) { File.expand_path("fixtures/normal_package.json", __dir__) }
+
+          specify { expect(node_package_version.semver_wildcard?).to be false }
+        end
+
+        context "when package json lists a semver caret version of '^1.2.3'" do
+          let(:package_json) { File.expand_path("fixtures/semver_caret_package.json", __dir__) }
+
+          specify { expect(node_package_version.semver_wildcard?).to be true }
+        end
+
+        context "when package json lists a semver tilde version of '~1.2.3'" do
+          let(:package_json) { File.expand_path("fixtures/semver_tilde_package.json", __dir__) }
+
+          specify { expect(node_package_version.semver_wildcard?).to be true }
+        end
+      end
 
       context "when package json lists a version of '0.0.2'" do
         let(:package_json) { File.expand_path("fixtures/normal_package.json", __dir__) }


### PR DESCRIPTION
We keep the react_on_rails gem and the react-on-rails node package at
the same exact versions so that we can be sure that the interaction
between them is precise.

This is so that if a bug is detected after some update, it's critical that
both the gem and the node package get the updates.

This change ensures that the package.json specification does not use a
~ or ^ as reported in https://github.com/shakacode/react_on_rails/issues/1062

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1063)
<!-- Reviewable:end -->
