### PR TITLE
Adding a forced generator option

### DIFF
--- a/node_package/src/ComponentRegistry.js
+++ b/node_package/src/ComponentRegistry.js
@@ -7,8 +7,9 @@ const registeredComponents = new Map();
 export default {
   /**
    * @param components { component1: component1, component2: component2, etc. }
+   * @param isGeneratorFunction boolean
    */
-  register(components) {
+  register(components, isGeneratorFunction) {
     Object.keys(components).forEach(name => {
       if (registeredComponents.has(name)) {
         console.warn('Called register for component that is already registered', name);
@@ -19,7 +20,7 @@ export default {
         throw new Error(`Called register with null component named ${name}`);
       }
 
-      const isGeneratorFunction = generatorFunction(component);
+      const isGeneratorFunction = isGeneratorFunction || generatorFunction(component);
       const isRenderer = isGeneratorFunction && component.length === 3;
 
       registeredComponents.set(name, {


### PR DESCRIPTION
### What is this?
This allows someone to force `ReactOnRails.register` to treat what they registered as a generator function(s). 

### Why is this needed?
It seems like webpack somehow transforms generator functions in such a way that React no longer recognizes them. I'm not the only person, someone has already logged #1097 to ask for help. For that person, the solution was to use Webpacks `useBuiltIns` and then include `babel-polyfil`. Unfortunately, we're rendering our code using Googles V8 Engine. `babel-polyfil` currently causes a fatal error if the V8 engine tries to create a snapshot of `babel-polyfil`. [Here's someone else reporting an issue with php-v8js](https://github.com/Limenius/ReactBundle/issues/29). I've [already logged a ticket with Google](https://bugs.chromium.org/p/v8/issues/detail?id=8063) about this, but they might take time to fix and release. And then it might take a while for the release to propagate and so on.

On the other hand, a simple flag to force the registry to accept that it's being given a generator function would be much easier to implement and distribute, and would give another option other than to include `babel-polyfil`