### PR TITLE
Fix MDX comment syntax in troubleshooting docs

### DIFF
--- a/docs/deployment/troubleshooting-build-errors.md
+++ b/docs/deployment/troubleshooting-build-errors.md
@@ -260,8 +260,6 @@ end
 
 **Note:** This workaround is not recommended for production. Upgrade to 16.2.0+ for the proper fix.
 
-{/_ TODO: Remove this section once llms.txt is implemented (shakacode/sc-website#451) _/}
-
 ## For Coding Agents
 
 ### Automated Diagnostics


### PR DESCRIPTION
## Summary

- Change HTML comment (`<!-- -->`) to MDX comment (`{/* */}`) in `docs/deployment/troubleshooting-build-errors.md`

HTML comments break MDX compilation on the website (gatsby-plugin-mdx). This was introduced in PR #2355.

## Test plan

- [ ] Verify the website builds without the `Unexpected character '!'` error on `troubleshooting-build-errors.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Cleaned up formatting in the troubleshooting guide: removed an extraneous HTML comment and an extra blank line before the "For Coding Agents" section to improve clarity and readability. No functional or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->