### PR TITLE
docs: fix incorrect license configuration option in Pro docs

### DIFF
--- a/react_on_rails_pro/docs/installation.md
+++ b/react_on_rails_pro/docs/installation.md
@@ -47,16 +47,15 @@ Set your license token as an environment variable:
 export REACT_ON_RAILS_PRO_LICENSE="your-license-token-here"
 ```
 
-Or configure it in your Rails initializer (not recommended for production):
+Or create a config file at `config/react_on_rails_pro_license.key`:
 
-```ruby
-# config/initializers/react_on_rails_pro.rb
-ReactOnRailsPro.configure do |config|
-  config.license_token = ENV["REACT_ON_RAILS_PRO_LICENSE"]
-end
+```bash
+echo "your-license-token-here" > config/react_on_rails_pro_license.key
 ```
 
-⚠️ **Security Warning**: Never commit your license token to version control. Always use environment variables or secure secret management systems (like Rails credentials, Heroku config vars, AWS Secrets Manager, etc.).
+⚠️ **Security Warning**: Never commit your license token to version control. Add `config/react_on_rails_pro_license.key` to your `.gitignore`. For production, use environment variables or secure secret management systems (Rails credentials, Heroku config vars, AWS Secrets Manager, etc.).
+
+For complete license setup instructions, see [LICENSE_SETUP.md](../LICENSE_SETUP.md).
 
 ## Rails Configuration
 

--- a/react_on_rails_pro/docs/updating.md
+++ b/react_on_rails_pro/docs/updating.md
@@ -169,18 +169,17 @@ Add your React on Rails Pro license token as an environment variable:
 export REACT_ON_RAILS_PRO_LICENSE="your-license-token-here"
 ```
 
-**Or** configure it in your Rails initializer:
+Or create a config file at `config/react_on_rails_pro_license.key`:
 
-```ruby
-# config/initializers/react_on_rails_pro.rb
-ReactOnRailsPro.configure do |config|
-  config.license_token = ENV["REACT_ON_RAILS_PRO_LICENSE"]
-end
+```bash
+echo "your-license-token-here" > config/react_on_rails_pro_license.key
 ```
 
-⚠️ **Security Warning**: Never commit your license token to version control. Always use environment variables or secure secret management systems (Rails credentials, Heroku config vars, AWS Secrets Manager, etc.).
+⚠️ **Security Warning**: Never commit your license token to version control. Add `config/react_on_rails_pro_license.key` to your `.gitignore`. For production, use environment variables or secure secret management systems (Rails credentials, Heroku config vars, AWS Secrets Manager, etc.).
 
 **Where to get your license token:** Contact [justin@shakacode.com](mailto:justin@shakacode.com) if you don't have your license token.
+
+For complete license setup instructions, see [LICENSE_SETUP.md](../LICENSE_SETUP.md).
 
 ### Verify Migration
 


### PR DESCRIPTION
## Summary

- Removes references to `config.license_token` which doesn't exist in the codebase
- Replaces with correct config file method (`config/react_on_rails_pro_license.key`)
- Adds link to LICENSE_SETUP.md for complete instructions

## Background

The `config.license_token` option was incorrectly documented in PR #1901 but was never actually implemented in PR #1857. The LicenseValidator only supports two methods:

1. **Environment variable**: `REACT_ON_RAILS_PRO_LICENSE`
2. **Config file**: `config/react_on_rails_pro_license.key`

There is no `license_token` attribute in the `ReactOnRailsPro::Configuration` class.

## Files Changed

- `react_on_rails_pro/docs/installation.md` - Fixed license configuration section
- `react_on_rails_pro/docs/updating.md` - Fixed license configuration section

## Test Plan

- [x] Verified the config file method matches what LICENSE_SETUP.md documents
- [x] Verified `config.license_token` does not exist in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * License configuration now uses file-based setup instead of environment variables.
  * New license key file requires .gitignore configuration.
  * Comprehensive setup guidance available in LICENSE_SETUP.md.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->