### PR TITLE
Fix Shakapacker version requirement from 8.2.0 to 8.0.0 for basic compatibility

### DIFF
--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -180,7 +180,7 @@ module ReactOnRails
         1. Use :sync or :defer loading strategy instead of :async
         2. Upgrade to Shakapacker v8.2.0 or above to enable async script loading
       MSG
-      if PackerUtils.shakapacker_version_requirement_met?("8.2.0")
+      if PackerUtils.supports_async_loading?
         self.generated_component_packs_loading_strategy ||= :async
       elsif generated_component_packs_loading_strategy.nil?
         Rails.logger.warn("**WARNING** #{msg}")

--- a/lib/react_on_rails/packer_utils.rb
+++ b/lib/react_on_rails/packer_utils.rb
@@ -10,7 +10,7 @@ module ReactOnRails
       return @using_shakapacker_const if defined?(@using_shakapacker_const)
 
       @using_shakapacker_const = ReactOnRails::Utils.gem_available?("shakapacker") &&
-                                 shakapacker_version_requirement_met?("8.2.0")
+                                 shakapacker_version_requirement_met?("8.0.0")
     end
 
     def self.packer_type
@@ -54,6 +54,16 @@ module ReactOnRails
 
     def self.shakapacker_version_requirement_met?(required_version)
       Gem::Version.new(shakapacker_version) >= Gem::Version.new(required_version)
+    end
+
+    def self.supports_async_loading?
+      using_shakapacker_const? && shakapacker_version_requirement_met?("8.2.0")
+    end
+
+    def self.supports_auto_registration?
+      using_shakapacker_const? &&
+        packer.config.respond_to?(:nested_entries?) &&
+        shakapacker_version_requirement_met?("7.0.0")
     end
 
     # This returns either a URL for the webpack-dev-server, non-server bundle or

--- a/lib/react_on_rails/system_checker.rb
+++ b/lib/react_on_rails/system_checker.rb
@@ -619,13 +619,13 @@ module ReactOnRails
 
           begin
             # Use proper semantic version comparison
-            version_obj = Gem::Version.new(version)
-            threshold_version = Gem::Version.new("8.2")
+            Gem::Version.new(version)
+            Gem::Version.new("8.2")
 
-            if version_obj >= threshold_version
+            if ReactOnRails::PackerUtils.supports_auto_registration?
               add_success("✅ Shakapacker #{version} (supports React on Rails auto-registration)")
             else
-              add_warning("⚠️  Shakapacker #{version} - Version 8.2+ needed for React on Rails auto-registration")
+              add_warning("⚠️  Shakapacker #{version} - Version 7.0+ needed for React on Rails auto-registration")
             end
           rescue ArgumentError
             # Fallback for invalid version strings

--- a/spec/react_on_rails/packer_utils_spec.rb
+++ b/spec/react_on_rails/packer_utils_spec.rb
@@ -76,5 +76,89 @@ module ReactOnRails
         end
       end
     end
+
+    describe ".supports_async_loading?" do
+      it "returns true when using Shakapacker >= 8.2.0" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(true)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("8.2.0").and_return(true)
+
+        expect(described_class.supports_async_loading?).to be(true)
+      end
+
+      it "returns false when using Shakapacker < 8.2.0" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(true)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("8.2.0").and_return(false)
+
+        expect(described_class.supports_async_loading?).to be(false)
+      end
+
+      it "returns false when not using Shakapacker" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(false)
+
+        expect(described_class.supports_async_loading?).to be(false)
+      end
+    end
+
+    describe ".supports_auto_registration?" do
+      let(:mock_config) { instance_double(Config) }
+      let(:mock_packer) { instance_double(Packer, config: mock_config) }
+
+      before do
+        allow(described_class).to receive(:packer).and_return(mock_packer)
+      end
+
+      it "returns true when using Shakapacker >= 7.0.0 with nested_entries support" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(true)
+        allow(mock_config).to receive(:respond_to?).with(:nested_entries?).and_return(true)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("7.0.0").and_return(true)
+
+        expect(described_class.supports_auto_registration?).to be(true)
+      end
+
+      it "returns false when using Shakapacker < 7.0.0" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(true)
+        allow(mock_config).to receive(:respond_to?).with(:nested_entries?).and_return(true)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("7.0.0").and_return(false)
+
+        expect(described_class.supports_auto_registration?).to be(false)
+      end
+
+      it "returns false when nested_entries method is not available" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(true)
+        allow(mock_config).to receive(:respond_to?).with(:nested_entries?).and_return(false)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("7.0.0").and_return(true)
+
+        expect(described_class.supports_auto_registration?).to be(false)
+      end
+
+      it "returns false when not using Shakapacker" do
+        allow(described_class).to receive(:using_shakapacker_const?).and_return(false)
+
+        expect(described_class.supports_auto_registration?).to be(false)
+      end
+    end
+
+    describe ".using_shakapacker_const?" do
+      before do
+        # Clear memoized value to ensure tests are isolated
+        if described_class.instance_variable_defined?(:@using_shakapacker_const)
+          described_class.remove_instance_variable(:@using_shakapacker_const)
+        end
+      end
+
+      it "requires Shakapacker >= 8.0.0 instead of 8.2.0" do
+        allow(ReactOnRails::Utils).to receive(:gem_available?).with("shakapacker").and_return(true)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("8.0.0").and_return(true)
+
+        expect(described_class.using_shakapacker_const?).to be(true)
+      end
+
+      it "returns false when Shakapacker < 8.0.0" do
+        allow(ReactOnRails::Utils).to receive(:gem_available?).with("shakapacker").and_return(true)
+        allow(described_class).to receive(:shakapacker_version_requirement_met?).with("8.0.0").and_return(false)
+
+        expect(described_class.using_shakapacker_const?).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

React on Rails 16 artificially required Shakapacker >= 8.2.0 for ALL functionality, causing the `:clean` task error when using Shakapacker 8.0.0. The 8.2.0 requirement is only needed for async script loading, not basic compatibility.

This was causing Docker build failures with:
```
Don't know how to build task ':clean'
```

## Root Cause

The issue was that `ReactOnRails::PackerUtils.packer_type` returned `nil` with Shakapacker < 8.2.0, causing React on Rails to try invoking `:clean` instead of `shakapacker:clean`.

## Solution

1. **Reduced basic compatibility requirement** from 8.2.0 to 8.0.0 in `using_shakapacker_const?`
2. **Added feature-specific methods**:
   - `supports_async_loading?` - checks Shakapacker >= 8.2.0 for async script loading
   - `supports_auto_registration?` - checks Shakapacker >= 7.0.0 + nested_entries support
3. **Updated configuration logic** to use feature-specific detection
4. **Updated system checker** to use proper feature detection methods

## Impact

- ✅ **Fixes Docker build failure**: `Don't know how to build task ':clean'`
- ✅ **Allows React on Rails 16 to work with Shakapacker 8.0.0** for basic functionality
- ✅ **Shows helpful warnings instead of fatal errors** for missing features
- ✅ **Maintains backward compatibility** while enabling gradual upgrades

## Testing

- All existing tests pass
- Added comprehensive test coverage for new methods
- Verified `assets:precompile` works with Shakapacker 8.0.0
- Confirmed proper `shakapacker:clean` task invocation

## Before/After

**Before (with Shakapacker 8.0.0):**
```
bin/rails aborted!
Don't know how to build task ':clean'
```

**After (with Shakapacker 8.0.0):**
```
Invoking task shakapacker:clean from React on Rails
assets compiled successfully
```

This eliminates the artificial breaking change that was forcing unnecessary Shakapacker upgrades.

🤖 Generated with [Claude Code](https://claude.ai/code)