### PR TITLE
Fix Claude Code Review workflow comment tooling

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,21 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_sticky_comment: true
           prompt: |
-            Review this PR for correctness, security issues, and potential improvements.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
This ports the Claude Code review workflow fix from [shakacode/hichee-data#367](https://github.com/shakacode/hichee-data/pull/367):

- update prompt instructions so Claude posts feedback via GitHub comments
- allow required tools via `claude_args --allowedTools`
- remove sticky-comment mode

This makes Claude review output appear as top-level and inline PR comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review workflow with improved PR context and expanded review focus areas (code quality, bugs, security, performance).
  * Improved inline comment handling in the code review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->