### PR TITLE
Fix Misc Bugs Introduced in Pack Generator Refactoring

### DIFF
--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -219,9 +219,5 @@ module ReactOnRails
 
       puts "Prepended\n#{text_to_prepend}to #{file}."
     end
-
-    def self.semver_to_string(ary)
-      "#{ary[0]}.#{ary[1]}.#{ary[2]}"
-    end
   end
 end

--- a/lib/react_on_rails/webpacker_utils.rb
+++ b/lib/react_on_rails/webpacker_utils.rb
@@ -119,9 +119,9 @@ module ReactOnRails
 
     def self.raise_shakapacker_version_incompatible_for_autobundling
       msg = <<~MSG
-        **ERROR** ReactOnRails: Please upgrade Shakapacker to version #{ReactOnRails::WebpackerUtils.semver_to_string(ReactOnRails::PacksGenerator::MINIMUM_SHAKAPACKER_VERSION)} or \
+        **ERROR** ReactOnRails: Please upgrade Shakapacker to version #{ReactOnRails::Utils.semver_to_string(ReactOnRails::PacksGenerator::MINIMUM_SHAKAPACKER_VERSION)} or \
         above to use the automated bundle generation feature. The currently installed version is \
-        #{ReactOnRails::WebpackerUtils.semver_to_string(ReactOnRails::WebpackerUtils.shakapacker_version_as_array)}.
+        #{ReactOnRails::Utils.semver_to_string(ReactOnRails::WebpackerUtils.shakapacker_version_as_array)}.
       MSG
 
       raise ReactOnRails::Error, msg
@@ -130,7 +130,7 @@ module ReactOnRails
     def self.raise_shakapacker_not_installed
       msg = <<~MSG
         **ERROR** ReactOnRails: Missing Shakapacker gem. Please upgrade to use Shakapacker \
-        #{ReactOnRails::WebpackerUtils.semver_to_string(minimum_required_shakapacker_version)} or above to use the \
+        #{ReactOnRails::Utils.semver_to_string(minimum_required_shakapacker_version)} or above to use the \
         automated bundle generation feature.
       MSG
 

--- a/lib/react_on_rails/webpacker_utils.rb
+++ b/lib/react_on_rails/webpacker_utils.rb
@@ -27,9 +27,10 @@ module ReactOnRails
       @shakapacker_version_as_array = [match[1].to_i, match[2].to_i, match[3].to_i]
     end
 
-    def self.shackapacker_version_requirement_met?(ary)
-      ary[0] >= shakapacker_version_as_array[0] && ary[1] >= shakapacker_version_as_array[1] &&
-        ary[2] >= shakapacker_version_as_array[2]
+    def self.shackapacker_version_requirement_met?(required_version)
+      req_ver = semver_to_string(required_version)
+
+      Gem::Version.new(shakapacker_version) >= Gem::Version.new(req_ver)
     end
 
     # This returns either a URL for the webpack-dev-server, non-server bundle or
@@ -119,9 +120,9 @@ module ReactOnRails
 
     def self.raise_shakapacker_version_incompatible_for_autobundling
       msg = <<~MSG
-        **ERROR** ReactOnRails: Please upgrade Shakapacker to version #{ReactOnRails::Utils.semver_to_string(ReactOnRails::PacksGenerator::MINIMUM_SHAKAPACKER_VERSION)} or \
+        **ERROR** ReactOnRails: Please upgrade Shakapacker to version #{ReactOnRails::WebpackerUtils.semver_to_string(ReactOnRails::PacksGenerator::MINIMUM_SHAKAPACKER_VERSION)} or \
         above to use the automated bundle generation feature. The currently installed version is \
-        #{ReactOnRails::Utils.semver_to_string(ReactOnRails::WebpackerUtils.shakapacker_version_as_array)}.
+        #{ReactOnRails::WebpackerUtils.semver_to_string(ReactOnRails::WebpackerUtils.shakapacker_version_as_array)}.
       MSG
 
       raise ReactOnRails::Error, msg
@@ -130,11 +131,15 @@ module ReactOnRails
     def self.raise_shakapacker_not_installed
       msg = <<~MSG
         **ERROR** ReactOnRails: Missing Shakapacker gem. Please upgrade to use Shakapacker \
-        #{ReactOnRails::Utils.semver_to_string(minimum_required_shakapacker_version)} or above to use the \
+        #{ReactOnRails::WebpackerUtils.semver_to_string(minimum_required_shakapacker_version)} or above to use the \
         automated bundle generation feature.
       MSG
 
       raise ReactOnRails::Error, msg
+    end
+
+    def self.semver_to_string(ary)
+      "#{ary[0]}.#{ary[1]}.#{ary[2]}"
     end
   end
 end

--- a/spec/react_on_rails/webpacker_utils_spec.rb
+++ b/spec/react_on_rails/webpacker_utils_spec.rb
@@ -9,7 +9,39 @@ module ReactOnRails
         described_class.using_webpacker?
       end
 
-      it { is_expected.to eq(true) }
+      it { is_expected.to be(true) }
+    end
+
+    describe ".shackapacker_version_requirement_met?" do
+      minimum_version = [6, 5, 3]
+
+      it "returns false when version is lower than minimum_version" do
+        allow(described_class).to receive(:shakapacker_version).and_return("6.5.0")
+
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(false)
+
+        allow(described_class).to receive(:shakapacker_version).and_return("6.4.7")
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(false)
+
+        allow(described_class).to receive(:shakapacker_version).and_return("5.7.7")
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(false)
+      end
+
+      it "returns true when version is equal to minimum_version" do
+        allow(described_class).to receive(:shakapacker_version).and_return("6.5.3")
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(true)
+      end
+
+      it "returns true when version is greater than minimum_version" do
+        allow(described_class).to receive(:shakapacker_version).and_return("6.6.0")
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(true)
+
+        allow(described_class).to receive(:shakapacker_version).and_return("6.5.4")
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(true)
+
+        allow(described_class).to receive(:shakapacker_version).and_return("7.7.7")
+        expect(described_class.shackapacker_version_requirement_met?(minimum_version)).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Refactoring in [PR1509](https://github.com/shakacode/react_on_rails/pull/1509/files#diff-76ac9622c1c83bf5694255c2474bfb0b9a68954e8598e475fc123ed7910874fb) introduced follwing bugs: 

- The refactor created `semver_to_string` method in `ReactOnRails::Utils` but they were referenced using `ReactOnRails::WebpackerUtils`

- `shackapacker_version_requirement_met?` is checking minimum version >= installed version whereas we want to check installed_version > minimum_version. Further, the logic will fail when a required version is 6.5.3 and the installed is 6.6.1.

This PR addresses these critical bugs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1515)
<!-- Reviewable:end -->
