### PR TITLE
Added documentation for typescript installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,26 @@ Note, the best way to understand how to use ReactOnRails is to study a few simpl
 
 7. Visit http://localhost:3000/hello_world.
 
-  
+## Typescript Installation *(Optional)*
+
+*After running the basic installation*
+
+1. Run the typescript installer
+
+   ```bash
+   $ bundle exec rails webpacker:install:typescript
+   ```
+
+2. Add react typescipt dependencies
+
+   ```bash
+   $ yarn add @types/react @types/react-dom
+   ```
+
+3. Rename the generated .js to .tsx or .ts. 
+
+4. Make the files valid typescript. Now you can use typescript with React.
+
 ### Turning on server rendering
 
 With the code from running the React on Rails generator above:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Note, the best way to understand how to use ReactOnRails is to study a few simpl
    $ yarn add @types/react @types/react-dom
    ```
 
-3. Rename the generated .js to .tsx or .ts. 
+3. Rename the generated .js files to .tsx or .ts. 
 
 4. Make the files valid typescript. Now you can use typescript with React.
 


### PR DESCRIPTION
Added documentation for typescript installation

Documentation now includes **optional** instructions as to how to use the Webpacker gem, running the react_on_rails generator, to support typescript.

Resolves: #635

![doc](https://user-images.githubusercontent.com/45657596/70876149-5d928080-1f6d-11ea-8f02-1c136306d946.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1236)
<!-- Reviewable:end -->
