### PR TITLE
docs: add wrapper-file pattern for transpiled languages

### DIFF
--- a/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
+++ b/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
@@ -534,7 +534,11 @@ export default ReScriptShow;
 This pattern works for any transpiled language and requires no gem configuration changes. The wrapper file can use `.js`, `.jsx`, `.ts`, or `.tsx` depending on your project setup.
 
 > [!NOTE]
-> While it's possible to add gem-level configuration for additional extensions, the wrapper-file pattern is recommended because it works immediately with no configuration changes and makes the component registration explicit.
+> While it's possible to add gem-level configuration for additional extensions, the wrapper-file pattern is recommended because it:
+>
+> - Works immediately with no configuration changes
+> - Makes the component registration explicit and visible in the file tree
+> - Avoids coupling your build pipeline to gem internals that may change between versions
 
 ### Using Automated Bundle Generation Feature with already defined packs
 
@@ -554,6 +558,7 @@ As of version 13.3.4, bundles inside directories that match `config.components_s
 - Run `rake react_on_rails:generate_packs` to generate the component bundles
 - Check that your component exports a default export: `export default MyComponent;`
 - Verify the component name matches the directory structure
+- If using a transpiled language (ReScript, Reason, etc.), see [Transpiled Languages](#transpiled-languages-rescript-reason-etc) — files like `MyComponent.bs.js` register as `MyComponent.bs` instead of `MyComponent`
 
 #### 2. CSS not loading (FOUC - Flash of Unstyled Content)
 


### PR DESCRIPTION
## Summary

- Document the recommended wrapper-file approach for auto-registering components from transpiled languages like ReScript (`.bs.js`, `.res.js`)
- A thin wrapper file in the `ror_components` directory avoids incorrect name extraction without requiring gem changes

This replaces the `component_extensions` config approach from PR #2348 with a simpler documentation-only solution.

Closes #2343

## Test plan

- [ ] Docs render correctly on the website
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new subsection explaining how transpiled-language build outputs (e.g., ReScript/Reason) can produce unexpected component names, with symptoms and error examples.
  * Introduced a recommended "wrapper file" pattern (compatible with .js/.jsx/.ts/.tsx) to ensure correct component registration.
  * Linked this guidance from Troubleshooting/Common Issues for visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->