### PR TITLE
Restrict css-minimizer-webpack-plugin version in the generator unless using Node v18+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 ### [Unreleased]
 Changes since the last non-beta release.
 
-#### Fixed
-- Limit `css-minimizer-webpack-plugin` version below v6.0.0, allowing the react_on_rails generator to work in environments with Nodejs < 18 [PR 1598](https://github.com/shakacode/react_on_rails/pull/1598) by [ahangarha](https://github.com/ahangarha).
-
 #### Changed
 - Bump minimum version of peer dependencies as following [PR 1596](https://github.com/shakacode/react_on_rails/pull/1596) by [ahangarha](https://github.com/ahangarha).
   - `js-yaml` to `4.1.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 ### [Unreleased]
 Changes since the last non-beta release.
 
+#### Fixed
+- Limit `css-minimizer-webpack-plugin` version below v6.0.0, allowing the react_on_rails generator to work in environments with Nodejs < 18 [PR 1598](https://github.com/shakacode/react_on_rails/pull/1598) by [ahangarha](https://github.com/ahangarha).
+
 #### Changed
 - Bump minimum version of peer dependencies as following [PR 1596](https://github.com/shakacode/react_on_rails/pull/1596) by [ahangarha](https://github.com/ahangarha).
   - `js-yaml` to `4.1.0`

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -91,8 +91,7 @@ module ReactOnRails
             babel-plugin-macros"
 
         puts "Adding CSS handlers"
-        # css-minimizer-webpack-plugin v6.0.0 requires Node 18+
-        run "yarn add css-loader 'css-minimizer-webpack-plugin@<6.0.0' mini-css-extract-plugin style-loader"
+        run "yarn add css-loader css-minimizer-webpack-plugin mini-css-extract-plugin style-loader"
 
         puts "Adding dev dependencies"
         run "yarn add -D @pmmmwh/react-refresh-webpack-plugin react-refresh"

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -91,7 +91,15 @@ module ReactOnRails
             babel-plugin-macros"
 
         puts "Adding CSS handlers"
-        run "yarn add css-loader css-minimizer-webpack-plugin mini-css-extract-plugin style-loader"
+
+        # css_minimizer_webpack_plugin version 6 only supports Nodejs v18+
+        # When we bump our minimum Nodejs version to 18, we can remove this logic
+        # and install css_minimizer_webpack_plugin directly.
+        node_major_version = `node -v`.match(/^v(\d{,2})\./)[1]&.to_i
+        css_minimizer_webpack_plugin_version = node_major_version >= 18 ? "" : "@<6.0.0"
+        css_minimizer_webpack_plugin = "css-minimizer-webpack-plugin#{css_minimizer_webpack_plugin_version}"
+
+        run "yarn add css-loader '#{css_minimizer_webpack_plugin}' mini-css-extract-plugin style-loader"
 
         puts "Adding dev dependencies"
         run "yarn add -D @pmmmwh/react-refresh-webpack-plugin react-refresh"

--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -91,7 +91,8 @@ module ReactOnRails
             babel-plugin-macros"
 
         puts "Adding CSS handlers"
-        run "yarn add css-loader css-minimizer-webpack-plugin mini-css-extract-plugin style-loader"
+        # css-minimizer-webpack-plugin v6.0.0 requires Node 18+
+        run "yarn add css-loader 'css-minimizer-webpack-plugin@<6.0.0' mini-css-extract-plugin style-loader"
 
         puts "Adding dev dependencies"
         run "yarn add -D @pmmmwh/react-refresh-webpack-plugin react-refresh"


### PR DESCRIPTION
### Summary

Recently `css-minimizer-webpack-plugin` [released v6.0.0](https://github.com/webpack-contrib/css-minimizer-webpack-plugin/releases/tag/v6.0.0) in which the minimum required Node version is 18.

We install this package in our generator, and we need this PR to ensure our generator doesn't break in an environment with an older Node.

~⚠️  We may need to make a release after this merge.~

~Alternatively, we can bump our Nodejs support to v18 (the current LTS)~

I have change the generator so that it limits the version of this package unless we use Node v18+.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~  

### Other Information
-

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1598)
<!-- Reviewable:end -->
