### PR TITLE
Fix rescript build command

### DIFF
--- a/spec/dummy/README.md
+++ b/spec/dummy/README.md
@@ -24,7 +24,7 @@ yalc link react-on-rails
 cd react_on_rails
 yarn run dummy:install 
 cd spec/dummy
-yarn rescript:build
+yarn build:rescript
 ```
 
 # Starting the Sample App


### PR DESCRIPTION
There is no `yarn rescript:build` command. This line is replaced with the correct one:

`yarn build:rescript`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1501)
<!-- Reviewable:end -->
