### PR TITLE
Include PR as a trigger for CI for main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Main test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-dummy-app-webpack-test-bundles:


### PR DESCRIPTION
Similar to Shakapacker and ReactRails, we need to include `pull_request` as a CI trigger for GitHub actions so that the `main` workflow gets run if other contributors than the officials open a new PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1553)
<!-- Reviewable:end -->
