### PR TITLE
react_component_hash always has pre-render true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes since last non-beta release.
 - Fix the setup for tests for spec/dummy so they automatically rebuild by correctly setting the source_path in the webpacker.yml
 - Updated documentation for the testing setup.
 - Above in [PR 1072](https://github.com/shakacode/react_on_rails/pull/1072) by [justin808](https://github.com/justin808).
+- `react_component_hash` has implicit `prerender: true` because it makes no sense to have react_component_hash not use prerrender. Improved docs on `react_component_hash`. Also, fixed issue where checking gem existence. [PR 1077](https://github.com/shakacode/react_on_rails/pull/1077) by [justin808](https://github.com/justin808).
 
 ### [11.0.3] - 2018-04-24
 

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -140,11 +140,11 @@ exitstatus: #{status.exitstatus}#{stdout_msg}#{stderr_msg}
     end
 
     def self.gem_available?(name)
-      Gem::Specification.find_by_name(name)
+      Gem::Specification.find_by_name(name).present?
     rescue Gem::LoadError
       false
     rescue StandardError
-      Gem.available?(name)
+      Gem.available?(name).present?
     end
 
     def self.react_on_rails_pro?

--- a/spec/dummy/app/views/pages/broken_app.html.erb
+++ b/spec/dummy/app/views/pages/broken_app.html.erb
@@ -1,4 +1,4 @@
-<%= react_component_hash("BrokenApp", prerender: true)['componentHtml'] %>
+<%= react_component_hash("BrokenApp")['componentHtml'] %>
 
 <hr/>
 

--- a/spec/dummy/app/views/pages/react_helmet.erb
+++ b/spec/dummy/app/views/pages/react_helmet.erb
@@ -1,6 +1,5 @@
 
 <% react_helmet_app = react_component_hash("ReactHelmetApp",
-                                           prerender: true,
                                            props: { helloWorldData: { name: "Mr. Server Side Rendering"}},
                                            id: "react-helmet-0",
                                            trace: true) %>


### PR DESCRIPTION
* Makes no sense to have react_component_hash not use prerrender.
* Fixed issue where checking gem existence.
* Added docs for react_component_hash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1077)
<!-- Reviewable:end -->
