### PR TITLE
Add RBS type signatures for error classes

### DIFF
--- a/sig/react_on_rails/error.rbs
+++ b/sig/react_on_rails/error.rbs
@@ -1,0 +1,4 @@
+module ReactOnRails
+  class Error < StandardError
+  end
+end

--- a/sig/react_on_rails/json_parse_error.rbs
+++ b/sig/react_on_rails/json_parse_error.rbs
@@ -1,0 +1,10 @@
+module ReactOnRails
+  class JsonParseError < ::ReactOnRails::Error
+    attr_reader json: String
+
+    def initialize: (parse_error: StandardError, json: String) -> void
+    def to_honeybadger_context: () -> Hash[Symbol, untyped]
+    def raven_context: () -> Hash[Symbol, untyped]
+    def to_error_context: () -> Hash[Symbol, untyped]
+  end
+end

--- a/sig/react_on_rails/prerender_error.rbs
+++ b/sig/react_on_rails/prerender_error.rbs
@@ -1,0 +1,21 @@
+module ReactOnRails
+  class PrerenderError < ::ReactOnRails::Error
+    MAX_ERROR_SNIPPET_TO_LOG: Integer
+
+    attr_reader component_name: String?
+    attr_reader err: StandardError?
+    attr_reader props: String?
+    attr_reader js_code: String?
+    attr_reader console_messages: String?
+
+    def initialize: (?component_name: String?, ?err: StandardError?, ?props: String?, ?js_code: String?, ?console_messages: String?) -> void
+    def to_honeybadger_context: () -> Hash[Symbol, untyped]
+    def raven_context: () -> Hash[Symbol, untyped]
+    def to_error_context: () -> Hash[Symbol, untyped]
+
+    private
+
+    def calc_message: (String? component_name, String? console_messages, StandardError? err, String? js_code, String? props) -> [String?, String]
+    def build_troubleshooting_suggestions: (String? component_name, StandardError? err, String? console_messages) -> String
+  end
+end

--- a/sig/react_on_rails/smart_error.rbs
+++ b/sig/react_on_rails/smart_error.rbs
@@ -1,0 +1,28 @@
+module ReactOnRails
+  class SmartError < Error
+    attr_reader error_type: Symbol
+    attr_reader component_name: String?
+    attr_reader props: String?
+    attr_reader js_code: String?
+    attr_reader additional_context: Hash[Symbol, untyped]
+
+    def initialize: (error_type: Symbol, ?component_name: String?, ?props: String?, ?js_code: String?, **untyped additional_context) -> void
+    def solution: () -> String
+
+    private
+
+    def build_error_message: () -> String
+    def error_type_title: () -> String
+    def error_description: () -> String
+    def component_not_registered_solution: () -> String
+    def missing_auto_loaded_bundle_solution: () -> String
+    def hydration_mismatch_solution: () -> String
+    def server_rendering_error_solution: () -> String
+    def redux_store_not_found_solution: () -> String
+    def configuration_error_solution: () -> String
+    def default_solution: () -> String
+    def additional_info: () -> String
+    def troubleshooting_section: () -> String
+    def find_similar_components: (String name) -> Array[String]
+  end
+end


### PR DESCRIPTION
## Summary

Adds RBS type signatures for all error-related classes to complete type coverage for the gem.

## Changes

Added RBS signatures for:
- `ReactOnRails::Error` - Base error class
- `ReactOnRails::JsonParseError` - JSON parsing error with context
- `ReactOnRails::PrerenderError` - Server rendering error with detailed info  
- `ReactOnRails::SmartError` - Enhanced error with actionable suggestions

## Files Added

- `sig/react_on_rails/error.rbs`
- `sig/react_on_rails/json_parse_error.rbs`
- `sig/react_on_rails/prerender_error.rbs`
- `sig/react_on_rails/smart_error.rbs`

## Testing

- RuboCop passes
- RBS files follow existing patterns in the codebase
- Type signatures match the actual implementations

## Related

Fixes #1954 (follow-up to PR #1945)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2004)
<!-- Reviewable:end -->
