### PR TITLE
[React 19] Update OSS package imports for consistency

### DIFF
--- a/packages/react-on-rails/src/createReactOutput.ts
+++ b/packages/react-on-rails/src/createReactOutput.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { createElement, isValidElement, type ReactElement } from 'react';
 import type { CreateParams, ReactComponent, RenderFunction, CreateReactOutputResult } from './types/index.ts';
 import { isServerRenderHash, isPromise } from './isServerRenderResult.ts';
 
@@ -6,8 +6,8 @@ function createReactElementFromRenderFunctionResult(
   renderFunctionResult: ReactComponent,
   name: string,
   props: Record<string, unknown> | undefined,
-): React.ReactElement {
-  if (React.isValidElement(renderFunctionResult)) {
+): ReactElement {
+  if (isValidElement(renderFunctionResult)) {
     // If already a ReactElement, then just return it.
     console.error(
       `Warning: ReactOnRails: Your registered render-function (ReactOnRails.register) for ${name}
@@ -19,7 +19,7 @@ work if you return JSX. Update by wrapping the result JSX of ${name} in a fat ar
   }
 
   // If a component, then wrap in an element
-  return React.createElement(renderFunctionResult, props);
+  return createElement(renderFunctionResult, props);
 }
 
 /**
@@ -88,5 +88,5 @@ export default function createReactOutput({
     return createReactElementFromRenderFunctionResult(renderFunctionResult, name, props);
   }
   // else
-  return React.createElement(component as ReactComponent, props);
+  return createElement(component as ReactComponent, props);
 }

--- a/packages/react-on-rails/src/handleError.ts
+++ b/packages/react-on-rails/src/handleError.ts
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { createElement } from 'react';
 import { renderToString } from './ReactDOMServer.cts';
 import type { ErrorOptions } from './types/index.ts';
 import generateRenderingErrorMessage from './generateRenderingErrorMessage.ts';
 
 const handleError = (options: ErrorOptions): string => {
   const msg = generateRenderingErrorMessage(options);
-  const reactElement = React.createElement('pre', null, msg);
+  const reactElement = createElement('pre', null, msg);
   return renderToString(reactElement);
 };
 

--- a/packages/react-on-rails/src/serverRenderReactComponent.ts
+++ b/packages/react-on-rails/src/serverRenderReactComponent.ts
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import type { ReactElement } from 'react';
+import { isValidElement, type ReactElement } from 'react';
 
 // ComponentRegistry is accessed via globalThis.ReactOnRails.getComponent for cross-bundle compatibility
 import createReactOutput from './createReactOutput.ts';
@@ -69,7 +68,7 @@ function processPromise(
     return '{}';
   }
   return result.then((promiseResult) => {
-    if (React.isValidElement(promiseResult)) {
+    if (isValidElement(promiseResult)) {
       return processReactElement(promiseResult);
     }
     return promiseResult;


### PR DESCRIPTION
## Summary

**This is part 3 of the React 19 support effort** - updates OSS package to use the same import pattern as Pro package for consistency.

## Problem

Code review on PR #1943 found that the Pro package was updated to use named imports but the OSS package still used namespace imports, creating inconsistency:

**Pro package (after #1943):**
```typescript
import React, { createElement, isValidElement } from 'react';
```

**OSS package (before this PR):**
```typescript
import * as React from 'react';
React.createElement()
```

## Changes

Updated 3 OSS files to use named imports:

### 1. `createReactOutput.ts`
- `React.createElement` → `createElement`
- `React.isValidElement` → `isValidElement`
- `React.ReactElement` → `ReactElement` type

### 2. `handleError.ts`
- `React.createElement` → `createElement`

### 3. `serverRenderReactComponent.ts`
- `React.isValidElement` → `isValidElement`
- Consolidated duplicate ReactElement type import

## Why This Matters

✅ **Consistency**: Matches Pro package import style
✅ **React 19 best practice**: Named imports recommended for better tree-shaking
✅ **Clearer code**: Explicit about what's being used from React
✅ **No breaking changes**: Both patterns work identically in React 18 & 19

## Testing

✅ Builds successfully
✅ All linting passes
✅ No API changes
✅ Runtime behavior unchanged

## Dependencies

**Independent** - can merge in any order:
- ✅ Not blocked by #1942 (webpack config)
- ✅ Not blocked by #1943 (Pro changes)
- Purely a code style/consistency improvement

## Impact

- ✅ Improves codebase consistency
- ✅ Follows React 19 best practices
- ✅ No breaking changes
- ✅ Works with React 18 and 19
- ✅ OSS-only changes

## Follow-up

After all 3 PRs merge, the entire codebase will have consistent React import patterns!

1. ✅ PR #1942: Webpack configuration (foundational)
2. ✅ PR #1943: Pro package changes  
3. ✅ This PR: OSS package consistency
4. 🔜 Next: Documentation

## Related

- Addresses code review feedback on #1943
- Part of breaking up #1937 into smaller PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1944)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization with improved module imports for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->