### PR TITLE
Provide error message when setup conflicts with Shakapacker

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -78,7 +78,6 @@ ReactOnRails.configure do |config|
   # When specifying `build_production_command`, you need to disable `rails/webpacker` 
   # configuration by setting `webpacker_precompile: false` in your `config/webpacker.yml` file.
 
-
   # See bottom for an example of the BuildProductionCommand module.
   # config.build_production_command = BuildProductionCommand
   # If you wish to utilize ReactOnRailsPro production bundle caching logic, then use

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -74,6 +74,11 @@ ReactOnRails.configure do |config|
   # In this example, the module BuildProductionCommand would have a class method `call`.
   config.build_production_command = "RAILS_ENV=production bin/webpacker"
 
+  # NOTE:
+  # When specifying `build_production_command`, you need to disable `rails/webpacker` 
+  # configuration by setting `webpacker_precompile: false` in your `config/webpacker.yml` file.
+
+
   # See bottom for an example of the BuildProductionCommand module.
   # config.build_production_command = BuildProductionCommand
   # If you wish to utilize ReactOnRailsPro production bundle caching logic, then use

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
+
 module ReactOnRails
   def self.configure
     yield(configuration)
@@ -128,7 +130,20 @@ module ReactOnRails
 
       # Ensure that shakacode/shakapacker does not call bin/webpacker if we're providing
       # the build command.
-      ENV["WEBPACKER_PRECOMPILE"] = "false"
+      if Webpacker.config.webpacker_precompile?
+        msg = <<~MSG
+
+          React on Rails and Shakapacker error in configuration!
+          In order to use config/react_on_rails.rb config.build_production_command,
+          you must edit config/webpacker.yml to include this value in the default configuration:
+          'webpacker_precompile: false'
+
+          Alternatively, remove the config/react_on_rails.rb config.build_production_command and the
+          default bin/webpacker script will be used for assets:precompile.
+
+        MSG
+        raise msg
+      end
 
       precompile_tasks = lambda {
         Rake::Task["react_on_rails:generate_packs"].invoke
@@ -232,3 +247,4 @@ module ReactOnRails
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -128,8 +128,6 @@ module ReactOnRails
 
       return if skip_react_on_rails_precompile || build_production_command.blank?
 
-      # Ensure that shakacode/shakapacker does not call bin/webpacker if we're providing
-      # the build command.
       if Webpacker.config.webpacker_precompile?
         msg = <<~MSG
 
@@ -142,7 +140,7 @@ module ReactOnRails
           default bin/webpacker script will be used for assets:precompile.
 
         MSG
-        raise msg
+        raise ReactOnRails::Error, msg
       end
 
       precompile_tasks = lambda {

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -2,6 +2,8 @@
 
 require_relative "spec_helper"
 
+# rubocop:disable Metrics/ModuleLength
+
 module ReactOnRails
   RSpec.describe Configuration do # rubocop:disable Metrics/BlockLength
     let(:existing_path) { Pathname.new(Dir.mktmpdir) }
@@ -73,7 +75,6 @@ module ReactOnRails
     end
 
     describe ".build_production_command" do
-
       it "fails when \"webpacker_precompile\" is truly and \"build_production_command\" is truly" do
         allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
           .and_return(true)
@@ -98,7 +99,7 @@ module ReactOnRails
         allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
           .and_return(true)
         expect do
-          ReactOnRails.configure {}
+          ReactOnRails.configure {} # rubocop:disable-line Lint/EmptyBlock
         end.not_to raise_error
       end
 
@@ -106,7 +107,7 @@ module ReactOnRails
         allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
           .and_return(false)
         expect do
-          ReactOnRails.configure {}
+          ReactOnRails.configure {} # rubocop:disable-line Lint/EmptyBlock
         end.not_to raise_error
       end
     end
@@ -230,3 +231,5 @@ module ReactOnRails
     end
   end
 end
+
+# rubocop:enable Metrics/ModuleLength

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -73,23 +73,40 @@ module ReactOnRails
     end
 
     describe ".build_production_command" do
-      it "fails when \"webpacker_precompile\" is truly" do
+
+      it "fails when \"webpacker_precompile\" is truly and \"build_production_command\" is truly" do
         allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
           .and_return(true)
         expect do
           ReactOnRails.configure do |config|
-            config.build_production_command = "a string or a module"
+            config.build_production_command = "RAILS_ENV=production NODE_ENV=production bin/webpacker"
           end
         end.to raise_error(ReactOnRails::Error, /webpacker_precompile: false/)
       end
 
-      it "doesn't fail when \"webpacker_precompile\" is falsy" do
+      it "doesn't fail when \"webpacker_precompile\" is falsy and \"build_production_command\" is truly" do
         allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
           .and_return(false)
         expect do
           ReactOnRails.configure do |config|
-            config.build_production_command = "a string or a module"
+            config.build_production_command = "RAILS_ENV=production NODE_ENV=production bin/webpacker"
           end
+        end.not_to raise_error
+      end
+
+      it "doesn't fail when \"webpacker_precompile\" is truly and \"build_production_command\" is falsy" do
+        allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
+          .and_return(true)
+        expect do
+          ReactOnRails.configure {}
+        end.not_to raise_error
+      end
+
+      it "doesn't fail when \"webpacker_precompile\" is falsy and \"build_production_command\" is falsy" do
+        allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
+          .and_return(false)
+        expect do
+          ReactOnRails.configure {}
         end.not_to raise_error
       end
     end

--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -73,23 +73,24 @@ module ReactOnRails
     end
 
     describe ".build_production_command" do
-      it "if configured, ENV[\"WEBPACKER_PRECOMPILE\"] gets set to \"false\"" do
-        expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
-
-        ReactOnRails.configure do |config|
-          config.build_production_command = "a string or a module"
-        end
-
-        expect(ENV["WEBPACKER_PRECOMPILE"]).to eq("false")
-        ENV["WEBPACKER_PRECOMPILE"] = nil
+      it "fails when \"webpacker_precompile\" is truly" do
+        allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
+          .and_return(true)
+        expect do
+          ReactOnRails.configure do |config|
+            config.build_production_command = "a string or a module"
+          end
+        end.to raise_error(ReactOnRails::Error, /webpacker_precompile: false/)
       end
 
-      it "if not configured, ENV[\"WEBPACKER_PRECOMPILE\"] remains nil" do
-        expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
-
-        ReactOnRails.configure {} # rubocop:disable-line Lint/EmptyBlock
-
-        expect(ENV["WEBPACKER_PRECOMPILE"]).to be_nil
+      it "doesn't fail when \"webpacker_precompile\" is falsy" do
+        allow(Webpacker).to receive_message_chain("config.webpacker_precompile?")
+          .and_return(false)
+        expect do
+          ReactOnRails.configure do |config|
+            config.build_production_command = "a string or a module"
+          end
+        end.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Since `shakapacker` configuration might eventually run prior to the `react_on_rails` configuration, settings `ENV["WEBPACKER_PRECOMPILE"] = "false"` might not give the expected result. In order to make this behaviour consistent, we wan't gem users to specify `webpacker_precompile: false` in the `config/webpacker.yml` file.

New error message:

```
RAILS_ENV=production NODE_ENV=production rake assets:precompile 1 ↵ ✹ ✭
rake aborted!

React on Rails and Shakapacker error in configuration!
In order to use config/react_on_rails.rb config.build_production_command,
you must edit config/webpacker.yml to include this value in the default configuration:
'webpacker_precompile: false'

Alternatively, remove the config/react_on_rails.rb config.build_production_command and the
default bin/webpacker script will be used for assets:precompile.

/Users/justin/shakacode/react-on-rails/react_on_rails_2/lib/react_on_rails/configuration.rb:143:in `adjust_precompile_task'
/Users/justin/shakacode/react-on-rails/react_on_rails_2/lib/react_on_rails/configuration.rb:119:in `setup_config_values'
/Users/justin/shakacode/react-on-rails/react_on_rails_2/lib/react_on_rails/configuration.rb:6:in `configure'
/Users/justin/shakacode/react-on-rails/react-webpack-rails-tutorial/config/initializers/react_on_rails.rb:4:in `<top (required)>'
/Users/justin/shakacode/react-on-rails/react-webpack-rails-tutorial/config/environment.rb:7:in `<top (required)>'
Tasks: TOP => environment
(See full trace by running task with --trace)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1502)
<!-- Reviewable:end -->
