### PR TITLE
chore: make docs MDX-compatible, pt. 2

### DIFF
--- a/docs/rails/turbolinks.md
+++ b/docs/rails/turbolinks.md
@@ -84,7 +84,7 @@ Async script loading can be done like this (starting with Shakapacker 8.2):
   <%= javascript_include_tag 'application', async: Rails.env.production? %>
 ```
 
-If you use `document.addEventListener("turbolinks:load", function() {...});` somewhere in your code, you will notice that Turbolinks 5 does not fire `turbolinks:load` on initial page load. A quick workaround for React on Rails <15 is to use `defer` instead of `async`:
+If you use `document.addEventListener("turbolinks:load", function() {...});` somewhere in your code, you will notice that Turbolinks 5 does not fire `turbolinks:load` on initial page load. A quick workaround for React on Rails earlier than 15 is to use `defer` instead of `async`:
 
 ```erb
   <%= javascript_include_tag 'application', defer: Rails.env.production? %>


### PR DESCRIPTION
### Summary

Followup to https://github.com/shakacode/react_on_rails/pull/1724 - I missed a file. Same intent: to make the `.md` files inside `docs/` parseable as MDX so Gatsby can pull them in and build properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1725)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified compatibility wording to state support for React on Rails versions earlier than 15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->