### PR TITLE
Fix rspack configuration not applying to all environments

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -311,10 +311,10 @@ module ReactOnRails
           '\1rspack\2'
         )
 
-        # Update webpack_loader to swc (rspack works best with SWC)
+        # Update javascript_transpiler to swc (rspack works best with SWC)
         gsub_file(
           shakapacker_config_path,
-          /^(\s*webpack_loader:\s*)["']?babel["']?(\s*(?:#.*)?)$/,
+          /^(\s*javascript_transpiler:\s*)["']?babel["']?(\s*(?:#.*)?)$/,
           '\1swc\2'
         )
 

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/switch-bundler
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/switch-bundler
@@ -57,11 +57,11 @@ class BundlerSwitcher
       "\\1#{@target_bundler}\\2"
     )
 
-    # Update webpack_loader based on bundler (rspack works best with SWC)
+    # Update javascript_transpiler based on bundler (rspack works best with SWC)
     new_loader = @target_bundler == "rspack" ? "swc" : "babel"
     old_loader = @target_bundler == "rspack" ? "babel" : "swc"
     new_content = new_content.gsub(
-      /^(\s*webpack_loader:\s*)["']?#{old_loader}["']?(\s*(?:#.*)?)$/,
+      /^(\s*javascript_transpiler:\s*)["']?#{old_loader}["']?(\s*(?:#.*)?)$/,
       "\\1#{new_loader}\\2"
     )
 
@@ -143,6 +143,7 @@ if ARGV.empty?
   puts "\nExamples:"
   puts "  bin/switch-bundler rspack   # Switch to Rspack"
   puts "  bin/switch-bundler webpack  # Switch to Webpack"
+  puts "\nNote: This also updates javascript_transpiler (rspack uses swc, webpack uses babel)"
   exit 1
 end
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the Rspack support feature (PR #1852):

1. **`bin/switch-bundler` crashes** with `Psych::AliasesNotEnabled` on YAML files containing anchors/aliases
2. **`--rspack` flag and `bin/switch-bundler` only update `default` section** - environment sections retain `webpack`

## Root Cause

Both the generator and `bin/switch-bundler` used `YAML.load` → modify default → `YAML.dump` which:
- `YAML.load` expands `<<: *default` inheritance into explicit copies
- Modifying `config["default"]` doesn't affect already-expanded environment sections
- `YAML.dump` writes back with all sections having explicit values (only default was changed)

## Solution

Replace YAML parse/dump with regex replacement (Thor's `gsub_file` pattern):
- Preserves file structure (comments, anchors, aliases)
- Updates `assets_bundler` in **all** sections, not just default
- Standard Rails generator pattern for config file modifications

## Testing

### Before (reproduce bugs)
```bash
cd /tmp
rails new test-app --skip-javascript
cd test-app
bundle add react_on_rails --version 16.2.0.rc.0 --strict
git add . && git commit -m "Add gem"
bin/rails generate react_on_rails:install --rspack

# Bug: Only default has rspack, environments have webpack
grep "assets_bundler" config/shakapacker.yml

# Bug: switch-bundler crashes
bin/switch-bundler webpack
```

### After (with this fix)
```bash
# All sections should show rspack after --rspack flag
grep "assets_bundler" config/shakapacker.yml
# Expected: All lines show "rspack"

# switch-bundler should work without crashing
bin/switch-bundler webpack
bin/switch-bundler rspack
```

## Test plan
- [ ] Fresh install with `--rspack` configures rspack in all environments
- [ ] `bin/switch-bundler rspack` updates all environment sections
- [ ] `bin/switch-bundler webpack` updates all environment sections
- [ ] YAML comments and structure preserved after switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broader, text-based bundler-switching that preserves configuration layout and inline comments.
* **New Features**
  * Switching bundlers now also updates the JavaScript transpiler to SWC.
  * CLI help updated to note transpiler updates when switching bundlers.
* **Tests**
  * Added tests validating config updates, comment/anchor preservation, and TypeScript-specific wiring during bundler switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->