### PR TITLE
Document content_for pattern to prevent FOUC with SSR and auto_load_bundle (#1864)

### DIFF
--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -6,13 +6,14 @@ Having issues with React on Rails? This guide covers the most common problems an
 
 ### Is your issue with...?
 
-| Problem Area         | Quick Check                                 | Go to Section                                |
-| -------------------- | ------------------------------------------- | -------------------------------------------- |
-| **Installation**     | Generator fails or components don't appear  | [Installation Issues](#-installation-issues) |
-| **Compilation**      | Webpack errors, build failures              | [Build Issues](#-build-issues)               |
-| **Runtime**          | Components not rendering, JavaScript errors | [Runtime Issues](#-runtime-issues)           |
-| **Server Rendering** | SSR not working, hydration mismatches       | [SSR Issues](#-server-side-rendering-issues) |
-| **Performance**      | Slow builds, large bundles, memory issues   | [Performance Issues](#-performance-issues)   |
+| Problem Area         | Quick Check                                 | Go to Section                                                |
+| -------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| **Installation**     | Generator fails or components don't appear  | [Installation Issues](#-installation-issues)                 |
+| **Compilation**      | Webpack errors, build failures              | [Build Issues](#-build-issues)                               |
+| **Runtime**          | Components not rendering, JavaScript errors | [Runtime Issues](#-runtime-issues)                           |
+| **Styling (FOUC)**   | Unstyled content flash with SSR             | [Flash of Unstyled Content](#flash-of-unstyled-content-fouc) |
+| **Server Rendering** | SSR not working, hydration mismatches       | [SSR Issues](#-server-side-rendering-issues)                 |
+| **Performance**      | Slow builds, large bundles, memory issues   | [Performance Issues](#-performance-issues)                   |
 
 ## 🚨 Installation Issues
 
@@ -162,6 +163,33 @@ useEffect(() => {
 <% else %>
   <%= react_component('MyComponent', props: @props) %>
 <% end %>
+```
+
+### "Flash of Unstyled Content (FOUC)"
+
+**Symptoms:** Page briefly shows unstyled content before CSS loads, particularly with SSR and `auto_load_bundle`
+
+**Root Cause:** When using `auto_load_bundle = true` with server-side rendering, `react_component` calls trigger `append_stylesheet_pack_tag` during body rendering, but these appends must execute BEFORE the `stylesheet_pack_tag` in the `<head>`.
+
+**Solution:** Use the `content_for :body_content` pattern to ensure appends happen before the head renders.
+
+**See:** [FOUC Prevention Guide](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#2-css-not-loading-fouc---flash-of-unstyled-content) for detailed solutions and examples.
+
+**Quick fix:**
+
+```erb
+<% content_for :body_content do %>
+  <%= react_component "MyComponent", prerender: true %>
+<% end %>
+<!DOCTYPE html>
+<html>
+<head>
+  <%= stylesheet_pack_tag(media: 'all') %>
+</head>
+<body>
+  <%= yield :body_content %>
+</body>
+</html>
 ```
 
 ## 🖥️ Server-Side Rendering Issues


### PR DESCRIPTION
## Summary

Documents the `content_for` pattern to prevent FOUC (Flash of Unstyled Content) when using `auto_load_bundle = true` with server-side rendering.

Fixes #1864

## Problem

When using `auto_load_bundle = true` with SSR, there's a chicken-and-egg problem:
- Stylesheets must load in the `<head>` to prevent FOUC
- But `react_component` calls in `<body>` trigger `append_stylesheet_pack_tag` after the head has rendered
- This violates Shakapacker's constraint that appends must happen before the main pack tag

## Solution

This PR documents three solutions in the troubleshooting section:

### Option 1: content_for pattern (Recommended)
Render body content BEFORE the head using `content_for` blocks, ensuring all auto-appends happen before the head renders:

```erb
<% content_for :body_content do %>
  <%= react_component "NavigationBarApp", prerender: true %>
  <%= yield %>
<% end %>
<!DOCTYPE html>
<html>
<head>
  <%= stylesheet_pack_tag(media: 'all') %>
</head>
<body>
  <%= yield :body_content %>
</body>
</html>
```

### Option 2: Disable auto_load_bundle
Set `auto_load_bundle = false` and manually manage pack loading.

### Option 3: HMR-related FOUC
Clarifies that HMR FOUC in development is separate from the SSR issue.

## Changes

- **Updated**: `docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md`
  - Rewrote the FOUC troubleshooting section (lines 523-594)
  - Added detailed explanation of the root cause with SSR + auto_load_bundle
  - Documented the `content_for` workaround pattern with full example
  - Provided alternative solutions for different architectures
  - Separated HMR FOUC from SSR FOUC issues

## References

- Working example: https://github.com/shakacode/react-webpack-rails-tutorial/pull/686
- Related Shakapacker issue: https://github.com/shakacode/shakapacker/issues/720

## Test Plan

- [x] Documentation is clear and accurate
- [x] Code examples are properly formatted
- [x] All linters pass (RuboCop, ESLint, Prettier)
- [x] Pattern tested in react-webpack-rails-tutorial

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1865)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  - Reworked troubleshooting to focus on SSR-related Flash of Unstyled Content (FOUC), adding a body-first rendering pattern and an option to disable auto-loading.
  - Added a dedicated FOUC guidance section with symptoms, root cause, solutions, and a quick-fix example.
  - Expanded SSR guidance for "document is not defined" errors, dynamic-import/client-only patterns, and skeleton fallbacks.
  - Broadened troubleshooting for missing bundles, manual pack issues, bundle size/performance, dev vs prod differences, and updated quick-diagnosis layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->