### PR TITLE
Enhance RSC demo with async data fetching and client component

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup.rb
@@ -209,6 +209,8 @@ module ReactOnRails
                   "#{ror_components_dir}/HelloServer.#{ext}")
         copy_file("templates/rsc/base/app/javascript/src/HelloServer/components/HelloServer.#{ext}",
                   "#{components_dir}/HelloServer.#{ext}")
+        copy_file("templates/rsc/base/app/javascript/src/HelloServer/components/LikeButton.#{ext}",
+                  "#{components_dir}/LikeButton.#{ext}")
 
         puts Rainbow("✅ Created HelloServer component").green
       end

--- a/react_on_rails/lib/generators/react_on_rails/templates/dev_tests/spec/system/hello_server_spec.rb
+++ b/react_on_rails/lib/generators/react_on_rails/templates/dev_tests/spec/system/hello_server_spec.rb
@@ -6,6 +6,12 @@ describe "Hello Server", :js do
   it "renders the React Server Component" do
     visit "/hello_server"
     expect(page).to have_text("Hello, React on Rails Pro!")
-    expect(page).to have_text("This is a React Server Component")
+    expect(page).to have_text("How is this different from SSR?")
+  end
+
+  it "renders the interactive LikeButton client component" do
+    visit "/hello_server"
+    expect(page).to have_button("👍 Like")
+    expect(page).to have_text("0 likes")
   end
 end

--- a/react_on_rails/lib/generators/react_on_rails/templates/pro/base/client/node-renderer.js
+++ b/react_on_rails/lib/generators/react_on_rails/templates/pro/base/client/node-renderer.js
@@ -11,7 +11,8 @@ const config = {
   // See value in /config/initializers/react_on_rails_pro.rb
   password: env.RENDERER_PASSWORD || 'devPassword',
 
-  // workersCount defaults to the number of CPUs minus 1
+  // Number of Node.js worker threads for SSR rendering
+  // Set NODE_RENDERER_CONCURRENCY env var to override (e.g., for production tuning)
   workersCount: env.NODE_RENDERER_CONCURRENCY != null ? Number(env.NODE_RENDERER_CONCURRENCY) : 3,
 
   // If set to true, `supportModules` enables the server-bundle code to call a default set of NodeJS modules

--- a/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/HelloServer.jsx
+++ b/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/HelloServer.jsx
@@ -1,18 +1,78 @@
 // HelloServer - React Server Component
-// Unlike HelloWorld (which runs in the browser), this component runs ONLY on the server.
-// No JavaScript is sent to the browser for this component.
 //
-// To add async data fetching, make this an async function and use await directly.
+// This component runs ONLY on the server. No JavaScript for it is sent to the browser.
+// It demonstrates key RSC capabilities:
+//
+// 1. Async data fetching — use await directly in the component (no useEffect needed)
+// 2. Server-only code — access databases, file systems, or secrets safely
+// 3. Zero client JS — heavy libraries used here don't increase your bundle size
+// 4. Streaming — wrapped in <Suspense>, this component streams HTML as it resolves
+//
 // For more information, see:
 // https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/
 
 import React from 'react';
+import LikeButton from './LikeButton';
 
-const HelloServer = ({ name = 'World' }) => {
+// Simulate an async data fetch (replace with a real API call or DB query)
+async function fetchGreeting(name) {
+  // In a real app, you could do:
+  //   const data = await db.query('SELECT greeting FROM greetings WHERE name = ?', [name]);
+  //   const file = await fs.readFile('./data/greeting.txt', 'utf-8');
+  //   const res = await fetch('http://internal-api/greeting');
+  // eslint-disable-next-line no-promise-executor-return
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const now = new Date();
+  return {
+    message: `Hello, ${name}!`,
+    serverTime: now.toLocaleString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    }),
+    facts: [
+      'This component rendered entirely on the server — zero JS was sent to the browser for it.',
+      'The date formatting above used server-side Intl APIs — no date library shipped to the client.',
+      'The "Like" button below IS a client component — only its JS is sent to the browser.',
+    ],
+  };
+}
+
+const HelloServer = async ({ name = 'World' }) => {
+  const { message, serverTime, facts } = await fetchGreeting(name);
+
   return (
-    <div>
-      <h3>Hello, {name}!</h3>
-      <p>This is a React Server Component.</p>
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 600, margin: '0 auto' }}>
+      <h2>{message}</h2>
+      <p style={{ color: '#666', fontSize: '0.9em' }}>Server-rendered at: {serverTime}</p>
+
+      <div
+        style={{
+          background: '#f0f9ff',
+          border: '1px solid #bae6fd',
+          borderRadius: 8,
+          padding: 16,
+          margin: '16px 0',
+        }}
+      >
+        <h3 style={{ margin: '0 0 12px' }}>How is this different from SSR?</h3>
+        <ul style={{ margin: 0, paddingLeft: 20 }}>
+          {facts.map((fact) => (
+            <li key={fact} style={{ marginBottom: 8 }}>
+              {fact}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* LikeButton is a client component — it ships JS for interactivity */}
+      <LikeButton />
     </div>
   );
 };

--- a/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/HelloServer.tsx
+++ b/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/HelloServer.tsx
@@ -1,22 +1,88 @@
 // HelloServer - React Server Component
-// Unlike HelloWorld (which runs in the browser), this component runs ONLY on the server.
-// No JavaScript is sent to the browser for this component.
 //
-// To add async data fetching, make this an async function and use await directly.
+// This component runs ONLY on the server. No JavaScript for it is sent to the browser.
+// It demonstrates key RSC capabilities:
+//
+// 1. Async data fetching — use await directly in the component (no useEffect needed)
+// 2. Server-only code — access databases, file systems, or secrets safely
+// 3. Zero client JS — heavy libraries used here don't increase your bundle size
+// 4. Streaming — wrapped in <Suspense>, this component streams HTML as it resolves
+//
 // For more information, see:
 // https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/
 
 import React from 'react';
+import LikeButton from './LikeButton';
 
 interface HelloServerProps {
   name?: string;
 }
 
-const HelloServer: React.FC<HelloServerProps> = ({ name = 'World' }) => {
+interface GreetingData {
+  message: string;
+  serverTime: string;
+  facts: string[];
+}
+
+// Simulate an async data fetch (replace with a real API call or DB query)
+async function fetchGreeting(name: string): Promise<GreetingData> {
+  // In a real app, you could do:
+  //   const data = await db.query('SELECT greeting FROM greetings WHERE name = ?', [name]);
+  //   const file = await fs.readFile('./data/greeting.txt', 'utf-8');
+  //   const res = await fetch('http://internal-api/greeting');
+  // eslint-disable-next-line no-promise-executor-return
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const now = new Date();
+  return {
+    message: `Hello, ${name}!`,
+    serverTime: now.toLocaleString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    }),
+    facts: [
+      'This component rendered entirely on the server — zero JS was sent to the browser for it.',
+      'The date formatting above used server-side Intl APIs — no date library shipped to the client.',
+      'The "Like" button below IS a client component — only its JS is sent to the browser.',
+    ],
+  };
+}
+
+const HelloServer = async ({ name = 'World' }: HelloServerProps) => {
+  const { message, serverTime, facts } = await fetchGreeting(name);
+
   return (
-    <div>
-      <h3>Hello, {name}!</h3>
-      <p>This is a React Server Component.</p>
+    <div style={{ fontFamily: 'system-ui, sans-serif', maxWidth: 600, margin: '0 auto' }}>
+      <h2>{message}</h2>
+      <p style={{ color: '#666', fontSize: '0.9em' }}>Server-rendered at: {serverTime}</p>
+
+      <div
+        style={{
+          background: '#f0f9ff',
+          border: '1px solid #bae6fd',
+          borderRadius: 8,
+          padding: 16,
+          margin: '16px 0',
+        }}
+      >
+        <h3 style={{ margin: '0 0 12px' }}>How is this different from SSR?</h3>
+        <ul style={{ margin: 0, paddingLeft: 20 }}>
+          {facts.map((fact) => (
+            <li key={fact} style={{ marginBottom: 8 }}>
+              {fact}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* LikeButton is a client component — it ships JS for interactivity */}
+      <LikeButton />
     </div>
   );
 };

--- a/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/LikeButton.jsx
+++ b/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/LikeButton.jsx
@@ -1,0 +1,54 @@
+'use client';
+
+// LikeButton - Client Component
+//
+// This component has the 'use client' directive, so its JavaScript IS sent to the browser.
+// It demonstrates how client components work alongside server components:
+//
+// - Only this component's JS is included in the client bundle
+// - The parent HelloServer component sends ZERO JS to the browser
+// - React hydrates just this interactive island within the server-rendered HTML
+
+import React, { useState } from 'react';
+
+const LikeButton = () => {
+  const [likes, setLikes] = useState(0);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        marginTop: 16,
+        padding: '12px 16px',
+        background: '#fefce8',
+        border: '1px solid #fde68a',
+        borderRadius: 8,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setLikes((prev) => prev + 1)}
+        style={{
+          padding: '8px 16px',
+          fontSize: '1em',
+          cursor: 'pointer',
+          borderRadius: 6,
+          border: '1px solid #d1d5db',
+          background: '#fff',
+        }}
+      >
+        👍 Like
+      </button>
+      <span>
+        {likes} {likes === 1 ? 'like' : 'likes'}
+      </span>
+      <span style={{ color: '#92400e', fontSize: '0.85em' }}>
+        ← This button is a client component (check your browser&apos;s Network tab — only its JS was sent)
+      </span>
+    </div>
+  );
+};
+
+export default LikeButton;

--- a/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/LikeButton.tsx
+++ b/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/javascript/src/HelloServer/components/LikeButton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+// LikeButton - Client Component
+//
+// This component has the 'use client' directive, so its JavaScript IS sent to the browser.
+// It demonstrates how client components work alongside server components:
+//
+// - Only this component's JS is included in the client bundle
+// - The parent HelloServer component sends ZERO JS to the browser
+// - React hydrates just this interactive island within the server-rendered HTML
+
+import React, { useState } from 'react';
+
+const LikeButton: React.FC = () => {
+  const [likes, setLikes] = useState(0);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        marginTop: 16,
+        padding: '12px 16px',
+        background: '#fefce8',
+        border: '1px solid #fde68a',
+        borderRadius: 8,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setLikes((prev) => prev + 1)}
+        style={{
+          padding: '8px 16px',
+          fontSize: '1em',
+          cursor: 'pointer',
+          borderRadius: 6,
+          border: '1px solid #d1d5db',
+          background: '#fff',
+        }}
+      >
+        👍 Like
+      </button>
+      <span>
+        {likes} {likes === 1 ? 'like' : 'likes'}
+      </span>
+      <span style={{ color: '#92400e', fontSize: '0.85em' }}>
+        ← This button is a client component (check your browser&apos;s Network tab — only its JS was sent)
+      </span>
+    </div>
+  );
+};
+
+export default LikeButton;

--- a/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/views/hello_server/index.html.erb
+++ b/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/app/views/hello_server/index.html.erb
@@ -1,24 +1,35 @@
-<h1>HelloServer - React Server Component</h1>
+<h1>React Server Components Demo</h1>
 
 <p>
-  This page demonstrates React Server Components (RSC) with React on Rails Pro.
-  HelloServer runs only on the server - no JavaScript is sent to the browser for this component.
+  This page demonstrates <strong>React Server Components (RSC)</strong> with React on Rails Pro.
+  The component below is an <em>async server component</em> that fetches data on the server
+  and streams HTML to the browser. No component JavaScript is sent to the client.
 </p>
 
 <%#
   stream_react_component renders the RSC with streaming support.
 
   Key points:
-  - prerender: true enables server-side rendering
+  - prerender: true enables server-side rendering with streaming
   - Props are passed from the controller (@hello_server_props)
-  - The component streams as it renders (no loading spinner needed)
-  - Only the HTML is sent to browser, no JS bundle for this component
+  - The component streams as it resolves (async data fetching happens server-side)
+  - Only the interactive LikeButton client component ships JS to the browser
+  - Open DevTools Network tab to verify — no HelloServer.js in the client bundle
 %>
 <%= stream_react_component('HelloServer', props: @hello_server_props, prerender: true) %>
 
 <hr>
 
-<p>
+<details style="margin-top: 16px;">
+  <summary><strong>What makes this different from traditional SSR?</strong></summary>
+  <ul style="margin-top: 8px;">
+    <li><strong>Traditional SSR:</strong> Server renders HTML, then ships ALL component JS to the browser for hydration. Every library used in rendering is in your bundle.</li>
+    <li><strong>RSC:</strong> Server components stay on the server permanently. Only client components (marked with <code>'use client'</code>) ship JS. Libraries used in server components are never bundled for the client.</li>
+    <li><strong>Async by default:</strong> Server components can be async functions that <code>await</code> data directly — no <code>useEffect</code>, no loading states for initial render, no client-side fetch waterfalls.</li>
+  </ul>
+</details>
+
+<p style="margin-top: 16px;">
   <strong>Learn more:</strong>
   <a href="https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/">
     React Server Components Documentation

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -729,6 +729,7 @@ describe InstallGenerator, type: :generator do
       # HelloServer should exist
       assert_file "app/javascript/src/HelloServer/ror_components/HelloServer.jsx"
       assert_file "app/javascript/src/HelloServer/components/HelloServer.jsx"
+      assert_file "app/javascript/src/HelloServer/components/LikeButton.jsx"
     end
 
     it "creates HelloServer controller and view" do
@@ -780,6 +781,7 @@ describe InstallGenerator, type: :generator do
       assert_file "app/javascript/src/HelloWorldApp/ror_components/HelloWorldApp.server.jsx"
       assert_file "app/javascript/src/HelloServer/ror_components/HelloServer.jsx"
       assert_file "app/javascript/src/HelloServer/components/HelloServer.jsx"
+      assert_file "app/javascript/src/HelloServer/components/LikeButton.jsx"
     end
 
     it "creates hello_world route and controller for Redux" do
@@ -820,6 +822,7 @@ describe InstallGenerator, type: :generator do
       assert_no_file "app/javascript/src/HelloServer/components/HelloServer.jsx"
       assert_file "app/javascript/src/HelloServer/ror_components/HelloServer.tsx"
       assert_file "app/javascript/src/HelloServer/components/HelloServer.tsx"
+      assert_file "app/javascript/src/HelloServer/components/LikeButton.tsx"
     end
 
     it "creates tsconfig.json file" do

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -65,9 +65,10 @@ describe RscGenerator, type: :generator do
       end
     end
 
-    it "creates HelloServer component" do
+    it "creates HelloServer component and LikeButton client component" do
       assert_file "app/javascript/src/HelloServer/ror_components/HelloServer.jsx"
       assert_file "app/javascript/src/HelloServer/components/HelloServer.jsx"
+      assert_file "app/javascript/src/HelloServer/components/LikeButton.jsx"
     end
 
     it "creates HelloServerController" do
@@ -151,6 +152,7 @@ describe RscGenerator, type: :generator do
     it "creates HelloServer component with tsx extension" do
       assert_file "app/javascript/src/HelloServer/ror_components/HelloServer.tsx"
       assert_file "app/javascript/src/HelloServer/components/HelloServer.tsx"
+      assert_file "app/javascript/src/HelloServer/components/LikeButton.tsx"
       assert_no_file "app/javascript/src/HelloServer/ror_components/HelloServer.jsx"
     end
   end


### PR DESCRIPTION
## Summary

Based on PR #2284, this enhances the HelloServer generator example to better showcase what makes React Server Components special:

- **Async server component**: HelloServer is now an `async` function that demonstrates server-side `await` for data fetching — no `useEffect` needed, no client-side fetch waterfalls
- **Client component boundary**: Added `LikeButton` with `'use client'` directive to demonstrate the RSC/client split — only the button's JS is shipped to the browser
- **Educational UI**: The component now explains how RSC differs from traditional SSR, with inline hints about checking DevTools Network tab
- **Bug fix**: Corrected misleading `workersCount` comment in `node-renderer.js` template (said "CPUs minus 1" but was hardcoded to 3)

### What the demo shows users

1. **Zero JS for server components** — HelloServer renders entirely on the server with no JS bundle sent to the client
2. **Async data fetching** — Uses `await` directly in the component with commented examples of DB queries, file reads, and API calls
3. **Server/client boundary** — LikeButton is interactive (useState) while HelloServer is static HTML — open DevTools to verify only LikeButton's JS is loaded
4. **Streaming** — The async component streams HTML as it resolves via `stream_react_component`

### Files changed

- Enhanced `HelloServer.jsx/tsx` — async component with simulated data fetch
- New `LikeButton.jsx/tsx` — client component demonstrating interactivity
- Updated `rsc_setup.rb` — copies LikeButton alongside HelloServer
- Updated view template — better explains RSC vs SSR
- Updated `hello_server_spec.rb` — tests for new component output
- Updated generator specs — assert LikeButton file creation
- Fixed `node-renderer.js` — corrected misleading comment

## Test plan

- [x] `bundle exec rspec spec/react_on_rails/generators/rsc_generator_spec.rb` — 13 examples, 0 failures
- [x] `bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb -e 'rsc'` — 39 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] ESLint — 0 errors (2 warnings for ignored .tsx files)
- [x] Prettier — all files unchanged
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)