### PR TITLE
Fix malformed code fences in improved-error-messages.md

### DIFF
--- a/docs/guides/improved-error-messages.md
+++ b/docs/guides/improved-error-messages.md
@@ -99,9 +99,8 @@ If you prefer manual registration:
    ```erb
    <%= javascript_pack_tag 'application' %>
    <%= stylesheet_pack_tag 'application' %>
+   ```
 ````
-
-```
 
 ### Enhanced SSR Errors
 
@@ -138,8 +137,7 @@ useEffect(() => { /_ DOM operations here _/ }, [])
 if (typeof window !== 'undefined') { /_ browser code _/ }
 
 • Use dynamic import for browser-only code
-
-````
+```
 
 ## Ruby Configuration
 
@@ -155,7 +153,7 @@ raise ReactOnRails::SmartError.new(
     available_components: ReactOnRails::PackerUtils.registered_components
   }
 )
-````
+```
 
 ### Error Types
 


### PR DESCRIPTION
## Summary
- Fixed malformed markdown code fences in `docs/guides/improved-error-messages.md`
- This was causing MDX parsing errors during Gatsby builds on the ShakaCode website

## Problem
The markdown file had mismatched code fence delimiters which broke the sc-website Cloudflare Pages build:
- Nested erb code block wasn't properly closed before outer fence closed
- Stray triple backticks after the first code example
- Two code blocks used ```````` to close when opened with ``````` 

The MDX parser failed with: `Objects are not valid as a React child (found: [object RegExp])`

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm sc-website Cloudflare Pages build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting consistency in error message guides for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->