### PR TITLE
Fix bug at resolving react-server-client-manifest.json file

### DIFF
--- a/lib/react_on_rails/utils.rb
+++ b/lib/react_on_rails/utils.rb
@@ -112,7 +112,8 @@ module ReactOnRails
     private_class_method def self.server_bundle?(bundle_name)
       config = ReactOnRails.configuration
       bundle_name == config.server_bundle_js_file ||
-      bundle_name == config.rsc_bundle_js_file
+      bundle_name == config.rsc_bundle_js_file ||
+      bundle_name == config.react_server_client_manifest_file
     end
 
     private_class_method def self.handle_missing_manifest_entry(bundle_name, is_server_bundle)
@@ -170,7 +171,7 @@ module ReactOnRails
               "react_server_client_manifest_file is nil, ensure it is set in your configuration"
       end
 
-      @react_server_manifest_path = File.join(public_bundles_full_path, asset_name)
+      @react_server_manifest_path = bundle_js_file_path(asset_name)
     end
 
     def self.running_on_windows?

--- a/spec/react_on_rails/utils_spec.rb
+++ b/spec/react_on_rails/utils_spec.rb
@@ -1,432 +1,459 @@
 # frozen_string_literal: true
 
+require_relative "spec_helper"
+require "shakapacker"
+
 # rubocop:disable Metrics/ModuleLength, Metrics/BlockLength
 module ReactOnRails
   RSpec.describe Utils do
-    describe ".bundle_js_file_path" do
-      include_context "with shakapacker enabled"
+    # Since React on Rails v15+ requires ::Shakapacker as an explicit dependency,
+    # we only test with ::Shakapacker
+    packers_to_test = ["shakapacker"]
 
-      # Context for testing server_bundle? and .bundle_js_file_path with various configurations.
-      packers_to_test = %i[shakapacker]
+    shared_context "with packer enabled" do
+      let(:mock_packer) { instance_double(::Shakapacker::Instance) }
+      let(:mock_config) { instance_double(::Shakapacker::Configuration) }
+      let(:mock_dev_server) { instance_double(::Shakapacker::DevServer) }
 
-      def mock_shakapacker_implementation
-        allow(::Shakapacker).to receive(:instance).and_return(double("Shakapacker Instance"))
-        allow(::Shakapacker).to receive(:manifest).and_return(double("Manifest", config: double("Config")))
-        allow(::Shakapacker.instance).to receive(:root_path).and_return(Rails.root)
-        allow(::Shakapacker.manifest.config).to receive(:public_output_path)
-          .and_return(::Pathname.new("public/webpack/dev"))
+      before do
+        allow(ReactOnRails).to receive_message_chain(:configuration, :generated_assets_dir)
+          .and_return("")
+        allow(::Shakapacker).to receive_messages(dev_server: mock_dev_server, config: mock_config)
+        allow(mock_dev_server).to receive(:running?).and_return(false)
+        allow(mock_config).to receive(:public_output_path).and_return(packer_public_output_path)
+      end
+    end
+
+    shared_context "with shakapacker enabled" do
+      include_context "with packer enabled"
+
+      # We don't need to mock anything here because the shakapacker gem is already installed and will be used by default
+      it "uses shakapacker" do
+        # PackerUtils now uses ::Shakapacker directly
+        expect(::Shakapacker).to be_present
+      end
+    end
+
+    def mock_bundle_in_manifest(bundle_name, hashed_bundle)
+      mock_manifest = instance_double(::Shakapacker::Manifest)
+      allow(mock_manifest).to receive(:lookup!)
+        .with(bundle_name)
+        .and_return(hashed_bundle)
+
+      allow(::Shakapacker).to receive(:manifest).and_return(mock_manifest)
+    end
+
+    def mock_missing_manifest_entry(bundle_name)
+      allow(::Shakapacker).to receive_message_chain("manifest.lookup!")
+        .with(bundle_name)
+        .and_raise(::Shakapacker::Manifest::MissingEntryError)
+    end
+
+    def random_bundle_name
+      "webpack-bundle-#{SecureRandom.hex(4)}.js"
+    end
+
+    # If bundle names are not provided, random unique names will be used for each bundle.
+    # This ensures that if server_bundle and rsc_bundle are accidentally swapped in the code,
+    # the tests will fail since each bundle has a distinct random name that won't match if used incorrectly.
+    def mock_bundle_configs(server_bundle_name: random_bundle_name, rsc_bundle_name: random_bundle_name)
+      allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+        .and_return(server_bundle_name)
+      allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+        .and_return(rsc_bundle_name)
+      allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+        .and_return("ssr-generated")
+      allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+        .and_return(false)
+    end
+
+    def mock_dev_server_running
+      allow(::Shakapacker).to receive_message_chain("dev_server.running?")
+        .and_return(true)
+      allow(::Shakapacker).to receive_message_chain("dev_server.protocol")
+        .and_return("http")
+      allow(::Shakapacker).to receive_message_chain("dev_server.host_with_port")
+        .and_return("localhost:3035")
+    end
+
+    context "when server_bundle_path cleared" do
+      before do
+        allow(Rails).to receive(:root).and_return(File.expand_path("."))
+        described_class.instance_variable_set(:@server_bundle_path, nil)
+        described_class.instance_variable_set(:@rsc_bundle_path, nil)
+        ReactOnRails::PackerUtils.instance_variables.each do |instance_variable|
+          ReactOnRails::PackerUtils.remove_instance_variable(instance_variable)
+        end
       end
 
-      def mock_bundle_in_manifest(bundle_name, manifest_path)
-        manifest = double("Manifest")
-        allow(manifest).to receive(:lookup!).with(bundle_name).and_return(manifest_path)
-        allow(Shakapacker).to receive(:manifest).and_return(manifest)
+      after do
+        described_class.instance_variable_set(:@server_bundle_path, nil)
+        described_class.instance_variable_set(:@rsc_bundle_path, nil)
       end
 
-      def mock_missing_manifest_entry(bundle_name)
-        manifest = double("Manifest")
-        allow(manifest).to receive(:lookup!).with(bundle_name)
-          .and_raise(Shakapacker::Manifest::MissingEntryError, "Entry #{bundle_name} not found")
-        allow(Shakapacker).to receive(:manifest).and_return(manifest)
-      end
-
-      # Generate random unique bundle names to prevent accidental test passes
-      # if server_bundle and rsc_bundle get swapped in the code
-      def random_bundle_name
-        "bundle-#{SecureRandom.hex(8)}.js"
-      end
-
-      # Helper to create a double for ReactOnRails.configuration with all server bundle settings
-      # This double includes the new server_bundle_output_path for configuring the private directory
-      # and the new enforce_private_server_bundles setting for controlling public/private fallback behavior
-      def make_config_double(
-        server_bundle_js_file: "server-bundle.js",
-        rsc_bundle_js_file: "rsc-bundle.js",
-        server_bundle_output_path: "ssr-generated",
-        enforce_private_server_bundles: false,
-        same_bundle_for_client_and_server: false
-      )
-        double("Configuration",
-               server_bundle_js_file: server_bundle_js_file,
-               rsc_bundle_js_file: rsc_bundle_js_file,
-               server_bundle_output_path: server_bundle_output_path,
-               enforce_private_server_bundles: enforce_private_server_bundles,
-               same_bundle_for_client_and_server: same_bundle_for_client_and_server)
-      end
-
-      # If bundle names are not provided, random unique names will be used for each bundle.
-      # This ensures that if server_bundle and rsc_bundle are accidentally swapped in the code,
-      # the tests will fail since each bundle has a distinct random name that won't match if used incorrectly.
-      def mock_bundle_configs(server_bundle_name: random_bundle_name, rsc_bundle_name: random_bundle_name,
-                              react_server_client_manifest_file: nil)
-        allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-          .and_return(server_bundle_name)
-        allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-          .and_return(rsc_bundle_name)
-        allow(ReactOnRails).to receive_message_chain("configuration.react_server_client_manifest_file")
-          .and_return(react_server_client_manifest_file)
-        allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-          .and_return("ssr-generated")
-        allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-          .and_return(false)
-      end
-
-      def mock_dev_server_running
-        allow(::Shakapacker).to receive_message_chain("dev_server.running?")
-          .and_return(true)
-        allow(::Shakapacker.dev_server).to receive(:host_with_port)
-          .and_return("localhost:3035")
-        allow(::Shakapacker.dev_server).to receive(:protocol)
-          .and_return("http")
-      end
-
-      context "with Shakapacker enabled", :shakapacker do
+      describe ".bundle_js_file_path" do
         before do
-          mock_shakapacker_implementation
+          # Mock configuration calls to avoid server bundle detection for regular client bundles
+          allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+            .and_return("server-bundle.js")
+          allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+            .and_return("rsc-bundle.js")
         end
 
-        context "when server_bundle_path set and server bundle file" do
-          before do
-            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-              .and_return("server-bundle.js")
-            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-              .and_return("ssr-generated")
-            allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-              .and_return("rsc-bundle.js")
-          end
+        subject do
+          described_class.bundle_js_file_path("webpack-bundle.js")
+        end
 
-          subject do
-            described_class.bundle_js_file_path("webpack-bundle.js")
-          end
+        packers_to_test.each do |packer_type|
+          context "with #{packer_type} enabled", packer_type.to_sym do
+            include_context "with #{packer_type} enabled"
 
-          packers_to_test.each do |packer_type|
-            context "with #{packer_type} enabled", packer_type.to_sym do
-              include_context "with #{packer_type} enabled"
+            let(:packer_public_output_path) do
+              File.expand_path(File.join(Rails.root, "public/webpack/dev"))
+            end
 
-              let(:packer_public_output_path) do
-                File.expand_path(File.join(Rails.root, "public/webpack/dev"))
+            context "when file in manifest", :shakapacker do
+              before do
+                mock_bundle_in_manifest("webpack-bundle.js", "/webpack/dev/webpack-bundle-0123456789abcdef.js")
+
+                mock_bundle_configs(server_bundle_name: "server-bundle.js")
               end
 
-              context "when file in manifest", :shakapacker do
+              it { is_expected.to eq("#{packer_public_output_path}/webpack-bundle-0123456789abcdef.js") }
+            end
+
+            context "with manifest.json" do
+              subject do
+                described_class.bundle_js_file_path("manifest.json")
+              end
+
+              it { is_expected.to eq("#{packer_public_output_path}/manifest.json") }
+            end
+
+            context "when file not in manifest" do
+              before do
+                mock_missing_manifest_entry("webpack-bundle.js")
+              end
+
+              let(:env_specific_path) { File.join(packer_public_output_path, "webpack-bundle.js") }
+
+              it "returns environment-specific path" do
+                result = described_class.bundle_js_file_path("webpack-bundle.js")
+                expect(result).to eq(File.expand_path(env_specific_path))
+              end
+            end
+
+            context "with server bundle (SSR/RSC) file not in manifest" do
+              let(:server_bundle_name) { "server-bundle.js" }
+              let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", server_bundle_name)) }
+              let(:public_path) { File.expand_path(File.join(packer_public_output_path, server_bundle_name)) }
+
+              context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
                 before do
-                  mock_bundle_in_manifest("webpack-bundle.js", "/webpack/dev/webpack-bundle-0123456789abcdef.js")
-
-                  mock_bundle_configs(server_bundle_name: "server-bundle.js")
-                end
-
-                it { is_expected.to eq("#{packer_public_output_path}/webpack-bundle-0123456789abcdef.js") }
-              end
-
-              context "with manifest.json" do
-                subject do
-                  described_class.bundle_js_file_path("manifest.json")
-                end
-
-                it { is_expected.to eq("#{packer_public_output_path}/manifest.json") }
-              end
-
-              context "when file not in manifest" do
-                before do
-                  mock_missing_manifest_entry("webpack-bundle.js")
-                end
-
-                let(:env_specific_path) { File.join(packer_public_output_path, "webpack-bundle.js") }
-
-                it "returns environment-specific path" do
-                  result = described_class.bundle_js_file_path("webpack-bundle.js")
-                  expect(result).to eq(File.expand_path(env_specific_path))
-                end
-              end
-
-              context "with server bundle (SSR/RSC) file not in manifest" do
-                let(:server_bundle_name) { "server-bundle.js" }
-                let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", server_bundle_name)) }
-                let(:public_path) { File.expand_path(File.join(packer_public_output_path, server_bundle_name)) }
-
-                before do
-                  mock_bundle_configs(server_bundle_name: server_bundle_name)
                   mock_missing_manifest_entry(server_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+                    .and_return(server_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return("ssr-generated")
+                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                    .and_return(false)
                 end
 
-                context "with server_bundle_output_path configured" do
-                  context "when enforce_private_server_bundles=false" do
-                    before do
-                      # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
-                      allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
-                    end
+                it "returns private path when it exists even if public path also exists" do
+                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
+                  allow(File).to receive(:exist?).with(public_path).and_return(true)
 
-                    it "returns the private ssr-generated path when file exists" do
-                      path = described_class.bundle_js_file_path(server_bundle_name)
-                      expect(path).to eq(ssr_generated_path)
-                    end
-
-                    context "when private file doesn't exist" do
-                      before do
-                        allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
-                        allow(File).to receive(:exist?).with(public_path).and_return(false)
-                      end
-
-                      it "returns the public path as fallback" do
-                        path = described_class.bundle_js_file_path(server_bundle_name)
-                        expect(path).to eq(public_path)
-                      end
-                    end
-                  end
-
-                  context "when enforce_private_server_bundles=true" do
-                    before do
-                      allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                        .and_return(true)
-                    end
-
-                    it "returns the private ssr-generated path without checking public paths" do
-                      # Should not check File.exist? for public paths
-                      expect(File).not_to receive(:exist?).with(public_path)
-
-                      path = described_class.bundle_js_file_path(server_bundle_name)
-                      expect(path).to eq(ssr_generated_path)
-                    end
-                  end
+                  result = described_class.bundle_js_file_path(server_bundle_name)
+                  expect(result).to eq(ssr_generated_path)
                 end
 
-                context "without server_bundle_output_path configured" do
-                  before do
-                    allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                      .and_return(nil)
-                  end
+                it "returns public path when private path does not exist and public path exists" do
+                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
+                  allow(File).to receive(:exist?).with(public_path).and_return(true)
 
-                  it "returns the public path directly" do
-                    path = described_class.bundle_js_file_path(server_bundle_name)
-                    expect(path).to eq(public_path)
+                  result = described_class.bundle_js_file_path(server_bundle_name)
+                  expect(result).to eq(public_path)
+                end
+
+                it "returns configured path if both private and public paths do not exist" do
+                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
+                  allow(File).to receive(:exist?).with(public_path).and_return(false)
+
+                  result = described_class.bundle_js_file_path(server_bundle_name)
+                  expect(result).to eq(ssr_generated_path)
+                end
+              end
+
+              context "with server_bundle_output_path configured and enforce_private_server_bundles=true" do
+                before do
+                  mock_missing_manifest_entry(server_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+                    .and_return(server_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return("ssr-generated")
+                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                    .and_return(true)
+                end
+
+                # It should always return the ssr_generated_path, regardless of which files exist
+                file_states_combinations = [
+                  { ssr_exists: true, public_exists: true },
+                  { ssr_exists: true, public_exists: false },
+                  { ssr_exists: false, public_exists: true },
+                  { ssr_exists: false, public_exists: false }
+                ]
+                file_states_combinations.each do |file_states|
+                  it "returns private path when enforce_private_server_bundles=true " \
+                     "(ssr_exists=#{file_states[:ssr_exists]}, " \
+                     "public_exists=#{file_states[:public_exists]})" do
+                    allow(File).to receive(:exist?)
+                      .with(ssr_generated_path)
+                      .and_return(file_states[:ssr_exists])
+                    allow(File).to receive(:exist?)
+                      .with(public_path)
+                      .and_return(file_states[:public_exists])
+
+                    result = described_class.bundle_js_file_path(server_bundle_name)
+                    expect(result).to eq(ssr_generated_path)
                   end
                 end
               end
 
-              context "with server bundle (SSR) file in manifest" do
-                let(:server_bundle_name) { "server-bundle.js" }
-                let(:manifest_path) { "/webpack/dev/server-bundle-abc123.js" }
-                let(:expected_path) do
-                  File.expand_path(File.join(packer_public_output_path, "server-bundle-abc123.js"))
-                end
-
+              context "without server_bundle_output_path configured" do
                 before do
-                  mock_bundle_configs(server_bundle_name: server_bundle_name)
-                  mock_bundle_in_manifest(server_bundle_name, manifest_path)
+                  mock_missing_manifest_entry(server_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+                    .and_return(server_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return(nil)
+                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                    .and_return(false)
                 end
 
-                context "with server_bundle_output_path configured" do
-                  it "returns manifest path (ignores server_bundle_output_path when in manifest)" do
-                    path = described_class.bundle_js_file_path(server_bundle_name)
-                    expect(path).to eq(expected_path)
-                  end
-                end
-
-                context "without server_bundle_output_path configured" do
-                  before do
-                    allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                      .and_return(nil)
-                  end
-
-                  it "returns manifest path directly" do
-                    path = described_class.bundle_js_file_path(server_bundle_name)
-                    expect(path).to eq(expected_path)
-                  end
+                it "uses packer public output path" do
+                  result = described_class.bundle_js_file_path(server_bundle_name)
+                  expect(result).to eq(File.expand_path(File.join(packer_public_output_path, server_bundle_name)))
                 end
               end
+            end
 
-              context "with RSC bundle file not in manifest" do
-                let(:rsc_bundle_name) { "rsc-bundle.js" }
-                let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", rsc_bundle_name)) }
-                let(:public_path) { File.expand_path(File.join(packer_public_output_path, rsc_bundle_name)) }
+            context "with RSC bundle file not in manifest" do
+              let(:rsc_bundle_name) { "rsc-bundle.js" }
+              let(:public_path) { File.expand_path(File.join(packer_public_output_path, rsc_bundle_name)) }
+              let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", rsc_bundle_name)) }
 
+              context "with enforce_private_server_bundles=false" do
                 before do
-                  mock_bundle_configs(rsc_bundle_name: rsc_bundle_name)
                   mock_missing_manifest_entry(rsc_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+                    .and_return(rsc_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return("ssr-generated")
+                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                    .and_return(false)
                 end
 
-                context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
-                  before do
-                    # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
-                    allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
-                  end
+                it "returns private path when it exists even if public path also exists" do
+                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
+                  expect(File).not_to receive(:exist?).with(public_path)
 
-                  it "returns the private ssr-generated path when file exists" do
-                    path = described_class.bundle_js_file_path(rsc_bundle_name)
-                    expect(path).to eq(ssr_generated_path)
-                  end
+                  result = described_class.bundle_js_file_path(rsc_bundle_name)
+                  expect(result).to eq(ssr_generated_path)
                 end
 
-                context "with enforce_private_server_bundles=true" do
-                  before do
-                    allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                      .and_return(true)
-                  end
+                it "fallbacks to public path when private path does not exist and public path exists" do
+                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
+                  allow(File).to receive(:exist?).with(public_path).and_return(true)
 
-                  it "returns the private ssr-generated path without checking public paths" do
-                    # Should not check File.exist? for public paths
-                    expect(File).not_to receive(:exist?).with(public_path)
+                  result = described_class.bundle_js_file_path(rsc_bundle_name)
+                  expect(result).to eq(public_path)
+                end
 
-                    path = described_class.bundle_js_file_path(rsc_bundle_name)
-                    expect(path).to eq(ssr_generated_path)
-                  end
+                it "returns configured path if both private and public paths do not exist" do
+                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
+                  allow(File).to receive(:exist?).with(public_path).and_return(false)
+
+                  result = described_class.bundle_js_file_path(rsc_bundle_name)
+                  expect(result).to eq(ssr_generated_path)
                 end
               end
 
-              context "with RSC bundle file in manifest" do
-                let(:rsc_bundle_name) { "rsc-bundle.js" }
-                let(:manifest_path) { "/webpack/dev/rsc-bundle-xyz789.js" }
-                let(:expected_path) do
-                  File.expand_path(File.join(packer_public_output_path, "rsc-bundle-xyz789.js"))
-                end
-
+              context "with enforce_private_server_bundles=true" do
                 before do
-                  mock_bundle_configs(rsc_bundle_name: rsc_bundle_name)
-                  mock_bundle_in_manifest(rsc_bundle_name, manifest_path)
+                  mock_missing_manifest_entry(rsc_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+                    .and_return(rsc_bundle_name)
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return("ssr-generated")
+                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                    .and_return(true)
                 end
 
-                it "returns manifest path" do
-                  path = described_class.bundle_js_file_path(rsc_bundle_name)
-                  expect(path).to eq(expected_path)
+                it "enforces private RSC bundles and never checks public directory" do
+                  public_path = File.expand_path(File.join(packer_public_output_path, rsc_bundle_name))
+
+                  # Should not check public path when enforcement is enabled
+                  expect(File).not_to receive(:exist?).with(public_path)
+
+                  result = described_class.bundle_js_file_path(rsc_bundle_name)
+                  expect(result).to eq(ssr_generated_path)
                 end
               end
             end
           end
         end
+      end
 
-        context "when server_bundle_path cleared" do
-          before do
-            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-              .and_return(nil)
-            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-              .and_return("server-bundle.js")
-            allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-              .and_return("rsc-bundle.js")
-          end
+      describe ".source_path_is_not_defined_and_custom_node_modules?" do
+        it "returns false if node_modules is blank" do
+          allow(ReactOnRails).to receive_message_chain("configuration.node_modules_location")
+            .and_return("")
+          allow(::Shakapacker).to receive_message_chain("config.send").with(:data)
+                                                                      .and_return({})
 
-          context ".server_bundle_js_file_path" do
-            context "with server_bundle_output_path configured" do
-              # This context block tests the behavior when a dedicated server bundle output path is configured.
-              # The server_bundle_output_path option allows placing server bundles (SSR/RSC) in a separate
-              # private directory outside the public assets folder for enhanced security.
-              # When this path is set, server bundles will be resolved from this directory rather than
-              # the public webpack output path.
-              it "returns the private ssr-generated path for server bundles" do
+          expect(described_class.using_packer_source_path_is_not_defined_and_custom_node_modules?).to be(false)
+        end
+
+        it "returns false if source_path is defined in the config/webpacker.yml and node_modules defined" do
+          allow(ReactOnRails).to receive_message_chain("configuration.node_modules_location")
+            .and_return("client")
+          allow(::Shakapacker).to receive_message_chain("config.send")
+            .with(:data).and_return(source_path: "client/app")
+
+          expect(described_class.using_packer_source_path_is_not_defined_and_custom_node_modules?).to be(false)
+        end
+
+        it "returns true if node_modules is not blank and the source_path is not defined in config/webpacker.yml" do
+          allow(ReactOnRails).to receive_message_chain("configuration.node_modules_location")
+            .and_return("node_modules")
+          allow(::Shakapacker).to receive_message_chain("config.send").with(:data)
+                                                                      .and_return({})
+
+          expect(described_class.using_packer_source_path_is_not_defined_and_custom_node_modules?).to be(true)
+        end
+      end
+
+      packers_to_test.each do |packer_type|
+        describe ".server_bundle_js_file_path with #{packer_type} enabled" do
+          let(:packer_public_output_path) { Pathname.new("public/webpack/development") }
+
+          include_context "with #{packer_type} enabled"
+
+          context "with server file not in manifest", packer_type.to_sym do
+            it "returns the private ssr-generated path for server bundles" do
+              server_bundle_name = "server-bundle.js"
+              mock_bundle_configs(server_bundle_name: server_bundle_name)
+              mock_missing_manifest_entry(server_bundle_name)
+
+              path = described_class.server_bundle_js_file_path
+
+              expect(path).to end_with("ssr-generated/#{server_bundle_name}")
+            end
+
+            context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
+              it "returns the configured path directly without checking file existence" do
                 server_bundle_name = "server-bundle.js"
                 mock_bundle_configs(server_bundle_name: server_bundle_name)
                 mock_missing_manifest_entry(server_bundle_name)
+                # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
+
+                # Since server_bundle_output_path is configured, it will try manifest lookup first,
+                # then fall back to candidate paths. With enforce_private_server_bundles=false,
+                # it will check File.exist? for both private and public paths
+                ssr_generated_path = File.expand_path(File.join("ssr-generated", server_bundle_name))
+                public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
+                allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
+                allow(File).to receive(:exist?).with(public_path).and_return(false)
 
                 path = described_class.server_bundle_js_file_path
 
                 expect(path).to end_with("ssr-generated/#{server_bundle_name}")
               end
-
-              context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
-                it "returns the configured path directly without checking file existence" do
-                  server_bundle_name = "server-bundle.js"
-                  mock_bundle_configs(server_bundle_name: server_bundle_name)
-                  mock_missing_manifest_entry(server_bundle_name)
-                  # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
-
-                  # Since server_bundle_output_path is configured, it will try manifest lookup first,
-                  # then fall back to candidate paths. With enforce_private_server_bundles=false,
-                  # it will check File.exist? for both private and public paths
-                  ssr_generated_path = File.expand_path(File.join("ssr-generated", server_bundle_name))
-                  public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
-                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
-                  allow(File).to receive(:exist?).with(public_path).and_return(false)
-
-                  path = described_class.server_bundle_js_file_path
-
-                  # Should return public path as final fallback
-                  expect(path).to eq(public_path)
-                end
-              end
-
-              context "with enforce_private_server_bundles=true" do
-                it "returns the private ssr-generated path without checking public paths" do
-                  server_bundle_name = "server-bundle.js"
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                    .and_return(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-                    .and_return("rsc-bundle.js")
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return("ssr-generated")
-                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                    .and_return(true)
-                  mock_missing_manifest_entry(server_bundle_name)
-
-                  # Should not check File.exist? at all when enforce_private_server_bundles is true
-                  expect(File).not_to receive(:exist?)
-
-                  path = described_class.server_bundle_js_file_path
-
-                  expect(path).to end_with("ssr-generated/#{server_bundle_name}")
-                end
-              end
             end
 
-            context "with shakapacker and same file used by server and client", :shakapacker do
+            context "with server_bundle_output_path configured and enforce_private_server_bundles=true" do
+              it "returns the private path without checking public directories" do
+                server_bundle_name = "server-bundle.js"
+                mock_missing_manifest_entry(server_bundle_name)
+                allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+                  .and_return(server_bundle_name)
+                allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                  .and_return("ssr-generated")
+                allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                  .and_return(true)
+
+                # Should not check public paths when enforcement is enabled
+                public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
+                expect(File).not_to receive(:exist?).with(public_path)
+
+                path = described_class.server_bundle_js_file_path
+                expect(path).to end_with("ssr-generated/#{server_bundle_name}")
+              end
+            end
+          end
+
+          context "with server file in the manifest, used for client", packer_type.to_sym do
+            it "returns the correct path hashed server path" do
+              # Use Shakapacker directly instead of packer method
+              mock_bundle_configs(server_bundle_name: "webpack-bundle.js")
+              # Clear server_bundle_output_path to test manifest behavior
+              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                .and_return(nil)
+              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                .and_return(true)
+              mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
+              allow(Shakapacker).to receive_message_chain("dev_server.running?")
+                .and_return(false)
+
+              path = described_class.server_bundle_js_file_path
+              expect(path).to end_with("public/webpack/development/webpack-bundle-123456.js")
+              expect(path).to start_with("/")
+            end
+
+            context "with webpack-dev-server running, and same file used for server and client" do
               it "returns the correct path hashed server path" do
-                # Use Shakapacker directly instead of packer method
                 mock_bundle_configs(server_bundle_name: "webpack-bundle.js")
                 # Clear server_bundle_output_path to test manifest behavior
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                   .and_return(nil)
                 allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
                   .and_return(true)
-                mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
-                allow(Shakapacker).to receive_message_chain("dev_server.running?")
-                  .and_return(false)
+                mock_dev_server_running
+                mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
 
                 path = described_class.server_bundle_js_file_path
 
-                expect(path).to include("webpack-bundle-123456.js")
-              end
-
-              context "with webpack-dev-server running, and same file used for server and client" do
-                it "returns the correct path hashed server path" do
-                  mock_bundle_configs(server_bundle_name: "webpack-bundle.js")
-                  # Clear server_bundle_output_path to test manifest behavior
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return(nil)
-                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                    .and_return(true)
-                  mock_dev_server_running
-                  mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
-
-                  path = described_class.server_bundle_js_file_path
-
-                  expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
-                end
-              end
-
-              context "with webpack-dev-server running, and server file separate from client files",
-                      packer_type.to_sym do
-                it "returns the correct path hashed server path" do
-                  mock_bundle_configs(server_bundle_name: "server-bundle.js")
-                  # Clear server_bundle_output_path to test manifest behavior
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return(nil)
-                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                    .and_return(false)
-                  mock_bundle_in_manifest("server-bundle.js", "webpack/development/server-bundle-123456.js")
-                  mock_dev_server_running
-
-                  path = described_class.server_bundle_js_file_path
-
-                  expect(path).to include("server-bundle-123456.js")
-                end
+                expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
               end
             end
           end
 
-          context ".rsc_bundle_js_file_path" do
-            context "with server_bundle_output_path configured" do
-              # This context block tests the behavior when a dedicated server bundle output path is configured.
-              # The server_bundle_output_path option allows placing server bundles (SSR/RSC) in a separate
-              # private directory outside the public assets folder for enhanced security.
-              # When this path is set, RSC bundles will be resolved from this directory rather than
-              # the public webpack output path.
+          context "with dev-server running, and server file in the manifest, and separate client/server files",
+                  packer_type.to_sym do
+            it "returns the correct path hashed server path" do
+              mock_bundle_configs(server_bundle_name: "server-bundle.js")
+              # Clear server_bundle_output_path to test manifest behavior
+              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                .and_return(nil)
+              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                .and_return(false)
+              mock_bundle_in_manifest("server-bundle.js", "webpack/development/server-bundle-123456.js")
+              mock_dev_server_running
+
+              path = described_class.server_bundle_js_file_path
+
+              expect(path).to end_with("/public/webpack/development/server-bundle-123456.js")
+            end
+          end
+        end
+
+        describe ".rsc_bundle_js_file_path with #{packer_type} enabled" do
+          let(:packer_public_output_path) { Pathname.new("public/webpack/development") }
+
+          include_context "with #{packer_type} enabled"
+
+          context "with server file not in manifest", packer_type.to_sym do
+            context "with enforce_private_server_bundles=false" do
               it "returns the private ssr-generated path for RSC bundles" do
                 server_bundle_name = "rsc-bundle.js"
                 mock_bundle_configs(rsc_bundle_name: server_bundle_name)
@@ -440,244 +467,321 @@ module ReactOnRails
 
             context "with enforce_private_server_bundles=true" do
               it "returns the private ssr-generated path for RSC bundles without checking public paths" do
-                rsc_bundle_name = "rsc-bundle.js"
+                server_bundle_name = "rsc-bundle.js"
+                mock_missing_manifest_entry(server_bundle_name)
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                  .and_return("server-bundle.js")
+                  .and_return("server-bundle.js") # Different from RSC bundle name
                 allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-                  .and_return(rsc_bundle_name)
+                  .and_return(server_bundle_name)
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                   .and_return("ssr-generated")
                 allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
                   .and_return(true)
-                mock_missing_manifest_entry(rsc_bundle_name)
 
-                # Should not check File.exist? at all when enforce_private_server_bundles is true
-                expect(File).not_to receive(:exist?)
+                # Should not check public paths when enforcement is enabled
+                public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
+                expect(File).not_to receive(:exist?).with(public_path)
 
                 path = described_class.rsc_bundle_js_file_path
-
-                expect(path).to end_with("ssr-generated/#{rsc_bundle_name}")
+                expect(path).to end_with("ssr-generated/#{server_bundle_name}")
               end
             end
+          end
 
-            context "with shakapacker and same file used by server and client", :shakapacker do
+          context "with server file in the manifest, used for client", packer_type.to_sym do
+            it "returns the correct path hashed server path" do
+              # Use Shakapacker directly instead of packer method
+              mock_bundle_configs(rsc_bundle_name: "webpack-bundle.js")
+              # Clear server_bundle_output_path to test manifest behavior
+              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                .and_return(nil)
+              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                .and_return(true)
+              mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
+              allow(Shakapacker).to receive_message_chain("dev_server.running?")
+                .and_return(false)
+
+              path = described_class.rsc_bundle_js_file_path
+              expect(path).to end_with("public/webpack/development/webpack-bundle-123456.js")
+              expect(path).to start_with("/")
+            end
+
+            context "with webpack-dev-server running, and same file used for server and client" do
               it "returns the correct path hashed server path" do
-                # Use Shakapacker directly instead of packer method
                 mock_bundle_configs(rsc_bundle_name: "webpack-bundle.js")
                 # Clear server_bundle_output_path to test manifest behavior
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                   .and_return(nil)
                 allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
                   .and_return(true)
-                mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
-                allow(Shakapacker).to receive_message_chain("dev_server.running?")
-                  .and_return(false)
+                mock_dev_server_running
+                mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
 
                 path = described_class.rsc_bundle_js_file_path
 
-                expect(path).to include("webpack-bundle-123456.js")
+                expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
               end
+            end
+          end
 
-              context "with webpack-dev-server running, and same file used for server and client" do
-                it "returns the correct path hashed server path" do
-                  mock_bundle_configs(rsc_bundle_name: "webpack-bundle.js")
-                  # Clear server_bundle_output_path to test manifest behavior
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return(nil)
-                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                    .and_return(true)
-                  mock_dev_server_running
-                  mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
+          context "with dev-server running, and server file in the manifest, and separate client/server files",
+                  packer_type.to_sym do
+            it "returns the correct path hashed server path" do
+              mock_bundle_configs(rsc_bundle_name: "rsc-bundle.js")
+              # Clear server_bundle_output_path to test manifest behavior
+              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                .and_return(nil)
+              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                .and_return(false)
+              mock_bundle_in_manifest("rsc-bundle.js", "webpack/development/server-bundle-123456.js")
+              mock_dev_server_running
 
-                  path = described_class.rsc_bundle_js_file_path
+              path = described_class.rsc_bundle_js_file_path
 
-                  expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
-                end
-              end
-
-              context "with webpack-dev-server running, and server file separate from client files",
-                      packer_type.to_sym do
-                it "returns the correct path hashed server path" do
-                  mock_bundle_configs(rsc_bundle_name: "rsc-bundle.js")
-                  # Clear server_bundle_output_path to test manifest behavior
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return(nil)
-                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                    .and_return(false)
-                  mock_bundle_in_manifest("rsc-bundle.js", "webpack/development/server-bundle-123456.js")
-                  mock_dev_server_running
-
-                  path = described_class.rsc_bundle_js_file_path
-
-                  expect(path).to include("server-bundle-123456.js")
-                end
-              end
+              expect(path).to end_with("/public/webpack/development/server-bundle-123456.js")
             end
           end
         end
       end
+
+      describe ".wrap_message" do
+        subject(:stripped_heredoc) do
+          <<-MSG.strip_heredoc
+          Something to wrap
+          with 2 lines
+          MSG
+        end
+
+        let(:expected) do
+          msg = <<-MSG.strip_heredoc
+          ================================================================================
+          Something to wrap
+          with 2 lines
+          ================================================================================
+          MSG
+          Rainbow(msg).red
+        end
+
+        it "outputs the correct text" do
+          expect(described_class.wrap_message(stripped_heredoc)).to eq(expected)
+        end
+      end
+
+      describe ".truthy_presence" do
+        context "with non-empty string" do
+          subject(:simple_string) { "foobar" }
+
+          it "returns subject (same value as presence) for a non-empty string" do
+            expect(described_class.truthy_presence(simple_string)).to eq(simple_string.presence)
+
+            # Blank strings are nil for presence
+            expect(described_class.truthy_presence(simple_string)).to eq(simple_string)
+          end
+        end
+
+        context "with empty string" do
+          it "returns \"\" for an empty string" do
+            expect(described_class.truthy_presence("")).to eq("")
+          end
+        end
+
+        context "with nil object" do
+          it "returns nil (same value as presence)" do
+            expect(described_class.truthy_presence(nil)).to eq(nil.presence)
+
+            # Blank strings are nil for presence
+            expect(described_class.truthy_presence(nil)).to be_nil
+          end
+        end
+
+        context "with pathname pointing to empty dir (obj.empty? is true)" do
+          subject(:empty_dir) { Pathname.new(Dir.mktmpdir) }
+
+          it "returns Pathname object" do
+            # Blank strings are nil for presence
+            expect(described_class.truthy_presence(empty_dir)).to eq(empty_dir)
+          end
+        end
+
+        context "with pathname pointing to empty file" do
+          subject(:empty_file) do
+            File.basename(Tempfile.new("tempfile",
+                                       empty_dir))
+          end
+
+          let(:empty_dir) { Pathname.new(Dir.mktmpdir) }
+
+          it "returns Pathname object" do
+            expect(described_class.truthy_presence(empty_file)).to eq(empty_file)
+          end
+        end
+      end
+
+      describe ".rails_version_less_than" do
+        subject { described_class.rails_version_less_than("4") }
+
+        describe ".rails_version_less_than" do
+          before { described_class.instance_variable_set :@rails_version_less_than, nil }
+
+          context "with Rails 3" do
+            before { allow(Rails).to receive(:version).and_return("3") }
+
+            it { is_expected.to be(true) }
+          end
+
+          context "with Rails 3.2" do
+            before { allow(Rails).to receive(:version).and_return("3.2") }
+
+            it { is_expected.to be(true) }
+          end
+
+          context "with Rails 4" do
+            before { allow(Rails).to receive(:version).and_return("4") }
+
+            it { is_expected.to be(false) }
+          end
+
+          context "with Rails 4.2" do
+            before { allow(Rails).to receive(:version).and_return("4.2") }
+
+            it { is_expected.to be(false) }
+          end
+
+          context "with Rails 10.0" do
+            before { allow(Rails).to receive(:version).and_return("10.0") }
+
+            it { is_expected.to be(false) }
+          end
+
+          context "when called twice" do
+            before do
+              allow(Rails).to receive(:version).and_return("4.2")
+            end
+
+            it "memoizes the result" do
+              2.times { described_class.rails_version_less_than("4") }
+
+              expect(Rails).to have_received(:version).once
+            end
+          end
+        end
+      end
+
+      describe ".smart_trim" do
+        let(:long_string) { "1234567890" }
+
+        context "when FULL_TEXT_ERRORS is true" do
+          before { ENV["FULL_TEXT_ERRORS"] = "true" }
+          after { ENV["FULL_TEXT_ERRORS"] = nil }
+
+          it "returns the full string regardless of length" do
+            expect(described_class.smart_trim(long_string, 5)).to eq(long_string)
+          end
+
+          it "handles a hash without trimming" do
+            hash = { a: long_string }
+            expect(described_class.smart_trim(hash, 5)).to eq(hash.to_s)
+          end
+        end
+
+        context "when FULL_TEXT_ERRORS is not set" do
+          before { ENV["FULL_TEXT_ERRORS"] = nil }
+
+          it "trims smartly" do
+            expect(described_class.smart_trim(long_string, -1)).to eq("1234567890")
+            expect(described_class.smart_trim(long_string, 0)).to eq("1234567890")
+            expect(described_class.smart_trim(long_string, 1)).to eq("1#{Utils::TRUNCATION_FILLER}")
+            expect(described_class.smart_trim(long_string, 2)).to eq("1#{Utils::TRUNCATION_FILLER}0")
+            expect(described_class.smart_trim(long_string, 3)).to eq("1#{Utils::TRUNCATION_FILLER}90")
+            expect(described_class.smart_trim(long_string, 4)).to eq("12#{Utils::TRUNCATION_FILLER}90")
+            expect(described_class.smart_trim(long_string, 5)).to eq("12#{Utils::TRUNCATION_FILLER}890")
+            expect(described_class.smart_trim(long_string, 6)).to eq("123#{Utils::TRUNCATION_FILLER}890")
+            expect(described_class.smart_trim(long_string, 7)).to eq("123#{Utils::TRUNCATION_FILLER}7890")
+            expect(described_class.smart_trim(long_string, 8)).to eq("1234#{Utils::TRUNCATION_FILLER}7890")
+            expect(described_class.smart_trim(long_string, 9)).to eq("1234#{Utils::TRUNCATION_FILLER}67890")
+            expect(described_class.smart_trim(long_string, 10)).to eq("1234567890")
+            expect(described_class.smart_trim(long_string, 11)).to eq("1234567890")
+          end
+
+          it "trims handles a hash" do
+            s = { a: "1234567890" }
+            result = described_class.smart_trim(s, 9)
+            # Ruby version compatibility: handle different hash syntax and trimming results
+            expect(result).to match(/\{(:a=|a: ")#{Regexp.escape(Utils::TRUNCATION_FILLER)}\d+"\}/o)
+          end
+        end
+      end
+
+      describe ".react_on_rails_pro?" do
+        subject { described_class.react_on_rails_pro? }
+
+        it { is_expected.to(be(false)) }
+      end
+
+      describe ".react_on_rails_pro_version?" do
+        subject { described_class.react_on_rails_pro_version }
+
+        it { is_expected.to eq("") }
+      end
+
+      describe ".gem_available?" do
+        it "calls Gem.loaded_specs" do
+          expect(Gem).to receive(:loaded_specs)
+          described_class.gem_available?("nonexistent_gem")
+        end
+      end
     end
 
-    describe ".truthy_presence" do
-      context "when string empty" do
-        it "returns nil" do
-          expect(described_class.truthy_presence("")).to eq nil
-        end
-      end
-
-      context "when string is yes" do
-        it "returns true" do
-          expect(described_class.truthy_presence("yes")).to eq true
-        end
-      end
-
-      context "when string is true" do
-        it "returns true" do
-          expect(described_class.truthy_presence("true")).to eq true
-        end
-      end
-    end
-
-    describe ".object_to_boolean" do
-      [nil, false, "false", "no", "n"].each do |value|
-        it "returns false when #{value.inspect} (#{value.class})" do
-          expect(described_class.object_to_boolean(value)).to eq(false)
-        end
-      end
-
-      [true, "true", "yes", "y", 1, "1", "anything else", Object.new].each do |value|
-        it "returns true when #{value.inspect} (#{value.class})" do
-          expect(described_class.object_to_boolean(value)).to eq(true)
-        end
-      end
-    end
-
-    describe ".running_on_windows?" do
+    describe ".react_client_manifest_file_path" do
       before do
-        stub_const("RUBY_PLATFORM", ruby_platform)
+        described_class.instance_variable_set(:@react_client_manifest_path, nil)
+        allow(ReactOnRails.configuration).to receive(:react_client_manifest_file)
+          .and_return("react-client-manifest.json")
       end
 
-      context "when platform is 32 bit Windows" do
-        let(:ruby_platform) { "i386-mingw32" }
-
-        it "returns true" do
-          expect(described_class.running_on_windows?).to eq true
-        end
+      after do
+        described_class.instance_variable_set(:@react_client_manifest_path, nil)
       end
 
-      context "when platform is 64 bit Windows" do
-        let(:ruby_platform) { "x64-mingw32" }
+      context "when using packer" do
+        let(:public_output_path) { "/path/to/public/webpack/dev" }
 
-        it "returns true" do
-          expect(described_class.running_on_windows?).to eq true
-        end
-      end
-
-      context "when platform is not Windows" do
-        let(:ruby_platform) { "x86_64-darwin14" }
-
-        it "returns false" do
-          expect(described_class.running_on_windows?).to eq false
-        end
-      end
-    end
-
-    describe ".rails_version_less_than" do
-      before do
-        allow(Rails).to receive(:version).and_return(Gem::Version.create(rails_version))
-      end
-
-      describe "when Rails version is 3.1.2" do
-        let(:rails_version) { "3.1.2" }
-
-        it "returns false for 3.1.0" do
-          expect(described_class.rails_version_less_than("3.1.0")).to eq false
+        before do
+          allow(::Shakapacker).to receive_message_chain("config.public_output_path")
+            .and_return(Pathname.new(public_output_path))
+          allow(::Shakapacker).to receive_message_chain("config.public_path")
+            .and_return(Pathname.new("/path/to/public"))
         end
 
-        it "returns false for 3.1.1" do
-          expect(described_class.rails_version_less_than("3.1.1")).to eq false
+        context "when dev server is running" do
+          before do
+            allow(::Shakapacker).to receive(:dev_server).and_return(
+              instance_double(
+                ::Shakapacker::DevServer,
+                running?: true,
+                protocol: "http",
+                host_with_port: "localhost:3035"
+              )
+            )
+          end
+
+          it "returns manifest URL with dev server path" do
+            expected_url = "http://localhost:3035/webpack/dev/react-client-manifest.json"
+            expect(described_class.react_client_manifest_file_path).to eq(expected_url)
+          end
         end
 
-        it "returns false for 3.1.2" do
-          expect(described_class.rails_version_less_than("3.1.2")).to eq false
+        context "when dev server is not running" do
+          before do
+            allow(::Shakapacker).to receive_message_chain("dev_server.running?")
+              .and_return(false)
+          end
+
+          it "returns file path to the manifest" do
+            expected_path = File.join(public_output_path, "react-client-manifest.json")
+            expect(described_class.react_client_manifest_file_path).to eq(expected_path)
+          end
         end
-
-        it "returns true for 3.1.3" do
-          expect(described_class.rails_version_less_than("3.1.3")).to eq true
-        end
-
-        it "returns true for 3.2" do
-          expect(described_class.rails_version_less_than("3.2")).to eq true
-        end
-      end
-    end
-
-    describe ".rails_version_less_than_4_1_1" do
-      describe "when rails version is 4.1.0" do
-        before { allow(Rails).to receive(:version).and_return(Gem::Version.create("4.1.0")) }
-
-        it "returns true" do
-          expect(described_class.rails_version_less_than_4_1_1).to eq true
-        end
-      end
-
-      describe "when rails version is 4.1.1" do
-        before { allow(Rails).to receive(:version).and_return(Gem::Version.create("4.1.1")) }
-
-        it "returns false" do
-          expect(described_class.rails_version_less_than_4_1_1).to eq false
-        end
-      end
-    end
-
-    describe ".server_bundle_js_file_path" do
-      include_context "with shakapacker enabled"
-
-      # Calls the bundle_js_file_path method from ReactOnRails::Utils
-      # to retrieve the file path for the server bundle configured
-      # in ReactOnRails.
-      it "delegates call to bundle_js_file_path with server bundle name" do
-        # The configuration holds the name of the server bundle file
-        server_bundle_js_file = "server.js"
-
-        # Setup mock configuration with specific server bundle name
-        allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-          .and_return(server_bundle_js_file)
-
-        # Mock the bundle_js_file_path method to verify it's being called correctly
-        allow(described_class).to receive(:bundle_js_file_path).with(server_bundle_js_file).and_return("/path/to/server.js")
-
-        # Call the method under test
-        result = described_class.server_bundle_js_file_path
-
-        # Verify the delegation occurs correctly
-        expect(described_class).to have_received(:bundle_js_file_path).with(server_bundle_js_file)
-        expect(result).to eq("/path/to/server.js")
-      end
-    end
-
-    describe ".rsc_bundle_js_file_path" do
-      include_context "with shakapacker enabled"
-
-      # Calls the bundle_js_file_path method from ReactOnRails::Utils
-      # to retrieve the file path for the RSC bundle configured in ReactOnRails.
-      it "delegates call to bundle_js_file_path with RSC bundle name" do
-        # The configuration holds the name of the RSC bundle file
-        rsc_bundle_js_file = "rsc-client-bundle.js"
-
-        # Setup mock configuration with specific RSC bundle name
-        allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-          .and_return(rsc_bundle_js_file)
-
-        # Mock the bundle_js_file_path method to verify it's being called correctly
-        allow(described_class).to receive(:bundle_js_file_path).with(rsc_bundle_js_file).and_return("/path/to/rsc-client-bundle.js")
-
-        # Call the method under test
-        result = described_class.rsc_bundle_js_file_path
-
-        # Verify the delegation occurs correctly
-        expect(described_class).to have_received(:bundle_js_file_path).with(rsc_bundle_js_file)
-        expect(result).to eq("/path/to/rsc-client-bundle.js")
       end
     end
 
@@ -696,21 +800,17 @@ module ReactOnRails
       context "when in development environment" do
         before do
           allow(Rails.env).to receive(:development?).and_return(true)
-          allow(described_class).to receive(:bundle_js_file_path)
-            .with("react-server-client-manifest.json")
-            .and_return("/path/to/generated/assets/react-server-client-manifest.json")
+          allow(described_class).to receive(:public_bundles_full_path)
+            .and_return("/path/to/generated/assets")
         end
 
         it "does not use cached path" do
           # Call once to potentially set the cached path
           described_class.react_server_client_manifest_file_path
 
-          # Change the configuration value and mock
+          # Change the configuration value
           allow(ReactOnRails.configuration).to receive(:react_server_client_manifest_file)
             .and_return("changed-manifest.json")
-          allow(described_class).to receive(:bundle_js_file_path)
-            .with("changed-manifest.json")
-            .and_return("/path/to/generated/assets/changed-manifest.json")
 
           # Should use the new value
           expect(described_class.react_server_client_manifest_file_path)
@@ -720,9 +820,8 @@ module ReactOnRails
 
       context "when not in development environment" do
         before do
-          allow(described_class).to receive(:bundle_js_file_path)
-            .with("react-server-client-manifest.json")
-            .and_return("/path/to/generated/assets/react-server-client-manifest.json")
+          allow(described_class).to receive(:public_bundles_full_path)
+            .and_return("/path/to/generated/assets")
         end
 
         it "caches the path" do
@@ -734,19 +833,15 @@ module ReactOnRails
           allow(ReactOnRails.configuration).to receive(:react_server_client_manifest_file)
             .and_return("changed-manifest.json")
 
-          # Should still use the cached path (not calling bundle_js_file_path again)
+          # Should still use the cached path
           expect(described_class.react_server_client_manifest_file_path).to eq(expected_path)
         end
       end
 
       context "with different manifest file names" do
         before do
-          allow(described_class).to receive(:bundle_js_file_path)
-            .with("react-server-client-manifest.json")
-            .and_return("/path/to/generated/assets/react-server-client-manifest.json")
-          allow(described_class).to receive(:bundle_js_file_path)
-            .with("custom-server-client-manifest.json")
-            .and_return("/path/to/generated/assets/custom-server-client-manifest.json")
+          allow(described_class).to receive(:public_bundles_full_path)
+            .and_return("/path/to/generated/assets")
         end
 
         it "returns the correct path for default manifest name" do
@@ -770,6 +865,8 @@ module ReactOnRails
         before do
           allow(ReactOnRails.configuration).to receive(:react_server_client_manifest_file)
             .and_return(nil)
+          allow(described_class).to receive(:public_bundles_full_path)
+            .and_return("/path/to/generated/assets")
         end
 
         it "raises an error when the manifest file name is nil" do

--- a/spec/react_on_rails/utils_spec.rb
+++ b/spec/react_on_rails/utils_spec.rb
@@ -1,459 +1,432 @@
 # frozen_string_literal: true
 
-require_relative "spec_helper"
-require "shakapacker"
-
 # rubocop:disable Metrics/ModuleLength, Metrics/BlockLength
 module ReactOnRails
   RSpec.describe Utils do
-    # Since React on Rails v15+ requires ::Shakapacker as an explicit dependency,
-    # we only test with ::Shakapacker
-    packers_to_test = ["shakapacker"]
+    describe ".bundle_js_file_path" do
+      include_context "with shakapacker enabled"
 
-    shared_context "with packer enabled" do
-      let(:mock_packer) { instance_double(::Shakapacker::Instance) }
-      let(:mock_config) { instance_double(::Shakapacker::Configuration) }
-      let(:mock_dev_server) { instance_double(::Shakapacker::DevServer) }
+      # Context for testing server_bundle? and .bundle_js_file_path with various configurations.
+      packers_to_test = %i[shakapacker]
 
-      before do
-        allow(ReactOnRails).to receive_message_chain(:configuration, :generated_assets_dir)
-          .and_return("")
-        allow(::Shakapacker).to receive_messages(dev_server: mock_dev_server, config: mock_config)
-        allow(mock_dev_server).to receive(:running?).and_return(false)
-        allow(mock_config).to receive(:public_output_path).and_return(packer_public_output_path)
-      end
-    end
-
-    shared_context "with shakapacker enabled" do
-      include_context "with packer enabled"
-
-      # We don't need to mock anything here because the shakapacker gem is already installed and will be used by default
-      it "uses shakapacker" do
-        # PackerUtils now uses ::Shakapacker directly
-        expect(::Shakapacker).to be_present
-      end
-    end
-
-    def mock_bundle_in_manifest(bundle_name, hashed_bundle)
-      mock_manifest = instance_double(::Shakapacker::Manifest)
-      allow(mock_manifest).to receive(:lookup!)
-        .with(bundle_name)
-        .and_return(hashed_bundle)
-
-      allow(::Shakapacker).to receive(:manifest).and_return(mock_manifest)
-    end
-
-    def mock_missing_manifest_entry(bundle_name)
-      allow(::Shakapacker).to receive_message_chain("manifest.lookup!")
-        .with(bundle_name)
-        .and_raise(::Shakapacker::Manifest::MissingEntryError)
-    end
-
-    def random_bundle_name
-      "webpack-bundle-#{SecureRandom.hex(4)}.js"
-    end
-
-    # If bundle names are not provided, random unique names will be used for each bundle.
-    # This ensures that if server_bundle and rsc_bundle are accidentally swapped in the code,
-    # the tests will fail since each bundle has a distinct random name that won't match if used incorrectly.
-    def mock_bundle_configs(server_bundle_name: random_bundle_name, rsc_bundle_name: random_bundle_name)
-      allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-        .and_return(server_bundle_name)
-      allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-        .and_return(rsc_bundle_name)
-      allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-        .and_return("ssr-generated")
-      allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-        .and_return(false)
-    end
-
-    def mock_dev_server_running
-      allow(::Shakapacker).to receive_message_chain("dev_server.running?")
-        .and_return(true)
-      allow(::Shakapacker).to receive_message_chain("dev_server.protocol")
-        .and_return("http")
-      allow(::Shakapacker).to receive_message_chain("dev_server.host_with_port")
-        .and_return("localhost:3035")
-    end
-
-    context "when server_bundle_path cleared" do
-      before do
-        allow(Rails).to receive(:root).and_return(File.expand_path("."))
-        described_class.instance_variable_set(:@server_bundle_path, nil)
-        described_class.instance_variable_set(:@rsc_bundle_path, nil)
-        ReactOnRails::PackerUtils.instance_variables.each do |instance_variable|
-          ReactOnRails::PackerUtils.remove_instance_variable(instance_variable)
-        end
+      def mock_shakapacker_implementation
+        allow(::Shakapacker).to receive(:instance).and_return(double("Shakapacker Instance"))
+        allow(::Shakapacker).to receive(:manifest).and_return(double("Manifest", config: double("Config")))
+        allow(::Shakapacker.instance).to receive(:root_path).and_return(Rails.root)
+        allow(::Shakapacker.manifest.config).to receive(:public_output_path)
+          .and_return(::Pathname.new("public/webpack/dev"))
       end
 
-      after do
-        described_class.instance_variable_set(:@server_bundle_path, nil)
-        described_class.instance_variable_set(:@rsc_bundle_path, nil)
+      def mock_bundle_in_manifest(bundle_name, manifest_path)
+        manifest = double("Manifest")
+        allow(manifest).to receive(:lookup!).with(bundle_name).and_return(manifest_path)
+        allow(Shakapacker).to receive(:manifest).and_return(manifest)
       end
 
-      describe ".bundle_js_file_path" do
+      def mock_missing_manifest_entry(bundle_name)
+        manifest = double("Manifest")
+        allow(manifest).to receive(:lookup!).with(bundle_name)
+          .and_raise(Shakapacker::Manifest::MissingEntryError, "Entry #{bundle_name} not found")
+        allow(Shakapacker).to receive(:manifest).and_return(manifest)
+      end
+
+      # Generate random unique bundle names to prevent accidental test passes
+      # if server_bundle and rsc_bundle get swapped in the code
+      def random_bundle_name
+        "bundle-#{SecureRandom.hex(8)}.js"
+      end
+
+      # Helper to create a double for ReactOnRails.configuration with all server bundle settings
+      # This double includes the new server_bundle_output_path for configuring the private directory
+      # and the new enforce_private_server_bundles setting for controlling public/private fallback behavior
+      def make_config_double(
+        server_bundle_js_file: "server-bundle.js",
+        rsc_bundle_js_file: "rsc-bundle.js",
+        server_bundle_output_path: "ssr-generated",
+        enforce_private_server_bundles: false,
+        same_bundle_for_client_and_server: false
+      )
+        double("Configuration",
+               server_bundle_js_file: server_bundle_js_file,
+               rsc_bundle_js_file: rsc_bundle_js_file,
+               server_bundle_output_path: server_bundle_output_path,
+               enforce_private_server_bundles: enforce_private_server_bundles,
+               same_bundle_for_client_and_server: same_bundle_for_client_and_server)
+      end
+
+      # If bundle names are not provided, random unique names will be used for each bundle.
+      # This ensures that if server_bundle and rsc_bundle are accidentally swapped in the code,
+      # the tests will fail since each bundle has a distinct random name that won't match if used incorrectly.
+      def mock_bundle_configs(server_bundle_name: random_bundle_name, rsc_bundle_name: random_bundle_name,
+                              react_server_client_manifest_file: nil)
+        allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+          .and_return(server_bundle_name)
+        allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+          .and_return(rsc_bundle_name)
+        allow(ReactOnRails).to receive_message_chain("configuration.react_server_client_manifest_file")
+          .and_return(react_server_client_manifest_file)
+        allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+          .and_return("ssr-generated")
+        allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+          .and_return(false)
+      end
+
+      def mock_dev_server_running
+        allow(::Shakapacker).to receive_message_chain("dev_server.running?")
+          .and_return(true)
+        allow(::Shakapacker.dev_server).to receive(:host_with_port)
+          .and_return("localhost:3035")
+        allow(::Shakapacker.dev_server).to receive(:protocol)
+          .and_return("http")
+      end
+
+      context "with Shakapacker enabled", :shakapacker do
         before do
-          # Mock configuration calls to avoid server bundle detection for regular client bundles
-          allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-            .and_return("server-bundle.js")
-          allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-            .and_return("rsc-bundle.js")
+          mock_shakapacker_implementation
         end
 
-        subject do
-          described_class.bundle_js_file_path("webpack-bundle.js")
-        end
+        context "when server_bundle_path set and server bundle file" do
+          before do
+            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+              .and_return("server-bundle.js")
+            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+              .and_return("ssr-generated")
+            allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+              .and_return("rsc-bundle.js")
+          end
 
-        packers_to_test.each do |packer_type|
-          context "with #{packer_type} enabled", packer_type.to_sym do
-            include_context "with #{packer_type} enabled"
+          subject do
+            described_class.bundle_js_file_path("webpack-bundle.js")
+          end
 
-            let(:packer_public_output_path) do
-              File.expand_path(File.join(Rails.root, "public/webpack/dev"))
-            end
+          packers_to_test.each do |packer_type|
+            context "with #{packer_type} enabled", packer_type.to_sym do
+              include_context "with #{packer_type} enabled"
 
-            context "when file in manifest", :shakapacker do
-              before do
-                mock_bundle_in_manifest("webpack-bundle.js", "/webpack/dev/webpack-bundle-0123456789abcdef.js")
-
-                mock_bundle_configs(server_bundle_name: "server-bundle.js")
+              let(:packer_public_output_path) do
+                File.expand_path(File.join(Rails.root, "public/webpack/dev"))
               end
 
-              it { is_expected.to eq("#{packer_public_output_path}/webpack-bundle-0123456789abcdef.js") }
-            end
-
-            context "with manifest.json" do
-              subject do
-                described_class.bundle_js_file_path("manifest.json")
-              end
-
-              it { is_expected.to eq("#{packer_public_output_path}/manifest.json") }
-            end
-
-            context "when file not in manifest" do
-              before do
-                mock_missing_manifest_entry("webpack-bundle.js")
-              end
-
-              let(:env_specific_path) { File.join(packer_public_output_path, "webpack-bundle.js") }
-
-              it "returns environment-specific path" do
-                result = described_class.bundle_js_file_path("webpack-bundle.js")
-                expect(result).to eq(File.expand_path(env_specific_path))
-              end
-            end
-
-            context "with server bundle (SSR/RSC) file not in manifest" do
-              let(:server_bundle_name) { "server-bundle.js" }
-              let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", server_bundle_name)) }
-              let(:public_path) { File.expand_path(File.join(packer_public_output_path, server_bundle_name)) }
-
-              context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
+              context "when file in manifest", :shakapacker do
                 before do
-                  mock_missing_manifest_entry(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                    .and_return(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return("ssr-generated")
-                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                    .and_return(false)
+                  mock_bundle_in_manifest("webpack-bundle.js", "/webpack/dev/webpack-bundle-0123456789abcdef.js")
+
+                  mock_bundle_configs(server_bundle_name: "server-bundle.js")
                 end
 
-                it "returns private path when it exists even if public path also exists" do
-                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
-                  allow(File).to receive(:exist?).with(public_path).and_return(true)
+                it { is_expected.to eq("#{packer_public_output_path}/webpack-bundle-0123456789abcdef.js") }
+              end
 
-                  result = described_class.bundle_js_file_path(server_bundle_name)
-                  expect(result).to eq(ssr_generated_path)
+              context "with manifest.json" do
+                subject do
+                  described_class.bundle_js_file_path("manifest.json")
                 end
 
-                it "returns public path when private path does not exist and public path exists" do
-                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
-                  allow(File).to receive(:exist?).with(public_path).and_return(true)
+                it { is_expected.to eq("#{packer_public_output_path}/manifest.json") }
+              end
 
-                  result = described_class.bundle_js_file_path(server_bundle_name)
-                  expect(result).to eq(public_path)
+              context "when file not in manifest" do
+                before do
+                  mock_missing_manifest_entry("webpack-bundle.js")
                 end
 
-                it "returns configured path if both private and public paths do not exist" do
-                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
-                  allow(File).to receive(:exist?).with(public_path).and_return(false)
+                let(:env_specific_path) { File.join(packer_public_output_path, "webpack-bundle.js") }
 
-                  result = described_class.bundle_js_file_path(server_bundle_name)
-                  expect(result).to eq(ssr_generated_path)
+                it "returns environment-specific path" do
+                  result = described_class.bundle_js_file_path("webpack-bundle.js")
+                  expect(result).to eq(File.expand_path(env_specific_path))
                 end
               end
 
-              context "with server_bundle_output_path configured and enforce_private_server_bundles=true" do
+              context "with server bundle (SSR/RSC) file not in manifest" do
+                let(:server_bundle_name) { "server-bundle.js" }
+                let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", server_bundle_name)) }
+                let(:public_path) { File.expand_path(File.join(packer_public_output_path, server_bundle_name)) }
+
                 before do
+                  mock_bundle_configs(server_bundle_name: server_bundle_name)
                   mock_missing_manifest_entry(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                    .and_return(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return("ssr-generated")
-                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                    .and_return(true)
                 end
 
-                # It should always return the ssr_generated_path, regardless of which files exist
-                file_states_combinations = [
-                  { ssr_exists: true, public_exists: true },
-                  { ssr_exists: true, public_exists: false },
-                  { ssr_exists: false, public_exists: true },
-                  { ssr_exists: false, public_exists: false }
-                ]
-                file_states_combinations.each do |file_states|
-                  it "returns private path when enforce_private_server_bundles=true " \
-                     "(ssr_exists=#{file_states[:ssr_exists]}, " \
-                     "public_exists=#{file_states[:public_exists]})" do
-                    allow(File).to receive(:exist?)
-                      .with(ssr_generated_path)
-                      .and_return(file_states[:ssr_exists])
-                    allow(File).to receive(:exist?)
-                      .with(public_path)
-                      .and_return(file_states[:public_exists])
+                context "with server_bundle_output_path configured" do
+                  context "when enforce_private_server_bundles=false" do
+                    before do
+                      # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
+                      allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
+                    end
 
-                    result = described_class.bundle_js_file_path(server_bundle_name)
-                    expect(result).to eq(ssr_generated_path)
+                    it "returns the private ssr-generated path when file exists" do
+                      path = described_class.bundle_js_file_path(server_bundle_name)
+                      expect(path).to eq(ssr_generated_path)
+                    end
+
+                    context "when private file doesn't exist" do
+                      before do
+                        allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
+                        allow(File).to receive(:exist?).with(public_path).and_return(false)
+                      end
+
+                      it "returns the public path as fallback" do
+                        path = described_class.bundle_js_file_path(server_bundle_name)
+                        expect(path).to eq(public_path)
+                      end
+                    end
+                  end
+
+                  context "when enforce_private_server_bundles=true" do
+                    before do
+                      allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                        .and_return(true)
+                    end
+
+                    it "returns the private ssr-generated path without checking public paths" do
+                      # Should not check File.exist? for public paths
+                      expect(File).not_to receive(:exist?).with(public_path)
+
+                      path = described_class.bundle_js_file_path(server_bundle_name)
+                      expect(path).to eq(ssr_generated_path)
+                    end
+                  end
+                end
+
+                context "without server_bundle_output_path configured" do
+                  before do
+                    allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                      .and_return(nil)
+                  end
+
+                  it "returns the public path directly" do
+                    path = described_class.bundle_js_file_path(server_bundle_name)
+                    expect(path).to eq(public_path)
                   end
                 end
               end
 
-              context "without server_bundle_output_path configured" do
-                before do
-                  mock_missing_manifest_entry(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                    .and_return(server_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return(nil)
-                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                    .and_return(false)
+              context "with server bundle (SSR) file in manifest" do
+                let(:server_bundle_name) { "server-bundle.js" }
+                let(:manifest_path) { "/webpack/dev/server-bundle-abc123.js" }
+                let(:expected_path) do
+                  File.expand_path(File.join(packer_public_output_path, "server-bundle-abc123.js"))
                 end
 
-                it "uses packer public output path" do
-                  result = described_class.bundle_js_file_path(server_bundle_name)
-                  expect(result).to eq(File.expand_path(File.join(packer_public_output_path, server_bundle_name)))
+                before do
+                  mock_bundle_configs(server_bundle_name: server_bundle_name)
+                  mock_bundle_in_manifest(server_bundle_name, manifest_path)
+                end
+
+                context "with server_bundle_output_path configured" do
+                  it "returns manifest path (ignores server_bundle_output_path when in manifest)" do
+                    path = described_class.bundle_js_file_path(server_bundle_name)
+                    expect(path).to eq(expected_path)
+                  end
+                end
+
+                context "without server_bundle_output_path configured" do
+                  before do
+                    allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                      .and_return(nil)
+                  end
+
+                  it "returns manifest path directly" do
+                    path = described_class.bundle_js_file_path(server_bundle_name)
+                    expect(path).to eq(expected_path)
+                  end
+                end
+              end
+
+              context "with RSC bundle file not in manifest" do
+                let(:rsc_bundle_name) { "rsc-bundle.js" }
+                let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", rsc_bundle_name)) }
+                let(:public_path) { File.expand_path(File.join(packer_public_output_path, rsc_bundle_name)) }
+
+                before do
+                  mock_bundle_configs(rsc_bundle_name: rsc_bundle_name)
+                  mock_missing_manifest_entry(rsc_bundle_name)
+                end
+
+                context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
+                  before do
+                    # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
+                    allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
+                  end
+
+                  it "returns the private ssr-generated path when file exists" do
+                    path = described_class.bundle_js_file_path(rsc_bundle_name)
+                    expect(path).to eq(ssr_generated_path)
+                  end
+                end
+
+                context "with enforce_private_server_bundles=true" do
+                  before do
+                    allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
+                      .and_return(true)
+                  end
+
+                  it "returns the private ssr-generated path without checking public paths" do
+                    # Should not check File.exist? for public paths
+                    expect(File).not_to receive(:exist?).with(public_path)
+
+                    path = described_class.bundle_js_file_path(rsc_bundle_name)
+                    expect(path).to eq(ssr_generated_path)
+                  end
+                end
+              end
+
+              context "with RSC bundle file in manifest" do
+                let(:rsc_bundle_name) { "rsc-bundle.js" }
+                let(:manifest_path) { "/webpack/dev/rsc-bundle-xyz789.js" }
+                let(:expected_path) do
+                  File.expand_path(File.join(packer_public_output_path, "rsc-bundle-xyz789.js"))
+                end
+
+                before do
+                  mock_bundle_configs(rsc_bundle_name: rsc_bundle_name)
+                  mock_bundle_in_manifest(rsc_bundle_name, manifest_path)
+                end
+
+                it "returns manifest path" do
+                  path = described_class.bundle_js_file_path(rsc_bundle_name)
+                  expect(path).to eq(expected_path)
                 end
               end
             end
+          end
+        end
 
-            context "with RSC bundle file not in manifest" do
-              let(:rsc_bundle_name) { "rsc-bundle.js" }
-              let(:public_path) { File.expand_path(File.join(packer_public_output_path, rsc_bundle_name)) }
-              let(:ssr_generated_path) { File.expand_path(File.join("ssr-generated", rsc_bundle_name)) }
+        context "when server_bundle_path cleared" do
+          before do
+            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+              .and_return(nil)
+            allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+              .and_return("server-bundle.js")
+            allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+              .and_return("rsc-bundle.js")
+          end
 
-              context "with enforce_private_server_bundles=false" do
-                before do
-                  mock_missing_manifest_entry(rsc_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-                    .and_return(rsc_bundle_name)
-                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                    .and_return("ssr-generated")
-                  allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                    .and_return(false)
-                end
+          context ".server_bundle_js_file_path" do
+            context "with server_bundle_output_path configured" do
+              # This context block tests the behavior when a dedicated server bundle output path is configured.
+              # The server_bundle_output_path option allows placing server bundles (SSR/RSC) in a separate
+              # private directory outside the public assets folder for enhanced security.
+              # When this path is set, server bundles will be resolved from this directory rather than
+              # the public webpack output path.
+              it "returns the private ssr-generated path for server bundles" do
+                server_bundle_name = "server-bundle.js"
+                mock_bundle_configs(server_bundle_name: server_bundle_name)
+                mock_missing_manifest_entry(server_bundle_name)
 
-                it "returns private path when it exists even if public path also exists" do
-                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(true)
-                  expect(File).not_to receive(:exist?).with(public_path)
+                path = described_class.server_bundle_js_file_path
 
-                  result = described_class.bundle_js_file_path(rsc_bundle_name)
-                  expect(result).to eq(ssr_generated_path)
-                end
+                expect(path).to end_with("ssr-generated/#{server_bundle_name}")
+              end
 
-                it "fallbacks to public path when private path does not exist and public path exists" do
-                  allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
-                  allow(File).to receive(:exist?).with(public_path).and_return(true)
+              context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
+                it "returns the configured path directly without checking file existence" do
+                  server_bundle_name = "server-bundle.js"
+                  mock_bundle_configs(server_bundle_name: server_bundle_name)
+                  mock_missing_manifest_entry(server_bundle_name)
+                  # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
 
-                  result = described_class.bundle_js_file_path(rsc_bundle_name)
-                  expect(result).to eq(public_path)
-                end
-
-                it "returns configured path if both private and public paths do not exist" do
+                  # Since server_bundle_output_path is configured, it will try manifest lookup first,
+                  # then fall back to candidate paths. With enforce_private_server_bundles=false,
+                  # it will check File.exist? for both private and public paths
+                  ssr_generated_path = File.expand_path(File.join("ssr-generated", server_bundle_name))
+                  public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
                   allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
                   allow(File).to receive(:exist?).with(public_path).and_return(false)
 
-                  result = described_class.bundle_js_file_path(rsc_bundle_name)
-                  expect(result).to eq(ssr_generated_path)
+                  path = described_class.server_bundle_js_file_path
+
+                  # Should return public path as final fallback
+                  expect(path).to eq(public_path)
                 end
               end
 
               context "with enforce_private_server_bundles=true" do
-                before do
-                  mock_missing_manifest_entry(rsc_bundle_name)
+                it "returns the private ssr-generated path without checking public paths" do
+                  server_bundle_name = "server-bundle.js"
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+                    .and_return(server_bundle_name)
                   allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-                    .and_return(rsc_bundle_name)
+                    .and_return("rsc-bundle.js")
                   allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                     .and_return("ssr-generated")
                   allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
                     .and_return(true)
-                end
+                  mock_missing_manifest_entry(server_bundle_name)
 
-                it "enforces private RSC bundles and never checks public directory" do
-                  public_path = File.expand_path(File.join(packer_public_output_path, rsc_bundle_name))
+                  # Should not check File.exist? at all when enforce_private_server_bundles is true
+                  expect(File).not_to receive(:exist?)
 
-                  # Should not check public path when enforcement is enabled
-                  expect(File).not_to receive(:exist?).with(public_path)
+                  path = described_class.server_bundle_js_file_path
 
-                  result = described_class.bundle_js_file_path(rsc_bundle_name)
-                  expect(result).to eq(ssr_generated_path)
+                  expect(path).to end_with("ssr-generated/#{server_bundle_name}")
                 end
               end
             end
-          end
-        end
-      end
 
-      describe ".source_path_is_not_defined_and_custom_node_modules?" do
-        it "returns false if node_modules is blank" do
-          allow(ReactOnRails).to receive_message_chain("configuration.node_modules_location")
-            .and_return("")
-          allow(::Shakapacker).to receive_message_chain("config.send").with(:data)
-                                                                      .and_return({})
-
-          expect(described_class.using_packer_source_path_is_not_defined_and_custom_node_modules?).to be(false)
-        end
-
-        it "returns false if source_path is defined in the config/webpacker.yml and node_modules defined" do
-          allow(ReactOnRails).to receive_message_chain("configuration.node_modules_location")
-            .and_return("client")
-          allow(::Shakapacker).to receive_message_chain("config.send")
-            .with(:data).and_return(source_path: "client/app")
-
-          expect(described_class.using_packer_source_path_is_not_defined_and_custom_node_modules?).to be(false)
-        end
-
-        it "returns true if node_modules is not blank and the source_path is not defined in config/webpacker.yml" do
-          allow(ReactOnRails).to receive_message_chain("configuration.node_modules_location")
-            .and_return("node_modules")
-          allow(::Shakapacker).to receive_message_chain("config.send").with(:data)
-                                                                      .and_return({})
-
-          expect(described_class.using_packer_source_path_is_not_defined_and_custom_node_modules?).to be(true)
-        end
-      end
-
-      packers_to_test.each do |packer_type|
-        describe ".server_bundle_js_file_path with #{packer_type} enabled" do
-          let(:packer_public_output_path) { Pathname.new("public/webpack/development") }
-
-          include_context "with #{packer_type} enabled"
-
-          context "with server file not in manifest", packer_type.to_sym do
-            it "returns the private ssr-generated path for server bundles" do
-              server_bundle_name = "server-bundle.js"
-              mock_bundle_configs(server_bundle_name: server_bundle_name)
-              mock_missing_manifest_entry(server_bundle_name)
-
-              path = described_class.server_bundle_js_file_path
-
-              expect(path).to end_with("ssr-generated/#{server_bundle_name}")
-            end
-
-            context "with server_bundle_output_path configured and enforce_private_server_bundles=false" do
-              it "returns the configured path directly without checking file existence" do
-                server_bundle_name = "server-bundle.js"
-                mock_bundle_configs(server_bundle_name: server_bundle_name)
-                mock_missing_manifest_entry(server_bundle_name)
-                # NOTE: mock_bundle_configs sets enforce_private_server_bundles to false
-
-                # Since server_bundle_output_path is configured, it will try manifest lookup first,
-                # then fall back to candidate paths. With enforce_private_server_bundles=false,
-                # it will check File.exist? for both private and public paths
-                ssr_generated_path = File.expand_path(File.join("ssr-generated", server_bundle_name))
-                public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
-                allow(File).to receive(:exist?).with(ssr_generated_path).and_return(false)
-                allow(File).to receive(:exist?).with(public_path).and_return(false)
-
-                path = described_class.server_bundle_js_file_path
-
-                expect(path).to end_with("ssr-generated/#{server_bundle_name}")
-              end
-            end
-
-            context "with server_bundle_output_path configured and enforce_private_server_bundles=true" do
-              it "returns the private path without checking public directories" do
-                server_bundle_name = "server-bundle.js"
-                mock_missing_manifest_entry(server_bundle_name)
-                allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                  .and_return(server_bundle_name)
-                allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                  .and_return("ssr-generated")
-                allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
-                  .and_return(true)
-
-                # Should not check public paths when enforcement is enabled
-                public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
-                expect(File).not_to receive(:exist?).with(public_path)
-
-                path = described_class.server_bundle_js_file_path
-                expect(path).to end_with("ssr-generated/#{server_bundle_name}")
-              end
-            end
-          end
-
-          context "with server file in the manifest, used for client", packer_type.to_sym do
-            it "returns the correct path hashed server path" do
-              # Use Shakapacker directly instead of packer method
-              mock_bundle_configs(server_bundle_name: "webpack-bundle.js")
-              # Clear server_bundle_output_path to test manifest behavior
-              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                .and_return(nil)
-              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                .and_return(true)
-              mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
-              allow(Shakapacker).to receive_message_chain("dev_server.running?")
-                .and_return(false)
-
-              path = described_class.server_bundle_js_file_path
-              expect(path).to end_with("public/webpack/development/webpack-bundle-123456.js")
-              expect(path).to start_with("/")
-            end
-
-            context "with webpack-dev-server running, and same file used for server and client" do
+            context "with shakapacker and same file used by server and client", :shakapacker do
               it "returns the correct path hashed server path" do
+                # Use Shakapacker directly instead of packer method
                 mock_bundle_configs(server_bundle_name: "webpack-bundle.js")
                 # Clear server_bundle_output_path to test manifest behavior
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                   .and_return(nil)
                 allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
                   .and_return(true)
-                mock_dev_server_running
-                mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
+                mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
+                allow(Shakapacker).to receive_message_chain("dev_server.running?")
+                  .and_return(false)
 
                 path = described_class.server_bundle_js_file_path
 
-                expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
+                expect(path).to include("webpack-bundle-123456.js")
+              end
+
+              context "with webpack-dev-server running, and same file used for server and client" do
+                it "returns the correct path hashed server path" do
+                  mock_bundle_configs(server_bundle_name: "webpack-bundle.js")
+                  # Clear server_bundle_output_path to test manifest behavior
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return(nil)
+                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                    .and_return(true)
+                  mock_dev_server_running
+                  mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
+
+                  path = described_class.server_bundle_js_file_path
+
+                  expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
+                end
+              end
+
+              context "with webpack-dev-server running, and server file separate from client files",
+                      packer_type.to_sym do
+                it "returns the correct path hashed server path" do
+                  mock_bundle_configs(server_bundle_name: "server-bundle.js")
+                  # Clear server_bundle_output_path to test manifest behavior
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return(nil)
+                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                    .and_return(false)
+                  mock_bundle_in_manifest("server-bundle.js", "webpack/development/server-bundle-123456.js")
+                  mock_dev_server_running
+
+                  path = described_class.server_bundle_js_file_path
+
+                  expect(path).to include("server-bundle-123456.js")
+                end
               end
             end
           end
 
-          context "with dev-server running, and server file in the manifest, and separate client/server files",
-                  packer_type.to_sym do
-            it "returns the correct path hashed server path" do
-              mock_bundle_configs(server_bundle_name: "server-bundle.js")
-              # Clear server_bundle_output_path to test manifest behavior
-              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                .and_return(nil)
-              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                .and_return(false)
-              mock_bundle_in_manifest("server-bundle.js", "webpack/development/server-bundle-123456.js")
-              mock_dev_server_running
-
-              path = described_class.server_bundle_js_file_path
-
-              expect(path).to end_with("/public/webpack/development/server-bundle-123456.js")
-            end
-          end
-        end
-
-        describe ".rsc_bundle_js_file_path with #{packer_type} enabled" do
-          let(:packer_public_output_path) { Pathname.new("public/webpack/development") }
-
-          include_context "with #{packer_type} enabled"
-
-          context "with server file not in manifest", packer_type.to_sym do
-            context "with enforce_private_server_bundles=false" do
+          context ".rsc_bundle_js_file_path" do
+            context "with server_bundle_output_path configured" do
+              # This context block tests the behavior when a dedicated server bundle output path is configured.
+              # The server_bundle_output_path option allows placing server bundles (SSR/RSC) in a separate
+              # private directory outside the public assets folder for enhanced security.
+              # When this path is set, RSC bundles will be resolved from this directory rather than
+              # the public webpack output path.
               it "returns the private ssr-generated path for RSC bundles" do
                 server_bundle_name = "rsc-bundle.js"
                 mock_bundle_configs(rsc_bundle_name: server_bundle_name)
@@ -467,321 +440,244 @@ module ReactOnRails
 
             context "with enforce_private_server_bundles=true" do
               it "returns the private ssr-generated path for RSC bundles without checking public paths" do
-                server_bundle_name = "rsc-bundle.js"
-                mock_missing_manifest_entry(server_bundle_name)
+                rsc_bundle_name = "rsc-bundle.js"
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
-                  .and_return("server-bundle.js") # Different from RSC bundle name
+                  .and_return("server-bundle.js")
                 allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
-                  .and_return(server_bundle_name)
+                  .and_return(rsc_bundle_name)
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                   .and_return("ssr-generated")
                 allow(ReactOnRails).to receive_message_chain("configuration.enforce_private_server_bundles")
                   .and_return(true)
+                mock_missing_manifest_entry(rsc_bundle_name)
 
-                # Should not check public paths when enforcement is enabled
-                public_path = File.expand_path(File.join(packer_public_output_path, server_bundle_name))
-                expect(File).not_to receive(:exist?).with(public_path)
+                # Should not check File.exist? at all when enforce_private_server_bundles is true
+                expect(File).not_to receive(:exist?)
 
                 path = described_class.rsc_bundle_js_file_path
-                expect(path).to end_with("ssr-generated/#{server_bundle_name}")
+
+                expect(path).to end_with("ssr-generated/#{rsc_bundle_name}")
               end
             end
-          end
 
-          context "with server file in the manifest, used for client", packer_type.to_sym do
-            it "returns the correct path hashed server path" do
-              # Use Shakapacker directly instead of packer method
-              mock_bundle_configs(rsc_bundle_name: "webpack-bundle.js")
-              # Clear server_bundle_output_path to test manifest behavior
-              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                .and_return(nil)
-              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                .and_return(true)
-              mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
-              allow(Shakapacker).to receive_message_chain("dev_server.running?")
-                .and_return(false)
-
-              path = described_class.rsc_bundle_js_file_path
-              expect(path).to end_with("public/webpack/development/webpack-bundle-123456.js")
-              expect(path).to start_with("/")
-            end
-
-            context "with webpack-dev-server running, and same file used for server and client" do
+            context "with shakapacker and same file used by server and client", :shakapacker do
               it "returns the correct path hashed server path" do
+                # Use Shakapacker directly instead of packer method
                 mock_bundle_configs(rsc_bundle_name: "webpack-bundle.js")
                 # Clear server_bundle_output_path to test manifest behavior
                 allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
                   .and_return(nil)
                 allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
                   .and_return(true)
-                mock_dev_server_running
-                mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
+                mock_bundle_in_manifest("webpack-bundle.js", "webpack/development/webpack-bundle-123456.js")
+                allow(Shakapacker).to receive_message_chain("dev_server.running?")
+                  .and_return(false)
 
                 path = described_class.rsc_bundle_js_file_path
 
-                expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
+                expect(path).to include("webpack-bundle-123456.js")
+              end
+
+              context "with webpack-dev-server running, and same file used for server and client" do
+                it "returns the correct path hashed server path" do
+                  mock_bundle_configs(rsc_bundle_name: "webpack-bundle.js")
+                  # Clear server_bundle_output_path to test manifest behavior
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return(nil)
+                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                    .and_return(true)
+                  mock_dev_server_running
+                  mock_bundle_in_manifest("webpack-bundle.js", "/webpack/development/webpack-bundle-123456.js")
+
+                  path = described_class.rsc_bundle_js_file_path
+
+                  expect(path).to eq("http://localhost:3035/webpack/development/webpack-bundle-123456.js")
+                end
+              end
+
+              context "with webpack-dev-server running, and server file separate from client files",
+                      packer_type.to_sym do
+                it "returns the correct path hashed server path" do
+                  mock_bundle_configs(rsc_bundle_name: "rsc-bundle.js")
+                  # Clear server_bundle_output_path to test manifest behavior
+                  allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
+                    .and_return(nil)
+                  allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
+                    .and_return(false)
+                  mock_bundle_in_manifest("rsc-bundle.js", "webpack/development/server-bundle-123456.js")
+                  mock_dev_server_running
+
+                  path = described_class.rsc_bundle_js_file_path
+
+                  expect(path).to include("server-bundle-123456.js")
+                end
               end
             end
           end
-
-          context "with dev-server running, and server file in the manifest, and separate client/server files",
-                  packer_type.to_sym do
-            it "returns the correct path hashed server path" do
-              mock_bundle_configs(rsc_bundle_name: "rsc-bundle.js")
-              # Clear server_bundle_output_path to test manifest behavior
-              allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_output_path")
-                .and_return(nil)
-              allow(ReactOnRails).to receive_message_chain("configuration.same_bundle_for_client_and_server")
-                .and_return(false)
-              mock_bundle_in_manifest("rsc-bundle.js", "webpack/development/server-bundle-123456.js")
-              mock_dev_server_running
-
-              path = described_class.rsc_bundle_js_file_path
-
-              expect(path).to end_with("/public/webpack/development/server-bundle-123456.js")
-            end
-          end
-        end
-      end
-
-      describe ".wrap_message" do
-        subject(:stripped_heredoc) do
-          <<-MSG.strip_heredoc
-          Something to wrap
-          with 2 lines
-          MSG
-        end
-
-        let(:expected) do
-          msg = <<-MSG.strip_heredoc
-          ================================================================================
-          Something to wrap
-          with 2 lines
-          ================================================================================
-          MSG
-          Rainbow(msg).red
-        end
-
-        it "outputs the correct text" do
-          expect(described_class.wrap_message(stripped_heredoc)).to eq(expected)
-        end
-      end
-
-      describe ".truthy_presence" do
-        context "with non-empty string" do
-          subject(:simple_string) { "foobar" }
-
-          it "returns subject (same value as presence) for a non-empty string" do
-            expect(described_class.truthy_presence(simple_string)).to eq(simple_string.presence)
-
-            # Blank strings are nil for presence
-            expect(described_class.truthy_presence(simple_string)).to eq(simple_string)
-          end
-        end
-
-        context "with empty string" do
-          it "returns \"\" for an empty string" do
-            expect(described_class.truthy_presence("")).to eq("")
-          end
-        end
-
-        context "with nil object" do
-          it "returns nil (same value as presence)" do
-            expect(described_class.truthy_presence(nil)).to eq(nil.presence)
-
-            # Blank strings are nil for presence
-            expect(described_class.truthy_presence(nil)).to be_nil
-          end
-        end
-
-        context "with pathname pointing to empty dir (obj.empty? is true)" do
-          subject(:empty_dir) { Pathname.new(Dir.mktmpdir) }
-
-          it "returns Pathname object" do
-            # Blank strings are nil for presence
-            expect(described_class.truthy_presence(empty_dir)).to eq(empty_dir)
-          end
-        end
-
-        context "with pathname pointing to empty file" do
-          subject(:empty_file) do
-            File.basename(Tempfile.new("tempfile",
-                                       empty_dir))
-          end
-
-          let(:empty_dir) { Pathname.new(Dir.mktmpdir) }
-
-          it "returns Pathname object" do
-            expect(described_class.truthy_presence(empty_file)).to eq(empty_file)
-          end
-        end
-      end
-
-      describe ".rails_version_less_than" do
-        subject { described_class.rails_version_less_than("4") }
-
-        describe ".rails_version_less_than" do
-          before { described_class.instance_variable_set :@rails_version_less_than, nil }
-
-          context "with Rails 3" do
-            before { allow(Rails).to receive(:version).and_return("3") }
-
-            it { is_expected.to be(true) }
-          end
-
-          context "with Rails 3.2" do
-            before { allow(Rails).to receive(:version).and_return("3.2") }
-
-            it { is_expected.to be(true) }
-          end
-
-          context "with Rails 4" do
-            before { allow(Rails).to receive(:version).and_return("4") }
-
-            it { is_expected.to be(false) }
-          end
-
-          context "with Rails 4.2" do
-            before { allow(Rails).to receive(:version).and_return("4.2") }
-
-            it { is_expected.to be(false) }
-          end
-
-          context "with Rails 10.0" do
-            before { allow(Rails).to receive(:version).and_return("10.0") }
-
-            it { is_expected.to be(false) }
-          end
-
-          context "when called twice" do
-            before do
-              allow(Rails).to receive(:version).and_return("4.2")
-            end
-
-            it "memoizes the result" do
-              2.times { described_class.rails_version_less_than("4") }
-
-              expect(Rails).to have_received(:version).once
-            end
-          end
-        end
-      end
-
-      describe ".smart_trim" do
-        let(:long_string) { "1234567890" }
-
-        context "when FULL_TEXT_ERRORS is true" do
-          before { ENV["FULL_TEXT_ERRORS"] = "true" }
-          after { ENV["FULL_TEXT_ERRORS"] = nil }
-
-          it "returns the full string regardless of length" do
-            expect(described_class.smart_trim(long_string, 5)).to eq(long_string)
-          end
-
-          it "handles a hash without trimming" do
-            hash = { a: long_string }
-            expect(described_class.smart_trim(hash, 5)).to eq(hash.to_s)
-          end
-        end
-
-        context "when FULL_TEXT_ERRORS is not set" do
-          before { ENV["FULL_TEXT_ERRORS"] = nil }
-
-          it "trims smartly" do
-            expect(described_class.smart_trim(long_string, -1)).to eq("1234567890")
-            expect(described_class.smart_trim(long_string, 0)).to eq("1234567890")
-            expect(described_class.smart_trim(long_string, 1)).to eq("1#{Utils::TRUNCATION_FILLER}")
-            expect(described_class.smart_trim(long_string, 2)).to eq("1#{Utils::TRUNCATION_FILLER}0")
-            expect(described_class.smart_trim(long_string, 3)).to eq("1#{Utils::TRUNCATION_FILLER}90")
-            expect(described_class.smart_trim(long_string, 4)).to eq("12#{Utils::TRUNCATION_FILLER}90")
-            expect(described_class.smart_trim(long_string, 5)).to eq("12#{Utils::TRUNCATION_FILLER}890")
-            expect(described_class.smart_trim(long_string, 6)).to eq("123#{Utils::TRUNCATION_FILLER}890")
-            expect(described_class.smart_trim(long_string, 7)).to eq("123#{Utils::TRUNCATION_FILLER}7890")
-            expect(described_class.smart_trim(long_string, 8)).to eq("1234#{Utils::TRUNCATION_FILLER}7890")
-            expect(described_class.smart_trim(long_string, 9)).to eq("1234#{Utils::TRUNCATION_FILLER}67890")
-            expect(described_class.smart_trim(long_string, 10)).to eq("1234567890")
-            expect(described_class.smart_trim(long_string, 11)).to eq("1234567890")
-          end
-
-          it "trims handles a hash" do
-            s = { a: "1234567890" }
-            result = described_class.smart_trim(s, 9)
-            # Ruby version compatibility: handle different hash syntax and trimming results
-            expect(result).to match(/\{(:a=|a: ")#{Regexp.escape(Utils::TRUNCATION_FILLER)}\d+"\}/o)
-          end
-        end
-      end
-
-      describe ".react_on_rails_pro?" do
-        subject { described_class.react_on_rails_pro? }
-
-        it { is_expected.to(be(false)) }
-      end
-
-      describe ".react_on_rails_pro_version?" do
-        subject { described_class.react_on_rails_pro_version }
-
-        it { is_expected.to eq("") }
-      end
-
-      describe ".gem_available?" do
-        it "calls Gem.loaded_specs" do
-          expect(Gem).to receive(:loaded_specs)
-          described_class.gem_available?("nonexistent_gem")
         end
       end
     end
 
-    describe ".react_client_manifest_file_path" do
+    describe ".truthy_presence" do
+      context "when string empty" do
+        it "returns nil" do
+          expect(described_class.truthy_presence("")).to eq nil
+        end
+      end
+
+      context "when string is yes" do
+        it "returns true" do
+          expect(described_class.truthy_presence("yes")).to eq true
+        end
+      end
+
+      context "when string is true" do
+        it "returns true" do
+          expect(described_class.truthy_presence("true")).to eq true
+        end
+      end
+    end
+
+    describe ".object_to_boolean" do
+      [nil, false, "false", "no", "n"].each do |value|
+        it "returns false when #{value.inspect} (#{value.class})" do
+          expect(described_class.object_to_boolean(value)).to eq(false)
+        end
+      end
+
+      [true, "true", "yes", "y", 1, "1", "anything else", Object.new].each do |value|
+        it "returns true when #{value.inspect} (#{value.class})" do
+          expect(described_class.object_to_boolean(value)).to eq(true)
+        end
+      end
+    end
+
+    describe ".running_on_windows?" do
       before do
-        described_class.instance_variable_set(:@react_client_manifest_path, nil)
-        allow(ReactOnRails.configuration).to receive(:react_client_manifest_file)
-          .and_return("react-client-manifest.json")
+        stub_const("RUBY_PLATFORM", ruby_platform)
       end
 
-      after do
-        described_class.instance_variable_set(:@react_client_manifest_path, nil)
+      context "when platform is 32 bit Windows" do
+        let(:ruby_platform) { "i386-mingw32" }
+
+        it "returns true" do
+          expect(described_class.running_on_windows?).to eq true
+        end
       end
 
-      context "when using packer" do
-        let(:public_output_path) { "/path/to/public/webpack/dev" }
+      context "when platform is 64 bit Windows" do
+        let(:ruby_platform) { "x64-mingw32" }
 
-        before do
-          allow(::Shakapacker).to receive_message_chain("config.public_output_path")
-            .and_return(Pathname.new(public_output_path))
-          allow(::Shakapacker).to receive_message_chain("config.public_path")
-            .and_return(Pathname.new("/path/to/public"))
+        it "returns true" do
+          expect(described_class.running_on_windows?).to eq true
+        end
+      end
+
+      context "when platform is not Windows" do
+        let(:ruby_platform) { "x86_64-darwin14" }
+
+        it "returns false" do
+          expect(described_class.running_on_windows?).to eq false
+        end
+      end
+    end
+
+    describe ".rails_version_less_than" do
+      before do
+        allow(Rails).to receive(:version).and_return(Gem::Version.create(rails_version))
+      end
+
+      describe "when Rails version is 3.1.2" do
+        let(:rails_version) { "3.1.2" }
+
+        it "returns false for 3.1.0" do
+          expect(described_class.rails_version_less_than("3.1.0")).to eq false
         end
 
-        context "when dev server is running" do
-          before do
-            allow(::Shakapacker).to receive(:dev_server).and_return(
-              instance_double(
-                ::Shakapacker::DevServer,
-                running?: true,
-                protocol: "http",
-                host_with_port: "localhost:3035"
-              )
-            )
-          end
-
-          it "returns manifest URL with dev server path" do
-            expected_url = "http://localhost:3035/webpack/dev/react-client-manifest.json"
-            expect(described_class.react_client_manifest_file_path).to eq(expected_url)
-          end
+        it "returns false for 3.1.1" do
+          expect(described_class.rails_version_less_than("3.1.1")).to eq false
         end
 
-        context "when dev server is not running" do
-          before do
-            allow(::Shakapacker).to receive_message_chain("dev_server.running?")
-              .and_return(false)
-          end
-
-          it "returns file path to the manifest" do
-            expected_path = File.join(public_output_path, "react-client-manifest.json")
-            expect(described_class.react_client_manifest_file_path).to eq(expected_path)
-          end
+        it "returns false for 3.1.2" do
+          expect(described_class.rails_version_less_than("3.1.2")).to eq false
         end
+
+        it "returns true for 3.1.3" do
+          expect(described_class.rails_version_less_than("3.1.3")).to eq true
+        end
+
+        it "returns true for 3.2" do
+          expect(described_class.rails_version_less_than("3.2")).to eq true
+        end
+      end
+    end
+
+    describe ".rails_version_less_than_4_1_1" do
+      describe "when rails version is 4.1.0" do
+        before { allow(Rails).to receive(:version).and_return(Gem::Version.create("4.1.0")) }
+
+        it "returns true" do
+          expect(described_class.rails_version_less_than_4_1_1).to eq true
+        end
+      end
+
+      describe "when rails version is 4.1.1" do
+        before { allow(Rails).to receive(:version).and_return(Gem::Version.create("4.1.1")) }
+
+        it "returns false" do
+          expect(described_class.rails_version_less_than_4_1_1).to eq false
+        end
+      end
+    end
+
+    describe ".server_bundle_js_file_path" do
+      include_context "with shakapacker enabled"
+
+      # Calls the bundle_js_file_path method from ReactOnRails::Utils
+      # to retrieve the file path for the server bundle configured
+      # in ReactOnRails.
+      it "delegates call to bundle_js_file_path with server bundle name" do
+        # The configuration holds the name of the server bundle file
+        server_bundle_js_file = "server.js"
+
+        # Setup mock configuration with specific server bundle name
+        allow(ReactOnRails).to receive_message_chain("configuration.server_bundle_js_file")
+          .and_return(server_bundle_js_file)
+
+        # Mock the bundle_js_file_path method to verify it's being called correctly
+        allow(described_class).to receive(:bundle_js_file_path).with(server_bundle_js_file).and_return("/path/to/server.js")
+
+        # Call the method under test
+        result = described_class.server_bundle_js_file_path
+
+        # Verify the delegation occurs correctly
+        expect(described_class).to have_received(:bundle_js_file_path).with(server_bundle_js_file)
+        expect(result).to eq("/path/to/server.js")
+      end
+    end
+
+    describe ".rsc_bundle_js_file_path" do
+      include_context "with shakapacker enabled"
+
+      # Calls the bundle_js_file_path method from ReactOnRails::Utils
+      # to retrieve the file path for the RSC bundle configured in ReactOnRails.
+      it "delegates call to bundle_js_file_path with RSC bundle name" do
+        # The configuration holds the name of the RSC bundle file
+        rsc_bundle_js_file = "rsc-client-bundle.js"
+
+        # Setup mock configuration with specific RSC bundle name
+        allow(ReactOnRails).to receive_message_chain("configuration.rsc_bundle_js_file")
+          .and_return(rsc_bundle_js_file)
+
+        # Mock the bundle_js_file_path method to verify it's being called correctly
+        allow(described_class).to receive(:bundle_js_file_path).with(rsc_bundle_js_file).and_return("/path/to/rsc-client-bundle.js")
+
+        # Call the method under test
+        result = described_class.rsc_bundle_js_file_path
+
+        # Verify the delegation occurs correctly
+        expect(described_class).to have_received(:bundle_js_file_path).with(rsc_bundle_js_file)
+        expect(result).to eq("/path/to/rsc-client-bundle.js")
       end
     end
 
@@ -800,17 +696,21 @@ module ReactOnRails
       context "when in development environment" do
         before do
           allow(Rails.env).to receive(:development?).and_return(true)
-          allow(described_class).to receive(:public_bundles_full_path)
-            .and_return("/path/to/generated/assets")
+          allow(described_class).to receive(:bundle_js_file_path)
+            .with("react-server-client-manifest.json")
+            .and_return("/path/to/generated/assets/react-server-client-manifest.json")
         end
 
         it "does not use cached path" do
           # Call once to potentially set the cached path
           described_class.react_server_client_manifest_file_path
 
-          # Change the configuration value
+          # Change the configuration value and mock
           allow(ReactOnRails.configuration).to receive(:react_server_client_manifest_file)
             .and_return("changed-manifest.json")
+          allow(described_class).to receive(:bundle_js_file_path)
+            .with("changed-manifest.json")
+            .and_return("/path/to/generated/assets/changed-manifest.json")
 
           # Should use the new value
           expect(described_class.react_server_client_manifest_file_path)
@@ -820,8 +720,9 @@ module ReactOnRails
 
       context "when not in development environment" do
         before do
-          allow(described_class).to receive(:public_bundles_full_path)
-            .and_return("/path/to/generated/assets")
+          allow(described_class).to receive(:bundle_js_file_path)
+            .with("react-server-client-manifest.json")
+            .and_return("/path/to/generated/assets/react-server-client-manifest.json")
         end
 
         it "caches the path" do
@@ -833,15 +734,19 @@ module ReactOnRails
           allow(ReactOnRails.configuration).to receive(:react_server_client_manifest_file)
             .and_return("changed-manifest.json")
 
-          # Should still use the cached path
+          # Should still use the cached path (not calling bundle_js_file_path again)
           expect(described_class.react_server_client_manifest_file_path).to eq(expected_path)
         end
       end
 
       context "with different manifest file names" do
         before do
-          allow(described_class).to receive(:public_bundles_full_path)
-            .and_return("/path/to/generated/assets")
+          allow(described_class).to receive(:bundle_js_file_path)
+            .with("react-server-client-manifest.json")
+            .and_return("/path/to/generated/assets/react-server-client-manifest.json")
+          allow(described_class).to receive(:bundle_js_file_path)
+            .with("custom-server-client-manifest.json")
+            .and_return("/path/to/generated/assets/custom-server-client-manifest.json")
         end
 
         it "returns the correct path for default manifest name" do
@@ -865,8 +770,6 @@ module ReactOnRails
         before do
           allow(ReactOnRails.configuration).to receive(:react_server_client_manifest_file)
             .and_return(nil)
-          allow(described_class).to receive(:public_bundles_full_path)
-            .and_return("/path/to/generated/assets")
         end
 
         it "raises an error when the manifest file name is nil" do


### PR DESCRIPTION
…ent_manifest_file in server_bundle? method and refactoring react_server_manifest_path assignment to use bundle_js_file_path. This improves configuration flexibility and maintains consistency in bundle management.

### Summary

_Remove this paragraph and provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together._

### Pull Request checklist

_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

_Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1818)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of server-related bundles so manifests are correctly recognized and loaded.

* **Improvements**
  * Server manifest path resolution now delegates to the standard asset resolution routine, improving SSR/RSC consistency and reducing configuration fragility.
  * Added caching behavior adjustments for non-development vs development environments.

* **Tests**
  * Expanded tests covering path delegation, caching semantics, error handling for missing manifest names, and environment variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->