### PR TITLE
Fix RuboCop workflow issues and warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
   NewCops: enable
   DisplayCopNames: true
   TargetRubyVersion: 3.0.0
+  SuggestExtensions: false
 
   Include:
     - '**/Rakefile'

--- a/Gemfile.development_dependencies
+++ b/Gemfile.development_dependencies
@@ -39,6 +39,10 @@ group :development, :test do
   gem "scss_lint", require: false
   gem "spring", "~> 4.0"
   gem "lefthook", require: false
+  # Added for Ruby 3.5+ compatibility to silence warnings
+  gem "benchmark", require: false
+  gem "logger", require: false
+  gem "ostruct", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     amazing_print (1.6.0)
     ast (2.4.2)
     base64 (0.2.0)
+    benchmark (0.4.1)
     bigdecimal (3.1.8)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -160,6 +161,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -189,6 +191,7 @@ GEM
     nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    ostruct (0.6.1)
     package_json (0.1.0)
     parallel (1.24.0)
     parser (3.3.1.0)
@@ -402,6 +405,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
+  benchmark
   bootsnap
   capybara
   capybara-screenshot
@@ -415,6 +419,8 @@ DEPENDENCIES
   launchy
   lefthook
   listen
+  logger
+  ostruct
   package_json
   pry
   pry-byebug


### PR DESCRIPTION
## Summary
Fixes RuboCop workflow issues and eliminates warnings for cleaner development experience.

## Issues Fixed
1. **Eliminated suggestion warnings**: Added `SuggestExtensions: false` to disable unnecessary rubocop-capybara/factory_bot/rspec_rails suggestions
2. **Ruby 3.5+ compatibility**: Added benchmark, logger, ostruct gems to silence deprecation warnings about gems moving out of stdlib  
3. **Cleaner RuboCop output**: No more tip messages or warnings during execution

## Changes
- **Updated .rubocop.yml**: Added `SuggestExtensions: false` 
- **Updated Gemfile.development_dependencies**: Added `benchmark`, `logger`, `ostruct` gems for Ruby 3.5+ compatibility

## Before
```
138 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)
  * rubocop-factory_bot (https://rubygems.org/gems/rubocop-factory_bot)
  * rubocop-rspec_rails (https://rubygems.org/gems/rubocop-rspec_rails)

/Users/justin/.asdf/installs/ruby/3.4.3/lib/ruby/gems/3.4.0/gems/rubocop-1.61.0/exe/rubocop:14: warning: benchmark was loaded from the standard library...
```

## After  
```
138 files inspected, no offenses detected
```

## Benefits
- ✅ Clean RuboCop execution without distracting warnings
- ✅ Forward compatibility with Ruby 3.5+  
- ✅ Better developer experience during linting
- ✅ Maintains all existing functionality and test coverage

## Testing
- [x] All RuboCop checks pass cleanly without warnings
- [x] All existing RSpec tests continue to pass  
- [x] Pre-commit and pre-push hooks work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1810)
<!-- Reviewable:end -->
