### PR TITLE
Fix release script to update execjs-compatible-dummy Gemfile.lock

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -297,6 +297,10 @@ task :release, %i[version dry_run] do |_t, args|
   unbundled_sh_in_dir(gem_root, "bundle install#{bundle_quiet_flag}")
   unbundled_sh_in_dir(dummy_app_dir, "bundle install#{bundle_quiet_flag}")
   unbundled_sh_in_dir(pro_dummy_app_dir, "bundle install#{bundle_quiet_flag}") if Dir.exist?(pro_dummy_app_dir)
+  if Dir.exist?(pro_execjs_dummy_app_dir)
+    unbundled_sh_in_dir(pro_execjs_dummy_app_dir,
+                        "bundle install#{bundle_quiet_flag}")
+  end
   unbundled_sh_in_dir(pro_gem_root, "bundle install#{bundle_quiet_flag}")
 
   unless is_dry_run

--- a/rakelib/task_helpers.rb
+++ b/rakelib/task_helpers.rb
@@ -32,6 +32,10 @@ module ReactOnRails
       File.join(pro_gem_root, "spec", "dummy")
     end
 
+    def pro_execjs_dummy_app_dir
+      File.join(pro_gem_root, "spec", "execjs-compatible-dummy")
+    end
+
     # Executes a string or an array of strings in a shell in the given directory in an unbundled environment
     def sh_in_dir(dir, *shell_commands)
       shell_commands.flatten.each { |shell_command| sh %(cd #{dir} && #{shell_command.strip}) }


### PR DESCRIPTION
## Summary
- Add `pro_execjs_dummy_app_dir` helper method in `task_helpers.rb`
- Include execjs-compatible-dummy directory in release script's Gemfile.lock update process

## Problem
The release script updates most `Gemfile.lock` files when bumping versions, but misses `react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock`. After releases, this file would still show the old version.

Fixes #2193

## Test plan
- [ ] Run `rake release[patch,true]` dry run to verify the new directory is included in the update process
- [ ] Verify `pro_execjs_dummy_app_dir` returns correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process infrastructure to improve build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->