### PR TITLE
Fixing wrong type

### DIFF
--- a/node_package/src/types/index.ts
+++ b/node_package/src/types/index.ts
@@ -123,7 +123,7 @@ export type RenderReturnType = void | Element | Component | Root;
 export interface ReactOnRails {
   register(components: { [id: string]: ReactComponentOrRenderFunction }): void;
   registerStore(stores: { [id: string]: Store }): void;
-  getStore(name: string, throwIfMissing: boolean): Store | undefined;
+  getStore(name: string, throwIfMissing?: boolean): Store | undefined;
   setOptions(newOptions: {traceTurbolinks: boolean}): void;
   reactOnRailsPageLoaded(): void;
   authenticityToken(): string | null;


### PR DESCRIPTION
The `throwIfMissing` param of `getStore` should be optional as it defaults to `true` https://github.com/shakacode/react_on_rails/blob/35d9d6943f4b52b652c6142a8aa5ef0f8ca36f70/node_package/src/ReactOnRails.ts#L73

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1480)
<!-- Reviewable:end -->
