### PR TITLE
Consolidate all beta versions into v16.2.0.beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1844,8 +1844,7 @@ such as:
 - Fix several generator-related issues.
 
 [unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.2.0.beta.10...master
-[v16.2.0.beta.10]: https://github.com/shakacode/react_on_rails/compare/16.2.0.beta.4...v16.2.0.beta.10
-[16.2.0.beta.4]: https://github.com/shakacode/react_on_rails/compare/16.1.1...16.2.0.beta.4
+[v16.2.0.beta.10]: https://github.com/shakacode/react_on_rails/compare/16.1.1...v16.2.0.beta.10
 [16.1.1]: https://github.com/shakacode/react_on_rails/compare/16.1.0...16.1.1
 [16.1.0]: https://github.com/shakacode/react_on_rails/compare/16.0.0...16.1.0
 [16.0.0]: https://github.com/shakacode/react_on_rails/compare/14.2.0...16.0.0


### PR DESCRIPTION
### Summary

This PR consolidates all beta changelog entries into v16.2.0.beta.10, removing the separate v16.2.0.beta.8 section. The duplicate rake task execution fix (PR 2052) has been moved from the Unreleased section to the Fixed section under beta.10. Version diff links at the bottom of the file have been updated to reference beta.10.

### Pull Request checklist

- [x] Update CHANGELOG file

🤖 Generated with [Claude Code](https://claude.com/claude-code)