### PR TITLE
Fix CI to always run full test suite on master branch

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'packages/**'
-      - 'react_on_rails_pro/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails_pro/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails_pro/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'lib/**'
-      - 'spec/react_on_rails/**'
-      - 'react_on_rails_pro/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,9 +3,7 @@ name: Playwright E2E Tests
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    # Never skip on master - always run full test suite
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'lib/**'
-      - 'spec/**'
-      - 'packages/react_on_rails/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/pro-lint.yml
+++ b/.github/workflows/pro-lint.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'lib/**'
-      - 'spec/**'
-      - 'packages/react_on_rails/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - 'master'
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'lib/**'
-      - 'spec/**'
-      - 'packages/react_on_rails/**'
+    # Never skip on master - always run full test suite
   pull_request:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
## Summary

Fixes critical CI logic flaw where documentation-only commits on master would skip all tests, allowing broken states to persist undetected.

## Problem

The `paths-ignore` directive was being applied to BOTH pull requests AND master branch pushes, causing:

1. **Doc-only commits on master skip ALL CI tests** - If commit A has failing tests, then commit B (doc-only) merges to master, the broken state persists with no CI feedback
2. **Inconsistent test coverage** - Master should always run the full test suite (both latest AND minimum dependency versions)
3. **Silent failures** - Test failures can be hidden by subsequent documentation commits

## Solution

Remove `paths-ignore` from push events on master branch while keeping it for pull requests:

```yaml
on:
  push:
    branches:
      - 'master'
    # Never skip on master - always run full test suite
  pull_request:
    paths-ignore:
      - '**.md'
      - 'docs/**'
```

This ensures:
- ✅ Master ALWAYS runs complete test suite (both latest AND minimum deps)
- ✅ PRs can still skip irrelevant tests for faster feedback
- ✅ No more silent failures hidden by doc-only commits

## Files Changed

All main CI workflows updated:
- `integration-tests.yml`
- `gem-tests.yml`
- `lint-js-and-ruby.yml`
- `package-js-tests.yml`
- `pro-integration-tests.yml`
- `pro-lint.yml`
- `pro-test-package-and-gem.yml`
- `examples.yml`
- `playwright.yml`

## Test Plan

- Verified workflow syntax with `actionlint`
- Confirmed linting passes locally
- CI will validate on this PR

Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react_on_rails/2035)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Ensured master branch pushes always run the full CI/test suite by removing path-based skip rules that previously excluded docs and other file types; pull request trigger behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->