### PR TITLE
Add bin/check-links for local link checking

### DIFF
--- a/bin/check-links
+++ b/bin/check-links
@@ -14,6 +14,11 @@
 
 set -eo pipefail
 
+if ! command -v lychee &> /dev/null; then
+  echo "Error: lychee is not installed. Install it with: cargo install lychee" >&2
+  exit 1
+fi
+
 {
   git ls-files 'docs/*.md' 'docs/**/*.md'
   git ls-files '*.md' | grep -v '/' || true


### PR DESCRIPTION
## Summary

Adds a `bin/check-links` script for running lychee link checker locally with the same behavior as CI.

## Problem

Running `lychee` directly locally can produce different results than CI because:
1. Local globs like `*.md` match untracked files that CI never sees
2. Different paths may be checked

## Solution

The script uses `git ls-files` to ensure only git-tracked files are checked, matching the exact paths CI checks:
- `docs/**/*.md`
- `*.md` (root level only)
- `react_on_rails_pro/docs/**/*.md`
- `react_on_rails_pro/*.md`

## Usage

```bash
bin/check-links
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an executable link-validation tool to enforce CI-consistent Markdown link checks across documentation, deduplicate targets, and mirror CI behavior for more reliable docs quality control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->