### PR TITLE
Don't compile locales in tests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+* `ReactOnRails::TestHelper.ensure_assets_compiled` no longer compiles locales by default.
+  You can compile locales by passing in `compile_locales: true`.
+  [PR 1299](https://github.com/shakacode/react_on_rails/pull/1299) by [peterzhu2118](https://github.com/peterzhu2118). 
+
 ## UPCOMING 12.0 RELEASE
 
 #### Improved

--- a/lib/react_on_rails/test_helper.rb
+++ b/lib/react_on_rails/test_helper.rb
@@ -56,7 +56,8 @@ module ReactOnRails
                                     webpack_assets_compiler: nil,
                                     source_path: nil,
                                     generated_assets_full_path: nil,
-                                    webpack_generated_files: nil)
+                                    webpack_generated_files: nil,
+                                    compile_locales: false)
       ReactOnRails::WebpackerUtils.check_manifest_not_cached
       if webpack_assets_status_checker.nil?
         source_path ||= ReactOnRails::Utils.source_path
@@ -92,7 +93,8 @@ module ReactOnRails
 
       ReactOnRails::TestHelper::EnsureAssetsCompiled.new(
         webpack_assets_status_checker: webpack_assets_status_checker,
-        webpack_assets_compiler: webpack_assets_compiler
+        webpack_assets_compiler: webpack_assets_compiler,
+        compile_locales: compile_locales
       ).call
     end
   end

--- a/lib/react_on_rails/test_helper/ensure_assets_compiled.rb
+++ b/lib/react_on_rails/test_helper/ensure_assets_compiled.rb
@@ -13,9 +13,11 @@ module ReactOnRails
                   :webpack_assets_compiler
 
       def initialize(webpack_assets_status_checker: nil,
-                     webpack_assets_compiler: nil)
+                     webpack_assets_compiler: nil,
+                     compile_locales: false)
         @webpack_assets_status_checker = webpack_assets_status_checker
         @webpack_assets_compiler = webpack_assets_compiler
+        @compile_locales = compile_locales
       end
 
       # Several Scenarios:
@@ -30,7 +32,7 @@ module ReactOnRails
         # Be sure we don't do this again.
         self.class.has_been_run = true
 
-        ReactOnRails::Locales.compile
+        ReactOnRails::Locales.compile if @compile_locales
 
         stale_gen_files = webpack_assets_status_checker.stale_generated_webpack_files
 

--- a/spec/react_on_rails/test_helper/ensure_assets_compiled_spec.rb
+++ b/spec/react_on_rails/test_helper/ensure_assets_compiled_spec.rb
@@ -32,6 +32,26 @@ describe ReactOnRails::TestHelper::EnsureAssetsCompiled do
       end
     end
 
+    context "compile_locales" do
+      let(:assets_checker) { double_assets_checker(stale_generated_webpack_files: []) }
+
+      it "does not compile locales by default" do
+        expect(ReactOnRails::Locales).not_to receive(:compile)
+
+        invoke_ensurer_with_doubles
+      end
+
+      it "does compile locales when specified" do
+        expect(ReactOnRails::Locales).to receive(:compile)
+
+        ReactOnRails::TestHelper.ensure_assets_compiled(
+          webpack_assets_status_checker: assets_checker,
+          webpack_assets_compiler: compiler,
+          compile_locales: true
+        )
+      end
+    end
+
     def invoke_ensurer_with_doubles
       ReactOnRails::TestHelper.ensure_assets_compiled(
         webpack_assets_status_checker: assets_checker,


### PR DESCRIPTION
Since we don't compile locales in development and `rails assets:precompile`, then it should be default that locales aren't compiled in tests either. The old behaviour can be brought back by passing in `compile_locales: true` to `ReactOnRails::TestHelper.ensure_assets_compiled`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1299)
<!-- Reviewable:end -->
