### PR TITLE
Always generate append_X_pack calls if not in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+### Removed
+- Removed a requirement for autoloaded pack files to be generated as part of CI or deployment separate from initial Shakapacker bundling. [PR 1545](https://github.com/shakacode/react_on_rails/pull/1545) by [judahmeek](https://github.com/judahmeek).
+
 ### [13.3.5] - 2022-05-31
 #### Fixed
 - Fixed race condition where a react component could attempt to initialize before it had been registered. [PR 1540](https://github.com/shakacode/react_on_rails/pull/1540) by [judahmeek](https://github.com/judahmeek).

--- a/docs/guides/file-system-based-automated-bundle-generation.md
+++ b/docs/guides/file-system-based-automated-bundle-generation.md
@@ -1,5 +1,3 @@
-Attention! If you are visiting this doc because you are encountering new failures on CI while implementing this feature, be sure to read [our section specifically for CI integration](#integrating-auto-bundling-into-ci-workflows)!
-
 # File-System-Based Automated Bundle Generation
 
 To use the automated bundle generation feature introduced in React on Rails v13.1.0, please upgrade to use [Shakapacker v6.5.1](https://github.com/shakacode/shakapacker/tree/v6.5.1) at least. If you are currently using webpacker, please follow the migration steps available [here](https://github.com/shakacode/shakapacker/blob/master/docs/v6_upgrade.md).
@@ -195,13 +193,5 @@ Once generated, all server entrypoints will be imported into a file named `[Reac
 ### Using Automated Bundle Generation Feature with already defined packs
 
 As of version 13.3.4, bundles inside of directories that match `config.components_subdirectory` will be automatically added as entrypoints, while bundles outside of those directories will have to be manually added to the Shakapacker.config.source_entry_path or Webpack's `entry` rules.
-
-### Integrating auto-bundling into CI workflows
-
-Currently, ReactOnRails contains conditional logic that checks for the existence of generated entrypoint files whenever `react_component` or one of its derivative methods are called. If a generated entrypoint of the same name as provided to `react_component` or `react_component_hash` exists, then an `append_javascript_pack` call is made automatically.
-
-This means that `rake react_on_rails:generate_packs` or its programmatic equivalent must be run as a prerequisite to any sort of test or spec that would result in `react_component` or `react_component_hash` being called, even if the generated entrypoint files have already been bundled in a previous workflow/job.
-
-Caching of the generated entrypoints between workflow/jobs should also resolve this issue.
 
 

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -38,12 +38,23 @@ describe ReactOnRailsHelper, type: :helper do
   end
 
   describe "#load_pack_for_generated_component" do
+    let(:render_options) do
+      ReactOnRails::ReactComponent::RenderOptions.new(react_component_name: "component_name",
+                                                      options: {})
+    end
+
     it "appends js/css pack tag" do
       allow(helper).to receive(:append_javascript_pack_tag)
       allow(helper).to receive(:append_stylesheet_pack_tag)
-      expect { helper.load_pack_for_generated_component("component_name") }.not_to raise_error
+      expect { helper.load_pack_for_generated_component("component_name", render_options) }.not_to raise_error
       expect(helper).to have_received(:append_javascript_pack_tag).with("generated/component_name", { defer: true })
       expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/component_name")
+    end
+
+    it "throws an error in development if generated component isn't found" do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      expect { helper.load_pack_for_generated_component("nonexisting_component", render_options) }
+        .to raise_error(ReactOnRails::Error, /the generated component entrypoint/)
     end
   end
 


### PR DESCRIPTION
### Summary

Instead of creating an `append_X_pack` call  conditional on the existence of the generated pack entrypoint, the new logic will always create the `append_X_pack` call for the component as long as the component's render option's `auto_load_bundle` is `true` in `test` or `production` environments.

In the development environment, however, a missing generated pack entrypoint will result in a raised error message.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [ ] Update CHANGELOG file

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1545)
<!-- Reviewable:end -->
