### PR TITLE
Remove outdated GitHub Packages token workaround from troubleshooting docs

### DIFF
--- a/react_on_rails_pro/docs/troubleshooting.md
+++ b/react_on_rails_pro/docs/troubleshooting.md
@@ -1,27 +1,3 @@
 # Troubleshooting
 
-## Invalid Token Workaround
-
-On June 27, 2024, tokens mysteriously did not work for a few hours. The problem resolved itself within a few hours.
-
-If you do see this problem, get in touch with the package maintainers via Slack. You can also message
-Justin Gordon at +1-808-281-7272.
-
-As an alternative to the token issue, if you have an account with access to the docs and this file, you can
-create a new token and follow these steps.
-
-To create a new token, visit https://github.com/settings/apps:
-
-1. Developer Settings
-2. Personal access tokens
-3. Tokens (classic)
-4. Generate a new token, classic
-5. 30-day expiration (to be safer)
-6. Repo privileges (not ideal) but shouldn't last long
-
-Then follow these steps to use your token:
-
-- [Ruby Gem](https://github.com/shakacode/react_on_rails_pro/blob/master/docs/installation.md#using-a-branch-in-your-gemfile)
-- [Node Package](https://github.com/shakacode/react_on_rails_pro/blob/master/docs/installation.md#instructions-for-using-a-branch)
-
-Note that this token gives `repo` access, so you want to revoke this token ASAP.
+For issues related to upgrading from GitHub Packages to public distribution, see the [Upgrading Guide](./updating.md).


### PR DESCRIPTION
## Summary

- Removed the obsolete "Invalid Token Workaround" section from `react_on_rails_pro/docs/troubleshooting.md`
- Added a pointer to the [Upgrading Guide](./react_on_rails_pro/docs/updating.md) for migration-related issues

The removed section referenced the old private distribution model (GitHub Packages) which was replaced with public distribution (npmjs.org / RubyGems.org) in #1901. It also contained broken links to `installation.md` anchors (`#using-a-branch-in-your-gemfile` and `#instructions-for-using-a-branch`) that were removed during the rewrite.

## Test plan

- [ ] Verify the relative link to `updating.md` resolves correctly on GitHub

Closes #2321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting documentation by consolidating token-related issue guidance, directing users to the Upgrading Guide for assistance with distribution-related concerns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->