### PR TITLE
Add size-limit configuration for bundle size tracking

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "react-on-rails (raw)",
+    "path": "packages/react-on-rails/lib/*.js",
+    "webpack": false,
+    "gzip": false,
+    "brotli": false
+  },
+  {
+    "name": "react-on-rails (gzip)",
+    "path": "packages/react-on-rails/lib/*.js",
+    "webpack": false,
+    "gzip": true
+  },
+  {
+    "name": "react-on-rails (brotli)",
+    "path": "packages/react-on-rails/lib/*.js",
+    "webpack": false,
+    "brotli": true
+  },
+  {
+    "name": "react-on-rails-pro (raw)",
+    "path": "packages/react-on-rails-pro/lib/*.js",
+    "webpack": false,
+    "gzip": false,
+    "brotli": false
+  },
+  {
+    "name": "react-on-rails-pro (gzip)",
+    "path": "packages/react-on-rails-pro/lib/*.js",
+    "webpack": false,
+    "gzip": true
+  },
+  {
+    "name": "react-on-rails-pro (brotli)",
+    "path": "packages/react-on-rails-pro/lib/*.js",
+    "webpack": false,
+    "brotli": true
+  },
+  {
+    "name": "react-on-rails-pro-node-renderer (raw)",
+    "path": "packages/react-on-rails-pro-node-renderer/lib/*.js",
+    "webpack": false,
+    "gzip": false,
+    "brotli": false
+  },
+  {
+    "name": "react-on-rails-pro-node-renderer (gzip)",
+    "path": "packages/react-on-rails-pro-node-renderer/lib/*.js",
+    "webpack": false,
+    "gzip": true
+  },
+  {
+    "name": "react-on-rails-pro-node-renderer (brotli)",
+    "path": "packages/react-on-rails-pro-node-renderer/lib/*.js",
+    "webpack": false,
+    "brotli": true
+  },
+  {
+    "name": "react-on-rails/client bundled (gzip)",
+    "path": "packages/react-on-rails/lib/ReactOnRails.client.js",
+    "import": "ReactOnRails",
+    "gzip": true
+  },
+  {
+    "name": "react-on-rails/client bundled (brotli)",
+    "path": "packages/react-on-rails/lib/ReactOnRails.client.js",
+    "import": "ReactOnRails",
+    "brotli": true
+  },
+  {
+    "name": "react-on-rails-pro/client bundled (gzip)",
+    "path": "packages/react-on-rails-pro/lib/ReactOnRails.client.js",
+    "import": "ReactOnRails",
+    "gzip": true
+  },
+  {
+    "name": "react-on-rails-pro/client bundled (brotli)",
+    "path": "packages/react-on-rails-pro/lib/ReactOnRails.client.js",
+    "import": "ReactOnRails",
+    "brotli": true
+  },
+  {
+    "name": "registerServerComponent/client bundled (gzip)",
+    "path": "packages/react-on-rails-pro/lib/registerServerComponent/client.js",
+    "import": "registerServerComponent",
+    "gzip": true
+  },
+  {
+    "name": "registerServerComponent/client bundled (brotli)",
+    "path": "packages/react-on-rails-pro/lib/registerServerComponent/client.js",
+    "import": "registerServerComponent",
+    "brotli": true
+  },
+  {
+    "name": "wrapServerComponentRenderer/client bundled (gzip)",
+    "path": "packages/react-on-rails-pro/lib/wrapServerComponentRenderer/client.js",
+    "import": "wrapServerComponentRenderer",
+    "gzip": true
+  },
+  {
+    "name": "wrapServerComponentRenderer/client bundled (brotli)",
+    "path": "packages/react-on-rails-pro/lib/wrapServerComponentRenderer/client.js",
+    "import": "wrapServerComponentRenderer",
+    "brotli": true
+  }
+]


### PR DESCRIPTION
## Summary
- Add `.size-limit.json` with configuration for measuring bundle sizes of all packages
- Includes raw, gzip, and brotli measurements
- Includes webpack bundled sizes for client imports

This is a prerequisite for the bundle size CI workflow in PR #2149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added bundle size auditing configuration to track and monitor build artifact sizes across multiple compression formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->