### PR TITLE
Fix packs generator error when server_bundle_js_file is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ After a release, please make sure to run `bundle exec rake update_changelog`. Th
 
 Changes since the last non-beta release.
 
+#### Bug Fixes
+
+- **Packs generator**: Fixed error when `server_bundle_js_file` configuration is empty (default). Added safety check to prevent attempting operations on invalid file paths when server-side rendering is not configured. [PR 1802](https://github.com/shakacode/react_on_rails/pull/1802)
+
 ### [16.0.1-rc.2] - 2025-09-20
 
 #### Bug Fixes

--- a/lib/react_on_rails/packs_generator.rb
+++ b/lib/react_on_rails/packs_generator.rb
@@ -164,6 +164,7 @@ module ReactOnRails
 
     def add_generated_pack_to_server_bundle
       return if ReactOnRails.configuration.make_generated_server_bundle_the_entrypoint
+      return if ReactOnRails.configuration.server_bundle_js_file.empty?
 
       relative_path_to_generated_server_bundle = relative_path(server_bundle_entrypoint,
                                                                generated_server_bundle_file_path)


### PR DESCRIPTION
## Summary
- Add safety check to prevent PacksGenerator from attempting operations on invalid file paths when `server_bundle_js_file` is not configured
- Fixes potential errors when server-side rendering is not enabled (default configuration)

## Problem
When `server_bundle_js_file` is empty (the default), the `add_generated_pack_to_server_bundle` method would:
1. Call `server_bundle_entrypoint` which joins the source path with an empty string
2. Create a malformed file path 
3. Potentially attempt operations on non-existent files

## Solution
Added `return if ReactOnRails.configuration.server_bundle_js_file.empty?` check, following the existing pattern used elsewhere in the class where `server_bundle_js_file.present?` is checked before operations.

## Test plan
- [x] All existing tests pass
- [x] RuboCop linting passes
- [x] Follows existing code patterns in the same class

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1802)
<!-- Reviewable:end -->
