### PR TITLE
refactor: Extract JS dependency management into shared module

### DIFF
--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -4,10 +4,12 @@ require "rails/generators"
 require "fileutils"
 require_relative "generator_messages"
 require_relative "generator_helper"
+require_relative "js_dependency_manager"
 module ReactOnRails
   module Generators
     class BaseGenerator < Rails::Generators::Base
       include GeneratorHelper
+      include JsDependencyManager
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
@@ -95,6 +97,10 @@ module ReactOnRails
         run "bundle"
       end
 
+      def add_js_dependencies
+        setup_js_dependencies
+      end
+
       def update_gitignore_for_auto_registration
         gitignore_path = File.join(destination_root, ".gitignore")
         return unless File.exist?(gitignore_path)
@@ -133,123 +139,6 @@ module ReactOnRails
       STR
 
       private
-
-      def setup_js_dependencies
-        add_js_dependencies
-        install_js_dependencies
-      end
-
-      def add_js_dependencies
-        add_react_on_rails_package
-        add_react_dependencies
-        add_css_dependencies
-        add_dev_dependencies
-      end
-
-      def add_react_on_rails_package
-        major_minor_patch_only = /\A\d+\.\d+\.\d+\z/
-
-        # Try to use package_json gem first, fall back to direct npm commands
-        react_on_rails_pkg = if ReactOnRails::VERSION.match?(major_minor_patch_only)
-                               ["react-on-rails@#{ReactOnRails::VERSION}"]
-                             else
-                               puts "Adding the latest react-on-rails NPM module. " \
-                                    "Double check this is correct in package.json"
-                               ["react-on-rails"]
-                             end
-
-        puts "Installing React on Rails package..."
-        return if add_npm_dependencies(react_on_rails_pkg)
-
-        puts "Using direct npm commands as fallback"
-        success = system("npm", "install", *react_on_rails_pkg)
-        handle_npm_failure("react-on-rails package", react_on_rails_pkg) unless success
-      end
-
-      def add_react_dependencies
-        puts "Installing React dependencies..."
-        react_deps = %w[
-          react
-          react-dom
-          @babel/preset-react
-          prop-types
-          babel-plugin-transform-react-remove-prop-types
-          babel-plugin-macros
-        ]
-        return if add_npm_dependencies(react_deps)
-
-        success = system("npm", "install", *react_deps)
-        handle_npm_failure("React dependencies", react_deps) unless success
-      end
-
-      def add_css_dependencies
-        puts "Installing CSS handling dependencies..."
-        css_deps = %w[
-          css-loader
-          css-minimizer-webpack-plugin
-          mini-css-extract-plugin
-          style-loader
-        ]
-        return if add_npm_dependencies(css_deps)
-
-        success = system("npm", "install", *css_deps)
-        handle_npm_failure("CSS dependencies", css_deps) unless success
-      end
-
-      def add_dev_dependencies
-        puts "Installing development dependencies..."
-        dev_deps = %w[
-          @pmmmwh/react-refresh-webpack-plugin
-          react-refresh
-        ]
-        return if add_npm_dependencies(dev_deps, dev: true)
-
-        success = system("npm", "install", "--save-dev", *dev_deps)
-        handle_npm_failure("development dependencies", dev_deps, dev: true) unless success
-      end
-
-      def install_js_dependencies
-        # Detect which package manager to use
-        success = if File.exist?(File.join(destination_root, "yarn.lock"))
-                    system("yarn", "install")
-                  elsif File.exist?(File.join(destination_root, "pnpm-lock.yaml"))
-                    system("pnpm", "install")
-                  elsif File.exist?(File.join(destination_root, "package-lock.json")) ||
-                        File.exist?(File.join(destination_root, "package.json"))
-                    # Use npm for package-lock.json or as default fallback
-                    system("npm", "install")
-                  else
-                    true # No package manager detected, skip
-                  end
-
-        unless success
-          GeneratorMessages.add_warning(<<~MSG.strip)
-            ⚠️  JavaScript dependencies installation failed.
-
-            This could be due to network issues or missing package manager.
-            You can install dependencies manually later by running:
-            • npm install (if using npm)
-            • yarn install (if using yarn)
-            • pnpm install (if using pnpm)
-          MSG
-        end
-
-        success
-      end
-
-      def handle_npm_failure(dependency_type, packages, dev: false)
-        install_command = dev ? "npm install --save-dev" : "npm install"
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to install #{dependency_type}.
-
-          The following packages could not be installed automatically:
-          #{packages.map { |pkg| "  • #{pkg}" }.join("\n")}
-
-          This could be due to network issues or missing package manager.
-          You can install them manually later by running:
-            #{install_command} #{packages.join(' ')}
-        MSG
-      end
 
       def copy_webpack_main_config(base_path, config)
         webpack_config_path = "config/webpack/webpack.config.js"

--- a/lib/generators/react_on_rails/install_generator.rb
+++ b/lib/generators/react_on_rails/install_generator.rb
@@ -4,12 +4,14 @@ require "rails/generators"
 require "json"
 require_relative "generator_helper"
 require_relative "generator_messages"
+require_relative "js_dependency_manager"
 
 module ReactOnRails
   module Generators
     # rubocop:disable Metrics/ClassLength
     class InstallGenerator < Rails::Generators::Base
       include GeneratorHelper
+      include JsDependencyManager
 
       # fetch USAGE file for details generator description
       source_root(File.expand_path(__dir__))
@@ -83,10 +85,7 @@ module ReactOnRails
       end
 
       def setup_react_dependencies
-        @added_dependencies_to_package_json ||= false
-        @ran_direct_installs ||= false
-        add_js_dependencies
-        install_js_dependencies if @added_dependencies_to_package_json && !@ran_direct_installs
+        setup_js_dependencies
       end
 
       # NOTE: other requirements for existing files such as .gitignore or application.
@@ -346,11 +345,17 @@ module ReactOnRails
         ]
 
         # Try using GeneratorHelper first (package manager agnostic)
-        return if add_npm_dependencies(typescript_packages, dev: true)
+        if add_npm_dependencies(typescript_packages, dev: true)
+          @added_dependencies_to_package_json = true
+          return
+        end
 
         # Fallback to npm if GeneratorHelper fails
         success = system("npm", "install", "--save-dev", *typescript_packages)
-        return if success
+        if success
+          @ran_direct_installs = true
+          return
+        end
 
         warning = <<~MSG.strip
           ⚠️  Failed to install TypeScript dependencies automatically.
@@ -418,134 +423,6 @@ module ReactOnRails
 
         File.write("tsconfig.json", JSON.pretty_generate(tsconfig_content))
         puts Rainbow("✅ Created tsconfig.json").green
-      end
-
-      def add_js_dependencies
-        add_react_on_rails_package
-        add_react_dependencies
-        add_css_dependencies
-        add_dev_dependencies
-      end
-
-      def add_react_on_rails_package
-        major_minor_patch_only = /\A\d+\.\d+\.\d+\z/
-
-        # Try to use package_json gem first, fall back to direct npm commands
-        react_on_rails_pkg = if ReactOnRails::VERSION.match?(major_minor_patch_only)
-                               ["react-on-rails@#{ReactOnRails::VERSION}"]
-                             else
-                               puts "Adding the latest react-on-rails NPM module. " \
-                                    "Double check this is correct in package.json"
-                               ["react-on-rails"]
-                             end
-
-        puts "Installing React on Rails package..."
-        if add_npm_dependencies(react_on_rails_pkg)
-          @added_dependencies_to_package_json = true
-          return
-        end
-
-        puts "Using direct npm commands as fallback"
-        success = system("npm", "install", *react_on_rails_pkg)
-        @ran_direct_installs = true if success
-        handle_npm_failure("react-on-rails package", react_on_rails_pkg) unless success
-      end
-
-      def add_react_dependencies
-        puts "Installing React dependencies..."
-        react_deps = %w[
-          react
-          react-dom
-          @babel/preset-react
-          prop-types
-          babel-plugin-transform-react-remove-prop-types
-          babel-plugin-macros
-        ]
-        if add_npm_dependencies(react_deps)
-          @added_dependencies_to_package_json = true
-          return
-        end
-
-        success = system("npm", "install", *react_deps)
-        @ran_direct_installs = true if success
-        handle_npm_failure("React dependencies", react_deps) unless success
-      end
-
-      def add_css_dependencies
-        puts "Installing CSS handling dependencies..."
-        css_deps = %w[
-          css-loader
-          css-minimizer-webpack-plugin
-          mini-css-extract-plugin
-          style-loader
-        ]
-        if add_npm_dependencies(css_deps)
-          @added_dependencies_to_package_json = true
-          return
-        end
-
-        success = system("npm", "install", *css_deps)
-        @ran_direct_installs = true if success
-        handle_npm_failure("CSS dependencies", css_deps) unless success
-      end
-
-      def add_dev_dependencies
-        puts "Installing development dependencies..."
-        dev_deps = %w[
-          @pmmmwh/react-refresh-webpack-plugin
-          react-refresh
-        ]
-        if add_npm_dependencies(dev_deps, dev: true)
-          @added_dependencies_to_package_json = true
-          return
-        end
-
-        success = system("npm", "install", "--save-dev", *dev_deps)
-        @ran_direct_installs = true if success
-        handle_npm_failure("development dependencies", dev_deps, dev: true) unless success
-      end
-
-      def install_js_dependencies
-        # Detect which package manager to use
-        success = if File.exist?(File.join(destination_root, "yarn.lock"))
-                    system("yarn", "install")
-                  elsif File.exist?(File.join(destination_root, "pnpm-lock.yaml"))
-                    system("pnpm", "install")
-                  elsif File.exist?(File.join(destination_root, "package-lock.json")) ||
-                        File.exist?(File.join(destination_root, "package.json"))
-                    # Use npm for package-lock.json or as default fallback
-                    system("npm", "install")
-                  else
-                    true # No package manager detected, skip
-                  end
-
-        unless success
-          GeneratorMessages.add_warning(<<~MSG.strip)
-            ⚠️  JavaScript dependencies installation failed.
-
-            This could be due to network issues or missing package manager.
-            You can install dependencies manually later by running:
-            • npm install (if using npm)
-            • yarn install (if using yarn)
-            • pnpm install (if using pnpm)
-          MSG
-        end
-
-        success
-      end
-
-      def handle_npm_failure(dependency_type, packages, dev: false)
-        install_command = dev ? "npm install --save-dev" : "npm install"
-        GeneratorMessages.add_warning(<<~MSG.strip)
-          ⚠️  Failed to install #{dependency_type}.
-
-          The following packages could not be installed automatically:
-          #{packages.map { |pkg| "  • #{pkg}" }.join("\n")}
-
-          This could be due to network issues or missing package manager.
-          You can install them manually later by running:
-            #{install_command} #{packages.join(' ')}
-        MSG
       end
 
       # Removed: Shakapacker auto-installation logic (now explicit dependency)

--- a/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require_relative "generator_messages"
+
+module ReactOnRails
+  module Generators
+    # Shared module for managing JavaScript dependencies across generators
+    # This module provides common functionality for adding and installing
+    # JS dependencies to avoid code duplication between generators.
+    module JsDependencyManager
+      private
+
+      def setup_js_dependencies
+        @added_dependencies_to_package_json ||= false
+        @ran_direct_installs ||= false
+        add_js_dependencies
+        install_js_dependencies if @added_dependencies_to_package_json && !@ran_direct_installs
+      end
+
+      def add_js_dependencies
+        add_react_on_rails_package
+        add_react_dependencies
+        add_css_dependencies
+        add_dev_dependencies
+      end
+
+      def add_react_on_rails_package
+        major_minor_patch_only = /\A\d+\.\d+\.\d+\z/
+
+        # Try to use package_json gem first, fall back to direct npm commands
+        react_on_rails_pkg = if ReactOnRails::VERSION.match?(major_minor_patch_only)
+                               ["react-on-rails@#{ReactOnRails::VERSION}"]
+                             else
+                               puts "Adding the latest react-on-rails NPM module. " \
+                                    "Double check this is correct in package.json"
+                               ["react-on-rails"]
+                             end
+
+        puts "Installing React on Rails package..."
+        if add_npm_dependencies(react_on_rails_pkg)
+          @added_dependencies_to_package_json = true
+          return
+        end
+
+        puts "Using direct npm commands as fallback"
+        success = system("npm", "install", *react_on_rails_pkg)
+        @ran_direct_installs = true if success
+        handle_npm_failure("react-on-rails package", react_on_rails_pkg) unless success
+      end
+
+      def add_react_dependencies
+        puts "Installing React dependencies..."
+        react_deps = %w[
+          react
+          react-dom
+          @babel/preset-react
+          prop-types
+          babel-plugin-transform-react-remove-prop-types
+          babel-plugin-macros
+        ]
+        if add_npm_dependencies(react_deps)
+          @added_dependencies_to_package_json = true
+          return
+        end
+
+        success = system("npm", "install", *react_deps)
+        @ran_direct_installs = true if success
+        handle_npm_failure("React dependencies", react_deps) unless success
+      end
+
+      def add_css_dependencies
+        puts "Installing CSS handling dependencies..."
+        css_deps = %w[
+          css-loader
+          css-minimizer-webpack-plugin
+          mini-css-extract-plugin
+          style-loader
+        ]
+        if add_npm_dependencies(css_deps)
+          @added_dependencies_to_package_json = true
+          return
+        end
+
+        success = system("npm", "install", *css_deps)
+        @ran_direct_installs = true if success
+        handle_npm_failure("CSS dependencies", css_deps) unless success
+      end
+
+      def add_dev_dependencies
+        puts "Installing development dependencies..."
+        dev_deps = %w[
+          @pmmmwh/react-refresh-webpack-plugin
+          react-refresh
+        ]
+        if add_npm_dependencies(dev_deps, dev: true)
+          @added_dependencies_to_package_json = true
+          return
+        end
+
+        success = system("npm", "install", "--save-dev", *dev_deps)
+        @ran_direct_installs = true if success
+        handle_npm_failure("development dependencies", dev_deps, dev: true) unless success
+      end
+
+      def install_js_dependencies
+        # Detect which package manager to use
+        success = if File.exist?(File.join(destination_root, "yarn.lock"))
+                    system("yarn", "install")
+                  elsif File.exist?(File.join(destination_root, "pnpm-lock.yaml"))
+                    system("pnpm", "install")
+                  elsif File.exist?(File.join(destination_root, "package-lock.json")) ||
+                        File.exist?(File.join(destination_root, "package.json"))
+                    # Use npm for package-lock.json or as default fallback
+                    system("npm", "install")
+                  else
+                    true # No package manager detected, skip
+                  end
+
+        unless success
+          GeneratorMessages.add_warning(<<~MSG.strip)
+            ⚠️  JavaScript dependencies installation failed.
+
+            This could be due to network issues or missing package manager.
+            You can install dependencies manually later by running:
+            • npm install (if using npm)
+            • yarn install (if using yarn)
+            • pnpm install (if using pnpm)
+          MSG
+        end
+
+        success
+      end
+
+      def handle_npm_failure(dependency_type, packages, dev: false)
+        install_command = dev ? "npm install --save-dev" : "npm install"
+        GeneratorMessages.add_warning(<<~MSG.strip)
+          ⚠️  Failed to install #{dependency_type}.
+
+          The following packages could not be installed automatically:
+          #{packages.map { |pkg| "  • #{pkg}" }.join("\n")}
+
+          This could be due to network issues or missing package manager.
+          You can install them manually later by running:
+            #{install_command} #{packages.join(' ')}
+        MSG
+      end
+    end
+  end
+end

--- a/spec/react_on_rails/generators/message_deduplication_spec.rb
+++ b/spec/react_on_rails/generators/message_deduplication_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require_relative "../support/generator_spec_helper"
+require_relative "../support/version_test_helpers"
+
+describe "Message Deduplication", type: :generator do
+  include GeneratorSpec::TestCase
+
+  destination File.expand_path("../dummy-for-generators", __dir__)
+
+  describe "Post-install message handling" do
+    before do
+      # Clear any previous messages to ensure clean test state
+      GeneratorMessages.clear
+      # Mock Shakapacker installation to succeed
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("bin/shakapacker").and_return(true)
+      allow(File).to receive(:exist?).with("bin/shakapacker-dev-server").and_return(true)
+      allow(File).to receive(:exist?).with("config/shakapacker.yml").and_return(true)
+      allow(File).to receive(:exist?).with("config/webpack/webpack.config.js").and_return(true)
+    end
+
+    context "with non-Redux installation" do
+      it "shows the success message exactly once" do
+        run_generator_test_with_args(%w[], package_json: true)
+        output_text = GeneratorMessages.output.join("\n")
+
+        # Count occurrences of the success message
+        success_count = output_text.scan("🎉 React on Rails Successfully Installed!").count
+        expect(success_count).to eq(1),
+          "Expected success message to appear exactly once, but appeared #{success_count} times"
+
+        # Ensure post-install message components are present
+        expect(output_text).to include("📋 QUICK START:")
+        expect(output_text).to include("✨ KEY FEATURES:")
+      end
+    end
+
+    context "with Redux installation" do
+      it "shows the success message exactly once" do
+        run_generator_test_with_args(%w[--redux], package_json: true)
+        output_text = GeneratorMessages.output.join("\n")
+
+        # Count occurrences of the success message
+        success_count = output_text.scan("🎉 React on Rails Successfully Installed!").count
+        expect(success_count).to eq(1),
+          "Expected success message to appear exactly once with Redux, but appeared #{success_count} times"
+
+        # Ensure post-install message components are present
+        expect(output_text).to include("📋 QUICK START:")
+        expect(output_text).to include("✨ KEY FEATURES:")
+
+        # The message should be from the Redux generator, containing Redux-specific info
+        expect(output_text).to include("HelloWorldApp")
+      end
+    end
+  end
+
+  describe "NPM install execution" do
+    let(:install_generator) { InstallGenerator.new }
+
+    before do
+      # Mock the system to track NPM install calls
+      allow(install_generator).to receive(:system).and_return(true)
+      allow(install_generator).to receive(:add_npm_dependencies).and_return(false)
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:exist?).with(File.join(anything, "package.json")).and_return(true)
+      allow(install_generator).to receive(:destination_root).and_return("/test/path")
+
+      # Initialize instance variables
+      install_generator.instance_variable_set(:@added_dependencies_to_package_json, false)
+      install_generator.instance_variable_set(:@ran_direct_installs, false)
+    end
+
+    context "when using package_json gem" do
+      before do
+        allow(install_generator).to receive(:add_npm_dependencies).and_return(true)
+      end
+
+      it "does not run duplicate install commands" do
+        # Setup expectation that system should be called only once for the final install
+        expect(install_generator).to receive(:system).with("npm", "install").once.and_return(true)
+
+        # Run the dependency setup
+        install_generator.send(:setup_js_dependencies)
+      end
+    end
+
+    context "when falling back to direct npm commands" do
+      before do
+        allow(install_generator).to receive(:add_npm_dependencies).and_return(false)
+      end
+
+      it "does not run the bulk install after direct installs" do
+        # Expect individual package installs but no bulk install
+        expect(install_generator).to receive(:system).with("npm", "install", anything).at_least(:once).and_return(true)
+        expect(install_generator).not_to receive(:system).with("npm", "install")
+
+        # Run the dependency setup
+        install_generator.send(:setup_js_dependencies)
+      end
+    end
+  end
+
+  describe "JS dependency method organization" do
+    it "uses the shared JsDependencyManager module in base_generator" do
+      expect(ReactOnRails::Generators::BaseGenerator.ancestors).to include(ReactOnRails::Generators::JsDependencyManager)
+    end
+
+    it "uses the shared JsDependencyManager module in install_generator" do
+      expect(ReactOnRails::Generators::InstallGenerator.ancestors).to include(ReactOnRails::Generators::JsDependencyManager)
+    end
+
+    it "does not duplicate JS dependency methods between generators" do
+      base_generator = ReactOnRails::Generators::BaseGenerator.new
+      install_generator = ReactOnRails::Generators::InstallGenerator.new
+
+      # Both should respond to the shared methods
+      shared_methods = [:setup_js_dependencies, :add_js_dependencies, :install_js_dependencies]
+
+      shared_methods.each do |method|
+        expect(base_generator).to respond_to(method, true)
+        expect(install_generator).to respond_to(method, true)
+      end
+
+      # The methods should come from the same module
+      shared_methods.each do |method|
+        base_method = base_generator.method(method)
+        install_method = install_generator.method(method)
+
+        expect(base_method.owner).to eq(ReactOnRails::Generators::JsDependencyManager)
+        expect(install_method.owner).to eq(ReactOnRails::Generators::JsDependencyManager)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses code review feedback from PR #1788:

## Changes

1. **Created shared JsDependencyManager module** to eliminate code duplication
   between base_generator.rb and install_generator.rb

2. **Added comprehensive test coverage** for:
   - Message deduplication (ensuring messages appear exactly once)
   - NPM install command deduplication
   - Proper module inclusion and method organization

3. **Improved method organization** in install_generator.rb

This refactoring follows DRY principles and makes the codebase more
maintainable by consolidating shared dependency management logic.

Follows up on: #1788

🤖 Generated with [Claude Code](https://claude.ai/code)