### PR TITLE
Fix React import to work with esModuleInterop: false

### DIFF
--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -14,7 +14,8 @@
 
 'use client';
 
-import React, { createContext, useContext, type ReactNode } from 'react';
+import * as React from 'react';
+import { createContext, useContext, type ReactNode } from 'react';
 import type { ClientGetReactServerComponentProps } from './getReactServerComponent.client.ts';
 import { createRSCPayloadKey } from './utils.ts';
 

--- a/packages/react-on-rails-pro/src/RSCRoute.tsx
+++ b/packages/react-on-rails-pro/src/RSCRoute.tsx
@@ -16,7 +16,8 @@
 
 'use client';
 
-import React, { Component, use, type ReactNode } from 'react';
+import * as React from 'react';
+import { Component, use, type ReactNode } from 'react';
 import { useRSC } from './RSCProvider.tsx';
 import { ServerComponentFetchError } from './ServerComponentFetchError.ts';
 


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation error in `tests/registerServerComponent.client.test.jsx` by changing React imports from default import syntax to namespace import syntax.

**Changes:**
- Updated `RSCRoute.tsx` to use `import * as React from 'react'`
- Updated `RSCProvider.tsx` to use `import * as React from 'react'`

**Root Cause:**
The project's `tsconfig.json` has `esModuleInterop: false`, but `@types/react` uses `export =` syntax. This combination requires namespace imports (`import * as React`) rather than default imports (`import React`).

**Before:**
```typescript
import React, { Component, use, type ReactNode } from 'react';
```

**After:**
```typescript
import * as React from 'react';
import { Component, use, type ReactNode } from 'react';
```

## Test Plan

- [x] Verified `tests/registerServerComponent.client.test.jsx` now passes
- [x] Ran all non-RSC tests in react-on-rails-pro package - all passing
- [x] Ran linting checks (ESLint, Prettier, RuboCop) - all passing
- [x] Pre-commit hooks passed automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1946)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->