### PR TITLE
Fix gem release OTP handling for react_on_rails_pro

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -70,8 +70,11 @@ def publish_gem_with_retry(dir, gem_name, otp: nil, max_retries: ENV.fetch("GEM_
 
   while retry_count < max_retries && !success
     begin
-      otp_flag = current_otp ? "--otp #{current_otp}" : ""
-      sh %(cd #{dir} && gem release #{otp_flag})
+      # Use GEM_HOST_OTP_CODE environment variable instead of --otp flag
+      # because `gem release` (gem-release gem) doesn't support --otp,
+      # but the underlying `gem push` reads OTP from this env var
+      env_prefix = current_otp ? "GEM_HOST_OTP_CODE=#{current_otp} " : ""
+      sh %(cd #{dir} && #{env_prefix}gem release)
       success = true
     # Rake's sh method raises RuntimeError (not Gem exceptions) when commands fail
     rescue RuntimeError, IOError => e


### PR DESCRIPTION
## Summary

- Fixes Ruby gem publishing failure for `react_on_rails_pro` when OTP retry is needed
- The `gem release` command (from gem-release gem) doesn't support the `--otp` flag
- Uses `GEM_HOST_OTP_CODE` environment variable instead, which the underlying `gem push` command reads

## Problem

When publishing `react_on_rails_pro` with MFA enabled, if the initial OTP fails (e.g., expired), the retry mechanism tried to pass `--otp CODE` to `gem release`:

```
$ gem release --otp 866508
ERROR:  While executing gem ... (Gem::OptionParser::InvalidOption)
    invalid option: --otp
```

This happened because `gem release` (from the gem-release gem) doesn't support the `--otp` flag - only `gem push` does.

## Solution

Use the `GEM_HOST_OTP_CODE` environment variable instead:

```ruby
env_prefix = current_otp ? "GEM_HOST_OTP_CODE=#{current_otp} " : ""
sh %(cd #{dir} && #{env_prefix}gem release)
```

RubyGems internally reads this environment variable in `gemcutter_utilities.rb`:
```ruby
options[:otp] || ENV["GEM_HOST_OTP_CODE"]
```

## Test plan

- [ ] Verify via next release that OTP retry works for both gems

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the gem release process to use environment variable-based authentication instead of command-line flags for one-time password handling, maintaining existing retry logic and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->