### PR TITLE
Fix HIGH severity jws vulnerability (CVE-2023-35916)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
   "pnpm": {
     "overrides": {
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
-      "sentry-testkit>express": "npm:empty-npm-package@1.0.0"
+      "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
+      "jws": "3.2.3"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
+  jws: 3.2.3
 
 importers:
 
@@ -3771,8 +3772,8 @@ packages:
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
 
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
+  jws@3.2.3:
+    resolution: {integrity: sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -9614,7 +9615,7 @@ snapshots:
 
   jsonwebtoken@9.0.2:
     dependencies:
-      jws: 3.2.2
+      jws: 3.2.3
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -9638,7 +9639,7 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jws@3.2.2:
+  jws@3.2.3:
     dependencies:
       jwa: 1.4.2
       safe-buffer: 5.2.1


### PR DESCRIPTION
Adds pnpm override to force jws to version 3.2.3, which fixes the improper HMAC signature verification vulnerability in the auth0/node-jws package. This vulnerability affected the jsonwebtoken package used for license validation in react-on-rails-pro-node-renderer.

### Summary

_Remove this paragraph and provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together._

### Pull Request checklist

_Remove this line after checking all the items here. If the item is not applicable to the PR, both check it out and wrap it by `~`._

- [ ] Add/update test to cover these changes
- [ ] Update documentation
- [ ] Update CHANGELOG file

_Add the CHANGELOG entry at the top of the file._

### Other Information

_Remove this paragraph and mention any other important and relevant information such as benchmarks._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependency overrides configuration to ensure compatible package versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->