### PR TITLE
Don't set NODE_ENV in assets.rake

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -6,7 +6,6 @@
 require "active_support"
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
 
 unless ReactOnRails::WebpackerUtils.webpacker_webpack_production_config_exists?
   # Ensure that rails/webpacker does not call bin/webpack if we're providing


### PR DESCRIPTION
Setting NODE_ENV here interferes with Rails'/webpacker's control of this
variable, particularly in production. In particular, this means that
compiling assets in production using
`bundle exec rails assets:precompile` uses the development webpacker
configuration rather than the production one.


1. NODE_ENV is not set when running precompile
2. React on Rails sees it's empty and sets to development
3. rails/webpacker does not apply default of production


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1356)
<!-- Reviewable:end -->
