### PR TITLE
remove extra js eval call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+### Improved
+- Improved performance by removing an unnecessary JS eval from Ruby. [PR 1544](https://github.com/shakacode/react_on_rails/pull/1544) by [wyattades](https://github.com/wyattades).
+
 ### Removed
 - Removed a requirement for autoloaded pack files to be generated as part of CI or deployment separate from initial Shakapacker bundling. [PR 1545](https://github.com/shakacode/react_on_rails/pull/1545) by [judahmeek](https://github.com/judahmeek).
 

--- a/lib/react_on_rails/server_rendering_js_code.rb
+++ b/lib/react_on_rails/server_rendering_js_code.rb
@@ -40,13 +40,17 @@ module ReactOnRails
           var railsContext = #{rails_context};
         #{redux_stores}
           var props = #{props_string};
-          return ReactOnRails.serverRenderReactComponent({
-            name: '#{react_component_name}',
-            domNodeId: '#{render_options.dom_id}',
-            props: props,
-            trace: #{render_options.trace},
-            railsContext: railsContext
-          });
+          try {
+            return ReactOnRails.serverRenderReactComponent({
+              name: '#{react_component_name}',
+              domNodeId: '#{render_options.dom_id}',
+              props: props,
+              trace: #{render_options.trace},
+              railsContext: railsContext
+            });
+          } finally {
+            console.history = [];
+          }
         })()
         JS
       end

--- a/lib/react_on_rails/server_rendering_js_code.rb
+++ b/lib/react_on_rails/server_rendering_js_code.rb
@@ -40,17 +40,13 @@ module ReactOnRails
           var railsContext = #{rails_context};
         #{redux_stores}
           var props = #{props_string};
-          try {
-            return ReactOnRails.serverRenderReactComponent({
-              name: '#{react_component_name}',
-              domNodeId: '#{render_options.dom_id}',
-              props: props,
-              trace: #{render_options.trace},
-              railsContext: railsContext
-            });
-          } finally {
-            console.history = [];
-          }
+          return ReactOnRails.serverRenderReactComponent({
+            name: '#{react_component_name}',
+            domNodeId: '#{render_options.dom_id}',
+            props: props,
+            trace: #{render_options.trace},
+            railsContext: railsContext
+          });
         })()
         JS
       end

--- a/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -113,9 +113,7 @@ module ReactOnRails
 
         def eval_js(js_code, _render_options)
           @js_context_pool.with do |js_context|
-            result = js_context.eval(js_code)
-            js_context.eval("console.history = []")
-            result
+            js_context.eval(js_code)
           end
         end
 

--- a/node_package/src/serverRenderReactComponent.ts
+++ b/node_package/src/serverRenderReactComponent.ts
@@ -9,7 +9,7 @@ import buildConsoleReplay from './buildConsoleReplay';
 import handleError from './handleError';
 import type { RenderParams, RenderResult, RenderingError } from './types/index';
 
-export default function serverRenderReactComponent(options: RenderParams): null | string | Promise<RenderResult> {
+function serverRenderReactComponentInternal(options: RenderParams): null | string | Promise<RenderResult> {
   const { name, domNodeId, trace, props, railsContext, renderingReturnsPromises, throwJsErrors } = options;
 
   let renderResult: null | string | Promise<string> = null;
@@ -153,3 +153,14 @@ as a renderFunction and not a simple React Function Component.`);
 
   return JSON.stringify(result);
 }
+
+const serverRenderReactComponent: typeof serverRenderReactComponentInternal = (options) => {
+  try {
+    return serverRenderReactComponentInternal(options);
+  } finally {
+    // Reset console history after each render.
+    // See `RubyEmbeddedJavaScript.console_polyfill` for initialization.
+    console.history = [];
+  }
+};
+export default serverRenderReactComponent;


### PR DESCRIPTION
### Summary

The current implementation calls `ExecJS::Runtime#eval` twice during every react server-side render, but we can refactor it to only call `eval` once.

This causes a 2x speedup (e.g. 800ms -> 400ms) with the Node.js runtime, and other runtimes with slow IO.

### Pull Request checklist

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file  

### Other Information

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1544)
<!-- Reviewable:end -->
