### PR TITLE
Remove webdrivers

### DIFF
--- a/Gemfile.development_dependencies
+++ b/Gemfile.development_dependencies
@@ -47,5 +47,4 @@ group :test do
   gem "rspec-rails"
   gem "rspec-retry"
   gem "selenium-webdriver"
-  gem "webdrivers"
 end

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     sdoc (2.0.4)
       rdoc (>= 5.0)
-    selenium-webdriver (4.8.6)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -299,10 +299,6 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -352,7 +348,6 @@ DEPENDENCIES
   sqlite3
   turbolinks
   uglifier
-  webdrivers
 
 BUNDLED WITH
    2.4.9

--- a/spec/dummy/spec/support/selenium_logger.rb
+++ b/spec/dummy/spec/support/selenium_logger.rb
@@ -27,7 +27,8 @@ RSpec.configure do |config|
     clean_errors = errors.reject do |err_msg|
       err_msg.include?("Timed out receiving message from renderer: 0.100") ||
         err_msg.include?("SharedArrayBuffer will require cross-origin isolation") ||
-        err_msg.include?("You are currently using minified code outside of NODE_ENV === \\\"production\\\"")
+        err_msg.include?("You are currently using minified code outside of NODE_ENV === \\\"production\\\"") ||
+        err_msg.include?("This version of ChromeDriver has not been tested with Chrome version 115.")
     end
 
     raise("Java Script Error(s) on the page:\n\n#{clean_errors.join("\n")}") if clean_errors.present?


### PR DESCRIPTION
This PR removes the `webdrivers` gem as suggested by the `webdrivers`' maintainer in [this comment](https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1641139415).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1560)
<!-- Reviewable:end -->
