### PR TITLE
Add 14.1.1 link to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1181,7 +1181,8 @@ Best done with Object destructing:
 ##### Fixed
 - Fix several generator-related issues.
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/14.1.0...master
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/14.1.1...master
+[14.1.1]: https://github.com/shakacode/react_on_rails/compare/14.1.0...14.1.1
 [14.1.0]: https://github.com/shakacode/react_on_rails/compare/14.0.5...14.1.0
 [14.0.5]: https://github.com/shakacode/react_on_rails/compare/14.0.4...14.0.5
 [14.0.4]: https://github.com/shakacode/react_on_rails/compare/14.0.3...14.0.4


### PR DESCRIPTION
Adding something I overlooked in #1680

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1683)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `CHANGELOG.md` with version `14.1.1` release details
  - Added comparison links between versions `14.1.0` and `14.1.1`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->