### PR TITLE
Replaced page title Webpacker text with Shakapacker

### DIFF
--- a/lib/generators/react_on_rails/templates/base/base/app/views/layouts/hello_world.html.erb
+++ b/lib/generators/react_on_rails/templates/base/base/app/views/layouts/hello_world.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>ReactOnRailsWithWebpacker</title>
+    <title>ReactOnRailsWithShakapacker</title>
     <%= csrf_meta_tags %>
     <%= javascript_pack_tag 'hello-world-bundle' %>
     <%= stylesheet_pack_tag 'hello-world-bundle' %>


### PR DESCRIPTION
The page title appears as `ReactOnRailsWithWebpacker` which can be changed to `ReactOnRailsWithShakapacker`.

Refer this image:
<img width="369" alt="Screenshot 2022-07-04 at 11 52 30 PM" src="https://user-images.githubusercontent.com/1019076/177319409-c57df820-011c-44c1-b1b5-461ed489ec16.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1467)
<!-- Reviewable:end -->
