### PR TITLE
Default to rails/webpacker precompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Changes since last non-beta release.
 ## UPCOMING 12.0 RELEASE
 
 #### Improved
-* Generator supports React Hooks
+### [12.0.0.pre.beta.2]
+* Changed the precompile task to use the rails/webpacker one by default
 
 ### [12.0.0.pre.beta.1]
 * Updated generators to use React hooks
@@ -39,6 +40,9 @@ See [docs/basics/upgrading-react-on-rails](./docs/basics/upgrading-react-on-rail
 for details.         
 
 * Requires the use of rails/webpacker helpers
+* If the webpacker webpack config files exist, then React on Rails will not override the default
+  assets:precompile setup by rails/webpacker. The fix is to remove the JS files inside of config/webpack,
+  like config/webpack/production.js.
 * Removed **env_javascript_include_tag** and **env_stylesheet_link_tag** as these are replaced by view helpers
   from rails/webpacker
 * Removal of support for old Rubies and Rails.

--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -61,8 +61,11 @@ ReactOnRails.configure do |config|
   #
   config.node_modules_location = "client" # If using webpacker you should use "".
 
-  # This configures the script to run to build the production assets by webpack. Set this to nil
+  # This configures the script to run to build the production assets by webpack . Set this to nil
   # if you don't want react_on_rails building this file for you.
+  # Note, if you want to use this command then you should remove the file
+  # config/webpack/production.js
+  # If that file exists, React on Rails thinks that you'll use the rails/webpacker bin/webpack compiler.
   config.build_production_command = "RAILS_ENV=production bin/webpack"
 
   ################################################################################
@@ -89,7 +92,9 @@ ReactOnRails.configure do |config|
   # Normally, you have different bundles for client and server, thus, the default is false.
   # Furthermore, if you are not hashing the server bundle (not in the manifest.json), then React on Rails
   # will only look for the server bundle to be created in the typical file location, typically by
-  # a `webpack --watch` process. 
+  # a `webpack --watch` process.
+  # If true, ensure that in config/webpacker.yml that you have both dev_server.hmr and
+  # dev_server.inline set to false.
   config.same_bundle_for_client_and_server = false
   
   # If set to true, this forces Rails to reload the server bundle if it is modified

--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -191,7 +191,7 @@ ReactOnRails.configure do |config|
   # CONFIGURE YOUR SOURCE FILES 
   # The test helper needs to know where your JavaScript files exist. The value is configured
   # by your config/webpacker.yml source_path:
-  # source_path: client/app/javascript # if using recommended /client directory
+  # source_path: client/app # if using recommended /client directory
   #
   # Define the files we need to check for webpack compilation when running tests.
   # The default is `%w( manifest.json )` as will be sufficient for most webpacker builds.

--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -139,6 +139,7 @@ ReactOnRails.configure do |config|
   # Replace the following line to the location where you keep translation.js & default.js for use
   # by the npm packages react-intl. Be sure this directory exists!
   # config.i18n_dir = Rails.root.join("client", "app", "libs", "i18n")
+  #
   # If not using the i18n feature, then leave this section commented out or set the value
   # of config.i18n_dir to nil.
   #
@@ -146,11 +147,11 @@ ReactOnRails.configure do |config|
   # that will source for automatic generation on translations.js & default.js
   # By default(without this option) all yaml files from Rails.root.join("config", "locales")
   # and installed gems are loaded
-  config.i18n_yml_dir = Rails.root.join("config", "locales", "client")
+  config.i18n_yml_dir = Rails.root.join("config", "locales")
   
   # Possible output formats are js and json
   # The default format is json
-  config.i18n_output_format = 'js'
+  config.i18n_output_format = 'json'
 
   ################################################################################
   ################################################################################

--- a/docs/basics/hmr-and-hot-reloading-with-the-webpack-dev-server.md
+++ b/docs/basics/hmr-and-hot-reloading-with-the-webpack-dev-server.md
@@ -1,0 +1,28 @@
+# HMR and Hot Reloading with the webpack-dev-server
+
+The webpack-dev-server provides:
+
+1. Speedy compilation of client side assets
+2. Optional HMR which means that the page will reload automatically when after compilation completes. Note,
+   some developers do not like this, as you'll abruptly lose any tweaks within the Chrome development
+   tools.
+3. Optional hot-reloading. The older react-hot-loader has been deprecated in favor of [fast-refresh](https://reactnative.dev/docs/fast-refresh).
+   For use with webpack, see [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin).
+
+If you are not using server-side rendering (`prerender: true`), then you can follow all the regular docs
+for using the `bin/webpack-dev-server` during development.
+
+If you are using server-side rendering, then you have a couple options.
+
+`dev_server.hmr` maps to [devServer.hot](https://webpack.js.org/configuration/dev-server/#devserverhot). This must be false if you're using the webpack-dev-server for client and server bundles.
+`dev_server.inline` maps to [devServer.inline](https://webpack.js.org/configuration/dev-server/#devserverinline). This must also be false.
+
+If you don't configure these two to false, you'll see errors like:
+
+* "ReferenceError: window is not defined" (if hmr is true)
+* "TypeError: Cannot read property 'prototype' of undefined" (if inline is true)
+
+
+
+
+

--- a/docs/basics/hmr-and-hot-reloading-with-the-webpack-dev-server.md
+++ b/docs/basics/hmr-and-hot-reloading-with-the-webpack-dev-server.md
@@ -3,19 +3,40 @@
 The webpack-dev-server provides:
 
 1. Speedy compilation of client side assets
-2. Optional HMR which means that the page will reload automatically when after compilation completes. Note,
-   some developers do not like this, as you'll abruptly lose any tweaks within the Chrome development
-   tools.
-3. Optional hot-reloading. The older react-hot-loader has been deprecated in favor of [fast-refresh](https://reactnative.dev/docs/fast-refresh).
+2. Optional HMR which means that the page will reload automatically when after
+   compilation completes. Note, some developers do not like this, as you'll
+   abruptly lose any tweaks within the Chrome development tools.
+3. Optional hot-reloading. The older react-hot-loader has been deprecated in 
+   favor of [fast-refresh](https://reactnative.dev/docs/fast-refresh).
    For use with webpack, see [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin).
 
-If you are not using server-side rendering (`prerender: true`), then you can follow all the regular docs
-for using the `bin/webpack-dev-server` during development.
+If you are ***not*** using server-side rendering (***not*** using `prerender: true`),
+then you can follow all the regular docs for using the `bin/webpack-dev-server` 
+during development.
 
-If you are using server-side rendering, then you have a couple options.
 
-`dev_server.hmr` maps to [devServer.hot](https://webpack.js.org/configuration/dev-server/#devserverhot). This must be false if you're using the webpack-dev-server for client and server bundles.
-`dev_server.inline` maps to [devServer.inline](https://webpack.js.org/configuration/dev-server/#devserverinline). This must also be false.
+# Server Side Rendering with the Default rails/webpacker bin/webpack-dev-server
+
+If you are using server-side rendering, then you have a couple options. The
+recommended technique is to have a different webpack configuration for server
+rendering.  
+
+
+
+
+## If you use the same Webpack setup for your server and client bundles 
+If you do use the webpack-dev-server for prerendering, be sure to set the
+`config/initializers/react_on_rails.rb` setting of 
+
+```
+  config.same_bundle_for_client_and_server = true
+```
+
+`dev_server.hmr` maps to [devServer.hot](https://webpack.js.org/configuration/dev-server/#devserverhot).
+This must be false if you're using the webpack-dev-server for client and server bundles.
+ 
+`dev_server.inline` maps to [devServer.inline](https://webpack.js.org/configuration/dev-server/#devserverinline).
+This must also be false.
 
 If you don't configure these two to false, you'll see errors like:
 

--- a/docs/basics/rspec-configuration.md
+++ b/docs/basics/rspec-configuration.md
@@ -1,9 +1,32 @@
 # RSpec Configuration
 _Click [here for minitest](./minitest-configuration.md)_
 
+# If your webpack configurations correspond to rails/webpacker's default setup
+If you're able to configure your webpack configuration to be run by having your webpack configuration
+returned by the files in `/config/webpack`, then you have 2 options to ensure that your files are
+compiled by webpack before running tests and during production deployment:
+
+1. **Use rails/webpacker's compile option**: Configure your `config/webpacker.yml` so that `compile: true` is for `test` and `production`
+   environments. Ensure that your `source_path` is correct, or else `rails/webpacker` won't correctly
+   detect changes. 
+2. **Use the react_on_rails settings and helpers**. Use the settings in `config/initializers/react_on_rails.rb`. Refer to [docs/configuration](./configuration.md).
+
+```yml
+  config.build_production_command = "RAILS_ENV=production bin/webpack"
+  config.build_test_command = "RAILS_ENV=test bin/webpack"
+``` 
+
+Which should you use? If you're already using the `rails/webpacker` way to configure webpack, then
+you can keep things simple and use the `rails/webpacker` options.
+
+# Checking for stale assets using React on Rails
+
 Because you will probably want to run RSpec tests that rely on compiled webpack assets (typically, your integration/feature specs where `js: true`), you will want to ensure you don't accidentally run tests on missing or stale webpack assets. If you did use stale Webpack assets, you will get invalid test results as your tests do not use the very latest JavaScript code.
 
-ReactOnRails provides a helper method called `ReactOnRails::TestHelper.configure_rspec_to_compile_assets`. Call this method from inside of the `RSpec.configure` block in your `spec/rails_helper.rb` file, passing the config as an argument. See file [lib/react_on_rails/test_helper.rb](../../lib/react_on_rails/test_helper.rb) for more details. You can customize this to your particular needs by replacing any of the default components used by `ReactOnRails::TestHelper.configure_rspec_to_compile_assets`.
+As mentioned above, you can configure `compile: true` in `config/webpacker.yml` _if_ you've got configuration for
+your webpack in the standard `rails/webpacker` spot of `config/webpack/<NODE_ENV>.js`
+
+ReactOnRails also provides a helper method called `ReactOnRails::TestHelper.configure_rspec_to_compile_assets`. Call this method from inside of the `RSpec.configure` block in your `spec/rails_helper.rb` file, passing the config as an argument. See file [lib/react_on_rails/test_helper.rb](../../lib/react_on_rails/test_helper.rb) for more details. You can customize this to your particular needs by replacing any of the default components used by `ReactOnRails::TestHelper.configure_rspec_to_compile_assets`.
 
 ```ruby
 RSpec.configure do |config|
@@ -26,26 +49,17 @@ Please take note of the following:
 
 - This utility uses your `build_test_command` to build the static generated files. This command **must not** include the `--watch` option. If you have different server and client bundle files, this command **must** create all the bundles. If you are using webpacker, the default value will come from the `config/webpacker.yml` value for the `public_output_path` and the `source_path`
 
-- If you add an older file to your source files, that is already older than the produced output files, no new recompilation is done. The solution to this issue is to clear out your directory of webpack generated files when adding new source files that may have older dates. This is actually a common occurrence when you've built your test generated files and then you sync up your repository files.
+- If you add an older file to your source files, that is already older than the produced output files, no new recompilation is done. The solution to this issue is to clear out your directory of webpack generated files when adding new source files that may have older dates. This can happen when you've built your test generated files and then you sync up your repository files.
 
-- By default, the webpack processes look for the `config.generated_assets_dir` folder for generated files, configured via setting `webpack_generated_files`, in the `config/react_on_rails.rb`. If the `config.generated_assets_dir` folder is missing, is empty, or contains files in the `config.webpack_generated_files` list with `mtime`s older than any of the files in your `client` folder, the helper will recompile your assets. You can override the location of these files inside of `config/initializers/react_on_rails.rb` by passing a filepath (relative to the root of the app) to the `generated_assets_dir` configuration option.
+- By default, the webpack processes look in the webpack generated files folder, configured via the `config/webpacker.yml` config values of `public_root_path` and `public_output_path`. If the webpack generated files folder is missing, is empty, or contains files in the `config.webpack_generated_files` list with `mtime`s older than any of the files in your `client` folder, the helper will recompile your assets. 
 
 The following `config/react_on_rails.rb` settings **must** match your setup:
 ```ruby
-  # Directory where your generated assets go. All generated assets must go to the same directory.
-  # Configure this in your webpack config files. This relative to your Rails root directory.
-  # We recommend having different generated assets dirs per Rails env.
-  config.generated_assets_dir = File.join(%w[public webpack], Rails.env)
-
   # Define the files we need to check for webpack compilation when running tests.
-  # Generally, the manifest.json is good enough for this check if using webpacker
   config.webpack_generated_files = %w( manifest.json )
   
   # OR if you're not hashing the server-bundle.js, then you should include your server-bundle.js in the list.
   # config.webpack_generated_files = %w( server-bundle.js manifest.json )
-  
-  # OR if you're not using webpacker, your setup might look like.
-  # config.webpack_generated_files = %w( client-bundle.js server-bundle.js )
   
   # If you are using the ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
   # with rspec then this controls what yarn command is run
@@ -53,9 +67,7 @@ The following `config/react_on_rails.rb` settings **must** match your setup:
   config.build_test_command = "yarn run build:test"
 ```
 
-If you want to speed up the re-compiling process so you don't wait to run your tests to build the files, you can run your test compilation with the "watch" flags.
-
-[spec/dummy](https://github.com/shakacode/react_on_rails/tree/master/spec/dummy) contains examples of how to set the proc files for this purpose.
+If you want to speed up the re-compiling process so you don't wait to run your tests to build the files, you can run your test compilation with the "watch" flags. For example, `yarn run build:test --watch`
 
 ![2016-01-27_02-36-43](https://cloud.githubusercontent.com/assets/1118459/12611951/7c56d070-c4a4-11e5-8a80-9615f99960d9.png)
 

--- a/docs/basics/upgrading-react-on-rails.md
+++ b/docs/basics/upgrading-react-on-rails.md
@@ -7,6 +7,12 @@ We specialize in helping companies to quickly and efficiently move from versions
 
 ## Upgrading to v12
 * Make sure that you are on a relatively more recent version of rails and webpacker.
+* If the webpacker webpack config files exist, then React on Rails will not override the default
+  assets:precompile setup by rails/webpacker. The fix is to remove the JS files inside of config/webpack,
+  like config/webpack/production.js.
+* If you're using the internalization helper, then set `config.i18n_output_format = 'js'`. You can
+  later update to the default JSON format as you will need to update your usage of that file.
+
 * Updated API for ReactOnRails.register.
 
 In order to solve the issues regarding React Hooks compatibility, the number of parameters

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -119,31 +119,12 @@ foreman start -f Procfile.dev-hmr
 
 Visit [http://localhost:3000/hello_world](http://localhost:3000/hello_world) and see your **React On Rails** app running!
 
-*Note, foreman may default to PORT 5000 unless you set the value of PORT in your environment or in the Procfile.*
-
 # HMR vs. React Hot Reloading
 
-First, check that the `hmr` option is `true` in your `config/webpacker.yml` file.
+First, check that the `hmr` and the `inline` options are `true` in your `config/webpacker.yml` file.
 
 The basic setup will have HMR working with the default webpacker setup. The basic HMR will cause
-a full page refresh each time you save a file. You also lose any state on your page during the refresh. Don't try to use HMR
-
-### Custom IP & PORT setup (Cloud9 example)
-
-In case you are running some custom setup with different IP or PORT you should also edit Procfile.dev. For example to be able to run on free Cloud9 IDE we are putting IP 0.0.0.0 and PORT 8080. The default generated file `Procfile.dev` uses `-p 3000`.
-
-``` Procfile.dev
-web: rails s -p 8080 -b 0.0.0.0
-```
-
-Then visit https://your-shared-addr.c9users.io:8080/hello_world 
-
-## RubyMine
-
-It's super important to exclude certain directories from RubyMine or else it will slow to a crawl as it tries to parse all the npm files.
-
-* Generated files, per the settings in your `config/webpacker.yml`, which default to `public/packs` and `public/packs-test`
-* `node_modules`
+a full page refresh each time you save a file. You also lose any state on your page during the refresh. 
 
 ## Deploying to Heroku
 
@@ -166,17 +147,16 @@ Set heroku to use multiple buildpacks:
 
 ### Swap out sqlite for postgres by doing the following:
 
-1. Delete the line with `sqlite` and replace it with:
+Run these two commands:
 
-```ruby
-   gem 'pg'
 ```
-
-2. Run `bundle`
+bundle remove sqlite3
+bundle add pg
+```
 
 ![07](https://cloud.githubusercontent.com/assets/20628911/17465015/1f2f4042-5cf4-11e6-8287-2fb077550809.png)
 
-3. Replace your `database.yml` file with this (assuming your app name is "ror").
+### Replace your `database.yml` file with this (assuming your app name is "ror").
 
 ```yml
 default: &default
@@ -204,7 +184,6 @@ production:
 Then you need to setup postgres so you can run locally:
 
 ```
-bundle
 rake db:setup
 rake db:migrate
 ```
@@ -228,7 +207,7 @@ Create `/Procfile`. This is what Heroku uses to start your app.
 web: bundle exec puma -C config/puma.rb
 ```
 
-Note, newer versions of Rails create this file automatically. However, the [docs on Heroku](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#config) have something a bit different, so please make it conform to those docs. As of 2018-10-13, the docs looked like this:
+Note, newer versions of Rails create this file automatically. However, the [docs on Heroku](https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#config) have something a bit different, so please make it conform to those docs. As of 2020-06-04, the docs looked like this:
 
 `config/puma.rb`
 ```rb
@@ -247,6 +226,15 @@ on_worker_boot do
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
   ActiveRecord::Base.establish_connection
 end
+```
+
+Next, update your `package.json` to specify the version of yarn and node. Add this section:
+
+```json
+  "engines": {
+    "node": "13.9.0",
+    "yarn": "1.22.4"
+  },
 ```
 
 Then after all changes are done don't forget to commit them with git and finally you can push your app to Heroku!
@@ -338,6 +326,27 @@ So you get some basics from HMR with no code changes. If you want to go further,
 * https://webpack.js.org/concepts/hot-module-replacement/
 
 React on Rails will automatically handle disabling server rendering if there is only one bundle file created by the Webpack development server by rails/webpacker.
+
+
+### Custom IP & PORT setup (Cloud9 example)
+
+In case you are running some custom setup with different IP or PORT you should also edit Procfile.dev. For example to be able to run on free Cloud9 IDE we are putting IP 0.0.0.0 and PORT 8080. The default generated file `Procfile.dev` uses `-p 3000`.
+
+``` Procfile.dev
+web: rails s -p 8080 -b 0.0.0.0
+```
+
+Then visit https://your-shared-addr.c9users.io:8080/hello_world 
+
+## RubyMine
+
+It's super important to exclude certain directories from RubyMine or else it will slow to a crawl as it tries to parse all the npm files.
+
+* Generated files, per the settings in your `config/webpacker.yml`, which default to `public/packs` and `public/packs-test`
+* `node_modules`
+
+
+
 
 ## Conclusion
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -123,8 +123,9 @@ Visit [http://localhost:3000/hello_world](http://localhost:3000/hello_world) and
 
 First, check that the `hmr` and the `inline` options are `true` in your `config/webpacker.yml` file.
 
-The basic setup will have HMR working with the default webpacker setup. The basic HMR will cause
-a full page refresh each time you save a file. You also lose any state on your page during the refresh. 
+The basic setup will have HMR working with the default webpacker setup. The basic
+[HMR](https://webpack.js.org/concepts/hot-module-replacement/), without a special
+React setup, will cause a full page refresh each time you save a file. 
 
 ## Deploying to Heroku
 

--- a/lib/generators/react_on_rails/templates/base/base/Procfile.dev-hmr
+++ b/lib/generators/react_on_rails/templates/base/base/Procfile.dev-hmr
@@ -1,17 +1,23 @@
+# Procfile for development using HMR
+
 web: rails s -p 3000
 
 # Note, hot and live reloading don't work with the default generator setup on
 # top of the rails/webpacker Webpack config with server rendering.
 # If you have server rendering enabled (prerender is true), you either need to
-# a. Skip using the webpack-dev-server. bin/webpack --watch is typically
+# a. Ensure that you have dev_server.hmr and dev_server.inline BOTH set to false,
+#    and you have this option in your config/initializers/react_on_rails.rb:
+#      config.same_bundle_for_client_and_server = true
+#    If you have either config/webpacker.yml option set to true, you'll see errors like
+#    "ReferenceError: window is not defined" (if hmr is true)
+#    "TypeError: Cannot read property 'prototype' of undefined" (if inline is true)
+# b. Skip using the webpack-dev-server. bin/webpack --watch is typically
      fast enough.
-# b. See the React on Rails README for a link to documentation for how to setup
-#    SSR with HMR and React hot loading
-# Otherwise, you will have an error. If you want HMR and Server Rendering, see
-# the example in the https://github.com/shakacode/react-webpack-rails-tutorial
-web: rails s -p 3000
+# c. See the React on Rails README for a link to documentation for how to setup
+#    SSR with HMR and React hot loading using the webpack-dev-server only for the
+#    client bundles and a static file for the server bundle.
 
-# Run the hot reload server for client development
+# Run the webpack-dev-server for client and maybe server files
 webpack-dev-server: bin/webpack-dev-server
 
 # Keep the JS fresh for server rendering. Remove if not server rendering

--- a/lib/generators/react_on_rails/templates/base/base/Procfile.dev-hmr
+++ b/lib/generators/react_on_rails/templates/base/base/Procfile.dev-hmr
@@ -20,5 +20,7 @@ web: rails s -p 3000
 # Run the webpack-dev-server for client and maybe server files
 webpack-dev-server: bin/webpack-dev-server
 
-# Keep the JS fresh for server rendering. Remove if not server rendering
-rails-server-assets: SERVER_BUNDLE_ONLY=yes bin/webpack --watch
+# Keep the JS fresh for server rendering. Remove if not server rendering.
+# Especially if you have not configured generation of a server bundle without a hash.
+# as that will conflict with the manifest created by the bin/webpack-dev-server
+# rails-server-assets: SERVER_BUNDLE_ONLY=yes bin/webpack --watch

--- a/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb
+++ b/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb
@@ -6,7 +6,8 @@
 ReactOnRails.configure do |config|
   # This configures the script to run to build the production assets by webpack. Set this to nil
   # if you don't want react_on_rails building this file for you.
-  config.build_production_command = "RAILS_ENV=production NODE_ENV=production bin/webpack"
+  # If nil, then the standard rails/webpacker assets:precompile will run
+  # config.build_production_command = nil
 
   ################################################################################
   ################################################################################

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,13 +1,25 @@
 # frozen_string_literal: true
 
+# Important: The default assets:precompile is modified ONLY if the rails/webpacker webpack config
+# does not exist!
+
 require "active_support"
 
-if Rake::Task.task_defined?("assets:precompile")
-  Rake::Task["assets:precompile"].enhance do
-    Rake::Task["react_on_rails:assets:webpack"].invoke
+ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["NODE_ENV"]  ||= "development"
+webpacker_webpack_config_abs_path = File.join(Rails.root, "config/webpack/#{ENV["NODE_ENV"]}.js")
+webpack_config_path = Pathname.new(webpacker_webpack_config_abs_path).relative_path_from(Rails.root).to_s
+
+unless File.exists?(webpacker_webpack_config_abs_path)
+  if Rake::Task.task_defined?("assets:precompile")
+    Rake::Task["assets:precompile"].enhance do
+      Rake::Task["react_on_rails:assets:webpack"].invoke
+      puts "Invoking task wepacker:clean from React on Rails"
+      Rake::Task["webpacker:clean"].invoke
+    end
+  else
+    Rake::Task.define_task("assets:precompile" => ["react_on_rails:assets:webpack"])
   end
-else
-  Rake::Task.define_task("assets:precompile" => ["react_on_rails:assets:webpack"])
 end
 
 # Sprockets independent tasks
@@ -18,6 +30,9 @@ namespace :react_on_rails do
       Uses command defined with ReactOnRails.configuration.build_production_command
 
       sh "#{ReactOnRails::Utils.prepend_cd_node_modules_directory('<ReactOnRails.configuration.build_production_command>')}"
+
+      Note: This command is not automatically added to assets:precompile if the rails/webpacker
+      configuration file #{webpack_config_path} exists.
     DESC
     task webpack: :locale do
       if ReactOnRails.configuration.build_production_command.present?

--- a/spec/dummy/Procfile.spec
+++ b/spec/dummy/Procfile.spec
@@ -1,9 +1,0 @@
-# For keeping webpack bundles up-to-date during a testing workflow.
-# If you don't keep this process going, you will rebuild the assets per spec run. This is configured
-# in rails_helper.rb.
-
-# Build client assets, watching for changes.
-rails-client-assets: yarn run build:dev:client
-
-# Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: yarn run build:dev:server

--- a/spec/dummy/bin/webpack-dev-server
+++ b/spec/dummy/bin/webpack-dev-server
@@ -2,7 +2,6 @@
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"]  ||= "development"
-ENV["WEBPACK_DEV_SERVER"] ||= "TRUE"
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -18,7 +18,7 @@ end
 ReactOnRails.configure do |config|
   config.random_dom_id = false # default is true
   config.node_modules_location = "" # Pre 9.0.0 always used "client"
-  config.build_production_command = "yarn run build:production"
+  config.build_production_command = nil # Use the rails/webpacker build
   config.build_test_command = "yarn run build:test"
 
   # See webpacker.yml public_output_path for replacement for generated_assets_dir


### PR DESCRIPTION
If the webpacker webpack config files exist, then React on Rails
will not override the default assets:precompile setup by rails/webpacker

The fix is to remove the JS files inside of config/webpack,
like config/webpack/production.js.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1298)
<!-- Reviewable:end -->
