### PR TITLE
Docs/auto bundle rename and dummy reference

### DIFF
--- a/docs/guides/file-system-based-automated-bundle-generation.md
+++ b/docs/guides/file-system-based-automated-bundle-generation.md
@@ -73,6 +73,7 @@ import './../generated/server-bundle-generated.js';
 ```
 
 We recommend committing this import statement to your version control system.
+
 > Example (dummy app): see the server bundle entrypoint import.
 > [Dummy server-bundle.js](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/packs/server-bundle.js)
 
@@ -219,7 +220,7 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
 
 ### Server Rendering and Client Rendering Components
 
-If server rendering is enabled, the component will be registered for usage both in server and client rendering. To have separate definitions for client and server rendering, name the component files `ComponentName.server.jsx` and `ComponentName.client.jsx`. The `ComponentName.server.jsx` file will be used for server rendering and the `ComponentName.client.jsx` file for client rendering. If you don't want the component rendered on the server, you should only have the `ComponentName.client.jsx` file. 
+If server rendering is enabled, the component will be registered for usage both in server and client rendering. To have separate definitions for client and server rendering, name the component files `ComponentName.server.jsx` and `ComponentName.client.jsx`. The `ComponentName.server.jsx` file will be used for server rendering and the `ComponentName.client.jsx` file for client rendering. If you don't want the component rendered on the server, you should only have the `ComponentName.client.jsx` file.
 
 > Example (dummy app): paired files such as [`ReduxApp.client.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReduxApp.client.jsx) and [`ReduxApp.server.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReduxApp.server.jsx), and [`RouterApp.client.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/RouterApp.client.jsx) and [`RouterApp.server.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/RouterApp.server.jsx).
 

--- a/docs/guides/file-system-based-automated-bundle-generation.md
+++ b/docs/guides/file-system-based-automated-bundle-generation.md
@@ -17,6 +17,9 @@ default:
 
 For more details, see [Configuration and Code](https://github.com/shakacode/shakapacker#configuration-and-code) section in [shakapacker](https://github.com/shakacode/shakapacker/).
 
+> Example (dummy app): `nested_entries: true` with a different `source_path: client/app`. See `config/shakapacker.yml` in the dummy app.
+> [Dummy shakapacker.yml](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/config/shakapacker.yml)
+
 ### Configure Components Subdirectory
 
 `components_subdirectory` is the name of the matched directories containing components that will be automatically registered for use by the view helpers.
@@ -28,6 +31,9 @@ config.components_subdirectory = "ror_components"
 
 Now all React components inside the directories called `ror_components` will automatically be registered for usage with [`react_component`](../api/view-helpers-api.md#react_component) and [`react_component_hash`](../api/view-helpers-api.md#react_component_hash) helper methods provided by React on Rails.
 
+> Example (dummy app): the configured components subdirectory is named `startup` instead of `ror_components`.
+> [Dummy initializer](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/config/initializers/react_on_rails.rb)
+
 ### Configure `auto_load_bundle` Option
 
 For automated component registry, [`react_component`](../api/view-helpers-api.md#react_component) and [`react_component_hash`](../api/view-helpers-api.md#react_component_hash) view helper method tries to load generated bundle for component from the generated directory automatically per `auto_load_bundle` option. `auto_load_bundle` option in `config/initializers/react_on_rails` configures the default value that will be passed to component helpers. The default is `false`, and the parameter can be passed explicitly for each call.
@@ -37,6 +43,9 @@ You can change the value in `config/initializers/react_on_rails` by updating it 
 ```rb
 config.auto_load_bundle = true
 ```
+
+> Example (dummy app): `auto_load_bundle` is set to `true` in the same initializer.
+> [Dummy initializer](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/config/initializers/react_on_rails.rb)
 
 ### Location of generated files
 
@@ -64,6 +73,8 @@ import './../generated/server-bundle-generated.js';
 ```
 
 We recommend committing this import statement to your version control system.
+> Example (dummy app): see the server bundle entrypoint import.
+> [Dummy server-bundle.js](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/packs/server-bundle.js)
 
 ## Usage
 
@@ -208,7 +219,9 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
 
 ### Server Rendering and Client Rendering Components
 
-If server rendering is enabled, the component will be registered for usage both in server and client rendering. To have separate definitions for client and server rendering, name the component files `ComponentName.server.jsx` and `ComponentName.client.jsx`. The `ComponentName.server.jsx` file will be used for server rendering and the `ComponentName.client.jsx` file for client rendering. If you don't want the component rendered on the server, you should only have the `ComponentName.client.jsx` file.
+If server rendering is enabled, the component will be registered for usage both in server and client rendering. To have separate definitions for client and server rendering, name the component files `ComponentName.server.jsx` and `ComponentName.client.jsx`. The `ComponentName.server.jsx` file will be used for server rendering and the `ComponentName.client.jsx` file for client rendering. If you don't want the component rendered on the server, you should only have the `ComponentName.client.jsx` file. 
+
+> Example (dummy app): paired files such as [`ReduxApp.client.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReduxApp.client.jsx) and [`ReduxApp.server.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReduxApp.server.jsx), and [`RouterApp.client.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/RouterApp.client.jsx) and [`RouterApp.server.jsx`](https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/RouterApp.server.jsx).
 
 Once generated, all server entrypoints will be imported into a file named `[ReactOnRails.configuration.server_bundle_js_file]-generated.js`, which in turn will be imported into a source file named the same as `ReactOnRails.configuration.server_bundle_js_file`. If your server bundling logic is such that your server bundle source entrypoint is not named the same as your `ReactOnRails.configuration.server_bundle_js_file` and changing it would be difficult, please let us know.
 

--- a/docs/guides/file-system-based-automated-bundle-generation.md
+++ b/docs/guides/file-system-based-automated-bundle-generation.md
@@ -194,9 +194,10 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
    4. You no longer need to register the React components within the `ReactOnRails.configuration.components_subdirectory` nor directly add their bundles. For example, you can have a Rails view using three components:
 
       ```erb
-      <% append_javascript_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
       <%= react_component("FooComponentOne", {}, auto_load_bundle: true) %>
       <%= react_component("BarComponentOne", {}, auto_load_bundle: true) %>
+
+      <% append_javascript_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
       <%= react_component("SpecialComponentNotToAutoLoadBundle", {}) %>
       ```
 

--- a/docs/guides/file-system-based-automated-bundle-generation.md
+++ b/docs/guides/file-system-based-automated-bundle-generation.md
@@ -146,7 +146,9 @@ The tricky part is to figure out which bundles to load on any Rails view. [Shaka
 
 File-system-based automated pack generation simplifies this process with a new option for the view helpers.
 
-For example, if you wanted to utilize our file-system based entrypoint generation for `FooComponentOne` and `BarComponentOne`, but not `BarComponentTwo` (for whatever reason), then...
+> Note: In the Background examples above, we used `BarComponentTwo`. In the Solution below, we refer to the same component as `SpecialComponentNotToAutoLoadBundle` to emphasize that it is excluded from auto-loading. You do not need to rename your files.
+
+For example, if you wanted to utilize our file-system based entrypoint generation for `FooComponentOne` and `BarComponentOne`, but not `SpecialComponentNotToAutoLoadBundle` (formerly `BarComponentTwo`) (for whatever reason), then...
 
 1. Remove generated entrypoints from parameters passed directly to `javascript_pack_tag` and `stylesheet_pack_tag`.
 2. Remove generated entrypoints from parameters passed directly to `append_javascript_pack_tag` and `append_stylesheet_pack_tag`.
@@ -154,8 +156,8 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
    Your layout would now contain:
 
    ```erb
-   <%= javascript_pack_tag('BarComponentTwo') %>
-   <%= stylesheet_pack_tag('BarComponentTwo') %>
+   <%= javascript_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
+   <%= stylesheet_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
    ```
 
 3. Create a directory structure where the components that you want to be auto-generated are within `ReactOnRails.configuration.components_subdirectory`, which should be a subdirectory of `Shakapacker.config.source_path`:
@@ -163,7 +165,7 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
    ```text
    app/javascript:
      └── packs:
-     │   └── BarComponentTwo.jsx  # Internally uses ReactOnRails.register
+     │   └── SpecialComponentNotToAutoLoadBundle.jsx  # Internally uses ReactOnRails.register
      └── src:
      │   └── Foo
      │   │ └── ...
@@ -174,16 +176,16 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
      │   │ └── ror_components          # configured as `components_subdirectory`
      │   │   │ └── BarComponentOne.jsx
      │   │ └── something_else
-     │   │   │ └── BarComponentTwo.jsx
+     │   │   │ └── SpecialComponentNotToAutoLoadBundle.jsx
    ```
 
    4. You no longer need to register the React components within the `ReactOnRails.configuration.components_subdirectory` nor directly add their bundles. For example, you can have a Rails view using three components:
 
       ```erb
-      <% append_javascript_pack('BarComponentTwo') %>
+      <% append_javascript_pack('SpecialComponentNotToAutoLoadBundle') %>
       <%= react_component("FooComponentOne", {}, auto_load_bundle: true) %>
       <%= react_component("BarComponentOne", {}, auto_load_bundle: true) %>
-      <%= react_component("BarComponentTwo", {}) %>
+      <%= react_component("SpecialComponentNotToAutoLoadBundle", {}) %>
       ```
 
       If a component uses multiple HTML strings for server rendering, the [`react_component_hash`](../api/view-helpers-api.md#react_component_hash) view helper can be used on the Rails view, as illustrated below.

--- a/docs/guides/file-system-based-automated-bundle-generation.md
+++ b/docs/guides/file-system-based-automated-bundle-generation.md
@@ -193,7 +193,7 @@ For example, if you wanted to utilize our file-system based entrypoint generatio
    4. You no longer need to register the React components within the `ReactOnRails.configuration.components_subdirectory` nor directly add their bundles. For example, you can have a Rails view using three components:
 
       ```erb
-      <% append_javascript_pack('SpecialComponentNotToAutoLoadBundle') %>
+      <% append_javascript_pack_tag('SpecialComponentNotToAutoLoadBundle') %>
       <%= react_component("FooComponentOne", {}, auto_load_bundle: true) %>
       <%= react_component("BarComponentOne", {}, auto_load_bundle: true) %>
       <%= react_component("SpecialComponentNotToAutoLoadBundle", {}) %>


### PR DESCRIPTION
### Summary

Closes #1756 

Rename example “BarComponentTwo” to “SpecialComponentNotToAutoLoadBundle” in Solution section.
Add targeted cross-references to the dummy app (nested_entries, initializer, startup dir, server-bundle import).

### Pull Request checklist

_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

[x] ~Add/update test to cover these changes~
[x] Update documentation
[x] ~Update CHANGELOG file~

_Add the CHANGELOG entry at the top of the file._

### Other Information

Verified behavior with a fresh demo app to ensure examples match expected outputs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1758)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Expanded guide for file-system-based automated bundle generation with additional dummy-app examples and configuration variations (nested entries, custom source paths, startup/component subdirectory).
  - Standardized example component alias (SpecialComponentNotToAutoLoadBundle) across snippets and tags; clarified it’s illustrative only.
  - Added server bundle import example and references to ReduxApp and RouterApp.
  - IMPORTANT note on removing a generalized component when splitting client/server definitions.
  - Clarified using the feature alongside existing packs; no runtime changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->