### PR TITLE
Removed keyword parameters warning. This will raise error in Ruby 3+ version.

### DIFF
--- a/spec/react_on_rails/react_component/render_options_spec.rb
+++ b/spec/react_on_rails/react_component/render_options_spec.rb
@@ -22,7 +22,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
     attrs = the_attrs
 
     expect do
-      described_class.new(attrs)
+      described_class.new(**attrs)
     end.not_to raise_error
   end
 
@@ -31,7 +31,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
       it "returns empty hash" do
         attrs = the_attrs
 
-        opts = described_class.new(attrs)
+        opts = described_class.new(**attrs)
 
         expect(opts.props).to eq({})
       end
@@ -42,7 +42,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         props = { a_prop: 2 }
         attrs = the_attrs(options: { props: props })
 
-        opts = described_class.new(attrs)
+        opts = described_class.new(**attrs)
 
         expect(opts.props).to eq(props)
       end
@@ -54,7 +54,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
       react_component_name = "some_app"
       attrs = the_attrs(react_component_name: react_component_name)
 
-      opts = described_class.new(attrs)
+      opts = described_class.new(**attrs)
 
       expect(opts.react_component_name).to eq "SomeApp"
     end
@@ -65,7 +65,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
       context "with random_dom_id set to true" do
         it "returns a unique identifier" do
           attrs = the_attrs(react_component_name: "SomeApp", options: { random_dom_id: true })
-          opts = described_class.new(attrs)
+          opts = described_class.new(**attrs)
 
           allow(SecureRandom).to receive(:uuid).and_return("123456789")
           expect(SecureRandom).to receive(:uuid)
@@ -74,7 +74,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         end
 
         it "is memoized" do
-          opts = described_class.new(the_attrs)
+          opts = described_class.new(**the_attrs)
           generated_value = opts.dom_id
 
           expect(opts.instance_variable_get(:@dom_id)).to eq generated_value
@@ -88,7 +88,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
       context "with random_dom_id set to false" do
         it "returns a default identifier" do
           attrs = the_attrs(react_component_name: "SomeApp", options: { random_dom_id: false })
-          opts = described_class.new(attrs)
+          opts = described_class.new(**attrs)
           expect(opts.dom_id).to eq "SomeApp-react-component"
           expect(opts.random_dom_id?).to eq(false)
         end
@@ -100,7 +100,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         options = { id: "im-an-id" }
         attrs = the_attrs(options: options)
 
-        opts = described_class.new(attrs)
+        opts = described_class.new(**attrs)
 
         expect(opts.dom_id).to eq "im-an-id"
         expect(opts.random_dom_id?).to eq(false)
@@ -113,7 +113,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
       it "returns empty hash" do
         attrs = the_attrs
 
-        opts = described_class.new(attrs)
+        opts = described_class.new(**attrs)
 
         expect(opts.html_options).to eq({})
       end
@@ -125,7 +125,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
         options = { html_options: html_options }
         attrs = the_attrs(options: options)
 
-        opts = described_class.new(attrs)
+        opts = described_class.new(**attrs)
 
         expect(opts.html_options).to eq html_options
       end
@@ -140,7 +140,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
           options[option] = false
           attrs = the_attrs(options: options)
 
-          opts = described_class.new(attrs)
+          opts = described_class.new(**attrs)
 
           expect(opts.public_send(option)).to be false
         end
@@ -151,7 +151,7 @@ describe ReactOnRails::ReactComponent::RenderOptions do
           ReactOnRails.configuration.public_send("#{option}=", true)
           attrs = the_attrs
 
-          opts = described_class.new(attrs)
+          opts = described_class.new(**attrs)
 
           expect(opts.public_send(option)).to be true
         end


### PR DESCRIPTION
With the Ruby 2.7 version we are facing the below warning:

<img width="1535" alt="Screenshot 2022-08-26 at 3 25 53 PM" src="https://user-images.githubusercontent.com/1019076/186880134-ad4d8915-9806-4011-a7e6-69c7092654a7.png">

When using Ruby 3.1.2 the test will break with the below error:

<img width="935" alt="Screenshot 2022-08-26 at 3 26 29 PM" src="https://user-images.githubusercontent.com/1019076/186880305-16251e21-33f5-4cc9-872d-32f0808bff12.png">

Raised this PR to fix the warning in the `render_options_spec` file. We won't face any issues in Ruby 3+ versions.

<img width="1534" alt="Screenshot 2022-08-26 at 3 27 00 PM" src="https://user-images.githubusercontent.com/1019076/186880500-b9edbb1c-c187-461b-b7bc-01610b1f3cd9.png">

Reference article: https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1479)
<!-- Reviewable:end -->
