### PR TITLE
chore: make docs MDX-compatible

### DIFF
--- a/docs/contributor-info/pull-requests.md
+++ b/docs/contributor-info/pull-requests.md
@@ -37,7 +37,7 @@ When making doc changes, we want the change to work on both the gitbook and the 
 
 ### Links to other docs:
 
-- When making references to doc files, use a full URL to <https://www.shakacode.com/react-on-rails/docs>, for example:
+- When making references to doc files, use a full URL to [https://www.shakacode.com/react-on-rails/docs](https://www.shakacode.com/react-on-rails/docs), for example:
   `[Installation Overview](https://www.shakacode.com/react-on-rails/docs/additional-details/manual-installation-overview/)`
 
 - When making references to source code files, use a full GitHub URL, for example:

--- a/docs/guides/tutorial.md
+++ b/docs/guides/tutorial.md
@@ -19,8 +19,8 @@ You can find it here:
 
 By the time you read this, the latest may have changed. Be sure to check the versions here:
 
-- <https://rubygems.org/gems/react_on_rails>
-- <https://www.npmjs.com/package/react-on-rails>
+- [https://rubygems.org/gems/react_on_rails](https://rubygems.org/gems/react_on_rails)
+- [https://www.npmjs.com/package/react-on-rails](https://www.npmjs.com/package/react-on-rails)
 
 # Table of Content:
 


### PR DESCRIPTION
### Summary

Required since over on our website, Gatsby ingests the `.md` files here as MDX, and the GFM syntax causes the build to break.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1724)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the URL formatting in our documentation, replacing plain text with clickable hyperlinks to improve readability and ease of access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->