### PR TITLE
Security and reliability improvements for CI debugging tools

### DIFF
--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -173,15 +173,41 @@ if [ -z "$FAILED_CHECKS" ]; then
   exit 0
 fi
 
-# Map CI job names to local commands
+# Map CI job names to identifiers
 # NOTE: Version numbers below must match .github/workflows/main.yml matrix configuration
 declare -A JOB_MAP
-JOB_MAP["lint-js-and-ruby"]="bundle exec rubocop && yarn run eslint --report-unused-disable-directives && yarn start format.listDifferent"
-JOB_MAP["rspec-package-tests"]="bundle exec rake run_rspec:gem"
-JOB_MAP["package-js-tests"]="yarn test"
-JOB_MAP["dummy-app-integration-tests (3.4, 22, latest)"]="bundle exec rake run_rspec:all_dummy"
-JOB_MAP["dummy-app-integration-tests (3.2, 20, minimum)"]="bundle exec rake run_rspec:all_dummy"
-JOB_MAP["examples"]="bundle exec rake run_rspec:shakapacker_examples"
+JOB_MAP["lint-js-and-ruby"]="lint-js-and-ruby"
+JOB_MAP["rspec-package-tests"]="rspec-package-tests"
+JOB_MAP["package-js-tests"]="package-js-tests"
+JOB_MAP["dummy-app-integration-tests (3.4, 22, latest)"]="dummy-app-integration-tests"
+JOB_MAP["dummy-app-integration-tests (3.2, 20, minimum)"]="dummy-app-integration-tests"
+JOB_MAP["examples"]="examples"
+
+# Function to execute commands without eval
+run_command() {
+  local cmd_id="$1"
+  case "$cmd_id" in
+    "lint-js-and-ruby")
+      bundle exec rubocop && yarn run eslint --report-unused-disable-directives && yarn start format.listDifferent
+      ;;
+    "rspec-package-tests")
+      bundle exec rake run_rspec:gem
+      ;;
+    "package-js-tests")
+      yarn test
+      ;;
+    "dummy-app-integration-tests")
+      bundle exec rake run_rspec:all_dummy
+      ;;
+    "examples")
+      bundle exec rake run_rspec:shakapacker_examples
+      ;;
+    *)
+      echo "Unknown command ID: $cmd_id"
+      return 1
+      ;;
+  esac
+}
 
 # Map CI job names to human-readable versions (matches SWITCHING_CI_CONFIGS.md)
 declare -A JOB_VERSION_MAP
@@ -236,10 +262,10 @@ if [ "$NUM_COMMANDS" -eq 0 ]; then
 fi
 
 echo -e "${BLUE}Will run the following commands:${NC}"
-for cmd in "${!COMMANDS_TO_RUN[@]}"; do
-  job_name="${COMMANDS_TO_RUN[$cmd]}"
+for cmd_id in "${!COMMANDS_TO_RUN[@]}"; do
+  job_name="${COMMANDS_TO_RUN[$cmd_id]}"
   version_info=$(get_version_info "$job_name")
-  echo -e "${BLUE}  • $job_name${version_info}:${NC} $cmd"
+  echo -e "${BLUE}  • $job_name${version_info}${NC}"
 done
 echo ""
 
@@ -270,17 +296,14 @@ fi
 # Run commands
 FAILED_COMMANDS=()
 
-for cmd in "${!COMMANDS_TO_RUN[@]}"; do
-  job_name="${COMMANDS_TO_RUN[$cmd]}"
+for cmd_id in "${!COMMANDS_TO_RUN[@]}"; do
+  job_name="${COMMANDS_TO_RUN[$cmd_id]}"
   version_info=$(get_version_info "$job_name")
 
   echo -e "${BLUE}▶ Running: $job_name${version_info}${NC}"
-  echo -e "${BLUE}Command: $cmd${NC}"
   echo ""
 
-  # Note: Using eval here is safe because $cmd comes from predefined JOB_MAP,
-  # not from user input. Commands may contain shell operators like && and ||.
-  if eval "$cmd"; then
+  if run_command "$cmd_id"; then
     echo -e "${GREEN}✓ $job_name${version_info} passed${NC}"
     echo ""
   else

--- a/bin/ci-run-failed-specs
+++ b/bin/ci-run-failed-specs
@@ -139,7 +139,7 @@ echo ""
 
 # Determine the working directory (check if we need to be in spec/dummy)
 WORKING_DIR="."
-if [[ "${UNIQUE_SPECS[0]}" == *"spec/system"* ]] || [[ "${UNIQUE_SPECS[0]}" == *"spec/helpers"* ]]; then
+if [ ${#UNIQUE_SPECS[@]} -gt 0 ] && ([[ "${UNIQUE_SPECS[0]}" == *"spec/system"* ]] || [[ "${UNIQUE_SPECS[0]}" == *"spec/helpers"* ]]); then
   if [ -d "spec/dummy" ]; then
     WORKING_DIR="spec/dummy"
     echo -e "${BLUE}Running from spec/dummy directory${NC}"

--- a/bin/ci-switch-config
+++ b/bin/ci-switch-config
@@ -255,6 +255,9 @@ EOF
   set_node_version "20.18.1" "$VERSION_MANAGER"
 
   # Run conversion script
+  # NOTE: This uses whatever 'ruby' is in PATH after version manager updates above.
+  # The version manager may not have reloaded yet, so ensure your current Ruby is
+  # compatible with script/convert (Ruby 2.6+ should work).
   print_header "Running script/convert to downgrade dependencies"
   cd "$PROJECT_ROOT"
   ruby script/convert
@@ -395,8 +398,11 @@ EOF
   # Restore files from git
   print_header "Restoring dependency files from git"
   cd "$PROJECT_ROOT"
-  git restore Gemfile.development_dependencies package.json spec/dummy/package.json packages/react-on-rails-pro/package.json 2>/dev/null || true
-  print_success "Files restored from git"
+  if ! git restore Gemfile.development_dependencies package.json spec/dummy/package.json packages/react-on-rails-pro/package.json 2>/dev/null; then
+    print_warning "Some files could not be restored (may not exist in git)"
+  else
+    print_success "Files restored from git"
+  fi
 
   # Clean and reinstall
   print_header "Cleaning node_modules and reinstalling"


### PR DESCRIPTION
## Summary

This PR addresses the security and reliability improvements outlined in issue #1975.

## Changes Made

### High Priority - Security
- **Remove eval from bin/ci-rerun-failures**
  - Replaced `eval` usage with a safe `run_command()` function using case statement
  - Commands are now explicitly defined in case branches, eliminating potential injection risks
  - Maintains same functionality while being more maintainable and secure

### Medium Priority - Documentation
- **Document Ruby version requirement in bin/ci-switch-config**
  - Added comment explaining that script/convert uses current Ruby in PATH
  - Documents that version manager may not have reloaded yet
  - Specifies Ruby 2.6+ compatibility requirement

### Low Priority - Reliability
- **Add bounds check for array access in bin/ci-run-failed-specs**
  - Added defensive check before accessing UNIQUE_SPECS[0]
  - Prevents potential errors if array is empty

- **Improve git restore error handling in bin/ci-switch-config**
  - Replaced silent failure (2>/dev/null || true) with explicit warning
  - Users now see a clear message if files cannot be restored
  - Differentiates between success and partial failure

## Testing

- All scripts validated with `bash -n` for syntax errors
- RuboCop linting passed with zero offenses
- Code formatted with Prettier

Fixes #1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2024)
<!-- Reviewable:end -->
