### PR TITLE
Investigation: Partial bundle error analysis

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/scripts/test-atomicity-parallel.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-atomicity-parallel.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * Test atomicity using child processes for TRUE parallelism.
+ *
+ * Usage:
+ *   node scripts/test-atomicity-parallel.mjs
+ */
+
+import { fork, spawn } from 'node:child_process';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TEST_FILE_SIZE_MB = 200;
+const TEST_DIR = path.join(os.tmpdir(), `atomicity-parallel-${Date.now()}`);
+
+async function generateTestFile(filePath, sizeMB) {
+  console.log(`Generating ${sizeMB}MB test file...`);
+  const start = Date.now();
+
+  const fd = fs.openSync(filePath, 'w');
+  const chunk = Buffer.alloc(1024 * 1024, 'x'); // 1MB of 'x'
+
+  for (let i = 0; i < sizeMB; i++) {
+    fs.writeSync(fd, chunk);
+  }
+  fs.writeSync(fd, '\n// COMPLETE_MARKER_12345_END //\n');
+  fs.closeSync(fd);
+
+  console.log(`Generated in ${Date.now() - start}ms`);
+}
+
+// Reader script that runs in a child process
+const READER_SCRIPT = `
+const fs = require('fs');
+const destPath = process.argv[2];
+const expectedSize = parseInt(process.argv[3], 10);
+
+let readAttempts = 0;
+let partialReads = 0;
+let completeReads = 0;
+let notFound = 0;
+let errors = 0;
+let sizes = new Set();
+
+const startTime = Date.now();
+
+// Run for max 30 seconds or until parent signals stop
+process.on('message', (msg) => {
+  if (msg === 'stop') {
+    report();
+    process.exit(0);
+  }
+});
+
+function report() {
+  process.send({
+    readAttempts,
+    partialReads,
+    completeReads,
+    notFound,
+    errors,
+    uniqueSizes: sizes.size,
+    duration: Date.now() - startTime
+  });
+}
+
+function poll() {
+  readAttempts++;
+
+  try {
+    const stats = fs.statSync(destPath);
+    sizes.add(stats.size);
+
+    // Read last 50 bytes to check for completion marker
+    if (stats.size >= 50) {
+      const fd = fs.openSync(destPath, 'r');
+      const buf = Buffer.alloc(50);
+      fs.readSync(fd, buf, 0, 50, stats.size - 50);
+      fs.closeSync(fd);
+
+      if (buf.toString().includes('COMPLETE_MARKER_12345_END')) {
+        completeReads++;
+      } else {
+        partialReads++;
+        // Log first few partial reads with their sizes
+        if (partialReads <= 5) {
+          console.error('  [Reader] Partial read #' + partialReads + ': size=' + (stats.size/1024/1024).toFixed(2) + 'MB');
+        }
+      }
+    } else if (stats.size > 0) {
+      partialReads++;
+    }
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      notFound++;
+    } else {
+      errors++;
+    }
+  }
+
+  // Continue polling immediately
+  setImmediate(poll);
+}
+
+poll();
+`;
+
+async function runTest(testName, operation) {
+  console.log('\n' + '='.repeat(60));
+  console.log(`TEST: ${testName}`);
+  console.log('='.repeat(60));
+
+  const destPath = path.join(TEST_DIR, `dest-${testName.replace(/\s+/g, '-').toLowerCase()}.dat`);
+
+  // Clean up destination
+  await fsp.unlink(destPath).catch(() => {});
+
+  // Spawn reader process
+  const reader = spawn('node', ['-e', READER_SCRIPT, destPath, String(TEST_FILE_SIZE_MB * 1024 * 1024)], {
+    stdio: ['pipe', 'inherit', 'inherit', 'ipc']
+  });
+
+  // Wait a bit for reader to start
+  await new Promise(r => setTimeout(r, 50));
+
+  // Run the operation
+  const opStart = Date.now();
+  await operation(destPath);
+  const opTime = Date.now() - opStart;
+
+  // Give reader a moment to see the final state
+  await new Promise(r => setTimeout(r, 100));
+
+  // Get results from reader
+  return new Promise((resolve) => {
+    reader.on('message', (results) => {
+      reader.kill();
+      console.log(`\nResults:`);
+      console.log(`  Operation time: ${opTime}ms`);
+      console.log(`  Read attempts: ${results.readAttempts}`);
+      console.log(`  Not found: ${results.notFound}`);
+      console.log(`  Partial reads: ${results.partialReads}`);
+      console.log(`  Complete reads: ${results.completeReads}`);
+      console.log(`  Unique sizes observed: ${results.uniqueSizes}`);
+
+      if (results.partialReads > 0) {
+        console.log(`\n  ❌ NOT ATOMIC! Observed ${results.partialReads} partial reads.`);
+      } else if (results.completeReads > 0) {
+        console.log(`\n  ✅ ATOMIC! File was either not found or complete.`);
+      } else {
+        console.log(`\n  ⚠️  Reader never saw complete file`);
+      }
+
+      resolve({ ...results, opTime, isAtomic: results.partialReads === 0 });
+    });
+
+    reader.send('stop');
+
+    // Timeout fallback
+    setTimeout(() => {
+      reader.kill();
+      resolve({ error: 'timeout', isAtomic: false });
+    }, 5000);
+  });
+}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('ATOMICITY TEST WITH TRUE PARALLELISM');
+  console.log('='.repeat(60));
+  console.log(`Test directory: ${TEST_DIR}`);
+  console.log(`Test file size: ${TEST_FILE_SIZE_MB} MB\n`);
+
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  const srcPath = path.join(TEST_DIR, 'source.dat');
+  await generateTestFile(srcPath, TEST_FILE_SIZE_MB);
+
+  const results = {};
+
+  // Test 1: fs.copyFile()
+  results.copyFile = await runTest('fs.copyFile()', async (dest) => {
+    await fsp.copyFile(srcPath, dest);
+  });
+
+  // Test 2: fs.rename() (need to copy source first)
+  const srcForRename = path.join(TEST_DIR, 'source-for-rename.dat');
+  await fsp.copyFile(srcPath, srcForRename);
+
+  results.rename = await runTest('fs.rename()', async (dest) => {
+    await fsp.rename(srcForRename, dest);
+  });
+
+  // Test 3: Atomic pattern (copy to temp, then rename)
+  results.atomicPattern = await runTest('Atomic Pattern (temp + rename)', async (dest) => {
+    const tempPath = dest + '.tmp';
+    await fsp.copyFile(srcPath, tempPath);
+    await fsp.rename(tempPath, dest);
+  });
+
+  // Summary
+  console.log('\n' + '='.repeat(60));
+  console.log('SUMMARY');
+  console.log('='.repeat(60));
+  console.log(`
+┌─────────────────────────────────┬──────────┬─────────────┐
+│ Operation                       │ Atomic?  │ Partial Rds │
+├─────────────────────────────────┼──────────┼─────────────┤
+│ fs.copyFile() ${TEST_FILE_SIZE_MB}MB             │ ${results.copyFile?.isAtomic ? '✅ Yes*  ' : '❌ NO    '} │ ${String(results.copyFile?.partialReads ?? '?').padStart(11)} │
+│ fs.rename() ${TEST_FILE_SIZE_MB}MB               │ ${results.rename?.isAtomic ? '✅ YES   ' : '❌ No    '} │ ${String(results.rename?.partialReads ?? '?').padStart(11)} │
+│ Atomic pattern (temp + rename)  │ ${results.atomicPattern?.isAtomic ? '✅ YES   ' : '❌ No    '} │ ${String(results.atomicPattern?.partialReads ?? '?').padStart(11)} │
+└─────────────────────────────────┴──────────┴─────────────┘
+`);
+
+  if (!results.copyFile?.isAtomic) {
+    console.log(`🔴 CONFIRMED: fs.copyFile() is NOT atomic!`);
+    console.log(`   File is visible at destination before fully written.`);
+    console.log(`   This affects copyUploadedAssets() in React on Rails Pro.\n`);
+  }
+
+  if (results.rename?.isAtomic) {
+    console.log(`🟢 CONFIRMED: fs.rename() IS atomic (same filesystem).\n`);
+  }
+
+  if (results.atomicPattern?.isAtomic) {
+    console.log(`🟢 SOLUTION: Atomic write pattern works!`);
+    console.log(`   Write to temp file, then atomic rename.\n`);
+  }
+
+  console.log(`Cleanup: rm -rf ${TEST_DIR}`);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-atomicity.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-atomicity.mjs
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+/**
+ * Test script to verify if copy and move operations are atomic.
+ *
+ * This script demonstrates that:
+ * 1. fs.copyFile() is NOT atomic - file is visible before fully written
+ * 2. fs.rename() IS atomic (same filesystem) - file appears only when complete
+ * 3. fs-extra move() falls back to copy on cross-device, making it non-atomic
+ *
+ * Usage:
+ *   node scripts/test-atomicity.mjs
+ */
+
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { Worker, isMainThread, parentPort, workerData } from 'node:worker_threads';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Test configuration
+const TEST_FILE_SIZE_MB = 50; // Large enough to observe the race
+const TEST_DIR = path.join(os.tmpdir(), `atomicity-test-${Date.now()}`);
+const POLL_INTERVAL_MS = 0; // Poll as fast as possible
+
+/**
+ * Generate a valid JavaScript file of specified size
+ */
+function generateTestBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// START OF BUNDLE\n(function() {\n';
+
+  const line = '  console.log("' + 'x'.repeat(100) + '");\n';
+
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+
+  content += '  return "COMPLETE_MARKER_12345";\n';
+  content += '})();\n// END OF BUNDLE\n';
+
+  return content;
+}
+
+/**
+ * Reader that continuously polls and reads the destination file
+ */
+async function pollAndRead(destPath, results, stopSignal) {
+  let readAttempts = 0;
+  let partialReads = 0;
+  let completeReads = 0;
+  let fileNotFoundCount = 0;
+  let firstPartialSize = null;
+  let readSizes = [];
+
+  while (!stopSignal.stopped) {
+    readAttempts++;
+
+    try {
+      // Check if file exists
+      const stats = await fsp.stat(destPath).catch(() => null);
+
+      if (stats) {
+        const content = await fsp.readFile(destPath, 'utf8');
+        readSizes.push(content.length);
+
+        // Check if we got complete content
+        if (content.includes('COMPLETE_MARKER_12345') && content.includes('END OF BUNDLE')) {
+          completeReads++;
+        } else {
+          partialReads++;
+          if (firstPartialSize === null) {
+            firstPartialSize = content.length;
+          }
+        }
+      } else {
+        fileNotFoundCount++;
+      }
+    } catch (err) {
+      // Ignore read errors during concurrent access
+      if (err.code !== 'ENOENT' && err.code !== 'EBUSY') {
+        // Could be reading while write is in progress
+      }
+    }
+
+    // Small delay to not overwhelm the system
+    await new Promise(resolve => setImmediate(resolve));
+  }
+
+  results.readAttempts = readAttempts;
+  results.partialReads = partialReads;
+  results.completeReads = completeReads;
+  results.fileNotFoundCount = fileNotFoundCount;
+  results.firstPartialSize = firstPartialSize;
+  results.uniqueReadSizes = [...new Set(readSizes)].sort((a, b) => a - b);
+}
+
+/**
+ * Test 1: fs.copyFile() atomicity
+ */
+async function testCopyFileAtomicity() {
+  console.log('\n' + '='.repeat(60));
+  console.log('TEST 1: fs.copyFile() Atomicity');
+  console.log('='.repeat(60));
+
+  const srcPath = path.join(TEST_DIR, 'source-copy.js');
+  const destPath = path.join(TEST_DIR, 'dest-copy.js');
+
+  // Create source file
+  const content = generateTestBundle(TEST_FILE_SIZE_MB);
+  await fsp.writeFile(srcPath, content);
+  console.log(`Source file: ${srcPath} (${(content.length / 1024 / 1024).toFixed(2)} MB)`);
+
+  // Remove destination if exists
+  await fsp.unlink(destPath).catch(() => {});
+
+  const results = {};
+  const stopSignal = { stopped: false };
+
+  // Start reader in parallel
+  const readerPromise = pollAndRead(destPath, results, stopSignal);
+
+  // Perform copy
+  const copyStart = Date.now();
+  await fsp.copyFile(srcPath, destPath);
+  const copyTime = Date.now() - copyStart;
+
+  // Stop reader
+  stopSignal.stopped = true;
+  await readerPromise;
+
+  // Verify final file
+  const finalContent = await fsp.readFile(destPath, 'utf8');
+  const isComplete = finalContent === content;
+
+  console.log(`\nResults:`);
+  console.log(`  Copy duration: ${copyTime}ms`);
+  console.log(`  Read attempts: ${results.readAttempts}`);
+  console.log(`  File not found: ${results.fileNotFoundCount}`);
+  console.log(`  Partial reads: ${results.partialReads}`);
+  console.log(`  Complete reads: ${results.completeReads}`);
+  console.log(`  First partial size: ${results.firstPartialSize ? `${(results.firstPartialSize / 1024).toFixed(2)} KB` : 'N/A'}`);
+  console.log(`  Unique sizes observed: ${results.uniqueReadSizes.length}`);
+  console.log(`  Final file complete: ${isComplete ? '✅ Yes' : '❌ No'}`);
+
+  if (results.partialReads > 0) {
+    console.log(`\n  ❌ fs.copyFile() is NOT ATOMIC!`);
+    console.log(`     Observed ${results.partialReads} partial reads during copy.`);
+    console.log(`     File was visible at sizes: ${results.uniqueReadSizes.slice(0, 5).map(s => `${(s/1024).toFixed(0)}KB`).join(', ')}...`);
+  } else if (results.fileNotFoundCount > 0 && results.completeReads > 0) {
+    console.log(`\n  ✅ fs.copyFile() appeared atomic in this test`);
+    console.log(`     (File was either not found or complete)`);
+  } else {
+    console.log(`\n  ⚠️  Inconclusive - try increasing file size`);
+  }
+
+  return { isAtomic: results.partialReads === 0, results };
+}
+
+/**
+ * Test 2: fs.rename() atomicity (same filesystem)
+ */
+async function testRenameAtomicity() {
+  console.log('\n' + '='.repeat(60));
+  console.log('TEST 2: fs.rename() Atomicity (Same Filesystem)');
+  console.log('='.repeat(60));
+
+  const srcPath = path.join(TEST_DIR, 'source-rename.js');
+  const destPath = path.join(TEST_DIR, 'dest-rename.js');
+
+  // Create source file
+  const content = generateTestBundle(TEST_FILE_SIZE_MB);
+  await fsp.writeFile(srcPath, content);
+  console.log(`Source file: ${srcPath} (${(content.length / 1024 / 1024).toFixed(2)} MB)`);
+
+  // Remove destination if exists
+  await fsp.unlink(destPath).catch(() => {});
+
+  const results = {};
+  const stopSignal = { stopped: false };
+
+  // Start reader in parallel
+  const readerPromise = pollAndRead(destPath, results, stopSignal);
+
+  // Small delay to ensure reader is polling
+  await new Promise(resolve => setTimeout(resolve, 10));
+
+  // Perform rename
+  const renameStart = Date.now();
+  await fsp.rename(srcPath, destPath);
+  const renameTime = Date.now() - renameStart;
+
+  // Give reader a moment to see the file
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  // Stop reader
+  stopSignal.stopped = true;
+  await readerPromise;
+
+  // Verify final file
+  const finalContent = await fsp.readFile(destPath, 'utf8');
+  const isComplete = finalContent === content;
+
+  console.log(`\nResults:`);
+  console.log(`  Rename duration: ${renameTime}ms`);
+  console.log(`  Read attempts: ${results.readAttempts}`);
+  console.log(`  File not found: ${results.fileNotFoundCount}`);
+  console.log(`  Partial reads: ${results.partialReads}`);
+  console.log(`  Complete reads: ${results.completeReads}`);
+  console.log(`  Unique sizes observed: ${results.uniqueReadSizes.length}`);
+  console.log(`  Final file complete: ${isComplete ? '✅ Yes' : '❌ No'}`);
+
+  if (results.partialReads === 0) {
+    console.log(`\n  ✅ fs.rename() IS ATOMIC!`);
+    console.log(`     File was either not found (${results.fileNotFoundCount}x) or complete (${results.completeReads}x).`);
+    console.log(`     No partial reads observed.`);
+  } else {
+    console.log(`\n  ❌ Unexpected: fs.rename() showed partial reads!`);
+  }
+
+  return { isAtomic: results.partialReads === 0, results };
+}
+
+/**
+ * Test 3: fs-extra move() with simulated cross-device (copy + unlink)
+ */
+async function testMoveAcrossDevice() {
+  console.log('\n' + '='.repeat(60));
+  console.log('TEST 3: Simulated Cross-Device Move (copy + unlink)');
+  console.log('='.repeat(60));
+
+  const srcPath = path.join(TEST_DIR, 'source-move.js');
+  const destPath = path.join(TEST_DIR, 'dest-move.js');
+
+  // Create source file
+  const content = generateTestBundle(TEST_FILE_SIZE_MB);
+  await fsp.writeFile(srcPath, content);
+  console.log(`Source file: ${srcPath} (${(content.length / 1024 / 1024).toFixed(2)} MB)`);
+
+  // Remove destination if exists
+  await fsp.unlink(destPath).catch(() => {});
+
+  const results = {};
+  const stopSignal = { stopped: false };
+
+  // Start reader in parallel
+  const readerPromise = pollAndRead(destPath, results, stopSignal);
+
+  // Simulate cross-device move (what fs-extra does on EXDEV)
+  const moveStart = Date.now();
+  await fsp.copyFile(srcPath, destPath);
+  await fsp.unlink(srcPath);
+  const moveTime = Date.now() - moveStart;
+
+  // Stop reader
+  stopSignal.stopped = true;
+  await readerPromise;
+
+  // Verify final file
+  const finalContent = await fsp.readFile(destPath, 'utf8');
+  const isComplete = finalContent === content;
+
+  console.log(`\nResults:`);
+  console.log(`  Move duration: ${moveTime}ms`);
+  console.log(`  Read attempts: ${results.readAttempts}`);
+  console.log(`  File not found: ${results.fileNotFoundCount}`);
+  console.log(`  Partial reads: ${results.partialReads}`);
+  console.log(`  Complete reads: ${results.completeReads}`);
+  console.log(`  Unique sizes observed: ${results.uniqueReadSizes.length}`);
+  console.log(`  Final file complete: ${isComplete ? '✅ Yes' : '❌ No'}`);
+
+  if (results.partialReads > 0) {
+    console.log(`\n  ❌ Cross-device move is NOT ATOMIC!`);
+    console.log(`     This is what fs-extra move() does when EXDEV occurs.`);
+    console.log(`     Observed ${results.partialReads} partial reads.`);
+  } else {
+    console.log(`\n  ⚠️  No partial reads observed (try larger file or faster polling)`);
+  }
+
+  return { isAtomic: results.partialReads === 0, results };
+}
+
+/**
+ * Test 4: Atomic write pattern (write to temp, then rename)
+ */
+async function testAtomicWritePattern() {
+  console.log('\n' + '='.repeat(60));
+  console.log('TEST 4: Atomic Write Pattern (temp file + rename)');
+  console.log('='.repeat(60));
+
+  const srcPath = path.join(TEST_DIR, 'source-atomic.js');
+  const destPath = path.join(TEST_DIR, 'dest-atomic.js');
+  const tempPath = path.join(TEST_DIR, 'dest-atomic.js.tmp');
+
+  // Create source file
+  const content = generateTestBundle(TEST_FILE_SIZE_MB);
+  await fsp.writeFile(srcPath, content);
+  console.log(`Source file: ${srcPath} (${(content.length / 1024 / 1024).toFixed(2)} MB)`);
+
+  // Remove destination if exists
+  await fsp.unlink(destPath).catch(() => {});
+  await fsp.unlink(tempPath).catch(() => {});
+
+  const results = {};
+  const stopSignal = { stopped: false };
+
+  // Start reader in parallel (watching destPath, NOT tempPath)
+  const readerPromise = pollAndRead(destPath, results, stopSignal);
+
+  // Atomic write pattern
+  const writeStart = Date.now();
+  await fsp.copyFile(srcPath, tempPath);  // Write to temp (destPath not visible yet)
+  await fsp.rename(tempPath, destPath);    // Atomic rename
+  const writeTime = Date.now() - writeStart;
+
+  // Give reader a moment
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  // Stop reader
+  stopSignal.stopped = true;
+  await readerPromise;
+
+  // Verify final file
+  const finalContent = await fsp.readFile(destPath, 'utf8');
+  const isComplete = finalContent === content;
+
+  console.log(`\nResults:`);
+  console.log(`  Total duration: ${writeTime}ms`);
+  console.log(`  Read attempts: ${results.readAttempts}`);
+  console.log(`  File not found: ${results.fileNotFoundCount}`);
+  console.log(`  Partial reads: ${results.partialReads}`);
+  console.log(`  Complete reads: ${results.completeReads}`);
+  console.log(`  Unique sizes observed: ${results.uniqueReadSizes.length}`);
+  console.log(`  Final file complete: ${isComplete ? '✅ Yes' : '❌ No'}`);
+
+  if (results.partialReads === 0) {
+    console.log(`\n  ✅ ATOMIC WRITE PATTERN WORKS!`);
+    console.log(`     File was either not found (${results.fileNotFoundCount}x) or complete (${results.completeReads}x).`);
+    console.log(`     This is the recommended fix for React on Rails Pro.`);
+  } else {
+    console.log(`\n  ❌ Unexpected partial reads!`);
+  }
+
+  return { isAtomic: results.partialReads === 0, results };
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  console.log('='.repeat(60));
+  console.log('FILE OPERATION ATOMICITY TEST');
+  console.log('='.repeat(60));
+  console.log(`Test directory: ${TEST_DIR}`);
+  console.log(`Test file size: ${TEST_FILE_SIZE_MB} MB`);
+
+  // Create test directory
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  const results = {};
+
+  try {
+    // Run tests
+    results.copyFile = await testCopyFileAtomicity();
+    results.rename = await testRenameAtomicity();
+    results.crossDeviceMove = await testMoveAcrossDevice();
+    results.atomicPattern = await testAtomicWritePattern();
+
+    // Summary
+    console.log('\n' + '='.repeat(60));
+    console.log('SUMMARY');
+    console.log('='.repeat(60));
+    console.log(`
+┌─────────────────────────────────────┬──────────┐
+│ Operation                           │ Atomic?  │
+├─────────────────────────────────────┼──────────┤
+│ fs.copyFile()                       │ ${results.copyFile.isAtomic ? '✅ Yes*  ' : '❌ NO    '} │
+│ fs.rename() (same filesystem)       │ ${results.rename.isAtomic ? '✅ YES   ' : '❌ No    '} │
+│ Cross-device move (copy + unlink)   │ ${results.crossDeviceMove.isAtomic ? '✅ Yes*  ' : '❌ NO    '} │
+│ Atomic pattern (temp + rename)      │ ${results.atomicPattern.isAtomic ? '✅ YES   ' : '❌ No    '} │
+└─────────────────────────────────────┴──────────┘
+
+* If marked "Yes" but expected "NO", try increasing TEST_FILE_SIZE_MB
+  or running on a slower disk.
+
+KEY FINDINGS:
+`);
+
+    if (!results.copyFile.isAtomic) {
+      console.log(`
+🔴 fs.copyFile() is NOT atomic!
+   - File appears at destination BEFORE fully written
+   - Readers can observe partial/truncated content
+   - This affects copyUploadedAssets() in React on Rails Pro
+`);
+    }
+
+    if (results.rename.isAtomic) {
+      console.log(`
+🟢 fs.rename() IS atomic (same filesystem)!
+   - File appears only after operation completes
+   - This is why moveUploadedAsset() works on same filesystem
+`);
+    }
+
+    if (!results.crossDeviceMove.isAtomic) {
+      console.log(`
+🔴 Cross-device move is NOT atomic!
+   - When EXDEV occurs, fs-extra falls back to copy + unlink
+   - This affects moveUploadedAsset() in Docker/K8s environments
+`);
+    }
+
+    if (results.atomicPattern.isAtomic) {
+      console.log(`
+🟢 RECOMMENDED FIX: Use atomic write pattern
+   1. Write to temporary file: dest.tmp
+   2. Atomic rename: dest.tmp → dest
+   3. File only appears when complete!
+`);
+    }
+
+  } finally {
+    // Cleanup
+    console.log(`\nTest files available at: ${TEST_DIR}`);
+    console.log(`To clean up: rm -rf ${TEST_DIR}`);
+  }
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-concurrent-race.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-concurrent-race.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Test for TRANSIENT errors caused by concurrent request race condition
+ *
+ * Hypothesis: If bundle copy is non-atomic (cross-device), a concurrent
+ * request could read a partially-written file, causing a transient error.
+ *
+ * This simulates:
+ * 1. Request A starts copying bundle (slow)
+ * 2. Request B sees file exists, skips upload, reads partial file
+ * 3. Request B gets SyntaxError
+ * 4. Request A completes
+ * 5. Request C reads complete file, works
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+
+const TEST_DIR = path.join(os.tmpdir(), `race-test-${Date.now()}`);
+const BUNDLE_DIR = path.join(TEST_DIR, 'bundles', '12345');
+const BUNDLE_PATH = path.join(BUNDLE_DIR, '12345.js');
+
+console.log('='.repeat(70));
+console.log('RACE CONDITION TEST: Concurrent Request During Non-Atomic Copy');
+console.log('='.repeat(70));
+console.log(`Test directory: ${TEST_DIR}\n`);
+
+// Generate a valid JS bundle
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Simulate slow copy (like cross-device copy under load)
+async function slowCopyFile(content, destPath, delayPerChunkMs = 50) {
+  const chunkSize = 64 * 1024; // 64KB chunks
+  let position = 0;
+
+  const readStream = new Readable({
+    read() {
+      if (position >= content.length) {
+        this.push(null);
+        return;
+      }
+
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+
+      // Simulate slow I/O
+      setTimeout(() => {
+        this.push(chunk);
+      }, delayPerChunkMs);
+    }
+  });
+
+  const writeStream = createWriteStream(destPath);
+  return pipeline(readStream, writeStream);
+}
+
+// Check if bundle is valid JavaScript
+async function validateBundle(filePath) {
+  try {
+    const content = await fsp.readFile(filePath, 'utf8');
+
+    // Try to parse as JavaScript
+    new Function(content);
+
+    return {
+      valid: true,
+      size: content.length,
+      hasMarker: content.includes('COMPLETE_MARKER')
+    };
+  } catch (error) {
+    const content = await fsp.readFile(filePath, 'utf8').catch(() => '');
+    return {
+      valid: false,
+      error: error.message,
+      size: content.length,
+      hasMarker: content.includes('COMPLETE_MARKER')
+    };
+  }
+}
+
+async function main() {
+  await fsp.mkdir(BUNDLE_DIR, { recursive: true });
+
+  const bundleContent = generateBundle(2); // 2MB bundle
+  console.log(`Bundle size: ${(bundleContent.length / 1024 / 1024).toFixed(2)}MB\n`);
+
+  console.log('─'.repeat(70));
+  console.log('Simulating race condition:');
+  console.log('─'.repeat(70));
+
+  const results = [];
+  let copyComplete = false;
+
+  // Start slow copy (Request A)
+  console.log(`[${Date.now()}] Request A: Starting slow copy...`);
+  const copyPromise = slowCopyFile(bundleContent, BUNDLE_PATH, 20).then(() => {
+    copyComplete = true;
+    console.log(`[${Date.now()}] Request A: Copy COMPLETE`);
+  });
+
+  // Wait a bit for copy to start and create the file
+  await new Promise(r => setTimeout(r, 100));
+
+  // Concurrent requests trying to read the bundle
+  const readAttempts = [];
+
+  for (let i = 0; i < 10; i++) {
+    await new Promise(r => setTimeout(r, 100));
+
+    const attemptNum = i + 1;
+    const timestamp = Date.now();
+
+    // Check if file exists (like the renderer does)
+    const exists = await fsp.access(BUNDLE_PATH).then(() => true).catch(() => false);
+
+    if (exists) {
+      const result = await validateBundle(BUNDLE_PATH);
+      const status = result.valid ? '✅ VALID' : '❌ INVALID';
+      console.log(`[${timestamp}] Request B${attemptNum}: File exists, ${status} (${(result.size/1024).toFixed(0)}KB, complete=${result.hasMarker})`);
+
+      if (!result.valid) {
+        console.log(`           Error: ${result.error.substring(0, 60)}...`);
+      }
+
+      readAttempts.push({
+        attempt: attemptNum,
+        copyComplete,
+        ...result
+      });
+    } else {
+      console.log(`[${timestamp}] Request B${attemptNum}: File does not exist yet`);
+    }
+  }
+
+  // Wait for copy to finish
+  await copyPromise;
+
+  // Final read after copy complete
+  await new Promise(r => setTimeout(r, 100));
+  const finalResult = await validateBundle(BUNDLE_PATH);
+  console.log(`\n[${Date.now()}] Final check: ${finalResult.valid ? '✅ VALID' : '❌ INVALID'}`);
+
+  // Summary
+  console.log('\n' + '─'.repeat(70));
+  console.log('SUMMARY');
+  console.log('─'.repeat(70));
+
+  const invalidDuringCopy = readAttempts.filter(r => !r.valid && !r.copyComplete);
+  const validDuringCopy = readAttempts.filter(r => r.valid && !r.copyComplete);
+  const invalidAfterCopy = readAttempts.filter(r => !r.valid && r.copyComplete);
+  const validAfterCopy = readAttempts.filter(r => r.valid && r.copyComplete);
+
+  console.log(`\nReads during copy:  ${invalidDuringCopy.length} invalid, ${validDuringCopy.length} valid`);
+  console.log(`Reads after copy:   ${invalidAfterCopy.length} invalid, ${validAfterCopy.length} valid`);
+
+  if (invalidDuringCopy.length > 0) {
+    console.log(`
+🔴 RACE CONDITION CONFIRMED!
+
+During non-atomic copy:
+- File EXISTS but is INCOMPLETE
+- Concurrent requests read partial file
+- Get "Invalid or unexpected token" or similar errors
+- After copy completes, subsequent requests succeed
+
+This explains TRANSIENT errors that appear on "first few requests"
+and then disappear once the bundle is fully written.
+`);
+  } else {
+    console.log(`
+✅ No race condition detected in this test run.
+(May need to adjust timing or run multiple times)
+`);
+  }
+
+  console.log(`Test directory: ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-concurrent-requests.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-concurrent-requests.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Test TRANSIENT errors with concurrent requests to the actual node renderer
+ *
+ * Scenario:
+ * - Request A: sends bundle (triggers move/copy)
+ * - Request B: does NOT send bundle (uses existing file)
+ * - If B reads during A's copy → SyntaxError (transient)
+ * - After A completes → subsequent requests work
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+import fsp from 'node:fs/promises';
+import { Readable, PassThrough } from 'node:stream';
+import crypto from 'node:crypto';
+
+const TEST_DIR = path.join(os.tmpdir(), `concurrent-test-${Date.now()}`);
+const BUNDLE_SIZE_MB = 5;
+
+console.log('='.repeat(70));
+console.log('CONCURRENT REQUESTS TEST: Transient Error Reproduction');
+console.log('='.repeat(70));
+console.log(`Test directory: ${TEST_DIR}\n`);
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Create a SLOW stream to simulate large upload
+function createSlowStream(buffer, chunkDelayMs = 10) {
+  let position = 0;
+  const chunkSize = 64 * 1024;
+
+  return new Readable({
+    read() {
+      if (position >= buffer.length) {
+        this.push(null);
+        return;
+      }
+
+      const chunk = buffer.slice(position, position + chunkSize);
+      position += chunk.length;
+
+      setTimeout(() => {
+        this.push(chunk);
+      }, chunkDelayMs);
+    }
+  });
+}
+
+function createMultipartWithBundle(bundleStream, bundleFilename) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const headerPart =
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="protocolVersion"\r\n\r\n2.0.0\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="gemVersion"\r\n\r\n16.2.0-beta.20\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="railsEnv"\r\n\r\ntest\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="renderingRequest"\r\n\r\nReactOnRails.dummy()\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n` +
+    `Content-Type: application/javascript\r\n\r\n`;
+
+  const footerPart = `\r\n--${boundary}--\r\n`;
+  const combinedStream = new PassThrough();
+
+  combinedStream.write(Buffer.from(headerPart, 'utf8'));
+  bundleStream.on('data', (chunk) => combinedStream.write(chunk));
+  bundleStream.on('end', () => {
+    combinedStream.write(Buffer.from(footerPart, 'utf8'));
+    combinedStream.end();
+  });
+
+  return { boundary, stream: combinedStream, contentType: `multipart/form-data; boundary=${boundary}` };
+}
+
+function createMultipartWithoutBundle() {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const body =
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="protocolVersion"\r\n\r\n2.0.0\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="gemVersion"\r\n\r\n16.2.0-beta.20\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="railsEnv"\r\n\r\ntest\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="renderingRequest"\r\n\r\nReactOnRails.dummy()\r\n` +
+    `--${boundary}--\r\n`;
+
+  return { boundary, body, contentType: `multipart/form-data; boundary=${boundary}` };
+}
+
+async function main() {
+  await fsp.mkdir(path.join(TEST_DIR, 'uploads'), { recursive: true });
+
+  // Load the worker module
+  console.log('Loading worker module...');
+  const { createRequire } = await import('module');
+  const require = createRequire(import.meta.url);
+  const workerModule = require('../lib/worker.js');
+  const worker = workerModule.default;
+  const disableHttp2 = workerModule.disableHttp2;
+
+  disableHttp2();
+
+  const app = worker({
+    serverBundleCachePath: TEST_DIR,
+    logHttpLevel: 'silent',
+  });
+
+  await app.ready();
+
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+
+  console.log(`Bundle timestamp: ${bundleTimestamp}`);
+  console.log(`Bundle size: ${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB\n`);
+
+  console.log('─'.repeat(70));
+  console.log('TEST: Concurrent requests - one with bundle, others without');
+  console.log('─'.repeat(70));
+
+  const results = [];
+
+  // Request A: Upload bundle (slow)
+  console.log(`\n[${Date.now()}] Starting Request A (with slow bundle upload)...`);
+
+  const bundleStream = createSlowStream(bundleBuffer, 5); // 5ms per 64KB chunk
+  const multipartA = createMultipartWithBundle(bundleStream, bundleFilename);
+
+  const requestAPromise = app.inject({
+    method: 'POST',
+    url: `/bundles/${bundleTimestamp}/render/test-digest`,
+    headers: { 'content-type': multipartA.contentType },
+    payload: multipartA.stream,
+  }).then(res => {
+    console.log(`[${Date.now()}] Request A completed: ${res.statusCode}`);
+    return { name: 'A (upload)', status: res.statusCode, time: Date.now() };
+  });
+
+  // Wait a bit for A to start, then send concurrent requests WITHOUT bundle
+  await new Promise(r => setTimeout(r, 100));
+
+  const concurrentRequests = [];
+  for (let i = 1; i <= 5; i++) {
+    await new Promise(r => setTimeout(r, 100)); // Stagger requests
+
+    const multipartB = createMultipartWithoutBundle();
+
+    console.log(`[${Date.now()}] Starting Request B${i} (without bundle, expects existing file)...`);
+
+    const requestPromise = app.inject({
+      method: 'POST',
+      url: `/bundles/${bundleTimestamp}/render/test-digest`,
+      headers: { 'content-type': multipartB.contentType },
+      payload: multipartB.body,
+    }).then(res => {
+      const isError = res.statusCode >= 400;
+      console.log(`[${Date.now()}] Request B${i} completed: ${res.statusCode} ${isError ? '❌' : '✅'}`);
+      return { name: `B${i} (no upload)`, status: res.statusCode, time: Date.now() };
+    });
+
+    concurrentRequests.push(requestPromise);
+  }
+
+  // Wait for all requests
+  const allResults = await Promise.all([requestAPromise, ...concurrentRequests]);
+  results.push(...allResults);
+
+  // Additional requests after A completes (should all work)
+  console.log(`\n[${Date.now()}] Sending requests AFTER upload complete...`);
+
+  for (let i = 1; i <= 3; i++) {
+    const multipartC = createMultipartWithoutBundle();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/bundles/${bundleTimestamp}/render/test-digest`,
+      headers: { 'content-type': multipartC.contentType },
+      payload: multipartC.body,
+    });
+
+    const isError = res.statusCode >= 400;
+    console.log(`[${Date.now()}] Request C${i} (after upload): ${res.statusCode} ${isError ? '❌' : '✅'}`);
+    results.push({ name: `C${i} (after)`, status: res.statusCode, time: Date.now() });
+  }
+
+  // Summary
+  console.log('\n' + '─'.repeat(70));
+  console.log('SUMMARY');
+  console.log('─'.repeat(70));
+
+  const errors = results.filter(r => r.status >= 400 && r.name.startsWith('B'));
+  const successes = results.filter(r => r.status < 400 || r.name === 'A (upload)');
+
+  console.log(`\nTotal requests: ${results.length}`);
+  console.log(`Errors during upload: ${errors.length}`);
+  console.log(`Successes: ${successes.length}`);
+
+  console.log('\nResults by request:');
+  for (const r of results) {
+    const symbol = r.status < 400 ? '✅' : '❌';
+    console.log(`  ${symbol} ${r.name}: ${r.status}`);
+  }
+
+  if (errors.length > 0) {
+    console.log(`
+🔴 TRANSIENT ERRORS DETECTED!
+
+Requests sent DURING the bundle upload got errors (likely 410 or 400).
+Requests sent AFTER the upload completed succeeded.
+
+This matches the "first few requests fail, then works" pattern.
+`);
+  } else {
+    console.log(`
+✅ No transient errors detected.
+(The timing may need adjustment to trigger the race condition)
+`);
+  }
+
+  await app.close();
+  console.log(`Test directory: ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-deploy-race.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-deploy-race.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * Test: DEPLOY RACE CONDITION
+ * 
+ * Hypothesis: If deployment process writes bundle directly to /bundles/ 
+ * (not via HTTP upload), concurrent requests can read partial file.
+ * 
+ * This matches the pattern:
+ * - Errors appear AFTER new deploy
+ * - First few requests fail with SyntaxError
+ * - Later requests succeed
+ * 
+ * The lock only protects the /uploads/ → /bundles/ move,
+ * NOT direct reads of existing bundles.
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+
+const TEST_DIR = path.join(os.tmpdir(), `deploy-race-${Date.now()}`);
+const BUNDLE_SIZE_MB = 5;
+
+console.log('='.repeat(70));
+console.log('DEPLOY RACE CONDITION TEST');
+console.log('='.repeat(70));
+console.log(`Test directory: ${TEST_DIR}\n`);
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Simulate slow deployment file write (like rsync or docker copy)
+async function slowWriteFile(content, destPath, delayPerChunkMs = 20) {
+  await fsp.mkdir(path.dirname(destPath), { recursive: true });
+  
+  const chunkSize = 64 * 1024;
+  let position = 0;
+
+  const readStream = new Readable({
+    read() {
+      if (position >= content.length) {
+        this.push(null);
+        return;
+      }
+
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+
+      setTimeout(() => {
+        this.push(chunk);
+      }, delayPerChunkMs);
+    }
+  });
+
+  const writeStream = createWriteStream(destPath);
+  return pipeline(readStream, writeStream);
+}
+
+// Simulate request that reads bundle (like buildVM does)
+async function simulateRequest(bundlePath, requestId) {
+  const startTime = Date.now();
+  
+  try {
+    // Check if file exists (like fileExistsAsync)
+    await fsp.access(bundlePath);
+    
+    // Read file (like readFileAsync in buildVM)
+    const content = await fsp.readFile(bundlePath, 'utf8');
+    
+    // Try to execute as JS (like vm.runInContext)
+    try {
+      new Function(content);
+      const isComplete = content.includes('COMPLETE_MARKER');
+      return {
+        id: requestId,
+        success: true,
+        complete: isComplete,
+        size: content.length,
+        elapsed: Date.now() - startTime
+      };
+    } catch (e) {
+      return {
+        id: requestId,
+        success: false,
+        error: e.message.substring(0, 50),
+        size: content.length,
+        elapsed: Date.now() - startTime
+      };
+    }
+  } catch (e) {
+    return {
+      id: requestId,
+      success: false,
+      error: `File access: ${e.code}`,
+      elapsed: Date.now() - startTime
+    };
+  }
+}
+
+async function main() {
+  const bundleHash = 'abc123';
+  const bundlePath = path.join(TEST_DIR, bundleHash, `${bundleHash}.js`);
+  const bundleContent = generateBundle(BUNDLE_SIZE_MB);
+
+  console.log(`Bundle path: ${bundlePath}`);
+  console.log(`Bundle size: ${(bundleContent.length / 1024 / 1024).toFixed(2)}MB`);
+  console.log('');
+  console.log('─'.repeat(70));
+  console.log('Simulating: Deploy writes bundle while requests arrive');
+  console.log('─'.repeat(70));
+  console.log('');
+
+  let deployComplete = false;
+  const results = [];
+
+  // Start "deployment" - writing bundle directly to bundles directory
+  console.log(`[${Date.now()}] DEPLOY: Starting to write bundle...`);
+  const deployPromise = slowWriteFile(bundleContent, bundlePath, 10).then(() => {
+    deployComplete = true;
+    console.log(`[${Date.now()}] DEPLOY: Bundle write COMPLETE`);
+  });
+
+  // Wait a bit for file to be created
+  await new Promise(r => setTimeout(r, 50));
+
+  // Concurrent requests during deployment
+  const concurrentRequests = [];
+  for (let i = 1; i <= 15; i++) {
+    await new Promise(r => setTimeout(r, 100));
+    
+    const reqPromise = simulateRequest(bundlePath, `R${i}`).then(result => {
+      result.deployComplete = deployComplete;
+      const status = result.success && result.complete 
+        ? '✅ SUCCESS' 
+        : result.success && !result.complete 
+          ? '⚠️ PARTIAL' 
+          : '❌ ERROR';
+      console.log(`[${Date.now()}] Request ${result.id}: ${status}${result.error ? ` (${result.error})` : ''} [deploy=${deployComplete}]`);
+      return result;
+    });
+    
+    concurrentRequests.push(reqPromise);
+  }
+
+  // Wait for all requests and deployment
+  const allResults = await Promise.all([deployPromise, ...concurrentRequests]);
+  results.push(...allResults.slice(1)); // Skip deploy promise result
+
+  // Requests after deployment complete
+  console.log('');
+  console.log(`[${Date.now()}] Sending requests AFTER deploy complete...`);
+  for (let i = 1; i <= 3; i++) {
+    const result = await simulateRequest(bundlePath, `POST-${i}`);
+    result.deployComplete = true;
+    const status = result.success && result.complete ? '✅ SUCCESS' : '❌ ERROR';
+    console.log(`[${Date.now()}] Request ${result.id}: ${status}`);
+    results.push(result);
+  }
+
+  // Summary
+  console.log('');
+  console.log('─'.repeat(70));
+  console.log('SUMMARY');
+  console.log('─'.repeat(70));
+
+  const errorsDuringDeploy = results.filter(r => (!r.success || !r.complete) && !r.deployComplete);
+  const successDuringDeploy = results.filter(r => r.success && r.complete && !r.deployComplete);
+  const errorsAfterDeploy = results.filter(r => (!r.success || !r.complete) && r.deployComplete);
+  const successAfterDeploy = results.filter(r => r.success && r.complete && r.deployComplete);
+
+  console.log('');
+  console.log(`During deploy:   ${errorsDuringDeploy.length} errors, ${successDuringDeploy.length} success`);
+  console.log(`After deploy:    ${errorsAfterDeploy.length} errors, ${successAfterDeploy.length} success`);
+
+  if (errorsDuringDeploy.length > 0 && errorsAfterDeploy.length === 0) {
+    console.log(`
+🔴 DEPLOY RACE CONDITION CONFIRMED!
+
+Pattern matches user report:
+- Errors occur DURING bundle deployment (first few requests)
+- Errors disappear AFTER deployment completes
+- File exists but is incomplete → SyntaxError
+
+This explains why:
+- "first few requests fail, then works"
+- Errors appear "after new deploy"
+- Bundle timestamp is stable (same hash until deploy)
+
+ROOT CAUSE:
+The bundle file is written directly during deployment.
+No lock protects reads of existing bundles.
+Concurrent requests read partial file during write.
+`);
+  } else if (errorsDuringDeploy.length === 0) {
+    console.log(`
+✅ No errors during deploy (timing may not have triggered the race).
+Try increasing BUNDLE_SIZE_MB or decreasing delay.
+`);
+  }
+
+  console.log(`Test directory: ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-fd-truncation.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-fd-truncation.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Test: What happens when file is truncated while another fd is writing?
+ * 
+ * Scenario:
+ * 1. Process A opens file, starts writing at position 0
+ * 2. Process A writes 100KB, position now at 100KB
+ * 3. Process B opens file with O_TRUNC, file becomes 0 bytes
+ * 4. Process B writes 50KB
+ * 5. Process A continues writing at position 100KB
+ * 
+ * Question: What's in the file? A's data at 100KB, B's data at 0, zeros in between?
+ */
+
+import fsp from 'node:fs/promises';
+import { createWriteStream, openSync, writeSync, closeSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `fd-trunc-${Date.now()}`);
+const TEST_FILE = path.join(TEST_DIR, 'test.txt');
+
+console.log('='.repeat(70));
+console.log('FILE DESCRIPTOR TRUNCATION TEST');
+console.log('='.repeat(70));
+console.log(`Test file: ${TEST_FILE}\n`);
+
+async function main() {
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  // Use sync operations for precise control
+  
+  // Step 1: Process A opens file
+  console.log('1. Process A opens file (O_CREAT | O_TRUNC | O_WRONLY)');
+  const fdA = openSync(TEST_FILE, 'w');
+  
+  // Step 2: Process A writes 100KB of 'A's
+  const chunkA1 = Buffer.alloc(100 * 1024, 'A');
+  console.log('2. Process A writes 100KB of "A"s');
+  writeSync(fdA, chunkA1);
+  console.log(`   File size now: ${(await fsp.stat(TEST_FILE)).size} bytes`);
+  
+  // Step 3: Process B opens with O_TRUNC - this truncates the file!
+  console.log('3. Process B opens file with O_TRUNC (truncates to 0!)');
+  const fdB = openSync(TEST_FILE, 'w');
+  console.log(`   File size now: ${(await fsp.stat(TEST_FILE)).size} bytes`);
+  
+  // Step 4: Process B writes 50KB of 'B's  
+  const chunkB = Buffer.alloc(50 * 1024, 'B');
+  console.log('4. Process B writes 50KB of "B"s');
+  writeSync(fdB, chunkB);
+  console.log(`   File size now: ${(await fsp.stat(TEST_FILE)).size} bytes`);
+  
+  // Step 5: Process A continues writing at ITS position (100KB)
+  const chunkA2 = Buffer.alloc(50 * 1024, 'A');
+  console.log('5. Process A writes 50KB more "A"s at its position (100KB)');
+  writeSync(fdA, chunkA2);
+  console.log(`   File size now: ${(await fsp.stat(TEST_FILE)).size} bytes`);
+  
+  // Close both
+  closeSync(fdA);
+  closeSync(fdB);
+  
+  // Analyze the result
+  console.log('\n' + '─'.repeat(70));
+  console.log('RESULT ANALYSIS');
+  console.log('─'.repeat(70));
+  
+  const content = await fsp.readFile(TEST_FILE);
+  console.log(`\nFinal file size: ${content.length} bytes`);
+  
+  // Count characters in different regions
+  const regions = [
+    { start: 0, end: 50 * 1024, name: 'First 50KB' },
+    { start: 50 * 1024, end: 100 * 1024, name: '50KB-100KB' },
+    { start: 100 * 1024, end: 150 * 1024, name: '100KB-150KB' },
+  ];
+  
+  for (const region of regions) {
+    if (region.start >= content.length) {
+      console.log(`${region.name}: (beyond file end)`);
+      continue;
+    }
+    
+    const slice = content.slice(region.start, Math.min(region.end, content.length));
+    const countA = slice.filter(b => b === 65).length; // 'A'
+    const countB = slice.filter(b => b === 66).length; // 'B'
+    const countZero = slice.filter(b => b === 0).length; // null bytes
+    const countOther = slice.length - countA - countB - countZero;
+    
+    console.log(`${region.name}: ${countA} A's, ${countB} B's, ${countZero} zeros, ${countOther} other`);
+  }
+  
+  // Check if file would be valid JS
+  const contentStr = content.toString('utf8');
+  const hasNullBytes = content.includes(0);
+  
+  console.log(`\nContains null bytes: ${hasNullBytes}`);
+  
+  if (hasNullBytes) {
+    console.log(`
+🔴 CORRUPTION CONFIRMED!
+
+When Process B truncates the file while A's fd is still open:
+- B writes at position 0
+- A continues writing at its saved position (100KB)
+- Gap between 50KB-100KB is filled with NULL BYTES!
+
+This creates an INVALID JavaScript file that causes:
+"Invalid or unexpected token" (null bytes are not valid JS)
+`);
+  }
+
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-http-client-slow.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-http-client-slow.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * HTTP Client that sends an interrupted upload to the node renderer
+ * This version sends data slowly to ensure the server receives it
+ *
+ * Usage:
+ *   node scripts/test-http-client-slow.mjs [interrupt_percent]
+ */
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+
+const PORT = 3222;
+const HOST = '127.0.0.1';
+const BUNDLE_SIZE_MB = 10;
+const INTERRUPT_PERCENT = parseInt(process.argv[2] || '50', 10);
+
+console.log('='.repeat(60));
+console.log('HTTP UPLOAD INTERRUPTION TEST (SLOW)');
+console.log('='.repeat(60));
+console.log(`Target: http://${HOST}:${PORT}`);
+console.log(`Bundle size: ${BUNDLE_SIZE_MB}MB`);
+console.log(`Interrupt at: ${INTERRUPT_PERCENT}%`);
+console.log('');
+
+// Generate a valid JS bundle
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Create multipart form body
+function createMultipartBody(bundleBuffer, bundleFilename) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const fields = [
+    { name: 'protocolVersion', value: '2.0.0' },
+    { name: 'gemVersion', value: '16.2.0-beta.20' },
+    { name: 'railsEnv', value: 'test' },
+    { name: 'renderingRequest', value: 'ReactOnRails.dummy()' },
+  ];
+
+  let body = '';
+  for (const field of fields) {
+    body += `--${boundary}\r\n`;
+    body += `Content-Disposition: form-data; name="${field.name}"\r\n\r\n`;
+    body += `${field.value}\r\n`;
+  }
+
+  // Add the bundle file
+  body += `--${boundary}\r\n`;
+  body += `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n`;
+  body += `Content-Type: application/javascript\r\n\r\n`;
+
+  const header = Buffer.from(body, 'utf8');
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+  return {
+    boundary,
+    header,
+    footer,
+    bundle: bundleBuffer,
+    totalSize: header.length + bundleBuffer.length + footer.length,
+  };
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+
+  console.log(`Generated bundle: ${bundleFilename} (${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB)`);
+
+  const multipart = createMultipartBody(bundleBuffer, bundleFilename);
+  const interruptAt = Math.floor(multipart.totalSize * (INTERRUPT_PERCENT / 100));
+
+  console.log(`Total payload size: ${(multipart.totalSize / 1024 / 1024).toFixed(2)}MB`);
+  console.log(`Will interrupt at: ${(interruptAt / 1024 / 1024).toFixed(2)}MB (${INTERRUPT_PERCENT}%)`);
+  console.log('');
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: HOST,
+      port: PORT,
+      path: `/bundles/${bundleTimestamp}/render/test-digest`,
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+        'Content-Length': multipart.totalSize,
+      },
+    }, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        console.log(`\nResponse status: ${res.statusCode}`);
+        console.log(`Response body (first 500 chars):\n${body.substring(0, 500)}`);
+        resolve();
+      });
+    });
+
+    req.on('error', (err) => {
+      console.log(`\nRequest error: ${err.message}`);
+      resolve();
+    });
+
+    // Write all data synchronously with delays
+    (async () => {
+      try {
+        // Write header
+        console.log('Sending header...');
+        req.write(multipart.header);
+        await sleep(10);
+
+        // Write bundle in chunks with delays
+        const chunkSize = 256 * 1024; // 256KB chunks
+        let position = 0;
+        let bytesSent = multipart.header.length;
+
+        console.log('Sending bundle...');
+        while (position < multipart.bundle.length) {
+          const chunk = multipart.bundle.slice(position, position + chunkSize);
+          position += chunk.length;
+          bytesSent += chunk.length;
+
+          // Check if we should interrupt
+          if (bytesSent >= interruptAt) {
+            console.log(`\n🔴 INTERRUPTING at ${(bytesSent / 1024 / 1024).toFixed(2)}MB (${((bytesSent / multipart.totalSize) * 100).toFixed(1)}%)`);
+            console.log('Waiting 100ms for server to receive data...');
+            await sleep(100);
+            console.log('Destroying socket...');
+            req.destroy();
+            await sleep(500);
+            console.log('\nConnection destroyed. Check server logs and test directory.');
+            resolve();
+            return;
+          }
+
+          req.write(chunk);
+
+          // Progress update every 1MB
+          if (position % (1024 * 1024) < chunkSize) {
+            process.stdout.write(`  Sent: ${(bytesSent / 1024 / 1024).toFixed(1)}MB\r`);
+          }
+
+          // Small delay to simulate real network
+          await sleep(1);
+        }
+
+        // Send footer
+        console.log('\nSending footer...');
+        req.write(multipart.footer);
+        req.end();
+      } catch (err) {
+        console.log(`Send error: ${err.message}`);
+        resolve();
+      }
+    })();
+  });
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-http-client.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-http-client.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * HTTP Client that sends an interrupted upload to the node renderer
+ *
+ * Usage:
+ *   node scripts/test-http-client.mjs [interrupt_percent]
+ *
+ * Example:
+ *   node scripts/test-http-client.mjs 50
+ */
+
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import crypto from 'node:crypto';
+
+const PORT = 3222;
+const HOST = '127.0.0.1';
+const BUNDLE_SIZE_MB = 10;
+const INTERRUPT_PERCENT = parseInt(process.argv[2] || '50', 10);
+
+console.log('='.repeat(60));
+console.log('HTTP UPLOAD INTERRUPTION TEST');
+console.log('='.repeat(60));
+console.log(`Target: http://${HOST}:${PORT}`);
+console.log(`Bundle size: ${BUNDLE_SIZE_MB}MB`);
+console.log(`Interrupt at: ${INTERRUPT_PERCENT}%`);
+console.log('');
+
+// Generate a valid JS bundle
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Create multipart form body
+function createMultipartBody(bundleBuffer, bundleFilename) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const fields = [
+    { name: 'protocolVersion', value: '2.0.0' },
+    { name: 'gemVersion', value: '16.2.0-beta.20' },
+    { name: 'railsEnv', value: 'test' },
+    { name: 'renderingRequest', value: 'ReactOnRails.dummy()' },
+  ];
+
+  let body = '';
+  for (const field of fields) {
+    body += `--${boundary}\r\n`;
+    body += `Content-Disposition: form-data; name="${field.name}"\r\n\r\n`;
+    body += `${field.value}\r\n`;
+  }
+
+  // Add the bundle file
+  body += `--${boundary}\r\n`;
+  body += `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n`;
+  body += `Content-Type: application/javascript\r\n\r\n`;
+
+  const header = Buffer.from(body, 'utf8');
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+  return {
+    boundary,
+    header,
+    footer,
+    bundle: bundleBuffer,
+    totalSize: header.length + bundleBuffer.length + footer.length,
+  };
+}
+
+async function main() {
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+
+  console.log(`Generated bundle: ${bundleFilename} (${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB)`);
+
+  const multipart = createMultipartBody(bundleBuffer, bundleFilename);
+  const interruptAt = Math.floor(multipart.totalSize * (INTERRUPT_PERCENT / 100));
+
+  console.log(`Total payload size: ${(multipart.totalSize / 1024 / 1024).toFixed(2)}MB`);
+  console.log(`Will interrupt at: ${(interruptAt / 1024 / 1024).toFixed(2)}MB (${INTERRUPT_PERCENT}%)`);
+  console.log('');
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: HOST,
+      port: PORT,
+      path: `/bundles/${bundleTimestamp}/render/test-digest`,
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+        'Content-Length': multipart.totalSize,
+      },
+    }, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        console.log(`\nResponse status: ${res.statusCode}`);
+        console.log(`Response body (first 500 chars):\n${body.substring(0, 500)}`);
+        resolve();
+      });
+    });
+
+    req.on('error', (err) => {
+      console.log(`\nRequest error: ${err.message}`);
+      resolve(); // Don't reject, we expect this might happen
+    });
+
+    // Write header
+    console.log('Sending header...');
+    req.write(multipart.header);
+
+    // Write bundle in chunks with interruption
+    let bytesSent = multipart.header.length;
+    const chunkSize = 64 * 1024; // 64KB chunks
+    let position = 0;
+
+    const sendNextChunk = () => {
+      if (position >= multipart.bundle.length) {
+        // Done with bundle, send footer
+        console.log('Sending footer...');
+        req.write(multipart.footer);
+        req.end();
+        return;
+      }
+
+      const chunk = multipart.bundle.slice(position, position + chunkSize);
+      position += chunk.length;
+      bytesSent += chunk.length;
+
+      // Check if we should interrupt
+      if (bytesSent >= interruptAt) {
+        console.log(`\n🔴 INTERRUPTING CONNECTION at ${(bytesSent / 1024 / 1024).toFixed(2)}MB (${((bytesSent / multipart.totalSize) * 100).toFixed(1)}%)`);
+        console.log('Destroying socket...');
+        req.destroy();
+
+        // Give server time to process, then resolve
+        setTimeout(() => {
+          console.log('\nConnection destroyed. Check server logs and test directory for partial files.');
+          resolve();
+        }, 1000);
+        return;
+      }
+
+      req.write(chunk, () => {
+        // Small delay to simulate realistic upload
+        setImmediate(sendNextChunk);
+      });
+    };
+
+    console.log('Sending bundle...');
+    sendNextChunk();
+  });
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-multipart-race.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-multipart-race.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Test: Multipart upload race condition causing null bytes
+ * 
+ * Simulates two concurrent requests uploading the same bundle,
+ * where one truncates while the other is mid-write.
+ */
+
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `multipart-race-${Date.now()}`);
+const UPLOAD_FILE = path.join(TEST_DIR, 'uploads', 'abc123.js');
+
+console.log('='.repeat(70));
+console.log('MULTIPART UPLOAD RACE CONDITION TEST');
+console.log('='.repeat(70));
+console.log(`Upload file: ${UPLOAD_FILE}\n`);
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { test: true };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 100) {
+    content += line;
+  }
+  content += '// BUNDLE END - COMPLETE_MARKER\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Simulates saveMultipartFile - streams content with delays
+async function simulateMultipartSave(id, content, startDelay = 0, chunkDelay = 2) {
+  await new Promise(r => setTimeout(r, startDelay));
+  
+  console.log(`[${Date.now()}] Request ${id}: Starting multipart save`);
+  
+  const chunkSize = 64 * 1024;
+  let position = 0;
+  let chunkCount = 0;
+  
+  const readable = new Readable({
+    read() {
+      if (position >= content.length) {
+        this.push(null);
+        return;
+      }
+      
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+      chunkCount++;
+      
+      // Simulate network/processing delay
+      setTimeout(() => {
+        this.push(chunk);
+      }, chunkDelay);
+    }
+  });
+  
+  // This is what saveMultipartFile does
+  const writeStream = createWriteStream(UPLOAD_FILE);
+  
+  await pipeline(readable, writeStream);
+  
+  console.log(`[${Date.now()}] Request ${id}: Finished (${chunkCount} chunks)`);
+  return chunkCount;
+}
+
+async function analyzeFile() {
+  const content = await fsp.readFile(UPLOAD_FILE);
+  
+  const hasNullBytes = content.includes(0);
+  const nullByteCount = content.filter(b => b === 0).length;
+  const hasStart = content.toString().includes('BUNDLE START');
+  const hasEnd = content.toString().includes('COMPLETE_MARKER');
+  
+  let jsValid = false;
+  let jsError = null;
+  try {
+    new Function(content.toString());
+    jsValid = true;
+  } catch (e) {
+    jsError = e.message;
+  }
+  
+  return { 
+    size: content.length, 
+    hasNullBytes, 
+    nullByteCount,
+    hasStart,
+    hasEnd,
+    jsValid,
+    jsError
+  };
+}
+
+async function runTest(name, delayA, delayB) {
+  console.log(`\n--- ${name} ---`);
+  
+  // Clean up
+  await fsp.mkdir(path.dirname(UPLOAD_FILE), { recursive: true });
+  try { await fsp.unlink(UPLOAD_FILE); } catch {}
+  
+  const bundle = generateBundle(2); // 2MB
+  
+  // Simulate two concurrent multipart saves
+  await Promise.all([
+    simulateMultipartSave('A', bundle, delayA),
+    simulateMultipartSave('B', bundle, delayB),
+  ]);
+  
+  const result = await analyzeFile();
+  
+  if (result.hasNullBytes) {
+    console.log(`🔴 CORRUPTED: ${result.nullByteCount} null bytes, JS error: ${result.jsError?.substring(0, 50)}`);
+  } else if (!result.jsValid) {
+    console.log(`🔴 INVALID JS: ${result.jsError?.substring(0, 50)}`);
+  } else if (!result.hasEnd) {
+    console.log(`⚠️ TRUNCATED: Missing end marker`);
+  } else {
+    console.log(`✅ VALID: ${result.size} bytes`);
+  }
+  
+  return result;
+}
+
+async function main() {
+  const results = [];
+  
+  // Test various timing scenarios
+  results.push(await runTest('B starts 20ms after A', 0, 20));
+  results.push(await runTest('B starts 50ms after A', 0, 50));
+  results.push(await runTest('A and B start together', 0, 0));
+  results.push(await runTest('A starts 30ms after B', 30, 0));
+  
+  // Run multiple iterations of most likely race scenario
+  console.log('\n--- Running 20 iterations of staggered start ---');
+  let corrupted = 0;
+  let valid = 0;
+  
+  for (let i = 0; i < 20; i++) {
+    const r = await runTest(`Iteration ${i+1}`, 0, 30);
+    if (r.hasNullBytes || !r.jsValid) corrupted++;
+    else valid++;
+  }
+  
+  console.log('\n' + '='.repeat(70));
+  console.log('SUMMARY');
+  console.log('='.repeat(70));
+  console.log(`Corrupted: ${corrupted}/20, Valid: ${valid}/20`);
+  
+  if (corrupted > 0) {
+    console.log(`
+🔴 UPLOAD RACE CORRUPTION CONFIRMED!
+
+When two requests upload the same bundle simultaneously:
+1. Request A opens /uploads/{hash}.js, starts writing
+2. Request B opens /uploads/{hash}.js with O_TRUNC (truncates!)
+3. Request A continues writing at ITS position (not file position)
+4. Result: NULL BYTES between B's end and A's continued position!
+
+This causes "Invalid or unexpected token" in the VM.
+
+WHY TRANSIENT?
+- The corrupted file is moved to /bundles/
+- BUT if you have multiple node renderer pods:
+  - Pod 1 might get the corrupted file
+  - Pod 2 might get a clean file (won the race differently)
+  - Load balancer distributes: some fail, some succeed
+  - After Pod 1 restarts → all work
+
+OR:
+- First bundle upload corrupts
+- Error returned to Rails
+- Rails' fallback (if enabled) serves the request via ExecJS
+- Next request might retry upload and get clean file
+`);
+  }
+
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-real-http-v2.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-real-http-v2.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+/**
+ * Real HTTP upload interruption test - Version 2
+ * Uses TCP cork/uncork to ensure data is flushed to server
+ */
+
+import http from 'node:http';
+import net from 'node:net';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import os from 'node:os';
+import fsp from 'node:fs/promises';
+
+const PORT = 3222;
+const HOST = '127.0.0.1';
+const BUNDLE_SIZE_MB = 10;
+const TEST_DIR = path.join(os.tmpdir(), `real-http-test-v2-${Date.now()}`);
+
+console.log('='.repeat(60));
+console.log('REAL HTTP UPLOAD INTERRUPTION TEST v2');
+console.log('='.repeat(60));
+console.log(`Test directory: ${TEST_DIR}`);
+console.log('');
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+function createMultipartBody(bundleBuffer, bundleFilename) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+  const fields = [
+    { name: 'protocolVersion', value: '2.0.0' },
+    { name: 'gemVersion', value: '16.2.0-beta.20' },
+    { name: 'railsEnv', value: 'test' },
+    { name: 'renderingRequest', value: 'ReactOnRails.dummy()' },
+  ];
+
+  let body = '';
+  for (const field of fields) {
+    body += `--${boundary}\r\n`;
+    body += `Content-Disposition: form-data; name="${field.name}"\r\n\r\n`;
+    body += `${field.value}\r\n`;
+  }
+  body += `--${boundary}\r\n`;
+  body += `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n`;
+  body += `Content-Type: application/javascript\r\n\r\n`;
+
+  const header = Buffer.from(body, 'utf8');
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+  return { boundary, header, footer, bundle: bundleBuffer };
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function listFilesRecursive(dir) {
+  const files = [];
+  try {
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...await listFilesRecursive(fullPath));
+      } else {
+        const stats = await fsp.stat(fullPath);
+        files.push({ path: fullPath, name: entry.name, size: stats.size });
+      }
+    }
+  } catch (err) { /* ignore */ }
+  return files;
+}
+
+async function isFileComplete(filePath) {
+  try {
+    const content = await fsp.readFile(filePath, 'utf8');
+    return {
+      hasStart: content.includes('BUNDLE START'),
+      hasEnd: content.includes('BUNDLE END'),
+      hasMarker: content.includes('COMPLETE_MARKER'),
+      size: content.length
+    };
+  } catch {
+    return { error: true };
+  }
+}
+
+// Send request using raw TCP for more control
+async function sendInterruptedRequestRaw(interruptPercent) {
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+  const multipart = createMultipartBody(bundleBuffer, bundleFilename);
+  const totalSize = multipart.header.length + multipart.bundle.length + multipart.footer.length;
+  const interruptAt = Math.floor(totalSize * (interruptPercent / 100));
+
+  console.log(`  Bundle: ${bundleFilename}`);
+  console.log(`  Total size: ${(totalSize / 1024 / 1024).toFixed(2)}MB`);
+  console.log(`  Interrupt at: ${interruptPercent}% (${(interruptAt / 1024 / 1024).toFixed(2)}MB)`);
+
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+
+    socket.connect(PORT, HOST, async () => {
+      // Build HTTP request
+      const requestLine = `POST /bundles/${bundleTimestamp}/render/test-digest HTTP/1.1\r\n`;
+      const headers = [
+        `Host: ${HOST}:${PORT}`,
+        `Content-Type: multipart/form-data; boundary=${multipart.boundary}`,
+        `Content-Length: ${totalSize}`,
+        'Connection: close',
+      ].join('\r\n') + '\r\n\r\n';
+
+      // Send HTTP headers
+      socket.write(requestLine + headers);
+
+      // Send multipart header
+      socket.write(multipart.header);
+      await sleep(10);
+
+      // Send bundle in chunks
+      const chunkSize = 64 * 1024; // 64KB
+      let position = 0;
+      let bytesSent = multipart.header.length;
+
+      while (position < multipart.bundle.length) {
+        const chunk = multipart.bundle.slice(position, position + chunkSize);
+        position += chunk.length;
+        bytesSent += chunk.length;
+
+        // Write and wait for it to drain
+        const canContinue = socket.write(chunk);
+        if (!canContinue) {
+          await new Promise(r => socket.once('drain', r));
+        }
+
+        // Progress
+        if (position % (1024 * 1024) < chunkSize) {
+          process.stdout.write(`  Sent: ${(bytesSent / 1024 / 1024).toFixed(1)}MB / ${(totalSize / 1024 / 1024).toFixed(1)}MB\r`);
+        }
+
+        // Check if we should interrupt
+        if (bytesSent >= interruptAt) {
+          console.log(`\n  🔴 Interrupting at ${(bytesSent / 1024 / 1024).toFixed(2)}MB`);
+
+          // Wait to ensure data is flushed to server
+          console.log('  Waiting for data to reach server...');
+          await sleep(200);
+
+          // Destroy the socket (simulating network failure)
+          socket.destroy();
+          console.log('  Socket destroyed');
+
+          await sleep(500);
+          resolve({ interrupted: true, bytesSent });
+          return;
+        }
+
+        // Small delay for realism
+        await sleep(1);
+      }
+
+      // Send footer
+      socket.write(multipart.footer);
+      socket.end();
+    });
+
+    socket.on('error', (err) => {
+      console.log(`  Socket error: ${err.message}`);
+    });
+
+    socket.on('data', (data) => {
+      const response = data.toString();
+      const statusMatch = response.match(/HTTP\/\d\.\d (\d+)/);
+      if (statusMatch) {
+        console.log(`  Response status: ${statusMatch[1]}`);
+      }
+    });
+
+    socket.on('close', () => {
+      resolve({ closed: true });
+    });
+  });
+}
+
+async function main() {
+  // Load the worker module
+  console.log('Loading worker module...');
+  const { createRequire } = await import('module');
+  const require = createRequire(import.meta.url);
+  const workerModule = require('../lib/worker.js');
+  const worker = workerModule.default;
+
+  // Create and start the server
+  console.log('Starting server...');
+  const app = worker({
+    serverBundleCachePath: TEST_DIR,
+    logHttpLevel: 'info',  // Enable logging to see what happens
+  });
+
+  await app.listen({ port: PORT, host: HOST });
+  console.log(`Server listening on http://${HOST}:${PORT}\n`);
+
+  // Test scenarios
+  const scenarios = [
+    { name: 'Interrupt at 50%', percent: 50 },
+    { name: 'Interrupt at 75%', percent: 75 },
+    { name: 'Interrupt at 90%', percent: 90 },
+  ];
+
+  const results = [];
+
+  for (const scenario of scenarios) {
+    console.log('─'.repeat(60));
+    console.log(`TEST: ${scenario.name}`);
+    console.log('─'.repeat(60));
+
+    const filesBefore = await listFilesRecursive(TEST_DIR);
+    const result = await sendInterruptedRequestRaw(scenario.percent);
+    await sleep(1000); // Wait for server to process
+
+    const filesAfter = await listFilesRecursive(TEST_DIR);
+    const newFiles = filesAfter.filter(f => !filesBefore.some(b => b.path === f.path));
+
+    let partialFound = false;
+    for (const file of newFiles) {
+      if (file.name.endsWith('.lock')) continue; // Skip lock files
+      const status = await isFileComplete(file.path);
+      const isPartial = status.hasStart && !status.hasMarker;
+      if (isPartial) {
+        partialFound = true;
+        console.log(`  🔴 PARTIAL FILE: ${file.name} (${(file.size / 1024 / 1024).toFixed(2)}MB)`);
+      } else if (status.hasMarker) {
+        console.log(`  ✅ Complete file: ${file.name}`);
+      }
+    }
+
+    if (newFiles.filter(f => !f.name.endsWith('.lock')).length === 0) {
+      console.log(`  ℹ️  No bundle files created`);
+    }
+
+    results.push({
+      scenario: scenario.name,
+      percent: scenario.percent,
+      partialFound,
+      newFiles: newFiles.filter(f => !f.name.endsWith('.lock')).length
+    });
+
+    console.log('');
+  }
+
+  // Summary
+  console.log('='.repeat(60));
+  console.log('SUMMARY');
+  console.log('='.repeat(60));
+  console.log('');
+  console.log('┌─────────────────────┬────────────┬─────────────┐');
+  console.log('│ Scenario            │ New Files  │ Partial?    │');
+  console.log('├─────────────────────┼────────────┼─────────────┤');
+  for (const r of results) {
+    const partial = r.partialFound ? '❌ YES' : '✅ NO';
+    console.log(`│ ${r.scenario.padEnd(19)} │ ${String(r.newFiles).padStart(10)} │ ${partial.padEnd(11)} │`);
+  }
+  console.log('└─────────────────────┴────────────┴─────────────┘');
+
+  const anyPartial = results.some(r => r.partialFound);
+  console.log('');
+  if (anyPartial) {
+    console.log('🔴 PARTIAL FILES DETECTED!');
+  } else if (results.some(r => r.newFiles > 0)) {
+    console.log('ℹ️  Files were created - check if they are complete.');
+  } else {
+    console.log('ℹ️  No files created - connection closed before data was saved.');
+  }
+
+  // Show test directory contents
+  console.log('');
+  console.log('Test directory contents:');
+  const allFiles = await listFilesRecursive(TEST_DIR);
+  if (allFiles.length === 0) {
+    console.log('  (empty)');
+  } else {
+    for (const f of allFiles) {
+      if (!f.name.endsWith('.lock')) {
+        console.log(`  ${f.path} (${(f.size / 1024 / 1024).toFixed(2)}MB)`);
+      }
+    }
+  }
+
+  // Cleanup
+  await app.close();
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-real-http.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-real-http.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Complete HTTP upload interruption test
+ * Starts server, sends interrupted request, checks for partial files
+ */
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import os from 'node:os';
+import fsp from 'node:fs/promises';
+
+const PORT = 3222;
+const HOST = '127.0.0.1';
+const BUNDLE_SIZE_MB = 10;
+const TEST_DIR = path.join(os.tmpdir(), `real-http-test-${Date.now()}`);
+
+console.log('='.repeat(60));
+console.log('REAL HTTP UPLOAD INTERRUPTION TEST');
+console.log('='.repeat(60));
+console.log(`Test directory: ${TEST_DIR}`);
+console.log('');
+
+// Generate a valid JS bundle
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Create multipart form body
+function createMultipartBody(bundleBuffer, bundleFilename) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+  const fields = [
+    { name: 'protocolVersion', value: '2.0.0' },
+    { name: 'gemVersion', value: '16.2.0-beta.20' },
+    { name: 'railsEnv', value: 'test' },
+    { name: 'renderingRequest', value: 'ReactOnRails.dummy()' },
+  ];
+
+  let body = '';
+  for (const field of fields) {
+    body += `--${boundary}\r\n`;
+    body += `Content-Disposition: form-data; name="${field.name}"\r\n\r\n`;
+    body += `${field.value}\r\n`;
+  }
+  body += `--${boundary}\r\n`;
+  body += `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n`;
+  body += `Content-Type: application/javascript\r\n\r\n`;
+
+  const header = Buffer.from(body, 'utf8');
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+  return { boundary, header, footer, bundle: bundleBuffer };
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function listFilesRecursive(dir) {
+  const files = [];
+  try {
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...await listFilesRecursive(fullPath));
+      } else {
+        const stats = await fsp.stat(fullPath);
+        files.push({ path: fullPath, name: entry.name, size: stats.size });
+      }
+    }
+  } catch (err) { /* ignore */ }
+  return files;
+}
+
+async function isFileComplete(filePath) {
+  try {
+    const content = await fsp.readFile(filePath, 'utf8');
+    return {
+      hasStart: content.includes('BUNDLE START'),
+      hasEnd: content.includes('BUNDLE END'),
+      hasMarker: content.includes('COMPLETE_MARKER'),
+      size: content.length
+    };
+  } catch {
+    return { error: true };
+  }
+}
+
+async function sendInterruptedRequest(interruptPercent) {
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+  const multipart = createMultipartBody(bundleBuffer, bundleFilename);
+  const totalSize = multipart.header.length + multipart.bundle.length + multipart.footer.length;
+  const interruptAt = Math.floor(totalSize * (interruptPercent / 100));
+
+  console.log(`  Bundle: ${bundleFilename}`);
+  console.log(`  Interrupt at: ${interruptPercent}% (${(interruptAt / 1024 / 1024).toFixed(2)}MB)`);
+
+  return new Promise((resolve) => {
+    const req = http.request({
+      hostname: HOST,
+      port: PORT,
+      path: `/bundles/${bundleTimestamp}/render/test-digest`,
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+        'Content-Length': totalSize,
+      },
+    }, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        console.log(`  Response: ${res.statusCode}`);
+        resolve({ statusCode: res.statusCode, body });
+      });
+    });
+
+    req.on('error', (err) => {
+      console.log(`  Request error: ${err.message}`);
+      resolve({ error: err.message });
+    });
+
+    // Send data
+    (async () => {
+      req.write(multipart.header);
+      await sleep(5);
+
+      const chunkSize = 256 * 1024;
+      let position = 0;
+      let bytesSent = multipart.header.length;
+
+      while (position < multipart.bundle.length) {
+        const chunk = multipart.bundle.slice(position, position + chunkSize);
+        position += chunk.length;
+        bytesSent += chunk.length;
+
+        if (bytesSent >= interruptAt) {
+          console.log(`  🔴 Interrupting connection...`);
+          await sleep(50); // Let data flush
+          req.destroy();
+          await sleep(200);
+          resolve({ interrupted: true });
+          return;
+        }
+
+        req.write(chunk);
+        await sleep(1);
+      }
+
+      req.write(multipart.footer);
+      req.end();
+    })();
+  });
+}
+
+async function main() {
+  // Load the worker module
+  console.log('Loading worker module...');
+  const { createRequire } = await import('module');
+  const require = createRequire(import.meta.url);
+  const workerModule = require('../lib/worker.js');
+  const worker = workerModule.default;
+
+  // Create and start the server
+  console.log('Starting server...');
+  const app = worker({
+    serverBundleCachePath: TEST_DIR,
+    logHttpLevel: 'silent',
+  });
+
+  await app.listen({ port: PORT, host: HOST });
+  console.log(`Server listening on http://${HOST}:${PORT}\n`);
+
+  // Test scenarios
+  const scenarios = [
+    { name: 'Interrupt at 25%', percent: 25 },
+    { name: 'Interrupt at 50%', percent: 50 },
+    { name: 'Interrupt at 75%', percent: 75 },
+  ];
+
+  const results = [];
+
+  for (const scenario of scenarios) {
+    console.log('─'.repeat(60));
+    console.log(`TEST: ${scenario.name}`);
+    console.log('─'.repeat(60));
+
+    const filesBefore = await listFilesRecursive(TEST_DIR);
+    const result = await sendInterruptedRequest(scenario.percent);
+    await sleep(500); // Wait for cleanup
+
+    const filesAfter = await listFilesRecursive(TEST_DIR);
+    const newFiles = filesAfter.filter(f => !filesBefore.some(b => b.path === f.path));
+
+    let partialFound = false;
+    for (const file of newFiles) {
+      const status = await isFileComplete(file.path);
+      const isPartial = status.hasStart && !status.hasMarker;
+      if (isPartial) {
+        partialFound = true;
+        console.log(`  🔴 PARTIAL FILE: ${file.name} (${(file.size / 1024 / 1024).toFixed(2)}MB)`);
+      }
+    }
+
+    if (newFiles.length === 0) {
+      console.log(`  ✅ No files created`);
+    }
+
+    results.push({
+      scenario: scenario.name,
+      percent: scenario.percent,
+      interrupted: result.interrupted,
+      statusCode: result.statusCode,
+      partialFound,
+      newFiles: newFiles.length
+    });
+
+    console.log('');
+  }
+
+  // Summary
+  console.log('='.repeat(60));
+  console.log('SUMMARY');
+  console.log('='.repeat(60));
+  console.log('');
+  console.log('┌─────────────────────┬────────────┬─────────────┐');
+  console.log('│ Scenario            │ New Files  │ Partial?    │');
+  console.log('├─────────────────────┼────────────┼─────────────┤');
+  for (const r of results) {
+    const partial = r.partialFound ? '❌ YES' : '✅ NO';
+    console.log(`│ ${r.scenario.padEnd(19)} │ ${String(r.newFiles).padStart(10)} │ ${partial.padEnd(11)} │`);
+  }
+  console.log('└─────────────────────┴────────────┴─────────────┘');
+
+  const anyPartial = results.some(r => r.partialFound);
+  console.log('');
+  if (anyPartial) {
+    console.log('🔴 PARTIAL FILES DETECTED!');
+    console.log('Upload interruption leaves corrupted files on disk.');
+  } else {
+    console.log('✅ No partial files - upload interruption handled correctly.');
+  }
+
+  // Show test directory contents
+  console.log('');
+  console.log('Test directory contents:');
+  const allFiles = await listFilesRecursive(TEST_DIR);
+  for (const f of allFiles) {
+    console.log(`  ${f.path} (${(f.size / 1024 / 1024).toFixed(2)}MB)`);
+  }
+
+  // Cleanup
+  await app.close();
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-server.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-server.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Start the node renderer server for testing
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `upload-test-server-${Date.now()}`);
+
+// Import the worker module (CommonJS)
+console.log('Loading worker module...');
+const { createRequire } = await import('module');
+const require = createRequire(import.meta.url);
+const workerModule = require('../lib/worker.js');
+const worker = workerModule.default;
+
+// Create the Fastify app
+console.log('Creating Fastify app...');
+console.log(`Test directory: ${TEST_DIR}`);
+
+const app = worker({
+  serverBundleCachePath: TEST_DIR,
+  logHttpLevel: 'info',
+});
+
+// Start listening
+const PORT = 3222;
+await app.listen({ port: PORT, host: '127.0.0.1' });
+console.log(`\n✅ Server listening on http://127.0.0.1:${PORT}`);
+console.log(`\nTest directory: ${TEST_DIR}`);
+console.log('\nPress Ctrl+C to stop the server\n');

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-timing.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-timing.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Test to prove the timing of file save vs move operations
+ *
+ * Question: Can the bundle get moved BEFORE the file is fully uploaded?
+ *
+ * This test traces the exact sequence of operations.
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+import fsp from 'node:fs/promises';
+import { Readable, PassThrough } from 'node:stream';
+import crypto from 'node:crypto';
+
+const TEST_DIR = path.join(os.tmpdir(), `timing-test-${Date.now()}`);
+const BUNDLE_SIZE_MB = 5;
+
+console.log('='.repeat(70));
+console.log('TIMING TEST: When does the bundle get moved?');
+console.log('='.repeat(70));
+console.log(`Test directory: ${TEST_DIR}\n`);
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+function createSlowInterruptingStream(buffer, interruptAtPercent, chunkDelayMs = 10) {
+  const interruptAt = Math.floor(buffer.length * (interruptAtPercent / 100));
+  let position = 0;
+  let chunkCount = 0;
+
+  const stream = new Readable({
+    async read(size) {
+      if (position >= buffer.length) {
+        console.log(`  [${new Date().toISOString()}] Stream: push(null) - END OF STREAM`);
+        this.push(null);
+        return;
+      }
+
+      const chunkSize = Math.min(size || 16384, buffer.length - position);
+      const chunk = buffer.slice(position, position + chunkSize);
+      position += chunkSize;
+      chunkCount++;
+
+      // Check if we should interrupt
+      if (position >= interruptAt) {
+        console.log(`  [${new Date().toISOString()}] Stream: INTERRUPTING at ${position} bytes (${((position / buffer.length) * 100).toFixed(1)}%)`);
+        console.log(`  [${new Date().toISOString()}] Stream: push(null) - PREMATURE END`);
+
+        // End stream prematurely but cleanly
+        setTimeout(() => {
+          this.push(null);
+        }, 10);
+        return;
+      }
+
+      // Log every 50 chunks
+      if (chunkCount % 50 === 0) {
+        console.log(`  [${new Date().toISOString()}] Stream: sent ${(position / 1024 / 1024).toFixed(2)}MB`);
+      }
+
+      this.push(chunk);
+
+      // Small delay to simulate network
+      await new Promise(r => setTimeout(r, chunkDelayMs));
+    }
+  });
+
+  stream.on('error', () => {});
+  return stream;
+}
+
+function createMultipartPayload(bundleStream, bundleFilename) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const headerPart =
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="protocolVersion"\r\n\r\n2.0.0\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="gemVersion"\r\n\r\n16.2.0-beta.20\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="railsEnv"\r\n\r\ntest\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="renderingRequest"\r\n\r\nReactOnRails.dummy()\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n` +
+    `Content-Type: application/javascript\r\n\r\n`;
+
+  const footerPart = `\r\n--${boundary}--\r\n`;
+  const combinedStream = new PassThrough();
+
+  combinedStream.write(Buffer.from(headerPart, 'utf8'));
+
+  bundleStream.on('data', (chunk) => combinedStream.write(chunk));
+  bundleStream.on('end', () => {
+    combinedStream.write(Buffer.from(footerPart, 'utf8'));
+    combinedStream.end();
+  });
+  bundleStream.on('error', (err) => combinedStream.destroy(err));
+
+  return {
+    boundary,
+    stream: combinedStream,
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
+
+async function fileExists(filePath) {
+  try {
+    await fsp.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getFileSize(filePath) {
+  try {
+    const stats = await fsp.stat(filePath);
+    return stats.size;
+  } catch {
+    return -1;
+  }
+}
+
+async function main() {
+  await fsp.mkdir(path.join(TEST_DIR, 'uploads'), { recursive: true });
+
+  // Load the worker module
+  console.log('Loading worker module...');
+  const { createRequire } = await import('module');
+  const require = createRequire(import.meta.url);
+  const workerModule = require('../lib/worker.js');
+  const worker = workerModule.default;
+  const disableHttp2 = workerModule.disableHttp2;
+
+  disableHttp2();
+
+  // Patch the worker to add timing logs
+  const originalWorker = worker;
+
+  console.log('Creating Fastify app with timing instrumentation...\n');
+  const app = originalWorker({
+    serverBundleCachePath: TEST_DIR,
+    logHttpLevel: 'silent',
+  });
+
+  await app.ready();
+
+  // Test with 50% interruption
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+
+  const uploadPath = path.join(TEST_DIR, 'uploads', bundleFilename);
+  const bundlePath = path.join(TEST_DIR, String(bundleTimestamp), `${bundleTimestamp}.js`);
+
+  console.log('─'.repeat(70));
+  console.log('TEST: Interrupt upload at 50%');
+  console.log('─'.repeat(70));
+  console.log(`Bundle size: ${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB`);
+  console.log(`Upload path: ${uploadPath}`);
+  console.log(`Final bundle path: ${bundlePath}`);
+  console.log('');
+
+  // Start monitoring file existence in background
+  let monitoring = true;
+  const monitorFiles = async () => {
+    while (monitoring) {
+      const uploadExists = await fileExists(uploadPath);
+      const bundleExists = await fileExists(bundlePath);
+      const uploadSize = await getFileSize(uploadPath);
+      const bundleSize = await getFileSize(bundlePath);
+
+      if (uploadExists || bundleExists) {
+        console.log(`  [${new Date().toISOString()}] FILES: upload=${uploadExists ? `${(uploadSize/1024/1024).toFixed(2)}MB` : 'NO'}, bundle=${bundleExists ? `${(bundleSize/1024/1024).toFixed(2)}MB` : 'NO'}`);
+      }
+
+      await new Promise(r => setTimeout(r, 100));
+    }
+  };
+
+  const monitorPromise = monitorFiles();
+
+  // Create the request
+  console.log(`[${new Date().toISOString()}] Starting request...`);
+
+  const bundleStream = createSlowInterruptingStream(bundleBuffer, 50, 5);
+  const multipart = createMultipartPayload(bundleStream, bundleFilename);
+
+  try {
+    const response = await app.inject({
+      method: 'POST',
+      url: `/bundles/${bundleTimestamp}/render/test-digest`,
+      headers: { 'content-type': multipart.contentType },
+      payload: multipart.stream,
+    });
+
+    console.log(`\n[${new Date().toISOString()}] Response received: ${response.statusCode}`);
+  } catch (err) {
+    console.log(`\n[${new Date().toISOString()}] Request error: ${err.message}`);
+  }
+
+  // Stop monitoring
+  monitoring = false;
+  await new Promise(r => setTimeout(r, 200));
+
+  // Final check
+  console.log('\n' + '─'.repeat(70));
+  console.log('FINAL STATE:');
+  console.log('─'.repeat(70));
+
+  const finalUploadExists = await fileExists(uploadPath);
+  const finalBundleExists = await fileExists(bundlePath);
+  const finalUploadSize = await getFileSize(uploadPath);
+  const finalBundleSize = await getFileSize(bundlePath);
+
+  console.log(`Upload file: ${finalUploadExists ? `EXISTS (${(finalUploadSize/1024/1024).toFixed(2)}MB)` : 'DOES NOT EXIST'}`);
+  console.log(`Bundle file: ${finalBundleExists ? `EXISTS (${(finalBundleSize/1024/1024).toFixed(2)}MB)` : 'DOES NOT EXIST'}`);
+
+  if (finalBundleExists) {
+    const content = await fsp.readFile(bundlePath, 'utf8');
+    const isComplete = content.includes('COMPLETE_MARKER');
+    console.log(`Bundle complete: ${isComplete ? 'YES ✅' : 'NO ❌ (PARTIAL FILE!)'}`);
+
+    if (!isComplete) {
+      console.log(`\n🔴 VULNERABILITY CONFIRMED:`);
+      console.log(`   The partial file was moved to the bundle directory!`);
+      console.log(`   Expected size: ${(bundleBuffer.length/1024/1024).toFixed(2)}MB`);
+      console.log(`   Actual size: ${(finalBundleSize/1024/1024).toFixed(2)}MB`);
+      console.log(`   Missing: ${((bundleBuffer.length - finalBundleSize)/1024/1024).toFixed(2)}MB`);
+    }
+  }
+
+  // Cleanup
+  await app.close();
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-truncated-upload.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-truncated-upload.mjs
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+/**
+ * Test script to reproduce truncated bundle upload issue.
+ *
+ * This script:
+ * 1. Creates a valid JavaScript bundle
+ * 2. Starts uploading it to the Node renderer
+ * 3. Aborts mid-upload to simulate network failure
+ * 4. Checks if a partial file was written to disk
+ * 5. Optionally tests if the renderer would try to use the truncated file
+ *
+ * Usage:
+ *   node scripts/test-truncated-upload.mjs [options]
+ *
+ * Options:
+ *   --renderer-url    URL of the Node renderer (default: http://localhost:3800)
+ *   --bundle-size     Size of test bundle in KB (default: 1000)
+ *   --abort-at        Percentage of upload to abort at (default: 50)
+ *   --cache-path      Path to serverBundleCachePath (default: /tmp/react-on-rails-pro)
+ *   --password        Renderer password (default: none)
+ *   --check-only      Only check for existing truncated files, don't upload
+ */
+
+import http2 from 'node:http2';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { Readable } from 'node:stream';
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+const getArg = (name, defaultValue) => {
+  const index = args.indexOf(`--${name}`);
+  return index !== -1 && args[index + 1] ? args[index + 1] : defaultValue;
+};
+
+const CONFIG = {
+  rendererUrl: getArg('renderer-url', 'http://localhost:3800'),
+  bundleSizeKB: parseInt(getArg('bundle-size', '1000'), 10),
+  abortAtPercent: parseInt(getArg('abort-at', '50'), 10),
+  cachePath: getArg('cache-path', '/tmp/react-on-rails-pro'),
+  password: getArg('password', ''),
+  checkOnly: args.includes('--check-only'),
+};
+
+console.log('='.repeat(60));
+console.log('Truncated Upload Reproduction Test');
+console.log('='.repeat(60));
+console.log('Configuration:');
+console.log(`  Renderer URL: ${CONFIG.rendererUrl}`);
+console.log(`  Bundle Size: ${CONFIG.bundleSizeKB} KB`);
+console.log(`  Abort At: ${CONFIG.abortAtPercent}%`);
+console.log(`  Cache Path: ${CONFIG.cachePath}`);
+console.log(`  Password: ${CONFIG.password ? '***' : '(none)'}`);
+console.log('');
+
+/**
+ * Generate a valid JavaScript bundle of specified size.
+ * The bundle will have valid syntax so we can verify truncation causes syntax errors.
+ */
+function generateTestBundle(sizeKB) {
+  const targetSize = sizeKB * 1024;
+
+  // Create a bundle with recognizable structure
+  let bundle = `
+// ==== START OF TEST BUNDLE ====
+// Generated at: ${new Date().toISOString()}
+// Target size: ${sizeKB} KB
+
+(function() {
+  'use strict';
+
+  // Component registry
+  var components = {};
+
+  // Register a test component
+  components['TestComponent'] = function(props) {
+    return {
+      type: 'div',
+      props: {
+        className: 'test-component',
+        children: [
+`;
+
+  // Add content to reach target size
+  // Use valid JS that will break if truncated mid-way
+  let contentCount = 0;
+  while (bundle.length < targetSize - 500) {
+    contentCount++;
+    bundle += `          { type: 'span', props: { key: ${contentCount}, children: 'Item ${contentCount}: ${'x'.repeat(100)}' } },\n`;
+  }
+
+  // Close the bundle properly
+  bundle += `
+        ]
+      }
+    };
+  };
+
+  // Export
+  if (typeof window !== 'undefined') {
+    window.TestComponents = components;
+  }
+  if (typeof global !== 'undefined') {
+    global.TestComponents = components;
+  }
+
+  console.log('Test bundle loaded successfully with ' + Object.keys(components).length + ' components');
+})();
+
+// ==== END OF TEST BUNDLE ====
+// Total items: ${contentCount}
+// Bundle hash: ${crypto.randomBytes(16).toString('hex')}
+`;
+
+  return bundle;
+}
+
+/**
+ * Create a readable stream that aborts after sending a percentage of data.
+ */
+function createAbortingStream(data, abortAtPercent) {
+  const buffer = Buffer.from(data);
+  const abortAt = Math.floor(buffer.length * (abortAtPercent / 100));
+  let position = 0;
+  const chunkSize = 1024; // 1KB chunks
+
+  console.log(`  Total size: ${buffer.length} bytes`);
+  console.log(`  Will abort at: ${abortAt} bytes (${abortAtPercent}%)`);
+
+  return new Readable({
+    read() {
+      if (position >= abortAt) {
+        console.log(`  [${new Date().toISOString()}] Aborting stream at position ${position}!`);
+        // Simulate abrupt connection close - destroy without ending properly
+        this.destroy(new Error('Simulated network failure'));
+        return;
+      }
+
+      const end = Math.min(position + chunkSize, abortAt);
+      const chunk = buffer.slice(position, end);
+      position = end;
+
+      if (position % (100 * 1024) === 0 || position === end) {
+        console.log(`  [${new Date().toISOString()}] Sent ${position} bytes (${Math.round(position / buffer.length * 100)}%)`);
+      }
+
+      this.push(chunk);
+    }
+  });
+}
+
+/**
+ * Build multipart form data manually.
+ */
+function buildMultipartFormData(bundleContent, bundleHash, password) {
+  const boundary = `----FormBoundary${crypto.randomBytes(16).toString('hex')}`;
+  const CRLF = '\r\n';
+
+  let formParts = [];
+
+  // Add protocol version
+  formParts.push(
+    `--${boundary}${CRLF}`,
+    `Content-Disposition: form-data; name="protocolVersion"${CRLF}${CRLF}`,
+    `2.0.0${CRLF}`
+  );
+
+  // Add gem version
+  formParts.push(
+    `--${boundary}${CRLF}`,
+    `Content-Disposition: form-data; name="gemVersion"${CRLF}${CRLF}`,
+    `1.0.0${CRLF}`
+  );
+
+  // Add password if provided
+  if (password) {
+    formParts.push(
+      `--${boundary}${CRLF}`,
+      `Content-Disposition: form-data; name="password"${CRLF}${CRLF}`,
+      `${password}${CRLF}`
+    );
+  }
+
+  // Add rendering request (minimal)
+  const renderingRequest = `ReactOnRails.serverRenderReactComponent({})`;
+  formParts.push(
+    `--${boundary}${CRLF}`,
+    `Content-Disposition: form-data; name="renderingRequest"${CRLF}${CRLF}`,
+    `${renderingRequest}${CRLF}`
+  );
+
+  // Add bundle file header
+  formParts.push(
+    `--${boundary}${CRLF}`,
+    `Content-Disposition: form-data; name="bundle_${bundleHash}"; filename="${bundleHash}.js"${CRLF}`,
+    `Content-Type: text/javascript${CRLF}${CRLF}`
+  );
+
+  const header = formParts.join('');
+  const footer = `${CRLF}--${boundary}--${CRLF}`;
+
+  return { header, footer, boundary, bundleContent };
+}
+
+/**
+ * Check for truncated files in the cache directory.
+ */
+function checkForTruncatedFiles() {
+  console.log('\n📁 Checking for files in cache directory...');
+
+  const uploadsDir = path.join(CONFIG.cachePath, 'uploads');
+  const bundlesDir = CONFIG.cachePath;
+
+  const checkDir = (dir, label) => {
+    console.log(`\n  ${label}: ${dir}`);
+    if (!fs.existsSync(dir)) {
+      console.log('    Directory does not exist');
+      return [];
+    }
+
+    const files = [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name.endsWith('.js')) {
+        const stats = fs.statSync(fullPath);
+        const content = fs.readFileSync(fullPath, 'utf8');
+
+        // Check for truncation indicators
+        const hasStart = content.includes('START OF TEST BUNDLE');
+        const hasEnd = content.includes('END OF TEST BUNDLE');
+        const isTruncated = hasStart && !hasEnd;
+
+        files.push({
+          path: fullPath,
+          name: entry.name,
+          size: stats.size,
+          hasStart,
+          hasEnd,
+          isTruncated,
+          lastModified: stats.mtime
+        });
+
+        console.log(`    📄 ${entry.name}`);
+        console.log(`       Size: ${stats.size} bytes`);
+        console.log(`       Has start marker: ${hasStart}`);
+        console.log(`       Has end marker: ${hasEnd}`);
+        console.log(`       TRUNCATED: ${isTruncated ? '⚠️  YES!' : '✅ No'}`);
+
+        if (isTruncated) {
+          // Try to parse it to show the syntax error
+          console.log('       Attempting to parse...');
+          try {
+            new Function(content);
+            console.log('       Parse result: ✅ Valid (unexpected!)');
+          } catch (e) {
+            console.log(`       Parse result: ❌ ${e.message}`);
+          }
+        }
+      } else if (entry.isDirectory() && entry.name.match(/^[a-f0-9]/)) {
+        // Check bundle subdirectories
+        const subFiles = checkDir(fullPath, `Bundle dir: ${entry.name}`);
+        files.push(...subFiles);
+      }
+    }
+
+    return files;
+  };
+
+  const allFiles = [];
+  allFiles.push(...checkDir(uploadsDir, 'Uploads directory'));
+  allFiles.push(...checkDir(bundlesDir, 'Bundles directory'));
+
+  const truncatedFiles = allFiles.filter(f => f.isTruncated);
+
+  console.log('\n' + '='.repeat(60));
+  console.log(`Summary: Found ${truncatedFiles.length} truncated file(s) out of ${allFiles.length} total`);
+
+  return truncatedFiles;
+}
+
+/**
+ * Perform the truncated upload test.
+ */
+async function performTruncatedUpload() {
+  console.log('\n🚀 Starting truncated upload test...\n');
+
+  // Generate test bundle
+  console.log('1. Generating test bundle...');
+  const bundleContent = generateTestBundle(CONFIG.bundleSizeKB);
+  const bundleHash = crypto.createHash('md5').update(bundleContent).digest('hex');
+  console.log(`   Bundle hash: ${bundleHash}`);
+  console.log(`   Bundle size: ${bundleContent.length} bytes`);
+
+  // Build form data
+  console.log('\n2. Building multipart form data...');
+  const { header, footer, boundary } = buildMultipartFormData(
+    bundleContent,
+    bundleHash,
+    CONFIG.password
+  );
+
+  const totalSize = header.length + bundleContent.length + footer.length;
+  console.log(`   Total form size: ${totalSize} bytes`);
+  console.log(`   Boundary: ${boundary}`);
+
+  // Parse renderer URL
+  const url = new URL(CONFIG.rendererUrl);
+  const isHttps = url.protocol === 'https:';
+
+  console.log('\n3. Connecting to renderer...');
+  console.log(`   URL: ${CONFIG.rendererUrl}/bundles/${bundleHash}/render/test-digest`);
+
+  return new Promise((resolve, reject) => {
+    const client = http2.connect(CONFIG.rendererUrl, {
+      // Allow self-signed certs for local testing
+      rejectUnauthorized: false
+    });
+
+    client.on('error', (err) => {
+      console.log(`   Connection error: ${err.message}`);
+      // This is expected when we abort
+    });
+
+    client.on('connect', () => {
+      console.log('   Connected!');
+    });
+
+    const req = client.request({
+      ':method': 'POST',
+      ':path': `/bundles/${bundleHash}/render/test-digest`,
+      'content-type': `multipart/form-data; boundary=${boundary}`,
+      'content-length': totalSize.toString()
+    });
+
+    let responseData = '';
+
+    req.on('response', (headers) => {
+      console.log(`\n4. Response received:`);
+      console.log(`   Status: ${headers[':status']}`);
+    });
+
+    req.on('data', (chunk) => {
+      responseData += chunk.toString();
+    });
+
+    req.on('end', () => {
+      console.log(`   Response body: ${responseData.substring(0, 200)}...`);
+      client.close();
+      resolve(responseData);
+    });
+
+    req.on('error', (err) => {
+      console.log(`   Request error (expected): ${err.message}`);
+      client.close();
+      // Don't reject - this is expected behavior
+      resolve(null);
+    });
+
+    // Send the header
+    console.log('\n4. Sending form data (will abort mid-stream)...');
+    req.write(header);
+
+    // Create aborting stream for bundle content
+    const abortingStream = createAbortingStream(bundleContent, CONFIG.abortAtPercent);
+
+    abortingStream.on('data', (chunk) => {
+      req.write(chunk);
+    });
+
+    abortingStream.on('error', (err) => {
+      console.log(`\n5. Stream aborted: ${err.message}`);
+      // Destroy the request without sending footer
+      req.destroy();
+      client.close();
+
+      // Give the server a moment to write the partial file
+      setTimeout(() => {
+        resolve(null);
+      }, 1000);
+    });
+
+    abortingStream.on('end', () => {
+      // This shouldn't happen in our test
+      req.write(footer);
+      req.end();
+    });
+  });
+}
+
+/**
+ * Alternative test: Use fetch with AbortController (simpler but may not work with HTTP/2)
+ */
+async function performTruncatedUploadFetch() {
+  console.log('\n🚀 Starting truncated upload test (using fetch)...\n');
+
+  // Generate test bundle
+  console.log('1. Generating test bundle...');
+  const bundleContent = generateTestBundle(CONFIG.bundleSizeKB);
+  const bundleHash = crypto.createHash('md5').update(bundleContent).digest('hex');
+  console.log(`   Bundle hash: ${bundleHash}`);
+  console.log(`   Bundle size: ${bundleContent.length} bytes`);
+
+  const abortController = new AbortController();
+  const abortAt = Math.floor(bundleContent.length * (CONFIG.abortAtPercent / 100));
+
+  // Create a custom ReadableStream that aborts
+  let bytesSent = 0;
+  const stream = new ReadableStream({
+    start(controller) {
+      const boundary = `----FormBoundary${crypto.randomBytes(16).toString('hex')}`;
+      const CRLF = '\r\n';
+
+      // Build header
+      let header = '';
+      header += `--${boundary}${CRLF}`;
+      header += `Content-Disposition: form-data; name="protocolVersion"${CRLF}${CRLF}`;
+      header += `2.0.0${CRLF}`;
+      header += `--${boundary}${CRLF}`;
+      header += `Content-Disposition: form-data; name="gemVersion"${CRLF}${CRLF}`;
+      header += `1.0.0${CRLF}`;
+      header += `--${boundary}${CRLF}`;
+      header += `Content-Disposition: form-data; name="renderingRequest"${CRLF}${CRLF}`;
+      header += `test${CRLF}`;
+      header += `--${boundary}${CRLF}`;
+      header += `Content-Disposition: form-data; name="bundle_${bundleHash}"; filename="${bundleHash}.js"${CRLF}`;
+      header += `Content-Type: text/javascript${CRLF}${CRLF}`;
+
+      controller.enqueue(new TextEncoder().encode(header));
+
+      // Stream bundle content in chunks
+      const chunkSize = 1024;
+      let position = 0;
+
+      const sendNextChunk = () => {
+        if (position >= bundleContent.length) {
+          const footer = `${CRLF}--${boundary}--${CRLF}`;
+          controller.enqueue(new TextEncoder().encode(footer));
+          controller.close();
+          return;
+        }
+
+        if (bytesSent >= abortAt) {
+          console.log(`\n   Aborting at ${bytesSent} bytes!`);
+          abortController.abort();
+          controller.error(new Error('Simulated abort'));
+          return;
+        }
+
+        const end = Math.min(position + chunkSize, bundleContent.length);
+        const chunk = bundleContent.slice(position, end);
+        controller.enqueue(new TextEncoder().encode(chunk));
+        bytesSent += chunk.length;
+        position = end;
+
+        if (bytesSent % (100 * 1024) < chunkSize) {
+          console.log(`   Sent ${bytesSent} bytes...`);
+        }
+
+        // Small delay to make abortion more realistic
+        setTimeout(sendNextChunk, 1);
+      };
+
+      sendNextChunk();
+    }
+  });
+
+  try {
+    const response = await fetch(
+      `${CONFIG.rendererUrl}/bundles/${bundleHash}/render/test-digest`,
+      {
+        method: 'POST',
+        body: stream,
+        signal: abortController.signal,
+        duplex: 'half', // Required for streaming body
+        headers: {
+          'Content-Type': 'multipart/form-data; boundary=----FormBoundary' + crypto.randomBytes(16).toString('hex')
+        }
+      }
+    );
+    console.log(`   Response status: ${response.status}`);
+  } catch (err) {
+    console.log(`   Request aborted (expected): ${err.message}`);
+  }
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  try {
+    if (CONFIG.checkOnly) {
+      checkForTruncatedFiles();
+      return;
+    }
+
+    // Perform the upload test
+    await performTruncatedUpload();
+
+    // Wait a moment for file system operations
+    console.log('\n⏳ Waiting for file system to settle...');
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Check for truncated files
+    const truncatedFiles = checkForTruncatedFiles();
+
+    console.log('\n' + '='.repeat(60));
+    if (truncatedFiles.length > 0) {
+      console.log('🔴 VULNERABILITY CONFIRMED!');
+      console.log('   Truncated files were written to disk without validation.');
+      console.log('   These files would cause syntax errors if loaded into the VM.');
+    } else {
+      console.log('🟢 No truncated files found.');
+      console.log('   Either:');
+      console.log('   1. The upload was rejected before any file was written');
+      console.log('   2. The truncation check is working (check for recent changes)');
+      console.log('   3. The cache path is incorrect');
+    }
+    console.log('='.repeat(60));
+
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-truncation-detection.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-truncation-detection.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+/**
+ * Unit test to verify truncation detection in saveMultipartFile.
+ *
+ * This script simulates what happens when a multipart file stream
+ * ends prematurely, similar to a network interruption.
+ *
+ * It tests:
+ * 1. Current behavior (no truncation check) - should FAIL to detect
+ * 2. Fixed behavior (with truncation check) - should DETECT and throw
+ *
+ * Usage:
+ *   node scripts/test-truncation-detection.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+console.log('='.repeat(60));
+console.log('Truncation Detection Test');
+console.log('='.repeat(60));
+
+const TEST_DIR = path.join(os.tmpdir(), 'truncation-test-' + Date.now());
+fs.mkdirSync(TEST_DIR, { recursive: true });
+console.log(`Test directory: ${TEST_DIR}\n`);
+
+/**
+ * Create a mock MultipartFile that simulates truncation.
+ * This mimics what @fastify/multipart provides.
+ */
+function createMockMultipartFile(fullContent, truncateAt) {
+  const buffer = Buffer.from(fullContent);
+  const truncatedBuffer = buffer.slice(0, truncateAt);
+
+  let position = 0;
+  const chunkSize = 1024;
+
+  // Create a readable stream that ends after truncateAt bytes
+  const file = new Readable({
+    read() {
+      if (position >= truncatedBuffer.length) {
+        this.push(null); // End stream (simulating abrupt end)
+        return;
+      }
+
+      const end = Math.min(position + chunkSize, truncatedBuffer.length);
+      this.push(truncatedBuffer.slice(position, end));
+      position = end;
+    }
+  });
+
+  // This is the key property that Fastify sets!
+  // When stream ends before all data is received, this is set to true
+  file.truncated = true;
+
+  return {
+    file,
+    filename: 'test-bundle.js',
+    fieldname: 'bundle',
+    mimetype: 'text/javascript',
+    encoding: '7bit',
+    // The full content that SHOULD have been sent
+    _expectedSize: buffer.length,
+    _actualSize: truncatedBuffer.length
+  };
+}
+
+/**
+ * Current implementation (vulnerable) - from utils.ts
+ */
+async function saveMultipartFile_CURRENT(multipartFile, destinationPath) {
+  // Simulating: await ensureDir(path.dirname(destinationPath));
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+  // Current implementation: just pump and return
+  const writeStream = fs.createWriteStream(destinationPath);
+  await pipeline(multipartFile.file, writeStream);
+
+  // ❌ NO CHECK for multipartFile.file.truncated!
+  return { checked: false };
+}
+
+/**
+ * Fixed implementation - with truncation check
+ */
+async function saveMultipartFile_FIXED(multipartFile, destinationPath) {
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+  const writeStream = fs.createWriteStream(destinationPath);
+  await pipeline(multipartFile.file, writeStream);
+
+  // ✅ CHECK for truncation!
+  if (multipartFile.file.truncated) {
+    // Clean up the partial file
+    fs.unlinkSync(destinationPath);
+    throw new Error(`Upload truncated: file stream ended prematurely`);
+  }
+
+  return { checked: true, truncated: false };
+}
+
+/**
+ * Generate valid JS content
+ */
+function generateValidJS(sizeKB) {
+  let content = '// START OF BUNDLE\n(function() {\n';
+  const line = '  console.log("' + 'x'.repeat(100) + '");\n';
+
+  while (content.length < sizeKB * 1024 - 100) {
+    content += line;
+  }
+
+  content += '})();\n// END OF BUNDLE\n';
+  return content;
+}
+
+/**
+ * Test 1: Verify current implementation does NOT detect truncation
+ */
+async function testCurrentImplementation() {
+  console.log('Test 1: Current Implementation (No Truncation Check)');
+  console.log('-'.repeat(50));
+
+  const fullContent = generateValidJS(100); // 100KB bundle
+  const truncateAt = Math.floor(fullContent.length * 0.5); // Truncate at 50%
+
+  console.log(`  Full content size: ${fullContent.length} bytes`);
+  console.log(`  Truncating at: ${truncateAt} bytes (50%)`);
+
+  const mockFile = createMockMultipartFile(fullContent, truncateAt);
+  const destPath = path.join(TEST_DIR, 'current-impl.js');
+
+  try {
+    await saveMultipartFile_CURRENT(mockFile, destPath);
+
+    // Check what was written
+    const written = fs.readFileSync(destPath, 'utf8');
+    const stats = fs.statSync(destPath);
+
+    console.log(`\n  Result:`);
+    console.log(`    File written: ✅ Yes`);
+    console.log(`    File size: ${stats.size} bytes`);
+    console.log(`    Expected size: ${fullContent.length} bytes`);
+    console.log(`    Truncation detected: ❌ NO!`);
+    console.log(`    file.truncated flag: ${mockFile.file.truncated}`);
+
+    // Try to parse the truncated JS
+    console.log(`\n  Parsing truncated JS...`);
+    try {
+      new Function(written);
+      console.log(`    Parse result: ✅ Valid (unexpected!)`);
+    } catch (e) {
+      console.log(`    Parse result: ❌ ${e.message}`);
+    }
+
+    console.log(`\n  ⚠️  VULNERABILITY CONFIRMED!`);
+    console.log(`     Truncated file was saved without any warning.`);
+    console.log(`     This file would cause syntax errors when loaded.\n`);
+
+    return { vulnerable: true, filePath: destPath };
+
+  } catch (error) {
+    console.log(`  Error (unexpected): ${error.message}`);
+    return { vulnerable: false, error };
+  }
+}
+
+/**
+ * Test 2: Verify fixed implementation DOES detect truncation
+ */
+async function testFixedImplementation() {
+  console.log('Test 2: Fixed Implementation (With Truncation Check)');
+  console.log('-'.repeat(50));
+
+  const fullContent = generateValidJS(100);
+  const truncateAt = Math.floor(fullContent.length * 0.5);
+
+  console.log(`  Full content size: ${fullContent.length} bytes`);
+  console.log(`  Truncating at: ${truncateAt} bytes (50%)`);
+
+  const mockFile = createMockMultipartFile(fullContent, truncateAt);
+  const destPath = path.join(TEST_DIR, 'fixed-impl.js');
+
+  try {
+    await saveMultipartFile_FIXED(mockFile, destPath);
+
+    console.log(`\n  Result:`);
+    console.log(`    File written: ✅ Yes (unexpected!)`);
+    console.log(`    Truncation detected: ❌ NO!`);
+    console.log(`\n  ❌ FIX NOT WORKING!\n`);
+
+    return { fixed: false };
+
+  } catch (error) {
+    console.log(`\n  Result:`);
+    console.log(`    Error thrown: ✅ Yes`);
+    console.log(`    Error message: "${error.message}"`);
+
+    // Verify file was cleaned up
+    const fileExists = fs.existsSync(destPath);
+    console.log(`    Partial file cleaned up: ${fileExists ? '❌ No' : '✅ Yes'}`);
+
+    console.log(`\n  ✅ FIX WORKING!`);
+    console.log(`     Truncation was detected and partial file was cleaned up.\n`);
+
+    return { fixed: true, error: error.message };
+  }
+}
+
+/**
+ * Test 3: Verify non-truncated upload works correctly
+ */
+async function testNonTruncatedUpload() {
+  console.log('Test 3: Non-Truncated Upload (Control Test)');
+  console.log('-'.repeat(50));
+
+  const fullContent = generateValidJS(10); // Small 10KB bundle
+
+  // Create a mock file that is NOT truncated
+  let position = 0;
+  const buffer = Buffer.from(fullContent);
+  const chunkSize = 1024;
+
+  const file = new Readable({
+    read() {
+      if (position >= buffer.length) {
+        this.push(null);
+        return;
+      }
+      const end = Math.min(position + chunkSize, buffer.length);
+      this.push(buffer.slice(position, end));
+      position = end;
+    }
+  });
+
+  file.truncated = false; // NOT truncated
+
+  const mockFile = {
+    file,
+    filename: 'complete-bundle.js'
+  };
+
+  const destPath = path.join(TEST_DIR, 'complete.js');
+
+  try {
+    await saveMultipartFile_FIXED(mockFile, destPath);
+
+    const written = fs.readFileSync(destPath, 'utf8');
+    const isComplete = written === fullContent;
+
+    console.log(`  Full content size: ${fullContent.length} bytes`);
+    console.log(`  Written size: ${written.length} bytes`);
+    console.log(`  Content matches: ${isComplete ? '✅ Yes' : '❌ No'}`);
+    console.log(`  file.truncated: ${mockFile.file.truncated}`);
+
+    // Parse to verify it's valid
+    try {
+      new Function(written);
+      console.log(`  Parse result: ✅ Valid`);
+    } catch (e) {
+      console.log(`  Parse result: ❌ ${e.message}`);
+    }
+
+    console.log(`\n  ✅ Non-truncated upload handled correctly.\n`);
+    return { success: true };
+
+  } catch (error) {
+    console.log(`  Unexpected error: ${error.message}`);
+    return { success: false, error };
+  }
+}
+
+/**
+ * Main execution
+ */
+async function main() {
+  const results = {};
+
+  results.current = await testCurrentImplementation();
+  results.fixed = await testFixedImplementation();
+  results.control = await testNonTruncatedUpload();
+
+  console.log('='.repeat(60));
+  console.log('Summary');
+  console.log('='.repeat(60));
+
+  if (results.current.vulnerable) {
+    console.log(`
+🔴 VULNERABILITY EXISTS in current implementation!
+
+The saveMultipartFile function in utils.ts does NOT check
+the 'truncated' property after pipeline() completes.
+
+When a network interruption causes a partial upload:
+1. The stream ends prematurely
+2. pipeline() resolves successfully
+3. file.truncated is set to TRUE by Fastify
+4. BUT this flag is never checked!
+5. Partial file is saved to disk
+6. Later, VM tries to parse it → SYNTAX ERROR
+
+This matches the reported errors:
+- "missing ) after argument list"
+- "Invalid or unexpected token"
+`);
+  }
+
+  if (results.fixed.fixed) {
+    console.log(`
+🟢 PROPOSED FIX WORKS!
+
+Add this check after pipeline() in saveMultipartFile():
+
+  if (multipartFile.file.truncated) {
+    await unlink(destinationPath);
+    throw new Error('Upload truncated: file stream ended prematurely');
+  }
+`);
+  }
+
+  // Cleanup
+  console.log(`\nTest files available at: ${TEST_DIR}`);
+  console.log('To clean up: rm -rf ' + TEST_DIR);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-upload-interruption-inject.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-upload-interruption-inject.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * Upload Interruption Test using Fastify inject()
+ *
+ * This test simulates upload interruption by directly testing the
+ * Fastify app without needing the full server running.
+ *
+ * Usage:
+ *   node scripts/test-upload-interruption-inject.mjs
+ */
+
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { Readable, PassThrough } from 'node:stream';
+import crypto from 'node:crypto';
+
+// Dynamically import the worker (ESM)
+const TEST_DIR = path.join(os.tmpdir(), `upload-interrupt-test-${Date.now()}`);
+const UPLOADS_DIR = path.join(TEST_DIR, 'uploads');
+const BUNDLE_SIZE_MB = 10;
+
+// Generate a valid JS bundle
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { dummy: function() { return { html: "test" }; } };\n';
+
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 200) {
+    content += line;
+  }
+
+  content += 'ReactOnRails.COMPLETE_MARKER = true;\n// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Create a readable stream that will abort mid-way
+function createInterruptingStream(buffer, interruptAtPercent) {
+  const interruptAt = Math.floor(buffer.length * (interruptAtPercent / 100));
+  let position = 0;
+  let interrupted = false;
+
+  const stream = new Readable({
+    read(size) {
+      if (interrupted) {
+        return;
+      }
+
+      if (position >= buffer.length) {
+        this.push(null);
+        return;
+      }
+
+      const chunkSize = Math.min(size || 16384, buffer.length - position);
+      const chunk = buffer.slice(position, position + chunkSize);
+      position += chunkSize;
+
+      // Check if we should interrupt
+      if (position >= interruptAt && !interrupted) {
+        interrupted = true;
+        console.log(`  [Stream] Interrupting at ${position} bytes (${((position / buffer.length) * 100).toFixed(1)}%)`);
+
+        // Just end the stream prematurely without error
+        // This simulates a clean but premature close
+        process.nextTick(() => {
+          this.push(null);  // Signal end of stream
+        });
+        return;
+      }
+
+      this.push(chunk);
+    }
+  });
+
+  // Suppress error events
+  stream.on('error', () => {});
+
+  return stream;
+}
+
+// Create multipart form data with a stream
+function createMultipartPayload(bundleStream, bundleFilename, bundleSize) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const renderingRequest = 'ReactOnRails.dummy()';
+
+  // Include required protocol fields in the multipart body
+  const headerPart =
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="protocolVersion"\r\n\r\n` +
+    `2.0.0\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="gemVersion"\r\n\r\n` +
+    `16.2.0-beta.20\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="railsEnv"\r\n\r\n` +
+    `test\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="renderingRequest"\r\n\r\n` +
+    `${renderingRequest}\r\n` +
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n` +
+    `Content-Type: application/javascript\r\n\r\n`;
+
+  const footerPart = `\r\n--${boundary}--\r\n`;
+
+  // Create a combined stream
+  const headerBuffer = Buffer.from(headerPart, 'utf8');
+  const footerBuffer = Buffer.from(footerPart, 'utf8');
+
+  const combinedStream = new PassThrough();
+
+  // Write header
+  combinedStream.write(headerBuffer);
+
+  // Pipe bundle stream
+  bundleStream.on('data', (chunk) => {
+    combinedStream.write(chunk);
+  });
+
+  bundleStream.on('end', () => {
+    combinedStream.write(footerBuffer);
+    combinedStream.end();
+  });
+
+  bundleStream.on('error', (err) => {
+    // Pass the error through
+    combinedStream.destroy(err);
+  });
+
+  return {
+    boundary,
+    stream: combinedStream,
+    contentType: `multipart/form-data; boundary=${boundary}`,
+    // Note: Content-Length would be wrong due to interruption - that's the point!
+  };
+}
+
+// List files in a directory recursively
+async function listFilesRecursive(dir) {
+  const files = [];
+  try {
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...await listFilesRecursive(fullPath));
+      } else {
+        const stats = await fsp.stat(fullPath);
+        files.push({ path: fullPath, name: entry.name, size: stats.size });
+      }
+    }
+  } catch (err) {
+    // Ignore errors
+  }
+  return files;
+}
+
+// Check if file contains complete marker
+async function isFileComplete(filePath) {
+  try {
+    const content = await fsp.readFile(filePath, 'utf8');
+    return {
+      hasStart: content.includes('BUNDLE START'),
+      hasEnd: content.includes('BUNDLE END'),
+      hasMarker: content.includes('COMPLETE_MARKER'),
+      size: content.length
+    };
+  } catch {
+    return { error: true };
+  }
+}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('UPLOAD INTERRUPTION TEST (via Fastify inject)');
+  console.log('='.repeat(60));
+  console.log(`Test directory: ${TEST_DIR}`);
+  console.log(`Bundle size: ${BUNDLE_SIZE_MB}MB\n`);
+
+  // Create test directories
+  await fsp.mkdir(UPLOADS_DIR, { recursive: true });
+
+  // Import the worker module (CommonJS)
+  console.log('Loading worker module...');
+  let worker, disableHttp2;
+  try {
+    const { createRequire } = await import('module');
+    const require = createRequire(import.meta.url);
+    const workerModule = require('../lib/worker.js');
+    worker = workerModule.default;
+    disableHttp2 = workerModule.disableHttp2;
+    console.log('Worker loaded:', typeof worker);
+  } catch (err) {
+    console.error('Failed to import worker:', err.message);
+    console.error(err.stack);
+    console.error('\nMake sure to run: pnpm run build');
+    process.exit(1);
+  }
+
+  // Disable HTTP/2 for inject() compatibility
+  disableHttp2();
+
+  // Create the Fastify app
+  console.log('Creating Fastify app...');
+  const app = worker({
+    serverBundleCachePath: TEST_DIR,
+    logHttpLevel: 'silent',
+  });
+
+  await app.ready();
+  console.log('App ready.\n');
+
+  // Test scenarios
+  const scenarios = [
+    { name: 'Interrupt at 10%', percent: 10 },
+    { name: 'Interrupt at 25%', percent: 25 },
+    { name: 'Interrupt at 50%', percent: 50 },
+    { name: 'Interrupt at 75%', percent: 75 },
+    { name: 'Interrupt at 90%', percent: 90 },
+  ];
+
+  const results = [];
+
+  for (const scenario of scenarios) {
+    console.log('='.repeat(60));
+    console.log(`TEST: ${scenario.name}`);
+    console.log('='.repeat(60));
+
+    const bundleTimestamp = Date.now();
+    const bundleFilename = `${bundleTimestamp}.js`;
+
+    // Generate bundle
+    const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+    console.log(`Bundle size: ${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB`);
+
+    // Create interrupting stream
+    const bundleStream = createInterruptingStream(bundleBuffer, scenario.percent);
+    const multipart = createMultipartPayload(bundleStream, bundleFilename, bundleBuffer.length);
+
+    // List files before
+    const filesBefore = await listFilesRecursive(TEST_DIR);
+    console.log(`Files before: ${filesBefore.length}`);
+
+    // Make request
+    console.log(`Sending request to /bundles/${bundleTimestamp}/render/test...`);
+
+    let response;
+    let requestError = null;
+
+    try {
+      response = await app.inject({
+        method: 'POST',
+        url: `/bundles/${bundleTimestamp}/render/test-digest`,
+        headers: {
+          'content-type': multipart.contentType,
+        },
+        payload: multipart.stream,
+      });
+
+      console.log(`Response status: ${response.statusCode}`);
+      console.log(`Response body: ${response.payload.substring(0, 100)}...`);
+    } catch (err) {
+      requestError = err;
+      console.log(`Request error (expected): ${err.message}`);
+    }
+
+    // Wait a moment for async cleanup
+    await new Promise(r => setTimeout(r, 500));
+
+    // List files after
+    const filesAfter = await listFilesRecursive(TEST_DIR);
+    console.log(`\nFiles after: ${filesAfter.length}`);
+
+    let partialFound = false;
+    for (const file of filesAfter) {
+      // Skip if file existed before
+      if (filesBefore.some(f => f.path === file.path)) continue;
+
+      const status = await isFileComplete(file.path);
+      const isPartial = status.hasStart && !status.hasMarker;
+
+      console.log(`  - ${file.name}`);
+      console.log(`    Size: ${(file.size / 1024 / 1024).toFixed(2)}MB`);
+      console.log(`    Has start marker: ${status.hasStart ? 'YES' : 'NO'}`);
+      console.log(`    Has end marker: ${status.hasEnd ? 'YES' : 'NO'}`);
+      console.log(`    Complete: ${status.hasMarker ? 'YES ✅' : 'NO ❌'}`);
+
+      if (isPartial) {
+        partialFound = true;
+        console.log(`    🔴 PARTIAL FILE LEFT ON DISK!`);
+      }
+    }
+
+    if (filesAfter.length === filesBefore.length) {
+      console.log(`  ✅ No new files created (properly rejected/cleaned up)`);
+    }
+
+    results.push({
+      scenario: scenario.name,
+      percent: scenario.percent,
+      statusCode: response?.statusCode,
+      error: requestError?.message,
+      partialFound,
+      newFiles: filesAfter.length - filesBefore.length
+    });
+
+    console.log('');
+  }
+
+  // Summary
+  console.log('='.repeat(60));
+  console.log('SUMMARY');
+  console.log('='.repeat(60));
+  console.log('');
+  console.log('┌────────────────────┬────────┬───────────────┬─────────────┐');
+  console.log('│ Scenario           │ Status │ New Files     │ Partial?    │');
+  console.log('├────────────────────┼────────┼───────────────┼─────────────┤');
+
+  for (const r of results) {
+    const status = r.error ? 'ERROR' : String(r.statusCode);
+    const partial = r.partialFound ? '❌ YES' : '✅ NO';
+    console.log(`│ ${r.scenario.padEnd(18)} │ ${status.padEnd(6)} │ ${String(r.newFiles).padStart(13)} │ ${partial.padEnd(11)} │`);
+  }
+
+  console.log('└────────────────────┴────────┴───────────────┴─────────────┘');
+
+  const anyPartial = results.some(r => r.partialFound);
+
+  if (anyPartial) {
+    console.log(`
+🔴 PARTIAL FILES WERE LEFT ON DISK!
+
+When upload is interrupted:
+- The partial file remains in the uploads directory
+- Another request could potentially find and use it
+- This could cause syntax errors if the file is executed
+
+The fix should:
+1. Clean up partial files on stream error
+2. Or use atomic write pattern (write to temp, rename when complete)
+`);
+  } else {
+    console.log(`
+✅ No partial files detected.
+
+The upload interruption was handled properly:
+- Stream errors caused request to fail
+- No partial files were left on disk
+`);
+  }
+
+  // Cleanup
+  await app.close();
+  console.log(`\nTest directory: ${TEST_DIR}`);
+  console.log(`Cleanup: rm -rf ${TEST_DIR}`);
+}
+
+main().catch(err => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-upload-interruption.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-upload-interruption.mjs
@@ -1,0 +1,600 @@
+#!/usr/bin/env node
+/**
+ * Real HTTP Upload Interruption Test
+ *
+ * This script makes REAL HTTP requests to the Node renderer and tests
+ * what happens when the upload is interrupted mid-stream.
+ *
+ * Usage:
+ *   # First, start the renderer in another terminal:
+ *   node dist/index.js
+ *
+ *   # Then run this test:
+ *   node scripts/test-upload-interruption.mjs
+ *
+ *   # Or with custom settings:
+ *   RENDERER_URL=http://localhost:3500 RENDERER_SECRET=your-secret node scripts/test-upload-interruption.mjs
+ */
+
+import http2 from 'node:http2';
+import http from 'node:http';
+import https from 'node:https';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+
+// Configuration
+const RENDERER_URL = process.env.RENDERER_URL || 'http://localhost:3500';
+const RENDERER_SECRET = process.env.RENDERER_SECRET || 'test-secret';
+const BUNDLE_SIZE_MB = 50; // Large enough to give time to interrupt
+const UPLOADS_DIR = process.env.UPLOADS_DIR || '/tmp/react-on-rails-pro/uploads';
+const BUNDLE_CACHE_DIR = process.env.BUNDLE_CACHE_DIR || '/tmp/react-on-rails-pro';
+
+// Generate a valid JS bundle of specified size
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\n(function() {\n';
+
+  const line = '  console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 500) {
+    content += line;
+  }
+
+  content += '  return { success: true, marker: "BUNDLE_COMPLETE_MARKER" };\n';
+  content += '})();\n// BUNDLE END\n';
+
+  return Buffer.from(content, 'utf8');
+}
+
+// Create multipart form data manually for precise control
+function createMultipartData(bundleBuffer, bundleFilename, bundleTimestamp) {
+  const boundary = '----FormBoundary' + crypto.randomBytes(16).toString('hex');
+
+  const parts = [];
+
+  // Add renderingRequest field
+  const renderingRequest = JSON.stringify({
+    serverSide: true,
+    componentName: 'TestComponent',
+    props: {}
+  });
+
+  parts.push(
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="renderingRequest"\r\n\r\n` +
+    `${renderingRequest}\r\n`
+  );
+
+  // Add bundle file
+  parts.push(
+    `--${boundary}\r\n` +
+    `Content-Disposition: form-data; name="bundle"; filename="${bundleFilename}"\r\n` +
+    `Content-Type: application/javascript\r\n\r\n`
+  );
+
+  const header = Buffer.from(parts.join(''), 'utf8');
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+  return {
+    boundary,
+    header,
+    body: bundleBuffer,
+    footer,
+    totalLength: header.length + bundleBuffer.length + footer.length
+  };
+}
+
+// List files in uploads directory
+async function listUploadsDir() {
+  try {
+    await fsp.mkdir(UPLOADS_DIR, { recursive: true });
+    const files = await fsp.readdir(UPLOADS_DIR);
+    const fileStats = await Promise.all(
+      files.map(async (f) => {
+        const filePath = path.join(UPLOADS_DIR, f);
+        const stats = await fsp.stat(filePath);
+        return { name: f, size: stats.size, path: filePath };
+      })
+    );
+    return fileStats;
+  } catch (err) {
+    return [];
+  }
+}
+
+// Clean uploads directory
+async function cleanUploadsDir() {
+  try {
+    const files = await fsp.readdir(UPLOADS_DIR);
+    for (const f of files) {
+      await fsp.unlink(path.join(UPLOADS_DIR, f));
+    }
+  } catch (err) {
+    // Ignore
+  }
+}
+
+// Check if a file contains complete bundle marker
+async function checkFileComplete(filePath) {
+  try {
+    const content = await fsp.readFile(filePath, 'utf8');
+    return {
+      hasStartMarker: content.includes('BUNDLE START'),
+      hasEndMarker: content.includes('BUNDLE END'),
+      hasCompleteMarker: content.includes('BUNDLE_COMPLETE_MARKER'),
+      size: content.length,
+      isComplete: content.includes('BUNDLE_COMPLETE_MARKER') && content.includes('BUNDLE END')
+    };
+  } catch (err) {
+    return { error: err.message };
+  }
+}
+
+// Test 1: HTTP/1.1 upload with socket destruction mid-stream
+async function testHttp1Interruption(interruptAtPercent) {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`TEST: HTTP/1.1 Upload Interrupted at ${interruptAtPercent}%`);
+  console.log('='.repeat(60));
+
+  const url = new URL(RENDERER_URL);
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+
+  console.log(`Generating ${BUNDLE_SIZE_MB}MB bundle...`);
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+  console.log(`Bundle size: ${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB`);
+
+  const multipart = createMultipartData(bundleBuffer, bundleFilename, bundleTimestamp);
+  const interruptAfterBytes = Math.floor(multipart.totalLength * (interruptAtPercent / 100));
+
+  console.log(`Total upload size: ${multipart.totalLength} bytes`);
+  console.log(`Will interrupt after: ${interruptAfterBytes} bytes (${interruptAtPercent}%)`);
+
+  // Clean uploads dir before test
+  await cleanUploadsDir();
+  const filesBefore = await listUploadsDir();
+  console.log(`Files in uploads dir before: ${filesBefore.length}`);
+
+  return new Promise((resolve) => {
+    const options = {
+      hostname: url.hostname,
+      port: url.port || 80,
+      path: `/bundles/${bundleTimestamp}/render/test-digest`,
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+        'Content-Length': multipart.totalLength,
+        'Authorization': `Bearer ${RENDERER_SECRET}`,
+        'X-React-On-Rails-Pro-Protocol-Version': '2.0.0'
+      }
+    };
+
+    console.log(`\nConnecting to ${url.hostname}:${url.port}...`);
+
+    const req = http.request(options);
+
+    let bytesSent = 0;
+    let interrupted = false;
+
+    req.on('error', (err) => {
+      console.log(`Request error (expected after interrupt): ${err.code || err.message}`);
+    });
+
+    req.on('response', (res) => {
+      console.log(`Response status: ${res.statusCode}`);
+      let body = '';
+      res.on('data', (chunk) => body += chunk);
+      res.on('end', () => {
+        console.log(`Response body: ${body.substring(0, 200)}...`);
+      });
+    });
+
+    // Write header
+    console.log(`\nSending multipart header (${multipart.header.length} bytes)...`);
+    req.write(multipart.header);
+    bytesSent += multipart.header.length;
+
+    // Write body in chunks with interrupt
+    const chunkSize = 64 * 1024; // 64KB chunks
+    let offset = 0;
+
+    const writeNextChunk = () => {
+      if (interrupted) return;
+
+      if (offset >= multipart.body.length) {
+        // Write footer
+        console.log(`Sending footer...`);
+        req.write(multipart.footer);
+        req.end();
+
+        // Check results after a delay
+        setTimeout(async () => {
+          const filesAfter = await listUploadsDir();
+          console.log(`\nFiles in uploads dir after: ${filesAfter.length}`);
+          for (const f of filesAfter) {
+            console.log(`  - ${f.name}: ${(f.size / 1024 / 1024).toFixed(2)}MB`);
+            const status = await checkFileComplete(f.path);
+            console.log(`    Complete: ${status.isComplete ? 'YES ✅' : 'NO ❌'}`);
+          }
+          resolve({ interrupted: false, filesAfter });
+        }, 1000);
+        return;
+      }
+
+      const end = Math.min(offset + chunkSize, multipart.body.length);
+      const chunk = multipart.body.slice(offset, end);
+
+      req.write(chunk);
+      bytesSent += chunk.length;
+      offset = end;
+
+      // Check if we should interrupt
+      if (bytesSent >= interruptAfterBytes && !interrupted) {
+        interrupted = true;
+        console.log(`\n>>> INTERRUPTING CONNECTION at ${bytesSent} bytes <<<`);
+
+        // Destroy the socket abruptly
+        req.destroy();
+
+        // Check for partial files after a delay
+        setTimeout(async () => {
+          const filesAfter = await listUploadsDir();
+          console.log(`\nFiles in uploads dir after interrupt: ${filesAfter.length}`);
+
+          let foundPartial = false;
+          for (const f of filesAfter) {
+            console.log(`  - ${f.name}: ${(f.size / 1024 / 1024).toFixed(2)}MB`);
+            const status = await checkFileComplete(f.path);
+            console.log(`    Has start marker: ${status.hasStartMarker ? 'YES' : 'NO'}`);
+            console.log(`    Has end marker: ${status.hasEndMarker ? 'YES' : 'NO'}`);
+            console.log(`    Is complete: ${status.isComplete ? 'YES ✅' : 'NO ❌ (PARTIAL FILE!)'}`);
+
+            if (!status.isComplete && status.hasStartMarker) {
+              foundPartial = true;
+              console.log(`\n  🔴 PARTIAL FILE DETECTED!`);
+              console.log(`     Size: ${(f.size / 1024 / 1024).toFixed(2)}MB of ${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB expected`);
+            }
+          }
+
+          if (filesAfter.length === 0) {
+            console.log(`\n  ✅ No partial files left (properly cleaned up)`);
+          }
+
+          resolve({ interrupted: true, filesAfter, foundPartial });
+        }, 1000);
+        return;
+      }
+
+      // Continue writing
+      setImmediate(writeNextChunk);
+    };
+
+    console.log(`Sending bundle data...`);
+    writeNextChunk();
+  });
+}
+
+// Test 2: HTTP/2 upload with stream reset
+async function testHttp2Interruption(interruptAtPercent) {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`TEST: HTTP/2 Upload Interrupted at ${interruptAtPercent}%`);
+  console.log('='.repeat(60));
+
+  const url = new URL(RENDERER_URL);
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+
+  console.log(`Generating ${BUNDLE_SIZE_MB}MB bundle...`);
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+  console.log(`Bundle size: ${(bundleBuffer.length / 1024 / 1024).toFixed(2)}MB`);
+
+  const multipart = createMultipartData(bundleBuffer, bundleFilename, bundleTimestamp);
+  const interruptAfterBytes = Math.floor(multipart.totalLength * (interruptAtPercent / 100));
+
+  console.log(`Total upload size: ${multipart.totalLength} bytes`);
+  console.log(`Will interrupt after: ${interruptAfterBytes} bytes (${interruptAtPercent}%)`);
+
+  // Clean uploads dir before test
+  await cleanUploadsDir();
+
+  return new Promise((resolve, reject) => {
+    const client = http2.connect(`http://${url.hostname}:${url.port}`, {
+      // Allow self-signed certs for testing
+      rejectUnauthorized: false
+    });
+
+    client.on('error', (err) => {
+      console.log(`HTTP/2 client error: ${err.message}`);
+      // This might be expected if server doesn't support HTTP/2
+      if (err.code === 'ERR_HTTP2_ERROR') {
+        console.log('Server may not support HTTP/2, try HTTP/1.1 test');
+        resolve({ skipped: true, reason: 'HTTP/2 not supported' });
+      }
+    });
+
+    const headers = {
+      ':method': 'POST',
+      ':path': `/bundles/${bundleTimestamp}/render/test-digest`,
+      'content-type': `multipart/form-data; boundary=${multipart.boundary}`,
+      'content-length': multipart.totalLength,
+      'authorization': `Bearer ${RENDERER_SECRET}`,
+      'x-react-on-rails-pro-protocol-version': '2.0.0'
+    };
+
+    const req = client.request(headers);
+
+    let bytesSent = 0;
+    let interrupted = false;
+
+    req.on('error', (err) => {
+      console.log(`Stream error (may be expected): ${err.message}`);
+    });
+
+    req.on('response', (headers) => {
+      console.log(`Response status: ${headers[':status']}`);
+    });
+
+    req.on('data', (chunk) => {
+      console.log(`Response data: ${chunk.toString().substring(0, 100)}...`);
+    });
+
+    req.on('end', () => {
+      client.close();
+    });
+
+    // Write header
+    req.write(multipart.header);
+    bytesSent += multipart.header.length;
+
+    // Write body in chunks
+    const chunkSize = 64 * 1024;
+    let offset = 0;
+
+    const writeNextChunk = () => {
+      if (interrupted) return;
+
+      if (offset >= multipart.body.length) {
+        req.write(multipart.footer);
+        req.end();
+
+        setTimeout(async () => {
+          client.close();
+          const filesAfter = await listUploadsDir();
+          console.log(`\nFiles in uploads dir after: ${filesAfter.length}`);
+          resolve({ interrupted: false, filesAfter });
+        }, 1000);
+        return;
+      }
+
+      const end = Math.min(offset + chunkSize, multipart.body.length);
+      const chunk = multipart.body.slice(offset, end);
+
+      req.write(chunk);
+      bytesSent += chunk.length;
+      offset = end;
+
+      if (bytesSent >= interruptAfterBytes && !interrupted) {
+        interrupted = true;
+        console.log(`\n>>> INTERRUPTING HTTP/2 STREAM at ${bytesSent} bytes <<<`);
+
+        // Close the stream abruptly
+        req.close(http2.constants.NGHTTP2_CANCEL);
+        client.close();
+
+        setTimeout(async () => {
+          const filesAfter = await listUploadsDir();
+          console.log(`\nFiles in uploads dir after interrupt: ${filesAfter.length}`);
+
+          let foundPartial = false;
+          for (const f of filesAfter) {
+            console.log(`  - ${f.name}: ${(f.size / 1024 / 1024).toFixed(2)}MB`);
+            const status = await checkFileComplete(f.path);
+            console.log(`    Is complete: ${status.isComplete ? 'YES ✅' : 'NO ❌'}`);
+            if (!status.isComplete && f.size > 0) {
+              foundPartial = true;
+            }
+          }
+
+          resolve({ interrupted: true, filesAfter, foundPartial });
+        }, 1000);
+        return;
+      }
+
+      setImmediate(writeNextChunk);
+    };
+
+    console.log(`\nSending via HTTP/2...`);
+    writeNextChunk();
+  });
+}
+
+// Test 3: Slow upload with connection timeout
+async function testSlowUpload() {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`TEST: Slow Upload (simulating network issues)`);
+  console.log('='.repeat(60));
+
+  const url = new URL(RENDERER_URL);
+  const bundleTimestamp = Date.now();
+  const bundleFilename = `${bundleTimestamp}.js`;
+
+  console.log(`Generating ${BUNDLE_SIZE_MB}MB bundle...`);
+  const bundleBuffer = generateBundle(BUNDLE_SIZE_MB);
+
+  const multipart = createMultipartData(bundleBuffer, bundleFilename, bundleTimestamp);
+
+  // Clean uploads dir before test
+  await cleanUploadsDir();
+
+  return new Promise((resolve) => {
+    const options = {
+      hostname: url.hostname,
+      port: url.port || 80,
+      path: `/bundles/${bundleTimestamp}/render/test-digest`,
+      method: 'POST',
+      headers: {
+        'Content-Type': `multipart/form-data; boundary=${multipart.boundary}`,
+        'Content-Length': multipart.totalLength,
+        'Authorization': `Bearer ${RENDERER_SECRET}`,
+        'X-React-On-Rails-Pro-Protocol-Version': '2.0.0'
+      }
+    };
+
+    const req = http.request(options);
+
+    req.on('error', (err) => {
+      console.log(`Request error: ${err.message}`);
+    });
+
+    // Write header
+    req.write(multipart.header);
+
+    // Write first 25% of body
+    const firstPart = multipart.body.slice(0, Math.floor(multipart.body.length * 0.25));
+    req.write(firstPart);
+    console.log(`Sent 25% of data, now pausing for 5 seconds...`);
+
+    // Pause to simulate slow network
+    setTimeout(async () => {
+      console.log(`Checking uploads dir during pause...`);
+      const filesDuring = await listUploadsDir();
+
+      for (const f of filesDuring) {
+        console.log(`  - ${f.name}: ${(f.size / 1024 / 1024).toFixed(2)}MB (file exists during upload!)`);
+        const status = await checkFileComplete(f.path);
+        console.log(`    Complete: ${status.isComplete ? 'YES' : 'NO - PARTIAL FILE VISIBLE!'}`);
+      }
+
+      // Now abort
+      console.log(`\nAborting connection...`);
+      req.destroy();
+
+      setTimeout(async () => {
+        const filesAfter = await listUploadsDir();
+        console.log(`\nFiles after abort: ${filesAfter.length}`);
+        for (const f of filesAfter) {
+          console.log(`  - ${f.name}: ${(f.size / 1024 / 1024).toFixed(2)}MB`);
+        }
+        resolve({ filesDuring, filesAfter });
+      }, 1000);
+    }, 5000);
+  });
+}
+
+// Main execution
+async function main() {
+  console.log('='.repeat(60));
+  console.log('REAL HTTP UPLOAD INTERRUPTION TEST');
+  console.log('='.repeat(60));
+  console.log(`Renderer URL: ${RENDERER_URL}`);
+  console.log(`Uploads dir: ${UPLOADS_DIR}`);
+  console.log(`Bundle size: ${BUNDLE_SIZE_MB}MB`);
+  console.log('');
+
+  // Create uploads dir if needed
+  await fsp.mkdir(UPLOADS_DIR, { recursive: true });
+
+  // Check if renderer is running
+  console.log('Checking if renderer is running...');
+  try {
+    const url = new URL(RENDERER_URL);
+    await new Promise((resolve, reject) => {
+      const req = http.get(`${RENDERER_URL}/info`, (res) => {
+        let body = '';
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', () => {
+          console.log(`Renderer info: ${body}`);
+          resolve(body);
+        });
+      });
+      req.on('error', reject);
+      req.setTimeout(5000, () => {
+        req.destroy();
+        reject(new Error('Connection timeout'));
+      });
+    });
+  } catch (err) {
+    console.error(`\n❌ Cannot connect to renderer at ${RENDERER_URL}`);
+    console.error(`   Error: ${err.message}`);
+    console.error(`\nPlease start the renderer first:`);
+    console.error(`   cd packages/react-on-rails-pro-node-renderer`);
+    console.error(`   npm run build && node dist/index.js`);
+    console.error(`\nOr set RENDERER_URL environment variable.`);
+    process.exit(1);
+  }
+
+  const results = {};
+
+  // Test 1: Interrupt at 25%
+  try {
+    results.http1_25 = await testHttp1Interruption(25);
+  } catch (err) {
+    console.error(`Test failed: ${err.message}`);
+    results.http1_25 = { error: err.message };
+  }
+
+  // Test 2: Interrupt at 50%
+  try {
+    results.http1_50 = await testHttp1Interruption(50);
+  } catch (err) {
+    console.error(`Test failed: ${err.message}`);
+    results.http1_50 = { error: err.message };
+  }
+
+  // Test 3: Interrupt at 75%
+  try {
+    results.http1_75 = await testHttp1Interruption(75);
+  } catch (err) {
+    console.error(`Test failed: ${err.message}`);
+    results.http1_75 = { error: err.message };
+  }
+
+  // Test 4: Slow upload test
+  try {
+    results.slow = await testSlowUpload();
+  } catch (err) {
+    console.error(`Test failed: ${err.message}`);
+    results.slow = { error: err.message };
+  }
+
+  // Summary
+  console.log('\n' + '='.repeat(60));
+  console.log('SUMMARY');
+  console.log('='.repeat(60));
+
+  const partialFilesFound = Object.values(results).some(r => r.foundPartial);
+
+  if (partialFilesFound) {
+    console.log(`
+🔴 PARTIAL FILES WERE CREATED!
+
+This means that when an upload is interrupted:
+1. The partial file remains on disk
+2. It could potentially be used by another worker
+3. This could cause "Invalid or unexpected token" errors
+
+The fix should ensure:
+- Partial uploads are cleaned up
+- Or uploads are written to temp files first
+`);
+  } else {
+    console.log(`
+✅ No partial files detected after interruption.
+
+Either:
+1. The server properly cleans up partial uploads
+2. The server rejects partial uploads with errors
+3. Our test didn't catch the race condition
+
+Note: The cross-device move (EXDEV) issue is separate and was
+proven in our earlier atomicity tests.
+`);
+  }
+
+  // Clean up
+  await cleanUploadsDir();
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-upload-race-detailed.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-upload-race-detailed.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `upload-race-detail-${Date.now()}`);
+const UPLOAD_FILE = path.join(TEST_DIR, 'bundle.js');
+
+function generateBundle(id, sizeMB = 0.5) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = `// BUNDLE FROM WRITER ${id}\n`;
+  content += `var WRITER_ID = "${id}";\n`;
+  const line = `console.log("Writer ${id}: ${'x'.repeat(80)}");\n`;
+  while (content.length < targetSize - 100) {
+    content += line;
+  }
+  content += `// END BUNDLE ${id}\n`;
+  return Buffer.from(content, 'utf8');
+}
+
+async function writeBundle(id, content) {
+  return new Promise((resolve, reject) => {
+    const stream = createWriteStream(UPLOAD_FILE);
+    let position = 0;
+    const chunkSize = 64 * 1024;
+
+    const writeNext = () => {
+      if (position >= content.length) {
+        stream.end();
+        return;
+      }
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+      setTimeout(() => {
+        stream.write(chunk, writeNext);
+      }, Math.random() * 10);
+    };
+
+    stream.on('finish', () => resolve());
+    stream.on('error', reject);
+    writeNext();
+  });
+}
+
+async function main() {
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  const bundle1 = generateBundle('A', 0.5);
+  const bundle2 = generateBundle('B', 0.5);
+  const bundle3 = generateBundle('C', 0.5);
+
+  await Promise.all([
+    writeBundle('A', bundle1),
+    writeBundle('B', bundle2),
+    writeBundle('C', bundle3),
+  ]);
+
+  const result = await fsp.readFile(UPLOAD_FILE, 'utf8');
+  
+  // Count how many times each writer's line appears
+  const countA = (result.match(/Writer A:/g) || []).length;
+  const countB = (result.match(/Writer B:/g) || []).length;
+  const countC = (result.match(/Writer C:/g) || []).length;
+  
+  const hasHeaderA = result.includes('WRITER_ID = "A"');
+  const hasHeaderB = result.includes('WRITER_ID = "B"');
+  const hasHeaderC = result.includes('WRITER_ID = "C"');
+  const hasEndA = result.includes('END BUNDLE A');
+  const hasEndB = result.includes('END BUNDLE B');
+  const hasEndC = result.includes('END BUNDLE C');
+  
+  const mixed = (countA > 0 && countB > 0) || (countA > 0 && countC > 0) || (countB > 0 && countC > 0);
+  
+  if (mixed) {
+    console.log(`INTERLEAVED: A=${countA} B=${countB} C=${countC} lines`);
+    // Try to parse as JS
+    try {
+      new Function(result);
+      console.log('JS: VALID (but corrupted content)');
+    } catch (e) {
+      console.log(`JS: INVALID - ${e.message.substring(0, 50)}`);
+    }
+  } else {
+    const header = hasHeaderA ? 'A' : hasHeaderB ? 'B' : 'C';
+    const footer = hasEndA ? 'A' : hasEndB ? 'B' : hasEndC ? 'C' : '?';
+    if (header !== footer) {
+      console.log(`TRUNCATED: Header=${header} Footer=${footer}`);
+    } else {
+      console.log(`CLEAN: ${header}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-upload-race.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-upload-race.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Test: Can multiple workers corrupt the upload file?
+ *
+ * Simulates multiple processes writing to the same file simultaneously.
+ */
+
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
+
+const TEST_DIR = path.join(os.tmpdir(), `upload-race-${Date.now()}`);
+const UPLOAD_FILE = path.join(TEST_DIR, 'bundle.js');
+
+console.log('='.repeat(70));
+console.log('UPLOAD FILE RACE CONDITION TEST');
+console.log('='.repeat(70));
+console.log(`Test file: ${UPLOAD_FILE}\n`);
+
+function generateBundle(id, sizeMB = 1) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = `// BUNDLE FROM WRITER ${id}\n`;
+  content += `var WRITER_ID = "${id}";\n`;
+
+  const line = `console.log("Writer ${id}: ${'x'.repeat(80)}");\n`;
+  while (content.length < targetSize - 100) {
+    content += line;
+  }
+
+  content += `// END BUNDLE ${id}\n`;
+  return Buffer.from(content, 'utf8');
+}
+
+async function writeBundle(id, content) {
+  return new Promise((resolve, reject) => {
+    const stream = createWriteStream(UPLOAD_FILE);
+    let position = 0;
+    const chunkSize = 64 * 1024;
+
+    const writeNext = () => {
+      if (position >= content.length) {
+        stream.end();
+        return;
+      }
+
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+
+      // Add random delay to increase chance of interleaving
+      setTimeout(() => {
+        stream.write(chunk, writeNext);
+      }, Math.random() * 10);
+    };
+
+    stream.on('finish', () => {
+      console.log(`Writer ${id}: finished writing`);
+      resolve();
+    });
+    stream.on('error', reject);
+
+    console.log(`Writer ${id}: starting to write ${(content.length / 1024).toFixed(0)}KB`);
+    writeNext();
+  });
+}
+
+async function main() {
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  // Generate different bundles for each "worker"
+  const bundle1 = generateBundle('A', 1);
+  const bundle2 = generateBundle('B', 1);
+  const bundle3 = generateBundle('C', 1);
+
+  console.log('Starting 3 concurrent writers to the SAME file...\n');
+
+  // Start all writers simultaneously
+  await Promise.all([
+    writeBundle('A', bundle1),
+    writeBundle('B', bundle2),
+    writeBundle('C', bundle3),
+  ]);
+
+  console.log('\n' + '─'.repeat(70));
+  console.log('RESULTS');
+  console.log('─'.repeat(70));
+
+  // Read the result
+  const result = await fsp.readFile(UPLOAD_FILE, 'utf8');
+
+  // Check what we got
+  const hasA = result.includes('WRITER_ID = "A"');
+  const hasB = result.includes('WRITER_ID = "B"');
+  const hasC = result.includes('WRITER_ID = "C"');
+  const hasEndA = result.includes('END BUNDLE A');
+  const hasEndB = result.includes('END BUNDLE B');
+  const hasEndC = result.includes('END BUNDLE C');
+
+  console.log(`\nFile contains Writer A header: ${hasA}`);
+  console.log(`File contains Writer B header: ${hasB}`);
+  console.log(`File contains Writer C header: ${hasC}`);
+  console.log(`File contains Writer A footer: ${hasEndA}`);
+  console.log(`File contains Writer B footer: ${hasEndB}`);
+  console.log(`File contains Writer C footer: ${hasEndC}`);
+
+  // Check if file is valid JS
+  let isValidJS = false;
+  try {
+    new Function(result);
+    isValidJS = true;
+  } catch (e) {
+    console.log(`\nJS Parse Error: ${e.message.substring(0, 100)}`);
+  }
+
+  console.log(`\nFile is valid JavaScript: ${isValidJS}`);
+  console.log(`File size: ${(result.length / 1024).toFixed(0)}KB`);
+
+  // Count how many different writers' content is in the file
+  const writerMatches = [hasA, hasB, hasC].filter(Boolean).length;
+
+  if (writerMatches > 1 || !isValidJS) {
+    console.log(`
+🔴 RACE CONDITION DEMONSTRATED!
+
+Multiple writers corrupted the file:
+- File contains content from ${writerMatches} different writers
+- File is ${isValidJS ? 'valid' : 'INVALID'} JavaScript
+
+This proves that concurrent writes to /uploads/{hash}.js
+can corrupt the bundle file!
+`);
+  } else {
+    console.log(`
+✅ One writer won the race cleanly.
+
+Last writer to finish: ${hasEndA ? 'A' : hasEndB ? 'B' : hasEndC ? 'C' : 'unknown'}
+File appears consistent.
+
+(Run multiple times - race conditions are probabilistic)
+`);
+  }
+
+  console.log(`Test directory: ${TEST_DIR}`);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-upload-truncate-race.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-upload-truncate-race.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Test: Upload truncation race with O_TRUNC
+ * 
+ * When multiple workers open the same file with createWriteStream,
+ * O_TRUNC truncates the file. This can cause corruption if:
+ * 1. Worker A opens file, truncates, starts writing
+ * 2. Worker B opens file, truncates (A's data lost!), starts writing
+ * 3. Worker A continues writing at its internal position
+ * 4. Result: corrupted file
+ */
+
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `trunc-race-${Date.now()}`);
+const UPLOAD_FILE = path.join(TEST_DIR, 'bundle.js');
+
+console.log('='.repeat(70));
+console.log('UPLOAD O_TRUNC RACE TEST');
+console.log('='.repeat(70));
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { test: true };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 100) {
+    content += line;
+  }
+  content += '// BUNDLE END - COMPLETE_MARKER\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Simulate saveMultipartFile - writes in chunks with delays
+async function simulateUpload(id, content, startDelay = 0) {
+  await new Promise(r => setTimeout(r, startDelay));
+  
+  console.log(`[${Date.now()}] Worker ${id}: Opening file (O_TRUNC)`);
+  
+  return new Promise((resolve, reject) => {
+    const stream = createWriteStream(UPLOAD_FILE); // O_TRUNC by default
+    let position = 0;
+    const chunkSize = 64 * 1024;
+    let chunksWritten = 0;
+
+    stream.on('open', () => {
+      console.log(`[${Date.now()}] Worker ${id}: File opened, starting write`);
+    });
+
+    const writeNext = () => {
+      if (position >= content.length) {
+        stream.end();
+        return;
+      }
+
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+      chunksWritten++;
+
+      // Random delay to simulate network/disk variability
+      setTimeout(() => {
+        stream.write(chunk, writeNext);
+      }, Math.random() * 5);
+    };
+
+    stream.on('finish', () => {
+      console.log(`[${Date.now()}] Worker ${id}: Finished (${chunksWritten} chunks)`);
+      resolve({ id, chunksWritten });
+    });
+    stream.on('error', reject);
+
+    writeNext();
+  });
+}
+
+async function runTest(description, delays) {
+  console.log(`\n--- ${description} ---`);
+  
+  // Clean up
+  try { await fsp.unlink(UPLOAD_FILE); } catch {}
+  
+  const bundle = generateBundle(2); // 2MB
+  const expectedSize = bundle.length;
+  
+  // Start uploads with specified delays
+  await Promise.all([
+    simulateUpload('A', bundle, delays.A),
+    simulateUpload('B', bundle, delays.B),
+  ]);
+
+  // Check result
+  const stats = await fsp.stat(UPLOAD_FILE);
+  const content = await fsp.readFile(UPLOAD_FILE, 'utf8');
+  const hasStart = content.includes('BUNDLE START');
+  const hasEnd = content.includes('COMPLETE_MARKER');
+  
+  let jsValid = false;
+  try {
+    new Function(content);
+    jsValid = true;
+  } catch (e) {
+    console.log(`JS Error: ${e.message.substring(0, 60)}`);
+  }
+
+  const status = jsValid && hasEnd ? '✅ VALID' : '❌ CORRUPTED';
+  console.log(`Result: ${status} (size: ${stats.size}/${expectedSize}, hasStart: ${hasStart}, hasEnd: ${hasEnd})`);
+  
+  return { valid: jsValid && hasEnd, size: stats.size, expectedSize };
+}
+
+async function main() {
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  const results = [];
+  
+  // Test 1: Worker B starts slightly after A (typical race)
+  results.push(await runTest('B starts 50ms after A', { A: 0, B: 50 }));
+  
+  // Test 2: Worker B starts much later (A might be done)
+  results.push(await runTest('B starts 500ms after A', { A: 0, B: 500 }));
+  
+  // Test 3: Both start simultaneously
+  results.push(await runTest('A and B start simultaneously', { A: 0, B: 0 }));
+  
+  // Test 4: A starts after B
+  results.push(await runTest('A starts 100ms after B', { A: 100, B: 0 }));
+
+  // Run multiple times for test 1 to catch probabilistic races
+  console.log('\n--- Running 10 iterations of 50ms delay test ---');
+  let corrupted = 0;
+  for (let i = 0; i < 10; i++) {
+    const r = await runTest(`Iteration ${i+1}`, { A: 0, B: 50 });
+    if (!r.valid) corrupted++;
+  }
+  
+  console.log(`\n${'='.repeat(70)}`);
+  console.log('SUMMARY');
+  console.log('='.repeat(70));
+  console.log(`Corrupted in 10 iterations: ${corrupted}/10`);
+  
+  if (corrupted > 0) {
+    console.log(`
+🔴 O_TRUNC RACE CONDITION CONFIRMED!
+
+When Worker B opens the file while Worker A is still writing,
+O_TRUNC truncates the file, causing corruption.
+
+This explains transient errors after deploy:
+1. New deploy = new bundle hash
+2. Multiple workers receive requests with new hash
+3. All try to upload to /uploads/{hash}.js simultaneously  
+4. O_TRUNC race corrupts the file
+5. Corrupted file moved to /bundles/
+6. SyntaxError on read!
+
+Why transient?
+- Only happens during the brief window when new hash appears
+- Once one worker successfully writes and moves, others skip upload
+- Subsequent requests use the (hopefully correct) cached file
+`);
+  }
+
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-upload-truncation.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-upload-truncation.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Test: Can concurrent writes to the SAME bundle cause truncation?
+ * 
+ * Scenario (realistic production):
+ * - Multiple workers receive request with same bundleTimestamp
+ * - All write the SAME content to /uploads/{hash}.js
+ * - createWriteStream uses O_TRUNC which truncates on open
+ * - If worker A is 60% done and worker B opens the file,
+ *   the file gets truncated to 0, losing A's progress
+ */
+
+import fsp from 'node:fs/promises';
+import { createWriteStream, statSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `upload-trunc-${Date.now()}`);
+const UPLOAD_FILE = path.join(TEST_DIR, 'bundle.js');
+const BUNDLE_SIZE_MB = 2;
+
+console.log('='.repeat(70));
+console.log('UPLOAD TRUNCATION TEST - Same Bundle, Multiple Writers');
+console.log('='.repeat(70));
+console.log(`Test file: ${UPLOAD_FILE}\n`);
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\n';
+  content += 'var ReactOnRails = { test: true };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 100) {
+    content += line;
+  }
+  content += '// BUNDLE END - COMPLETE_MARKER\n';
+  return Buffer.from(content, 'utf8');
+}
+
+async function writeWithRandomDelay(id, content, delayRange = 10) {
+  return new Promise((resolve, reject) => {
+    const stream = createWriteStream(UPLOAD_FILE);
+    let position = 0;
+    const chunkSize = 64 * 1024;
+    let chunksWritten = 0;
+
+    const writeNext = () => {
+      if (position >= content.length) {
+        stream.end();
+        return;
+      }
+
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+      chunksWritten++;
+
+      // Random delay to increase chance of interleaving
+      setTimeout(() => {
+        stream.write(chunk, writeNext);
+      }, Math.random() * delayRange);
+    };
+
+    stream.on('finish', () => {
+      resolve({ id, chunksWritten, bytesWritten: position });
+    });
+    stream.on('error', reject);
+
+    writeNext();
+  });
+}
+
+async function main() {
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+
+  // Generate ONE bundle (same content for all workers)
+  const bundle = generateBundle(BUNDLE_SIZE_MB);
+  const expectedSize = bundle.length;
+  console.log(`Bundle size: ${(expectedSize / 1024 / 1024).toFixed(2)}MB`);
+  console.log(`Expected final size: ${expectedSize} bytes`);
+  console.log('');
+
+  // Run test 5 times
+  for (let run = 1; run <= 5; run++) {
+    // Clean the file before each run
+    try { await fsp.unlink(UPLOAD_FILE); } catch {}
+    
+    console.log(`\n--- Run ${run} ---`);
+    console.log('Starting 3 concurrent writers with SAME content...');
+
+    const results = await Promise.all([
+      writeWithRandomDelay('A', bundle, 5),
+      writeWithRandomDelay('B', bundle, 5),
+      writeWithRandomDelay('C', bundle, 5),
+    ]);
+
+    // Check the final file
+    const stats = await fsp.stat(UPLOAD_FILE);
+    const content = await fsp.readFile(UPLOAD_FILE, 'utf8');
+    const isComplete = content.includes('COMPLETE_MARKER');
+    
+    console.log(`Final file size: ${stats.size} bytes (${((stats.size / expectedSize) * 100).toFixed(1)}%)`);
+    
+    if (stats.size < expectedSize) {
+      console.log(`🔴 TRUNCATED! Missing ${expectedSize - stats.size} bytes`);
+    } else if (!isComplete) {
+      console.log(`🔴 CORRUPTED! File is full size but missing end marker`);
+    } else {
+      console.log(`✅ Complete`);
+    }
+
+    // Check if file is valid JS
+    try {
+      new Function(content);
+    } catch (e) {
+      console.log(`🔴 INVALID JS: ${e.message.substring(0, 60)}`);
+    }
+  }
+
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(console.error);

--- a/packages/react-on-rails-pro-node-renderer/scripts/test-varied-timing-race.mjs
+++ b/packages/react-on-rails-pro-node-renderer/scripts/test-varied-timing-race.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Test with varied timing to trigger null byte corruption
+ * 
+ * The key is: Request A must be AHEAD in writing when B truncates.
+ * Then A continues at its position, creating a gap.
+ */
+
+import fsp from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_DIR = path.join(os.tmpdir(), `varied-race-${Date.now()}`);
+const UPLOAD_FILE = path.join(TEST_DIR, 'uploads', 'bundle.js');
+
+function generateBundle(sizeMB) {
+  const targetSize = sizeMB * 1024 * 1024;
+  let content = '// BUNDLE START\nvar ReactOnRails = { test: true };\n';
+  const line = 'console.log("' + 'x'.repeat(100) + '");\n';
+  while (content.length < targetSize - 100) {
+    content += line;
+  }
+  content += '// BUNDLE END\n';
+  return Buffer.from(content, 'utf8');
+}
+
+// Request A: Fast start, slow middle
+// Request B: Slow start, fast finish
+async function simulateSaveWithPattern(id, content, pattern) {
+  console.log(`[${Date.now()}] ${id}: Starting upload`);
+  
+  const chunkSize = 64 * 1024;
+  let position = 0;
+  let chunkIndex = 0;
+  const totalChunks = Math.ceil(content.length / chunkSize);
+  
+  const readable = new Readable({
+    read() {
+      if (position >= content.length) {
+        this.push(null);
+        return;
+      }
+      
+      const chunk = content.slice(position, position + chunkSize);
+      position += chunk.length;
+      chunkIndex++;
+      
+      // Different delay patterns
+      let delay;
+      if (pattern === 'fast-then-slow') {
+        // Fast first half, slow second half
+        delay = chunkIndex < totalChunks / 2 ? 1 : 20;
+      } else if (pattern === 'slow-then-fast') {
+        // Slow first half, fast second half
+        delay = chunkIndex < totalChunks / 2 ? 20 : 1;
+      } else {
+        delay = 5;
+      }
+      
+      setTimeout(() => {
+        if (chunkIndex === 1) {
+          console.log(`[${Date.now()}] ${id}: First chunk written`);
+        }
+        this.push(chunk);
+      }, delay);
+    }
+  });
+  
+  const writeStream = createWriteStream(UPLOAD_FILE);
+  await pipeline(readable, writeStream);
+  console.log(`[${Date.now()}] ${id}: Upload complete`);
+}
+
+async function analyzeFile(expectedSize) {
+  const content = await fsp.readFile(UPLOAD_FILE);
+  const hasNullBytes = content.includes(0);
+  const nullByteCount = content.filter(b => b === 0).length;
+  
+  let jsValid = false;
+  try {
+    new Function(content.toString());
+    jsValid = true;
+  } catch (e) {}
+  
+  return { 
+    size: content.length,
+    expectedSize,
+    hasNullBytes, 
+    nullByteCount,
+    jsValid,
+    sizeMatch: content.length === expectedSize
+  };
+}
+
+async function runTest(name, delayA, patternA, delayB, patternB) {
+  console.log(`\n${'─'.repeat(60)}\n${name}\n${'─'.repeat(60)}`);
+  
+  await fsp.mkdir(path.dirname(UPLOAD_FILE), { recursive: true });
+  try { await fsp.unlink(UPLOAD_FILE); } catch {}
+  
+  const bundle = generateBundle(2);
+  
+  await Promise.all([
+    new Promise(r => setTimeout(r, delayA)).then(() => 
+      simulateSaveWithPattern('A', bundle, patternA)
+    ),
+    new Promise(r => setTimeout(r, delayB)).then(() => 
+      simulateSaveWithPattern('B', bundle, patternB)
+    ),
+  ]);
+  
+  const result = await analyzeFile(bundle.length);
+  
+  if (result.hasNullBytes) {
+    console.log(`🔴 CORRUPTED: ${result.nullByteCount} null bytes in ${result.size} byte file`);
+    return true;
+  } else if (!result.jsValid) {
+    console.log(`🔴 INVALID JS`);
+    return true;
+  } else if (!result.sizeMatch) {
+    console.log(`⚠️ SIZE MISMATCH: ${result.size} vs expected ${result.expectedSize}`);
+    return true;
+  } else {
+    console.log(`✅ VALID`);
+    return false;
+  }
+}
+
+async function main() {
+  await fsp.mkdir(TEST_DIR, { recursive: true });
+  
+  console.log('='.repeat(60));
+  console.log('VARIED TIMING RACE TEST');
+  console.log('='.repeat(60));
+  
+  let corrupted = 0;
+  const iterations = 10;
+  
+  // A starts fast, writes a lot, then B comes in and truncates
+  for (let i = 0; i < iterations; i++) {
+    if (await runTest(
+      `Test ${i+1}: A fast-start, B slow-start`,
+      0,  // A starts immediately
+      'fast-then-slow',  // A writes fast initially
+      100,  // B starts 100ms later (A already wrote ~500KB)
+      'uniform'
+    )) {
+      corrupted++;
+    }
+  }
+  
+  console.log('\n' + '='.repeat(60));
+  console.log(`SUMMARY: ${corrupted}/${iterations} corrupted`);
+  console.log('='.repeat(60));
+  
+  if (corrupted > 0) {
+    console.log('\n🔴 NULL BYTE CORRUPTION CONFIRMED IN REALISTIC SCENARIO!');
+  } else {
+    console.log('\n✅ No corruption detected (timing may not have triggered it)');
+  }
+
+  console.log(`\nTest directory: ${TEST_DIR}`);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Investigation scripts for reported "Invalid or unexpected token" / "missing ) after argument list" errors during SSR

## Investigation Findings

### Scenarios Tested

| Scenario | Result | Can Cause Error? |
|----------|--------|------------------|
| Concurrent uploads of same bundle content | Files end up valid | ❌ No |
| File descriptor race with O_TRUNC | Null bytes appear | ⚠️ Only with different content |
| Non-atomic move (cross-device) | Partial file readable | ✅ Yes |
| Direct deploy file writes | Partial file during write | ✅ Yes (if not using HTTP upload) |
| Interrupted HTTP upload | Partial file saved | ✅ Yes (but persistent, not transient) |

### Root Cause Analysis

The **only scenario** that matches the reported "transient" error pattern (first few requests fail, then works) is:

**Non-atomic move operation** when bundle path is on a different filesystem than the uploads directory.

When `fs.rename()` fails with `EXDEV` (cross-device link), `fs-extra.move()` falls back to `copy()` + `unlink()`. During the copy operation, a concurrent request can read a partial file.

### Evidence

1. **Null byte corruption requires different content** - When two requests upload the same bundle, the file ends up valid even with race conditions.

2. **Same-filesystem moves are atomic** - `fs.rename()` is atomic on the same filesystem, so no partial reads are possible.

3. **Cross-device moves are NOT atomic** - The copy fallback creates a window where partial files can be read.

### Conclusion

This appears to be a **project-specific configuration issue** rather than a bug in react_on_rails:

- The bundle path (`bundlePath: path.resolve(__dirname, 'tmp/bundles')`) must be on a different filesystem than the uploads directory
- This is an unusual configuration that causes cross-device moves
- Only one project has reported this issue

## Test Scripts

22 test scripts were created to investigate various race condition scenarios. These can be run to reproduce and understand the behavior:

```bash
cd packages/react-on-rails-pro-node-renderer
node scripts/test-fd-truncation.mjs      # Proves null byte corruption mechanism
node scripts/test-concurrent-race.mjs    # Tests non-atomic copy race
node scripts/test-multipart-race.mjs     # Tests multipart upload race
```

## Recommendation

For the affected project:
1. Ensure `serverBundleCachePath` is on the same filesystem as the application
2. Or use a RAM disk / tmpfs for both uploads and bundles directories
3. Check if there are any NFS or network mounts involved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added comprehensive test suite for file operation atomicity, concurrent requests, race conditions, truncation scenarios, and upload interruptions to enhance system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->