### PR TITLE
Skip version validation when package.json doesn't exist during setup

### DIFF
--- a/lib/react_on_rails/engine.rb
+++ b/lib/react_on_rails/engine.rb
@@ -6,8 +6,13 @@ module ReactOnRails
   class Engine < ::Rails::Engine
     # Validate package versions and compatibility on Rails startup
     # This ensures the application fails fast if versions don't match or packages are misconfigured
+    # Skip validation during installation tasks (e.g., shakapacker:install)
     initializer "react_on_rails.validate_version_and_package_compatibility" do
       config.after_initialize do
+        # Skip validation if package.json doesn't exist yet (during initial setup)
+        package_json = VersionChecker::NodePackageVersion.package_json_path
+        next unless File.exist?(package_json)
+
         Rails.logger.info "[React on Rails] Validating package version and compatibility..."
         VersionChecker.build.validate_version_and_package_compatibility!
         Rails.logger.info "[React on Rails] Package validation successful"


### PR DESCRIPTION
## Summary

Fixes an error that occurs when running `rake shakapacker:install` on a fresh Rails application. The version validation was introduced in commit 0d87ea75 (#1881) and runs during Rails initialization via an `after_initialize` hook.

## Problem

`shakapacker:install` needs to load the Rails environment before it can create package.json, but the version validation runs during environment loading and fails because package.json doesn't exist yet.

**Error message:**
```
ReactOnRails::Error: **ERROR** ReactOnRails: package.json file not found.

Expected location: /path/to/project/package.json
```

## Solution

Skip validation if package.json doesn't exist yet. This allows installation tasks to complete successfully while still validating versions on normal Rails application startup.

## Root Cause Analysis

1. Commit 0d87ea75 (9 days ago) added strict version validation that runs on Rails initialization
2. This validation checks for package.json existence and raises an error if not found
3. The `shakapacker:install` rake task needs to load the Rails environment to run (via `config/environment.rb`)
4. The validation runs during environment loading, before the task can create package.json

## Testing

- Validated that `bundle exec rubocop` passes
- Confirmed the fix matches the implementation in branch `justin808/shakapacker-9.3.0` (commit 42c109ca)
- Tested that the example generation would work with this fix

## Related

This fix was already implemented in the `justin808/shakapacker-9.3.0` branch (commit 42c109ca) but hadn't been merged to master yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1913)
<!-- Reviewable:end -->
