### PR TITLE
Add support for React 18 server rendering

### DIFF
--- a/node_package/src/ReactOnRails.ts
+++ b/node_package/src/ReactOnRails.ts
@@ -1,4 +1,3 @@
-import ReactDOM from 'react-dom';
 import type { ReactElement, Component } from 'react';
 
 import * as ClientStartup from './clientStartup';
@@ -19,6 +18,8 @@ import type {
   AuthenticityHeaders,
   StoreGenerator
 } from './types/index';
+import reactHydrate from './reactHydrate';
+import reactRender from './reactRender';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type Store = any;
@@ -187,9 +188,9 @@ ctx.ReactOnRails = {
     const componentObj = ComponentRegistry.get(name);
     const reactElement = createReactOutput({ componentObj, props, domNodeId });
 
-    const render = hydrate ? ReactDOM.hydrate : ReactDOM.render;
+    const render = hydrate ? reactHydrate : reactRender;
     // eslint-disable-next-line react/no-render-return-value
-    return render(reactElement as ReactElement, document.getElementById(domNodeId));
+    return render(document.getElementById(domNodeId) as Element, reactElement as ReactElement);
   },
 
   /**

--- a/node_package/src/clientStartup.ts
+++ b/node_package/src/clientStartup.ts
@@ -9,6 +9,8 @@ import type {
 
 import createReactOutput from './createReactOutput';
 import {isServerRenderHash} from './isServerRenderResult';
+import reactHydrate from './reactHydrate';
+import reactRender from './reactRender';
 
 declare global {
   interface Window {
@@ -128,26 +130,6 @@ function domNodeIdForEl(el: Element): string {
   return el.getAttribute('data-dom-id') || "";
 }
 
-function hydrateWithLegacyReactSupport(domNode : Element, reactElement : ReactElement) {
-  // @ts-expect-error potentially present if React 18 or greater
-  if (ReactDOM.hydrateRoot) {
-    // @ts-expect-error potentially present if React 18 or greater
-    return ReactDOM.hydrateRoot(domNode, reactElement)
-  }
-  return ReactDOM.hydrate(reactElement, domNode)
-}
-
-function renderWithLegacyReactSupport(domNode : Element, reactElement: ReactElement) {
-  // @ts-expect-error potentially present if React 18 or greater
-  if (ReactDOM.createRoot) {
-    // @ts-expect-error potentially present if React 18 or greater
-    const root = ReactDOM.createRoot(domNode)
-    root.render(reactElement)
-  } else {
-    ReactDOM.render(reactElement, domNode)
-  }
-}
-
 /**
  * Used for client rendering by ReactOnRails. Either calls ReactDOM.hydrate, ReactDOM.render, or
  * delegates to a renderer registered by the user.
@@ -187,9 +169,9 @@ function render(el: Element, railsContext: RailsContext): void {
 You returned a server side type of react-router error: ${JSON.stringify(reactElementOrRouterResult)}
 You should return a React.Component always for the client side entry point.`);
       } else if (shouldHydrate) {
-        hydrateWithLegacyReactSupport(domNode, reactElementOrRouterResult as ReactElement);
+        reactHydrate(domNode, reactElementOrRouterResult as ReactElement);
       } else {
-        renderWithLegacyReactSupport(domNode, reactElementOrRouterResult as ReactElement);
+        reactRender(domNode, reactElementOrRouterResult as ReactElement);
       }
     }
   } catch (e) {

--- a/node_package/src/clientStartup.ts
+++ b/node_package/src/clientStartup.ts
@@ -128,6 +128,26 @@ function domNodeIdForEl(el: Element): string {
   return el.getAttribute('data-dom-id') || "";
 }
 
+function hydrateWithLegacyReactSupport(domNode : Element, reactElement : ReactElement) {
+  // @ts-expect-error potentially present if React 18 or greater
+  if (ReactDOM.hydrateRoot) {
+    // @ts-expect-error potentially present if React 18 or greater
+    return ReactDOM.hydrateRoot(domNode, reactElement)
+  }
+  return ReactDOM.hydrate(reactElement, domNode)
+}
+
+function renderWithLegacyReactSupport(domNode : Element, reactElement: ReactElement) {
+  // @ts-expect-error potentially present if React 18 or greater
+  if (ReactDOM.createRoot) {
+    // @ts-expect-error potentially present if React 18 or greater
+    const root = ReactDOM.createRoot(domNode)
+    root.render(reactElement)
+  } else {
+    ReactDOM.render(reactElement, domNode)
+  }
+}
+
 /**
  * Used for client rendering by ReactOnRails. Either calls ReactDOM.hydrate, ReactDOM.render, or
  * delegates to a renderer registered by the user.
@@ -166,9 +186,9 @@ function render(el: Element, railsContext: RailsContext): void {
 You returned a server side type of react-router error: ${JSON.stringify(reactElementOrRouterResult)}
 You should return a React.Component always for the client side entry point.`);
       } else if (shouldHydrate) {
-        ReactDOM.hydrate(reactElementOrRouterResult as ReactElement, domNode);
+        hydrateWithLegacyReactSupport(domNode, reactElementOrRouterResult as ReactElement);
       } else {
-        ReactDOM.render(reactElementOrRouterResult as ReactElement, domNode);
+        renderWithLegacyReactSupport(domNode, reactElementOrRouterResult as ReactElement);
       }
     }
   } catch (e) {

--- a/node_package/src/clientStartup.ts
+++ b/node_package/src/clientStartup.ts
@@ -170,7 +170,8 @@ function render(el: Element, railsContext: RailsContext): void {
       }
 
       // Hydrate if available and was server rendered
-      const shouldHydrate = !!ReactDOM.hydrate && !!domNode.innerHTML;
+      // @ts-expect-error potentially present if React 18 or greater
+      const shouldHydrate = !!(ReactDOM.hydrate || ReactDOM.hydrateRoot) && !!domNode.innerHTML;
 
       const reactElementOrRouterResult = createReactOutput({
         componentObj,

--- a/node_package/src/reactHydrate.ts
+++ b/node_package/src/reactHydrate.ts
@@ -1,9 +1,9 @@
 import ReactDOM from 'react-dom';
 import { ReactElement, Component } from 'react';
+import supportsReactCreateRoot from './supportsReactCreateRoot';
 
 export default function reactHydrate(domNode: Element, reactElement: ReactElement): void | Element | Component {
-  // @ts-expect-error potentially present if React 18 or greater
-  if (ReactDOM.hydrateRoot) {
+  if (supportsReactCreateRoot) {
     // @ts-expect-error potentially present if React 18 or greater
     return ReactDOM.hydrateRoot(domNode, reactElement);
   }

--- a/node_package/src/reactHydrate.ts
+++ b/node_package/src/reactHydrate.ts
@@ -1,0 +1,12 @@
+import ReactDOM from 'react-dom';
+import { ReactElement, Component } from 'react';
+
+export default function reactHydrate(domNode: Element, reactElement: ReactElement): void | Element | Component {
+  // @ts-expect-error potentially present if React 18 or greater
+  if (ReactDOM.hydrateRoot) {
+    // @ts-expect-error potentially present if React 18 or greater
+    return ReactDOM.hydrateRoot(domNode, reactElement);
+  }
+
+  return ReactDOM.hydrate(reactElement, domNode);
+}

--- a/node_package/src/reactRender.ts
+++ b/node_package/src/reactRender.ts
@@ -1,9 +1,9 @@
 import ReactDOM from 'react-dom';
 import { ReactElement, Component } from 'react';
+import supportsReactCreateRoot from './supportsReactCreateRoot';
 
 export default function reactRender(domNode: Element, reactElement: ReactElement): void | Element | Component {
-  // @ts-expect-error potentially present if React 18 or greater
-  if (ReactDOM.createRoot) {
+  if (supportsReactCreateRoot) {
     // @ts-expect-error potentially present if React 18 or greater
     const root = ReactDOM.createRoot(domNode);
     root.render(reactElement);

--- a/node_package/src/reactRender.ts
+++ b/node_package/src/reactRender.ts
@@ -1,0 +1,15 @@
+import ReactDOM from 'react-dom';
+import { ReactElement, Component } from 'react';
+
+export default function reactRender(domNode: Element, reactElement: ReactElement): void | Element | Component {
+  // @ts-expect-error potentially present if React 18 or greater
+  if (ReactDOM.createRoot) {
+    // @ts-expect-error potentially present if React 18 or greater
+    const root = ReactDOM.createRoot(domNode);
+    root.render(reactElement);
+    return root
+  }
+
+  // eslint-disable-next-line react/no-render-return-value
+  return ReactDOM.render(reactElement, domNode);
+}

--- a/node_package/src/supportsReactCreateRoot.js
+++ b/node_package/src/supportsReactCreateRoot.js
@@ -1,0 +1,4 @@
+import ReactDOM from 'react-dom';
+
+const reactMajorVersion = parseInt(ReactDOM.version.split('.')[0], 10);
+export default reactMajorVersion >= 18;


### PR DESCRIPTION
With React 18, the client-side rendering process has been updated.  To prepare the way for supporting React 18's features, the new way of rendering needs to be adopted.

This change creates some helpers that support both methods of rendering and hydrating on the client to start the path forward to supporting React 18.

NOTE: Because there is no current support for testing against React versions, I am forgoing adding extra tests for this.  If there is an approach to doing this, we can add that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1409)
<!-- Reviewable:end -->
