### PR TITLE
Fix bin/dev --verbose option causing error

### DIFF
--- a/lib/react_on_rails/dev/server_manager.rb
+++ b/lib/react_on_rails/dev/server_manager.rb
@@ -144,10 +144,11 @@ module ReactOnRails
           puts help_troubleshooting
         end
 
+        # rubocop:disable Metrics/AbcSize
         def run_from_command_line(args = ARGV)
           require "optparse"
 
-          options = { route: nil, rails_env: nil }
+          options = { route: nil, rails_env: nil, verbose: false }
 
           OptionParser.new do |opts|
             opts.banner = "Usage: dev [command] [options]"
@@ -158,6 +159,10 @@ module ReactOnRails
 
             opts.on("--rails-env ENV", "Override RAILS_ENV for assets:precompile step only (prod mode only)") do |env|
               options[:rails_env] = env
+            end
+
+            opts.on("-v", "--verbose", "Enable verbose output for pack generation") do
+              options[:verbose] = true
             end
 
             opts.on("-h", "--help", "Prints this help") do
@@ -172,21 +177,23 @@ module ReactOnRails
           # Main execution
           case command
           when "production-assets", "prod"
-            start(:production_like, nil, verbose: false, route: options[:route], rails_env: options[:rails_env])
+            start(:production_like, nil, verbose: options[:verbose], route: options[:route],
+                                         rails_env: options[:rails_env])
           when "static"
-            start(:static, "Procfile.dev-static-assets", verbose: false, route: options[:route])
+            start(:static, "Procfile.dev-static-assets", verbose: options[:verbose], route: options[:route])
           when "kill"
             kill_processes
           when "help", "--help", "-h"
             show_help
           when "hmr", nil
-            start(:development, "Procfile.dev", verbose: false, route: options[:route])
+            start(:development, "Procfile.dev", verbose: options[:verbose], route: options[:route])
           else
             puts "Unknown argument: #{command}"
             puts "Run 'dev help' for usage information"
             exit 1
           end
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 


### PR DESCRIPTION
## Summary
- Implements the `--verbose`/`-v` flag that was documented but not functional
- Fixes OptionParser to properly handle the verbose flag
- Updates all start() calls to pass through the verbose option

## What was the problem?
The `--verbose` option was shown in `bin/dev --help` output but caused an `OptionParser::InvalidOption` error when used. This happened because:
1. The help text documented `--verbose, -v`
2. The `start()` method accepted a `verbose:` parameter
3. But the OptionParser in `run_from_command_line()` didn't parse the flag
4. All calls to `start()` hardcoded `verbose: false`

## Changes
- Added `verbose: false` to the options hash initialization
- Implemented `--verbose`/`-v` flag parsing in OptionParser
- Updated three `start()` calls to use `options[:verbose]` instead of hardcoded `false`
- Added RuboCop disable/enable comments for AbcSize metric (slightly increased by parameter handling)

## Test Plan
- ✅ Manually tested `--verbose` and `-v` flags with all commands
- ✅ All existing RSpec tests pass
- ✅ RuboCop passes with no violations
- ✅ Pre-commit and pre-push hooks pass

## Testing
```bash
# All of these now work without error:
bin/dev --verbose
bin/dev -v
bin/dev static --verbose
bin/dev prod -v
```

Closes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2023)
<!-- Reviewable:end -->
