### PR TITLE
Handle <script async> transparently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Upgrading React on Rails](./docs/basics/upgrading-react-on-rails.md) for mo
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
+- Handle <script async> for Webpack bundle transparently. Closes [issue #290](https://github.com/shakacode/react_on_rails/issues/290) [PR 1099](https://github.com/shakacode/react_on_rails/pull/1099) by [squadette](https://github.com/squadette).
 
 #### Changed
 - Document how to manually rehydrate XHR-substituted components on client side. [PR 1095](https://github.com/shakacode/react_on_rails/pull/1095) by [hchevalier](https://github.com/hchevalier).
@@ -87,7 +88,7 @@ both the gem and the node package get the updates. This change ensures that the 
 
 ### [10.1.3] - 2018-02-28
 #### Fixed
-- Improved error reporting on version mismatches between Javascript and Ruby packages. [PR 1025](https://github.com/shakacode/react_on_rails/pull/1025) by [theJoeBiz](https://github.com/squadette).
+- Improved error reporting on version mismatches between Javascript and Ruby packages. [PR 1025](https://github.com/shakacode/react_on_rails/pull/1025) by [squadette](https://github.com/squadette).
 
 ### [10.1.2] - 2018-02-27
 #### Fixed

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -196,6 +196,27 @@ export function clientStartup(context) {
 
   debugTurbolinks('Adding DOMContentLoaded event to install event listeners.');
 
+  window.setTimeout(() => {
+    if (!turbolinksInstalled() || !turbolinksSupported()) {
+      if (document.readyState === 'complete' ||
+                                   (document.readyState !== 'loading' && !document.documentElement.doScroll)
+      ) {
+        debugTurbolinks(
+          'NOT USING TURBOLINKS: DOM is already loaded, calling reactOnRailsPageLoaded',
+        );
+
+        reactOnRailsPageLoaded();
+      } else {
+        document.addEventListener('DOMContentLoaded', () => {
+          debugTurbolinks(
+            'NOT USING TURBOLINKS: DOMContentLoaded event, calling reactOnRailsPageLoaded',
+          );
+          reactOnRailsPageLoaded();
+        });
+      }
+    }
+  });
+
   document.addEventListener('DOMContentLoaded', () => {
     // Install listeners when running on the client (browser).
     // We must do this check for turbolinks AFTER the document is loaded because we load the
@@ -216,11 +237,6 @@ export function clientStartup(context) {
         document.addEventListener('page:before-unload', reactOnRailsPageUnloaded);
         document.addEventListener('page:change', reactOnRailsPageLoaded);
       }
-    } else {
-      debugTurbolinks(
-        'NOT USING TURBOLINKS: DOMContentLoaded event, calling reactOnRailsPageLoaded',
-      );
-      reactOnRailsPageLoaded();
     }
   });
 }


### PR DESCRIPTION
I believe that this commit fixes #290, transparently handling <script async> tag.  If the document was already loaded, the DOMContentLoaded event handler no longer fires, so we just execute it directly, the same way as jQuery does in `$.ready()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1099)
<!-- Reviewable:end -->
