### PR TITLE
Remove JsonOutput.escape workaround for Rails < 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 ### [Unreleased]
 Changes since the last non-beta release.
 
-*Please add entries here for your pull requests that are not yet released.*
+- Removed a workaround in `JsonOutput#escape` for an no-longer supported Rails version. Additionally, removed `Utils.rails_version_less_than_4_1_1`
+which was only used in the workaround. [PR 1580](https://github.com/shakacode/react_on_rails/pull/1580) by [wwahammy](https://github.com/wwahammy)
+
 ### [13.4.0] - 2023-07-30
 #### Fixed
 - Fixed Pack Generation logic during `assets:precompile` if `auto_load_bundle` is `false` & `components_subdirectory` is not set. [PR 1567](https://github.com/shakacode/react_on_rails/pull/1545) by [blackjack26](https://github.com/blackjack26) & [judahmeek](https://github.com/judahmeek).

--- a/lib/react_on_rails/json_output.rb
+++ b/lib/react_on_rails/json_output.rb
@@ -4,25 +4,8 @@ require "active_support/core_ext/string/output_safety"
 
 module ReactOnRails
   class JsonOutput
-    ESCAPE_REPLACEMENT = {
-      "&" => '\u0026',
-      ">" => '\u003e',
-      "<" => '\u003c',
-      "\u2028" => '\u2028',
-      "\u2029" => '\u2029'
-    }.freeze
-    ESCAPE_REGEXP = /[\u2028\u2029&><]/u.freeze
-
     def self.escape(json)
-      return escape_without_erb_util(json) if Utils.rails_version_less_than_4_1_1
-
       ERB::Util.json_escape(json)
-    end
-
-    def self.escape_without_erb_util(json)
-      # https://github.com/rails/rails/blob/60257141462137331387d0e34931555cf0720886/activesupport/lib/active_support/core_ext/string/output_safety.rb#L113
-
-      json.to_s.gsub(ESCAPE_REGEXP, ESCAPE_REPLACEMENT)
     end
   end
 end

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -118,12 +118,6 @@ module ReactOnRails
       end
     end
 
-    # rubocop:disable Naming/VariableNumber
-    def self.rails_version_less_than_4_1_1
-      rails_version_less_than("4.1.1")
-    end
-    # rubocop:enable Naming/VariableNumber
-
     module Required
       def required(arg_name)
         raise ReactOnRails::Error, "#{arg_name} is required"

--- a/spec/react_on_rails/json_output_spec.rb
+++ b/spec/react_on_rails/json_output_spec.rb
@@ -27,11 +27,5 @@ module ReactOnRails
 
       it_behaves_like "escaped json"
     end
-
-    describe ".escaped_without_erb_utils" do
-      subject { described_class.escape_without_erb_util(hash_value.to_json) }
-
-      it_behaves_like "escaped json"
-    end
   end
 end

--- a/spec/react_on_rails/utils_spec.rb
+++ b/spec/react_on_rails/utils_spec.rb
@@ -301,24 +301,6 @@ module ReactOnRails
             end
           end
         end
-
-        describe ".rails_version_less_than_4_1_1" do
-          subject { described_class.rails_version_less_than_4_1_1 }
-
-          before { described_class.instance_variable_set :@rails_version_less_than, nil }
-
-          context "with Rails 4.1.0" do
-            before { allow(Rails).to receive(:version).and_return("4.1.0") }
-
-            it { is_expected.to be(true) }
-          end
-
-          context "with Rails 4.1.1" do
-            before { allow(Rails).to receive(:version).and_return("4.1.1") }
-
-            it { is_expected.to be(false) }
-          end
-        end
       end
 
       describe ".smart_trim" do


### PR DESCRIPTION
### Summary

I noticed that JsonOutput.escape had a workaround for Rails < 4.1.1. Since the minimum supported Rails version for the gem is greater than that, it doesn't seem like this needs to be there. 

Addititionally, I removed the `Utils.rails_version_less_than_4_1_1` method since that was the only place it was used

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file 

### Other Information

N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1580)
<!-- Reviewable:end -->
