### PR TITLE
Remove gap in page lifecycle check for setup listeners

### DIFF
--- a/node_package/src/pageLifecycle.ts
+++ b/node_package/src/pageLifecycle.ts
@@ -67,7 +67,7 @@ function initializePageEventListeners(): void {
   }
   isPageLifecycleInitialized = true;
 
-  if (document.readyState === 'complete') {
+  if (document.readyState !== 'loading') {
     setupPageNavigationListeners();
   } else {
     document.addEventListener('DOMContentLoaded', setupPageNavigationListeners);


### PR DESCRIPTION
We currently have a gap between the `DOMContentLoaded` event & `readystate === 'complete'` (which is after the `load` event), where this script could run and NOTHING happen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1771)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Page navigation listeners now initialize earlier when the document is interactive, reducing startup latency and improving responsiveness after page load.
- **Bug Fixes**
  - Prevents delayed setup that could miss early user interactions on fast-loading pages by ensuring listeners attach as soon as the DOM is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->