### PR TITLE
Fix broken RSC documentation link in Pro docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    react_on_rails (16.0.1.rc.0)
+    react_on_rails (16.0.1.rc.2)
       addressable
       connection_pool
       execjs (~> 2.5)

--- a/docs/react-on-rails-pro/react-on-rails-pro.md
+++ b/docs/react-on-rails-pro/react-on-rails-pro.md
@@ -22,7 +22,7 @@ See https://www.shakacode.com/react-on-rails-pro/docs/.
 
 ### Pro: React Server Components
 
-See the [announcement here](./react-server-components.md).
+See the [performance breakthroughs guide here](./major-performance-breakthroughs-upgrade-guide.md).
 
 Yes! Big performance gains for the newest React features!
 


### PR DESCRIPTION
### Summary

Fixed broken link to `react-server-components.md` in Pro documentation. The file was deleted and merged into `major-performance-breakthroughs-upgrade-guide.md` in commit 30a41c1f, but the link wasn't updated.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~ (Not applicable - documentation only)
- [x] Update documentation
- [ ] Update CHANGELOG file

### Other Information

This fixes a 404 link reported by Justin in the React on Rails Pro documentation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1799)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Pro: React Server Components” section to link to the Performance Breakthroughs guide, improving clarity and directing readers to the most up-to-date resource.
  * Surrounding content remains unchanged; no behavioral or UI impact.
  * Enhances discoverability for users seeking optimization insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->