### PR TITLE
Add /address-review slash command for Claude Code

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -100,8 +100,10 @@ gh api repos/${REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f 
 **For standalone review comments (not in a thread):**
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/comments -X POST -f body="<response>" -f commit_id="<COMMIT_SHA>" -f path="<FILE_PATH>" -f line=<LINE_NUMBER>
+gh api repos/${REPO}/pulls/{PR_NUMBER}/comments -X POST -f body="<response>" -f commit_id="<COMMIT_SHA>" -f path="<FILE_PATH>" -f line=<LINE_NUMBER> -f side="RIGHT"
 ```
+
+Note: `side` is required when using `line`. Use `"RIGHT"` for the PR commit side (most common) or `"LEFT"` for the base commit side.
 
 The response should briefly explain:
 


### PR DESCRIPTION
## Summary

Adds a custom Claude Code slash command (`/address-review`) that fetches GitHub PR review comments and creates a todo list to address them.

## Features

- Accepts full PR URLs or just PR numbers
- Supports specific review comments (`#pullrequestreview-...`)
- Supports specific issue comments (`#issuecomment-...`)
- Creates organized todo list with file paths, line numbers, and reviewer names
- Automatically replies to comments after addressing them to close the feedback loop

## Usage

```
/address-review 12345
/address-review https://github.com/org/repo/pull/12345
/address-review https://github.com/org/repo/pull/12345#pullrequestreview-123456789
/address-review https://github.com/org/repo/pull/12345#issuecomment-123456789
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a comprehensive guide for an automated workflow to manage GitHub PR review comments. The workflow converts comments into actionable todo lists with support for multiple PR reference formats, intelligent filtering to exclude non-actionable items, error handling for edge cases, and GitHub API integration for seamless comment management and responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->