### PR TITLE
Update Rainbow gem dependency

### DIFF
--- a/react_on_rails.gemspec
+++ b/react_on_rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "connection_pool"
   s.add_dependency "execjs", "~> 2.5"
   s.add_dependency "rails", ">= 3.2"
-  s.add_dependency "rainbow", "~> 2.2"
+  s.add_dependency "rainbow", "~> 3.0"
 
   s.add_development_dependency "awesome_print"
   s.add_development_dependency "bundler", "~> 1"

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.2)
+    rainbow (3.0.0)
       rake
     rake (12.3.1)
     rb-fsevent (0.10.3)

--- a/spec/dummy_no_webpacker/Gemfile.lock
+++ b/spec/dummy_no_webpacker/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.2)
+    rainbow (3.0.0)
       rake
     rake (12.3.1)
     rb-fsevent (0.10.3)

--- a/spec/dummy_no_webpacker/Gemfile.rails32.lock
+++ b/spec/dummy_no_webpacker/Gemfile.rails32.lock
@@ -179,7 +179,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
-    rainbow (2.2.2)
+    rainbow (3.0.0)
       rake
     rake (12.0.0)
     rb-fsevent (0.10.2)


### PR DESCRIPTION
Updating Rainbow dependency to v3, as it prevents other gems in some other gems to update.

The main breaking change of Rainbow v3 is the deprecation for Ruby 2.0.0, but it should not affect this project because the lower limit is already 2.1.0.

https://github.com/sickill/rainbow/blob/master/Changelog.md

[NOTE: Tests are failing because Rubocop is outdated. I will update as well]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1078)
<!-- Reviewable:end -->
