### PR TITLE
Update Control Plane link

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The following companies support our open source projects, and ShakaCode uses the
     <img alt="ScoutAPM" src="https://user-images.githubusercontent.com/4244251/184881152-9f2d8fba-88ac-4ba6-873b-22387f8711c5.png" height="120px">
   </picture>
 </a>
-<a href="https://controlplane.com">
+<a href="https://shakacode.controlplane.com">
   <picture>
     <img alt="Control Plane" src="https://github.com/shakacode/.github/assets/20628911/90babd87-62c4-4de3-baa4-3d78ef4bec25" height="120px">
   </picture>


### PR DESCRIPTION
Very minor change - links to our page on the Control Plane website (which has info about our `cpl` tool and services) rather than the regular homepage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1617)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated hyperlink in README to reflect the new URL: "https://shakacode.controlplane.com".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->