### PR TITLE
Fix shakapacker.yml template to prevent 'Slow setup' warnings (#1850)

### DIFF
--- a/lib/generators/react_on_rails/templates/base/base/config/shakapacker.yml
+++ b/lib/generators/react_on_rails/templates/base/base/config/shakapacker.yml
@@ -55,6 +55,11 @@ default: &default
   # https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling
   useContentHash: false
 
+  # On-demand compilation of packs when modified. Defaults to false.
+  # Set to false if using bin/shakapacker-dev-server or bin/shakapacker --watch via Procfiles.
+  # Set to true only in test environment for on-demand compilation.
+  compile: false
+
   # Setting the asset host here will override Rails.application.config.asset_host.
   # Here, you can set different asset_host per environment. Note that
   # SHAKAPACKER_ASSET_HOST will override both configurations.
@@ -72,7 +77,6 @@ default: &default
 
 development:
   <<: *default
-  compile: true
   compiler_strategy: mtime
 
   # Reference: https://webpack.js.org/configuration/dev-server/


### PR DESCRIPTION
## Summary

Fixes #1850 by correcting the `shakapacker.yml` template configuration to prevent unnecessary "Slow setup for development" warnings when using Procfiles with `bin/dev`.

## Changes

- **Set `compile: false` in default section** - This becomes the default for development and production environments
- **Remove `compile: true` from development section** - Now inherits `compile: false` from default
- **Keep `compile: true` in test section** - Tests still need on-demand compilation
- **Add clarifying comments** - Explain when to use `compile: true` vs `false`

## Problem Solved

Previously, the installer generated:
```yaml
development:
  compile: true  # ❌ Wrong - causes on-demand compilation
```

This caused Rails to attempt on-demand asset compilation even when `bin/shakapacker-dev-server` or `bin/shakapacker --watch` were already running via Procfiles, resulting in this warning on every request:

```
Shakapacker::Compiler - Slow setup for development

Prepare JS assets with either:
1. Running bin/shakapacker-dev-server
2. Set compile to false in shakapacker.yml and run bin/shakapacker -w
```

## After This Fix

The generated configuration now follows best practices:
```yaml
default: &default
  compile: false  # Default is false (use Procfiles)

development:
  <<: *default
  # Inherits compile: false - no on-demand compilation

test:
  <<: *default
  compile: true  # Only tests need on-demand compilation

production:
  <<: *default
  compile: false  # Assets are precompiled
```

## Impact

- ✅ Eliminates confusing warnings on every page load during development
- ✅ Aligns with standard Procfile-based development workflow
- ✅ Maintains correct behavior for test environment
- ✅ No impact on production (already had `compile: false`)

## Test Plan

- [x] Changes made to installer template
- [x] RuboCop passes with no violations
- [x] Pre-commit hooks pass (prettier, trailing newlines)

To test the fix:
1. Generate a new app with the updated installer
2. Run `bin/dev` (which starts rails server + shakapacker-dev-server)
3. Visit any page
4. Verify no "Slow setup for development" warning appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2021)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default build configuration to use on-demand compilation instead of always compiling. Development environments now inherit this default behavior for optimized build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->