### PR TITLE
Remove `ApplicationController.helpers` for append_tags

### DIFF
--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -328,8 +328,8 @@ module ReactOnRails
 
       ReactOnRails::WebpackerUtils.raise_nested_entries_disabled unless ReactOnRails::WebpackerUtils.nested_entries?
 
-      ApplicationController.helpers.append_javascript_pack_tag "generated/#{component_name}"
-      ApplicationController.helpers.append_stylesheet_pack_tag "generated/#{component_name}"
+      append_javascript_pack_tag "generated/#{component_name}"
+      append_stylesheet_pack_tag "generated/#{component_name}"
     end
 
     def generated_components_pack_path(component_name)


### PR DESCRIPTION
## Summary
- Having `ApplicationController.helpers.append_(stylsheet/javascript)_pack_tags` breaks Components registration for Application using `content_for` for rendering partials containing react copmonents in views.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1516)
<!-- Reviewable:end -->
