### PR TITLE
fix: remove v prefix from git tags to restore historical convention

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -109,7 +109,9 @@ To determine the most recent version:
    git tag --sort=-v:refname | head -10
    ```
 
-   This shows tags like `v16.2.0.beta.20`, `v16.2.0.beta.19`, etc.
+   This shows tags like `16.2.1`, `16.2.0`, `16.1.1`, etc.
+   Note: Some historical tags (v16.2.0.beta.0 through v16.2.0.rc.0) have a `v` prefix due to a
+   temporary convention change, but the standard convention is no `v` prefix.
 
 2. **Check the CHANGELOG.md** for version headers (note: changelog uses versions WITHOUT the `v` prefix):
    - `### [16.2.0.beta.19] - 2025-12-10` (beta version)
@@ -123,7 +125,7 @@ To determine the most recent version:
 
 4. **The first match after `### [Unreleased]`** is the most recent version in the changelog.
 
-**IMPORTANT**: Git tags use `v` prefix (e.g., `v16.2.0.beta.20`) but the changelog and compare links use versions WITHOUT the `v` prefix (e.g., `16.2.0.beta.20`). Strip the `v` when adding to the changelog.
+**IMPORTANT**: Git tags do NOT use a `v` prefix (e.g., `16.2.1`, `16.1.1`). The changelog and compare links also use versions without the `v` prefix. Note: Some historical tags from v16.2.0.beta.0 through v16.2.0.rc.0 have a `v` prefix - strip it when adding to the changelog.
 
 ### Version Links
 
@@ -210,7 +212,10 @@ When a new version is released:
 
 ### For Beta to Non-Beta Version Release
 
-When releasing from beta to a stable version (e.g., git tag `v16.1.0.beta.3` → `v16.1.0`):
+When releasing from beta to a stable version (e.g., git tag `16.3.0.beta.3` → `16.3.0`):
+
+> **Note**: Historical tags v16.2.0.beta.0 through v16.2.0.rc.0 have a `v` prefix due to a temporary
+> convention change. Future releases use no `v` prefix.
 
 1. **Remove all beta version labels** from the changelog:
    - Change `### [16.1.0.beta.1]`, `### [16.1.0.beta.2]`, etc. to a single `### [16.1.0]` section
@@ -233,7 +238,8 @@ When a new beta version is released (e.g., `16.2.0.beta.20`):
    git tag --sort=-v:refname | head -5
    ```
 
-   This shows the latest tags (e.g., `v16.2.0.beta.20`). Strip the `v` prefix for changelog use.
+   This shows the latest tags (e.g., `16.2.0.beta.21`, `16.2.0.beta.20`).
+   Note: Historical tags v16.2.0.beta.0 through v16.2.0.rc.0 have a `v` prefix - strip it for changelog use.
 
 2. **Find the most recent version** in the changelog by looking for the first `### [VERSION] - DATE` after `### [Unreleased]`
 

--- a/docs/contributor-info/releasing.md
+++ b/docs/contributor-info/releasing.md
@@ -115,7 +115,7 @@ When you run `rake release[X.Y.Z]`, the task will:
 7. Update the Pro package's dependency on react-on-rails
 8. Update the dummy app's Gemfile.lock
 9. Commit all version changes with message "Bump version to X.Y.Z"
-10. Create a git tag `vX.Y.Z`
+10. Create a git tag `X.Y.Z` (no `v` prefix, matching historical convention)
 11. Push commits and tags to the remote repository
 12. Publish `react-on-rails` to NPM (requires 2FA token)
 13. Publish `react-on-rails-pro` to NPM (requires 2FA token)
@@ -264,7 +264,7 @@ If the release fails partway through (e.g., during NPM publish):
    - RubyGems: `gem list react_on_rails -r -a`
 
 2. If the git tag was created but packages weren't published:
-   - Delete the tag: `git tag -d vX.Y.Z && git push origin :vX.Y.Z`
+   - Delete the tag: `git tag -d X.Y.Z && git push origin :X.Y.Z`
    - Revert the version commit: `git reset --hard HEAD~1 && git push -f`
    - Start over with `rake release[X.Y.Z]`
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -246,7 +246,9 @@ task :release, %i[version dry_run] do |_t, args|
     end
 
     # Create git tag (skip if it already exists)
-    tag_name = "v#{actual_gem_version}"
+    # Note: Tags use version without 'v' prefix (e.g., '16.2.0' not 'v16.2.0')
+    # to match the historical convention used from version 2.0.0 through 16.1.2
+    tag_name = actual_gem_version
     tag_exists = system("cd #{monorepo_root} && git rev-parse #{tag_name} >/dev/null 2>&1")
     if tag_exists
       puts "Git tag #{tag_name} already exists, skipping tag creation"

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -46,7 +46,7 @@ TIP: Use /update-changelog in Claude Code for full automation."
 task :update_changelog, %i[tag] do |_, args|
   puts CLAUDE_CODE_TIP
 
-  # Git tags use 'v' prefix (e.g., v16.2.0), but CHANGELOG uses versions without it
+  # Git tags may have 'v' prefix (historical tags) - strip it for CHANGELOG
   git_tag = args[:tag] || `git describe --tags --abbrev=0`.strip
   changelog_version = git_tag.delete_prefix("v")
   anchor = "[#{changelog_version}]"


### PR DESCRIPTION
## Summary

- Removes the `v` prefix from git tag creation in the release script to restore the historical convention used from version 2.0.0 through 16.1.2
- Updates documentation to reflect the correct tagging convention
- Adds notes about the historical `v16.2.0.beta.x` tags that were created with `v` prefix

## Background

PR #1856 unintentionally introduced a `v` prefix to git tags when replacing `release-it` with manual git commands. The `release-it` tool auto-detected the existing tag format (no `v` prefix), but the manual implementation explicitly added `v#{version}`.

This broke 9+ years of consistent tagging (222 tags without `v` prefix vs 30 tags with `v` prefix) and caused issues like broken CHANGELOG links (fixed in PR #2263).

## Changes

| File | Change |
|------|--------|
| `rakelib/release.rake` | Remove `v` prefix from `tag_name` variable |
| `docs/contributor-info/releasing.md` | Update tag format examples |
| `.claude/commands/update-changelog.md` | Update tag convention documentation |

## Test plan

- [ ] Verify release script creates tags without `v` prefix (dry run: `rake release[16.3.0,true]`)
- [ ] Confirm documentation accurately describes the tag convention

Fixes #2267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release and contributor docs to use unprefixed version tags (e.g., 16.2.1) in examples and commands.
  * Added notes clarifying historical beta/rc tags may include a temporary "v" prefix and instructing to strip any historical "v" when adding entries to the changelog.
  * Adjusted examples and guidance for creating, deleting, and displaying latest tags to the non‑prefixed convention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->