### PR TITLE
Fixed intl parsing bug when trying to parse non-string entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Fixed bug where intl parsing would fail when trying to parse integers or blank entries. by [sepehr500](https://github.com/sepehr500)
+
 
 ### [11.1.6] - 2018-10-05
 #### Fixed

--- a/lib/react_on_rails/locales_to_js.rb
+++ b/lib/react_on_rails/locales_to_js.rb
@@ -107,7 +107,7 @@ module ReactOnRails
       translations.each_with_object({}) do |(k, v), h|
         if v.is_a? Hash
           flatten(v).map { |hk, hv| h["#{k}.#{hk}".to_sym] = hv }
-        elsif !v.is_a? Array # Arrays are not supported by react-intl
+        elsif v.is_a?(String) # Arrays are not supported by react-intl
           h[k] = v.gsub("%{", "{")
         end
       end

--- a/lib/react_on_rails/locales_to_js.rb
+++ b/lib/react_on_rails/locales_to_js.rb
@@ -107,7 +107,7 @@ module ReactOnRails
       translations.each_with_object({}) do |(k, v), h|
         if v.is_a? Hash
           flatten(v).map { |hk, hv| h["#{k}.#{hk}".to_sym] = hv }
-        elsif v.is_a?(String) # Arrays are not supported by react-intl
+        elsif v.is_a? String # Arrays are not supported by react-intl
           h[k] = v.gsub("%{", "{")
         end
       end

--- a/lib/react_on_rails/locales_to_js.rb
+++ b/lib/react_on_rails/locales_to_js.rb
@@ -107,8 +107,10 @@ module ReactOnRails
       translations.each_with_object({}) do |(k, v), h|
         if v.is_a? Hash
           flatten(v).map { |hk, hv| h["#{k}.#{hk}".to_sym] = hv }
-        elsif v.is_a? String # Arrays are not supported by react-intl
+        elsif v.is_a?(String)
           h[k] = v.gsub("%{", "{")
+        elsif !v.is_a?(Array)
+          h[k] = v
         end
       end
     end

--- a/spec/react_on_rails/fixtures/i18n/locales/en.yml
+++ b/spec/react_on_rails/fixtures/i18n/locales/en.yml
@@ -4,3 +4,5 @@ en:
   day_names: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
   blank:
   number: 2
+  bool: true
+  float: 2.0

--- a/spec/react_on_rails/fixtures/i18n/locales/en.yml
+++ b/spec/react_on_rails/fixtures/i18n/locales/en.yml
@@ -2,3 +2,4 @@ en:
   hello: "Hello world"
   argument: "I am %{age} years old."
   day_names: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
+  blank:

--- a/spec/react_on_rails/fixtures/i18n/locales/en.yml
+++ b/spec/react_on_rails/fixtures/i18n/locales/en.yml
@@ -3,3 +3,4 @@ en:
   argument: "I am %{age} years old."
   day_names: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
   blank:
+  number: 2

--- a/spec/react_on_rails/locales_to_js_spec.rb
+++ b/spec/react_on_rails/locales_to_js_spec.rb
@@ -31,6 +31,7 @@ module ReactOnRails
           expect(default).to include('{"hello":{"id":"hello","defaultMessage":"Hello world"}')
           expect(default).to include('"argument":{"id":"argument","defaultMessage":"I am {age} years old."}}')
           expect(default).not_to include("day_names:")
+          expect(default).not_to include("blank:")
 
           expect(File.mtime(translations_path)).to be >= File.mtime(en_path)
         end

--- a/spec/react_on_rails/locales_to_js_spec.rb
+++ b/spec/react_on_rails/locales_to_js_spec.rb
@@ -29,10 +29,12 @@ module ReactOnRails
           expect(translations).to include('{"hello":"Hallo welt"')
           expect(default).to include("const defaultLocale = 'en';")
           expect(default).to include('{"hello":{"id":"hello","defaultMessage":"Hello world"}')
-          expect(default).to include('"argument":{"id":"argument","defaultMessage":"I am {age} years old."}}')
+          expect(default).to include('"argument":{"id":"argument","defaultMessage":"I am {age} years old."}')
+          expect(default).to include('"blank":{"id":"blank","defaultMessage":null}')
+          expect(default).to include("number")
+          expect(default).to include("bool")
+          expect(default).to include("float")
           expect(default).not_to include("day_names:")
-          expect(default).not_to include("blank:")
-          expect(default).not_to include("number:")
 
           expect(File.mtime(translations_path)).to be >= File.mtime(en_path)
         end

--- a/spec/react_on_rails/locales_to_js_spec.rb
+++ b/spec/react_on_rails/locales_to_js_spec.rb
@@ -32,6 +32,7 @@ module ReactOnRails
           expect(default).to include('"argument":{"id":"argument","defaultMessage":"I am {age} years old."}}')
           expect(default).not_to include("day_names:")
           expect(default).not_to include("blank:")
+          expect(default).not_to include("number:")
 
           expect(File.mtime(translations_path)).to be >= File.mtime(en_path)
         end


### PR DESCRIPTION
Fixed intl parsing bug when trying to parse non-string entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1153)
<!-- Reviewable:end -->
