### PR TITLE
build: trigger on main instead of master

### DIFF
--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -4,7 +4,7 @@ name: Lint JS and Ruby
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main test
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -4,7 +4,7 @@ name: JS unit tests for Renderer package
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:

--- a/.github/workflows/rspec-package-specs.yml
+++ b/.github/workflows/rspec-package-specs.yml
@@ -3,7 +3,7 @@ name: Rspec test for gem
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
 
 jobs:


### PR DESCRIPTION
### Summary

This PR changes the GH Actions triggers from `master` to `main`.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] ~Add/update test to cover these changes~
- [ ] Update documentation
- [ ] Update CHANGELOG file

### Other Information

~If any more changes are required, let me know and I can implement it.~
This PR is a kick-off, likely we'll need to open another to make all the changes. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1589)
<!-- Reviewable:end -->
