### PR TITLE
Fix unsafe system calls to use array form in pack_generator.rb

### DIFF
--- a/lib/react_on_rails/dev/pack_generator.rb
+++ b/lib/react_on_rails/dev/pack_generator.rb
@@ -110,9 +110,12 @@ module ReactOnRails
 
         def run_via_bundle_exec(silent: false)
           if silent
-            system "bundle exec rake react_on_rails:generate_packs > /dev/null 2>&1"
+            system(
+              "bundle", "exec", "rake", "react_on_rails:generate_packs",
+              out: File::NULL, err: File::NULL
+            )
           else
-            system "bundle exec rake react_on_rails:generate_packs"
+            system("bundle", "exec", "rake", "react_on_rails:generate_packs")
           end
         end
       end

--- a/spec/react_on_rails/dev/pack_generator_spec.rb
+++ b/spec/react_on_rails/dev/pack_generator_spec.rb
@@ -6,24 +6,27 @@ require "react_on_rails/dev/pack_generator"
 RSpec.describe ReactOnRails::Dev::PackGenerator do
   describe ".generate" do
     it "runs pack generation successfully in verbose mode" do
-      command = "bundle exec rake react_on_rails:generate_packs"
-      allow(described_class).to receive(:system).with(command).and_return(true)
+      allow(described_class).to receive(:system)
+        .with("bundle", "exec", "rake", "react_on_rails:generate_packs")
+        .and_return(true)
 
       expect { described_class.generate(verbose: true) }
         .to output(/📦 Generating React on Rails packs.../).to_stdout_from_any_process
     end
 
     it "runs pack generation successfully in quiet mode" do
-      command = "bundle exec rake react_on_rails:generate_packs > /dev/null 2>&1"
-      allow(described_class).to receive(:system).with(command).and_return(true)
+      allow(described_class).to receive(:system)
+        .with("bundle", "exec", "rake", "react_on_rails:generate_packs", out: File::NULL, err: File::NULL)
+        .and_return(true)
 
       expect { described_class.generate(verbose: false) }
         .to output(/📦 Generating packs\.\.\. ✅/).to_stdout_from_any_process
     end
 
     it "exits with error when pack generation fails" do
-      command = "bundle exec rake react_on_rails:generate_packs > /dev/null 2>&1"
-      allow(described_class).to receive(:system).with(command).and_return(false)
+      allow(described_class).to receive(:system)
+        .with("bundle", "exec", "rake", "react_on_rails:generate_packs", out: File::NULL, err: File::NULL)
+        .and_return(false)
 
       expect { described_class.generate(verbose: false) }.to raise_error(SystemExit)
     end


### PR DESCRIPTION
## Summary

Updates system calls in `lib/react_on_rails/dev/pack_generator.rb` to use the safer array form instead of string form for better security and cross-platform compatibility.

## Changes

- Convert string-based `system` calls to array form
- Update output redirection to use `File::NULL` with `out:` and `err:` options
- Update corresponding RSpec tests to match new system call signatures

## Impact

- **Security**: Prevents potential shell injection issues
- **Cross-platform**: Better compatibility across different operating systems
- **Safety**: Avoids shell interpretation of special characters

## Testing

- All RSpec tests pass
- RuboCop checks pass with zero offenses
- Git hooks successfully validated the changes

Fixes #1910

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1914)
<!-- Reviewable:end -->
