### PR TITLE
hussainakram/Fix setup issues with prerender:true

### DIFF
--- a/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "open-uri"
+require "execjs"
 
 module ReactOnRails
   module ServerRenderingPool

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -12,7 +12,8 @@ namespace :react_on_rails do
     the "ReactOnRails.configuration.i18n_dir".
   DESC
   task locale: :environment do
-    if ReactOnRails.configuration.i18n_output_format.downcase == 'js'
+    if ReactOnRails.configuration.i18n_output_format &&
+       ReactOnRails.configuration.i18n_output_format.downcase == "js"
       ReactOnRails::Locales::ToJs.new
     else
       ReactOnRails::Locales::ToJson.new


### PR DESCRIPTION
# Summary
Following [setup docs](https://github.com/shakacode/react_on_rails/blob/master/docs/tutorial.md) there are some issues to be fixed
## Details
1. When we set `prerender: true`  it throws error of ExecJS as show [here](https://share.getcloudapp.com/bLujr6op) 
2. With unset `i18n_output_format` config option, it throws error of of **NoMethodError: undefined method `downcase`** due to default `nil` value of `i18n_output_format`
https://github.com/shakacode/react_on_rails/blob/50798b87a352364ddfaa2dc92fa18e29cf2bdd7e/lib/react_on_rails/configuration.rb#L38

## Implementation Tasks
- [x] require `"execjs"` in `ruby_embedded_java_script.rb`
- [x] Fix NoMethodError error for i18n_output_format
