### PR TITLE
exposes all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Changes since the last non-beta release.
 - Removed a workaround in `JsonOutput#escape` for an no-longer supported Rails version. Additionally, removed `Utils.rails_version_less_than_4_1_1`
 which was only used in the workaround. [PR 1580](https://github.com/shakacode/react_on_rails/pull/1580) by [wwahammy](https://github.com/wwahammy)
 
+#### Added
+
+- Exposed TypeScript all types [PR 1586](https://github.com/shakacode/react_on_rails/pull/1586) by [kotarella1110](https://github.com/kotarella1110)
+
 ### [13.4.0] - 2023-07-30
 #### Fixed
 - Fixed Pack Generation logic during `assets:precompile` if `auto_load_bundle` is `false` & `components_subdirectory` is not set. [PR 1567](https://github.com/shakacode/react_on_rails/pull/1545) by [blackjack26](https://github.com/blackjack26) & [judahmeek](https://github.com/judahmeek).

--- a/node_package/src/ReactOnRails.ts
+++ b/node_package/src/ReactOnRails.ts
@@ -289,4 +289,5 @@ ctx.ReactOnRails.resetOptions();
 
 ClientStartup.clientStartup(ctx);
 
+export * from "./types";
 export default ctx.ReactOnRails;


### PR DESCRIPTION
### Summary

This PR exposes all types of React on Rails. There are two main reasons for this:

Firstly, I frequently use types such as `RenderFunction` and `RailsContext` and would like to import them with minimal code:

```diff
- import { RenderFunction, RailsContext } from "react-on-rails/node_package/lib/types";
+ import { RenderFunction, RailsContext } from "react-on-rails";
```

Additionally, since [`railsContext` is customizable](https://www.shakacode.com/react-on-rails/docs/guides/render-functions-and-railscontext/#customization-of-the-rails_context), exposing the `RailsContext` type allows for extensions like the following:

`react-on-rails.d.ts`:

```ts
declare module "react-on-rails" {
  interface RailsContext {
    key1: string;
    key2: string;
  }
}

export {};
```

![スクリーンショット 2023-11-21 18 34 17](https://github.com/shakacode/react_on_rails/assets/12913947/3007332e-b0b7-44d9-9a3b-edcf2809ec24)


### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] ~Add/update test to cover these changes~
- [ ] ~Update documentation~
- [x] Update CHANGELOG file
  _Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1586)
<!-- Reviewable:end -->
