### PR TITLE
Show warning badge when force_load feature is enabled and RORP is not used

### DIFF
--- a/lib/react_on_rails/helper.rb
+++ b/lib/react_on_rails/helper.rb
@@ -448,8 +448,8 @@ module ReactOnRails
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
     def pro_warning_badge_if_needed(force_load)
-      return "".html_safe if !force_load && !ReactOnRails.configuration.force_load
-      return "".html_safe if ReactOnRails::Utils.react_on_rails_pro?
+      return "".html_safe unless force_load
+      return "".html_safe if ReactOnRails::Utils.react_on_rails_pro_licence_valid?
 
       warning_message = "[REACT ON RAILS] The 'force_load' feature requires a React on Rails Pro license. " \
                         "Please visit https://shakacode.com/react-on-rails-pro to learn more."

--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -7,7 +7,7 @@ require "active_support"
 require "active_support/core_ext/string"
 
 module ReactOnRails
-  module Utils
+  module Utils # rubocop:disable Metrics/ModuleLength
     TRUNCATION_FILLER = "\n... TRUNCATED #{
       Rainbow('To see the full output, set FULL_TEXT_ERRORS=true.').red
     } ...\n".freeze
@@ -211,6 +211,21 @@ module ReactOnRails
                                     else
                                       ""
                                     end
+    end
+
+    def self.react_on_rails_pro_licence_valid?
+      return @react_on_rails_pro_licence_valid if defined?(@react_on_rails_pro_licence_valid)
+
+      @react_on_rails_pro_licence_valid = begin
+        return false unless react_on_rails_pro?
+
+        # Maintain compatibility with legacy versions of React on Rails Pro:
+        # Earlier releases did not require license validation, as they were distributed as private gems.
+        # This check ensures that the method works correctly regardless of the installed version.
+        return true unless ReactOnRailsPro::Utils.respond_to?(:licence_valid?)
+
+        ReactOnRailsPro::Utils.licence_valid?
+      end
     end
 
     def self.rsc_support_enabled?

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -23,9 +23,7 @@ describe ReactOnRailsHelper do
     }
 
     allow(ReactOnRails::Utils).to receive_messages(
-      react_on_rails_pro?: true,
-      react_on_rails_pro_version: "4.0.0",
-      rsc_support_enabled?: false
+      react_on_rails_pro_licence_valid?: true
     )
   end
 
@@ -388,7 +386,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
         subject(:react_app) { react_component("App", props: props, force_load: true) }
 
         before do
-          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(false)
         end
 
         it { is_expected.to include(badge_html_string) }
@@ -403,7 +401,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
         subject(:react_app) { react_component("App", props: props) }
 
         before do
-          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(false)
         end
 
         around do |example|
@@ -419,7 +417,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
         subject(:react_app) { react_component("App", props: props, force_load: false) }
 
         before do
-          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(false)
         end
 
         it { is_expected.not_to include(badge_html_string) }
@@ -435,8 +433,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
 
         before do
           allow(ReactOnRails::Utils).to receive_messages(
-            react_on_rails_pro?: true,
-            react_on_rails_pro_version: "4.0.0"
+            react_on_rails_pro_licence_valid?: true
           )
         end
 
@@ -482,7 +479,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
         subject(:react_app) { react_component_hash("App", props: props, force_load: true) }
 
         before do
-          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(false)
         end
 
         it "adds badge to componentHtml" do
@@ -495,8 +492,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
 
         before do
           allow(ReactOnRails::Utils).to receive_messages(
-            react_on_rails_pro?: true,
-            react_on_rails_pro_version: "4.0.0"
+            react_on_rails_pro_licence_valid?: true
           )
         end
 
@@ -541,7 +537,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
         subject(:store) { redux_store("reduxStore", props: props, force_load: true) }
 
         before do
-          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(false)
         end
 
         it { is_expected.to include(badge_html_string) }
@@ -556,7 +552,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
         subject(:store) { redux_store("reduxStore", props: props, force_load: false) }
 
         before do
-          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(false)
+          allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(false)
         end
 
         it { is_expected.not_to include(badge_html_string) }
@@ -567,8 +563,7 @@ typeof ReactOnRails === 'object' && ReactOnRails.reactOnRailsComponentLoaded('Ap
 
         before do
           allow(ReactOnRails::Utils).to receive_messages(
-            react_on_rails_pro?: true,
-            react_on_rails_pro_version: "4.0.0"
+            react_on_rails_pro_licence_valid?: true
           )
         end
 


### PR DESCRIPTION
### Summary
<img width="1853" height="820" alt="image" src="https://github.com/user-attachments/assets/4b1ba2eb-a7e5-485b-b823-6c16ad12c6b3" />


_Remove this paragraph and provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together._

### Pull Request checklist

_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

_Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1780)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “React On Rails Pro Required” persistent badge overlay when force-loading features without an active Pro license; shown for server-rendered components, component-hash responses, and Redux stores, linking to Pro details and logging a warning.
- Tests
  - Expanded tests to cover badge visibility and warning logs across Pro vs non‑Pro and force_load scenarios (per-component, hash, store, and global).
- Chores
  - Improved Pro-license detection with caching to stabilize badge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->