### PR TITLE
Fix reactOnRailsPageUnloaded when there is no component on the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
-### Added
+### [13.2.0] - 2022-12-23
+                                           
+### Fixed
 - Fix reactOnRailsPageUnloaded when there is no component on the page. Important for apps using both hotwire and react_on_rails. [PR 1498](https://github.com/shakacode/react_on_rails/pull/1498) by [NhanHo](https://github.com/NhanHo).
-- Exposed `reactHydrateOrRender` utility via [PR 1481](https://github.com/shakacode/react_on_rails/pull/1481)
+- Fixing wrong type. The throwIfMissing param of getStore should be optional as it defaults to true. [PR 1480](https://github.com/shakacode/react_on_rails/pull/1480) by [wouldntsavezion](https://github.com/wouldntsavezion).
+
+### Added
+- Exposed `reactHydrateOrRender` utility via [PR 1481](https://github.com/shakacode/react_on_rails/pull/1481) by [vaukalak](https://github.com/vaukalak).
 
 ### [13.1.0] - 2022-08-20
 
@@ -1046,7 +1051,8 @@ Best done with Object destructing:
 ##### Fixed
 - Fix several generator related issues.
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/13.0.2...master
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/13.2.0...master
+[13.2.0]: https://github.com/shakacode/react_on_rails/compare/13.1.0...13.2.0
 [13.1.0]: https://github.com/shakacode/react_on_rails/compare/13.0.2...13.1.0
 [13.0.2]: https://github.com/shakacode/react_on_rails/compare/13.0.1...13.0.2
 [13.0.1]: https://github.com/shakacode/react_on_rails/compare/13.0.0...13.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes since last non-beta release.
 *Please add entries here for your pull requests that are not yet released.*
 
 ### Added
+- Fix reactOnRailsPageUnloaded when there is no component on the page. Important for apps using both hotwire and react_on_rails. [PR 1498](https://github.com/shakacode/react_on_rails/pull/1498) by [NhanHo](https://github.com/NhanHo).
 - Exposed `reactHydrateOrRender` utility via [PR 1481](https://github.com/shakacode/react_on_rails/pull/1481)
 
 ### [13.1.0] - 2022-08-20

--- a/node_package/src/clientStartup.ts
+++ b/node_package/src/clientStartup.ts
@@ -233,7 +233,12 @@ function unmount(el: Element): void {
 function reactOnRailsPageUnloaded(): void {
   debugTurbolinks('reactOnRailsPageUnloaded');
   if (supportsRootApi) {
-    for (const root of findContext().roots) {
+    const { roots } = findContext();
+
+    // If no react on rails components
+    if (!roots) return;
+
+    for (const root of roots) {
       root.unmount();
     }
   } else {


### PR DESCRIPTION
In `reactOnRailsPageLoaded`, if we finds no react component, the function [return ](https://github.com/NhanHo/react_on_rails/blob/f121906bf94a7f84ad4dde20c1cd7e93fa75f550/node_package/src/clientStartup.ts#L209) and `context.roots` is not initialized. This cause `findContext().roots` in `reactOnRailsPageUnloaded` to be undefined, and `for .. of` throws an exception.

This should mostly affect app using both hotwire and react_on_rails, as the recommended way to load js is to do the same file everywhere, otherwise the issue can be avoided by just not loading react_on_rails

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1498)
<!-- Reviewable:end -->
