### PR TITLE
Add webpacker for Rails 5.1+ in tests

### DIFF
--- a/rakelib/example_type.rb
+++ b/rakelib/example_type.rb
@@ -49,8 +49,9 @@ module ReactOnRails
       end
 
       # Options we pass when running `rails new` from the command-line.
+      attr_writer :rails_options
       def rails_options
-        "--skip-bundle --skip-spring --skip-git --skip-test-unit --skip-active-record"
+        @rails_options ||= "--skip-bundle --skip-spring --skip-git --skip-test-unit --skip-active-record"
       end
 
       %w[gen clobber npm_install build_webpack_bundles].each do |task_type|

--- a/rakelib/examples.rake
+++ b/rakelib/examples.rake
@@ -6,6 +6,8 @@
 # Also see example_type.rb
 
 require "yaml"
+require 'rails/version'
+
 require_relative "example_type"
 require_relative "task_helpers"
 
@@ -28,6 +30,7 @@ namespace :examples do # rubocop:disable Metrics/BlockLength
     desc "Generates #{example_type.name_pretty}"
     task example_type.gen_task_name_short => example_type.clobber_task_name do
       mkdir_p(example_type.dir)
+      example_type.rails_options += " --webpack" if Rails.version >= "5.1" && Rails.version < "6"
       sh_in_dir(examples_dir, "rails new #{example_type.name} #{example_type.rails_options}")
       sh_in_dir(example_type.dir, "touch .gitignore")
       sh_in_dir(example_type.dir, "rake webpacker:install")


### PR DESCRIPTION
Since Rails 5.1+ you can find the option the new projects `rails new foo --webpack`. 
After the Rails 6.0 webpack should be installed by default.

Environment:
Ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin18]
Rails 5.2.3

Steps to reproduce:

`$ rake`

error message
```
(...cut)

cd /Users/mike/proj/react_on_rails/gen-examples/examples/basic && touch .gitignore
cd /Users/mike/proj/react_on_rails/gen-examples/examples/basic && rake webpacker:install
rake aborted!
Don't know how to build task 'webpacker:install' (See the list of available tasks with `rake --tasks`)

(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [cd /Users/mike/proj/react_on_rails/gen-exa...]
/Users/mike/proj/react_on_rails/rakelib/task_helpers.rb:22:in `block in sh_in_dir'
/Users/mike/proj/react_on_rails/rakelib/task_helpers.rb:22:in `each'
/Users/mike/proj/react_on_rails/rakelib/task_helpers.rb:22:in `sh_in_dir'
/Users/mike/proj/react_on_rails/rakelib/examples.rake:36:in `block (3 levels) in <top (required)>'
Tasks: TOP => default => run_rspec => run_rspec:run_rspec => run_rspec:examples => examples:gen_all => examples:gen_basic
(See full trace by running task with --trace)
```

So it looks like somewhere between Rails 5.1.0 and Rails 5.2.3 breaking change appears.

This PR fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1210)
<!-- Reviewable:end -->
