### PR TITLE
Fix broken file path links in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1740,7 +1740,7 @@ RSpec.configure do |config|
 - Added EnsureAssetsCompiled feature so that you do not accidentally run tests without properly compiling the JavaScript bundles. Add a line to your `rails_helper.rb` file to check that the latest Webpack bundles have been generated prior to running tests that may depend on your client-side code. See [docs](https://www.shakacode.com/react-on-rails/docs/building-features/rspec-configuration) for more detailed instructions. [#222](https://github.com/shakacode/react_on_rails/pull/222)
 - Added [migration guide](https://www.shakacode.com/react-on-rails/docs/migrating/migrating-from-react-rails) for migrating from React-Rails. [#219](https://github.com/shakacode/react_on_rails/pull/219)
 - Added [React on Rails Doctrine](https://www.shakacode.com/react-on-rails/docs/misc/doctrine) to docs. Discusses the project's motivations, conventions, and principles. [#220](https://github.com/shakacode/react_on_rails/pull/220)
-- Added ability to skip `display:none` style in the generated content tag for a component. Some developers may want to disable inline styles for security reasons. See generated config [initializer file](lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb#L27) for example on setting `skip_display_none`. [#218](https://github.com/shakacode/react_on_rails/pull/218)
+- Added ability to skip `display:none` style in the generated content tag for a component. Some developers may want to disable inline styles for security reasons. See the `skip_display_none` configuration option. [#218](https://github.com/shakacode/react_on_rails/pull/218)
 
 ##### Changed
 

--- a/react_on_rails_pro/CONTRIBUTING.md
+++ b/react_on_rails_pro/CONTRIBUTING.md
@@ -173,7 +173,7 @@ To do this, follow the instructions in the
 
 ### Example: Testing NPM changes with the dummy app
 
-1. Add `console.log('Hello!')` [here](https://github.com/shakacode/react_on_rails_pro/blob/more_test_and_docs/packages/node-renderer/src/ReactOnRailsProNodeRenderer.js#L6) in `packages/node-renderer/src/ReactOnRailsProNodeRenderer.js` to confirm we're getting an update to the node package.
+1. Add `console.log('Hello!')` [here](https://github.com/shakacode/react_on_rails_pro/blob/master/packages/node-renderer/src/ReactOnRailsProNodeRenderer.ts#L6) in `packages/node-renderer/src/ReactOnRailsProNodeRenderer.ts` to confirm we're getting an update to the node package.
 2. The `preinstall` script of `spec/dummy` builds the NPM package and sets up `yalc` to use it for the renderer.
    It's run automatically when you run `yarn install`.
 3. Refresh the browser if the server is already running or start the server using `foreman start -f Procfile.dev` from `spec/dummy` and navigate to `http://localhost:3000/`. You will now see the `Hello!` message printed in the browser's console.
@@ -276,7 +276,7 @@ Hit F8 and then a debugger statement within the test will get hit.
 ### Async issues with Jest
 
 Beware that Jest runs multiple test files synchronously, so you can't use the same temporary directory
-between tests. See the file [`packages/node-renderer/tests/helper.ts`](packages/node-renderer/tests/helper.ts) for how we handle this.
+between tests. See the file [`packages/node-renderer/tests/helper.ts`](https://github.com/shakacode/react_on_rails_pro/blob/master/packages/node-renderer/tests/helper.ts) for how we handle this.
 
 ### Run most tests and linting
 


### PR DESCRIPTION
## Summary

Fixes broken file path links identified in #2231.

## Changes

| File | Fix |
|------|-----|
| CHANGELOG.md:1743 | Remove broken `file://` link to deleted generator template (`skip_display_none` is deprecated) |
| react_on_rails_pro/CONTRIBUTING.md:176 | Update branch `more_test_and_docs` → `master`, extension `.js` → `.ts` |
| react_on_rails_pro/CONTRIBUTING.md:279 | Change relative path → absolute GitHub URL (matches documented pattern) |

## Verification

- Confirmed generator template was removed (existed in 2016 commit `cae4eeb4`)
- Confirmed `skip_display_none` is deprecated per `configuration.rb:50`
- Confirmed Pro repo files exist at master branch URLs (HTTP 200)
- Confirmed absolute URL pattern matches CONTRIBUTING.md guidelines for non-doc files

Closes #2231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration documentation for the skip_display_none option
  * Updated internal documentation references to point to current source locations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->