### PR TITLE
Fix bin/dev pack generation in Bundler context

### DIFF
--- a/lib/react_on_rails/dev/pack_generator.rb
+++ b/lib/react_on_rails/dev/pack_generator.rb
@@ -27,11 +27,20 @@ module ReactOnRails
         def run_pack_generation(silent: false)
           # If we're already inside a Bundler context AND Rails is available (e.g., called from bin/dev),
           # we can directly require and run the task. Otherwise, use bundle exec.
-          if defined?(Bundler) && rails_available?
+          if should_run_directly?
             run_rake_task_directly(silent: silent)
           else
             run_via_bundle_exec(silent: silent)
           end
+        end
+
+        def should_run_directly?
+          # Check if we're in a meaningful Bundler context with BUNDLE_GEMFILE
+          return false unless defined?(Bundler)
+          return false unless ENV["BUNDLE_GEMFILE"]
+          return false unless rails_available?
+
+          true
         end
 
         def rails_available?
@@ -39,36 +48,64 @@ module ReactOnRails
           return false unless Rails.respond_to?(:application)
           return false if Rails.application.nil?
 
-          true
+          # Verify Rails app can actually load tasks
+          begin
+            Rails.application.respond_to?(:load_tasks)
+          rescue StandardError
+            false
+          end
         end
 
         def run_rake_task_directly(silent: false)
           require "rake"
 
-          # Load tasks only if not already loaded (don't clear all tasks)
-          Rails.application.load_tasks unless Rake::Task.task_defined?("react_on_rails:generate_packs")
+          load_rake_tasks
+          task = prepare_rake_task
 
-          if silent
-            original_stdout = $stdout
-            original_stderr = $stderr
-            $stdout = StringIO.new
-            $stderr = StringIO.new
-          end
-
-          begin
-            task = Rake::Task["react_on_rails:generate_packs"]
-            task.reenable # Allow re-execution if called multiple times
+          capture_output(silent) do
             task.invoke
             true
-          rescue StandardError => e
-            warn "Error generating packs: #{e.message}" unless silent
-            false
-          ensure
-            if silent
-              $stdout = original_stdout
-              $stderr = original_stderr
-            end
           end
+        rescue StandardError => e
+          handle_rake_error(e, silent)
+          false
+        end
+
+        def load_rake_tasks
+          return if Rake::Task.task_defined?("react_on_rails:generate_packs")
+
+          Rails.application.load_tasks
+        end
+
+        def prepare_rake_task
+          task = Rake::Task["react_on_rails:generate_packs"]
+          task.reenable # Allow re-execution if called multiple times
+          task
+        end
+
+        def capture_output(silent)
+          return yield unless silent
+
+          original_stdout = $stdout
+          original_stderr = $stderr
+          output_buffer = StringIO.new
+          $stdout = output_buffer
+          $stderr = output_buffer
+
+          begin
+            yield
+          ensure
+            $stdout = original_stdout
+            $stderr = original_stderr
+          end
+        end
+
+        def handle_rake_error(error, _silent)
+          error_msg = "Error generating packs: #{error.message}"
+          error_msg += "\n#{error.backtrace.join("\n")}" if ENV["DEBUG"]
+
+          # Always write to stderr, even in silent mode
+          warn error_msg
         end
 
         def run_via_bundle_exec(silent: false)


### PR DESCRIPTION
## Summary
- Detects when running inside a Bundler context (e.g., from bin/dev)
- Runs Rake tasks directly instead of shelling out to `bundle exec rake`
- Falls back to bundle exec when not in Bundler context
- Properly handles silent mode for both execution paths

## Why this change
When bin/dev runs in a Bundler context, calling `bundle exec rake` can fail or cause issues. This fix detects the context and chooses the appropriate execution method.

## Test plan
- [ ] Verify pack generation works from bin/dev
- [ ] Confirm it still works from command line
- [ ] Test both verbose and silent modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1907)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved pack generation execution to intelligently determine when to run directly within the Rails/Bundler context versus falling back to bundle exec
  * Enhanced error handling for pack generation with improved stderr reporting and debugging capabilities
  * Optimized output capture behavior for both verbose and silent modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->