### PR TITLE
Fix Pro CHANGELOG.md structure for 16.2.x releases

### DIFF
--- a/react_on_rails_pro/CHANGELOG.md
+++ b/react_on_rails_pro/CHANGELOG.md
@@ -23,12 +23,6 @@ Changes since the last non-beta release.
 
 - **Node Renderer Master/Worker Exports**: Added public `master` and `worker` exports to `react-on-rails-pro-node-renderer` package, allowing users to import from `react-on-rails-pro-node-renderer/master` and `react-on-rails-pro-node-renderer/worker`. [PR 2326](https://github.com/shakacode/react_on_rails/pull/2326) by [justin808](https://github.com/justin808).
 
-## [16.2.1] - 2026-01-18
-
-### Developer (Contributors Only)
-
-- **Benchmarking in CI**: Added performance testing infrastructure. [PR 1868](https://github.com/shakacode/react_on_rails/pull/1868) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
-
 ## [16.2.0] - 2026-01-14
 
 ### Improved
@@ -549,8 +543,7 @@ Above changes in [PR 52](https://github.com/shakacode/react_on_rails_pro/pull/52
 - support for javascript evaluation caching
 - advanced error handling
 
-[Unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...master
-[16.2.1]: https://github.com/shakacode/react_on_rails/compare/v16.2.0...v16.2.1
+[Unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.2.0...master
 [16.2.0]: https://github.com/shakacode/react_on_rails/compare/v16.1.1...v16.2.0
 [4.0.0-rc.15]: https://github.com/shakacode/react_on_rails_pro/compare/4.0.0-rc.14...4.0.0-rc.15
 [4.0.0.rc.11]: https://github.com/shakacode/react_on_rails_pro/compare/4.0.0-rc.9...4.0.0-rc.11


### PR DESCRIPTION
## Summary

- Add missing `[16.2.0]` and `[16.2.1]` release sections (these versions shipped but had no changelog entries)
- Move PR 2326 (Node Renderer exports) to Unreleased (merged after 16.2.1)
- Consolidate rc.0 content under 16.2.0 (matching main CHANGELOG approach)
- Update header version examples from `3.0.0.rc.1` to `16.2.1`
- Fix comparison links at bottom for 16.2.x versions
- Remove empty `### Changed` section and duplicate "Changes since the last non-beta release" text

## Context

The Pro CHANGELOG.md had structural issues after the 16.2.x releases:
- `### [v16.2.0.rc.0]` was incorrectly placed as a sub-heading under `## [Unreleased]` with wrong heading level
- No `## [16.2.0]` or `## [16.2.1]` sections existed despite these versions being shipped
- PR 2326 was incorrectly placed under the rc.0 section when it was merged after 16.2.1

## Follow-up

This is step 1 of 2. A follow-up PR will merge the Pro changelog into the main CHANGELOG.md with clear Pro/non-Pro sections per version, providing a single source of truth.

## Test plan

- [x] Verify comparison links resolve correctly on GitHub
- [x] Verify no duplicate changelog entries
- [x] Verify file ends with newline
- [x] Visual inspection that structure matches main CHANGELOG.md format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for version 16.2.1 release with versioning references and comparison links.

* **New Features**
  * Added Node Renderer Master/Worker Exports functionality.

* **Chores**
  * Enhanced benchmarking in CI pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->