### PR TITLE
Fix E2E test for Issue #2210 hydration mismatch

### DIFF
--- a/react_on_rails/spec/dummy/app/views/pages/manual_render_test.html.erb
+++ b/react_on_rails/spec/dummy/app/views/pages/manual_render_test.html.erb
@@ -30,7 +30,7 @@
 <h2>Components</h2>
 
 <div id="components-container">
-  <%= react_component("ManualRenderComponent", props: { name: "First Component" }, prerender: false, id: "ManualRenderComponent-1") %>
+  <%= react_component("ManualRenderComponent", props: { name: "First Component" }, prerender: false, id: "ManualRenderComponent-1", auto_load_bundle: false) %>
 </div>
 
 <hr/>


### PR DESCRIPTION
## Summary
- Fixes a test configuration issue in the Issue #2210 E2E test page
- Adds `auto_load_bundle: false` to the ManualRenderComponent since it's already registered in client-bundle.js

## Context
Issue #2210 reported hydration mismatch errors when `ReactOnRails.reactOnRailsPageLoaded()` was called multiple times for client-side only components.

The fix for this issue was already implemented in `ClientRenderer.ts`:
- Track rendered components in a Map to avoid re-rendering
- Skip components that are already rendered (same DOM node)
- Handle DOM node replacement (same ID, new element) by unmounting old root and rendering to new node

The E2E tests for this fix existed but were failing because the test page was using `auto_load_bundle: true` (global config) which tried to load `generated/ManualRenderComponent.js` instead of using the component from `client-bundle.js`.

## Test plan
- [x] Unit tests pass (`pnpm run test` in packages/react-on-rails)
- [x] E2E tests pass with Chromium (`pnpm test:e2e react_on_rails/page_loaded_multiple_calls.spec.js --project=chromium`)

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to disable automatic bundle loading for component rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->