### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+    # libyaml-dev is needed for psych v5
+    # this gem depends on sdoc which depends on rdoc which depends on psych
+    - name: Fix dependency for libyaml-dev
+      run: sudo apt install libyaml-dev
     - name: Setup Node
       uses: actions/setup-node@v2-beta
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         ruby: [2.7]
         node: [14]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Ruby
@@ -77,7 +77,7 @@ jobs:
         ruby: [2.7]
         node: [14]
         rake_task: ['run_rspec:all_dummy', 'run_rspec:all_but_examples', 'run_rspec:examples']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup Ruby


### PR DESCRIPTION
In this PR I have resolved two issues:
- We have indirect dependency to `psych`. In their recent major release (5.0.0), `libyaml` is not bundled with the gem so it relies on this library to be installed on the system.
- We have dependency to `ffi` which requires `libffi` version 7 to be available on the system. Since Ubuntu 20.10, we have version 8 of this library. So I used `ubuntu-20.04` instead of `ubuntu-latest` to ensure we have this library on the host machine.

This should resolve CI issues on #1491 and #1495.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1497)
<!-- Reviewable:end -->
