### PR TITLE
Fix bin/ci-run-failed-specs to handle bare spec paths

### DIFF
--- a/bin/ci-run-failed-specs
+++ b/bin/ci-run-failed-specs
@@ -105,6 +105,15 @@ else
     if [[ "$line" =~ rspec[[:space:]]+(\./spec/[^[:space:]]+) ]]; then
       spec="${BASH_REMATCH[1]}"
       SPECS+=("$spec")
+    # Also handle bare spec paths like "spec/foo.rb[1:2:3]" or "./spec/foo.rb[1:2:3]"
+    # Strip trailing % and whitespace
+    elif [[ "$line" =~ (\.?/?spec/[^[:space:]%]+) ]]; then
+      spec="${BASH_REMATCH[1]}"
+      # Normalize to ./spec/ format
+      if [[ ! "$spec" =~ ^\. ]]; then
+        spec="./$spec"
+      fi
+      SPECS+=("$spec")
     fi
   done
 fi
@@ -153,9 +162,24 @@ echo ""
 
 # Confirm (read from /dev/tty to handle piped input)
 if [ -t 0 ]; then
+  # stdin is a TTY, read directly
   read -p "Run these specs now? [Y/n] " -n 1 -r REPLY
 else
-  read -p "Run these specs now? [Y/n] " -n 1 -r REPLY < /dev/tty
+  # stdin is not a TTY (piped input), try /dev/tty
+  # Check if we can actually open /dev/tty by attempting to use it in a subshell
+  set +e  # Temporarily disable errexit for the check
+  (exec 0</dev/tty) 2>/dev/null
+  TTY_CHECK=$?
+  set -e  # Re-enable errexit
+
+  if [ $TTY_CHECK -eq 0 ]; then
+    # Successfully opened /dev/tty, use it for confirmation
+    read -p "Run these specs now? [Y/n] " -n 1 -r REPLY < /dev/tty
+  else
+    # Cannot open /dev/tty, auto-confirm
+    echo "Run these specs now? [Y/n] Y (auto-confirmed, TTY unavailable)"
+    REPLY="Y"
+  fi
 fi
 echo
 if [[ ! "${REPLY}" =~ ^[Yy]$ ]] && [[ ! -z "${REPLY}" ]]; then


### PR DESCRIPTION
## Summary

Fixes the `bin/ci-run-failed-specs` script to handle bare spec paths that users might copy directly from their terminal, like `spec/system/integration_spec.rb[1:1:6:1:2]%`.

Previously, the script only recognized the format `rspec ./spec/...` and would fail with "No specs found!" when given bare spec paths.

## Changes

- Added regex pattern to match bare spec paths (with or without `./` prefix)
- Strip trailing `%` characters from spec paths (common in shell output)
- Normalize all paths to `./spec/` format for consistency
- Improved TTY detection to avoid spurious error messages when piping input
- Auto-confirm when TTY is unavailable instead of failing

## Test Plan

The script now correctly handles all these input formats:
- `spec/foo.rb[1:2:3]%` (bare with trailing %)
- `./spec/foo.rb[1:2:3]` (with ./ prefix)
- `rspec ./spec/foo.rb[1:2:3]` (full rspec command format)

Tested with:
```bash
echo "spec/system/integration_spec.rb[1:1:6:1:2]%" | bin/ci-run-failed-specs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/1989)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI test runner to better handle test file path formats
  * Improved user confirmation prompts for automated CI environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->