### PR TITLE
Don't log full props or JS code

### DIFF
--- a/lib/react_on_rails/prerender_error.rb
+++ b/lib/react_on_rails/prerender_error.rb
@@ -3,6 +3,7 @@
 # rubocop:disable: Layout/IndentHeredoc
 module ReactOnRails
   class PrerenderError < ::ReactOnRails::Error
+    MAX_ERROR_SNIPPET_TO_LOG = 1000
     # TODO: Consider remove providing original `err` as already have access to `self.cause`
     # http://blog.honeybadger.io/nested-errors-in-ruby-with-exception-cause/
     attr_reader :component_name, :err, :props, :js_code, :console_messages
@@ -58,9 +59,9 @@ Encountered error: \"#{err}\"
       end
       # rubocop:disable Layout/IndentHeredoc
       message << <<-MSG
-when prerendering #{component_name} with props: #{props}
+when prerendering #{component_name} with props (truncated): #{props.to_s[0, MAX_ERROR_SNIPPET_TO_LOG]}
 js_code was:
-#{js_code}
+#{js_code[0, MAX_ERROR_SNIPPET_TO_LOG]}
       MSG
       # rubocop:enable Layout/IndentHeredoc
 


### PR DESCRIPTION
Long props result in very long error messages. This change truncates
the props and code to 1,000 chars



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1117)
<!-- Reviewable:end -->
