### PR TITLE
RBS: Narrow type signatures for props parameters

### DIFF
--- a/sig/react_on_rails/controller.rbs
+++ b/sig/react_on_rails/controller.rbs
@@ -5,7 +5,7 @@ module ReactOnRails
 
     def redux_store: (
       String store_name,
-      ?props: untyped,
+      ?props: Hash[Symbol, untyped] | String,
       ?immediate_hydration: bool
     ) -> void
 

--- a/sig/react_on_rails/helper.rbs
+++ b/sig/react_on_rails/helper.rbs
@@ -21,7 +21,7 @@ module ReactOnRails
     # Returns html_safe string (ActiveSupport::SafeBuffer)
     def redux_store: (
       String store_name,
-      ?Hash[Symbol, untyped] props
+      ?Hash[Symbol, untyped] | String props
     ) -> safe_buffer
 
     # Returns html_safe string (ActiveSupport::SafeBuffer)
@@ -33,7 +33,7 @@ module ReactOnRails
       ?Hash[Symbol, untyped] options
     ) -> safe_buffer
 
-    def sanitized_props_string: (untyped props) -> String
+    def sanitized_props_string: (Hash[Symbol, untyped] | String props) -> String
 
     def rails_context: (
       ?server_side: bool


### PR DESCRIPTION
## Summary
Improves type precision for props parameters in RBS signatures by changing from `untyped` to `Hash[Symbol, untyped] | String`.

## Changes
- **helper.rbs**: Updated `sanitized_props_string` props parameter type
- **controller.rbs**: Updated `redux_store` props parameter type

## Benefits
- More precise type checking for props parameters
- Accepts both common formats (Hash or JSON string)
- Better IDE support and autocomplete
- Catches type errors earlier

## Testing
- ✅ `bundle exec rubocop` passes with no violations
- ✅ Pre-commit hooks pass (formatting, linting, trailing newlines)

Fixes #1951

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1966)
<!-- Reviewable:end -->
