### PR TITLE
#1127 `TRUE` was deprecated in ruby 2.4, using `true` instead.

### DIFF
--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -9,7 +9,7 @@ module ReactOnRails
   DEFAULT_GENERATED_ASSETS_DIR = File.join(%w[public webpack], Rails.env).freeze
   DEFAULT_SERVER_RENDER_TIMEOUT = 20
   DEFAULT_POOL_SIZE = 1
-  DEFAULT_RANDOM_DOM_ID = TRUE # for backwards compatability
+  DEFAULT_RANDOM_DOM_ID = true # for backwards compatability
 
   def self.configuration
     @configuration ||= Configuration.new(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1128)
<!-- Reviewable:end -->
