### PR TITLE
Modernize release process for monorepo

### DIFF
--- a/docs/contributor-info/releasing.md
+++ b/docs/contributor-info/releasing.md
@@ -1,77 +1,185 @@
 # Install and Release
 
-We're now releasing this as a combined ruby gem plus npm package. We will keep the version numbers in sync.
+We're releasing this as a combined Ruby gem plus two NPM packages. We keep the version numbers in sync across all packages.
 
 ## Testing the Gem before Release from a Rails App
 
 See [Contributing](https://github.com/shakacode/react_on_rails/tree/master/CONTRIBUTING.md)
 
-## Releasing a new gem version
+## Releasing a New Version
 
 Run `rake -D release` to see instructions on how to release via the rake task.
 
-As of 01-26-2016, this would give you an output like this:
+### Release Command
 
-```
-rake release[gem_version,dry_run,tools_install]
-    Releases both the gem and node package using the given version.
-
-    IMPORTANT: the gem version must be in valid rubygem format (no dashes).
-    It will be automatically converted to a valid npm semver by the rake task
-    for the node package version. This only makes a difference for pre-release
-    versions such as `3.0.0.beta.1` (npm version would be `3.0.0-beta.1`).
-
-    This task will also globally install gem-release (ruby gem) and
-    release-it (node package) unless you specify skip installing tools.
-
-    2nd argument: Perform a dry run by passing 'true' as a second argument.
-    3rd argument: Skip installing tools by passing 'false' as a third argument (default is true).
-
-    Example: `rake release[2.1.0,false,false]`
+```bash
+rake release[gem_version,dry_run]
 ```
 
-Running `rake release[2.1.0]` will create a commit that looks like this:
+**Arguments:**
+
+- `gem_version`: The new version in rubygem format (no dashes). Pass no argument to automatically perform a patch version bump.
+- `dry_run`: Optional. Pass `true` to see what would happen without actually releasing.
+
+**Example:**
+
+```bash
+rake release[16.2.0]        # Release version 16.2.0
+rake release[16.2.0,true]   # Dry run to preview changes
+rake release                # Auto-bump patch version
+```
+
+### What Gets Released
+
+The release task publishes three packages with the same version number:
+
+1. **react-on-rails** NPM package
+2. **react-on-rails-pro** NPM package
+3. **react_on_rails** Ruby gem
+
+### Version Synchronization
+
+The task updates versions in all the following files:
+
+- `lib/react_on_rails/version.rb` (source of truth)
+- `package.json` (root workspace)
+- `packages/react-on-rails/package.json`
+- `packages/react-on-rails-pro/package.json` (both version field and react-on-rails dependency)
+- `spec/dummy/Gemfile.lock`
+
+**Note:** The `react-on-rails-pro` package declares an exact version dependency on `react-on-rails` (e.g., `"react-on-rails": "16.2.0"`). This ensures users install compatible versions of both packages.
+
+### Pre-release Versions
+
+For pre-release versions, the gem version format is automatically converted to NPM semver format:
+
+- Gem: `3.0.0.beta.1`
+- NPM: `3.0.0-beta.1`
+
+### Release Process
+
+When you run `rake release[X.Y.Z]`, the task will:
+
+1. Check for uncommitted changes (will abort if found)
+2. Pull latest changes from the remote repository
+3. Clean up example directories
+4. Bump the gem version in `lib/react_on_rails/version.rb`
+5. Update all package.json files with the new version
+6. Update the Pro package's dependency on react-on-rails
+7. Update the dummy app's Gemfile.lock
+8. Commit all version changes with message "Bump version to X.Y.Z"
+9. Create a git tag `vX.Y.Z`
+10. Push commits and tags to the remote repository
+11. Publish `react-on-rails` to NPM (requires 2FA token)
+12. Publish `react-on-rails-pro` to NPM (requires 2FA token)
+13. Publish `react_on_rails` to RubyGems (requires 2FA token)
+
+### Two-Factor Authentication
+
+You'll need to enter OTP tokens when prompted:
+
+- Once for publishing `react-on-rails` to NPM
+- Once for publishing `react-on-rails-pro` to NPM
+- Once for publishing `react_on_rails` to RubyGems
+
+### Post-Release Steps
+
+After a successful release, you'll see instructions to:
+
+1. Update the CHANGELOG.md:
+
+   ```bash
+   bundle exec rake update_changelog
+   ```
+
+2. Update the dummy app's Gemfile.lock:
+
+   ```bash
+   cd spec/dummy && bundle update react_on_rails
+   ```
+
+3. Commit the CHANGELOG and Gemfile.lock:
+   ```bash
+   cd /path/to/react_on_rails
+   git commit -a -m 'Update CHANGELOG.md and spec/dummy Gemfile.lock'
+   git push
+   ```
+
+## Requirements
+
+This task depends on the `gem-release` Ruby gem, which is installed via `bundle install`.
+
+For NPM publishing, you must be logged in to npm and have publish permissions for both packages:
+
+```bash
+npm login
+```
+
+## Troubleshooting
+
+### Dry Run First
+
+Always test with a dry run before actually releasing:
+
+```bash
+rake release[16.2.0,true]
+```
+
+This shows you exactly what would be updated without making any changes.
+
+### If Release Fails
+
+If the release fails partway through (e.g., during NPM publish):
+
+1. Check what was published:
+
+   - NPM: `npm view react-on-rails@X.Y.Z`
+   - RubyGems: `gem list react_on_rails -r -a`
+
+2. If the git tag was created but packages weren't published:
+
+   - Delete the tag: `git tag -d vX.Y.Z && git push origin :vX.Y.Z`
+   - Revert the version commit: `git reset --hard HEAD~1 && git push -f`
+   - Start over with `rake release[X.Y.Z]`
+
+3. If some packages were published but not others:
+   - You can manually publish the missing packages:
+     ```bash
+     cd packages/react-on-rails && yarn publish --new-version X.Y.Z
+     cd ../react-on-rails-pro && yarn publish --new-version X.Y.Z
+     gem release
+     ```
+
+## Version History
+
+Running `rake release[X.Y.Z]` will create a commit that looks like this:
 
 ```
-commit d07005cde9784c69e41d73fb9a0ebe8922e556b3
-Author: Rob Wise <robert.wise@outlook.com>
-Date:   Tue Jan 26 19:49:14 2016 -0500
+commit abc123...
+Author: Your Name <your.email@example.com>
+Date:   Mon Jan 1 12:00:00 2024 -0500
 
-    Release 2.1.0
+    Bump version to 16.2.0
 
 diff --git a/lib/react_on_rails/version.rb b/lib/react_on_rails/version.rb
-index 3de9606..b71aa7a 100644
+index 1234567..abcdefg 100644
 --- a/lib/react_on_rails/version.rb
 +++ b/lib/react_on_rails/version.rb
 @@ -1,3 +1,3 @@
  module ReactOnRails
--  VERSION = "2.0.2".freeze
-+  VERSION = "2.1.0".freeze
+-  VERSION = "16.1.1"
++  VERSION = "16.2.0"
  end
+
 diff --git a/package.json b/package.json
-index aa7b000..af8761e 100644
+index 2345678..bcdefgh 100644
 --- a/package.json
 +++ b/package.json
 @@ -1,6 +1,6 @@
  {
-   "name": "react-on-rails",
--  "version": "2.0.2",
-+  "version": "2.1.0",
-   "description": "react-on-rails JavaScript for react_on_rails Ruby gem",
-   "main": "packages/react-on-rails/lib/ReactOnRails.js",
-   "directories": {
-diff --git a/spec/dummy/Gemfile.lock b/spec/dummy/Gemfile.lock
-index 8ef51df..4489bfe 100644
---- a/spec/dummy/Gemfile.lock
-+++ b/spec/dummy/Gemfile.lock
-@@ -1,7 +1,7 @@
- PATH
-   remote: ../..
-   specs:
--    react_on_rails (2.0.2)
-+    react_on_rails (2.1.0)
-       connection_pool
-       execjs (~> 2.5)
-       rails (>= 3.2)
-(END)
+   "name": "react-on-rails-workspace",
+-  "version": "16.1.1",
++  "version": "16.2.0",
+   ...
+}
 ```

--- a/package.json
+++ b/package.json
@@ -70,9 +70,6 @@
     "yalc:publish": "yarn workspaces run yalc:publish",
     "yalc": "yarn workspaces run yalc",
     "publish": "yarn workspaces run publish",
-    "release:patch": "yarn workspaces run release:patch",
-    "release:minor": "yarn workspaces run release:minor",
-    "release:major": "yarn workspaces run release:major",
     "postinstall": "test -f .lefthook.yml && test -d .git && command -v bundle >/dev/null 2>&1 && bundle exec lefthook install || true"
   },
   "repository": {

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -54,7 +54,7 @@
     "./ServerComponentFetchError": "./lib/ServerComponentFetchError.js"
   },
   "dependencies": {
-    "react-on-rails": "16.1.2"
+    "react-on-rails": "*"
   },
   "peerDependencies": {
     "react": ">= 16",

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -54,7 +54,7 @@
     "./ServerComponentFetchError": "./lib/ServerComponentFetchError.js"
   },
   "dependencies": {
-    "react-on-rails": "*"
+    "react-on-rails": "16.1.1"
   },
   "peerDependencies": {
     "react": ">= 16",

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -54,7 +54,7 @@
     "./ServerComponentFetchError": "./lib/ServerComponentFetchError.js"
   },
   "dependencies": {
-    "react-on-rails": "*"
+    "react-on-rails": "16.1.2"
   },
   "peerDependencies": {
     "react": ">= 16",

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -14,10 +14,7 @@
     "prepare": "nps build.prepack",
     "prepublishOnly": "yarn run build",
     "yalc:publish": "yalc publish",
-    "yalc": "yalc",
-    "release:patch": "./scripts/release patch",
-    "release:minor": "./scripts/release minor",
-    "release:major": "./scripts/release major"
+    "yalc": "yalc"
   },
   "repository": {
     "type": "git",

--- a/packages/react-on-rails/scripts/release
+++ b/packages/react-on-rails/scripts/release
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-yarn version $1 -m "Bump version to %s"
-git push -u origin master
-git push --tags
-yarn publish

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -45,8 +45,23 @@ task :release, %i[gem_version dry_run registry skip_push] do |_t, args|
   args_hash = args.to_hash
 
   is_dry_run = ReactOnRails::Utils.object_to_boolean(args_hash[:dry_run])
-  use_verdaccio = args_hash.fetch(:registry, "") == "verdaccio"
-  skip_push = args_hash.fetch(:skip_push, "") == "skip_push"
+
+  # Validate registry parameter
+  registry_value = args_hash.fetch(:registry, "")
+  unless registry_value.empty? || registry_value == "verdaccio" || registry_value == "npm"
+    raise ArgumentError,
+          "Invalid registry value '#{registry_value}'. Valid values are: 'verdaccio', 'npm', or empty string"
+  end
+
+  use_verdaccio = registry_value == "verdaccio"
+
+  # Validate skip_push parameter
+  skip_push_value = args_hash.fetch(:skip_push, "")
+  unless skip_push_value.empty? || skip_push_value == "skip_push"
+    raise ArgumentError, "Invalid skip_push value '#{skip_push_value}'. Valid values are: 'skip_push' or empty string"
+  end
+
+  skip_push = skip_push_value == "skip_push"
 
   gem_version = args_hash.fetch(:gem_version, "")
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -108,6 +108,7 @@ task :release, %i[gem_version dry_run registry skip_push] do |_t, args|
     puts "  Updated #{file}"
   end
 
+  bundle_install_in(gem_root)
   # Update dummy app's Gemfile.lock
   bundle_install_in(dummy_app_dir)
 


### PR DESCRIPTION
## Summary

Modernizes the release process to properly handle the monorepo structure with both NPM packages (`react-on-rails` and `react-on-rails-pro`) and the Ruby gem.

## Changes

### 🔧 Updated Release Workflow
- **Replaced `release-it`** with native Yarn workspace publish commands
- **Updated `rakelib/release.rake`** to handle both NPM packages plus the gem
- **Synchronized versions** across all 5 locations:
  - `lib/react_on_rails/version.rb` (source of truth)
  - `package.json` (root)
  - `packages/react-on-rails/package.json`
  - `packages/react-on-rails-pro/package.json` (version + dependency)
  - `spec/dummy/Gemfile.lock`

### 📦 Package Dependencies
- **Set exact version dependency**: `react-on-rails-pro` now depends on the exact version of `react-on-rails` (e.g., `"16.1.1"` not `"*"`)
- This ensures users can't install incompatible version combinations

### 🗑️ Cleanup
- Removed obsolete `packages/react-on-rails/scripts/release` script
- Removed `release:patch`, `release:minor`, `release:major` scripts from package.json files

### 📚 Documentation
- Completely rewrote `docs/contributor-info/releasing.md` with:
  - Clear step-by-step release process
  - Dry run instructions
  - Troubleshooting guide
  - Version synchronization explanation

## Release Task Options

The `rake release` task now supports comprehensive options for different release scenarios:

### Parameters

1. **`gem_version`** (optional): Version in rubygem format (e.g., `16.2.0`). Omit for auto patch bump.
2. **`dry_run`** (optional): Pass `true` to preview changes without publishing
3. **`registry`** (optional): 
   - `verdaccio` - Publish to local Verdaccio registry (http://localhost:4873/)
   - `npm` - Publish to npmjs.org (default)
4. **`skip_push`** (optional): Pass `skip_push` to skip git push operations (commits/tags created locally only)

### Usage Examples

```bash
# Production releases
rake release[16.2.0]                          # Release version 16.2.0 to production
rake release                                  # Auto-bump patch version

# Testing & validation
rake release[16.2.0,true]                     # Dry run to preview changes
rake release[16.2.0,false,verdaccio]          # Test release to local Verdaccio registry
rake release[16.2.0,false,npm,skip_push]      # Release without pushing to remote

# Development workflow
rake release[16.2.0-beta.1,false,verdaccio]   # Test pre-release versions locally
```

### Verdaccio Support

The release task now includes full support for local testing with [Verdaccio](https://verdaccio.org/):

- **Local registry testing**: Test the complete release process without publishing to production
- **Pre-release validation**: Verify package installations work correctly before production release
- **Setup requirements**:
  1. Install Verdaccio: `npm install -g verdaccio`
  2. Start server: `verdaccio`
  3. Authenticate: `npm adduser --registry http://localhost:4873/`
  4. Run release: `rake release[16.2.0,false,verdaccio]`

When using Verdaccio mode:
- NPM packages publish to http://localhost:4873/
- Ruby gem publication is skipped (Verdaccio is NPM-only)
- Git commits and tags are still created

## Release Process Flow

The task executes these steps:

1. Validates parameters (registry and skip_push values)
2. Checks for uncommitted changes
3. Pulls latest changes from remote
4. Bumps gem version in `lib/react_on_rails/version.rb`
5. Updates all package.json files with converted npm version
6. Updates `react-on-rails-pro` dependency to exact version
7. Commits all version changes
8. Creates git tag `v{version}`
9. Pushes commits and tags (unless `skip_push` is set)
10. Publishes `react-on-rails` to NPM/Verdaccio
11. Publishes `react-on-rails-pro` to NPM/Verdaccio
12. Publishes `react_on_rails` to RubyGems (unless Verdaccio mode)

## Benefits

✅ No external `release-it` dependency
✅ Both NPM packages properly released
✅ Version sync enforced across all packages
✅ Simpler, pure Ruby + Yarn solution
✅ Single command releases everything
✅ Local testing support with Verdaccio
✅ Flexible workflow options (dry-run, skip-push)
✅ Parameter validation prevents typos

## Test Plan

- [x] RuboCop passes with no offenses
- [x] Parameter validation works correctly
- [x] Verdaccio support implemented
- [ ] Test dry run: `rake release[16.1.2,true]`
- [ ] Verify all files would be updated correctly
- [ ] Review commit message format

🤖 Generated with Claude Code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1856)
<!-- Reviewable:end -->
