### PR TITLE
Update documentation links

### DIFF
--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -93,7 +93,7 @@ module ReactOnRails
         msg = <<~MSG
           **ERROR** ReactOnRails: `nested_entries` is configured to be disabled in shakapacker. Please update \
           webpacker.yml to enable nested entries. for more information read
-          https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation.md#enable-nested_entries-for-shakapacker
+          https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation/#enable-nested_entries-for-shakapacker
         MSG
 
         expect { described_class.generate }.to raise_error(ReactOnRails::Error, msg)
@@ -153,7 +153,7 @@ module ReactOnRails
         msg = <<~MSG
           **ERROR** ReactOnRails: client specific definition for Component '#{component_name}' overrides the \
           common definition. Please delete the common definition and have separate server and client files. For more \
-          information, please see https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation.md
+          information, please see https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation/
         MSG
 
         expect { described_class.generate }.to raise_error(ReactOnRails::Error, msg)
@@ -173,7 +173,7 @@ module ReactOnRails
         msg = <<~MSG
           **ERROR** ReactOnRails: server specific definition for Component '#{component_name}' overrides the \
           common definition. Please delete the common definition and have separate server and client files. For more \
-          information, please see https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation.md
+          information, please see https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation/
         MSG
 
         expect { described_class.generate }.to raise_error(ReactOnRails::Error, msg)
@@ -207,7 +207,7 @@ module ReactOnRails
       it "raises missing client file error" do
         msg = <<~MSG
           **ERROR** ReactOnRails: Component '#{component_name}' is missing a client specific file. For more \
-          information, please see https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation.md
+          information, please see https://www.shakacode.com/react-on-rails/docs/guides/file-system-based-automated-bundle-generation/
         MSG
 
         expect { described_class.generate }.to raise_error(ReactOnRails::Error, msg)


### PR DESCRIPTION
### Summary

While running `react_on_rails:generate_packs` I saw an error that pointed me at a documentation page that was no longer available. This PR updates all of these outdated links in the file. where this error was raised.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [x] Update documentation
- [ ] Update CHANGELOG file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1534)
<!-- Reviewable:end -->
