### PR TITLE
Update catch types to be any for TypeScript 4.4

### DIFF
--- a/node_package/src/buildConsoleReplay.ts
+++ b/node_package/src/buildConsoleReplay.ts
@@ -24,7 +24,7 @@ export function consoleReplay(): string {
         if (val === undefined) {
           val = 'undefined';
         }
-      } catch (e) {
+      } catch (e: any) {
         val = `${e.message}: ${arg}`;
       }
 

--- a/node_package/src/clientStartup.ts
+++ b/node_package/src/clientStartup.ts
@@ -174,7 +174,7 @@ You should return a React.Component always for the client side entry point.`);
         reactRender(domNode, reactElementOrRouterResult as ReactElement);
       }
     }
-  } catch (e) {
+  } catch (e: any) {
     e.message = `ReactOnRails encountered an error while rendering component: ${name}.\n` +
       `Original message: ${e.message}`;
     throw e;
@@ -214,7 +214,7 @@ function unmount(el: Element): void {
   if(domNode === null){return;}
   try {
     ReactDOM.unmountComponentAtNode(domNode);
-  } catch (e) {
+  } catch (e: any) {
     console.info(`Caught error calling unmountComponentAtNode: ${e.message} for domNode`,
       domNode, e);
   }

--- a/node_package/src/serverRenderReactComponent.ts
+++ b/node_package/src/serverRenderReactComponent.ts
@@ -83,7 +83,7 @@ as a renderFunction and not a simple React Function Component.`);
     } else {
       renderResult = processReactElement();
     }
-  } catch (e) {
+  } catch (e: any) {
     if (throwJsErrors) {
       throw e;
     }
@@ -115,7 +115,7 @@ as a renderFunction and not a simple React Function Component.`);
           consoleReplayScript,
           hasErrors,
         };
-      } catch (e) {
+      } catch (e: any) {
         if (throwJsErrors) {
           throw e;
         }


### PR DESCRIPTION
Due to https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables,
some TypeScript files failed to compile under TS 4.4 or later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1444)
<!-- Reviewable:end -->
