### PR TITLE
Fix compatibility with connection_pool >= 3.0

### DIFF
--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -13,7 +13,7 @@ module ReactOnRails
             size: ReactOnRails.configuration.server_renderer_pool_size,
             timeout: ReactOnRails.configuration.server_renderer_timeout
           }
-          @js_context_pool = ConnectionPool.new(options) { create_js_context }
+          @js_context_pool = ConnectionPool.new(**options) { create_js_context }
         end
 
         def reset_pool_if_server_bundle_was_modified


### PR DESCRIPTION
## Summary

- Fix `ArgumentError: wrong number of arguments (given 1, expected 0)` when using `connection_pool` gem version 3.0+
- Use keyword argument splatting (`**options`) instead of positional hash argument when initializing `ConnectionPool`

Fixes #2185

## Background

The `connection_pool` gem [changed its API in version 3.0](https://github.com/mperham/connection_pool/blob/main/Changes.md#300) to use keyword arguments instead of positional arguments. This breaking change caused React on Rails to fail during Rails boot when `connection_pool` 3.0+ was installed.

This is the same fix that [Rails applied](https://github.com/rails/rails/pull/56292) for their `RedisCacheStore`.

## Test plan

- [x] Verified fix works with `connection_pool` 3.0.2 using fresh Rails 8 app with local gem
- [x] The `**options` syntax is backwards compatible with older versions of `connection_pool`
- [x] RuboCop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code structure in server rendering components for enhanced maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->