### PR TITLE
Handle missing Bencher baseline gracefully in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -577,6 +577,7 @@ jobs:
           # so we can distinguish missing baselines (404) from actual regression alerts.
           # Use set +e to capture exit code without failing immediately.
           BENCHER_STDERR=$(mktemp)
+          trap 'rm -f "$BENCHER_STDERR"' EXIT
           set +e
           bencher run \
             --project react-on-rails-t8a9ncxo \
@@ -637,6 +638,7 @@ jobs:
             echo "⚠️ Benchmark data was collected but regression comparison is unavailable for this run"
             echo "📋 Bencher stderr output:"
             cat "$BENCHER_STDERR"
+            echo "::warning::Bencher baseline not found for start-point hash '$START_POINT_HASH' — regression comparison unavailable for this run"
             BENCHER_EXIT_CODE=0
           fi
           rm -f "$BENCHER_STDERR"


### PR DESCRIPTION
## Summary
- When the PR base commit was not benchmarked (e.g., docs-only changes skipped by `paths-ignore`), Bencher returns a 404 Not Found error, failing the entire benchmark workflow even though benchmarks completed successfully
- Now captures Bencher stderr to a temp file and treats 404 errors as warnings instead of failures, while still failing for actual performance regression alerts

## Test plan
- [ ] Verify benchmark workflow passes on a PR whose base commit has no Bencher data
- [ ] Verify benchmark workflow still fails on actual performance regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved benchmark workflow diagnostics: captures tool stderr separately and surfaces it immediately in logs while preserving generated HTML benchmark reports and PR comments.
  * Treats a missing baseline (404) as a non-fatal warning when no regressions are detected, allowing the workflow to continue and produce results.
  * Adds safety checks to avoid masking real regressions and cleans up temporary diagnostic artifacts after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->