### PR TITLE
Keep workspace:* protocol in react-on-rails-pro package.json

### DIFF
--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -55,7 +55,7 @@
     "./ServerComponentFetchError": "./lib/ServerComponentFetchError.js"
   },
   "dependencies": {
-    "react-on-rails": "16.2.0-beta.13"
+    "react-on-rails": "workspace:*"
   },
   "peerDependencies": {
     "react": ">= 16",

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -196,12 +196,8 @@ task :release, %i[version dry_run registry skip_push] do |_t, args|
   package_json_files.each do |file|
     content = JSON.parse(File.read(file))
     content["version"] = actual_npm_version
-
-    # For react-on-rails-pro package, also update the react-on-rails dependency to exact version
-    if content["name"] == "react-on-rails-pro"
-      content["dependencies"] ||= {}
-      content["dependencies"]["react-on-rails"] = actual_npm_version
-    end
+    # Note: workspace:* dependencies (e.g., in react-on-rails-pro) are automatically
+    # converted to exact versions by pnpm during publish. No manual conversion needed.
 
     File.write(file, "#{JSON.pretty_generate(content)}\n")
     puts "  Updated #{file}"
@@ -340,7 +336,7 @@ task :release, %i[version dry_run registry skip_push] do |_t, args|
     puts "  - react_on_rails_pro/lib/react_on_rails_pro/version.rb"
     puts "  - package.json (root)"
     puts "  - packages/react-on-rails/package.json"
-    puts "  - packages/react-on-rails-pro/package.json (version + dependency)"
+    puts "  - packages/react-on-rails-pro/package.json (version only; workspace:* converted by pnpm)"
     puts "  - packages/react-on-rails-pro-node-renderer/package.json"
     puts "  - Gemfile.lock files (root, dummy apps, pro)"
     puts "\nAuto-synced (no write needed):"


### PR DESCRIPTION
## Summary
- Removes unnecessary manual conversion of `workspace:*` to explicit version during release
- Restores `workspace:*` in `packages/react-on-rails-pro/package.json`

Fixes #2176

## Details

The release script (`rakelib/release.rake`) was manually converting `workspace:*` to an explicit version in `packages/react-on-rails-pro/package.json` during release. This is **unnecessary** because pnpm automatically handles this conversion during `pnpm publish`.

### How pnpm handles workspace:* 

When running `pnpm pack` or `pnpm publish`, pnpm dynamically replaces `workspace:*` with the corresponding version. This is documented behavior: https://pnpm.io/workspaces

### Verified locally

```bash
# 1. Set dependency to workspace:*
# 2. Run pnpm pack
# 3. Extract tarball's package.json
# Result: "react-on-rails": "16.2.0-beta.13" (exact version)
```

### Benefits

- **Cleaner development experience** - Developers see `workspace:*` indicating a workspace dependency
- **No spurious git changes** - The dependency line won't change on every release
- **pnpm best practice** - Let the tool handle what it's designed for
- **Simpler release script** - Less code to maintain

## Test plan
- [x] Verified `pnpm pack` converts `workspace:*` to exact version in tarball
- [x] Confirmed published package.json in tarball has correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified dependency management and release process for internal packages by streamlining version handling during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->