### PR TITLE
Fix bin/dev route argument format

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/dev
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/dev
@@ -29,6 +29,6 @@ DEFAULT_ROUTE = "hello_world"
 # Main execution
 # Add the default route to ARGV if no --route option is provided
 argv_with_defaults = ARGV.dup
-argv_with_defaults.push("--route", DEFAULT_ROUTE) unless argv_with_defaults.any? { |arg| arg.start_with?("--route") }
+argv_with_defaults.push("--route=#{DEFAULT_ROUTE}") unless argv_with_defaults.any? { |arg| arg.start_with?("--route") }
 
 ReactOnRails::Dev::ServerManager.run_from_command_line(argv_with_defaults)


### PR DESCRIPTION
## Summary
- Fix `--route` argument in `bin/dev` template to use single argument format (`--route=value`) instead of two separate arguments

## Problem
When running `./bin/dev` without arguments, the DEFAULT_ROUTE value (`hello_world`) was being treated as a standalone command rather than the value for `--route`, causing:
```
Unknown argument: hello_world
Run 'dev help' for usage information
```

## Solution
Changed from:
```ruby
argv_with_defaults.push("--route", DEFAULT_ROUTE)
```
To:
```ruby
argv_with_defaults.push("--route=#{DEFAULT_ROUTE}")
```

## Test plan
- [ ] Run `./bin/dev` without arguments - should no longer error
- [ ] Run `./bin/dev --route=custom_route` - should still work with custom routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development environment configuration formatting for improved consistency with standard conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->