### PR TITLE
Update `tsconfig.json` to extend a standard one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Changes since the last non-beta release.
 - Fix obscure errors by introducing FULL_TEXT_ERRORS [PR 1695](https://github.com/shakacode/react_on_rails/pull/1695) by [Romex91](https://github.com/Romex91).
 - Disable `esModuleInterop` to increase interoperability [PR 1699](https://github.com/shakacode/react_on_rails/pull/1699) by [alexeyr-ci](https://github.com/alexeyr-ci).
 
+#### Changed
+- More up-to-date TS config [PR 1700](https://github.com/shakacode/react_on_rails/pull/1700) by [alexeyr-ci](https://github.com/alexeyr-ci).
+
 ### [14.1.1] - 2025-01-15
 
 #### Fixed

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
+    "@tsconfig/node14": "^14.1.2",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.17.16",
     "@types/react": "^18.3.18",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,14 @@
 {
+  "extends": "@tsconfig/node14",
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": false,
+    // needed for Jest tests even though we don't use .tsx
     "jsx": "react-jsx",
-    "lib": ["dom", "es2015"],
-    "module": "CommonJS",
     "noImplicitAny": true,
     "outDir": "node_package/lib",
     "strict": true,
-    "incremental": true,
-    "target": "es5"
+    "incremental": true
   },
   "include": ["node_package/src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node14@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-14.1.2.tgz#ed84879e927a2f12ae8bb020baa990bd4cc3dabb"
+  integrity sha512-1vncsbfCZ3TBLPxesRYz02Rn7SNJfbLoDVkcZ7F/ixOV6nwxwgdhD1mdPcc5YQ413qBJ8CvMxXMFfJ7oawjo7Q==
+
 "@types/babel__core@^7.1.14":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"


### PR DESCRIPTION
### Summary

Extracted `tsconfig.json` changes equivalent from #1697 (except `lib` is set to `["es2020"]` without `"dom"`, but we don't use any DOM APIs).

Effectively:
- Updates `module` and `moduleResolution` to `node16` (strictly superior to `commonjs`);
- Updates `lib` and `target` to `es2020`.

### Pull Request checklist
- ~[ ] Add/update test to cover these changes~
- ~[ ] Update documentation~
- [x] Update CHANGELOG file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1700)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Enhanced the development configuration by adding a new dependency for Node.js version 14.
  - Updated TypeScript configuration for improved compatibility.
  - Documented changes in the changelog to reflect updates in the TypeScript configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->