### PR TITLE
Add docs for ignoring warning related to react dom client not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Changes since last non-beta release.
 
 - Fixed the `You are importing hydrateRoot from "react-dom" [...] You should instead import it from "react-dom/client"` warning under React 18 ([#1441](https://github.com/shakacode/react_on_rails/issues/1441)). [PR 1460](https://github.com/shakacode/react_on_rails/pull/1460) by [alexeyr](https://github.com/alexeyr).
 
-  In exchange, you may see a warning like this when building a Webpack bundle under React 16:
+  In exchange, you may see a warning like this when building using any version of React below 18:
   ```
   WARNING in ./node_modules/react-on-rails/node_package/lib/reactHydrateOrRender.js19:25-52
   Module not found: Error: Can't resolve 'react-dom/client' in '/home/runner/work/react_on_rails/react_on_rails/spec/dummy/node_modules/react-on-rails/node_package/lib'

--- a/docs/guides/rails-webpacker-react-integration-options.md
+++ b/docs/guides/rails-webpacker-react-integration-options.md
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ## Suppress warning related to Can't resolve 'react-dom/client' in React < 18
 
-You may see a warning like this when building using any version of React below 18:
+You may see a warning like this when building a Webpack bundle using any version of React below 18:
 
 ```
 Module not found: Error: Can't resolve 'react-dom/client' in ....

--- a/docs/guides/rails-webpacker-react-integration-options.md
+++ b/docs/guides/rails-webpacker-react-integration-options.md
@@ -56,6 +56,36 @@ document.addEventListener('DOMContentLoaded', () => {
 
 ----
 
+## Suppress warning related to Can't resolve 'react-dom/client' in React < 18
+
+You may see a warning like this when building using any version of React below 18:
+
+```
+Module not found: Error: Can't resolve 'react-dom/client' in ....
+```
+
+It can be safely [suppressed](https://webpack.js.org/configuration/other-options/#ignorewarnings) in your Webpack configuration. The following is an example of this suppression in `config/webpack/commonWebpackConfig.js`:
+
+```js
+const { webpackConfig: baseClientWebpackConfig, merge } = require('shakapacker');
+
+const commonOptions = {
+  resolve: {
+    extensions: ['.css', '.ts', '.tsx'],
+  },
+};
+
+const ignoreWarningsConfig = {
+  ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
+};
+
+const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptions, ignoreWarningsConfig);
+
+module.exports = commonWebpackConfig;
+```
+
+----
+
 ## HMR and React Hot Reloading
 
 Before turning HMR on, consider upgrading to the latest stable gems and packages:


### PR DESCRIPTION
### Summary

- Add documentation for suppressing warning messages related to `Module not found: Error: Can't resolve 'react-dom/client'`
- Improve clarity of old entries in changelog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1528)
<!-- Reviewable:end -->
