### PR TITLE
Don't apply babel-plugin-transform-runtime inside react-on-rails to work with babel 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Don't apply babel-plugin-transform-runtime inside react-on-rails to work with babel 7. [PR 1136](https://github.com/shakacode/react_on_rails/pull/1136) by [Ryunosuke Sato](https://github.com/tricknotes)
+
 ### [11.1.2] - 2018-08-18
 
 #### Fixed

--- a/node_package/.babelrc
+++ b/node_package/.babelrc
@@ -2,6 +2,5 @@
   "presets": ["es2015", "stage-2", "react"],
   "plugins": [
     "transform-flow-strip-types",
-    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,12 +756,6 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Don't apply babel-plugin-transform-runtime inside react-on-rails to work with babel@7

It should be applied by user land.

Why?
The generated code depends on built babel's version.
It means that user couldn' build their code with babel@7 that depends on react-on-rails built by babel@6.

For example, babel-plugin-transform-runtime (babel 6) generates the 
following code.
``` js
var _assign = require('babel-runtime/core-js/object/assign');
```

However @babel/plugin-transform-runtime (babel 7) expects the 
path that beginning of `@babel/runtime/`.
                     
The change allows to use react-on-rails on babel@7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1136)
<!-- Reviewable:end -->
