### PR TITLE
corrects bundle exec rake instead of rails in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ See [Issue 982: Tutorial Generating Correct Project Structure?](https://github.c
 
 2. Run the following 2 commands to install Webpacker with React:
    ```
-   bundle exec rails webpacker:install
-   bundle exec rails webpacker:install:react
+   bundle exec rake webpacker:install
+   bundle exec rake webpacker:install:react
 
    ```
 


### PR DESCRIPTION
Just small error in the readme. You put `rails webpacker...` instead of `rake...`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1083)
<!-- Reviewable:end -->
