### PR TITLE
Not pusing mini_racer in default install. Closes #1438

### DIFF
--- a/Gemfile.development_dependencies
+++ b/Gemfile.development_dependencies
@@ -21,8 +21,6 @@ gem "sprockets", "~> 4.0"
 
 gem "amazing_print"
 
-gem "mini_racer", ">= 0.6.2"
-
 group :development, :test do
   gem "listen"
   gem "pry"

--- a/docs/guides/client-vs-server-rendering.md
+++ b/docs/guides/client-vs-server-rendering.md
@@ -4,7 +4,7 @@
 
 In most cases, you should use the `prerender: false` (default behavior) with the provided helper method to render the React component from your Rails views. In some cases, such as when SEO is vital, or many users will not have JavaScript enabled, you can enable server-rendering by passing `prerender: true` to your helper, or you can simply change the default in `config/initializers/react_on_rails`.
 
-Now the server will interpret your JavaScript. The default is to use [ExecJS](https://github.com/rails/execjs) and pass the resulting HTML to the client. We recommend using [mini_racer](https://github.com/discourse/mini_racer) as ExecJS's runtime.
+Now the server will interpret your JavaScript. The default is to use Node.js.
 
 If you want to maximize the perfomance of your server rendering, then you want to use React on Rails Pro which uses NodeJS to do the server rendering. See the [docs for React on Rails Pro](https://github.com/shakacode/react_on_rails/wiki).
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -137,14 +137,14 @@ ReactOnRails.configure do |config|
   ################################################################################
   # Server Renderer Configuration for ExecJS
   ################################################################################
-  # The default server rendering is ExecJS, probably using the mini_racer gem
+  # The default server rendering is Node.js
   # If you wish to use an alternative Node server rendering for higher performance,
   # contact justin@shakacode.com for details.
   #
   # For ExecJS:
   # You can configure your pool of JS virtual machines and specify where it should load code:
-  # On MRI, use `mini_racer` for the best performance
-  # (see [discussion](https://github.com/reactjs/react-rails/pull/290))
+  # On MRI, use `Node.js` for good performance
+  # (see [issue](https://github.com/shakacode/react_on_rails/issues/1438))
   # On MRI, you'll get a deadlock with `pool_size` > 1
   # If you're using JRuby, you can increase `pool_size` to have real multi-threaded rendering.
   config.server_renderer_pool_size = 1 # increase if you're on JRuby

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -91,8 +91,6 @@ Install React on Rails: `rails generate react_on_rails:install`. You need to fir
 Note, using `redux` is no longer recommended as the basic installer uses React Hooks.
 If you want the redux install: `rails generate react_on_rails:install --redux`
 
-The generator will add `mini_racer`'s latest version. If you're using linux & encounter issues installing `libv8`, here's [a common solution](https://github.com/rubyjs/mini_racer/issues/218).
-
 ```
 bundle exec rails generate react_on_rails:install
 ```

--- a/docs/javascript/server-rendering-tips.md
+++ b/docs/javascript/server-rendering-tips.md
@@ -2,9 +2,6 @@
 
 For the best performance with Server Rendering, consider using [React on Rails Pro]
 
-Be sure to use mini_racer. See [issues/428](https://github.com/shakacode/react_on_rails/issues/428).
-
-
 
 ## General Tips
 - Your code can't reference `document`. Server side JS execution does not have access to `document`,

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -73,7 +73,6 @@ module ReactOnRails
       end
 
       def add_base_gems_to_gemfile
-        gem "mini_racer", platforms: :ruby
         run "bundle"
       end
 


### PR DESCRIPTION
node is used by default and usually it has less problems than mini_racer.

react_on_rails shouldn't push `mini_racer` in new installations. This patch removes such behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1437)
<!-- Reviewable:end -->
