### PR TITLE
Fix ESLint import resolution errors in dummy app

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -160,6 +160,13 @@ const config = tsEslint.config([
     },
   },
   {
+    files: ['spec/dummy/**/*'],
+    rules: {
+      // The dummy app dependencies are managed separately and may not be installed
+      'import/no-unresolved': 'off',
+    },
+  },
+  {
     files: ['**/*.ts{x,}', '**/*.[cm]ts'],
 
     extends: tsEslint.configs.strictTypeChecked,


### PR DESCRIPTION
## Summary
- Disable `import/no-unresolved` rule for `spec/dummy/**` files to resolve ESLint errors

The dummy app dependencies are managed separately and may not be installed during linting, causing false positive import resolution errors.

## Changes
- Added ESLint rule override in `eslint.config.ts` for `spec/dummy/**` pattern

## Test plan
- [x] Verify `bundle exec rubocop` passes with no offenses
- [x] Verify `yarn run lint` (ESLint) passes with no errors  
- [x] Verify `npx nps format.listDifferent` shows all files are properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1793)
<!-- Reviewable:end -->
