### PR TITLE
Postpone hydration to the next JS task to fix a bug in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 Changes since the last non-beta release.
 
 ### [14.2.1] - 2025-04-11
+
 #### Fixed
 - Fixed a bug where the `load` event was not firing in Safari. [PR 1729](https://github.com/shakacode/react_on_rails/pull/1729) by [Romex91](https://github.com/Romex91).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Please follow the recommendations outlined at [keepachangelog.com](http://keepac
 ### [Unreleased]
 Changes since the last non-beta release.
 
+### [14.2.1] - 2025-04-11
+#### Fixed
+- Fixed a bug where the `load` event was not firing in Safari. [PR 1729](https://github.com/shakacode/react_on_rails/pull/1729) by [Romex91](https://github.com/Romex91).
+
 ### [14.2.0] - 2025-03-03
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changes since the last non-beta release.
 ### [14.2.1] - 2025-04-11
 
 #### Fixed
-- Fixed a bug where the `load` event was not firing in Safari. [PR 1729](https://github.com/shakacode/react_on_rails/pull/1729) by [Romex91](https://github.com/Romex91).
+- Fixed a bug where the `load` event was not firing in Safari by postponing hydration to the next JavaScript task using `setTimeout(callback, 0)`. [PR 1729](https://github.com/shakacode/react_on_rails/pull/1729) by [Romex91](https://github.com/Romex91).
 
 ### [14.2.0] - 2025-03-03
 

--- a/lib/react_on_rails/version.rb
+++ b/lib/react_on_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ReactOnRails
-  VERSION = "14.2.0"
+  VERSION = "14.2.1"
 end

--- a/node_package/src/clientStartup.ts
+++ b/node_package/src/clientStartup.ts
@@ -309,7 +309,9 @@ function isWindow(context: Context): context is Window {
 
 function onPageReady(callback: () => void) {
   if (document.readyState === "complete") {
-    callback();
+    // When hydrating React from the `readystatechange` listener, Safari skips the `load` event.
+    // To avoid this, we use a timeout to postpone the callback until after the `load` event.
+    setTimeout(callback, 0);
   } else {
     document.addEventListener("readystatechange", function onReadyStateChange() {
         onPageReady(callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-on-rails",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
   "main": "node_package/lib/ReactOnRails.full.js",
   "exports": {

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    react_on_rails (14.2.0)
+    react_on_rails (14.2.1)
       addressable
       connection_pool
       execjs (~> 2.5)


### PR DESCRIPTION
### Summary

When hydrating React from the `readystatechange` listener, Safari skips the `load` event.
Not sure why, but looks like a bug in the browser.

This issue caused the Web Builder to load infinitely in Popmenu

### Pull Request checklist

_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

_Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1729)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the page readiness sequence to improve compatibility with Safari, ensuring consistent and reliable page behavior upon load.
	- Documented a fix for the `load` event not firing in Safari in the CHANGELOG.
- **Version Updates**
	- Updated the version of the `ReactOnRails` module and the `react-on-rails` package from "14.2.0" to "14.2.1".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->