### PR TITLE
Add doctor checks for :async usage without React on Rails Pro

### DIFF
--- a/lib/react_on_rails/doctor.rb
+++ b/lib/react_on_rails/doctor.rb
@@ -1151,6 +1151,7 @@ module ReactOnRails
     # Comment patterns used for filtering out commented async usage
     ERB_COMMENT_PATTERN = /<%\s*#.*javascript_pack_tag/
     HAML_COMMENT_PATTERN = /^\s*-#.*javascript_pack_tag/
+    SLIM_COMMENT_PATTERN = %r{^\s*/.*javascript_pack_tag}
     HTML_COMMENT_PATTERN = /<!--.*javascript_pack_tag/
 
     def check_async_usage
@@ -1186,7 +1187,7 @@ module ReactOnRails
     end
 
     def scan_view_files_for_async_pack_tag
-      view_patterns = ["app/views/**/*.erb", "app/views/**/*.haml"]
+      view_patterns = ["app/views/**/*.erb", "app/views/**/*.haml", "app/views/**/*.slim"]
       files_with_async = view_patterns.flat_map { |pattern| scan_pattern_for_async(pattern) }
       files_with_async.compact
     rescue Errno::ENOENT, Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError => e
@@ -1235,6 +1236,7 @@ module ReactOnRails
       uncommented_lines = content.each_line.reject do |line|
         line.match?(ERB_COMMENT_PATTERN) ||
           line.match?(HAML_COMMENT_PATTERN) ||
+          line.match?(SLIM_COMMENT_PATTERN) ||
           line.match?(HTML_COMMENT_PATTERN)
       end
 

--- a/spec/lib/react_on_rails/doctor_spec.rb
+++ b/spec/lib/react_on_rails/doctor_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe ReactOnRails::Doctor do
         before do
           allow(Dir).to receive(:glob).with("app/views/**/*.erb").and_return(["app/views/layouts/application.html.erb"])
           allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+          allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
           allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
           allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                        .and_return('<%= javascript_pack_tag "application", :async %>')
@@ -279,6 +280,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<%= javascript_pack_tag "app", :async %>')
@@ -297,6 +299,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<%= javascript_pack_tag "app", async: true %>')
@@ -315,6 +318,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<%= javascript_pack_tag "app", defer: "async" %>')
@@ -331,6 +335,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<%= javascript_pack_tag "app" %>')
@@ -347,6 +352,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<%= javascript_pack_tag "app", defer: true %>
@@ -364,6 +370,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<%# javascript_pack_tag "app", :async %>')
@@ -380,6 +387,7 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb").and_return([])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml")
                                     .and_return(["app/views/layouts/application.html.haml"])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.haml").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.haml")
                                      .and_return('-# javascript_pack_tag "app", :async')
@@ -396,6 +404,8 @@ RSpec.describe ReactOnRails::Doctor do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return('<!-- <%= javascript_pack_tag "app", :async %> -->')
@@ -407,11 +417,50 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when async is only in Slim comments" do
+      before do
+        allow(Dir).to receive(:glob).with("app/views/**/*.erb").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim")
+                                    .and_return(["app/views/layouts/application.html.slim"])
+        allow(File).to receive(:exist?).with("app/views/layouts/application.html.slim").and_return(true)
+        allow(File).to receive(:read).with("app/views/layouts/application.html.slim")
+                                     .and_return('/ = javascript_pack_tag "app", :async')
+      end
+
+      it "returns empty array" do
+        files = doctor.send(:scan_view_files_for_async_pack_tag)
+        expect(files).to be_empty
+      end
+    end
+
+    context "when view files contain Slim javascript_pack_tag with :async" do
+      before do
+        allow(Dir).to receive(:glob).with("app/views/**/*.erb").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim")
+                                    .and_return(["app/views/layouts/application.html.slim"])
+        allow(File).to receive(:exist?).with("app/views/layouts/application.html.slim").and_return(true)
+        allow(File).to receive(:read).with("app/views/layouts/application.html.slim")
+                                     .and_return('= javascript_pack_tag "app", :async')
+        allow(doctor).to receive(:relativize_path).with("app/views/layouts/application.html.slim")
+                                                  .and_return("app/views/layouts/application.html.slim")
+      end
+
+      it "returns files with async" do
+        files = doctor.send(:scan_view_files_for_async_pack_tag)
+        expect(files).to include("app/views/layouts/application.html.slim")
+      end
+    end
+
     context "when javascript_pack_tag spans multiple lines" do
       before do
         allow(Dir).to receive(:glob).with("app/views/**/*.erb")
                                     .and_return(["app/views/layouts/application.html.erb"])
         allow(Dir).to receive(:glob).with("app/views/**/*.haml").and_return([])
+        allow(Dir).to receive(:glob).with("app/views/**/*.slim").and_return([])
         allow(File).to receive(:exist?).with("app/views/layouts/application.html.erb").and_return(true)
         allow(File).to receive(:read).with("app/views/layouts/application.html.erb")
                                      .and_return("<%= javascript_pack_tag \"app\",\n  :async %>")


### PR DESCRIPTION
## Summary

Adds proactive doctor checks to detect `:async` loading strategy usage in projects without React on Rails Pro, which can cause component registration race conditions.

## Changes

The doctor now checks for and reports errors when it detects:
- `javascript_pack_tag` with `:async` in view files
- `config.generated_component_packs_loading_strategy = :async` in initializer

When detected without Pro, provides clear guidance to either upgrade to Pro or use `:defer`/`:sync` loading strategies.

This complements PR #1993's configuration validation by adding runtime detection during development to help developers identify and fix async usage issues.

## Testing

All new tests pass (155+ examples in doctor spec). The checks are skipped when React on Rails Pro is installed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2010)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic that detects async component-loading usage when the Pro edition is not present, reporting affected view and initializer locations, distinguishing commented/false-positive cases, and providing guidance and upgrade options.

* **Tests**
  * Expanded tests for async-detection across template formats, comment-aware and multiline scanning, initializer strategies, error handling, and skipping when Pro is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->