### PR TITLE
Fix buildConsoleReplay test parameter order regression

### DIFF
--- a/packages/react-on-rails/tests/buildConsoleReplay.test.js
+++ b/packages/react-on-rails/tests/buildConsoleReplay.test.js
@@ -78,7 +78,7 @@ console.warn.apply(console, ["other message","{\\"c\\":3,\\"d\\":4}"]);
 
   it('buildConsoleReplay adds nonce attribute when provided', () => {
     console.history = [{ arguments: ['test message'], level: 'log' }];
-    const actual = buildConsoleReplay(0, undefined, 'abc123');
+    const actual = buildConsoleReplay(undefined, 0, 'abc123');
 
     expect(actual).toContain('nonce="abc123"');
     expect(actual).toContain('<script id="consoleReplayLog" nonce="abc123">');
@@ -87,7 +87,7 @@ console.warn.apply(console, ["other message","{\\"c\\":3,\\"d\\":4}"]);
 
   it('buildConsoleReplay returns empty string when no console messages', () => {
     console.history = [];
-    const actual = buildConsoleReplay(0, undefined, 'abc123');
+    const actual = buildConsoleReplay(undefined, 0, 'abc123');
 
     expect(actual).toEqual('');
   });
@@ -112,7 +112,7 @@ console.warn.apply(console, ["other message","{\\"c\\":3,\\"d\\":4}"]);
     console.history = [{ arguments: ['test'], level: 'log' }];
     // Attempt attribute injection attack
     const maliciousNonce = 'abc123" onload="alert(1)';
-    const actual = buildConsoleReplay(0, undefined, maliciousNonce);
+    const actual = buildConsoleReplay(undefined, 0, maliciousNonce);
 
     // Should strip dangerous characters (quotes, parens, spaces)
     // = is kept as it's valid in base64, but the quotes are stripped making it harmless


### PR DESCRIPTION
## Summary

Fixes the failing `buildConsoleReplay.test.js` tests by correcting the parameter order in test calls.

## Problem

Commit c3a02254a (Phase 5: Add Pro Node Renderer Package to workspace #2069) incorrectly changed test calls from:
```javascript
buildConsoleReplay(undefined, 0, 'abc123')  // correct
```
to:
```javascript
buildConsoleReplay(0, undefined, 'abc123')  // incorrect
```

The function signature is `buildConsoleReplay(customConsoleHistory, numberOfMessagesToSkip, nonce)`, so passing `0` as the first parameter caused:
1. `customConsoleHistory = 0` instead of `undefined`
2. Nullish coalescing `0 ?? console.history` returns `0` (not `console.history`)
3. `!Array.isArray(0)` returns `true`, causing early return of `''`

## Fix

Restored the correct parameter order in 3 test calls (lines 81, 90, 115).

## Test plan

- [x] `pnpm jest tests/buildConsoleReplay.test.js` - All 14 tests pass

Fixes #2167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases for console replay functionality to reflect refined argument patterns while maintaining existing validation expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->