### PR TITLE
change config link from `basics` to `guides`

### DIFF
--- a/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb
+++ b/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# See https://github.com/shakacode/react_on_rails/blob/master/docs/basics/configuration.md
+# See https://github.com/shakacode/react_on_rails/blob/master/docs/guides/configuration.md
 # for many more options.
 
 ReactOnRails.configure do |config|


### PR DESCRIPTION
I noticed `configuration.md` link in initializer template file is old. So I changed it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1512)
<!-- Reviewable:end -->
