### PR TITLE
Generate Pack if Missing Generated Pack for Registered Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,14 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
-- Added `./bin/dev` and `./bin/dev-static` executables to ease and standardize running the dev server. [PR 1491](https://github.com/shakacode/react_on_rails/pull/1491) by [ahangarha](https://github.com/ahangarha)
+
+### [13.3.0] - 2022-01-28
+### Fixed
 - Fixed pack not found warning while using `react_component` and `react_component_hash` helpers, even when corresponding chunks are present. [PR 1511](https://github.com/shakacode/react_on_rails/pull/1511) by [pulkitkkr](https://github.com/pulkitkkr)
 - Fixed FS-based packs generation functionality to trigger pack generation  on the creation of a new react component inside `components_subdirectory`. [PR 1506](https://github.com/shakacode/react_on_rails/pull/1506) by [pulkitkkr](https://github.com/pulkitkkr)
+
+### Added
+- Added `./bin/dev` and `./bin/dev-static` executables to ease and standardize running the dev server. [PR 1491](https://github.com/shakacode/react_on_rails/pull/1491) by [ahangarha](https://github.com/ahangarha)
 
 ### [13.2.0] - 2022-12-23
                                            

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changes since last non-beta release.
 *Please add entries here for your pull requests that are not yet released.*
 - Added `./bin/dev` and `./bin/dev-static` executables to ease and standardize running the dev server. [PR 1491](https://github.com/shakacode/react_on_rails/pull/1491) by [ahangarha](https://github.com/ahangarha)
 - Fixed pack not found warning while using `react_component` and `react_component_hash` helpers, even when corresponding chunks are present. [PR 1511](https://github.com/shakacode/react_on_rails/pull/1511) by [pulkitkkr](https://github.com/pulkitkkr)
+- Fixed FS-based packs generation functionality to trigger pack generation  on the creation of a new react component inside `components_subdirectory`. [PR 1506](https://github.com/shakacode/react_on_rails/pull/1506) by [pulkitkkr](https://github.com/pulkitkkr)
 
 ### [13.2.0] - 2022-12-23
                                            

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -93,27 +93,6 @@ module ReactOnRails
       end
     end
 
-    def load_pack_for_component(component_name)
-      is_component_pack_present = File.exist?(generated_components_pack_path(component_name))
-      is_development = ENV["RAILS_ENV"] == "development"
-
-      if is_development && !is_component_pack_present
-        ReactOnRails::PacksGenerator.generate
-        raise_missing_pack_error(component_name)
-      end
-
-      ReactOnRails::PacksGenerator.raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
-
-      append_javascript_pack_tag "generated/#{component_name}"
-      append_stylesheet_pack_tag "generated/#{component_name}"
-    end
-
-    def generated_components_pack_path(component_name)
-      extension = PacksGenerator::GENERATED_PACK_EXTENSION
-
-      "#{ReactOnRails::WebpackerUtils.webpacker_source_entry_path}/generated/#{component_name}.#{extension}"
-    end
-
     # react_component_hash is used to return multiple HTML strings for server rendering, such as for
     # adding meta-tags to a page.
     # It is exactly like react_component except for the following:
@@ -339,6 +318,27 @@ module ReactOnRails
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
     private
+
+    def load_pack_for_component(component_name)
+      is_component_pack_present = File.exist?(generated_components_pack_path(component_name))
+      is_development = ENV["RAILS_ENV"] == "development"
+
+      if is_development && !is_component_pack_present
+        ReactOnRails::PacksGenerator.generate
+        raise_missing_pack_error(component_name)
+      end
+
+      ReactOnRails::PacksGenerator.raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
+
+      append_javascript_pack_tag "generated/#{component_name}"
+      append_stylesheet_pack_tag "generated/#{component_name}"
+    end
+
+    def generated_components_pack_path(component_name)
+      extension = PacksGenerator::GENERATED_PACK_EXTENSION
+
+      "#{ReactOnRails::WebpackerUtils.webpacker_source_entry_path}/generated/#{component_name}.#{extension}"
+    end
 
     def build_react_component_result_for_server_rendered_string(
       server_rendered_html: required("server_rendered_html"),

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -557,8 +557,7 @@ module ReactOnRails
 
     def raise_generated_missing_pack_warning(component_name)
       msg = <<~MSG
-        **ERROR** ReactOnRails: Generated missing pack for Component: #{component_name}. Please refresh the webpage \
-        once webpack has finished generating the bundles. If the problem persists
+        **ERROR** ReactOnRails: Generated missing pack for Component: #{component_name}. Please restart the webpack dev server to ensure webpack generates the chunks corresponding to #{component_name} component. If the problem persists
         1. Verify `components_subdirectory` is configured in `config/initializers/react_on_rails`.
         2. Component: #{component_name} is placed inside the configured `components_subdirectory`.
       MSG

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -99,7 +99,7 @@ module ReactOnRails
 
       if is_development && !is_component_pack_present
         ReactOnRails::PacksGenerator.generate
-        raise_generated_missing_pack_warning(component_name)
+        raise_missing_pack_error(component_name)
       end
 
       ReactOnRails::PacksGenerator.raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
@@ -555,7 +555,7 @@ module ReactOnRails
       result
     end
 
-    def raise_generated_missing_pack_warning(component_name)
+    def raise_missing_pack_error(component_name)
       msg = <<~MSG
         **ERROR** ReactOnRails: Generated missing pack for Component: #{component_name}. Please restart the webpack dev server or webpack in watch mode, to ensure webpack generates the chunks corresponding to #{component_name} component. If the problem persists
         1. Verify `components_subdirectory` is configured in `config/initializers/react_on_rails`.

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -557,7 +557,7 @@ module ReactOnRails
 
     def raise_generated_missing_pack_warning(component_name)
       msg = <<~MSG
-        **ERROR** ReactOnRails: Generated missing pack for Component: #{component_name}. Please restart the webpack dev server to ensure webpack generates the chunks corresponding to #{component_name} component. If the problem persists
+        **ERROR** ReactOnRails: Generated missing pack for Component: #{component_name}. Please restart the webpack dev server or webpack in watch mode, to ensure webpack generates the chunks corresponding to #{component_name} component. If the problem persists
         1. Verify `components_subdirectory` is configured in `config/initializers/react_on_rails`.
         2. Component: #{component_name} is placed inside the configured `components_subdirectory`.
       MSG

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -29,8 +29,9 @@ module ReactOnRails
       raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
 
       is_generated_directory_present = Dir.exist?(generated_packs_directory_path)
+      stale_packs = webpack_assets_status_checker.stale_generated_component_packs
 
-      return if is_generated_directory_present && webpack_assets_status_checker.stale_generated_component_packs.empty?
+      return if is_generated_directory_present && stale_packs.empty? && missing_packs.empty?
 
       clean_generated_packs_directory
       generate_packs
@@ -296,6 +297,16 @@ module ReactOnRails
       content_with_prepended_text = text_to_prepend + file_content
       File.write(file, content_with_prepended_text)
       puts "Prepended\n#{text_to_prepend}to #{file}."
+    end
+
+    def missing_packs
+      required_files = common_component_to_path.values + client_component_to_path.values
+
+      required_files.each_with_object([]) do |file, missing_list|
+        is_generated_pack_present = File.exist?(generated_pack_path(file))
+
+        missing_list << file unless  is_generated_pack_present
+      end
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -24,9 +24,7 @@ module ReactOnRails
     def verify_setup_and_generate_packs
       return unless components_subdirectory.present?
 
-      raise_webpacker_not_installed unless ReactOnRails::WebpackerUtils.using_webpacker?
-      raise_shakapacker_version_incompatible unless shackapacker_version_requirement_met?
-      raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
+      verify_configuration
 
       is_generated_directory_present = Dir.exist?(generated_packs_directory_path)
       stale_packs = webpack_assets_status_checker.stale_generated_component_packs
@@ -307,6 +305,12 @@ module ReactOnRails
 
         missing_list << file unless  is_generated_pack_present
       end
+    end
+
+    def verify_configuration
+      raise_webpacker_not_installed unless ReactOnRails::WebpackerUtils.using_webpacker?
+      raise_shakapacker_version_incompatible unless shackapacker_version_requirement_met?
+      raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -298,12 +298,13 @@ module ReactOnRails
 
     def stale_or_missing_packs
       component_files = common_component_to_path.values + client_component_to_path.values
-      most_recent_mtime = WebpackAssetsStatusChecker.find_most_recent_mtime(component_files)
+      most_recent_mtime = Utils.find_most_recent_mtime(component_files)
 
       component_files.each_with_object([]) do |file, missing_or_stale_list|
         path = generated_pack_path(file)
 
         missing_or_stale_list << file if !File.exist?(path) || File.mtime(path) < most_recent_mtime
+        missing_or_stale_list
       end
     end
 

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -28,7 +28,7 @@ module ReactOnRails
 
       is_generated_directory_present = Dir.exist?(generated_packs_directory_path)
 
-      return if is_generated_directory_present && stale_or_missing_packs.empty?
+      return if is_generated_directory_present && !stale_or_missing_packs?
 
       clean_generated_packs_directory
       generate_packs
@@ -296,15 +296,14 @@ module ReactOnRails
       puts "Prepended\n#{text_to_prepend}to #{file}."
     end
 
-    def stale_or_missing_packs
+    def stale_or_missing_packs?
       component_files = common_component_to_path.values + client_component_to_path.values
       most_recent_mtime = Utils.find_most_recent_mtime(component_files)
 
-      component_files.each_with_object([]) do |file, missing_or_stale_list|
+      component_files.each_with_object([]).any? do |file|
         path = generated_pack_path(file)
 
-        missing_or_stale_list << file if !File.exist?(path) || File.mtime(path) < most_recent_mtime
-        missing_or_stale_list
+        !File.exist?(path) || File.mtime(path) < most_recent_mtime
       end
     end
 

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -27,9 +27,8 @@ module ReactOnRails
       verify_configuration
 
       is_generated_directory_present = Dir.exist?(generated_packs_directory_path)
-      stale_packs = webpack_assets_status_checker.stale_generated_component_packs
 
-      return if is_generated_directory_present && stale_packs.empty? && missing_packs.empty?
+      return if is_generated_directory_present && stale_or_missing_packs.empty?
 
       clean_generated_packs_directory
       generate_packs
@@ -297,13 +296,14 @@ module ReactOnRails
       puts "Prepended\n#{text_to_prepend}to #{file}."
     end
 
-    def missing_packs
-      required_files = common_component_to_path.values + client_component_to_path.values
+    def stale_or_missing_packs
+      component_files = common_component_to_path.values + client_component_to_path.values
+      most_recent_mtime = WebpackAssetsStatusChecker.find_most_recent_mtime(component_files)
 
-      required_files.each_with_object([]) do |file, missing_list|
-        is_generated_pack_present = File.exist?(generated_pack_path(file))
+      component_files.each_with_object([]) do |file, missing_or_stale_list|
+        path = generated_pack_path(file)
 
-        missing_list << file unless  is_generated_pack_present
+        missing_or_stale_list << file if !File.exist?(path) || File.mtime(path) < most_recent_mtime
       end
     end
 

--- a/lib/react_on_rails/test_helper/webpack_assets_status_checker.rb
+++ b/lib/react_on_rails/test_helper/webpack_assets_status_checker.rb
@@ -35,7 +35,7 @@ module ReactOnRails
 
         return ["manifest.json"] if manifest_needed
 
-        most_recent_mtime = find_most_recent_mtime(files)
+        most_recent_mtime = Utils.find_most_recent_mtime(files)
         all_compiled_assets.each_with_object([]) do |webpack_generated_file, stale_gen_list|
           if !File.exist?(webpack_generated_file) ||
              File.mtime(webpack_generated_file) < most_recent_mtime
@@ -46,13 +46,6 @@ module ReactOnRails
       end
 
       private
-
-      def find_most_recent_mtime(files)
-        files.reduce(1.year.ago) do |newest_time, file|
-          mt = File.mtime(file)
-          mt > newest_time ? mt : newest_time
-        end
-      end
 
       def all_compiled_assets
         @all_compiled_assets ||= begin

--- a/lib/react_on_rails/test_helper/webpack_assets_status_checker.rb
+++ b/lib/react_on_rails/test_helper/webpack_assets_status_checker.rb
@@ -29,10 +29,6 @@ module ReactOnRails
         stale_generated_files(client_files)
       end
 
-      def stale_generated_component_packs
-        stale_generated_files(component_pack_files)
-      end
-
       def stale_generated_files(files)
         manifest_needed = ReactOnRails::WebpackerUtils.using_webpacker? &&
                           !ReactOnRails::WebpackerUtils.manifest_exists?
@@ -87,14 +83,6 @@ module ReactOnRails
 
       def client_files
         @client_files ||= make_file_list(make_globs(source_path)).to_ary
-      end
-
-      def component_pack_files
-        make_file_list(make_globs(components_search_path)).to_ary
-      end
-
-      def components_search_path
-        "#{source_path}/**/#{ReactOnRails.configuration.components_subdirectory}"
       end
 
       def make_globs(dirs)

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -197,5 +197,12 @@ module ReactOnRails
       rstrip = to_remove - lstrip
       str[0..(midpoint - lstrip - 1)] + TRUNCATION_FILLER + str[(midpoint + rstrip)..-1]
     end
+
+    def self.find_most_recent_mtime(files)
+      files.reduce(1.year.ago) do |newest_time, file|
+        mt = File.mtime(file)
+        mt > newest_time ? mt : newest_time
+      end
+    end
   end
 end

--- a/lib/react_on_rails/version.rb
+++ b/lib/react_on_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReactOnRails
-  VERSION = "13.2.0"
+  VERSION = "13.3.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "13.2.0",
+  "version": "13.3.0",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "node_package/lib/ReactOnRails.js",
   "directories": {

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    react_on_rails (13.2.0)
+    react_on_rails (13.3.0)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -4,7 +4,7 @@ require_relative "rails_helper"
 
 # rubocop:disable Metrics/ModuleLength
 module ReactOnRails
-  GENERATED_PACKS_OUTPUT_REGEX = /Generated Packs:/.freeze
+  GENERATED_PACKS_CONSOLE_OUTPUT_TEXT= "Generated Packs:"
 
   # rubocop:disable Metrics/BlockLength
   describe PacksGenerator do
@@ -264,25 +264,25 @@ module ReactOnRails
       end
 
       it "does not generate packs if there are no new components or stale files" do
-        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+        expect { described_class.generate }.to output(GENERATED_PACKS_CONSOLE_OUTPUT_TEXT).to_stdout
 
-        expect { described_class.generate }.not_to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+        expect { described_class.generate }.not_to output(GENERATED_PACKS_CONSOLE_OUTPUT_TEXT).to_stdout
       end
 
       it "generate packs if a new component is added" do
-        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+        expect { described_class.generate }.to output(GENERATED_PACKS_CONSOLE_OUTPUT_TEXT).to_stdout
 
         create_new_component("NewComponent")
 
-        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+        expect { described_class.generate }.to output(GENERATED_PACKS_CONSOLE_OUTPUT_TEXT).to_stdout
       end
 
       it "generate packs if an old component is updated" do
-        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+        expect { described_class.generate }.to output(GENERATED_PACKS_CONSOLE_OUTPUT_TEXT).to_stdout
 
         create_new_component(component_name)
 
-        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+        expect { described_class.generate }.to output(GENERATED_PACKS_CONSOLE_OUTPUT_TEXT).to_stdout
       end
 
       def create_new_component(name)

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -4,7 +4,7 @@ require_relative "rails_helper"
 
 # rubocop:disable Metrics/ModuleLength
 module ReactOnRails
-  GENERATED_PACKS_CONSOLE_OUTPUT_TEXT= "Generated Packs:"
+  GENERATED_PACKS_CONSOLE_OUTPUT_TEXT = "Generated Packs:"
 
   # rubocop:disable Metrics/BlockLength
   describe PacksGenerator do

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -4,6 +4,8 @@ require_relative "rails_helper"
 
 # rubocop:disable Metrics/ModuleLength
 module ReactOnRails
+  GENERATED_PACKS_OUTPUT_REGEX = /Generated Packs:/.freeze
+
   # rubocop:disable Metrics/BlockLength
   describe PacksGenerator do
     let(:webpacker_source_path) { File.expand_path("fixtures/automated_packs_generation", __dir__) }
@@ -249,6 +251,45 @@ module ReactOnRails
         expect(generated_server_bundle_content).not_to include("#{component_name}.jsx")
         expect(generated_server_bundle_content).not_to include("#{component_name}.client.jsx")
         expect(generated_server_bundle_content).not_to include("#{component_name}.server.jsx")
+      end
+    end
+
+    context "when pack generator is called" do
+      let(:component_name) { "ComponentWithCommonOnly" }
+      let(:component_pack) { "#{generated_directory}/#{component_name}.js" }
+
+      before do
+        stub_webpacker_source_path(component_name: component_name,
+                                   webpacker_source_path: webpacker_source_path)
+      end
+
+      it "does not generate packs if there are no new components or stale files" do
+        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+
+        expect { described_class.generate }.not_to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+      end
+
+      it "generate packs if a new component is added" do
+        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+
+        create_new_component("NewComponent")
+
+        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+      end
+
+      it "generate packs if an old component is updated" do
+        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+
+        create_new_component(component_name)
+
+        expect { described_class.generate }.to output(GENERATED_PACKS_OUTPUT_REGEX).to_stdout
+      end
+
+      def create_new_component(name)
+        components_subdirectory = ReactOnRails.configuration.components_subdirectory
+        path = "#{webpacker_source_path}/components/#{component_name}/#{components_subdirectory}/#{name}.jsx"
+
+        File.write(path, "// Empty Test Component\n")
       end
     end
 


### PR DESCRIPTION
## Problem
Currently, The Generate Pack Script handles the on-demand generation of packs only for existing components by checking m_time to verify if the generated packs are stale. If a user creates a new Component under `components_subdirectory,` It's not tracked by `stale_generated_component_packs`; 

## Solution and Changes in PR
This PR updates the FS-based Pack generation feature by adding a check for missing_packs. The system will generate a new pack when either the components are stale, or a new component is created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1506)
<!-- Reviewable:end -->
