### PR TITLE
Fix CI failures on master

### DIFF
--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -188,6 +188,7 @@ You should return a React.Component always for the client side entry point.`);
       }
 
       try {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         unmountComponentAtNode(domNode);
       } catch (e: unknown) {
         const error = e instanceof Error ? e : new Error('Unknown error');

--- a/packages/react-on-rails-pro/src/createReactOnRailsPro.ts
+++ b/packages/react-on-rails-pro/src/createReactOnRailsPro.ts
@@ -145,11 +145,13 @@ export default function createReactOnRailsPro(
 
   if (reactOnRailsPro.streamServerRenderedReactComponent) {
     reactOnRailsProSpecificFunctions.streamServerRenderedReactComponent =
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       reactOnRailsPro.streamServerRenderedReactComponent;
   }
 
   if (reactOnRailsPro.serverRenderRSCReactComponent) {
     reactOnRailsProSpecificFunctions.serverRenderRSCReactComponent =
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       reactOnRailsPro.serverRenderRSCReactComponent;
   }
 

--- a/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -128,7 +128,7 @@ describe ReactOnRailsHelper do
     it "throws an error in development if generated component isn't found" do
       allow(Rails.env).to receive(:development?).and_return(true)
       expect { helper.load_pack_for_generated_component("nonexisting_component", render_options) }
-        .to raise_error(ReactOnRails::Error, /the generated component entrypoint/)
+        .to raise_error(ReactOnRails::SmartError, /Auto-loaded Bundle Missing/)
     end
   end
 


### PR DESCRIPTION
## Summary
This PR fixes the CI failures on master that were introduced by PR #1934 (smart error messages).

### Changes Made

**ESLint Fixes:**
- Fixed `@typescript-eslint/no-deprecated` error in `ClientSideRenderer.ts` by adding eslint-disable comment for `unmountComponentAtNode` (React 18 deprecated API that we still need to support for older versions)
- Fixed `@typescript-eslint/unbound-method` errors in `createReactOnRailsPro.ts` by adding eslint-disable comments for method references

**Test Fixes:**
- Updated test expectation in `react_on_rails_helper_spec.rb` to expect `ReactOnRails::SmartError` instead of `ReactOnRails::Error`
- Updated error message regex from `/the generated component entrypoint/` to `/Auto-loaded Bundle Missing/` to match the new SmartError format

### Test Plan
- ✅ All linting passes locally (`bundle exec rubocop` and `yarn run lint`)
- ✅ Specific failing test now passes (`spec/helpers/react_on_rails_helper_spec.rb:128`)
- ✅ Pre-commit hooks pass

### Notes
- `SmartError` is a subclass of `Error`, so this change maintains backward compatibility
- The new error messages are more user-friendly and actionable
- All changes align with the smart error messages introduced in PR #1934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1940)
<!-- Reviewable:end -->
