### PR TITLE
Have the lint job its own cache keys

### DIFF
--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-newest
+          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-lint
       - name: Install Node modules with Yarn for renderer package
         run: |
           yarn install --no-progress --no-emoji --frozen-lockfile
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-newest
+          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-lint
       - name: Install Ruby Gems for dummy app
         run: |
           cd spec/dummy

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-oldest
+          key: package-app-gem-cache-${{ hashFiles('Gemfile.lock') }}-newest
       - name: Install Node modules with Yarn for renderer package
         run: |
           yarn install --no-progress --no-emoji --frozen-lockfile
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-oldest
+          key: dummy-app-gem-cache-${{ hashFiles('spec/dummy/Gemfile.lock') }}-newest
       - name: Install Ruby Gems for dummy app
         run: |
           cd spec/dummy

--- a/node_package/tests/jest.setup.js
+++ b/node_package/tests/jest.setup.js
@@ -63,12 +63,14 @@ if (typeof window !== 'undefined') {
   global.ReadableStreamDefaultReader = ReadableStreamDefaultReader;
 }
 
-global.console.log('All calls to console have been disabled in jest.setup.js');
+if (!['yes', 'true', 'y', 't'].includes(process.env.ENABLE_JEST_CONSOLE || ''.toLowerCase())) {
+  global.console.log('All calls to console have been disabled in jest.setup.js');
 
-global.console = {
-  log: jest.fn(),
-  error: jest.fn(),
-  warn: jest.fn(),
-  info: jest.fn(),
-  debug: jest.fn(),
-};
+  global.console = {
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+}

--- a/node_package/tests/jest.setup.js
+++ b/node_package/tests/jest.setup.js
@@ -62,3 +62,11 @@ if (typeof window !== 'undefined') {
   global.ReadableStream = ReadableStream;
   global.ReadableStreamDefaultReader = ReadableStreamDefaultReader;
 }
+
+global.console = {
+  log: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};

--- a/node_package/tests/jest.setup.js
+++ b/node_package/tests/jest.setup.js
@@ -63,7 +63,7 @@ if (typeof window !== 'undefined') {
   global.ReadableStreamDefaultReader = ReadableStreamDefaultReader;
 }
 
-global.console.log("All calls to console have been disabled in jest.setup.js")
+global.console.log('All calls to console have been disabled in jest.setup.js');
 
 global.console = {
   log: jest.fn(),
@@ -71,4 +71,4 @@ global.console = {
   warn: jest.fn(),
   info: jest.fn(),
   debug: jest.fn(),
-}
+};

--- a/node_package/tests/jest.setup.js
+++ b/node_package/tests/jest.setup.js
@@ -63,10 +63,12 @@ if (typeof window !== 'undefined') {
   global.ReadableStreamDefaultReader = ReadableStreamDefaultReader;
 }
 
+global.console.log("All calls to console have been disabled in jest.setup.js")
+
 global.console = {
   log: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
   info: jest.fn(),
   debug: jest.fn(),
-};
+}

--- a/node_package/tests/renderFunction.test.jsx
+++ b/node_package/tests/renderFunction.test.jsx
@@ -15,7 +15,7 @@ describe('isRenderFunction', () => {
       },
     });
 
-    expect(true).toBe(false);
+    expect(isRenderFunction(es5Component)).toBe(false);
   });
 
   it('returns false for a ES6 React class', () => {

--- a/node_package/tests/renderFunction.test.jsx
+++ b/node_package/tests/renderFunction.test.jsx
@@ -15,7 +15,7 @@ describe('isRenderFunction', () => {
       },
     });
 
-    expect(isRenderFunction(es5Component)).toBe(false);
+    expect(true).toBe(false);
   });
 
   it('returns false for a ES6 React class', () => {

--- a/spec/dummy/tests/react-on-rails.import.test.js
+++ b/spec/dummy/tests/react-on-rails.import.test.js
@@ -1,5 +1,7 @@
 import ReactOnRails from 'react-on-rails';
 
 test('ReactOnRails', () => {
-  ReactOnRails.register({});
+  expect(() => {
+    ReactOnRails.register({});
+  }).not.toThrow();
 });

--- a/spec/dummy/tests/react-on-rails.require.test.js
+++ b/spec/dummy/tests/react-on-rails.require.test.js
@@ -1,5 +1,7 @@
 const ReactOnRails = require('react-on-rails').default;
 
 test('ReactOnRails', () => {
-  ReactOnRails.register({});
+  expect(() => {
+    ReactOnRails.register({});
+  }).not.toThrow();
 });


### PR DESCRIPTION
Currently, the lint job is trying to use the oldest spec/dummy's gem cache without running the conversion script. This causes every gem that would be removed/modified by the conversion script to instead be installed every time the job runs.

However, running the conversion script would cause eslint to be removed.

Therefore, we should switch to using the newest spec/dummy gem cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1749)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test assertions to explicitly verify that registering with an empty object does not throw errors.
  * Enhanced test setup to conditionally mock console output based on an environment variable, allowing more flexible control over console logging during tests.

* **Chores**
  * Updated caching keys for Ruby gem dependencies in the continuous integration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->