### PR TITLE
Improve server bundle security test coverage and fix misleading comments

### DIFF
--- a/lib/generators/react_on_rails/base_generator.rb
+++ b/lib/generators/react_on_rails/base_generator.rb
@@ -95,7 +95,7 @@ module ReactOnRails
         run "bundle"
       end
 
-      def update_gitignore_for_auto_registration
+      def update_gitignore_for_generated_bundles
         gitignore_path = File.join(destination_root, ".gitignore")
         return unless File.exist?(gitignore_path)
 

--- a/lib/generators/react_on_rails/react_no_redux_generator.rb
+++ b/lib/generators/react_on_rails/react_no_redux_generator.rb
@@ -37,7 +37,7 @@ module ReactOnRails
           component_name: "HelloWorld"
         }
 
-        # Only create the view template - no manual bundle needed for auto registration
+        # Only create the view template - no manual bundle needed for auto-bundling
         template("#{base_path}/app/views/hello_world/index.html.erb.tt",
                  "app/views/hello_world/index.html.erb", config)
       end

--- a/lib/generators/react_on_rails/react_with_redux_generator.rb
+++ b/lib/generators/react_on_rails/react_with_redux_generator.rb
@@ -68,7 +68,7 @@ module ReactOnRails
           component_name: "HelloWorldApp"
         }
 
-        # Only create the view template - no manual bundle needed for auto registration
+        # Only create the view template - no manual bundle needed for auto-bundling
         template("#{base_path}/app/views/hello_world/index.html.erb.tt",
                  "app/views/hello_world/index.html.erb", config)
       end

--- a/spec/react_on_rails/support/shared_examples/react_no_redux_generator_examples.rb
+++ b/spec/react_on_rails/support/shared_examples/react_no_redux_generator_examples.rb
@@ -2,7 +2,7 @@
 
 shared_examples "no_redux_generator" do
   it "creates appropriate templates" do
-    # No manual bundle for non-Redux (auto-registration only)
+    # No manual bundle for non-Redux (auto-bundling only)
     assert_no_file("app/javascript/packs/hello-world-bundle.js")
 
     assert_file("app/views/hello_world/index.html.erb") do |contents|


### PR DESCRIPTION
## Summary

This PR addresses critical gaps in test coverage and terminology issues found in the server bundle security implementation from PR #1798. The changes focus on improving test quality and code maintainability without altering the actual functionality.

### 🧪 Test Coverage Improvements

- **Added comprehensive tests for `enforce_private_server_bundles=true`** - the main security feature was previously untested
- **Enhanced bundle path resolution testing** with parametrized tests covering all file existence combinations
- **Added security enforcement tests** for both server bundles and RSC bundles
- **Improved test organization** with clearer context descriptions and better mocking

### 🐛 Code Quality Fixes

- **Fixed misleading terminology**: Changed "auto-registration" to "auto-bundling" in comments and method names
- **Updated method naming**: `update_gitignore_for_auto_registration` → `update_gitignore_for_generated_bundles`
- **Improved code consistency** across generator files and test examples

### 🔒 Security Testing

The new tests ensure that the critical security feature `enforce_private_server_bundles=true` works correctly:
- ✅ Server bundles are never loaded from public directories when enforcement is enabled
- ✅ RSC bundles follow the same security model as server bundles  
- ✅ Fallback behavior is properly disabled when security enforcement is active
- ✅ File.exist? is never called on public paths when enforcement is enabled

### 🚦 Test Results

- **RuboCop**: ✅ 0 violations across 5 modified files
- **RSpec**: ✅ All 97 relevant tests pass, including 12+ new security-focused tests
- **Coverage**: Critical security feature now has comprehensive test coverage

### 📝 Files Changed

- `lib/generators/react_on_rails/base_generator.rb` - Method name fix
- `lib/generators/react_on_rails/react_*_generator.rb` - Comment terminology fixes
- `spec/react_on_rails/utils_spec.rb` - Major test coverage expansion
- `spec/react_on_rails/support/shared_examples/react_no_redux_generator_examples.rb` - Comment fix

## Why This Matters

The original implementation in PR #1798 was solid, but the tests only covered `enforce_private_server_bundles=false` scenarios. This left the main security feature completely untested, which could have led to undetected regressions. These improvements ensure the server bundle security functionality is properly validated according to software engineering best practices.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1815)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed a generator method for clearer intent; no functional changes for end-users.
* **Documentation**
  * Updated comments to use “auto-bundling” terminology for consistency.
* **Tests**
  * Expanded coverage for bundle path resolution across private/public locations and configurations, validating preference rules and fallbacks for server and RSC bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->