### PR TITLE
Move webpacker task adjustment logic to Configuration class method

### DIFF
--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -120,7 +120,7 @@ module ReactOnRails
     def adjust_precompile_task
       skip_react_on_rails_precompile = %w[no false n f].include?(ENV["REACT_ON_RAILS_PRECOMPILE"])
 
-      return unless !skip_react_on_rails_precompile && build_production_command.present?
+      return if skip_react_on_rails_precompile || build_production_command.blank?
 
       # Ensure that rails/webpacker does not call bin/webpack if we're providing
       # the build command.

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -111,7 +111,7 @@ module ReactOnRails
       check_i18n_yml_directory_exists
       check_server_render_method_is_only_execjs
       error_if_using_webpacker_and_generated_assets_dir_not_match_public_output_path
-      check_deprecated_settings
+      # check_deprecated_settings
       adjust_precompile_task
     end
 
@@ -148,19 +148,20 @@ module ReactOnRails
       end
     end
 
-    def check_deprecated_settings
-      if build_production_command.present? &&
-         ReactOnRails::WebpackerUtils.webpacker_webpack_production_config_exists?
-        msg = <<~MSG
-          Setting ReactOnRails configuration for `build_production_command` is
-          not necessary if you have config/webpack/production.js. When that file
-          exists, React on Rails DOES NOT modify the standard assets:precompile.
-          If you want React on Rails to modify to the standard assets:precompile
-          to use your config/initializers/react_on_rails.rb config.build_production_command
-          then delete the config/webpack/production.js.
-        MSG
-        Rails.logger.warn(msg)
-      end
+    # Pending updates to rails/webpacker v6, we may have some message that prints after configuration runs.
+    # def check_deprecated_settings
+    #   if build_production_command.present? &&
+    #      ReactOnRails::WebpackerUtils.webpacker_webpack_production_config_exists?
+    #     msg = <<~MSG
+    #       Setting ReactOnRails configuration for `build_production_command` is
+    #       not necessary if you have config/webpack/production.js. When that file
+    #       exists, React on Rails DOES NOT modify the standard assets:precompile.
+    #       If you want React on Rails to modify to the standard assets:precompile
+    #       to use your config/initializers/react_on_rails.rb config.build_production_command
+    #       then delete the config/webpack/production.js.
+    #     MSG
+    #     Rails.logger.warn(msg)
+    #  end
       #
       # msg = <<~MSG
       #   ReactOnRails configuration for `build_production_command` is removed.
@@ -181,7 +182,7 @@ module ReactOnRails
       #   Move this command into `bin/webpack` converting the script to a shell script.
       # MSG
       # raise ReactOnRails::Error, msg
-    end
+    # end
 
     def error_if_using_webpacker_and_generated_assets_dir_not_match_public_output_path
       return unless ReactOnRails::WebpackerUtils.using_webpacker?

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -162,26 +162,26 @@ module ReactOnRails
     #     MSG
     #     Rails.logger.warn(msg)
     #  end
-      #
-      # msg = <<~MSG
-      #   ReactOnRails configuration for `build_production_command` is removed.
-      #   Move this command into `bin/webpack` converting the script to a shell script.
-      # MSG
-      # raise ReactOnRails::Error, msg
-      # Commenting out until v13 when
-      # https://github.com/rails/webpacker/issues/2640 gets resolved
-      # if node_modules_location.present?
-      #   Rails.logger.warn("ReactOnRails configuration for `node_modules_location` is deprecated. "\
-      #    "Instead, prepend a `cd client` (or whichever location) before your test command.")
-      # end
-      #
-      # return unless build_production_command.present?
-      #
-      # msg = <<~MSG
-      #   ReactOnRails configuration for `build_production_command` is removed.
-      #   Move this command into `bin/webpack` converting the script to a shell script.
-      # MSG
-      # raise ReactOnRails::Error, msg
+    #
+    # msg = <<~MSG
+    #   ReactOnRails configuration for `build_production_command` is removed.
+    #   Move this command into `bin/webpack` converting the script to a shell script.
+    # MSG
+    # raise ReactOnRails::Error, msg
+    # Commenting out until v13 when
+    # https://github.com/rails/webpacker/issues/2640 gets resolved
+    # if node_modules_location.present?
+    #   Rails.logger.warn("ReactOnRails configuration for `node_modules_location` is deprecated. "\
+    #    "Instead, prepend a `cd client` (or whichever location) before your test command.")
+    # end
+    #
+    # return unless build_production_command.present?
+    #
+    # msg = <<~MSG
+    #   ReactOnRails configuration for `build_production_command` is removed.
+    #   Move this command into `bin/webpack` converting the script to a shell script.
+    # MSG
+    # raise ReactOnRails::Error, msg
     # end
 
     def error_if_using_webpacker_and_generated_assets_dir_not_match_public_output_path

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -5,38 +5,6 @@
 
 require "active_support"
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-
-skip_react_on_rails_precompile = %w[no false n f].include?(ENV["REACT_ON_RAILS_PRECOMPILE"])
-
-if !skip_react_on_rails_precompile && ReactOnRails.configuration.build_production_command.present?
-  # Ensure that rails/webpacker does not call bin/webpack if we're providing
-  # the build command.
-  ENV["WEBPACKER_PRECOMPILE"] = "false"
-
-  precompile_tasks = lambda {
-    Rake::Task["react_on_rails:assets:webpack"].invoke
-    puts "Invoking task webpacker:clean from React on Rails"
-
-    # VERSIONS is per the rails/webpacker clean method definition.
-    # We set it very big so that it is not used, and then clean just
-    # removes files older than 1 hour.
-    versions = 100_000
-    Rake::Task["webpacker:clean"].invoke(versions)
-  }
-
-  if Rake::Task.task_defined?("assets:precompile")
-    Rake::Task["assets:precompile"].enhance do
-      precompile_tasks.call
-    end
-  else
-    Rake::Task.define_task("assets:precompile") do
-      precompile_tasks.call
-    end
-  end
-end
-
-# Sprockets independent tasks
 # rubocop:disable Metrics/BlockLength
 namespace :react_on_rails do
   namespace :assets do
@@ -65,10 +33,6 @@ namespace :react_on_rails do
         msg = <<~MSG
           React on Rails is aborting webpack compilation from task react_on_rails:assets:webpack
           because you do not have the `config.build_production_command` defined.
-
-          Note, this task may have run as part of `assets:precompile`. If file
-          config/webpack/production.js does not exist, React on Rails will modify
-          the default `asset:precompile` to run task `react_on_rails:assets:webpack`.
         MSG
         puts Rainbow(msg).red
         exit!(1)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-# Important: The default assets:precompile is modified ONLY if the rails/webpacker webpack config
-# does not exist!
-
-require "active_support/core_ext/string/strip"
-
 # rubocop:disable Metrics/BlockLength
 namespace :react_on_rails do
   namespace :assets do
-    desc <<~DESC.strip_heredoc
+    desc <<~DESC
       If config.build_production_command is defined, this command is automatically
       added to task assets:precompile and the regular webpacker compile will not run.
       The defined command is either a script or a module with a method `call`.

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -3,7 +3,7 @@
 # Important: The default assets:precompile is modified ONLY if the rails/webpacker webpack config
 # does not exist!
 
-require "active_support"
+require "active_support/core_ext/string/strip"
 
 # rubocop:disable Metrics/BlockLength
 namespace :react_on_rails do

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -3,10 +3,9 @@
 require "react_on_rails/locales/base"
 require "react_on_rails/locales/to_js"
 require "react_on_rails/locales/to_json"
-require "active_support/core_ext/string/strip"
 
 namespace :react_on_rails do
-  desc <<-DESC.strip_heredoc
+  desc <<~DESC
     Generate i18n javascript files
     This task generates javascript locale files: `translations.js` & `default.js` and places them in
     the "ReactOnRails.configuration.i18n_dir".

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -3,7 +3,7 @@
 require "react_on_rails/locales/base"
 require "react_on_rails/locales/to_js"
 require "react_on_rails/locales/to_json"
-require "active_support"
+require "active_support/core_ext/string/strip"
 
 namespace :react_on_rails do
   desc <<-DESC.strip_heredoc

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -20,7 +20,7 @@ ReactOnRails.configure do |config|
   config.random_dom_id = false # default is true
 
   # config.build_test_command = "yarn run build:test"
-  # config.build_production_command = "echo 'ran ReactOnRails config.build_production_command'"
+  config.build_production_command = "echo 'ran ReactOnRails config.build_production_command'"
   # config.webpack_generated_files = %w[server-bundle.js manifest.json]
   config.rendering_extension = RenderingExtension
 end

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -20,6 +20,7 @@ ReactOnRails.configure do |config|
   config.random_dom_id = false # default is true
 
   # config.build_test_command = "yarn run build:test"
+  # config.build_production_command = "yarn run build:prod"
   # config.webpack_generated_files = %w[server-bundle.js manifest.json]
   config.rendering_extension = RenderingExtension
 end

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -20,7 +20,7 @@ ReactOnRails.configure do |config|
   config.random_dom_id = false # default is true
 
   # config.build_test_command = "yarn run build:test"
-  config.build_production_command = "echo 'ran ReactOnRails config.build_production_command'"
+  # config.build_production_command = "RAILS_ENV=production NODE_ENV=production bin/webpack"
   # config.webpack_generated_files = %w[server-bundle.js manifest.json]
   config.rendering_extension = RenderingExtension
 end

--- a/spec/dummy/config/initializers/react_on_rails.rb
+++ b/spec/dummy/config/initializers/react_on_rails.rb
@@ -20,7 +20,7 @@ ReactOnRails.configure do |config|
   config.random_dom_id = false # default is true
 
   # config.build_test_command = "yarn run build:test"
-  # config.build_production_command = "yarn run build:prod"
+  # config.build_production_command = "echo 'ran ReactOnRails config.build_production_command'"
   # config.webpack_generated_files = %w[server-bundle.js manifest.json]
   config.rendering_extension = RenderingExtension
 end

--- a/spec/dummy/spec/initialized_configuration_spec.rb
+++ b/spec/dummy/spec/initialized_configuration_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-describe "ReactOnRails initializer" do
-  it "changes ENV[\"WEBPACKER_PRECOMPILE\"] to \"false\" because config.build_production_command is defined" do
-    expect(ENV["WEBPACKER_PRECOMPILE"]).to eq("false")
-  end
-end

--- a/spec/dummy/spec/initialized_configuration_spec.rb
+++ b/spec/dummy/spec/initialized_configuration_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "ReactOnRails initializer" do
+  it "should change ENV[\"WEBPACKER_PRECOMPILE\"] to \"false\" because config.build_production_command is defined" do
+    expect(ENV["WEBPACKER_PRECOMPILE"]).to eq("false")
+  end
+end

--- a/spec/dummy/spec/initialized_configuration_spec.rb
+++ b/spec/dummy/spec/initialized_configuration_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 require "rails_helper"
 
 describe "ReactOnRails initializer" do
-  it "should change ENV[\"WEBPACKER_PRECOMPILE\"] to \"false\" because config.build_production_command is defined" do
+  it "changes ENV[\"WEBPACKER_PRECOMPILE\"] to \"false\" because config.build_production_command is defined" do
     expect(ENV["WEBPACKER_PRECOMPILE"]).to eq("false")
   end
 end

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -81,6 +81,15 @@ module ReactOnRails
         end
 
         expect(ENV["WEBPACKER_PRECOMPILE"]).to eq("false")
+        ENV["WEBPACKER_PRECOMPILE"] = nil
+      end
+
+      it "if not configured, ENV[\"WEBPACKER_PRECOMPILE\"] remains nil" do
+        expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
+
+        ReactOnRails.configure {} # rubocop:disable-line Lint/EmptyBlock
+
+        expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
       end
     end
 

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -72,7 +72,7 @@ module ReactOnRails
       end
     end
 
-    describe ".build_production_command", :focus do
+    describe ".build_production_command" do
       it "if configured, ENV[\"WEBPACKER_PRECOMPILE\"] gets set to \"false\"" do
         expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
 

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -72,6 +72,18 @@ module ReactOnRails
       end
     end
 
+    describe ".build_production_command", :focus do
+      it "if configured, ENV[\"WEBPACKER_PRECOMPILE\"] gets set to \"false\"" do
+        expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
+
+        ReactOnRails.configure do |config|
+          config.build_production_command = "a string or a module"
+        end
+
+        ENV["WEBPACKER_PRECOMPILE"] = "false"
+      end
+    end
+
     describe ".i18n_dir" do
       let(:i18n_dir) { existing_path }
 

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -80,7 +80,7 @@ module ReactOnRails
           config.build_production_command = "a string or a module"
         end
 
-        ENV["WEBPACKER_PRECOMPILE"] = "false"
+        expect(ENV["WEBPACKER_PRECOMPILE"]).to eq("false")
       end
     end
 


### PR DESCRIPTION
The only way I found to actually test the logic of `assets.rake` with an un-initialized Rails application was by using `bundle exec irb`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1415)
<!-- Reviewable:end -->
