### PR TITLE
Fix FOUC in Pro spec/dummy app with critical CSS

### DIFF
--- a/react_on_rails_pro/spec/dummy/app/views/layouts/application.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/layouts/application.html.erb
@@ -16,10 +16,39 @@
   <% end %>
   <%= yield :head %>
   <style>
+      /* Critical CSS inlined to prevent FOUC (Flash of Unstyled Content)
+         These styles ensure the layout renders correctly before the main CSS loads.
+         See: https://github.com/shakacode/react_on_rails/issues/2100 */
       html {
           font-size: 16px !important;
       }
+      /* Base layout styles */
+      .flex { display: flex; }
+      .flex-row { flex-direction: row; }
+      .flex-col { flex-direction: column; }
+      .flex-1 { flex: 1 1 0%; }
+      .h-screen { height: 100vh; }
+      .w-screen { width: 100vw; }
+      /* Sidebar styles */
+      .min-w-\[400px\] { min-width: 400px; }
+      .max-w-\[400px\] { max-width: 400px; }
+      .bg-slate-100 { background-color: #f1f5f9; }
+      .bg-white { background-color: #ffffff; }
+      .border-solid { border-style: solid; }
+      .border-r-2 { border-right-width: 2px; }
+      .border-slate-700 { border-color: #334155; }
+      /* Spacing */
+      .p-5 { padding: 1.25rem; }
+      .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+      /* Overflow handling */
+      .overflow-y-auto { overflow-y: auto; }
+      .overflow-x-hidden { overflow-x: hidden; }
+      /* Typography (minimal for initial render) */
+      .text-red-700 { color: #b91c1c; }
+      .underline { text-decoration: underline; }
   </style>
+  <!-- Preload CSS for faster loading -->
+  <%= preload_pack_asset('client-bundle.css', as: 'style') %>
   <%= stylesheet_pack_tag('client-bundle',
                           media: 'all',
                           'data-turbo-track': 'reload') %>


### PR DESCRIPTION
## Summary
- Inline critical CSS styles in the `<head>` to prevent Flash of Unstyled Content (FOUC) on initial page load
- Add CSS preload hint for client-bundle.css for faster loading

## Problem
The Pro `spec/dummy` app exhibited severe FOUC where:
1. Completely unstyled HTML appeared with no layout/formatting
2. Layout jumped when CSS finally loaded and applied
3. This undermined confidence in the library's production-readiness

## Solution
Following the recommended approach from #2100, this PR:
1. Inlines critical layout CSS (~50 lines) for immediate rendering
2. Adds preload hint for faster CSS delivery
3. Keeps `async: true` on JavaScript (correct for React 18 Selective Hydration)

The inlined CSS covers:
- Flex layout classes (flex, flex-row, flex-col, flex-1)
- Screen dimensions (h-screen, w-screen)
- Sidebar dimensions (min-w-[400px], max-w-[400px])
- Background colors (bg-slate-100, bg-white)
- Borders (border-solid, border-r-2, border-slate-700)
- Spacing (p-5, px-2)
- Overflow handling (overflow-y-auto, overflow-x-hidden)
- Typography (text-red-700, underline)

## Test plan
- [ ] Run `bin/dev` in `react_on_rails_pro/spec/dummy`
- [ ] Open browser with network throttling (Slow 3G)
- [ ] Load any page - verify no unstyled flash before CSS applies
- [ ] Verify layout appears correctly immediately on page load

Fixes #2100

🤖 Generated with [Claude Code](https://claude.com/claude-code)