### PR TITLE
Fix Version Checker's hard-coded path for package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Changes since the last non-beta release.
 
 #### Fixed
 
-- Changed the ReactOnRails' version checker to check package.jsons in both root and client directories. [PR 1657](https://github.com/shakacode/react_on_rails/pull/1657) by [judahmeek](https://github.com/judahmeek).
+- Changed the ReactOnRails' version checker to use `ReactOnRails.configuration.node_modules_location` to determine the location of the package.json that the `react-on-rails` dependency is expected to be set by.
+- Also, all errors that would be raised by the version checking have been converted to `Rails.Logger` warnings to avoid any breaking changes. [PR 1657](https://github.com/shakacode/react_on_rails/pull/1657) by [judahmeek](https://github.com/judahmeek).
 
 #### Added
 - Added streaming server rendering support:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 ### [Unreleased]
 Changes since the last non-beta release.
 
-#### Added(https://github.com/AbanoubGhadban).
+#### Fixed
+
+- Changed the ReactOnRails' version checker to check package.jsons in both root and client directories. [PR 1657](https://github.com/shakacode/react_on_rails/pull/1657) by [judahmeek](https://github.com/judahmeek).
+
+#### Added
 - Added streaming server rendering support:
   - [PR #1633](https://github.com/shakacode/react_on_rails/pull/1633) by [AbanoubGhadban](https://github.com/AbanoubGhadban).
     - New `stream_react_component` helper for adding streamed components to views

--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -5,8 +5,8 @@ require "rails/railtie"
 module ReactOnRails
   class Engine < ::Rails::Engine
     config.to_prepare do
-      if VersionChecker.instance("package.json").raise_if_gem_and_node_package_versions_differ &&
-         VersionChecker.instance("client/package.json").raise_if_gem_and_node_package_versions_differ
+      if VersionChecker.instance("package.json").log_if_gem_and_node_package_versions_differ &&
+         VersionChecker.instance("client/package.json").log_if_gem_and_node_package_versions_differ
         Rails.logger.warn("No 'react-on-rails' entry found in 'dependencies' in package.json or client/package.json.")
       end
       ReactOnRails::ServerRenderingPool.reset_pool

--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -5,8 +5,8 @@ require "rails/railtie"
 module ReactOnRails
   class Engine < ::Rails::Engine
     config.to_prepare do
-      if VersionChecker.new(NodePackageVersion.new("package.json")).raise_if_gem_and_node_package_versions_differ &&
-         VersionChecker.new(NodePackageVersion.new("client/package.json")).raise_if_gem_and_node_package_versions_differ
+      if VersionChecker.instance("package.json").raise_if_gem_and_node_package_versions_differ &&
+         VersionChecker.instance("client/package.json").raise_if_gem_and_node_package_versions_differ
         Rails.logger.warn("No 'react-on-rails' entry found in 'dependencies' in package.json or client/package.json.")
       end
       ReactOnRails::ServerRenderingPool.reset_pool

--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -5,8 +5,9 @@ require "rails/railtie"
 module ReactOnRails
   class Engine < ::Rails::Engine
     config.to_prepare do
-      if File.exist?(VersionChecker::NodePackageVersion.package_json_path)
-        VersionChecker.build.raise_if_gem_and_node_package_versions_differ
+      if VersionChecker.new(NodePackageVersion.new("package.json")).raise_if_gem_and_node_package_versions_differ &&
+         VersionChecker.new(NodePackageVersion.new("client/package.json")).raise_if_gem_and_node_package_versions_differ
+        Rails.logger.warn("No 'react-on-rails' entry found in 'dependencies' in package.json or client/package.json.")
       end
       ReactOnRails::ServerRenderingPool.reset_pool
     end

--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -5,10 +5,7 @@ require "rails/railtie"
 module ReactOnRails
   class Engine < ::Rails::Engine
     config.to_prepare do
-      if VersionChecker.instance("package.json").log_if_gem_and_node_package_versions_differ &&
-         VersionChecker.instance("client/package.json").log_if_gem_and_node_package_versions_differ
-        Rails.logger.warn("No 'react-on-rails' entry found in 'dependencies' in package.json or client/package.json.")
-      end
+      VersionChecker.build.log_if_gem_and_node_package_versions_differ
       ReactOnRails::ServerRenderingPool.reset_pool
     end
   end

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -23,37 +23,20 @@ module ReactOnRails
     # For compatibility, the gem and the node package versions should always match,
     # unless the user really knows what they're doing. So we will give a
     # warning if they do not.
-    def raise_if_gem_and_node_package_versions_differ
-      return true unless node_package_version.raw
-      return if node_package_version.relative_path?
-
-      raise_node_semver_version_warning if node_package_version.semver_wildcard?
-
-      versions_match = compare_versions(node_package_version.major_minor_patch, gem_major_minor_patch_version)
-
-      raise_differing_versions_warning unless versions_match
-      false
-    end
-
     def log_if_gem_and_node_package_versions_differ
-      return true unless node_package_version.raw
-      return if node_package_version.relative_path?
+      return if node_package_version.raw.nil? || node_package_version.relative_path?
+      return log_node_semver_version_warning if node_package_version.semver_wildcard?
 
-      log_node_semver_version_warning if node_package_version.semver_wildcard?
-
-      versions_match = compare_versions(node_package_version.major_minor_patch, gem_major_minor_patch_version)
+      node_major_minor_patch = node_package_version.major_minor_patch
+      gem_major_minor_patch = gem_major_minor_patch_version
+      versions_match = node_major_minor_patch[0] == gem_major_minor_patch[0] &&
+                       node_major_minor_patch[1] == gem_major_minor_patch[1] &&
+                       node_major_minor_patch[2] == gem_major_minor_patch[2]
 
       log_differing_versions_warning unless versions_match
-      false
     end
 
     private
-
-    def compare_versions(node_major_minor_patch, gem_major_minor_patch)
-      node_major_minor_patch[0] == gem_major_minor_patch[0] &&
-        node_major_minor_patch[1] == gem_major_minor_patch[1] &&
-        node_major_minor_patch[2] == gem_major_minor_patch[2]
-    end
 
     def common_error_msg
       <<-MSG.strip_heredoc
@@ -63,19 +46,7 @@ module ReactOnRails
          your installed node package. Do not use >= or ~> in your Gemfile for react_on_rails.
          Do not use ^ or ~ in your package.json for react-on-rails.
          Run `yarn add react-on-rails --exact` in the directory containing folder node_modules.
-         ***This warning will become a fatal error in ReactOnRails v15***
       MSG
-    end
-
-    def raise_differing_versions_warning
-      msg = "**WARNING** ReactOnRails: ReactOnRails gem and node package versions do not match\n#{common_error_msg}"
-      raise ReactOnRails::Error, msg
-    end
-
-    def raise_node_semver_version_warning
-      msg = "**WARNING** ReactOnRails: Your node package version for react-on-rails contains a " \
-            "^ or ~\n#{common_error_msg}"
-      raise ReactOnRails::Error, msg
     end
 
     def log_differing_versions_warning
@@ -105,8 +76,8 @@ module ReactOnRails
         new(package_json_path)
       end
 
-      def self.package_json_path(relative_path = "package.json")
-        Rails.root.join(relative_path)
+      def self.package_json_path
+        Rails.root.join(ReactOnRails.configuration.node_modules_location, "package.json")
       end
 
       def initialize(package_json)
@@ -120,6 +91,10 @@ module ReactOnRails
         if parsed_package_contents.key?("dependencies") &&
            parsed_package_contents["dependencies"].key?("react-on-rails")
           parsed_package_contents["dependencies"]["react-on-rails"]
+        else
+          msg = "No 'react-on-rails' entry in the dependencies of #{NodePackageVersion.package_json_path}, " \
+                "which is the expected location according to ReactOnRails.configuration.node_modules_location"
+          Rails.logger.warn(msg)
         end
       end
 

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -85,17 +85,17 @@ module ReactOnRails
       end
 
       def raw
-        return nil unless File.exist?(package_json)
-
-        parsed_package_contents = JSON.parse(package_json_contents)
-        if parsed_package_contents.key?("dependencies") &&
-           parsed_package_contents["dependencies"].key?("react-on-rails")
-          parsed_package_contents["dependencies"]["react-on-rails"]
-        else
-          msg = "No 'react-on-rails' entry in the dependencies of #{NodePackageVersion.package_json_path}, " \
-                "which is the expected location according to ReactOnRails.configuration.node_modules_location"
-          Rails.logger.warn(msg)
+        if File.exist?(package_json)
+          parsed_package_contents = JSON.parse(package_json_contents)
+          if parsed_package_contents.key?("dependencies") &&
+             parsed_package_contents["dependencies"].key?("react-on-rails")
+            return parsed_package_contents["dependencies"]["react-on-rails"]
+          end
         end
+        msg = "No 'react-on-rails' entry in the dependencies of #{NodePackageVersion.package_json_path}, " \
+              "which is the expected location according to ReactOnRails.configuration.node_modules_location"
+        Rails.logger.warn(msg)
+        nil
       end
 
       def semver_wildcard?

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -12,10 +12,6 @@ module ReactOnRails
       new(NodePackageVersion.build)
     end
 
-    def self.instance(package_json_path)
-      new(NodePackageVersion.new(package_json_path))
-    end
-
     def initialize(node_package_version)
       @node_package_version = node_package_version
     end

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -20,7 +20,10 @@ module ReactOnRails
     # unless the user really knows what they're doing. So we will give a
     # warning if they do not.
     def raise_if_gem_and_node_package_versions_differ
+      return true unless node_package_version.raw
       return if node_package_version.relative_path?
+
+      raise_node_semver_version_warning if node_package_version.semver_wildcard?
 
       node_major_minor_patch = node_package_version.major_minor_patch
       gem_major_minor_patch = gem_major_minor_patch_version
@@ -29,8 +32,7 @@ module ReactOnRails
                        node_major_minor_patch[2] == gem_major_minor_patch[2]
 
       raise_differing_versions_warning unless versions_match
-
-      raise_node_semver_version_warning if node_package_version.semver_wildcard?
+      false
     end
 
     private
@@ -43,18 +45,19 @@ module ReactOnRails
          your installed node package. Do not use >= or ~> in your Gemfile for react_on_rails.
          Do not use ^ or ~ in your package.json for react-on-rails.
          Run `yarn add react-on-rails --exact` in the directory containing folder node_modules.
+         ***This warning will become a fatal error in ReactOnRails v15***
       MSG
     end
 
     def raise_differing_versions_warning
-      msg = "**ERROR** ReactOnRails: ReactOnRails gem and node package versions do not match\n#{common_error_msg}"
-      raise ReactOnRails::Error, msg
+      msg = "**WARNING** ReactOnRails: ReactOnRails gem and node package versions do not match\n#{common_error_msg}"
+      Rails.logger.warn(msg)
     end
 
     def raise_node_semver_version_warning
-      msg = "**ERROR** ReactOnRails: Your node package version for react-on-rails contains a " \
+      msg = "**WARNING** ReactOnRails: Your node package version for react-on-rails contains a " \
             "^ or ~\n#{common_error_msg}"
-      raise ReactOnRails::Error, msg
+      Rails.logger.warn(msg)
     end
 
     def gem_version
@@ -73,8 +76,8 @@ module ReactOnRails
         new(package_json_path)
       end
 
-      def self.package_json_path
-        Rails.root.join("client", "package.json")
+      def self.package_json_path(relative_path = "package.json")
+        Rails.root.join(relative_path)
       end
 
       def initialize(package_json)
@@ -82,12 +85,12 @@ module ReactOnRails
       end
 
       def raw
+        return nil unless File.exist?(package_json)
+
         parsed_package_contents = JSON.parse(package_json_contents)
         if parsed_package_contents.key?("dependencies") &&
            parsed_package_contents["dependencies"].key?("react-on-rails")
           parsed_package_contents["dependencies"]["react-on-rails"]
-        else
-          raise ReactOnRails::Error, "No 'react-on-rails' entry in package.json dependencies"
         end
       end
 
@@ -96,7 +99,7 @@ module ReactOnRails
       end
 
       def relative_path?
-        raw.match(%r{(\.\.|\Afile:///)}).present?
+        raw.match(/(\.\.|\Afile:)/).present?
       end
 
       def major_minor_patch

--- a/lib/react_on_rails/version_checker.rb
+++ b/lib/react_on_rails/version_checker.rb
@@ -12,6 +12,10 @@ module ReactOnRails
       new(NodePackageVersion.build)
     end
 
+    def self.instance(package_json_path)
+      new(NodePackageVersion.new(package_json_path))
+    end
+
     def initialize(node_package_version)
       @node_package_version = node_package_version
     end

--- a/spec/react_on_rails/fixtures/yalc_package.json
+++ b/spec/react_on_rails/fixtures/yalc_package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "babel": "^6.3.26",
+    "react-on-rails": "file:.yalc/react-on-rails",
+    "webpack": "^1.12.8"
+  },
+  "devDependencies": {
+    "babel-eslint": "^5.0.0-beta6"
+  }
+}

--- a/spec/react_on_rails/version_checker_spec.rb
+++ b/spec/react_on_rails/version_checker_spec.rb
@@ -250,11 +250,27 @@ module ReactOnRails # rubocop:disable Metrics/ModuleLength
         end
       end
 
+      context "with package.json without react-on-rails dependency" do
+        let(:package_json) { File.expand_path("../../package.json", __dir__) }
+
+        describe "#raw" do
+          it "returns nil" do
+            root_package_json_path = File.expand_path("fixtures/nonexistent_package.json", __dir__)
+            allow(Rails).to receive_message_chain(:root, :join).and_return(root_package_json_path)
+            expect(node_package_version.raw).to be_nil
+          end
+        end
+      end
+
       context "with non-existing package.json" do
         let(:package_json) { File.expand_path("fixtures/nonexistent_package.json", __dir__) }
 
         describe "#raw" do
-          specify { expect(node_package_version.raw).to be_nil }
+          it "returns nil" do
+            root_package_json_path = File.expand_path("fixtures/nonexistent_package.json", __dir__)
+            allow(Rails).to receive_message_chain(:root, :join).and_return(root_package_json_path)
+            expect(node_package_version.raw).to be_nil
+          end
         end
       end
     end

--- a/spec/react_on_rails/version_checker_spec.rb
+++ b/spec/react_on_rails/version_checker_spec.rb
@@ -35,9 +35,11 @@ module ReactOnRails
 
         before { stub_gem_version("2.2.5") }
 
-        it "does raise" do
-          error = /ReactOnRails: Your node package version for react-on-rails contains a \^ or ~/
-          expect { check_version(node_package_version) }.to raise_error(error)
+        it "logs" do
+          allow(Rails.logger).to receive(:warn)
+          message = /ReactOnRails: Your node package version for react-on-rails contains a \^ or ~/
+          # expect { check_version(node_package_version) }.to raise_error(message)
+          expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
 
@@ -48,9 +50,11 @@ module ReactOnRails
 
         before { stub_gem_version("12.0.0.beta.1") }
 
-        it "raises" do
-          error = /ReactOnRails: ReactOnRails gem and node package versions do not match/
-          expect { check_version(node_package_version) }.to raise_error(error)
+        it "logs" do
+          allow(Rails.logger).to receive(:warn)
+          message = /ReactOnRails: ReactOnRails gem and node package versions do not match/
+          # expect { check_version(node_package_version) }.to raise_error(message)
+          expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
 
@@ -61,9 +65,11 @@ module ReactOnRails
 
         before { stub_gem_version("13.1.0") }
 
-        it "raises" do
-          error = /ReactOnRails: ReactOnRails gem and node package versions do not match/
-          expect { check_version(node_package_version) }.to raise_error(error)
+        it "logs" do
+          allow(Rails.logger).to receive(:warn)
+          message = /ReactOnRails: ReactOnRails gem and node package versions do not match/
+          # expect { check_version(node_package_version) }.to raise_error(message)
+          expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
 
@@ -74,9 +80,11 @@ module ReactOnRails
 
         before { stub_gem_version("13.0.0") }
 
-        it "raises" do
-          error = /ReactOnRails: ReactOnRails gem and node package versions do not match/
-          expect { check_version(node_package_version) }.to raise_error(error)
+        it "logs" do
+          allow(Rails.logger).to receive(:warn)
+          message = /ReactOnRails: ReactOnRails gem and node package versions do not match/
+          # expect { check_version(node_package_version) }.to raise_error(message)
+          expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
 
@@ -183,6 +191,22 @@ module ReactOnRails
 
         describe "#raw" do
           specify { expect(node_package_version.raw).to eq("file:///Users/justin/shakacode/react_on_rails") }
+        end
+
+        describe "#relative_path?" do
+          specify { expect(node_package_version.relative_path?).to be true }
+        end
+
+        describe "#major" do
+          specify { expect(node_package_version.major_minor_patch).to be_nil }
+        end
+      end
+
+      context "with node version of 'file:.yalc/react-on-rails'" do
+        let(:package_json) { File.expand_path("fixtures/yalc_package.json", __dir__) }
+
+        describe "#raw" do
+          specify { expect(node_package_version.raw).to eq("file:.yalc/react-on-rails") }
         end
 
         describe "#relative_path?" do

--- a/spec/react_on_rails/version_checker_spec.rb
+++ b/spec/react_on_rails/version_checker_spec.rb
@@ -39,6 +39,7 @@ module ReactOnRails
           allow(Rails.logger).to receive(:warn)
           message = /ReactOnRails: Your node package version for react-on-rails contains a \^ or ~/
           # expect { check_version(node_package_version) }.to raise_error(message)
+          check_version(node_package_version)
           expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
@@ -54,6 +55,7 @@ module ReactOnRails
           allow(Rails.logger).to receive(:warn)
           message = /ReactOnRails: ReactOnRails gem and node package versions do not match/
           # expect { check_version(node_package_version) }.to raise_error(message)
+          check_version(node_package_version)
           expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
@@ -69,6 +71,7 @@ module ReactOnRails
           allow(Rails.logger).to receive(:warn)
           message = /ReactOnRails: ReactOnRails gem and node package versions do not match/
           # expect { check_version(node_package_version) }.to raise_error(message)
+          check_version(node_package_version)
           expect(Rails.logger).to have_received(:warn).with(message)
         end
       end
@@ -84,6 +87,7 @@ module ReactOnRails
           allow(Rails.logger).to receive(:warn)
           message = /ReactOnRails: ReactOnRails gem and node package versions do not match/
           # expect { check_version(node_package_version) }.to raise_error(message)
+          check_version(node_package_version)
           expect(Rails.logger).to have_received(:warn).with(message)
         end
       end


### PR DESCRIPTION
### Summary

Currently, the version checker is hard-coded to use `client/package.json`. If `client/package.json` doesn't exist, then the version checker silently fails.

This PR changes the version checker to match Shakapacker v8's requirements, which are that the `package.json` exists at the root of the project directory.

Alternately, we'll need to make the package.json path configurable.

### Pull Request checklist
_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [x] Update CHANGELOG file  
  _Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1657)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced streaming server rendering support with a new helper for integrating streamed components.
	- Added a function for enhanced performance and progressive page loading using React 18's streaming capabilities.
	- Enabled console log replay during server rendering for better debugging.
	- Improved error handling during server rendering.

- **Bug Fixes**
	- Corrected and renamed the `ReactOnRails.registerStore` method for clarity.

- **Chores**
	- Updated the changelog to reflect new features and fixes.
	- Enhanced version checking logic for `package.json` files.
	- Added a new JSON file for managing project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->