### PR TITLE
Add mise-exec wrapper for Conductor compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
 
   Exclude:
     - '**/*.js'
+    - 'bin/mise-exec' # Shell script, not Ruby
     - '**/node_modules/**/*'
     - '**/public/**/*'
     - '**/tmp/**/*'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -803,3 +803,37 @@ Exclude these directories to prevent IDE slowdowns:
 - `/node_modules`, `/react_on_rails/spec/dummy/node_modules`, `/react_on_rails/spec/dummy/tmp`
 - `/react_on_rails/spec/dummy/app/assets/webpack`, `/react_on_rails/spec/dummy/log`
 - `/react_on_rails/spec/dummy/e2e/playwright-report`, `/react_on_rails/spec/dummy/test-results`
+
+## Conductor Compatibility (mise Version Manager)
+
+### Problem
+
+Conductor runs commands in a non-interactive shell that doesn't source `.zshrc`. This means mise's shell hook (which reorders PATH based on `.tool-versions`) never runs. Commands will use system Ruby/Node instead of project-specified versions.
+
+**Symptoms:**
+- `ruby --version` returns system Ruby (e.g., 2.6.10) instead of project Ruby (e.g., 3.3.4)
+- Pre-commit hooks fail with wrong tool versions
+- `bundle` commands fail due to incompatible Ruby versions
+- Node/pnpm commands use wrong Node version
+
+### Solution
+
+Use the `bin/mise-exec` wrapper to ensure commands run with correct tool versions:
+
+```bash
+# Instead of:
+ruby --version
+bundle exec rubocop
+pnpm install
+git commit -m "message"
+
+# Use:
+bin/mise-exec ruby --version
+bin/mise-exec bundle exec rubocop
+bin/mise-exec pnpm install
+bin/mise-exec git commit -m "message"  # Pre-commit hooks work correctly
+```
+
+### Reference
+
+See [react_on_rails-demos#105](https://github.com/shakacode/react_on_rails-demos/issues/105) for detailed problem analysis and solution development.

--- a/bin/mise-exec
+++ b/bin/mise-exec
@@ -1,0 +1,23 @@
+#!/usr/bin/env zsh
+# Wrapper script to run commands with mise-managed tool versions
+# Usage: bin/mise-exec <command> [args...]
+#
+# This is needed because Conductor (and other non-interactive shells) don't
+# source .zshrc, so mise's PATH ordering based on .tool-versions isn't active
+# by default.
+#
+# Examples:
+#   bin/mise-exec ruby --version       # Uses .tool-versions Ruby
+#   bin/mise-exec bundle exec rubocop  # Correct Ruby for linting
+#   bin/mise-exec git commit -m "msg"  # Pre-commit hooks work correctly
+#   bin/mise-exec pnpm install         # Uses .tool-versions Node
+#
+# See: https://github.com/shakacode/react_on_rails-demos/issues/105
+
+if ! command -v mise &> /dev/null; then
+  echo "Error: mise is not installed or not in PATH" >&2
+  echo "Install: https://mise.jdx.dev/getting-started.html" >&2
+  exit 1
+fi
+
+exec mise exec -- "$@"


### PR DESCRIPTION
## Summary

- Add `bin/mise-exec` wrapper script to ensure commands use mise-managed tool versions
- Update `.rubocop.yml` to exclude the shell script from linting
- Document Conductor compatibility in `CLAUDE.md`

## Problem

Conductor (and other non-interactive shells) don't source `.zshrc`, so mise's shell hook that reorders PATH based on `.tool-versions` never runs. This causes commands to use system Ruby/Node instead of the project-specified versions.

**Symptoms:**
- `ruby --version` returns system Ruby (e.g., 2.6.10) instead of project Ruby (3.3.4)
- Pre-commit hooks fail with wrong tool versions
- `bundle` commands fail due to incompatible Ruby versions

## Solution

The `bin/mise-exec` wrapper explicitly invokes mise to ensure correct tool versions:

```bash
bin/mise-exec ruby --version       # Uses .tool-versions Ruby
bin/mise-exec bundle exec rubocop  # Correct Ruby for linting
bin/mise-exec pnpm install         # Uses .tool-versions Node
```

## Related

- Mirrors implementation from [react_on_rails-demos#106](https://github.com/shakacode/react_on_rails-demos/pull/106)
- See [react_on_rails-demos#105](https://github.com/shakacode/react_on_rails-demos/issues/105) for detailed problem analysis

## Test plan

- [x] Verify `bin/mise-exec ruby --version` returns mise-managed Ruby (3.3.4)
- [x] Verify `bin/mise-exec bundle exec rubocop` runs successfully
- [x] Verify pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing tool versions with mise in non-interactive shell environments, including solutions for mismatched tool versions and broken development hooks.

* **Chores**
  * Updated configuration to properly exclude tooling from code analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->