### PR TITLE
Skip generate_packs when shakapacker precompile hook configured

### DIFF
--- a/lib/react_on_rails/configuration.rb
+++ b/lib/react_on_rails/configuration.rb
@@ -240,7 +240,8 @@ module ReactOnRails
       precompile_tasks = lambda {
         # Skip generate_packs if shakapacker has a precompile hook configured
         if ReactOnRails::PackerUtils.shakapacker_precompile_hook_configured?
-          puts "Skipping react_on_rails:generate_packs (configured in shakapacker precompile hook)"
+          hook_value = ReactOnRails::PackerUtils.shakapacker_precompile_hook_value
+          puts "Skipping react_on_rails:generate_packs (configured in shakapacker precompile hook: #{hook_value})"
         else
           Rake::Task["react_on_rails:generate_packs"].invoke
         end

--- a/lib/react_on_rails/dev/pack_generator.rb
+++ b/lib/react_on_rails/dev/pack_generator.rb
@@ -28,7 +28,10 @@ module ReactOnRails
         def generate(verbose: false)
           # Skip if shakapacker has a precompile hook configured
           if ReactOnRails::PackerUtils.shakapacker_precompile_hook_configured?
-            puts "⏭️  Skipping pack generation (handled by shakapacker precompile hook)" if verbose
+            if verbose
+              hook_value = ReactOnRails::PackerUtils.shakapacker_precompile_hook_value
+              puts "⏭️  Skipping pack generation (handled by shakapacker precompile hook: #{hook_value})"
+            end
             return
           end
 

--- a/lib/react_on_rails/packer_utils.rb
+++ b/lib/react_on_rails/packer_utils.rb
@@ -172,13 +172,16 @@ module ReactOnRails
     #
     # Returns false if detection fails for any reason (missing shakapacker, malformed config, etc.)
     # to ensure generate_packs runs rather than being incorrectly skipped
+    #
+    # Note: Currently checks a single hook value. Future enhancement will support hook lists
+    # to allow prepending/appending multiple commands. See related Shakapacker issue for details.
     def self.shakapacker_precompile_hook_configured?
       return false unless defined?(::Shakapacker)
 
-      hooks = extract_precompile_hooks
-      return false if hooks.nil?
+      hook_value = extract_precompile_hook
+      return false if hook_value.nil?
 
-      hook_contains_generate_packs?(hooks)
+      hook_contains_generate_packs?(hook_value)
     rescue StandardError => e
       # Swallow errors during hook detection to fail safe - if we can't detect the hook,
       # we should run generate_packs rather than skip it incorrectly.
@@ -188,19 +191,53 @@ module ReactOnRails
       false
     end
 
-    def self.extract_precompile_hooks
+    def self.extract_precompile_hook
       # Access config data using private :data method since there's no public API
       # to access the raw configuration hash needed for hook detection
       config_data = ::Shakapacker.config.send(:data)
 
       # Try symbol keys first (Shakapacker's internal format), then fall back to string keys
+      # Note: Currently only one hook value is supported, but this will change to support lists
       config_data&.dig(:hooks, :precompile) || config_data&.dig("hooks", "precompile")
     end
 
-    def self.hook_contains_generate_packs?(hooks)
-      # Check if any hook contains the generate_packs rake task using word boundary
-      # to avoid false positives from comments or similar strings
-      Array(hooks).any? { |hook| hook.to_s.match?(/\breact_on_rails:generate_packs\b/) }
+    def self.hook_contains_generate_packs?(hook_value)
+      # The hook value can be either:
+      # 1. A direct command containing the rake task
+      # 2. A path to a script file that needs to be read
+      return false if hook_value.blank?
+
+      # Check if it's a direct command first
+      return true if hook_value.to_s.match?(/\breact_on_rails:generate_packs\b/)
+
+      # Check if it's a script file path
+      script_path = resolve_hook_script_path(hook_value)
+      return false unless script_path && File.exist?(script_path)
+
+      # Read and check script contents
+      script_contents = File.read(script_path)
+      script_contents.match?(/\breact_on_rails:generate_packs\b/)
+    rescue StandardError
+      # If we can't read the script, assume it doesn't contain generate_packs
+      false
+    end
+
+    def self.resolve_hook_script_path(hook_value)
+      # Hook value might be a script path relative to Rails root
+      return nil unless defined?(Rails) && Rails.respond_to?(:root)
+
+      potential_path = Rails.root.join(hook_value.to_s.strip)
+      potential_path if potential_path.file?
+    end
+
+    # Returns the configured precompile hook value for logging/debugging
+    # Returns nil if no hook is configured
+    def self.shakapacker_precompile_hook_value
+      return nil unless defined?(::Shakapacker)
+
+      extract_precompile_hook
+    rescue StandardError
+      nil
     end
   end
 end

--- a/spec/react_on_rails/dev/pack_generator_spec.rb
+++ b/spec/react_on_rails/dev/pack_generator_spec.rb
@@ -25,12 +25,13 @@ RSpec.describe ReactOnRails::Dev::PackGenerator do
 
     context "when shakapacker precompile hook is configured" do
       before do
-        allow(ReactOnRails::PackerUtils).to receive(:shakapacker_precompile_hook_configured?).and_return(true)
+        allow(ReactOnRails::PackerUtils).to receive_messages(shakapacker_precompile_hook_configured?: true,
+                                                             shakapacker_precompile_hook_value: "bin/precompile_hook")
       end
 
-      it "skips pack generation in verbose mode" do
+      it "skips pack generation in verbose mode and shows hook value" do
         expect { described_class.generate(verbose: true) }
-          .to output(/⏭️  Skipping pack generation \(handled by shakapacker precompile hook\)/)
+          .to output(%r{⏭️  Skipping pack generation \(handled by shakapacker precompile hook: bin/precompile_hook\)})
           .to_stdout_from_any_process
       end
 


### PR DESCRIPTION
## Summary

This PR adds detection for shakapacker precompile hooks to prevent running `react_on_rails:generate_packs` twice when shakapacker is configured to run it automatically.

## Changes

- **New Method**: Added `PackerUtils.shakapacker_precompile_hook_configured?` to detect if shakapacker.yml has a precompile hook that runs `react_on_rails:generate_packs`
- **Skip in `assets:precompile`**: Updated `configuration.rb` to skip invoking `react_on_rails:generate_packs` if the shakapacker hook is configured
- **Skip in `bin/dev`**: Updated `PackGenerator.generate` to skip pack generation if the shakapacker hook is configured
- **Comprehensive Tests**: Added test coverage for all new functionality

## Why This Matters

When shakapacker supports precompile hooks (upcoming feature), users can configure:

yaml
# config/shakapacker.yml
hooks:
  precompile: "bundle exec rake react_on_rails:generate_packs"


Without this PR, `generate_packs` would run twice:
1. Once by shakapacker's precompile hook
2. Once by react_on_rails during `assets:precompile` or `bin/dev`

This PR ensures it only runs once by detecting the hook configuration.

## Test Plan

- [x] Added unit tests for `PackerUtils.shakapacker_precompile_hook_configured?`
- [x] Added tests for `PackGenerator.generate` with hook configured
- [x] All existing tests pass
- [x] RuboCop passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1861)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Precompile now skips internal pack generation when a Shakapacker precompile hook is detected; behavior unchanged when no hook is present.
  - Verbose mode reports the skip; quiet mode stays silent. Precompile flow and error handling otherwise unchanged.

- Tests
  - Added test coverage for hook detection, skip vs full-generation paths, verbose/quiet outputs, success/failure cases, missing configs, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->