### PR TITLE
Run link checker daily instead of weekly

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -13,8 +13,9 @@ on:
       - '.github/workflows/check-markdown-links.yml'
       - '.lychee.toml'
   schedule:
-    # Run weekly on Monday at 8am UTC
-    - cron: '0 8 * * 1'
+    # Run daily at 3am UTC to catch stale cached links
+    # See: https://lychee.cli.rs/github_action_recipes/caching/
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Changes scheduled link check from weekly to daily per [lychee community best practices](https://lychee.cli.rs/github_action_recipes/caching/).

## Problem

A broken link introduced in PR #2239 (Dec 22) wasn't caught until Jan 27 - over a month later. The link checker's cache (`max_cache_age=1d`) kept getting refreshed by frequent PR runs, hiding the stale entry.

## Solution

Run the scheduled check daily at 3am UTC instead of weekly. This ensures:
- Cache entries older than 1 day get refreshed
- Broken links are caught within 24 hours instead of up to 7 days

## Impact

Minimal - one ~2 minute CI run per day instead of per week.

## Related

- Issue #2319 - documents the broken link discovery
- PR #2318 - fixes the immediate broken link

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated link verification workflow to run daily, improving the frequency of link validity checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->