### PR TITLE
Replace spec/dummy/bin/dev symlink with wrapper script

### DIFF
--- a/spec/dummy/bin/dev
+++ b/spec/dummy/bin/dev
@@ -1,1 +1,5 @@
-../../../lib/generators/react_on_rails/templates/base/base/bin/dev
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script calls the base dev script with a fixed route for the dummy app
+exec File.join(__dir__, "../../../lib/generators/react_on_rails/templates/base/base/bin/dev"), "--route=/", *ARGV


### PR DESCRIPTION
## Summary
- Replace spec/dummy/bin/dev symlink with a wrapper script that calls the template bin/dev with `--route=/` argument
- Ensures the dummy app always uses the root route instead of the default hello_world route

## Test plan
- [ ] Run `spec/dummy/bin/dev` and verify it opens the root route
- [ ] Verify the script properly passes through additional arguments

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1835)
<!-- Reviewable:end -->
