### PR TITLE
Mark react-on-rails-rsc peerdep as optional

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -45,6 +45,9 @@ const config: KnipConfig = {
         '@eslint/js',
         // used by Jest
         'jsdom',
+        // This is an optional peer dependency because users without RSC don't need it
+        // but Knip doesn't like such dependencies to be referenced directly in code
+        'react-on-rails-rsc',
       ],
     },
     'spec/dummy': {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
     "react-dom": ">= 16",
     "react-on-rails-rsc": "19.0.2"
   },
+  "peerDependenciesMeta": {
+    "react-on-rails-rsc": {
+      "optional": true
+    }
+  },
   "files": [
     "node_package/lib"
   ],


### PR DESCRIPTION
### Summary

Mark react-on-rails-rsc peerdep as optional.

### Pull Request checklist

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1740)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked the `react-on-rails-rsc` dependency as optional, allowing more flexible installation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->