### PR TITLE
Fix CI failure

### DIFF
--- a/Gemfile.development_dependencies
+++ b/Gemfile.development_dependencies
@@ -3,7 +3,9 @@
 gem "shakapacker", "7.0.1"
 gem "bootsnap", require: false
 gem "rails", "~> 7.0", ">= 7.0.1"
-gem "sqlite3"
+
+# sqlite3 1.7.0 ends native gem support for Ruby 2.7
+gem "sqlite3", "~> 1.0", "< 1.7.0"
 gem "sass-rails", "~> 6.0"
 gem "uglifier"
 gem "jquery-rails"

--- a/lib/react_on_rails/locales/base.rb
+++ b/lib/react_on_rails/locales/base.rb
@@ -138,7 +138,7 @@ module ReactOnRails
       def flatten(translations)
         translations.each_with_object({}) do |(k, v), h|
           if v.is_a? Hash
-            flatten(v).map { |hk, hv| h["#{k}.#{hk}".to_sym] = hv }
+            flatten(v).map { |hk, hv| h[:"#{k}.#{hk}"] = hv }
           elsif v.is_a?(String)
             h[k] = v.gsub("%{", "{")
           elsif !v.is_a?(Array)

--- a/spec/dummy/spec/rails_helper.rb
+++ b/spec/dummy/spec/rails_helper.rb
@@ -79,7 +79,7 @@ RSpec.configure do |config|
   # More information about headless=new option at https://www.selenium.dev/blog/2023/headless-is-going-away/
   Capybara.register_driver :selenium_chrome_headless do |app|
     options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('--headless=new')
+    options.add_argument("--headless=new")
 
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end

--- a/spec/dummy/spec/rails_helper.rb
+++ b/spec/dummy/spec/rails_helper.rb
@@ -75,6 +75,15 @@ RSpec.configure do |config|
 
   # Capybara config
   config.include Capybara::DSL
+
+  # More information about headless=new option at https://www.selenium.dev/blog/2023/headless-is-going-away/
+  Capybara.register_driver :selenium_chrome_headless do |app|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('--headless=new')
+
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
+
   #
   # selenium_firefox webdriver only works for Travis-CI builds.
   default_driver = :selenium_chrome_headless

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -92,7 +92,7 @@ describe "Turbolinks across pages", :js do
   it "changes name in message according to input" do
     visit "/client_side_hello_world"
     expect_change_text_in_dom_selector("#HelloWorld-react-component-0")
-    click_link "Hello World Component Server Rendered, with extra options"
+    click_on "Hello World Component Server Rendered, with extra options"
     expect_change_text_in_dom_selector("#my-hello-world-id")
   end
 end
@@ -164,19 +164,19 @@ describe "React Router", :js do
 
   before do
     visit "/"
-    click_link "React Router"
+    click_on "React Router"
   end
 
   context "when rendering /react_router" do
     it { is_expected.to have_text("Woohoo, we can use react-router here!") }
 
     it "clicking links correctly renders other pages" do
-      click_link "Router First Page"
+      click_on "Router First Page"
       expect(page).to have_current_path("/react_router/first_page")
       first_page_header_text = page.find(:css, "h2#first-page").text
       expect(first_page_header_text).to eq("React Router First Page")
 
-      click_link "Router Second Page"
+      click_on "Router Second Page"
       expect(page).to have_current_path("/react_router/second_page")
       second_page_header_text = page.find(:css, "h2#second-page").text
       expect(second_page_header_text).to eq("React Router Second Page")
@@ -212,7 +212,7 @@ describe "Manual client hydration", :js do
 
   it "HelloWorldRehydratable onChange should trigger" do
     within("form") do
-      click_button "refresh"
+      click_on "refresh"
     end
     wait_for_ajax
     within("#HelloWorldRehydratable-react-component-1") do


### PR DESCRIPTION
## Key notes:

- Fixed the version of `sqlite3` to be below `1.7.0` since [the native gem support for Ruby 2.7 ended in this version.](https://github.com/sparklemotion/sqlite3-ruby/blob/main/CHANGELOG.md#170--2023-12-27)
- Customized selenium driver to use `headless=new` option. More information: [Headless is Going Away!](https://www.selenium.dev/blog/2023/headless-is-going-away/)
- Linter fixes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1593)
<!-- Reviewable:end -->
