### PR TITLE
Conditionally require react-dom/client in reactHydrate/reactRender if React version >= 18

### DIFF
--- a/node_package/src/reactHydrate.ts
+++ b/node_package/src/reactHydrate.ts
@@ -1,10 +1,11 @@
-import ReactDOM from 'react-dom';
 import { ReactElement, Component } from 'react';
 import supportsReactCreateRoot from './supportsReactCreateRoot';
 
+// eslint-disable-next-line import/no-unresolved
+const ReactDOM = supportsReactCreateRoot ? require("react-dom/client") : require("react-dom");
+
 export default function reactHydrate(domNode: Element, reactElement: ReactElement): void | Element | Component {
   if (supportsReactCreateRoot) {
-    // @ts-expect-error potentially present if React 18 or greater
     return ReactDOM.hydrateRoot(domNode, reactElement);
   }
 

--- a/node_package/src/reactRender.ts
+++ b/node_package/src/reactRender.ts
@@ -1,10 +1,11 @@
-import ReactDOM from 'react-dom';
 import { ReactElement, Component } from 'react';
 import supportsReactCreateRoot from './supportsReactCreateRoot';
 
+// eslint-disable-next-line import/no-unresolved
+const ReactDOM = supportsReactCreateRoot ? require("react-dom/client") : require("react-dom");
+
 export default function reactRender(domNode: Element, reactElement: ReactElement): void | Element | Component {
   if (supportsReactCreateRoot) {
-    // @ts-expect-error potentially present if React 18 or greater
     const root = ReactDOM.createRoot(domNode);
     root.render(reactElement);
     return root


### PR DESCRIPTION
### Summary
This resolves https://github.com/shakacode/react_on_rails/issues/1441. 

With React 18, `hydrateRoot` and `createRoot` have been moved to `react-dom/client`. If you try to access these methods on `react-dom`, you'll see a warning that looks like this:

>  Warning: You are importing createRoot from “react-dom” which is not supported. You should instead import it from “react-dom/client”.

React 18 support was added in https://github.com/shakacode/react_on_rails/pull/1409 but also resulted in this warning since `createRoot` and `hydrateRoot` were being called on `react-dom`.

In order to prevent the warning, I added a conditional require using a ternary statement in `reactHydrate.ts` and `reactRender.ts`. I also had to disable the `import/no-unresolved` rule as it was throwing an error when `react-dom/client` wasn't present (in React < 18). I _think_ this should do it but I struggled making eslint and typescript happy so let me know if I'm missing anything.
