### PR TITLE
Fix failure to render during interactive readyState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
+- Fix additional cases of client startup failing during interactive readyState
 
 ### [11.1.5] - 2018-09-12
 #### Fixed


### PR DESCRIPTION
This is a follow-up to [PR 1151](https://github.com/shakacode/react_on_rails/pull/1151).  I apologize for doubling up on this, but the last change was insufficient and we've found additional edge cases of undesired behavior with aggressive preloading of deferred scripts.

In addition to solving behavior for non-turbolinks users, this change also restores the original intent of `clientStartup()`, which explicitly calls out the turbolink check as needing to be done AFTER page load.  Since [PR 1099](https://github.com/shakacode/react_on_rails/pull/1099) this check has potentially been done prior to load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1152)
<!-- Reviewable:end -->
