### PR TITLE
Remove mini_racer as the default ExecJS runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
+
+#### Improved
+- Remove addition of `mini_racer` gem by default. [PR 1453](https://github.com/shakacode/react_on_rails/pull/1453) by [vtamara](https://github.com/vtamara) and [tomdracz](https://github.com/tomdracz).
+
+  Using `mini_racer` makes most sense when deploying or building in environments that do not have Javascript runtime present. Since `react_on_rails` requires Node.js, there's no reason to override `ExecJS` runtime with `mini_racer`.
+
+  To migrate this change, remove `mini_racer` gem from your `Gemfile` and test your app for correct behaviour. You can continue using `mini_racer` and it will be still picked as the default `ExecJS` runtime, if present in your app `Gemfile`.
+
 ### [13.0.2] - 2022-03-09
 #### Fixed
 - React 16 doesn't support version property, causing problems loading React on Rails. [PR 1435](https://github.com/shakacode/react_on_rails/pull/1435) by [justin808](https://github.com/justin808).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes since last non-beta release.
 
   To migrate this change, remove `mini_racer` gem from your `Gemfile` and test your app for correct behaviour. You can continue using `mini_racer` and it will be still picked as the default `ExecJS` runtime, if present in your app `Gemfile`.
 
+
 ### [13.0.2] - 2022-03-09
 #### Fixed
 - React 16 doesn't support version property, causing problems loading React on Rails. [PR 1435](https://github.com/shakacode/react_on_rails/pull/1435) by [justin808](https://github.com/justin808).

--- a/Gemfile.development_dependencies
+++ b/Gemfile.development_dependencies
@@ -21,8 +21,6 @@ gem "sprockets", "~> 4.0"
 
 gem "amazing_print"
 
-gem "mini_racer", ">= 0.6.2"
-
 group :development, :test do
   gem "listen"
   gem "pry"

--- a/docs/guides/client-vs-server-rendering.md
+++ b/docs/guides/client-vs-server-rendering.md
@@ -4,7 +4,7 @@
 
 In most cases, you should use the `prerender: false` (default behavior) with the provided helper method to render the React component from your Rails views. In some cases, such as when SEO is vital, or many users will not have JavaScript enabled, you can enable server-rendering by passing `prerender: true` to your helper, or you can simply change the default in `config/initializers/react_on_rails`.
 
-Now the server will interpret your JavaScript. The default is to use [ExecJS](https://github.com/rails/execjs) and pass the resulting HTML to the client. We recommend using [mini_racer](https://github.com/discourse/mini_racer) as ExecJS's runtime.
+Now the server will interpret your JavaScript. The default is to use [ExecJS](https://github.com/rails/execjs) and pass the resulting HTML to the client. By default Node.js runtime is used by ExecJS. You can use alternative runtimes as outlined in [ExecJS readme](https://github.com/rails/execjs/blob/master/README.md).
 
 If you want to maximize the perfomance of your server rendering, then you want to use React on Rails Pro which uses NodeJS to do the server rendering. See the [docs for React on Rails Pro](https://github.com/shakacode/react_on_rails/wiki).
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -137,14 +137,14 @@ ReactOnRails.configure do |config|
   ################################################################################
   # Server Renderer Configuration for ExecJS
   ################################################################################
-  # The default server rendering is ExecJS, probably using the mini_racer gem
+  # The default server rendering is ExecJS, by default using Node.js runtime
   # If you wish to use an alternative Node server rendering for higher performance,
   # contact justin@shakacode.com for details.
   #
   # For ExecJS:
   # You can configure your pool of JS virtual machines and specify where it should load code:
-  # On MRI, use `mini_racer` for the best performance
-  # (see [discussion](https://github.com/reactjs/react-rails/pull/290))
+  # On MRI, use `node.js` runtime for the best performance
+  # (see [issues](https://github.com/shakacode/react_on_rails/issues/1438))
   # On MRI, you'll get a deadlock with `pool_size` > 1
   # If you're using JRuby, you can increase `pool_size` to have real multi-threaded rendering.
   config.server_renderer_pool_size = 1 # increase if you're on JRuby

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -91,8 +91,6 @@ Install React on Rails: `rails generate react_on_rails:install`. You need to fir
 Note, using `redux` is no longer recommended as the basic installer uses React Hooks.
 If you want the redux install: `rails generate react_on_rails:install --redux`
 
-The generator will add `mini_racer`'s latest version. If you're using linux & encounter issues installing `libv8`, here's [a common solution](https://github.com/rubyjs/mini_racer/issues/218).
-
 ```
 bundle exec rails generate react_on_rails:install
 ```

--- a/docs/javascript/server-rendering-tips.md
+++ b/docs/javascript/server-rendering-tips.md
@@ -2,9 +2,6 @@
 
 For the best performance with Server Rendering, consider using [React on Rails Pro]
 
-Be sure to use mini_racer. See [issues/428](https://github.com/shakacode/react_on_rails/issues/428).
-
-
 
 ## General Tips
 - Your code can't reference `document`. Server side JS execution does not have access to `document`,

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -73,7 +73,6 @@ module ReactOnRails
       end
 
       def add_base_gems_to_gemfile
-        gem "mini_racer", platforms: :ruby
         run "bundle"
       end
 

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
     json (2.5.1)
     launchy (2.5.0)
       addressable (~> 2.7)
-    libv8-node (16.10.0.0)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -137,8 +136,6 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
-    mini_racer (0.6.2)
-      libv8-node (~> 16.10.0.0)
     minitest (5.15.0)
     msgpack (1.4.2)
     nio4r (2.5.8)
@@ -329,7 +326,6 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen
-  mini_racer (>= 0.6.2)
   pry
   pry-byebug
   pry-doc


### PR DESCRIPTION
Closes #1438 
Supersedes and closes #1437 

Removes `mini_racer` addition as `Node.js` runtime will be picked up automatically and used if present (and it needs to be for NPM dependencies installs)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1453)
<!-- Reviewable:end -->
