### PR TITLE
Fix CI: Ignore LinkedIn links in markdown-link-check

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -26,6 +26,9 @@
     },
     {
       "pattern": "^https://reactrails\\.slack\\.com"
+    },
+    {
+      "pattern": "^https://www\\.linkedin\\.com"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
## Summary

LinkedIn returns 999 status codes for automated link checkers, causing false positives in CI markdown link checking. This is well-documented LinkedIn anti-bot behavior.

## Change

Added LinkedIn to the  in 

## Impact

- Fixes failing markdown-link-check CI workflow
- Prevents future false positives from LinkedIn URLs in documentation

## Related

This fixes the CI failure seen in docs/testimonials/hvmn.md and any other files with LinkedIn profile links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1955)
<!-- Reviewable:end -->
