### PR TITLE
Update react_on_rails gem version

### DIFF
--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: ../..
   specs:
-    react_on_rails (11.0.3)
+    react_on_rails (11.0.5)
       addressable
       connection_pool
       execjs (~> 2.5)


### PR DESCRIPTION
When running `bin/setup` as suggested in the [contributing guide](https://github.com/shakacode/react_on_rails/blob/fa52ac65d0248e002dd7fb4b22e1fec7a84aebd4/CONTRIBUTING.md#prereqs), the Gemfile.lock gets automatically updated to the newest react_on_rails version. This should point to the newest version already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1085)
<!-- Reviewable:end -->
