### PR TITLE
Run "link-source" script in development environment only at node renderer package

### DIFF
--- a/react_on_rails_pro/package.json
+++ b/react_on_rails_pro/package.json
@@ -103,7 +103,7 @@
     "packages/node-renderer/dist"
   ],
   "scripts": {
-    "preinstall": "(test -f yarn.lock && yarn run link-source && yalc add --link react-on-rails) || true",
+    "preinstall": "test -f yarn.lock || exit 0; yarn run link-source && yalc add --link react-on-rails",
     "postinstall": "test -f post-yarn-install.local && ./post-yarn-install.local || true",
     "link-source": "cd ../packages/react-on-rails && yarn && yalc publish",
     "test": "nps test",


### PR DESCRIPTION
…erer package

don't run the "link-source" script on preinstall of the node renderer package when it's installed at a client project and not running in dev environment

it depends on checking if yarn.lock file exist at installing directory to check if it's in dev environment

### Summary

_Remove this paragraph and provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together._

### Pull Request checklist

_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

_Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1884)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved installation robustness: the preinstall step now skips linking when no lockfile is present, and only runs linking when a lockfile exists.
  * Linking errors will now surface during installation when the lockfile is present, instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->