### PR TITLE
Change custom precompile to check ReactOnRails.configuration.build_production_command present?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Changes since last non-beta release.
 #### Added
 - Added webpack configuration files as part of the generator and updated webpacker to version 6 [PR 1404](https://github.com/shakacode/react_on_rails/pull/1404) by [gscarv13](https://github.com/gscarv13).
 
+#### Changed
+- Changed logic of determining the usage of the default rails/webpacker webpack config or a custom command to only check if the config.build_production_command is defined. [PR 1402](https://github.com/shakacode/react_on_rails/pull/1402)by [justin808](https://github.com/justin808) and [gscarv13](https://github.com/gscarv13).
+
 ### [12.4.0] - 2021-09-22
 #### Added
 - ScoutAPM tracing support for server rendering [PR 1379](https://github.com/shakacode/react_on_rails/pull/1379) by [justin808](https://github.com/justin808).

--- a/docs/deployment/heroku-deployment.md
+++ b/docs/deployment/heroku-deployment.md
@@ -17,8 +17,3 @@ For more information, see [Using Multiple Buildpacks for an App](https://devcent
 ### rails/webpacker webpack configuration
 If you're using the standard rails/webpacker configuration of webpack, then rails/webpacker
 will automatically modify or create an assets:precompile task to build your assets.
-
-### custom webpack configuration
-If you're a custom webpack configuration, and you **do not have the default
-`config/webpack/production.js`** file, then the `config/initializers/react_on_rails.rb`
-configuration `config.build_production_command` will be used.

--- a/docs/deployment/heroku-deployment.md
+++ b/docs/deployment/heroku-deployment.md
@@ -16,4 +16,20 @@ For more information, see [Using Multiple Buildpacks for an App](https://devcent
 
 ### rails/webpacker webpack configuration
 If you're using the standard rails/webpacker configuration of webpack, then rails/webpacker
-will automatically modify or create an assets:precompile task to build your assets.
+will automatically modify or create an assets:precompile task to build your assets. 
+
+Alternatively, you can specify `config.build_production_command` to have
+react_on_rails invoke a command for you during assets:precompile.
+
+```
+config.build_production_command = "RAILS_ENV=production bin/webpack"
+```
+
+### Consider Removing Webpacker's clean task
+
+If you are deploying on Heroku, then you don't need Webpacker's clean task which
+might delete files that you need.
+
+```
+Rake::Task['webpacker:clean'].clear
+```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -66,11 +66,8 @@ ReactOnRails.configure do |config|
   # defaults to "" (top level)
   config.node_modules_location = "client" # If using webpacker you should use "".
 
-  # This configures the script to run to build the production assets by webpack . Set this to nil
+  # This configures the script to run to build the production assets by webpack. Set this to nil
   # if you don't want react_on_rails building this file for you.
-  # Note, if you want to use this command then you should remove the file
-  # config/webpack/production.js
-  # If that file exists, React on Rails thinks that you'll use the rails/webpacker bin/webpack compiler.
   config.build_production_command = "RAILS_ENV=production bin/webpack"
 
   # Alternatively, you can also specify a module containing a class method `call`

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -66,12 +66,14 @@ ReactOnRails.configure do |config|
   # defaults to "" (top level)
   config.node_modules_location = "client" # If using webpacker you should use "".
 
-  # This configures the script to run to build the production assets by webpack. Set this to nil
-  # if you don't want react_on_rails building this file for you.
+  # If you're using the standard rails/webpacker configuration of webpack, then rails/webpacker
+  # will automatically modify or create an assets:precompile task to build your assets. If so,
+  # set this value to nil.  Alternatively, you can specify `config.build_production_command` 
+  # to have react_on_rails invoke a command for you during assets:precompile.
+  # The command is either a script or a module containing a class method `call`
+  # In this example, the module BuildProductionCommand would have a class method `call`.
   config.build_production_command = "RAILS_ENV=production bin/webpack"
 
-  # Alternatively, you can also specify a module containing a class method `call`
-  # In this example, the module BuildProductionCommand would have a class method `call`.
   # See bottom for an example of the BuildProductionCommand module.
   # config.build_production_command = BuildProductionCommand
   # If you wish to utilize ReactOnRailsPro production bundle caching logic, then use
@@ -83,7 +85,7 @@ ReactOnRails.configure do |config|
   # SERVER RENDERING OPTIONS
   ################################################################################
   # This is the file used for server rendering of React when using `(prerender: true)`
-  # If you are never using server rendering, you should set this to "".
+  # If you are not using server rendering, you should set this to `nil`.
   # Note, there is only one server bundle, unlike JavaScript where you want to minimize the size
   # of the JS sent to the client. For the server rendering, React on Rails creates a pool of
   # JavaScript execution instances which should handle any component requested.

--- a/docs/guides/how-react-on-rails-works.md
+++ b/docs/guides/how-react-on-rails-works.md
@@ -35,7 +35,6 @@ For example, you might create a [Procfile.dev](https://github.com/shakacode/reac
 On production deployments that use asset precompilation, such as Heroku deployments, `rails/webpacker`, by default, will automatically run webpack to build your JavaScript bundles, running the command `bin/webpack` in your app.
 
 However, if you want to run a custom command to run webpack to build your bundles, then you will:
-1. Ensure you do not have a `config/webpack/production.js` file
 1. Define `config.build_production_command` in your [config/initializers/react_on_rails.rb](https://www.shakacode.com/react-on-rails/docs/guides/configuration/)
 
 Then React on Rails modifies the `assets:precompile` task to run your `build_production_command`.

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -9,7 +9,8 @@ ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 
 skip_react_on_rails_precompile = %w[no false n f].include?(ENV["REACT_ON_RAILS_PRECOMPILE"])
 
-if !skip_react_on_rails_precompile && !ReactOnRails::WebpackerUtils.webpacker_webpack_production_config_exists?
+
+if !skip_react_on_rails_precompile && ReactOnRails.configuration.build_production_command.present?
   # Ensure that rails/webpacker does not call bin/webpack if we're providing
   # the build command.
   ENV["WEBPACKER_PRECOMPILE"] = "false"

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -41,9 +41,8 @@ end
 namespace :react_on_rails do
   namespace :assets do
     desc <<~DESC.strip_heredoc
-            If config.build_production_command is defined, his command is automatically
-            added to task assets:precompile and the regular webpacker compile will not run.#{' '}
-      #{'      '}
+            If config.build_production_command is defined, this command is automatically
+            added to task assets:precompile and the regular webpacker compile will not run.
             The defined command is either a script or a module with a method `call`.
     DESC
     task webpack: :locale do

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -9,7 +9,6 @@ ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 
 skip_react_on_rails_precompile = %w[no false n f].include?(ENV["REACT_ON_RAILS_PRECOMPILE"])
 
-
 if !skip_react_on_rails_precompile && ReactOnRails.configuration.build_production_command.present?
   # Ensure that rails/webpacker does not call bin/webpack if we're providing
   # the build command.

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -41,11 +41,10 @@ end
 namespace :react_on_rails do
   namespace :assets do
     desc <<-DESC.strip_heredoc
-      Compile assets with webpack
-      Uses command defined with ReactOnRails.configuration.build_production_command
-      sh "#{ReactOnRails::Utils.prepend_cd_node_modules_directory('<ReactOnRails.configuration.build_production_command>')}"
-      Note: This command is not automatically added to assets:precompile if the rails/webpacker
-      configuration file config/webpack/production.js exists.
+      If config.build_production_command is defined, his command is automatically
+      added to task assets:precompile and the regular webpacker compile will not run. 
+      
+      The defined command is either a script or a module with a method `call`.
     DESC
     task webpack: :locale do
       build_production_command = ReactOnRails.configuration.build_production_command
@@ -63,6 +62,7 @@ namespace :react_on_rails do
           exit!(1)
         end
       else
+        # Left in this warning message in case this rake task is run directly
         msg = <<~MSG
           React on Rails is aborting webpack compilation from task react_on_rails:assets:webpack
           because you do not have the `config.build_production_command` defined.

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -41,9 +41,9 @@ end
 namespace :react_on_rails do
   namespace :assets do
     desc <<~DESC.strip_heredoc
-            If config.build_production_command is defined, this command is automatically
-            added to task assets:precompile and the regular webpacker compile will not run.
-            The defined command is either a script or a module with a method `call`.
+      If config.build_production_command is defined, this command is automatically
+      added to task assets:precompile and the regular webpacker compile will not run.
+      The defined command is either a script or a module with a method `call`.
     DESC
     task webpack: :locale do
       build_production_command = ReactOnRails.configuration.build_production_command

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -40,11 +40,11 @@ end
 # rubocop:disable Metrics/BlockLength
 namespace :react_on_rails do
   namespace :assets do
-    desc <<-DESC.strip_heredoc
-      If config.build_production_command is defined, his command is automatically
-      added to task assets:precompile and the regular webpacker compile will not run. 
-      
-      The defined command is either a script or a module with a method `call`.
+    desc <<~DESC.strip_heredoc
+            If config.build_production_command is defined, his command is automatically
+            added to task assets:precompile and the regular webpacker compile will not run.#{' '}
+      #{'      '}
+            The defined command is either a script or a module with a method `call`.
     DESC
     task webpack: :locale do
       build_production_command = ReactOnRails.configuration.build_production_command


### PR DESCRIPTION
Update logic on what build command to use in assets:precompile to be based on whether or not
config.build_production_command is defined.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1402)
<!-- Reviewable:end -->
