### PR TITLE
Remove `js-yaml` peer dependency and mentions of removed `webpackConfigLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes since the last non-beta release.
 #### Fixed
 
 - Separated streamServerRenderedReactComponent from the ReactOnRails object in order to stop users from getting errors during webpack compilation about needing the `stream-browserify` package. [PR 1680](https://github.com/shakacode/react_on_rails/pull/1680) by [judahmeek](https://github.com/judahmeek).
+- Removed obsolete `js-yaml` peer dependency. [PR 1678](https://github.com/shakacode/react_on_rails/pull/1678) by [alexeyr-ci](https://github.com/alexeyr-ci).
 
 ### [14.1.0] - 2025-01-06
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    react_on_rails (15.0.0.alpha.1)
+    react_on_rails (14.1.0)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/docs/additional-details/manual-installation-overview.md
+++ b/docs/additional-details/manual-installation-overview.md
@@ -16,8 +16,6 @@ The only requirements within this directory for basic React on Rails integration
    1. Provide server rendering if you wish to use that feature.
 1. Your JavaScript code "registers" any components and stores per the ReactOnRails APIs of ReactOnRails.register(components) and ReactOnRails.registerStore(stores). See [our javascript API docs](https://www.shakacode.com/react-on-rails/docs/api/javascript-api/) and the [ReactOnRails.js source](https://github.com/shakacode/react_on_rails/tree/master/node_package/src/ReactOnRails.js).
 1. Set your registration file as an "entry" point in your Webpack configs.
-1. Add the [Manifest plugin](https://github.com/danethurber/webpack-manifest-plugin) to your config.
-The default path: `public/webpack` can be loaded with webpackConfigLoader as shown in the dummy example.
 1. You create scripts in `client/package.json` per the example apps. These are used for building your Webpack assets. Also do this for your top level `package.json`.
 
 ## Rails Steps (outside of /client)

--- a/docs/guides/webpack-configuration.md
+++ b/docs/guides/webpack-configuration.md
@@ -36,7 +36,7 @@ You can access values in the `config/shakapacker.yml`
 const { config, devServer } = require('shakapacker');
 ```
 
-You will want consider using some of the same values set in these files:
+You will want to consider using some of the same values set in these files:
 
 * https://github.com/shakacode/shakapacker/blob/master/package/environments/base.js
 * https://github.com/shakacode/shakapacker/blob/master/package/environments/development.js

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@babel/runtime-corejs3": "^7.12.5"
   },
   "peerDependencies": {
-    "js-yaml": ">= 3.0.0",
     "react": ">= 16",
     "react-dom": ">= 16"
   },


### PR DESCRIPTION
### Summary

It looks like `js-yaml` was only needed for `webpackConfigLoader`, which was removed in 14.1.0.

### Pull Request checklist

- [ ] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] Update CHANGELOG file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1678)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated Webpack configuration guide with minor grammatical correction.
	- Removed specific line about default Webpack asset loading path in manual installation overview.

- **Dependency Management**
	- Removed `js-yaml` peer dependency from project configuration.

- **Changelog Updates**
	- Added details about version changes, including method renaming and server rendering improvements.
	- Documented fixes and enhancements for version 14.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->