### PR TITLE
Add SSL certificate error exclusions to lychee config

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -32,6 +32,12 @@ exclude = [
   '^https://hichee\.com',
   '^https?://rubyonrails\.org/doctrine',  # DNS issues
 
+  # SSL certificate issues (expired/hostname mismatch/verification failed)
+  '^https://(www\.)?blinkinc\.com',     # SSL certificate expired
+  '^https://(www\.)?localwise\.com',    # SSL verification failed
+  '^https://(www\.)?mycfsapp\.com',     # SSL hostname mismatch
+  '^https://(www\.)?scoutapp\.com',     # SSL hostname mismatch
+
   # Sites from PROJECTS.md that block bots or are unreliable
   '^https://blog\.shakacode\.com',  # May block automated requests
   '^https?://(www\.)?foxford\.ru',  # Russian site, often blocks bots


### PR DESCRIPTION
## Summary

Adds exclusions for 4 sites with SSL certificate issues that cannot be fixed by us.

## Changes

Added the following exclusions to `.lychee.toml`:

| Site | SSL Issue |
|------|-----------|
| blinkinc.com | SSL certificate expired |
| localwise.com | SSL verification failed |
| mycfsapp.com | SSL hostname mismatch |
| scoutapp.com | SSL hostname mismatch |

## Testing

✅ Verified locally with lychee that:
- These sites no longer appear in error output
- Exclusion patterns work correctly
- No false positives (only SSL-error sites are excluded)

## Context

These sites are referenced in PROJECTS.md and README.md (ShakaCode portfolio/sponsor sites). The SSL issues are on their end and we cannot fix them.

## Related

- Closes #2227
- Related to PR #2219 (lychee migration)
- Related to PR #2216 (monorepo paths) and PR #2229 (docs links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated link validation to exclude four additional domains from automated checks due to recurring SSL connectivity issues: blinkinc.com, localwise.com, mycfsapp.com, scoutapp.com.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->