### PR TITLE
Fix integration tests for immediate_hydration Pro license changes

### DIFF
--- a/spec/dummy/spec/system/integration_spec.rb
+++ b/spec/dummy/spec/system/integration_spec.rb
@@ -90,11 +90,18 @@ describe "Turbolinks across pages", :js do
   subject { page }
 
   it "changes name in message according to input" do
-    skip "Flaky test - needs investigation"
+    allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(true)
+
     visit "/client_side_hello_world"
     expect_change_text_in_dom_selector("#HelloWorld-react-component-0")
     click_on "Hello World Component Server Rendered, with extra options"
     expect_change_text_in_dom_selector("#my-hello-world-id")
+  end
+
+  around do |example|
+    ReactOnRails.configure { |config| config.immediate_hydration = true }
+    example.run
+    ReactOnRails.configure { |config| config.immediate_hydration = false }
   end
 end
 
@@ -102,10 +109,17 @@ describe "TurboStream send react component", :js do
   subject { page }
 
   it "force load hello-world component immediately" do
-    skip "Flaky test - needs investigation"
+    allow(ReactOnRails::Utils).to receive(:react_on_rails_pro_licence_valid?).and_return(true)
+
     visit "/turbo_frame_tag_hello_world"
     click_on "send me hello-turbo-stream component"
     expect(page).to have_text "Hello, Mrs. Client Side Rendering From Turbo Stream!"
+  end
+
+  around do |example|
+    ReactOnRails.configure { |config| config.immediate_hydration = true }
+    example.run
+    ReactOnRails.configure { |config| config.immediate_hydration = false }
   end
 end
 


### PR DESCRIPTION
### Summary

Fix two integration tests broken by immediate_hydration Pro license requirements in PR #1781. Tests were marked as `skip "Flaky test - needs investigation"` but the real issue was Pro license validation blocking immediate hydration behavior.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~ (tests already exist, just fixed)
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Uses per-test mocking approach consistent with existing helper specs. Both tests now pass reliably.