### PR TITLE
Fix Knip configuration after monorepo restructure

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -5,13 +5,11 @@ const config: KnipConfig = {
   workspaces: {
     // Root workspace - manages the monorepo and global tooling
     '.': {
-      entry: ['eslint.config.ts'],
+      entry: ['eslint.config.ts', 'jest.config.base.js'],
       project: ['*.{js,mjs,ts}'],
       ignoreBinaries: [
         // Has to be installed globally
         'yalc',
-        // Used in package.json scripts (devDependency, so unlisted in production mode)
-        'nps',
         // Pro package binaries used in Pro workflows
         'playwright',
         'e2e-test',
@@ -41,6 +39,17 @@ const config: KnipConfig = {
         // SWC transpiler dependencies used in dummy apps
         '@swc/core',
         'swc-loader',
+        // Test dependencies used by child workspaces (packages/react-on-rails, packages/react-on-rails-pro)
+        '@testing-library/dom',
+        '@testing-library/jest-dom',
+        '@testing-library/react',
+        '@types/react-dom',
+        'create-react-class',
+        'jest-fetch-mock',
+        'prop-types',
+        'react',
+        'react-dom',
+        'redux',
       ],
     },
 
@@ -89,6 +98,11 @@ const config: KnipConfig = {
         'src/RSCRoute.tsx:RSCRouteProps',
         'src/streamServerRenderedReactComponent.ts:StreamingTrackers',
       ],
+      ignoreDependencies: [
+        // Test dependencies used only in tests
+        '@types/mock-fs',
+        'mock-fs',
+      ],
     },
     'spec/dummy': {
       entry: [
@@ -124,9 +138,6 @@ const config: KnipConfig = {
         'bin/.*',
       ],
       ignoreDependencies: [
-        // Build-time dependencies not detected by Knip in any mode
-        '@babel/runtime',
-        'mini-css-extract-plugin',
         // There's no ReScript plugin for Knip
         '@rescript/react',
         // The Babel plugin fails to detect it
@@ -136,13 +147,10 @@ const config: KnipConfig = {
         'node-libs-browser',
         // The below dependencies are not detected by the Webpack plugin
         // due to the config issue.
-        'css-loader',
         'expose-loader',
         'file-loader',
         'imports-loader',
         'null-loader',
-        'sass',
-        'sass-loader',
         'sass-resources-loader',
         'style-loader',
         'url-loader',


### PR DESCRIPTION
## Summary

Fixes the failing "Detect dead code" CI job on master after the monorepo restructure.

## Problem

After moving packages to `packages/react-on-rails` and `packages/react-on-rails-pro`, Knip was detecting false positives:
- `jest.config.base.js` marked as unused (but it's used by both packages)
- Test dependencies in root `package.json` marked as unused (shared by child workspaces)
- `mock-fs` dependencies in Pro package marked as unused
- Some dependencies marked as unused that are now properly detected

## Changes

1. **Added `jest.config.base.js` as entry point** - This shared Jest config is imported by both packages
2. **Removed `nps` from ignoreBinaries** - No longer referenced in package.json scripts
3. **Added test dependencies to root ignoreDependencies**:
   - `@testing-library/dom`, `@testing-library/jest-dom`, `@testing-library/react`
   - `@types/react-dom`, `create-react-class`, `jest-fetch-mock`
   - `prop-types`, `react`, `react-dom`, `redux`
4. **Added Pro package ignoreDependencies**: `@types/mock-fs`, `mock-fs`
5. **Removed now-detected dependencies** from spec/dummy

## Testing

CI will validate the fix by running `yarn run knip --exclude binaries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency checking configuration to exclude test-related packages from checks across multiple workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->