### PR TITLE
Update changelog for v16.1.0: Consolidate RC versions and organize release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@ Changes since the last non-beta release.
 
 - **`react_on_rails:doctor` rake task**: New diagnostic command to validate React on Rails setup and identify configuration issues. Provides comprehensive checks for environment prerequisites, dependencies, Rails integration, and Webpack configuration. Use `rake react_on_rails:doctor` to diagnose your setup, with optional `VERBOSE=true` for detailed output. [PR 1791](https://github.com/shakacode/react_on_rails/pull/1791) by [AbanoubGhadban](https://github.com/AbanoubGhadban)
 
-#### Breaking Changes
+#### Deprecations
 
-- **Removed `generated_assets_dirs` configuration**: The legacy `config.generated_assets_dirs` option is no longer supported and will raise an error if used. Since Shakapacker is now required, asset paths are automatically determined from `shakapacker.yml` configuration. Remove any `config.generated_assets_dirs` from your `config/initializers/react_on_rails.rb` file. Use `public_output_path` in `config/shakapacker.yml` to customize asset output location instead. [PR 1798](https://github.com/shakacode/react_on_rails/pull/1798) by [justin808](https://github.com/justin808)
+- **Deprecated `generated_assets_dirs` configuration**: The legacy `config.generated_assets_dirs` option is now deprecated and will show a deprecation warning if used. Since Shakapacker is now required, asset paths are automatically determined from `shakapacker.yml` configuration. Remove any `config.generated_assets_dirs` from your `config/initializers/react_on_rails.rb` file. Use `public_output_path` in `config/shakapacker.yml` to customize asset output location instead. [PR 1798](https://github.com/shakacode/react_on_rails/pull/1798) by [justin808](https://github.com/justin808)
 
 #### API Improvements
 


### PR DESCRIPTION
## Summary

This PR consolidates the React on Rails changelog by removing all 16.0.1-rc.X references and organizing them into a clean 16.1.0 release with proper categorization and complete attribution.

### Key Changes

- **Version bump to 16.1.0**: Changed from 16.0.1 due to new server bundle security feature (private bundle location)
- **Consolidated RC versions**: Merged 16.0.1-rc.0, 16.0.1-rc.2, and 16.0.1-rc.4 into single 16.1.0 release
- **Complete attribution**: Added proper PR numbers and author credits to all changelog entries
- **Improved organization**: Structured release notes into clear, logical categories

### Release Categories

#### New Features
- Server bundle security with `server_bundle_output_path` and `enforce_private_server_bundles` configuration options
- New `react_on_rails:doctor` rake task for setup diagnostics

#### Deprecations
- `generated_assets_dirs` configuration now shows deprecation warning (corrected from breaking change)

#### Security Enhancements
- Private server bundle enforcement
- Fixed command injection vulnerabilities in generators
- Hardened DOM selectors with XSS protection

#### Pro License Features
- Core/Pro separation with clear licensing boundaries
- Runtime license validation with graceful fallback
- Enhanced immediate hydration functionality

#### Generator Improvements
- Modern TypeScript patterns with improved type inference
- Optimized tsconfig.json with bundler module resolution
- Enhanced Redux TypeScript integration

#### Bug Fixes
- Fixed LoadError in doctor rake task
- Fixed packs generator for empty server bundle configuration
- Fixed Shakapacker version requirement inconsistencies

#### Code Improvements
- Removed PackerUtils abstraction
- Centralized Pro utilities architecture

### Attribution Complete

All entries now include proper attribution following the existing changelog format:
- [PR 1798] by [justin808]
- [PR 1791] by [AbanoubGhadban]
- [PR 1786] by [justin808]
- [PR 1795], [PR 1802] by [justin808]

This creates a clean, professional release that accurately reflects the scope of changes and provides proper credit to all contributors.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1814)
<!-- Reviewable:end -->
