### PR TITLE
Update order of args in rails new command

### DIFF
--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -50,7 +50,7 @@ cd <directory where you want to create your new Rails app>
 # Any name you like for the rails app
 # Skip javascript so will add that next and get the current version
 # This is for Rails 7
-rails new --skip-turbolinks --skip-javascript test-react-on-rails
+rails new test-react-on-rails --skip-turbolinks --skip-javascript
 
 cd test-react-on-rails
 ```


### PR DESCRIPTION
The current command creates a project with the name of `--skip-turbolinks` rather taking it as an option.

As per rails documentation, options comes at the end, after the APP_PATH:

`rails new APP_PATH [options]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1490)
<!-- Reviewable:end -->
