### PR TITLE
Fix TypeScript error

### DIFF
--- a/node_package/src/ReactOnRails.ts
+++ b/node_package/src/ReactOnRails.ts
@@ -30,6 +30,7 @@ if (ctx === undefined) {
 
 const DEFAULT_OPTIONS = {
   traceTurbolinks: false,
+  turbo: false,
 };
 
 ctx.ReactOnRails = {


### PR DESCRIPTION
It fixes the following Typescript error:

```
error TS2345: Argument of type '{ traceTurbolinks: true; turbo: boolean; }' is not assignable to parameter of type '{ traceTurbolinks: boolean; }'.
  Object literal may only specify known properties, and ''turbo'' does not exist in type '{ traceTurbolinks: boolean; }'.
```

That happens on this code:

```ts
ReactOnRails.setOptions({
  'traceTurbolinks': true,
  'turbo': true
})
```

Due to the fact that the `options` type is inferred by `DEFAULT_OPTIONS`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1377)
<!-- Reviewable:end -->
