### PR TITLE
Fix pre-commit hook to only check changed files

### DIFF
--- a/bin/lefthook/ruby-autofix
+++ b/bin/lefthook/ruby-autofix
@@ -17,6 +17,7 @@ else
 fi
 printf "  %s\n" $files
 
-bundle exec rake autofix
+# Run RuboCop only on changed files (not the full rake autofix)
+bundle exec rubocop -A --force-exclusion -- $files
 
 echo "✅ Auto-fix complete (fixed files staged automatically)"


### PR DESCRIPTION
## Summary

- Fixed `ruby-autofix` pre-commit hook to run RuboCop only on changed Ruby files
- Reduces pre-commit time from ~24 seconds to <1 second for typical commits
- During releases, this will only check changed files (version files, Gemfile.locks) instead of all 154 files

## Problem

The pre-commit hook was running `bundle exec rake autofix` which checks ALL files in the project:

```
cd /Users/justin/shakacode/react-on-rails/react_on_rails && bundle exec rubocop -A
Inspecting 154 files
..........................................................................................................................................................

154 files inspected, no offenses detected
Completed auto-fixing all linting violations
```

This made every commit (especially release commits) very slow at ~24 seconds.

## Solution

Changed `bin/lefthook/ruby-autofix` to run `bundle exec rubocop -A` directly on only the changed files:

```bash
bundle exec rubocop -A --force-exclusion -- $files
```

The `get-changed-files` script already identifies which files changed, but we were ignoring that and running the full rake task.

## Test Plan

- Committed this change and verified hook runs in <1 second
- Next release will verify it still works with many changed files
- Hook correctly skips when no Ruby files are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2013)
<!-- Reviewable:end -->
