### PR TITLE
Add support for replaying logs happen on async server operations

### DIFF
--- a/lib/react_on_rails/server_rendering_js_code.rb
+++ b/lib/react_on_rails/server_rendering_js_code.rb
@@ -40,6 +40,7 @@ module ReactOnRails
           var railsContext = #{rails_context};
         #{redux_stores}
           var props = #{props_string};
+          console.history = [];
           return ReactOnRails.serverRenderReactComponent({
             name: '#{react_component_name}',
             domNodeId: '#{render_options.dom_id}',

--- a/lib/react_on_rails/server_rendering_js_code.rb
+++ b/lib/react_on_rails/server_rendering_js_code.rb
@@ -40,7 +40,6 @@ module ReactOnRails
           var railsContext = #{rails_context};
         #{redux_stores}
           var props = #{props_string};
-          console.history = [];
           return ReactOnRails.serverRenderReactComponent({
             name: '#{react_component_name}',
             domNodeId: '#{render_options.dom_id}',

--- a/node_package/src/buildConsoleReplay.ts
+++ b/node_package/src/buildConsoleReplay.ts
@@ -9,13 +9,15 @@ declare global {
   }
 }
 
-export function consoleReplay(): string {
+export function consoleReplay(customConsoleHistory: typeof console['history'] | undefined = undefined): string {
   // console.history is a global polyfill used in server rendering.
-  if (!(console.history instanceof Array)) {
+  const consoleHistory = customConsoleHistory ?? console.history;
+
+  if (!(Array.isArray(consoleHistory))) {
     return '';
   }
 
-  const lines = console.history.map(msg => {
+  const lines = consoleHistory.map(msg => {
     const stringifiedList = msg.arguments.map(arg => {
       let val: string;
       try {
@@ -42,6 +44,6 @@ export function consoleReplay(): string {
   return lines.join('\n');
 }
 
-export default function buildConsoleReplay(): string {
-  return RenderUtils.wrapInScriptTags('consoleReplayLog', consoleReplay());
+export default function buildConsoleReplay(customConsoleHistory: typeof console['history'] | undefined = undefined): string {
+  return RenderUtils.wrapInScriptTags('consoleReplayLog', consoleReplay(customConsoleHistory));
 }

--- a/node_package/src/serverRenderReactComponent.ts
+++ b/node_package/src/serverRenderReactComponent.ts
@@ -138,7 +138,7 @@ function createFinalResult(
   return JSON.stringify(createResultObject(result, consoleReplayScript, renderState));
 }
 
-function serverRenderReactComponentInternal(options: RenderParams): null | string | Promise<RenderResult> {
+function serverRenderReactComponent(options: RenderParams): null | string | Promise<RenderResult> {
   const { name: componentName, domNodeId, trace, props, railsContext, renderingReturnsPromises, throwJsErrors } = options;
 
   let renderState: RenderState = {
@@ -179,21 +179,5 @@ function serverRenderReactComponentInternal(options: RenderParams): null | strin
   // 4. For Promise results, it awaits resolution before creating the final JSON
   return createFinalResult(renderState, componentName, throwJsErrors);
 }
-
-const serverRenderReactComponent: typeof serverRenderReactComponentInternal = (options) => {
-  let result: string | Promise<RenderResult> | null = null;
-  try {
-    result = serverRenderReactComponentInternal(options);
-  } finally {
-    // Reset console history after each render.
-    // See `RubyEmbeddedJavaScript.console_polyfill` for initialization.
-    // We don't need to clear the console history if the result is a promise
-    // Promises only supported in node renderer and node renderer takes care of cleanining console history
-    if (typeof result === 'string') {
-      console.history = [];
-    }
-  }
-  return result;
-};
 
 export default serverRenderReactComponent;

--- a/node_package/src/serverRenderReactComponent.ts
+++ b/node_package/src/serverRenderReactComponent.ts
@@ -181,19 +181,15 @@ function serverRenderReactComponentInternal(options: RenderParams): null | strin
 }
 
 const serverRenderReactComponent: typeof serverRenderReactComponentInternal = (options) => {
-  let result: string | Promise<RenderResult> | null = null;
   try {
-    result = serverRenderReactComponentInternal(options);
+    return serverRenderReactComponentInternal(options);
   } finally {
     // Reset console history after each render.
     // See `RubyEmbeddedJavaScript.console_polyfill` for initialization.
-    // We don't need to clear the console history if the result is a promise
-    // Promises only supported in node renderer and node renderer takes care of cleanining console history
-    if (typeof result === 'string') {
-      console.history = [];
-    }
+    // This is necessary when ExecJS and old versions of node renderer are used.
+    // New versions of node renderer reset the console history automatically.
+    console.history = [];
   }
-  return result;
 };
 
 export default serverRenderReactComponent;

--- a/node_package/src/serverRenderReactComponent.ts
+++ b/node_package/src/serverRenderReactComponent.ts
@@ -105,16 +105,22 @@ function createResultObject(html: string | null, consoleReplayScript: string, re
 
 async function createPromiseResult(
   renderState: RenderState & { result: Promise<string> },
-  consoleReplayScript: string,
   componentName: string,
   throwJsErrors: boolean
 ): Promise<RenderResult> {
+  // Capture console history before awaiting the promise
+  // Node renderer will reset the global console.history after executing the synchronous part of the request.
+  // It resets it only if replayServerAsyncOperationLogs renderer config is set to false.
+  // In both cases, we need to keep a reference to console.history to avoid losing console logs in case of reset.
+  const consoleHistory = console.history;
   try {
     const html = await renderState.result;
+    const consoleReplayScript = buildConsoleReplay(consoleHistory);
     return createResultObject(html, consoleReplayScript, renderState);
   } catch (e: unknown) {
     const errorRenderState = handleRenderingError(e, { componentName, throwJsErrors });
-    return createResultObject(errorRenderState.result, consoleReplayScript, errorRenderState);
+    const consoleReplayScript = buildConsoleReplay(consoleHistory);
+    return createResultObject(errorRenderState.result, consoleReplayScript, renderState);
   }
 }
 
@@ -123,20 +129,12 @@ function createFinalResult(
   componentName: string,
   throwJsErrors: boolean
 ): null | string | Promise<RenderResult> {
-  // Console history is stored globally in `console.history`.
-  // If node renderer is handling a render request that returns a promise,
-  // It can handle another request while awaiting the promise.
-  // To prevent cross-request console logs leakage between these requests,
-  // we build the consoleReplayScript before awaiting any promises.
-  // The console history is reset after the synchronous part of each request.
-  // This causes console logs happening during async operations to not be captured.
-  const consoleReplayScript = buildConsoleReplay();
-
   const { result } = renderState;
   if (isPromise(result)) {
-    return createPromiseResult({ ...renderState, result }, consoleReplayScript, componentName, throwJsErrors);
+    return createPromiseResult({ ...renderState, result }, componentName, throwJsErrors);
   }
 
+  const consoleReplayScript = buildConsoleReplay();
   return JSON.stringify(createResultObject(result, consoleReplayScript, renderState));
 }
 
@@ -183,13 +181,19 @@ function serverRenderReactComponentInternal(options: RenderParams): null | strin
 }
 
 const serverRenderReactComponent: typeof serverRenderReactComponentInternal = (options) => {
+  let result: string | Promise<RenderResult> | null = null;
   try {
-    return serverRenderReactComponentInternal(options);
+    result = serverRenderReactComponentInternal(options);
   } finally {
     // Reset console history after each render.
     // See `RubyEmbeddedJavaScript.console_polyfill` for initialization.
-    console.history = [];
+    // We don't need to clear the console history if the result is a promise
+    // Promises only supported in node renderer and node renderer takes care of cleanining console history
+    if (typeof result === 'string') {
+      console.history = [];
+    }
   }
+  return result;
 };
 
 export default serverRenderReactComponent;


### PR DESCRIPTION
### Summary

_Remove this paragraph and provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together._

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file  
  _Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1649)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of `console.history` to ensure accurate console replay functionality across different execution contexts.
	- Enhanced management of `console.history` based on the rendering outcome, ensuring it resets appropriately.

- **New Features**
	- Added support for custom console history in console replay functionality, allowing for greater flexibility in console state management.
	- Introduced new types and functions to streamline the server rendering process for React components, enhancing error handling and output management.
	- Updated the `isPromise` function to handle a broader range of input types for improved flexibility.
	- Added new properties to the `RegisteredComponent` interface to improve component registration and rendering capabilities.
	- Initialized `console.history` as an empty array during server rendering for better console log management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->