### PR TITLE
Fix Node.js 22 V8 cache crash by reverting to Node 20

### DIFF
--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -54,11 +54,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
-          # TODO: Re-enable cache when Node.js 22 V8 bug is fixed
-          # Disable cache for Node 22 due to V8 bug in 22.21.0
-          # Track: https://github.com/nodejs/node/issues/56010
-          cache: ''
+          node-version: 20
+          cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         include:
           # Always run: Latest versions (fast feedback on PRs)
           - ruby-version: '3.4'
-            node-version: '22'
+            node-version: '20'
             dependency-level: 'latest'
           # Master only: Minimum supported versions (full coverage)
           - ruby-version: '3.2'
@@ -69,9 +69,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          # Disable cache for Node 22 due to V8 bug in 22.21.0
-          # https://github.com/nodejs/node/issues/56010
-          cache: ${{ matrix.node-version != '22' && 'yarn' || '' }}
+          cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
@@ -150,9 +148,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          # Disable cache for Node 22 due to V8 bug in 22.21.0
-          # https://github.com/nodejs/node/issues/56010
-          cache: ${{ matrix.node-version != '22' && 'yarn' || '' }}
+          cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -47,11 +47,7 @@ jobs:
       (github.ref == 'refs/heads/master' || needs.detect-changes.outputs.run_js_tests == 'true')
     strategy:
       matrix:
-        include:
-          # Always run: Latest Node version (fast feedback on PRs)
-          - node-version: '22'
-          # Master only: Minimum supported Node version (full coverage)
-          - node-version: '20'
+        node-version: ['20']
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -61,10 +57,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          # TODO: Re-enable cache when Node.js 22 V8 bug is fixed
-          # Disable cache for Node 22 due to V8 bug in 22.21.0
-          # Track: https://github.com/nodejs/node/issues/56010
-          cache: ${{ matrix.node-version != '22' && 'yarn' || '' }}
+          cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
       - name: Print system information
         run: |
@@ -74,11 +67,10 @@ jobs:
           echo "Node version: "; node -v
           echo "Yarn version: "; yarn --version
       - name: run conversion script
-        if: matrix.node-version == '20'
         run: script/convert
       - name: Install Node modules with Yarn for renderer package
         run: |
-          yarn install --no-progress --no-emoji ${{ matrix.node-version == '22' && '--frozen-lockfile' || '' }}
+          yarn install --no-progress --no-emoji
           sudo yarn global add yalc
       - name: Build Renderer package
         run: yarn build


### PR DESCRIPTION
## Summary

The previous attempt to disable yarn caching for Node 22 using `cache: ''` caused CI failures because GitHub Actions setup-node doesn't accept empty strings for the cache parameter and still attempts to initialize caching.

This PR reverts all workflows to use Node 20 until the V8 bug is resolved (https://github.com/nodejs/node/issues/56010).

## Key Changes

- Revert `lint-js-and-ruby.yml` from Node 22 to Node 20 with normal caching
- Revert `main.yml` matrix to use Node 20 for both latest and minimum dependency levels  
- Simplify `package-js-tests.yml` to only test Node 20
- Remove conditional cache logic that was causing failures
- Remove conditional frozen-lockfile flag that depended on Node 22

## CI Failures Fixed

This PR addresses the following CI failures:
- https://github.com/shakacode/react_on_rails/actions/runs/19094420849/job/54551179246
- https://github.com/shakacode/react_on_rails/actions/runs/19094420849/job/54551179250
- https://github.com/shakacode/react_on_rails/actions/runs/19094420881/job/54551179365

## Test Plan

- [x] RuboCop passes locally
- [x] Git hooks pass (prettier, trailing newlines check)
- [ ] CI workflows pass with Node 20 configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1925)
<!-- Reviewable:end -->
