### PR TITLE
Make the release script update Gemfile.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,16 @@ If you think ShakaCode can help your project, [click here](https://meetings.hubs
 
 ## Contributors
 
-Please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide, and add a link for the version diff at the bottom of the file. Also, please update the `Unreleased` link to compare to the latest release version.
+Please follow the recommendations outlined at [keepachangelog.com](http://keepachangelog.com/). Please use the existing headings and styling as a guide.
+After a release, please make sure to run `bundle exec rake update_changelog`. This will add a heading for the latest version and update the links at the end of the file.
 
 ## Versions
 
-### [15.0.0-alpha.2] - 2025-03-07
+### [Unreleased]
 
 Changes since the last non-beta release.
+
+### [15.0.0-alpha.2] - 2025-03-07
 
 See [Release Notes](docs/release-notes/15.0.0.md) for full details.
 
@@ -1531,7 +1534,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/14.2.0...master
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/15.0.0-alpha.2...master
+[15.0.0-alpha.2]: https://github.com/shakacode/react_on_rails/compare/14.2.0...15.0.0-alpha.2
 [14.2.0]: https://github.com/shakacode/react_on_rails/compare/14.1.1...14.2.0
 [14.1.1]: https://github.com/shakacode/react_on_rails/compare/14.1.0...14.1.1
 [14.1.0]: https://github.com/shakacode/react_on_rails/compare/14.0.5...14.1.0

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -75,11 +75,12 @@ task :release, %i[gem_version dry_run tools_install] do |_t, args|
   sh_in_dir(gem_root, "gem release") unless is_dry_run
 
   msg = <<~MSG
-    Once you have successfully published, run these commands to update the spec apps:
+    Once you have successfully published, run these commands to update Gemfile.lock locally and in the spec apps:
 
+    bundle install
     cd #{dummy_app_dir}; bundle update react_on_rails
-    cd #{gem_root}#{' '}
-    git commit -a -m 'Update Gemfile.lock for spec app'
+    cd #{gem_root}
+    git commit -a -m 'Update Gemfile.lock'
     git push
   MSG
   puts msg
@@ -87,7 +88,8 @@ end
 # rubocop:enable Metrics/BlockLength
 
 task :test do
+  bundle_install_in(gem_root)
   unbundled_sh_in_dir(gem_root, "cd #{dummy_app_dir}; bundle update react_on_rails")
-  sh_in_dir(gem_root, "git commit -a -m 'Update Gemfile.lock for spec app'")
+  sh_in_dir(gem_root, "git commit -a -m 'Update Gemfile.lock'")
   sh_in_dir(gem_root, "git push")
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -89,9 +89,7 @@ end
 # rubocop:enable Metrics/BlockLength
 
 task :test do
-  bundle_install_in(gem_root)
-  bundle_exec(gem_root, "rake update_changelog")
   unbundled_sh_in_dir(gem_root, "cd #{dummy_app_dir}; bundle update react_on_rails")
-  sh_in_dir(gem_root, "git commit -a -m 'Update Gemfile.lock and CHANGELOG.md'")
+  sh_in_dir(gem_root, "git commit -a -m 'Update Gemfile.lock for spec app'")
   sh_in_dir(gem_root, "git push")
 end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -75,12 +75,13 @@ task :release, %i[gem_version dry_run tools_install] do |_t, args|
   sh_in_dir(gem_root, "gem release") unless is_dry_run
 
   msg = <<~MSG
-    Once you have successfully published, run these commands to update Gemfile.lock locally and in the spec apps:
+    Once you have successfully published, run these commands to update Gemfile.lock and CHANGELOG.md:
 
     bundle install
+    bundle exec rake update_changelog
     cd #{dummy_app_dir}; bundle update react_on_rails
     cd #{gem_root}
-    git commit -a -m 'Update Gemfile.lock'
+    git commit -a -m 'Update Gemfile.lock and CHANGELOG.md'
     git push
   MSG
   puts msg
@@ -89,7 +90,8 @@ end
 
 task :test do
   bundle_install_in(gem_root)
+  bundle_exec(gem_root, "rake update_changelog")
   unbundled_sh_in_dir(gem_root, "cd #{dummy_app_dir}; bundle update react_on_rails")
-  sh_in_dir(gem_root, "git commit -a -m 'Update Gemfile.lock'")
+  sh_in_dir(gem_root, "git commit -a -m 'Update Gemfile.lock and CHANGELOG.md'")
   sh_in_dir(gem_root, "git push")
 end

--- a/rakelib/task_helpers.rb
+++ b/rakelib/task_helpers.rb
@@ -44,7 +44,7 @@ module ReactOnRails
 
     # Runs bundle exec using that directory's Gemfile
     def bundle_exec(dir: nil, args: nil, env_vars: "")
-      sh_in_dir(dir, "#{env_vars} #{args}")
+      sh_in_dir(dir, "#{env_vars} bundle exec #{args}")
     end
 
     def generators_source_dir

--- a/rakelib/update_changelog.rake
+++ b/rakelib/update_changelog.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "English"
+require "bundler"
+require_relative "task_helpers"
+
+desc "Updates CHANGELOG.md inserting headers for the new version.
+
+Argument: Git tag. Defaults to the latest tag."
+
+task :update_changelog, %i[tag] do |_, args|
+  tag = args[:tag] || `git describe --tags --abbrev=0`.strip
+  anchor = "[#{tag}]"
+
+  changelog = File.read("CHANGELOG.md")
+
+  if changelog.include?(anchor)
+    puts "Tag #{tag} is already documented in CHANGELOG.md, update manually if needed"
+    next
+  end
+
+  tag_date_output = `git show -s --format=%cs #{tag} 2>&1`
+  if $CHILD_STATUS.success?
+    tag_date = tag_date_output.split("\n").last.strip
+  else
+    abort("Failed to find tag #{tag}")
+  end
+
+  # after "Changes since the last non-beta release.", insert link header
+  changelog.sub!("Changes since the last non-beta release.", "\\0\n\n### #{anchor} - #{tag_date}")
+
+  # find the link in "[Unreleased]: ...", update it, and add the link for our new tag after it
+  compare_link_prefix = "https://github.com/shakacode/react_on_rails/compare"
+  match_data = %r{#{compare_link_prefix}/(?<prev_tag>.*)\.\.\.master}.match(changelog)
+  if match_data
+    prev_tag = match_data[:prev_tag]
+    new_unreleased_link = "#{compare_link_prefix}/#{tag}...master"
+    new_tag_link = "#{anchor}: #{compare_link_prefix}/#{prev_tag}...#{tag}"
+    changelog.sub!(match_data[0], "#{new_unreleased_link}\n#{new_tag_link}")
+  end
+
+  File.write("CHANGELOG.md", changelog)
+  puts "Updated CHANGELOG.md with an entry for #{tag}"
+end


### PR DESCRIPTION
### Summary

Update the release task post-instructions to make `Gemfile.lock` stable after release.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~
- ~[ ] Update documentation~
- ~[ ] Update CHANGELOG file~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1711)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced release messaging to clearly guide users on updating both `Gemfile.lock` and `CHANGELOG.md` after publication.
  - Introduced a reminder to run the `bundle install` command after publication.
  - Simplified the commit messaging for clarity.

- **New Features**
  - Added a new Rake task to automate the updating of the `CHANGELOG.md` file, improving the documentation process for version releases.

- **Documentation**
  - Added a new version entry for `15.0.0-alpha.2` in the `CHANGELOG.md`, including updated links for version comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->