### PR TITLE
Fix render during interactive readyState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
+- Fix client startup invoking render prematurely.  Closes [issue #1150](https://github.com/shakacode/react_on_rails/issues/1150).
 
 ### [11.1.4] - 2018-09-12
 

--- a/node_package/src/clientStartup.js
+++ b/node_package/src/clientStartup.js
@@ -198,9 +198,7 @@ export function clientStartup(context) {
 
   window.setTimeout(() => {
     if (!turbolinksInstalled() || !turbolinksSupported()) {
-      if (document.readyState === 'complete' ||
-                                   (document.readyState !== 'loading' && !document.documentElement.doScroll)
-      ) {
+      if (document.readyState === 'complete') {
         debugTurbolinks(
           'NOT USING TURBOLINKS: DOM is already loaded, calling reactOnRailsPageLoaded',
         );


### PR DESCRIPTION
This fixes a regression introduced by [PR 1099](https://github.com/shakacode/react_on_rails/pull/1099), explained in [issue 1150](https://github.com/shakacode/react_on_rails/issues/1150).  The potential for this issue [was raised](https://github.com/shakacode/react_on_rails/pull/1099#issuecomment-397938518) during review of PR 1099 but not reproduced at that time, and is currently only reproducible for us in Chrome when utilizing `defer`ed scripts which are preloaded.

The code was cloned from jQuery `$.ready()`, with the offending part of the condition existing to support IE versions < 9.  This PR introduces a backwards-compatibility-break for those versions of IE, but should have no impact on any non-EOL browsers other than resolving this bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1151)
<!-- Reviewable:end -->
