### PR TITLE
Make sure that bundler:2.5.3 is used by all CI workflows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -61,7 +61,7 @@ jobs:
     - name: yalc publish for react-on-rails
       run: yalc publish
     - name: Install Ruby Gems for package
-      run:  bundle lock --add-platform 'x86_64-linux' && bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      run:  bundle lock --add-platform 'x86_64-linux' && bundle check --path=vendor/bundle || bundle  _2.5.3_ install --path=vendor/bundle --jobs=4 --retry=3
     - name: Ensure minimum required Chrome version
       run: |
         echo -e "Already installed $(google-chrome --version)\n"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,7 +145,7 @@ jobs:
     - name: yalc add react-on-rails
       run: cd spec/dummy && yalc add react-on-rails
     - name: Install Ruby Gems for package
-      run:  bundle lock --add-platform 'x86_64-linux' && bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      run:  bundle lock --add-platform 'x86_64-linux' && bundle check --path=vendor/bundle || bundle  _2.5.3_ install --path=vendor/bundle --jobs=4 --retry=3
     - name: Install Ruby Gems for dummy app
       run: cd spec/dummy && bundle lock --add-platform 'x86_64-linux' && bundle check --path=vendor/bundle || bundle _2.5.3_ install --path=vendor/bundle --jobs=4 --retry=3
     - name: Ensure minimum required Chrome version

--- a/.github/workflows/rspec-package-specs.yml
+++ b/.github/workflows/rspec-package-specs.yml
@@ -37,7 +37,7 @@ jobs:
         path: vendor/bundle
         key: v5-package-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}
     - name: Install Ruby Gems for package
-      run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      run: bundle check --path=vendor/bundle || bundle  _2.5.3_ install --path=vendor/bundle --jobs=4 --retry=3
     - name: Run rspec tests
       run: bundle exec rspec spec/react_on_rails
     - name: Store test results


### PR DESCRIPTION
See title.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1618)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to use Ruby version 2.5.3 for consistent dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->