### PR TITLE
docs: deduplicate AGENTS and CLAUDE guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ yamllint .github/                    # YAML lint (do NOT run RuboCop on .yml fil
 
 ## Testing
 
+- **Prefer local testing over CI iteration** — don't push "hopeful" fixes. Apply the **15-minute rule**: if 15 more minutes of local testing would catch the issue before CI does, spend the 15 minutes.
+- **Never claim a test is "fixed" without running it locally first.** Use "This SHOULD fix..." or "Proposed fix (UNTESTED)" for unverified changes.
 - **Ruby**: RSpec. Unit tests in `react_on_rails/spec/react_on_rails/`, integration tests via a dummy Rails app in `react_on_rails/spec/dummy/`.
 - **JavaScript/TypeScript**: Jest. Tests in `packages/react-on-rails/tests/`.
 - **E2E**: Playwright. Tests in `react_on_rails/spec/dummy/e2e/playwright/e2e/`. Run with `cd react_on_rails/spec/dummy && pnpm test:e2e`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,6 @@ If this file conflicts with `AGENTS.md`, follow `AGENTS.md`.
 ## Behavioral Defaults
 
 - When confident in your changes, **commit and push without asking for permission**. Always monitor CI after pushing.
-- Apply the **15-minute rule**: "If I spent 15 more minutes testing locally, would I discover this issue before CI does?" If yes, spend the 15 minutes.
-- **Never claim a test is "fixed" without running it locally first.** Use "This SHOULD fix..." or "Proposed fix (UNTESTED)" for unverified changes.
-- **Prefer local testing over CI iteration** — don't push "hopeful" fixes.
 
 ## Claude-Specific Workflow
 


### PR DESCRIPTION
## Why
Agent guidance is duplicated across `AGENTS.md` and `CLAUDE.md`, which causes drift and contradictory instructions.

## What
- Declares `AGENTS.md` as canonical for repo-wide agent policy.
- Updates `AGENTS.md` project structure to use `internal/` for internal docs.
- Refactors `CLAUDE.md` to Claude-specific workflow notes and references, with explicit fallback to `AGENTS.md` on conflicts.

## Scope
- Documentation-only changes in:
  - `AGENTS.md`
  - `CLAUDE.md`

## Notes
- This PR should merge before PRs that continue to edit `CLAUDE.md` (for example #2370) to minimize rebase churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical agent policy defining repository-wide rules and conflict resolution.
  * Expanded command and testing guidance, including new test subsets and setup/workflow sequences.
  * Added an analysis/docs category and clarified where tests and documentation live.
  * Reorganized docs structure with named subdirectories for guides, API, deployment, migration, and contributor info.
  * Introduced changelog formatting and guidance; updated tool-specific operational guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->