### PR TITLE
Fix: Universal process manager bundler context fallback

### DIFF
--- a/lib/react_on_rails/dev/process_manager.rb
+++ b/lib/react_on_rails/dev/process_manager.rb
@@ -5,6 +5,9 @@ require "timeout"
 module ReactOnRails
   module Dev
     class ProcessManager
+      # Timeout for version check operations to prevent hanging
+      VERSION_CHECK_TIMEOUT = 5
+
       class << self
         # Check if a process is available and usable in the current execution context
         # This accounts for bundler context where system commands might be intercepted
@@ -49,7 +52,7 @@ module ReactOnRails
           # Use system() because that's how we'll actually call it later
           version_flags_for(process).any? do |flag|
             # Add timeout to prevent hanging on version checks
-            Timeout.timeout(5) do
+            Timeout.timeout(VERSION_CHECK_TIMEOUT) do
               system(process, flag, out: File::NULL, err: File::NULL)
             end
           end
@@ -103,7 +106,7 @@ module ReactOnRails
             # Try version flags to check if process exists outside bundler context
             version_flags_for(process).any? do |flag|
               # Add timeout to prevent hanging on version checks
-              Timeout.timeout(5) do
+              Timeout.timeout(VERSION_CHECK_TIMEOUT) do
                 system(process, flag, out: File::NULL, err: File::NULL)
               end
             end

--- a/lib/react_on_rails/dev/process_manager.rb
+++ b/lib/react_on_rails/dev/process_manager.rb
@@ -8,9 +8,6 @@ module ReactOnRails
       # Timeout for version check operations to prevent hanging
       VERSION_CHECK_TIMEOUT = 5
 
-      # Process managers in order of preference
-      PROCESS_MANAGERS = %w[overmind foreman].freeze
-
       class << self
         # Check if a process is available and usable in the current execution context
         # This accounts for bundler context where system commands might be intercepted
@@ -39,9 +36,8 @@ module ReactOnRails
           FileManager.cleanup_stale_files
 
           # Try process managers in order of preference
-          PROCESS_MANAGERS.each do |pm|
-            return if run_process_if_available(pm, ["start", "-f", procfile])
-          end
+          return if run_process_if_available("overmind", ["start", "-f", procfile])
+          return if run_process_if_available("foreman", ["start", "-f", procfile])
 
           show_process_manager_installation_help
           exit 1
@@ -159,9 +155,11 @@ module ReactOnRails
         end
 
         def valid_procfile_path?(procfile)
-          # system is invoked with args (no shell), so shell metacharacters are safe.
-          # Ensure it's a readable regular file.
-          File.file?(procfile) && File.readable?(procfile)
+          # Reject paths with shell metacharacters
+          return false if procfile.match?(/[;&|`$(){}\[\]<>]/)
+
+          # Ensure it's a readable file
+          File.readable?(procfile)
         rescue StandardError
           false
         end

--- a/lib/react_on_rails/dev/process_manager.rb
+++ b/lib/react_on_rails/dev/process_manager.rb
@@ -33,18 +33,87 @@ module ReactOnRails
 
           if installed?("overmind")
             system("overmind", "start", "-f", procfile)
-          elsif installed?("foreman")
-            system("foreman", "start", "-f", procfile)
+          elsif foreman_available?
+            run_foreman(procfile)
           else
-            warn <<~MSG
-              NOTICE:
-              For this script to run, you need either 'overmind' or 'foreman' installed on your machine. Please try this script after installing one of them.
-            MSG
+            show_process_manager_installation_help
             exit 1
           end
         end
 
         private
+
+        # Check if foreman is available in either bundler context or system-wide
+        def foreman_available?
+          installed?("foreman") || foreman_available_in_system?
+        end
+
+        # Try to run foreman with intelligent fallback strategy
+        # First attempt: within bundler context (for projects that include foreman in Gemfile)
+        # Fallback: outside bundler context (for projects following React on Rails best practices)
+        def run_foreman(procfile)
+          success = if installed?("foreman")
+                      # Try within bundle context first
+                      system("foreman", "start", "-f", procfile)
+                    else
+                      false
+                    end
+
+          # If bundler context failed or foreman not in bundle, try system foreman
+          return if success
+
+          run_foreman_outside_bundle(procfile)
+        end
+
+        # Run foreman outside of bundler context using Bundler.with_unbundled_env
+        # This allows using system-installed foreman even when it's not in the Gemfile
+        def run_foreman_outside_bundle(procfile)
+          if defined?(Bundler)
+            Bundler.with_unbundled_env do
+              system("foreman", "start", "-f", procfile)
+            end
+          else
+            # Fallback if Bundler is not available
+            system("foreman", "start", "-f", procfile)
+          end
+        end
+
+        # Check if foreman is available system-wide (outside bundle context)
+        def foreman_available_in_system?
+          if defined?(Bundler)
+            Bundler.with_unbundled_env do
+              installed?("foreman")
+            end
+          else
+            false
+          end
+        end
+
+        # Improved error message with helpful guidance
+        def show_process_manager_installation_help
+          warn <<~MSG
+            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+            ERROR: Process Manager Not Found
+            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+            To run the React on Rails development server, you need either 'overmind' or
+            'foreman' installed on your system.
+
+            RECOMMENDED INSTALLATION:
+
+              macOS:    brew install overmind
+              Linux:    gem install foreman
+
+            IMPORTANT:
+            DO NOT add foreman to your Gemfile. Install it globally on your system.
+
+            For more information about why foreman should not be in your Gemfile, see:
+            https://github.com/shakacode/react_on_rails/blob/master/docs/javascript/foreman-issues.md
+
+            After installation, try running this script again.
+            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+          MSG
+        end
 
         def valid_procfile_path?(procfile)
           # Reject paths with shell metacharacters

--- a/lib/react_on_rails/dev/process_manager.rb
+++ b/lib/react_on_rails/dev/process_manager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 module ReactOnRails
   module Dev
     class ProcessManager
@@ -46,9 +48,12 @@ module ReactOnRails
           # Try to execute the process with version flags to see if it works
           # Use system() because that's how we'll actually call it later
           version_flags_for(process).any? do |flag|
-            system(process, flag, out: File::NULL, err: File::NULL)
+            # Add timeout to prevent hanging on version checks
+            Timeout.timeout(5) do
+              system(process, flag, out: File::NULL, err: File::NULL)
+            end
           end
-        rescue Errno::ENOENT
+        rescue Errno::ENOENT, Timeout::Error
           false
         end
 
@@ -97,10 +102,13 @@ module ReactOnRails
           Bundler.with_unbundled_env do
             # Try version flags to check if process exists outside bundler context
             version_flags_for(process).any? do |flag|
-              system(process, flag, out: File::NULL, err: File::NULL)
+              # Add timeout to prevent hanging on version checks
+              Timeout.timeout(5) do
+                system(process, flag, out: File::NULL, err: File::NULL)
+              end
             end
           end
-        rescue Errno::ENOENT
+        rescue Errno::ENOENT, Timeout::Error
           false
         end
 

--- a/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/spec/react_on_rails/dev/process_manager_spec.rb
@@ -56,17 +56,19 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
       described_class.run_with_process_manager("Procfile.dev")
     end
 
-    it "uses foreman when overmind not available" do
+    it "uses foreman when overmind not available and foreman is in bundle" do
       allow(described_class).to receive(:installed?).with("overmind").and_return(false)
+      allow(described_class).to receive(:foreman_available?).and_return(true)
       allow(described_class).to receive(:installed?).with("foreman").and_return(true)
-      expect_any_instance_of(Kernel).to receive(:system).with("foreman", "start", "-f", "Procfile.dev")
+      expect(described_class).to receive(:run_foreman).with("Procfile.dev")
 
       described_class.run_with_process_manager("Procfile.dev")
     end
 
     it "exits with error when no process manager available" do
       allow(described_class).to receive(:installed?).with("overmind").and_return(false)
-      allow(described_class).to receive(:installed?).with("foreman").and_return(false)
+      allow(described_class).to receive(:foreman_available?).and_return(false)
+      expect(described_class).to receive(:show_process_manager_installation_help)
       expect_any_instance_of(Kernel).to receive(:exit).with(1)
 
       described_class.run_with_process_manager("Procfile.dev")
@@ -77,6 +79,105 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
       expect(ReactOnRails::Dev::FileManager).to receive(:cleanup_stale_files)
 
       described_class.run_with_process_manager("Procfile.dev")
+    end
+  end
+
+  describe ".foreman_available?" do
+    it "returns true when foreman is available in bundle context" do
+      allow(described_class).to receive(:installed?).with("foreman").and_return(true)
+      allow(described_class).to receive(:foreman_available_in_system?).and_return(false)
+
+      expect(described_class.send(:foreman_available?)).to be true
+    end
+
+    it "returns true when foreman is available system-wide" do
+      allow(described_class).to receive(:installed?).with("foreman").and_return(false)
+      allow(described_class).to receive(:foreman_available_in_system?).and_return(true)
+
+      expect(described_class.send(:foreman_available?)).to be true
+    end
+
+    it "returns false when foreman is not available anywhere" do
+      allow(described_class).to receive(:installed?).with("foreman").and_return(false)
+      allow(described_class).to receive(:foreman_available_in_system?).and_return(false)
+
+      expect(described_class.send(:foreman_available?)).to be false
+    end
+  end
+
+  describe ".run_foreman" do
+    before do
+      allow_any_instance_of(Kernel).to receive(:system).and_return(true)
+    end
+
+    it "tries bundle context first when foreman is in bundle" do
+      allow(described_class).to receive(:installed?).with("foreman").and_return(true)
+      expect_any_instance_of(Kernel).to receive(:system).with("foreman", "start", "-f", "Procfile.dev").and_return(true)
+      expect(described_class).not_to receive(:run_foreman_outside_bundle)
+
+      described_class.send(:run_foreman, "Procfile.dev")
+    end
+
+    it "falls back to system foreman when bundle context fails" do
+      allow(described_class).to receive(:installed?).with("foreman").and_return(true)
+      expect_any_instance_of(Kernel).to receive(:system)
+        .with("foreman", "start", "-f", "Procfile.dev").and_return(false)
+      expect(described_class).to receive(:run_foreman_outside_bundle).with("Procfile.dev")
+
+      described_class.send(:run_foreman, "Procfile.dev")
+    end
+
+    it "uses system foreman directly when not in bundle" do
+      allow(described_class).to receive(:installed?).with("foreman").and_return(false)
+      expect(described_class).to receive(:run_foreman_outside_bundle).with("Procfile.dev")
+
+      described_class.send(:run_foreman, "Procfile.dev")
+    end
+  end
+
+  describe ".run_foreman_outside_bundle" do
+    it "uses Bundler.with_unbundled_env when Bundler is available" do
+      bundler_double = class_double(Bundler)
+      stub_const("Bundler", bundler_double)
+      expect(bundler_double).to receive(:with_unbundled_env).and_yield
+      expect_any_instance_of(Kernel).to receive(:system).with("foreman", "start", "-f", "Procfile.dev")
+
+      described_class.send(:run_foreman_outside_bundle, "Procfile.dev")
+    end
+
+    it "falls back to direct system call when Bundler is not available" do
+      hide_const("Bundler")
+      expect_any_instance_of(Kernel).to receive(:system).with("foreman", "start", "-f", "Procfile.dev")
+
+      described_class.send(:run_foreman_outside_bundle, "Procfile.dev")
+    end
+  end
+
+  describe ".foreman_available_in_system?" do
+    it "checks foreman availability outside bundle context" do
+      bundler_double = class_double(Bundler)
+      stub_const("Bundler", bundler_double)
+      expect(bundler_double).to receive(:with_unbundled_env).and_yield
+      expect(described_class).to receive(:installed?).with("foreman").and_return(true)
+
+      expect(described_class.send(:foreman_available_in_system?)).to be true
+    end
+
+    it "returns false when Bundler is not available" do
+      hide_const("Bundler")
+
+      expect(described_class.send(:foreman_available_in_system?)).to be false
+    end
+  end
+
+  describe ".show_process_manager_installation_help" do
+    it "displays helpful error message with installation instructions" do
+      expect { described_class.send(:show_process_manager_installation_help) }
+        .to output(/ERROR: Process Manager Not Found/).to_stderr
+      expect { described_class.send(:show_process_manager_installation_help) }
+        .to output(/DO NOT add foreman to your Gemfile/).to_stderr
+      expect { described_class.send(:show_process_manager_installation_help) }
+        .to output(/foreman-issues\.md/).to_stderr
     end
   end
 end

--- a/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/spec/react_on_rails/dev/process_manager_spec.rb
@@ -5,16 +5,22 @@ require "react_on_rails/dev/process_manager"
 
 RSpec.describe ReactOnRails::Dev::ProcessManager do
   # Suppress stdout/stderr during tests
-  before(:all) do
-    @original_stderr = $stderr
-    @original_stdout = $stdout
-    $stderr = File.open(File::NULL, "w")
-    $stdout = File.open(File::NULL, "w")
-  end
+  around do |example|
+    original_stderr = $stderr
+    original_stdout = $stdout
+    null_stderr = File.open(File::NULL, "w")
+    null_stdout = File.open(File::NULL, "w")
 
-  after(:all) do
-    $stderr = @original_stderr
-    $stdout = @original_stdout
+    begin
+      $stderr = null_stderr
+      $stdout = null_stdout
+      example.run
+    ensure
+      $stderr = original_stderr
+      $stdout = original_stdout
+      null_stderr.close
+      null_stdout.close
+    end
   end
 
   describe ".installed?" do

--- a/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/spec/react_on_rails/dev/process_manager_spec.rb
@@ -4,8 +4,6 @@ require_relative "../spec_helper"
 require "react_on_rails/dev/process_manager"
 
 RSpec.describe ReactOnRails::Dev::ProcessManager do
-RSpec.describe ReactOnRails::Dev::ProcessManager do
-  describe ".installed?" do
   describe ".installed?" do
     it "returns true when process is available in current context" do
       expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_yield

--- a/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/spec/react_on_rails/dev/process_manager_spec.rb
@@ -19,19 +19,19 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
 
   describe ".installed?" do
     it "returns true when process is available in current context" do
-      expect(Timeout).to receive(:timeout).with(5).and_yield
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_yield
       expect_any_instance_of(Kernel).to receive(:system)
         .with("overmind", "--version", out: File::NULL, err: File::NULL).and_return(true)
       expect(described_class).to be_installed("overmind")
     end
 
     it "returns false when process is not available in current context" do
-      expect(Timeout).to receive(:timeout).with(5).and_raise(Errno::ENOENT)
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_raise(Errno::ENOENT)
       expect(described_class.installed?("nonexistent")).to be false
     end
 
     it "returns false when all version flags fail" do
-      expect(Timeout).to receive(:timeout).with(5).exactly(3).times.and_yield
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).exactly(3).times.and_yield
       expect_any_instance_of(Kernel).to receive(:system)
         .with("failing_process", "--version", out: File::NULL, err: File::NULL).and_return(false)
       expect_any_instance_of(Kernel).to receive(:system)
@@ -42,7 +42,7 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
     end
 
     it "returns true when second version flag succeeds" do
-      expect(Timeout).to receive(:timeout).with(5).twice.and_yield
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).twice.and_yield
       expect_any_instance_of(Kernel).to receive(:system)
         .with("foreman", "--version", out: File::NULL, err: File::NULL).and_return(false)
       expect_any_instance_of(Kernel).to receive(:system)
@@ -51,7 +51,7 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
     end
 
     it "returns false when version check times out" do
-      expect(Timeout).to receive(:timeout).with(5).and_raise(Timeout::Error)
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_raise(Timeout::Error)
       expect(described_class.installed?("hanging_process")).to be false
     end
   end
@@ -158,7 +158,7 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
   describe ".process_available_in_system?" do
     it "checks process availability outside bundle context with version flags" do
       expect(described_class).to receive(:with_unbundled_context).and_yield
-      expect(Timeout).to receive(:timeout).with(5).and_yield
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_yield
       expect_any_instance_of(Kernel).to receive(:system)
         .with("foreman", "--version", out: File::NULL, err: File::NULL).and_return(true)
 
@@ -173,7 +173,7 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
 
     it "tries multiple version flags before failing" do
       expect(described_class).to receive(:with_unbundled_context).and_yield
-      expect(Timeout).to receive(:timeout).with(5).twice.and_yield
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).twice.and_yield
       expect_any_instance_of(Kernel).to receive(:system)
         .with("foreman", "--version", out: File::NULL, err: File::NULL).and_return(false)
       expect_any_instance_of(Kernel).to receive(:system)
@@ -184,7 +184,7 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
 
     it "returns false when version check times out in system context" do
       expect(described_class).to receive(:with_unbundled_context).and_yield
-      expect(Timeout).to receive(:timeout).with(5).and_raise(Timeout::Error)
+      expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_raise(Timeout::Error)
 
       expect(described_class.send(:process_available_in_system?, "hanging_process")).to be false
     end

--- a/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/spec/react_on_rails/dev/process_manager_spec.rb
@@ -4,7 +4,8 @@ require_relative "../spec_helper"
 require "react_on_rails/dev/process_manager"
 
 RSpec.describe ReactOnRails::Dev::ProcessManager do
-
+RSpec.describe ReactOnRails::Dev::ProcessManager do
+  describe ".installed?" do
   describe ".installed?" do
     it "returns true when process is available in current context" do
       expect(Timeout).to receive(:timeout).with(described_class::VERSION_CHECK_TIMEOUT).and_yield

--- a/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/spec/react_on_rails/dev/process_manager_spec.rb
@@ -4,24 +4,6 @@ require_relative "../spec_helper"
 require "react_on_rails/dev/process_manager"
 
 RSpec.describe ReactOnRails::Dev::ProcessManager do
-  # Suppress stdout/stderr during tests
-  around do |example|
-    original_stderr = $stderr
-    original_stdout = $stdout
-    null_stderr = File.open(File::NULL, "w")
-    null_stdout = File.open(File::NULL, "w")
-
-    begin
-      $stderr = null_stderr
-      $stdout = null_stdout
-      example.run
-    ensure
-      $stderr = original_stderr
-      $stdout = original_stdout
-      null_stderr.close
-      null_stdout.close
-    end
-  end
 
   describe ".installed?" do
     it "returns true when process is available in current context" do


### PR DESCRIPTION
## Summary

Fixes #1832 

This PR resolves the issue where `bin/dev` fails when foreman is not included in the Gemfile, implementing a comprehensive solution that works for **all process managers** (overmind, foreman, and future additions).

## Problem

The dummy app's `bin/dev` script was failing with:
```
can't find executable foreman for gem foreman. foreman is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
```

However, `foreman start -f Procfile.dev` worked fine when run directly.

## Root Cause

1. **Foreman intentionally NOT in Gemfile** (following React on Rails best practices)
2. **Bundler intercepts system calls** when binstubs are active
3. **Process manager calls intercepted** by bundler context, failing to find system-installed processes

## Solution

### 🎯 Universal Bundler Context Fallback

Implemented an intelligent fallback strategy that works for **all process managers**:

1. **First attempt**: Try process in current bundler context (for projects with process in Gemfile)
2. **Fallback**: Use `Bundler.with_unbundled_env` to access system-installed processes
3. **Clear error messaging**: Helpful guidance when no process manager is found

### 🚀 Key Improvements

- **Context-aware detection**: `installed?` method correctly detects process usability in current execution context
- **Universal API**: `run_process_if_available(process, args)` works for any process manager
- **Intelligent fallback**: Automatic bundler context switching when needed
- **Enhanced error messages**: Clear guidance with links to documentation
- **Comprehensive testing**: 22 test cases covering all scenarios

## Architecture

### Before (Foreman-specific)
```ruby
if installed?("overmind")
  system("overmind", "start", "-f", procfile)
elsif foreman_available?  # Special foreman logic
  run_foreman(procfile)   # Foreman-specific method
end
```

### After (Universal)
```ruby
return if run_process_if_available("overmind", ["start", "-f", procfile])
return if run_process_if_available("foreman", ["start", "-f", procfile])
# Any future process manager automatically gets fallback support
```

## Benefits

✅ **Maintains best practices**: Keeps foreman out of Gemfile  
✅ **Backwards compatible**: Works with projects that do include process managers  
✅ **Future-proof**: Any new process manager automatically gets fallback support  
✅ **Better UX**: Clear error messages guide users to proper setup  
✅ **Robust**: Handles both bundled and system installations universally  

## Testing

- **All existing tests pass**: No regressions in core functionality
- **New comprehensive test suite**: 22 examples covering all fallback scenarios
- **RuboCop compliant**: Clean, maintainable code
- **Manual testing**: Confirmed `bin/dev` now works correctly

## Related

- Closes issue created for this problem
- Builds on React on Rails best practices documented in `docs/javascript/foreman-issues.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1833)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundler-aware startup: tries project-local process managers first, then system-wide, and shows clear installation guidance if none found.
  * Added timeout-protected version checks, procfile path validation, and safer unbundled-environment handling for running managers.

* **Bug Fixes**
  * Guarded version probes with a configurable timeout to avoid hangs.
  * Improved execution outside Bundler to reduce false negatives when detecting/running managers.

* **Tests**
  * Expanded coverage for context fallbacks, timeout behavior, multi-flag version probing, fallback execution, and user-facing installation messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->