### PR TITLE
Fix Claude Code Review workflow: use built-in review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,5 +24,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          review_triggered_on: pr
           use_sticky_comment: true
+          prompt: |
+            Review this PR for correctness, security issues, and potential improvements.


### PR DESCRIPTION
## Summary

- Fixes the `claude-code-review.yml` workflow to use the built-in review instead of the broken plugin approach
- The plugin-based setup fails because it tries to call `gh api` via the Bash tool, which the action's sandbox blocks
- Replaces `plugin_marketplaces`/`plugins`/`prompt` with `review_triggered_on: pr` and `use_sticky_comment: true`

## Test plan

- [ ] Open a test PR and verify Claude auto-reviews it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now triggers on pull requests without path-based filtering.
  * Increased workflow permissions for pull requests and issues.
  * Upgraded repository checkout handling to a newer action version.
  * Removed integrated plugin and prompt configuration fields.
  * Enabled persistent ("sticky") review comments and replaced the prompt with a concise multi-line review prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->