### PR TITLE
Pin Node.js to 22.11.0 to avoid V8 crash bug

### DIFF
--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -95,7 +95,9 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node-with-retry
         with:
-          node-version: 22
+          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # https://github.com/nodejs/node/issues/56010
+          node-version: '22.11.0'
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
       - name: Print system information

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -78,11 +78,11 @@ jobs:
 
       - name: Build test assets
         working-directory: spec/dummy
-        run: yarn build:test
+        run: yarn run build:test
 
       - name: Run Playwright tests
         working-directory: spec/dummy
-        run: yarn test:e2e
+        run: yarn run test:e2e
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary

Pins Node.js version to 22.11.0 (LTS) in CI workflows to avoid a V8 bug that causes crashes during Will not publish package with `private: true` use --private flag to force publishing. and other operations.

## Changes

- Pin  to  in lint-js-and-ruby workflow
- Standardize Playwright workflow to use yarn run v1.22.22
info Commands available from binary scripts: acorn, attw, baseline-browser-mapping, browserslist, create-jest, cssesc, ejs, escodegen, esgenerate, eslint, eslint-config-prettier, esparse, esvalidate, github-codeowners, he, highlight, honeybadger-checkins-sync, import-local-fixture, jake, jest, jiti, js-yaml, jsesc, json5, knip, knip-bun, loose-envify, lz-string, marked, mime, mkdirp, nanoid, nodetouch, nps, parser, pino, pino-pretty, prettier, ps-tree, publint, regjsparser, resolve, semver, stylelint, ts-jest, tsc, tsserver, update-browserslist-db, uuid, which
info Project commands
   - build
      yarn workspace react-on-rails run build && yarn workspace react-on-rails-pro run build
   - build-watch
      yarn workspaces run build-watch
   - check
      yarn run lint && yarn workspaces run check
   - clean
      yarn workspaces run clean
   - lint
      nps eslint
   - lint:scss
      stylelint "spec/dummy/app/assets/stylesheets/**/*.scss" "spec/dummy/client/**/*.scss"
   - postinstall
      test -f .lefthook.yml && test -d .git && command -v bundle >/dev/null 2>&1 && bundle exec lefthook install || true
   - publish
      yarn workspaces run publish
   - start
      nps
   - test
      yarn workspaces run test
   - type-check
      yarn workspaces run type-check
   - yalc
      yarn workspaces run yalc
   - yalc:publish
      yarn workspaces run yalc:publish
Done in 0.03s. instead of bare yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
$ test -f .lefthook.yml && test -d .git && command -v bundle >/dev/null 2>&1 && bundle exec lefthook install || true
Done in 2.45s. commands for consistency

## References

- Node.js V8 bug: https://github.com/nodejs/node/issues/56010

## Testing

- ✅ No code changes, only CI configuration
- ✅ Workflows will use pinned Node.js version on next run

## Context

This is part of preparing for the monorepo node-renderer package. This small fix can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version pinning in build workflows to use a specific LTS patch version, improving build stability and consistency.
  * Standardized script invocation syntax in test workflows to align with best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->