### PR TITLE
Packs generator subdirectory check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changes since last non-beta release.
 
 #### Changed
 - Throw error when attempting to redefine ReactOnRails. [PR 1562](https://github.com/shakacode/react_on_rails/pull/1562) by [rubenochiavone](https://github.com/rubenochiavone).
+- Prevent generating FS-based packs when `component_subdirectory` configuration is not present. [PR 1567](https://github.com/shakacode/react_on_rails/pull/1567) by [blackjack26](https://github.com/blackjack26).
 
 ### [13.3.5] - 2023-05-31
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changes since last non-beta release.
 
 *Please add entries here for your pull requests that are not yet released.*
 
+#### Fixed
+- Fixed Pack Generation logic during `assets:precompile` if `auto_load_bundle` is `false` & `components_subdirectory` is not set. [PR 1567](https://github.com/shakacode/react_on_rails/pull/1545) by [blackjack26](https://github.com/blackjack26) & [judahmeek](https://github.com/judahmeek).
+
 #### Improved
 - Improved performance by removing an unnecessary JS eval from Ruby. [PR 1544](https://github.com/shakacode/react_on_rails/pull/1544) by [wyattades](https://github.com/wyattades).
 

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -13,7 +13,7 @@ module ReactOnRails
     end
 
     def generate_packs_if_stale
-      return unless ReactOnRails.configuration.components_subdirectory.present?
+      return unless ReactOnRails.configuration.auto_load_bundle
 
       are_generated_files_present_and_up_to_date = Dir.exist?(generated_packs_directory_path) &&
                                                    File.exist?(generated_server_bundle_file_path) &&

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -13,6 +13,8 @@ module ReactOnRails
     end
 
     def generate_packs_if_stale
+      return unless ReactOnRails.configuration.components_subdirectory.present?
+
       are_generated_files_present_and_up_to_date = Dir.exist?(generated_packs_directory_path) &&
                                                    File.exist?(generated_server_bundle_file_path) &&
                                                    !stale_or_missing_packs?

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -260,7 +260,7 @@ module ReactOnRails
       end
     end
 
-    context "when components subdirectory is not set" do
+    context "when components subdirectory is not set", :focus do
       before do
           ReactOnRails.configuration.components_subdirectory = nil
           ReactOnRails.configuration.auto_load_bundle = false

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -19,7 +19,6 @@ module ReactOnRails
 
     let(:old_server_bundle) { ReactOnRails.configuration.server_bundle_js_file }
     let(:old_subdirectory) { ReactOnRails.configuration.components_subdirectory }
-    let(:old_auto_load_bundle) { ReactOnRails.configuration.auto_load_bundle }
 
     before do
       ReactOnRails.configuration.server_bundle_js_file = server_bundle_js_file
@@ -257,28 +256,6 @@ module ReactOnRails
         path = "#{webpacker_source_path}/components/#{component_name}/#{components_subdirectory}/#{name}.jsx"
 
         File.write(path, "// Empty Test Component\n")
-      end
-    end
-
-    context "when components subdirectory is not set" do
-      before do
-        ReactOnRails.configure do |config|
-          config.components_subdirectory = nil
-          config.auto_load_bundle = false
-        end
-      end
-
-      after do
-        ReactOnRails.configure do |config|
-          config.components_subdirectory = old_subdirectory
-          config.auto_load_bundle = old_auto_load_bundle
-        end
-      end
-
-      it "does not generate packs" do
-        expect do
-          described_class.instance.generate_packs_if_stale
-        end.not_to output(GENERATED_PACKS_CONSOLE_OUTPUT_REGEX).to_stdout
       end
     end
 

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -260,7 +260,7 @@ module ReactOnRails
       end
     end
 
-    context "when components subdirectory is not set & auto_load_bundle is false", :focus do
+    context "when components subdirectory is not set & auto_load_bundle is false" do
       it "does not generate packs" do
         puts "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
         puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -262,7 +262,8 @@ module ReactOnRails
 
     context "when components subdirectory is not set & auto_load_bundle is false" do
       it "does not generate packs" do
-        old_sub, old_auto = old_subdirectory, old_auto_load_bundle
+        old_sub = old_subdirectory
+        old_auto = old_auto_load_bundle
         ReactOnRails.configuration.components_subdirectory = nil
         ReactOnRails.configuration.auto_load_bundle = false
         expect do

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -262,23 +262,14 @@ module ReactOnRails
 
     context "when components subdirectory is not set & auto_load_bundle is false" do
       it "does not generate packs" do
-        puts "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
-        puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"
-        puts "ReactOnRails.configuration.auto_load_bundle: #{ReactOnRails.configuration.auto_load_bundle}"
-        puts "old_subdirectory: #{old_subdirectory}"
-        puts "old_auto_load_bundle: #{old_auto_load_bundle}"
+        old_sub, old_auto = old_subdirectory, old_auto_load_bundle
         ReactOnRails.configuration.components_subdirectory = nil
         ReactOnRails.configuration.auto_load_bundle = false
         expect do
           described_class.instance.generate_packs_if_stale
         end.not_to output(GENERATED_PACKS_CONSOLE_OUTPUT_REGEX).to_stdout
-        ReactOnRails.configuration.components_subdirectory = old_subdirectory
-        ReactOnRails.configuration.auto_load_bundle = old_auto_load_bundle
-        puts "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
-        puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"
-        puts "ReactOnRails.configuration.auto_load_bundle: #{ReactOnRails.configuration.auto_load_bundle}"
-        puts "old_subdirectory: #{old_subdirectory}"
-        puts "old_auto_load_bundle: #{old_auto_load_bundle}"
+        ReactOnRails.configuration.components_subdirectory = old_sub
+        ReactOnRails.configuration.auto_load_bundle = old_auto
       end
     end
 

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -262,6 +262,11 @@ module ReactOnRails
 
     context "when components subdirectory is not set & auto_load_bundle is false", :focus do
       it "does not generate packs" do
+        puts "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY"
+        puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"
+        puts "ReactOnRails.configuration.auto_load_bundle: #{ReactOnRails.configuration.auto_load_bundle}"
+        puts "old_subdirectory: #{old_subdirectory}"
+        puts "old_auto_load_bundle: #{old_auto_load_bundle}"
         ReactOnRails.configuration.components_subdirectory = nil
         ReactOnRails.configuration.auto_load_bundle = false
         expect do
@@ -269,6 +274,11 @@ module ReactOnRails
         end.not_to output(GENERATED_PACKS_CONSOLE_OUTPUT_REGEX).to_stdout
         ReactOnRails.configuration.components_subdirectory = old_subdirectory
         ReactOnRails.configuration.auto_load_bundle = old_auto_load_bundle
+        puts "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+        puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"
+        puts "ReactOnRails.configuration.auto_load_bundle: #{ReactOnRails.configuration.auto_load_bundle}"
+        puts "old_subdirectory: #{old_subdirectory}"
+        puts "old_auto_load_bundle: #{old_auto_load_bundle}"
       end
     end
 

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -262,17 +262,13 @@ module ReactOnRails
 
     context "when components subdirectory is not set" do
       before do
-        ReactOnRails.configure do |config|
-          config.components_subdirectory = nil
-          config.auto_load_bundle = false
-        end
+          ReactOnRails.configuration.components_subdirectory = nil
+          ReactOnRails.configuration.auto_load_bundle = false
       end
 
       after do
-        ReactOnRails.configure do |config|
-          config.components_subdirectory = old_subdirectory
-          config.auto_load_bundle = old_auto_load_bundle
-        end
+        ReactOnRails.configuration.components_subdirectory = old_subdirectory
+        ReactOnRails.configuration.auto_load_bundle = old_auto_load_bundle
       end
 
       it "does not generate packs" do

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -260,21 +260,15 @@ module ReactOnRails
       end
     end
 
-    context "when components subdirectory is not set", :focus do
-      before do
-          ReactOnRails.configuration.components_subdirectory = nil
-          ReactOnRails.configuration.auto_load_bundle = false
-      end
-
-      after do
-        ReactOnRails.configuration.components_subdirectory = old_subdirectory
-        ReactOnRails.configuration.auto_load_bundle = old_auto_load_bundle
-      end
-
+    context "when components subdirectory is not set & auto_load_bundle is false", :focus do
       it "does not generate packs" do
+        ReactOnRails.configuration.components_subdirectory = nil
+        ReactOnRails.configuration.auto_load_bundle = false
         expect do
           described_class.instance.generate_packs_if_stale
         end.not_to output(GENERATED_PACKS_CONSOLE_OUTPUT_REGEX).to_stdout
+        ReactOnRails.configuration.components_subdirectory = old_subdirectory
+        ReactOnRails.configuration.auto_load_bundle = old_auto_load_bundle
       end
     end
 

--- a/spec/dummy/spec/packs_generator_spec.rb
+++ b/spec/dummy/spec/packs_generator_spec.rb
@@ -19,6 +19,7 @@ module ReactOnRails
 
     let(:old_server_bundle) { ReactOnRails.configuration.server_bundle_js_file }
     let(:old_subdirectory) { ReactOnRails.configuration.components_subdirectory }
+    let(:old_auto_load_bundle) { ReactOnRails.configuration.auto_load_bundle }
 
     before do
       ReactOnRails.configuration.server_bundle_js_file = server_bundle_js_file
@@ -256,6 +257,28 @@ module ReactOnRails
         path = "#{webpacker_source_path}/components/#{component_name}/#{components_subdirectory}/#{name}.jsx"
 
         File.write(path, "// Empty Test Component\n")
+      end
+    end
+
+    context "when components subdirectory is not set" do
+      before do
+        ReactOnRails.configure do |config|
+          config.components_subdirectory = nil
+          config.auto_load_bundle = false
+        end
+      end
+
+      after do
+        ReactOnRails.configure do |config|
+          config.components_subdirectory = old_subdirectory
+          config.auto_load_bundle = old_auto_load_bundle
+        end
+      end
+
+      it "does not generate packs" do
+        expect do
+          described_class.instance.generate_packs_if_stale
+        end.not_to output(GENERATED_PACKS_CONSOLE_OUTPUT_REGEX).to_stdout
       end
     end
 

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -76,7 +76,7 @@ describe "Pages/Index", :js do
   end
 end
 
-context "when Server Rendering with Options", :js, :focus do
+context "when Server Rendering with Options", :js do
   subject { page }
 
   before do

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -31,7 +31,7 @@ shared_examples "React Component" do |dom_selector|
   end
 end
 
-describe "Pages/Index", :js, :focus do
+describe "Pages/Index", :js do
   subject { page }
 
   context "when rendering All in one page" do

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -31,7 +31,7 @@ shared_examples "React Component" do |dom_selector|
   end
 end
 
-describe "Pages/Index", :js do
+describe "Pages/Index", :js, :focus do
   subject { page }
 
   context "when rendering All in one page" do

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -80,9 +80,6 @@ context "when Server Rendering with Options", :js do
   subject { page }
 
   before do
-    puts "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"
-    puts "ReactOnRails.configuration.auto_load_bundle: #{ReactOnRails.configuration.auto_load_bundle}"
     visit server_side_hello_world_with_options_path
   end
 

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -76,10 +76,13 @@ describe "Pages/Index", :js do
   end
 end
 
-context "when Server Rendering with Options", :js do
+context "when Server Rendering with Options", :js, :focus do
   subject { page }
 
   before do
+    puts "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    puts "ReactOnRails.configuration.components_subdirectory: #{ReactOnRails.configuration.components_subdirectory}"
+    puts "ReactOnRails.configuration.auto_load_bundle: #{ReactOnRails.configuration.auto_load_bundle}"
     visit server_side_hello_world_with_options_path
   end
 


### PR DESCRIPTION
### Summary

Verifies that the `component_subdirectory` is set before generating packs. This is especially important when running the `assets:precompile` task.

Fixes #1566 

### Pull Request checklist
- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1567)
<!-- Reviewable:end -->
