### PR TITLE
fix: add main field to pro packages for legacy resolver compatibility

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -3,6 +3,7 @@
   "version": "16.2.0-beta.20",
   "protocolVersion": "2.0.0",
   "description": "React on Rails Pro Node Renderer for server-side rendering",
+  "main": "lib/ReactOnRailsProNodeRenderer.js",
   "directories": {
     "doc": "docs"
   },

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -2,6 +2,7 @@
   "name": "react-on-rails-pro",
   "version": "16.2.0-beta.20",
   "description": "React on Rails Pro package with React Server Components support",
+  "main": "lib/ReactOnRails.full.js",
   "type": "module",
   "scripts": {
     "build": "pnpm run clean && tsc",


### PR DESCRIPTION
## Summary

- Adds `main` field to `react-on-rails-pro` package.json pointing to `lib/ReactOnRails.full.js`
- Adds `main` field to `react-on-rails-pro-node-renderer` package.json pointing to `lib/ReactOnRailsProNodeRenderer.js`

This ensures compatibility with legacy module resolvers like `eslint-import-resolver-node` and `eslint-import-resolver-babel-module` that use the `resolve` npm package, which doesn't support Node.js conditional exports.

Without the `main` field, these resolvers produce false positive "Unable to resolve path to module" errors even though imports work correctly at runtime.

## Test plan

- [x] Verify the `main` field paths match the `default` export in each package's `exports` field
- [ ] Confirm ESLint import resolver no longer produces false positives for pro package imports

Fixes #2255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package configuration for the React on Rails Pro packages to improve module resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->