### PR TITLE
Fix TS2769 build error in node renderer onFile callback

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -176,7 +176,9 @@ export default function run(config: Partial<Config>) {
     },
     // Use regular function (not arrow) because @fastify/multipart binds `this`
     // to the Fastify request in attachFieldsToBody mode.
-    async onFile(this: FastifyRequest, part) {
+    // Note: do NOT annotate `this` with the local Http2Server-typed FastifyRequest;
+    // the plugin types expect the default (RawServerDefault) FastifyRequest.
+    async onFile(part) {
       if (typeof this?.uploadDir !== 'string') {
         throw new Error('onFile: expected `this` to be bound to the Fastify request');
       }


### PR DESCRIPTION
## Summary
- Removes the explicit `this: FastifyRequest` (Http2Server-typed) annotation from the `onFile` callback in `worker.ts`, which was incompatible with `@fastify/multipart`'s type definitions that expect the default `RawServerDefault` `FastifyRequest`
- This fixes the `TS2769: No overload matches this call` error that broke `pnpm build` and `pnpm install` on fresh runners (where the `prepare` script runs `tsc`)

Fixes #2467

## Test plan
- [x] `pnpm install` succeeds (triggers `prepare` → `tsc`)
- [x] `pnpm build` succeeds in `packages/react-on-rails-pro-node-renderer`
- [x] `pnpm type-check` succeeds in `packages/react-on-rails-pro-node-renderer`
- [ ] CI `check-bundle-size` job passes on a fresh runner (no cached `lib/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type annotations for file handling functionality. No user-facing changes or functionality modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->