### PR TITLE
Fix obscure errors by introducing FULL_TEXT_ERRORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 ### [Unreleased]
 Changes since the last non-beta release.
 
+#### Fixed
+  - Fix obscure errors by introducing FULL_TEXT_ERRORS [PR 1695](https://github.com/shakacode/react_on_rails/pull/1695) by [Romex91](https://github.com/Romex91).
+
 ### [14.1.1] - 2025-01-15
 
 #### Fixed
@@ -387,7 +390,7 @@ Do not use. Unpublished. Caused by an issue with the release script.
 #### Fixed
 - Don't apply babel-plugin-transform-runtime inside react-on-rails to work with babel 7. [PR 1136](https://github.com/shakacode/react_on_rails/pull/1136) by [Ryunosuke Sato](https://github.com/tricknotes).
 - Add support for webpacker 4 prereleases. [PR 1134](https://github.com/shakacode/react_on_rails/pull/1134) by [Judahmeek](https://github.com/Judahmeek))
-
+CHANGELOG
 ### [11.1.2] - 2018-08-18
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 Changes since the last non-beta release.
 
 #### Fixed
-  - Fix obscure errors by introducing FULL_TEXT_ERRORS [PR 1695](https://github.com/shakacode/react_on_rails/pull/1695) by [Romex91](https://github.com/Romex91).
+- Fix obscure errors by introducing FULL_TEXT_ERRORS [PR 1695](https://github.com/shakacode/react_on_rails/pull/1695) by [Romex91](https://github.com/Romex91).
 
 ### [14.1.1] - 2025-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,7 +390,7 @@ Do not use. Unpublished. Caused by an issue with the release script.
 #### Fixed
 - Don't apply babel-plugin-transform-runtime inside react-on-rails to work with babel 7. [PR 1136](https://github.com/shakacode/react_on_rails/pull/1136) by [Ryunosuke Sato](https://github.com/tricknotes).
 - Add support for webpacker 4 prereleases. [PR 1134](https://github.com/shakacode/react_on_rails/pull/1134) by [Judahmeek](https://github.com/Judahmeek))
-CHANGELOG
+
 ### [11.1.2] - 2018-08-18
 
 #### Fixed

--- a/lib/react_on_rails/prerender_error.rb
+++ b/lib/react_on_rails/prerender_error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rainbow"
+
 # rubocop:disable: Layout/IndentHeredoc
 module ReactOnRails
   class PrerenderError < ::ReactOnRails::Error
@@ -51,11 +53,17 @@ module ReactOnRails
         message << <<~MSG
           Encountered error:
 
-          #{err}
+          #{err.inspect}
 
         MSG
 
-        backtrace = err.backtrace.first(15).join("\n")
+        backtrace = if ENV["FULL_TEXT_ERRORS"] == "true"
+                      err.backtrace.join("\n")
+                    else
+                      "#{err.backtrace.first(15).join("\n")}\n" +
+                        Rainbow("The rest of the backtrace is hidden. " \
+                                "To see the full backtrace, set FULL_TEXT_ERRORS=true.").red
+                    end
       else
         backtrace = nil
       end

--- a/lib/react_on_rails/prerender_error.rb
+++ b/lib/react_on_rails/prerender_error.rb
@@ -60,7 +60,7 @@ module ReactOnRails
         backtrace = if Utils.full_text_errors_enabled?
                       err.backtrace.join("\n")
                     else
-                      "#{err.backtrace.first(15).join("\n")}\n" +
+                      "#{Rails.backtrace_cleaner.clean(err.backtrace).join("\n")}\n" +
                         Rainbow("The rest of the backtrace is hidden. " \
                                 "To see the full backtrace, set FULL_TEXT_ERRORS=true.").red
                     end

--- a/lib/react_on_rails/prerender_error.rb
+++ b/lib/react_on_rails/prerender_error.rb
@@ -57,7 +57,7 @@ module ReactOnRails
 
         MSG
 
-        backtrace = if ENV["FULL_TEXT_ERRORS"] == "true"
+        backtrace = if Utils.full_text_errors_enabled?
                       err.backtrace.join("\n")
                     else
                       "#{err.backtrace.first(15).join("\n")}\n" +

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -185,10 +185,14 @@ module ReactOnRails
                                     end
     end
 
+    def self.full_text_errors_enabled?
+      ENV["FULL_TEXT_ERRORS"] == "true"
+    end
+
     def self.smart_trim(str, max_length = 1000)
       # From https://stackoverflow.com/a/831583/1009332
       str = str.to_s
-      return str if ENV["FULL_TEXT_ERRORS"] == "true"
+      return str if full_text_errors_enabled?
       return str unless str.present? && max_length >= 1
       return str if str.length <= max_length
 

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -8,7 +8,9 @@ require "active_support/core_ext/string"
 
 module ReactOnRails
   module Utils
-    TRUNCATION_FILLER = "\n... TRUNCATED ...\n"
+    TRUNCATION_FILLER = "\n... TRUNCATED #{
+      Rainbow('To see the full output, set FULL_TEXT_ERRORS=true.').red
+    } ...\n".freeze
 
     # https://forum.shakacode.com/t/yak-of-the-week-ruby-2-4-pathname-empty-changed-to-look-at-file-size/901
     # return object if truthy, else return nil
@@ -186,6 +188,7 @@ module ReactOnRails
     def self.smart_trim(str, max_length = 1000)
       # From https://stackoverflow.com/a/831583/1009332
       str = str.to_s
+      return str if ENV["FULL_TEXT_ERRORS"] == "true"
       return str unless str.present? && max_length >= 1
       return str if str.length <= max_length
 

--- a/spec/react_on_rails/prender_error_spec.rb
+++ b/spec/react_on_rails/prender_error_spec.rb
@@ -65,7 +65,9 @@ module ReactOnRails
         it "shows truncated backtrace with notice" do
           message = expected_error.message
           expect(message).to include(err.inspect)
-          expect(message).to include(err.backtrace.first(15).join("\n"))
+          expect(message).to include(
+            "spec/react_on_rails/prender_error_spec.rb:20:in `block (2 levels) in <module:ReactOnRails>'"
+          )
           expect(message).to include("The rest of the backtrace is hidden")
         end
       end

--- a/spec/react_on_rails/prender_error_spec.rb
+++ b/spec/react_on_rails/prender_error_spec.rb
@@ -45,5 +45,30 @@ module ReactOnRails
         expect(expected_error.raven_context).to eq(expected_error_info)
       end
     end
+
+    describe "error message formatting" do
+      context "when FULL_TEXT_ERRORS is true" do
+        before { ENV["FULL_TEXT_ERRORS"] = "true" }
+        after { ENV["FULL_TEXT_ERRORS"] = nil }
+
+        it "shows the full backtrace" do
+          message = expected_error.message
+          expect(message).to include(err.inspect)
+          expect(message).to include(err.backtrace.join("\n"))
+          expect(message).not_to include("The rest of the backtrace is hidden")
+        end
+      end
+
+      context "when FULL_TEXT_ERRORS is not set" do
+        before { ENV["FULL_TEXT_ERRORS"] = nil }
+
+        it "shows truncated backtrace with notice" do
+          message = expected_error.message
+          expect(message).to include(err.inspect)
+          expect(message).to include(err.backtrace.first(15).join("\n"))
+          expect(message).to include("The rest of the backtrace is hidden")
+        end
+      end
+    end
   end
 end

--- a/spec/react_on_rails/utils_spec.rb
+++ b/spec/react_on_rails/utils_spec.rb
@@ -310,30 +310,47 @@ module ReactOnRails
       end
 
       describe ".smart_trim" do
-        it "trims smartly" do
-          s = "1234567890"
+        let(:long_string) { "1234567890" }
 
-          expect(described_class.smart_trim(s, -1)).to eq("1234567890")
-          expect(described_class.smart_trim(s, 0)).to eq("1234567890")
-          expect(described_class.smart_trim(s, 1)).to eq("1#{Utils::TRUNCATION_FILLER}")
-          expect(described_class.smart_trim(s, 2)).to eq("1#{Utils::TRUNCATION_FILLER}0")
-          expect(described_class.smart_trim(s, 3)).to eq("1#{Utils::TRUNCATION_FILLER}90")
-          expect(described_class.smart_trim(s, 4)).to eq("12#{Utils::TRUNCATION_FILLER}90")
-          expect(described_class.smart_trim(s, 5)).to eq("12#{Utils::TRUNCATION_FILLER}890")
-          expect(described_class.smart_trim(s, 6)).to eq("123#{Utils::TRUNCATION_FILLER}890")
-          expect(described_class.smart_trim(s, 7)).to eq("123#{Utils::TRUNCATION_FILLER}7890")
-          expect(described_class.smart_trim(s, 8)).to eq("1234#{Utils::TRUNCATION_FILLER}7890")
-          expect(described_class.smart_trim(s, 9)).to eq("1234#{Utils::TRUNCATION_FILLER}67890")
-          expect(described_class.smart_trim(s, 10)).to eq("1234567890")
-          expect(described_class.smart_trim(s, 11)).to eq("1234567890")
+        context "when FULL_TEXT_ERRORS is true" do
+          before { ENV["FULL_TEXT_ERRORS"] = "true" }
+          after { ENV["FULL_TEXT_ERRORS"] = nil }
+
+          it "returns the full string regardless of length" do
+            expect(described_class.smart_trim(long_string, 5)).to eq(long_string)
+          end
+
+          it "handles a hash without trimming" do
+            hash = { a: long_string }
+            expect(described_class.smart_trim(hash, 5)).to eq(hash.to_s)
+          end
         end
 
-        it "trims handles a hash" do
-          s = { a: "1234567890" }
+        context "when FULL_TEXT_ERRORS is not set" do
+          before { ENV["FULL_TEXT_ERRORS"] = nil }
 
-          expect(described_class.smart_trim(s, 9)).to eq(
-            "{:a=#{Utils::TRUNCATION_FILLER}890\"}"
-          )
+          it "trims smartly" do
+            expect(described_class.smart_trim(long_string, -1)).to eq("1234567890")
+            expect(described_class.smart_trim(long_string, 0)).to eq("1234567890")
+            expect(described_class.smart_trim(long_string, 1)).to eq("1#{Utils::TRUNCATION_FILLER}")
+            expect(described_class.smart_trim(long_string, 2)).to eq("1#{Utils::TRUNCATION_FILLER}0")
+            expect(described_class.smart_trim(long_string, 3)).to eq("1#{Utils::TRUNCATION_FILLER}90")
+            expect(described_class.smart_trim(long_string, 4)).to eq("12#{Utils::TRUNCATION_FILLER}90")
+            expect(described_class.smart_trim(long_string, 5)).to eq("12#{Utils::TRUNCATION_FILLER}890")
+            expect(described_class.smart_trim(long_string, 6)).to eq("123#{Utils::TRUNCATION_FILLER}890")
+            expect(described_class.smart_trim(long_string, 7)).to eq("123#{Utils::TRUNCATION_FILLER}7890")
+            expect(described_class.smart_trim(long_string, 8)).to eq("1234#{Utils::TRUNCATION_FILLER}7890")
+            expect(described_class.smart_trim(long_string, 9)).to eq("1234#{Utils::TRUNCATION_FILLER}67890")
+            expect(described_class.smart_trim(long_string, 10)).to eq("1234567890")
+            expect(described_class.smart_trim(long_string, 11)).to eq("1234567890")
+          end
+
+          it "trims handles a hash" do
+            s = { a: "1234567890" }
+            expect(described_class.smart_trim(s, 9)).to eq(
+              "{:a=#{Utils::TRUNCATION_FILLER}890\"}"
+            )
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

Troubleshooting 500 errors is challenging as important parts of the error messages are hidden.

This PR adds the following message to truncated error texts:
```
The rest of the backtrace is hidden. To see the full backtrace, set FULL_TEXT_ERRORS=true
```

### Pull Request checklist

- [x] Add/update test to cover these changes
~~- [ ] Update documentation~~ - No need, the new feature is self-documented
- [x] Update CHANGELOG file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1695)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an option to display complete error details, allowing users to view full diagnostic information when needed.
  - Added a new feature to control error message verbosity based on the `FULL_TEXT_ERRORS` environment variable.

- **Bug Fixes**
  - Enhanced the clarity of error messages with improved formatting and a more intuitive backtrace summary to resolve issues with previously obscure outputs.
  - Updated the changelog to reflect the new error handling features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->