### PR TITLE
Fix `yarn`/`bundle install` in CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,12 +8,13 @@ on:
 
 jobs:
   examples:
-    env:
-      SKIP_YARN_COREPACK_CHECK: 0
     strategy:
       fail-fast: false
       matrix:
         versions: ['oldest', 'newest']
+    env:
+      SKIP_YARN_COREPACK_CHECK: 0
+      BUNDLE_FROZEN: ${{ matrix.versions == 'oldest' && 'false' || 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +72,7 @@ jobs:
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Install Node modules with Yarn for renderer package
         run: |
-          yarn install --no-progress --no-emoji
+          yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
           sudo yarn global add yalc
       - name: yalc publish for react-on-rails
         run: yalc publish

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -46,6 +46,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue
@@ -58,11 +60,6 @@ jobs:
       - name: run conversion script to support shakapacker v6
         if: matrix.versions == 'oldest'
         run: script/convert
-      - name: Save root node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: v5-package-node-modules-cache-${{ hashFiles('yarn.lock') }}
       - name: Save root ruby gems to cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ hashFiles('Gemfile.development_dependencies') }}-${{ matrix.versions }}
+          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-${{ matrix.versions }}
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Install Node modules with Yarn for renderer package

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ hashFiles('Gemfile.development_dependencies') }}-oldest
+          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-oldest
       - name: Install Node modules with Yarn for renderer package
         run: |
           yarn install --no-progress --no-emoji
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: spec/dummy/node_modules
-          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/package.json') }}-newest
+          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/yarn.lock') }}-newest
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ hashFiles('Gemfile.development_dependencies') }}-oldest
+          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-oldest
       - name: Install Ruby Gems for dummy app
         run: |
           cd spec/dummy

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue
@@ -33,11 +35,6 @@ jobs:
           echo "Node version: "; node -v
           echo "Yarn version: "; yarn --version
           echo "Bundler version: "; bundle --version
-      - name: Save root node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: v5-package-node-modules-cache-${{ hashFiles('yarn.lock') }}
       - name: Save root ruby gems to cache
         uses: actions/cache@v4
         with:
@@ -49,11 +46,6 @@ jobs:
           sudo yarn global add yalc
       - name: yalc publish for react-on-rails
         run: yalc publish
-      - name: Save spec/dummy/node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: spec/dummy/node_modules
-          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/yarn.lock') }}-newest
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    env:
+      BUNDLE_FROZEN: true
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +45,7 @@ jobs:
           key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-oldest
       - name: Install Node modules with Yarn for renderer package
         run: |
-          yarn install --no-progress --no-emoji
+          yarn install --no-progress --no-emoji --frozen-lockfile
           sudo yarn global add yalc
       - name: yalc publish for react-on-rails
         run: yalc publish
@@ -55,13 +57,13 @@ jobs:
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app
-        run: cd spec/dummy && yarn install --no-progress --no-emoji
+        run: cd spec/dummy && yarn install --no-progress --no-emoji --frozen-lockfile
       - name: Install Ruby Gems for package
         run: bundle check --path=vendor/bundle || bundle _2.5.9_ install --path=vendor/bundle --jobs=4 --retry=3
       - name: Lint Ruby
         run: bundle exec rubocop
       - name: Install Node modules with Yarn for dummy app
-        run: cd spec/dummy && yarn install --ignore-scripts --no-progress --no-emoji
+        run: cd spec/dummy && yarn install --no-progress --no-emoji --frozen-lockfile
       - name: Save dummy app ruby gems to cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           key: v5-package-node-modules-cache-${{ hashFiles('yarn.lock') }}
       - name: Install Node modules with Yarn for renderer package
         run: |
-          yarn install --no-progress --no-emoji
+          yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
           sudo yarn global add yalc
       - name: yalc publish for react-on-rails
         run: yalc publish
@@ -60,7 +60,7 @@ jobs:
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app
-        run: cd spec/dummy && yarn install --no-progress --no-emoji
+        run: cd spec/dummy && yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' }}
       - name: Save dummy app ruby gems to cache
         uses: actions/cache@v4
         with:
@@ -146,14 +146,14 @@ jobs:
           key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-${{ matrix.versions }}
       - name: Install Node modules with Yarn
         run: |
-          yarn install --no-progress --no-emoji
+          yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
           sudo yarn global add yalc
       - name: yalc publish for react-on-rails
         run: yalc publish
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app
-        run: cd spec/dummy && yarn install --no-progress --no-emoji
+        run: cd spec/dummy && yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
       - name: Dummy JS tests
         run: |
           cd spec/dummy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.versions == 'oldest' && '16' || '20' }}
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue
@@ -41,26 +43,16 @@ jobs:
       - name: run conversion script to support shakapacker v6
         if: matrix.versions == 'oldest'
         run: script/convert
-      - name: Save root node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: v5-package-node-modules-cache-${{ hashFiles('yarn.lock') }}
       - name: Install Node modules with Yarn for renderer package
         run: |
           yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
           sudo yarn global add yalc
       - name: yalc publish for react-on-rails
         run: yalc publish
-      - name: Save spec/dummy/node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: spec/dummy/node_modules
-          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/yarn.lock') }}-${{ matrix.versions }}
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app
-        run: cd spec/dummy && yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' }}
+        run: cd spec/dummy && yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
       - name: Save dummy app ruby gems to cache
         uses: actions/cache@v4
         with:
@@ -105,6 +97,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.versions == 'oldest' && '16' || '20' }}
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue
@@ -117,11 +111,6 @@ jobs:
       - name: run conversion script to support shakapacker v6
         if: matrix.versions == 'oldest'
         run: script/convert
-      - name: Save root node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: v5-package-node-modules-cache-${{ hashFiles('yarn.lock') }}
       - name: Save root ruby gems to cache
         uses: actions/cache@v4
         with:
@@ -132,11 +121,6 @@ jobs:
         with:
           path: spec/dummy/vendor/bundle
           key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-${{ matrix.versions }}
-      - name: Save spec/dummy/node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: spec/dummy/node_modules
-          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/yarn.lock') }}-${{ matrix.versions }}
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Save test Webpack bundles to cache (for build number checksum used by RSpec job)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: spec/dummy/node_modules
-          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/package.json') }}-${{ matrix.versions }}
+          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/yarn.lock') }}-${{ matrix.versions }}
       - name: yalc add react-on-rails
         run: cd spec/dummy && yalc add react-on-rails
       - name: Install Node modules with Yarn for dummy app
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ hashFiles('Gemfile.development_dependencies') }}-${{ matrix.versions }}
+          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-${{ matrix.versions }}
       - name: Install Ruby Gems for dummy app
         run: |
           cd spec/dummy
@@ -126,17 +126,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ hashFiles('Gemfile.development_dependencies') }}-${{ matrix.versions }}
+          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-${{ matrix.versions }}
       - name: Save dummy app ruby gems to cache
         uses: actions/cache@v4
         with:
           path: spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ hashFiles('Gemfile.development_dependencies') }}-${{ matrix.versions }}
+          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-${{ matrix.versions }}
       - name: Save spec/dummy/node_modules to cache
         uses: actions/cache@v4
         with:
           path: spec/dummy/node_modules
-          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/package.json') }}-${{ matrix.versions }}
+          key: dummy-app-node-modules-cache-${{ hashFiles('spec/dummy/yarn.lock') }}-${{ matrix.versions }}
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Save test Webpack bundles to cache (for build number checksum used by RSpec job)

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: script/convert
       - name: Install Node modules with Yarn for renderer package
         run: |
-          yarn install --no-progress --no-emoji
+          yarn install --no-progress --no-emoji ${{ matrix.versions == 'newest' && '--frozen-lockfile' || '' }}
           sudo yarn global add yalc
       - name: Run JS unit tests for Renderer package
         run: yarn test

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.versions == 'oldest' && '16' || '20' }}
+          cache: yarn
+          cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue
@@ -27,11 +29,6 @@ jobs:
           echo "Current directory: "; pwd
           echo "Node version: "; node -v
           echo "Yarn version: "; yarn --version
-      - name: Save root node_modules to cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: v5-package-node-modules-cache-${{ hashFiles('yarn.lock') }}
       - name: run conversion script
         if: matrix.versions == 'oldest'
         run: script/convert

--- a/.github/workflows/rspec-package-specs.yml
+++ b/.github/workflows/rspec-package-specs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails.gemspec') }}-${{ matrix.versions }}
+          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-${{ matrix.versions }}
       - name: Install Ruby Gems for package
         run: bundle check --path=vendor/bundle || bundle  _2.5.9_ install --path=vendor/bundle --jobs=4 --retry=3
       - name: Git Stuff

--- a/.github/workflows/rspec-package-specs.yml
+++ b/.github/workflows/rspec-package-specs.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         versions: ['oldest', 'newest']
+    env:
+      BUNDLE_FROZEN: ${{ matrix.versions == 'oldest' && 'false' || 'true' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Summary

* Cache actions for `node_modules` and `vendor/bundle` should use lockfile hash in their key, not the main `package.json`/`Gemfile`
* Run `yarn install` and `bundle install` in frozen lockfile mode to be sure the lockfiles are updated.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~
- ~[ ] Update documentation~
- ~[ ] Update CHANGELOG file~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1735)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved workflow dependency caching by switching cache keys to use lockfiles for both Node and Ruby dependencies, enhancing cache accuracy.
	- Updated environment variables and install commands to enforce stricter or conditional dependency installation based on the matrix version, increasing consistency and reliability in CI runs.
	- Adjusted Yarn and bundle install steps to use the `--frozen-lockfile` flag and `BUNDLE_FROZEN` variable where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->