### PR TITLE
Update changelog reference for 12.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Changes since last non-beta release.
 
 ### [12.0.2] - 2020-07-09
 #### Fixed
-- Remove dependency upon Redux for Typescript types. [PR 1323](https://github.com/shakacode/react_on_rails/pull/1306) by [justin808](https://github.com/justin808).
+- Remove dependency upon Redux for Typescript types. [PR 1323](https://github.com/shakacode/react_on_rails/pull/1323) by [justin808](https://github.com/justin808).
 
 ### [12.0.1] - 2020-07-09
 #### Fixed


### PR DESCRIPTION
The URL for described changes in 12.0.2 release was pointing to the wrong PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1373)
<!-- Reviewable:end -->
