### PR TITLE
Fix Turbo navigation script tag

### DIFF
--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
   <%= yield :head %>
 
   <!--  NOTE: Must use defer and not async to keep async scripts loading in correct order  -->
-  <%= javascript_pack_tag('client-bundle', 'data-turbolinks-track': true) %>
+  <%= javascript_pack_tag('client-bundle', 'data-turbo-track': 'reload', defer: true) %>
 
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
## Summary
- Changed from deprecated `data-turbolinks-track` to modern `data-turbo-track: 'reload'`
- Explicitly added `defer: true` for clarity
- Fixes Turbo navigation issues in the dummy app

## Test plan
- [ ] Verify dummy app loads correctly
- [ ] Confirm Turbo navigation works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1906)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated script loading configuration for improved performance and compatibility with current framework standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->