### PR TITLE
Remove Bootstrap option from generator docs

### DIFF
--- a/docs/additional-details/generator-details.md
+++ b/docs/additional-details/generator-details.md
@@ -1,6 +1,6 @@
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating Webpack with Rails. Defaults for options are such that the default is for the flag to be off. For example, the default for `-R` is that `redux` is off, and the default of `-b` is that `skip-bootstrap` is off.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating Webpack with Rails. Defaults for options are such that the default is for the flag to be off. For example, the default for `-R` is that `redux` is off.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 


### PR DESCRIPTION
I just noticed this part in the docs, which seems to be removed a long time ago.

I think we must have relevant entries in Changelog. Since it is an old change, it might not be critical to do so.

Any thought?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1575)
<!-- Reviewable:end -->
