### PR TITLE
Add configuration option to camelCase props

### DIFF
--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -183,6 +183,13 @@ ReactOnRails.configure do |config|
   
   ################################################################################
   ################################################################################
+  # CAMELCASE PROPS
+  # This option will automatically convert any props with snake_case keys to camelCase
+  # The default is false
+  config.camel_case_props = false
+
+  ################################################################################
+  ################################################################################
   # CLIENT RENDERING OPTIONS
   # Below options can be overriden by passing options to the react_on_rails
   # `render_component` view helper method.

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -34,7 +34,8 @@ module ReactOnRails
       symlink_non_digested_assets_regex: nil,
       build_test_command: "",
       build_production_command: "",
-      random_dom_id: DEFAULT_RANDOM_DOM_ID
+      random_dom_id: DEFAULT_RANDOM_DOM_ID,
+      camel_case_props: false
     )
   end
 
@@ -47,7 +48,7 @@ module ReactOnRails
                   :webpack_generated_files, :rendering_extension, :build_test_command,
                   :build_production_command,
                   :i18n_dir, :i18n_yml_dir,
-                  :server_render_method, :symlink_non_digested_assets_regex, :random_dom_id
+                  :server_render_method, :symlink_non_digested_assets_regex, :random_dom_id, :camel_case_props
 
     def initialize(node_modules_location: nil, server_bundle_js_file: nil, prerender: nil,
                    replay_console: nil,
@@ -59,7 +60,7 @@ module ReactOnRails
                    rendering_extension: nil, build_test_command: nil,
                    build_production_command: nil,
                    i18n_dir: nil, i18n_yml_dir: nil, random_dom_id: nil,
-                   server_render_method: nil, symlink_non_digested_assets_regex: nil)
+                   server_render_method: nil, symlink_non_digested_assets_regex: nil, camel_case_props: false)
       self.node_modules_location = node_modules_location.present? ? node_modules_location : Rails.root
       self.server_bundle_js_file = server_bundle_js_file
       self.generated_assets_dirs = generated_assets_dirs
@@ -91,6 +92,7 @@ module ReactOnRails
 
       self.server_render_method = server_render_method
       self.symlink_non_digested_assets_regex = symlink_non_digested_assets_regex
+      self.camel_case_props = camel_case_props
     end
 
     # on ReactOnRails

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -57,8 +57,7 @@ module ReactOnRails
                    server_renderer_timeout: nil, raise_on_prerender_error: true,
                    skip_display_none: nil, generated_assets_dirs: nil,
                    generated_assets_dir: nil, webpack_generated_files: nil,
-                   rendering_extension: nil, build_test_command: nil,
-                   build_production_command: nil,
+                   rendering_extension: nil, build_test_command: nil, build_production_command: nil,
                    i18n_dir: nil, i18n_yml_dir: nil, random_dom_id: nil,
                    server_render_method: nil, symlink_non_digested_assets_regex: nil, camel_case_props: false)
       self.node_modules_location = node_modules_location.present? ? node_modules_location : Rails.root

--- a/lib/react_on_rails/react_component/render_options.rb
+++ b/lib/react_on_rails/react_component/render_options.rb
@@ -13,7 +13,12 @@ module ReactOnRails
 
       def initialize(react_component_name: required("react_component_name"), options: required("options"))
         @react_component_name = react_component_name.camelize
-        @options = options
+
+        @options = if ReactOnRails.configuration.camel_case_props
+                     camel_case_props(options)
+                   else
+                     options
+                   end
       end
 
       attr_reader :react_component_name
@@ -88,6 +93,11 @@ module ReactOnRails
         options.fetch(key) do
           ReactOnRails.configuration.public_send(key)
         end
+      end
+
+      def camel_case_props(options)
+        options[:props] = options[:props].deep_transform_keys! { |key| key.to_s.camelize(:lower).to_sym }
+        options
       end
     end
   end

--- a/spec/react_on_rails/react_component/render_options_spec.rb
+++ b/spec/react_on_rails/react_component/render_options_spec.rb
@@ -53,12 +53,11 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         ReactOnRails.configuration.camel_case_props = true
       end
 
-      after do 
+      after do
         ReactOnRails.configuration.camel_case_props = false
       end
 
       it "converts all prop keys to camelCase" do
-
         props = { snake_case: "foo", alreadyCamelCase: "bar", deeply_nested: { snake_case: "baz" } }
 
         attrs = the_attrs(options: { props: props })

--- a/spec/react_on_rails/react_component/render_options_spec.rb
+++ b/spec/react_on_rails/react_component/render_options_spec.rb
@@ -47,6 +47,29 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         expect(opts.props).to eq(props)
       end
     end
+
+    context "when camel_case_props is set to true" do
+      before do
+        ReactOnRails.configuration.camel_case_props = true
+      end
+
+      after do 
+        ReactOnRails.configuration.camel_case_props = false
+      end
+
+      it "converts all prop keys to camelCase" do
+
+        props = { snake_case: "foo", alreadyCamelCase: "bar", deeply_nested: { snake_case: "baz" } }
+
+        attrs = the_attrs(options: { props: props })
+
+        opts = described_class.new(attrs)
+
+        expected_props = { snakeCase: "foo", alreadyCamelCase: "bar", deeplyNested: { snakeCase: "baz" } }
+
+        expect(opts.props).to eq(expected_props)
+      end
+    end
   end
 
   describe "#react_component_name" do


### PR DESCRIPTION
When passing props in server-side rendering, they are often in snake_case, since this is ruby standard, however many prefer to use camelCase when working with javascript. This PR introduces the configuration option to automatically convert any props that have keys in snake_case to camelCase. Tests included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1214)
<!-- Reviewable:end -->
