### PR TITLE
Fix doctor rake task LoadError with excluded task_helpers

### DIFF
--- a/lib/tasks/doctor.rake
+++ b/lib/tasks/doctor.rake
@@ -37,7 +37,6 @@ rescue LoadError
 end
 
 namespace :react_on_rails do
-
   desc "Diagnose React on Rails setup and configuration"
   task :doctor do
     verbose = ENV["VERBOSE"] == "true"

--- a/lib/tasks/doctor.rake
+++ b/lib/tasks/doctor.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../rakelib/task_helpers"
 require_relative "../react_on_rails"
 require_relative "../react_on_rails/doctor"
 
@@ -38,7 +37,6 @@ rescue LoadError
 end
 
 namespace :react_on_rails do
-  include ReactOnRails::TaskHelpers
 
   desc "Diagnose React on Rails setup and configuration"
   task :doctor do

--- a/spec/lib/react_on_rails/doctor_rake_task_spec.rb
+++ b/spec/lib/react_on_rails/doctor_rake_task_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe "doctor rake task" do
       expect(Rake::Task.task_defined?("react_on_rails:doctor")).to be true
     end
 
+    it "can be loaded without requiring missing task_helpers" do
+      # This test ensures the rake file doesn't try to require excluded files
+      # that would cause LoadError in packaged gems
+      expect { load rake_file }.not_to raise_error
+    end
+
     it "can be invoked without errors" do
       # Mock the Doctor class to avoid actual diagnosis
       doctor_instance = instance_double(ReactOnRails::Doctor)


### PR DESCRIPTION
## Summary
Fixes LoadError in the `rake react_on_rails:doctor` task when using the packaged gem due to reference to excluded `rakelib/task_helpers`.

## Problem
- The `lib/tasks/doctor.rake` file (added in commit 27dba50b) was trying to require `"../../rakelib/task_helpers"`
- The `rakelib` directory has been excluded from gem packaging in the gemspec since commit 2c04db6f (1.5+ years ago)
- This caused `LoadError: cannot load such file -- rakelib/task_helpers` when using the packaged gem

## Solution
- Remove the unnecessary `require_relative "../../rakelib/task_helpers"` line from `doctor.rake`
- Remove the unused `include ReactOnRails::TaskHelpers` line
- Add test to verify the rake file can be loaded without missing dependencies

## Testing
- Added specific test case: "can be loaded without requiring missing task_helpers"
- Verified `rake react_on_rails:doctor` works correctly after the fix
- All existing tests pass

The doctor task functionality is fully preserved - it was not actually using anything from the excluded TaskHelpers module.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1795)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a loading error so the Doctor rake task no longer fails in packaged installations due to a missing helper dependency; task loads and runs reliably with existing options unchanged.

* **Tests**
  * Added test coverage to ensure the rake task loads and can be invoked without the helper dependency, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->