### PR TITLE
Fix failing rspec test for non hydrated streamed page

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -257,8 +257,12 @@ module ReactOnRailsPro
             # :operation_timeout
             # :keep_alive_timeout
             timeout: {
-              connect_timeout: ReactOnRailsPro.configuration.renderer_http_pool_timeout,
-              read_timeout: ReactOnRailsPro.configuration.ssr_timeout
+              connect_timeout: 100,
+              read_timeout: 100,
+              write_timeout: 100,
+              request_timeout: 100,
+              operation_timeout: 100,
+              keep_alive_timeout: 100,
             }
           )
       rescue StandardError => e

--- a/react_on_rails_pro/packages/node-renderer/src/worker.ts
+++ b/react_on_rails_pro/packages/node-renderer/src/worker.ts
@@ -125,6 +125,11 @@ export default function run(config: Partial<Config>) {
     logger:
       logHttpLevel !== 'silent' ? { name: 'RORP HTTP', level: logHttpLevel, ...sharedLoggerOptions } : false,
     ...fastifyServerOptions,
+    pluginTimeout: 1_000_1000,
+    requestTimeout: 1_000_1000,
+    keepAliveTimeout: 1_000_1000,
+    connectionTimeout: 1_000_1000,
+    http2SessionTimeout: 1_000_1000,
   });
 
   // We shouldn't have unhandled errors here, but just in case


### PR DESCRIPTION
### Summary
#### Cause of the error
The error happens because of the following bug:
- If a streaming page started streaming and sent some html chunks to rails side.
- In the middle of the streaming process, a connection error happens like `ConnectionTimeout` or a `descriptor closed` error.
- The [`retries` plugin](https://github.com/shakacode/react_on_rails/blob/master/react_on_rails_pro/lib/react_on_rails_pro/request.rb) at HTTPx retries to make the request again.
- When the retry happens, some of the HTML chunks are already processed and sent or are on the way to the client.
- When the request is made again, the returned chunks are appended to the original HTML chunks returned from the first erroneous request.
- The sent HTML to the client contains erroneous and non-errornous HTML, which causes DOM errors and hydration errrors.
- The same problem happens if [the retry logic written by us](https://github.com/shakacode/react_on_rails/blob/master/react_on_rails_pro/lib/react_on_rails_pro/request.rb#L105-L116) at the `request.rb` file is executed instead of the HTTPx retry logic.

#### The exact scenario happens at the failing test
To check the error that happens and cause HTTPx retry plugin to retry the request, I wrote the following code at the code that initiates the HTTPx object
```rb
HTTPX
# For persistent connections we want retries,
# so the requests don't just fail if the other side closes the connection
# https://honeyryderchuck.gitlab.io/httpx/wiki/Persistent
.plugin(
  :retries,
  max_retries: 1,
  retry_change_requests: true,
  retry_after: ->(req, res) do
    Rails.logger.error("An error occured and retry is going to be made")
    Rails.logger.error("Error: #{res.error}")
    Rails.logger.error("Request Body: #{req.body&.to_s.first(1000)}")
    nil
  end,
)
```
It logs the error that happens and causes the retry to happen. And by checking the testing log file [here](https://github.com/shakacode/react_on_rails/actions/runs/19015210126/job/54302148437?pr=1892). I found that the error happens is
```
Error: descriptor closed
```
Which happens for no specific reason, I already increased all timeout values at HTTPx side by setting the following configs
```rb
timeout: {
  connect_timeout: 100,
  read_timeout: 100,
  write_timeout: 100,
  request_timeout: 100,
  operation_timeout: 100,
  keep_alive_timeout: 100,
}
```
And at Fastify side, I added the following:
```ts
const app = fastify({
  http2: useHttp2 as true,
  bodyLimit: 104857600, // 100 MB
  logger:
    logHttpLevel !== 'silent' ? { name: 'RORP HTTP', level: logHttpLevel, ...sharedLoggerOptions } : false,
  ...fastifyServerOptions,
  pluginTimeout: 1_000_1000,
  requestTimeout: 1_000_1000,
  keepAliveTimeout: 1_000_1000,
  connectionTimeout: 1_000_1000,
  http2SessionTimeout: 1_000_1000,
});
```

And the same error still happens. **It's planned to reproduce the error outside React on Rails and check if it's a problem at HTTPx or at Fastify and report the issue then**. However, when the HTTPx `retries` plugin is removed, the error disappears, which makes us suspect that the problem is at HTTPx.

#### Reproduce the problem locally
To reproduce the problem locally, try opening a streaming page that takes too long to render and causes a `Timeout` error. You can try to open `http://localhost:3000/rsc_posts_page_over_redis?artificial_delay=3000` page, and you can see that the page content is repeated twice before redirecting you to the `500` error page. At the CI test, the page is not redirected to the `500` error page, because at the second trial to SSR the page, no `Timeout` error happens.
You can try to reproduce it locally by adding a code like this  to the `RSCPageComponent`
```ts
const newProps = { ...props };
if (fs.existsSync('./skip_js_delay')) {
  newProps.artificialDelay = 0;
  fs.rmSync('./skip_js_delay');
} else {
  fs.writeFileSync('./skip_js_delay', '');
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1892)
<!-- Reviewable:end -->
