### PR TITLE
Don't set NODE_ENV in assets.rake

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -6,7 +6,6 @@
 require "active_support"
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
 
 unless ReactOnRails::WebpackerUtils.webpacker_webpack_production_config_exists?
   # Ensure that rails/webpacker does not call bin/webpack if we're providing


### PR DESCRIPTION
I was running into some issues with webpacker not generating gzipped .js files when compiling assets in production, and after some digging I think that react_on_rails is interfering with Rails and webpacker by defaulting `NODE_ENV` to `development` in assets.rake.

With a fresh Rails install, if I run

`RAILS_ENV=production bundle exec rails assets:precompile` I get gzipped .js files built by webpack:

```
Compiling...
Compiled all packs in /Users/rozanski/Documents/Scratchpad/test-rails/public/packs
Hash: 666d45eeef50ba415ec8
Version: webpack 4.44.2
Time: 968ms
Built at: 28/11/2020 23:43:55
                                        Asset       Size  Chunks                         Chunk Names
       js/application-dd6e88065a32b23f8e21.js   69.3 KiB       0  [emitted] [immutable]  application
    js/application-dd6e88065a32b23f8e21.js.br   15.3 KiB          [emitted]
    js/application-dd6e88065a32b23f8e21.js.gz   17.7 KiB          [emitted]
   js/application-dd6e88065a32b23f8e21.js.map    205 KiB       0  [emitted] [dev]        application
js/application-dd6e88065a32b23f8e21.js.map.br     44 KiB          [emitted]
js/application-dd6e88065a32b23f8e21.js.map.gz     51 KiB          [emitted]
                                manifest.json  364 bytes          [emitted]
                             manifest.json.br  129 bytes          [emitted]
                             manifest.json.gz  142 bytes          [emitted]
Entrypoint application = js/application-dd6e88065a32b23f8e21.js js/application-dd6e88065a32b23f8e21.js.map
[0] (webpack)/buildin/module.js 552 bytes {0} [built]
[1] ./app/javascript/packs/application.js 742 bytes {0} [built]
[5] ./app/javascript/channels/index.js 205 bytes {0} [built]
[6] ./app/javascript/channels sync _channel\.js$ 160 bytes {0} [built]
    + 3 hidden modules
```

However, after simply adding react_on_rails to my Gemfile, running the same command outputs:

```
Compiled all packs in /Users/rozanski/Documents/Scratchpad/test-rails/public/packs
Hash: 15d1bb7b54cf6326b9ba
Version: webpack 4.44.2
Time: 754ms
Built at: 28/11/2020 23:40:44
                                     Asset       Size       Chunks                         Chunk Names
    js/application-9afcbb5693aa87623e69.js    124 KiB  application  [emitted] [immutable]  application
js/application-9afcbb5693aa87623e69.js.map    139 KiB  application  [emitted] [dev]        application
                             manifest.json  364 bytes               [emitted]
Entrypoint application = js/application-9afcbb5693aa87623e69.js js/application-9afcbb5693aa87623e69.js.map
[./app/javascript/channels sync recursive _channel\.js$] ./app/javascript/channels sync _channel\.js$ 160 bytes {application} [built]
[./app/javascript/channels/index.js] 211 bytes {application} [built]
[./app/javascript/packs/application.js] 749 bytes {application} [built]
[./node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 552 bytes {application} [built]
    + 3 hidden modules
```

Note the missing .gz output files, and you can see that the files in the second trace are a lot larger, suggesting they're not minified.

After some digging I discovered that when invoking `rails assets:precompile` with `RAILS_ENV=production`, `NODE_ENV` is set to `development`, when it should be `production`, which causes webpacker to use the configuration in `config/webpack/development.js` and not `config/webpack/production.js`. Commenting out `ENV["NODE_ENV"]  ||= "development"` in `assets.rake` fixes the issue.

I assume somewhere inside webpacker it initialises `NODE_ENV` to `production` in production but only if it hasn't already been set.

What is this `NODE_ENV` initialisation needed for? After removing it I ran the rspec tests and they all pass (and my own Rails site does too) but am I missing something here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1344)
<!-- Reviewable:end -->
