### PR TITLE
Add support for passing `children` in from Rails

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,6 +121,24 @@ issue.
   };
   ```
 
+- You can pass a block to `react_component`, and it will be provided as the `children` prop to the React component, as a React element:
+  ```ruby
+    <%= react_component("YourComponent") do %>
+      <p>Contained HTML<p>
+      <%= render "your/partial" %>
+    <% end %>
+  ```
+  ```js
+  import React from 'react';
+
+  export default (props) => {
+    return () => (
+      <div>{ props.children }</div>
+    );
+  };
+  ```
+  **Note that this is implementing using React's [dangerouslySetInnerHtml](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html)**, so named because of the exposure to cross-site scripting attacks. You should generally be fine since the HTML is coming from your own code via the Rails rendering engine, but this is sharp knife so please exercise caution :)
+
 See the [View Helpers API](https://www.shakacode.com/react-on-rails/docs/api/view-helpers-api/) for more details on `react_component` and its sibling function `react_component_hash`.
 
 ## Globally Exposing Your React Components

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,13 +131,13 @@ issue.
   ```js
   import React from 'react';
 
-  export default (props) => {
-    return () => (
-      <div>{ props.children }</div>
-    );
-  };
+  const YourComponent = (props) => (
+    <div>{ props.children }</div>
+  );
+  
+  export default YourComponent;
   ```
-  **Note that this is implementing using React's [dangerouslySetInnerHtml](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html)**, so named because of the exposure to cross-site scripting attacks. You should generally be fine since the HTML is coming from your own code via the Rails rendering engine, but this is sharp knife so please exercise caution :)
+  **Security Note**: This feature is implemented using React's [dangerouslySetInnerHtml](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html)**. While generally safe when the HTML comes from your own Rails rendering engine, it can expose your application to cross-site scripting (XSS) attacks if not used carefully. Always ensure that the content passed to the block is properly sanitized and comes from trusted sources. Avoid passing user-generated content without proper sanitization.
 
 See the [View Helpers API](https://www.shakacode.com/react-on-rails/docs/api/view-helpers-api/) for more details on `react_component` and its sibling function `react_component_hash`.
 

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -54,9 +54,7 @@ module ReactOnRails
     # random_dom_id can be set to override the default from the config/initializers. That's only
     # used if you have multiple instance of the same component on the Rails view.
     def react_component(component_name, options = {}, &block)
-      (options[:props] ||= {})[:children_html] = capture(&block) if block
-
-      internal_result = internal_react_component(component_name, options)
+      internal_result = internal_react_component(component_name, options, &block)
       server_rendered_html = internal_result[:result]["html"]
       console_script = internal_result[:result]["consoleReplayScript"]
       render_options = internal_result[:render_options]
@@ -111,10 +109,9 @@ module ReactOnRails
     #    <%= react_helmet_app["componentHtml"] %>
     #
     def react_component_hash(component_name, options = {}, &block)
-      (options[:props] ||= {})[:children_html] = capture(&block) if block
       options[:prerender] = true
 
-      internal_result = internal_react_component(component_name, options)
+      internal_result = internal_react_component(component_name, options, &block)
       server_rendered_html = internal_result[:result]["html"]
       console_script = internal_result[:result]["consoleReplayScript"]
       render_options = internal_result[:render_options]
@@ -424,13 +421,15 @@ module ReactOnRails
       "#{rails_context_content}\n#{render_value}".html_safe
     end
 
-    def internal_react_component(react_component_name, options = {})
+    def internal_react_component(react_component_name, options = {}, &block)
       # Create the JavaScript and HTML to allow either client or server rendering of the
       # react_component.
       #
       # Create the JavaScript setup of the global to initialize the client rendering
       # (re-hydrate the data). This enables react rendered on the client to see that the
       # server has already rendered the HTML.
+
+      (options[:props] ||= {})[:children_html] = capture(&block) if block
 
       render_options = ReactOnRails::ReactComponent::RenderOptions.new(react_component_name: react_component_name,
                                                                        options: options)

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -53,7 +53,9 @@ module ReactOnRails
     # Any other options are passed to the content tag, including the id.
     # random_dom_id can be set to override the default from the config/initializers. That's only
     # used if you have multiple instance of the same component on the Rails view.
-    def react_component(component_name, options = {})
+    def react_component(component_name, options = {}, &block)
+      (options[:props] ||= {})[:children_html] = capture(&block) if block
+
       internal_result = internal_react_component(component_name, options)
       server_rendered_html = internal_result[:result]["html"]
       console_script = internal_result[:result]["consoleReplayScript"]

--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -110,8 +110,10 @@ module ReactOnRails
     #    <% end %>
     #    <%= react_helmet_app["componentHtml"] %>
     #
-    def react_component_hash(component_name, options = {})
+    def react_component_hash(component_name, options = {}, &block)
+      (options[:props] ||= {})[:children_html] = capture(&block) if block
       options[:prerender] = true
+
       internal_result = internal_react_component(component_name, options)
       server_rendered_html = internal_result[:result]["html"]
       console_script = internal_result[:result]["consoleReplayScript"]

--- a/node_package/src/createReactOutput.ts
+++ b/node_package/src/createReactOutput.ts
@@ -26,6 +26,8 @@ export default function createReactOutput({
 }: CreateParams): CreateReactOutputResult {
   const { name, component, renderFunction } = componentObj;
 
+  const children = props?.children_html ? React.createElement('div', {dangerouslySetInnerHTML: {__html: props.children_html }}) : null;
+
   if (trace) {
     if (railsContext && railsContext.serverSide) {
       console.log(`RENDERED ${name} to dom node with id: ${domNodeId}`);
@@ -68,8 +70,8 @@ work if you return JSX. Update by wrapping the result JSX of ${name} in a fat ar
 
     // If a component, then wrap in an element
     const reactComponent = renderFunctionResult as ReactComponent;
-    return React.createElement(reactComponent, props);
+    return React.createElement(reactComponent, props, children);
   }
   // else
-  return React.createElement(component as ReactComponent, props);
+  return React.createElement(component as ReactComponent, props, children);
 }

--- a/spec/dummy/app/views/pages/children_example.erb
+++ b/spec/dummy/app/views/pages/children_example.erb
@@ -1,0 +1,4 @@
+<%= react_component("ChildrenExample", prerender: true, trace: true) do %>
+  <p>This page demonstrates using Rails to produce content for child nodes of React components</p>
+  <p>And, just to check that multiple DOM nodes are fine</p>
+<% end %>

--- a/spec/dummy/app/views/shared/_header.erb
+++ b/spec/dummy/app/views/shared/_header.erb
@@ -104,5 +104,8 @@
   <li>
     <%= link_to "Incorrectly wrapping a pure component in a function", pure_component_wrapped_in_function_path %>
   </li>
+    <li>
+    <%= link_to "Children Example", children_example_path %>
+  </li>
 </ul>
 <hr/>

--- a/spec/dummy/client/app/startup/ChildrenExample.jsx
+++ b/spec/dummy/client/app/startup/ChildrenExample.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const ComponentWithChildren = ({ children }) => (
+  <div>
+    <h1>This is component for testing passing children in from Rails</h1>
+    { children }
+  </div>
+);
+
+export default ComponentWithChildren;

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   get "react_helmet_broken" => "pages#react_helmet_broken"
   get "broken_app" => "pages#broken_app"
   get "image_example" => "pages#image_example"
+  get "children_example" => "pages#children_example"
   get "context_function_return_jsx" => "pages#context_function_return_jsx"
   get "pure_component_wrapped_in_function" => "pages#pure_component_wrapped_in_function"
   get "turbo_frame_tag_hello_world" => "pages#turbo_frame_tag_hello_world"

--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -284,6 +284,21 @@ describe "display images", :js do
   end
 end
 
+describe "with children", :js do
+  subject { page }
+
+  before { visit "/children_example" }
+
+  it "children_example should not have any errors" do
+    expect(page).to have_text(
+      "This page demonstrates using Rails to produce content for child nodes of React components"
+    )
+    expect(page).to have_text(
+      "And, just to check that multiple DOM nodes are fine"
+    )
+  end
+end
+
 describe "use different props for server/client", :js do
   subject { page }
 


### PR DESCRIPTION
### Summary

Allows you to do:
(rails template)
```
<%= react_component "MyComponent" do %>
  <%= render "events/form", event: Event.new %>
<% end %>
```

(react component)
```
const MyComponent= () => {
    return (
    <div>
      { props.children }
    </div>
  )
}
```

Note that this uses React's `dangerouslySetInnerHtml`, which... maybe isn't a good idea, but might be fine, since the HTML being set is coming in from the Rails template engine.

You _could_ just include the changes to the Ruby code so that the block gets rendered, and that gets passed in a a nice prop (like `children_html`) but then the React components would have to care about whether their `children` are coming in from more React code, or from the Rails side of things.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [x] Add/update test to cover these changes
- [x] Update documentation
- [ ] Update CHANGELOG file  
  _Add the CHANGELOG entry at the top of the file._

### Other Information

As per the contribution guidelines, I'm supposed to run `rake examples:gen_all`, but that task doesn't exist

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1650)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `react_component` and `react_component_hash` methods to accept child HTML elements via block parameters.
	- Updated documentation for `ReactOnRails` to clarify new functionality and usage of render-functions.

- **Bug Fixes**
	- Improved handling of child elements in React components, ensuring proper rendering and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->