### PR TITLE
Add support for webpacker 4 prereleases

### DIFF
--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -153,7 +153,7 @@ exitstatus: #{status.exitstatus}#{stdout_msg}#{stderr_msg}
     end
 
     def self.gem_available?(name)
-      Gem::Specification.find_by_name(name).present?
+      Gem::Specification.find_all_by_name(name).present?
     rescue Gem::LoadError
       false
     rescue StandardError


### PR DESCRIPTION
For some reason, Gem::Specification.find_by_name("webpacker") doesn't identify Webpacker 4 prereleases like webpacker 4.0.0.pre.pre.2 while Gem::Specification.find_all_by_name("webpacker") does. I've tested Gem::Specification.find_all_by_name for possible undesired side-effects, like returning multiple results for Gem::Specification.find_all_by_name("react"), and it has worked as desired in all cases that I've tested it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1134)
<!-- Reviewable:end -->
