### PR TITLE
exposing reactHydrateOrRender api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+### Added
+- Exposed `reactHydrateOrRender` utility via [PR 1481](https://github.com/shakacode/react_on_rails/pull/1481)
+
 ### [13.1.0] - 2022-08-20
 
 #### Improved

--- a/docs/api/javascript-api.md
+++ b/docs/api/javascript-api.md
@@ -59,6 +59,15 @@ The best source of docs is the main [ReactOnRails.js](https://github.com/shakaco
   getStore(name, throwIfMissing = true )
 
   /**
+   * Renders or hydrates the react element passed. In case react version is >=18 will use the new api.
+   * @param domNode
+   * @param reactElement
+   * @param hydrate if true will perform hydration, if false will render
+   * @returns {Root|ReactComponent|ReactElement|null}
+   */
+  reactHydrateOrRender(domNode, reactElement, hydrate)
+
+  /**
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events

--- a/node_package/src/ReactOnRails.ts
+++ b/node_package/src/ReactOnRails.ts
@@ -75,6 +75,17 @@ ctx.ReactOnRails = {
   },
 
   /**
+   * Renders or hydrates the react element passed. In case react version is >=18 will use the new api.
+   * @param domNode
+   * @param reactElement
+   * @param hydrate if true will perform hydration, if false will render
+   * @returns {Root|ReactComponent|ReactElement|null}
+   */
+  reactHydrateOrRender(domNode: Element, reactElement: ReactElement, hydrate: boolean): RenderReturnType {
+    return reactHydrateOrRender(domNode, reactElement, hydrate);
+  },
+
+  /**
    * Set options for ReactOnRails, typically before you call ReactOnRails.register
    * Available Options:
    * `traceTurbolinks: true|false Gives you debugging messages on Turbolinks events

--- a/node_package/src/types/index.ts
+++ b/node_package/src/types/index.ts
@@ -125,6 +125,7 @@ export interface ReactOnRails {
   registerStore(stores: { [id: string]: Store }): void;
   getStore(name: string, throwIfMissing: boolean): Store | undefined;
   setOptions(newOptions: {traceTurbolinks: boolean}): void;
+  reactHydrateOrRender(domNode: Element, reactElement: ReactElement, hydrate: boolean): RenderReturnType;
   reactOnRailsPageLoaded(): void;
   authenticityToken(): string | null;
   authenticityHeaders(otherHeaders: { [id: string]: string }): AuthenticityHeaders;


### PR DESCRIPTION
`reactHydrateOrRender` is a useful utility for projects with SSR. Also, it takes care of using the correct version of react API. Which is important for projects migrating to react 18.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1481)
<!-- Reviewable:end -->
