### PR TITLE
Trigger generator tests when TypeScript files change

### DIFF
--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -267,7 +267,9 @@ if [ "$SPEC_DUMMY_CHANGED" = true ] || [ "$RUBY_CORE_CHANGED" = true ] || [ "$JS
   RUN_DUMMY_TESTS=true
 fi
 
-if [ "$GENERATORS_CHANGED" = true ]; then
+# JS changes trigger generator tests because generators do a full build
+# which catches TypeScript compilation errors (see issue #2205)
+if [ "$GENERATORS_CHANGED" = true ] || [ "$JS_CHANGED" = true ]; then
   RUN_GENERATORS=true
 fi
 


### PR DESCRIPTION
## Summary
- When TypeScript files in `packages/react-on-rails/` change, CI now also triggers generator tests
- Generator tests perform a full build which catches TypeScript compilation errors

## Problem (Fixes #2205)
PR #2125 changed TypeScript types in `packages/react-on-rails/src/types/index.ts`, which exposed a latent type error in `serverRenderReactComponent.ts`. This wasn't caught until the release script ran `pnpm publish` which performs a fresh TypeScript build.

The generator/example tests would have caught this because they run a full build, but they weren't triggered because the CI change detection didn't consider `packages/react-on-rails/**` changes as requiring generator tests.

## Solution
Updated `script/ci-changes-detector` to trigger generator tests when `JS_CHANGED=true` (which includes TypeScript file changes in `packages/react-on-rails/src/`).

## Test plan
- [ ] Verify the script correctly detects TypeScript changes and sets `run_generators=true`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)