### PR TITLE
Fix lychee exclude pattern for npmjs.com without www

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -24,7 +24,7 @@ exclude = [
   # ============================================================================
   # SITES THAT BLOCK BOTS OR REQUIRE AUTH
   # ============================================================================
-  '^https://www\.npmjs\.(org|com)',
+  '^https://(www\.)?npmjs\.(org|com)',  # Returns 403 for automated requests
   '^https://medium\.com',  # Returns 403 for automated requests
   '^https://www\.linkedin\.com',
   '^https://reactrails\.slack\.com',


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in the `markdown-link-check` job caused by `https://npmjs.com/` returning 403 Forbidden.

The existing exclude pattern only matched URLs with `www.`:
```
^https://www\.npmjs\.(org|com)
```

But `docs/getting-started/tutorial.md` links to `https://npmjs.com/` (without `www`), which wasn't excluded.

## Changes

Updated the pattern to make `www.` optional:
```
^https://(www\.)?npmjs\.(org|com)
```

## Test plan

- [x] Pattern syntax is valid regex
- [x] CI `markdown-link-check` job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude additional npmjs URL variants from link checking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->