### PR TITLE
Fix TypeScript error in processPromise return type

### DIFF
--- a/packages/react-on-rails/src/serverRenderReactComponent.ts
+++ b/packages/react-on-rails/src/serverRenderReactComponent.ts
@@ -9,6 +9,7 @@ import { renderToString } from './ReactDOMServer.cts';
 import { createResultObject, convertToError, validateComponent } from './serverRenderUtils.ts';
 import type {
   CreateReactOutputResult,
+  FinalHtmlResult,
   RenderParams,
   RenderResult,
   RenderState,
@@ -71,7 +72,8 @@ function processPromise(
     if (isValidElement(promiseResult)) {
       return processReactElement(promiseResult);
     }
-    return promiseResult;
+    // promiseResult is string | ServerRenderHashRenderedHtml (both are FinalHtmlResult)
+    return promiseResult as FinalHtmlResult;
   });
 }
 


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation error in `serverRenderReactComponent.ts` that was blocking the release script
- The error occurred because TypeScript couldn't narrow the type properly after the `isValidElement` check in the `.then()` callback
- Added explicit type assertion to `FinalHtmlResult` since after the `isValidElement` check, the remaining types (`string` and `ServerRenderHashRenderedHtml`) are all valid `FinalHtmlResult` types

## Test plan
- [x] TypeScript type-check passes (`pnpm run type-check`)
- [x] Build completes successfully (`pnpm run build`)
- [x] ESLint passes (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for server-side rendering operations to ensure more robust handling of promise resolutions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->