### PR TITLE
Work on babel 7 with transform-runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes since last non-beta release.
 
 #### Fixed
 - Ignore Arrays in Rails i18n yml files. [PR 1129](https://github.com/shakacode/react_on_rails/pull/1129) by [vcarel](https://github.com/vcarel).
+- Fix to apply transform-runtime. And work with Babel 6 and 7. (Include revert of [PR 1136](https://github.com/shakacode/react_on_rails/pull/1136)) [PR 1140](https://github.com/shakacode/react_on_rails/pull/1140) by [Ryunosuke Sato](https://github.com/tricknotes).
 
 *Please add entries here for your pull requests that are not yet released.*
 

--- a/node_package/.babelrc
+++ b/node_package/.babelrc
@@ -2,5 +2,6 @@
   "presets": ["es2015", "stage-2", "react"],
   "plugins": [
     "transform-flow-strip-types",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "babel-runtime": "^6.25.0",
     "babel-tape-runner": "^2.0.1",
     "babel-types": "^6.25.0",
     "babelify": "^7.3.0",
@@ -41,7 +40,6 @@
     "webpack-manifest-plugin": "^1.2.1"
   },
   "peerDependencies": {
-    "babel-runtime": ">= 6",
     "js-yaml": ">= 3.0.0",
     "react": ">= 0.14",
     "react-dom": ">= 0.14"
@@ -88,5 +86,7 @@
     "url": "https://github.com/shakacode/react_on_rails/issues"
   },
   "homepage": "https://github.com/shakacode/react_on_rails#readme",
-  "dependencies": {}
+  "dependencies": {
+    "babel-runtime": "6"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,7 +854,7 @@ babel-register@^6.26.0, babel-register@^6.3.13:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.25.0, babel-runtime@^6.26.0:
+babel-runtime@6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,6 +756,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
Previously, I sent a PR to stop using babel-plugin-transform-runtime. https://github.com/shakacode/react_on_rails/pull/1136
But this breaks build for legacy browser.

So I fixed to apply babel-plugin-transform-runtime.
And it is allow to use for Babel 7 users by providing babel-runtime as "dependencies".