### PR TITLE
CI Fix for sqlite

### DIFF
--- a/Gemfile.development_dependencies
+++ b/Gemfile.development_dependencies
@@ -4,7 +4,7 @@ gem "shakapacker", "7.2.1"
 gem "bootsnap", require: false
 gem "rails", "~> 7.1"
 
-gem "sqlite3"
+gem "sqlite3", "~> 1.6"
 gem "sass-rails", "~> 6.0"
 gem "uglifier"
 gem "jquery-rails"

--- a/react_on_rails.gemspec
+++ b/react_on_rails.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rainbow", "~> 3.0"
 
   s.add_development_dependency "gem-release"
-  s.add_development_dependency "sqlite3", "~> 1.6"
   s.post_install_message = '
 --------------------------------------------------------------------------------
 Checkout https://www.shakacode.com/react-on-rails-pro for information about

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "sqlite3", "~> 1.6"
 eval_gemfile File.expand_path("../../Gemfile.development_dependencies", __dir__)
 
 gem "react_on_rails", path: "../.."

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.6"
 eval_gemfile File.expand_path("../../Gemfile.development_dependencies", __dir__)
 
 gem "react_on_rails", path: "../.."


### PR DESCRIPTION
gemspec development dependencies don't get installed by CI so this PR moves squlite from the gemspec to the Gemfile.development_dependencies file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1613)
<!-- Reviewable:end -->
