### PR TITLE
Fix lefthook glob patterns to match root directory files

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -6,22 +6,22 @@ pre-commit:
   parallel: true
   commands:
     autofix:
-      glob: "**/*.{rb,rake,ru}"
+      glob: "{*.{rb,rake,ru},**/*.{rb,rake,ru}}"
       run: bin/lefthook/ruby-autofix all-changed
       stage_fixed: true
 
     rubocop:
-      glob: "**/*.{rb,rake,ru}"
+      glob: "{*.{rb,rake,ru},**/*.{rb,rake,ru}}"
       run: bin/lefthook/ruby-lint all-changed
       stage_fixed: true
 
     eslint:
-      glob: "**/*.{js,jsx,ts,tsx}"
+      glob: "{*.{js,jsx,ts,tsx},**/*.{js,jsx,ts,tsx}}"
       run: bin/lefthook/eslint-lint all-changed
       stage_fixed: true
 
     prettier:
-      glob: "**/*.{js,jsx,ts,tsx,json,md,yml,yaml}"
+      glob: "{*.{js,jsx,ts,tsx,json,md,yml,yaml},**/*.{js,jsx,ts,tsx,json,md,yml,yaml}}"
       run: bin/lefthook/prettier-format all-changed
       stage_fixed: true
 


### PR DESCRIPTION
## Summary

Fixed pre-commit hooks not catching linting errors in root-level files. The glob patterns like `**/*.rb` only match files in subdirectories. Updated to use `{*.ext,**/*.ext}` format to match files at all directory levels.

## Testing

- Verified RuboCop now catches errors in root-level `.rb` files
- Verified Prettier now catches formatting errors in root-level `.md` and `.yml` files
- Pre-commit hook now runs successfully on staged files in any directory

## Pull Request checklist

- [x] Testing completed locally
- [ ] Add/update test to cover these changes (not applicable—configuration-only)
- [ ] Update documentation (not applicable—configuration-only)
- [ ] Update CHANGELOG file (not applicable—tooling fix)