### PR TITLE
Ignore Slack URL in markdown link checks

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -23,6 +23,9 @@
     },
     {
       "pattern": "^https://github\\.com/shakacode/react-webpack-rails-tutorial/blob/master/client/webpack\\.client\\.base\\.config\\.js"
+    },
+    {
+      "pattern": "^https://reactrails\\.slack\\.com"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
## Summary

- Added `reactrails.slack.com` to the ignored URLs in markdown link check configuration
- Fixes CI failures caused by Slack's 503 responses to automated link checkers

## Details

The Slack workspace URL (`https://reactrails.slack.com`) consistently returns 503 errors when checked by automated tools, causing the markdown link check CI job to fail. This URL is still valid for users who have access to the Slack workspace, but Slack's servers reject requests from link checking bots.

This change adds the URL to the `ignorePatterns` in `.github/markdown-link-check-config.json` to prevent these false positives from blocking CI.

## Test plan

- ✅ Verified the JSON configuration is valid
- ✅ All linting and formatting checks pass
- CI should now pass the markdown link check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1936)
<!-- Reviewable:end -->
