### PR TITLE
Add foreman/overmind requirement to Getting Started guides

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -13,6 +13,7 @@ Before starting, make sure you have:
 - **Rails 7+** application (Rails 5.2+ supported)
 - **Ruby 3.0+** (required)
 - **Node.js 20+** and **Yarn**
+- **Foreman or Overmind** (for running `bin/dev`)
 - **Basic familiarity** with React and Rails
 
 > 💡 **Don't have a Rails app?** Run `rails new my_react_app` first.
@@ -41,6 +42,11 @@ Take a look at the files created by the generator.
 - Webpack configuration
 
 ## 🎯 Step 2: Start the Development Server (1 minute)
+
+> **Note:** Ensure you have `overmind` or `foreman` installed to run `bin/dev`.
+>
+> - **overmind**: `brew install overmind` (macOS) or see [installation guide](https://github.com/DarthSim/overmind#installation)
+> - **foreman**: `gem install foreman` (install globally, not in your project bundle - [details](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman))
 
 Start both Rails and the Webpack dev server:
 

--- a/docs/getting-started/using-react-on-rails.md
+++ b/docs/getting-started/using-react-on-rails.md
@@ -149,6 +149,8 @@ The generator creates `bin/dev` for starting both:
 - Rails server (port 3000)
 - Webpack dev server (for hot reloading)
 
+> **Note:** You need `overmind` or `foreman` installed to run `bin/dev`. Install with `brew install overmind` (macOS) or `gem install foreman` (globally). See the [Quick Start Guide](./quick-start.md#-step-2-start-the-development-server-1-minute) for detailed installation instructions.
+
 ---
 
 ## Render-Functions and RailsContext


### PR DESCRIPTION
## Summary

This PR addresses the issue where new developers following the Getting Started guides encounter the "can't find executable foreman" error when running `./bin/dev`. The PR adds clear documentation about the foreman/overmind prerequisite in both the Quick Start and Using React on Rails guides.

**Supersedes:** #1870 (rebased on latest master after docs reorganization in #1860)

## Changes

### Quick Start Guide (`docs/getting-started/quick-start.md`)
- Added "Foreman or Overmind" to Prerequisites section
- Added installation instructions before the `bin/dev` command with:
  - `brew install overmind` for macOS users
  - `gem install foreman` for global installation
  - Links to detailed installation guides for both tools
  - Important note about global installation for foreman

### Using React on Rails Guide (`docs/getting-started/using-react-on-rails.md`)
- Added note in Development Workflow section about foreman/overmind requirement
- Included quick installation commands
- Cross-referenced Quick Start guide for detailed instructions

## Impact

- **Existing installations**: No impact - documentation only
- **New installations**: Better developer experience with clear requirements upfront, preventing common "can't find executable" errors

## Testing

- Verified all files end with newline characters (CLAUDE.md requirement)
- Passed all pre-commit hooks (prettier, rubocop, trailing-newlines)
- Manually verified markdown formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1897)
<!-- Reviewable:end -->
