### PR TITLE
Add server bundle security features for private bundle locations

### DIFF
--- a/spec/react_on_rails/configuration_spec.rb
+++ b/spec/react_on_rails/configuration_spec.rb
@@ -459,6 +459,67 @@ module ReactOnRails
         end
       end
     end
+
+    describe "server bundle security configuration" do
+      before do
+        allow(Rails).to receive(:root).and_return(Pathname.new("/app"))
+      end
+
+      describe ".server_bundle_output_path" do
+        it "has default value of nil" do
+          ReactOnRails.configure {} # rubocop:disable Lint/EmptyBlock
+          expect(ReactOnRails.configuration.server_bundle_output_path).to be_nil
+        end
+
+        it "accepts custom path" do
+          ReactOnRails.configure do |config|
+            config.server_bundle_output_path = "app/assets/builds"
+          end
+          expect(ReactOnRails.configuration.server_bundle_output_path).to eq("app/assets/builds")
+        end
+      end
+
+      describe ".enforce_private_server_bundles" do
+        it "has default value of false" do
+          ReactOnRails.configure {} # rubocop:disable Lint/EmptyBlock
+          expect(ReactOnRails.configuration.enforce_private_server_bundles).to be(false)
+        end
+
+        it "accepts true value" do
+          ReactOnRails.configure do |config|
+            config.server_bundle_output_path = "app/assets/builds"
+            config.enforce_private_server_bundles = true
+          end
+          expect(ReactOnRails.configuration.enforce_private_server_bundles).to be(true)
+        end
+
+        it "raises error when enabled without server_bundle_output_path" do
+          expect do
+            ReactOnRails.configure do |config|
+              config.enforce_private_server_bundles = true
+            end
+          end.to raise_error(ReactOnRails::Error, /server_bundle_output_path is nil/)
+        end
+
+        it "raises error when server_bundle_output_path is inside public directory" do
+          expect do
+            ReactOnRails.configure do |config|
+              config.server_bundle_output_path = "public/webpack"
+              config.enforce_private_server_bundles = true
+            end
+          end.to raise_error(ReactOnRails::Error, /is inside the public directory/)
+        end
+
+        it "allows server_bundle_output_path outside public directory" do
+          expect do
+            ReactOnRails.configure do |config|
+              config.server_bundle_output_path = "app/assets/builds"
+              config.enforce_private_server_bundles = true
+            end
+          end.not_to raise_error
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

This PR adds server bundle security features to prevent server bundles from being served from public directories, addressing security concerns around server-side rendering code exposure.

• **Add `server_bundle_output_path` configuration** - Allows specifying private locations for server bundles (e.g., `app/assets/builds`)
• **Add `enforce_private_server_bundles` security option** - When enabled, prevents fallback to public paths for server bundles
• **Improve bundle path resolution** - Enhanced logic to check for server bundles in configured private locations first
• **Add comprehensive validation** - Ensures server bundles are outside public directory when enforcement is enabled
• **Maintain backwards compatibility** - All defaults preserve existing behavior

## Security Benefits

- Server bundles can be kept in private directories inaccessible via web requests
- Prevents accidental exposure of server-side rendering code and business logic
- Configurable enforcement allows gradual adoption in existing applications

## Configuration Example

```ruby
# config/initializers/react_on_rails.rb
ReactOnRails.configure do |config|
  config.server_bundle_output_path = "app/assets/builds"
  config.enforce_private_server_bundles = true
end
```

## Test Plan

- [x] All existing tests pass
- [x] New configuration validation tests added
- [x] Security enforcement behavior tested
- [x] Backwards compatibility verified
- [x] RuboCop compliance maintained

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1805)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added settings to configure a private output location for server bundles and optionally enforce keeping them outside public assets.
  - Supports resolving server bundle paths directly when a private path is set.

- Refactor
  - Improved path resolution and fallback behavior for missing manifest entries, with stricter handling for server bundles when enforcement is enabled.

- Tests
  - Added tests covering server bundle configuration defaults, custom paths, enforcement validation, and public-directory restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->