### PR TITLE
Add PropsTransformer to reduce RSC props embedded in HTML

### DIFF
--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -223,8 +223,8 @@ export default function injectRSCPayload(
       const rscPromises: Promise<void>[] = [];
 
       rscRequestTracker.onRSCPayloadGenerated((streamInfo) => {
-        const { stream, props, componentName } = streamInfo;
-        const rscPayloadKey = createRSCPayloadKey(componentName, props, domNodeId);
+        const { stream, props, keyProps, componentName } = streamInfo;
+        const rscPayloadKey = createRSCPayloadKey(componentName, keyProps ?? props, domNodeId);
 
         // CRITICAL TIMING: Initialize global array IMMEDIATELY when component requests RSC
         // This ensures the array exists before the component's HTML is rendered and sent.

--- a/packages/react-on-rails-pro/src/streamingUtils.ts
+++ b/packages/react-on-rails-pro/src/streamingUtils.ts
@@ -187,11 +187,15 @@ export const streamServerRenderedComponent = <T, P extends RenderParams>(
   renderStrategy: StreamRenderer<T, P>,
   handleError: (options: ErrorOptions) => PipeableOrReadableStream,
 ): T => {
-  const { name: componentName, domNodeId, trace, props, railsContext, throwJsErrors } = options;
+  const { name: componentName, domNodeId, trace, props, keyProps, railsContext, throwJsErrors } = options;
 
   assertRailsContextWithServerComponentMetadata(railsContext);
   const postSSRHookTracker = new PostSSRHookTracker();
   const rscRequestTracker = new RSCRequestTracker(railsContext);
+
+  if (keyProps !== undefined) {
+    rscRequestTracker.setKeyPropsOverride(keyProps);
+  }
   const streamingTrackers = {
     postSSRHookTracker,
     rscRequestTracker,

--- a/packages/react-on-rails/src/types/index.ts
+++ b/packages/react-on-rails/src/types/index.ts
@@ -222,6 +222,7 @@ export interface RenderParams extends Params {
   name: string;
   throwJsErrors: boolean;
   renderingReturnsPromises: boolean;
+  keyProps?: unknown;
 }
 
 export interface RSCRenderParams extends Omit<RenderParams, 'railsContext'> {
@@ -351,6 +352,7 @@ export interface ReactOnRails {
 export type RSCPayloadStreamInfo = {
   stream: NodeJS.ReadableStream;
   props: unknown;
+  keyProps?: unknown;
   componentName: string;
 };
 

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -611,7 +611,7 @@ module ReactOnRails
       return { "html" => "", "consoleReplayScript" => "" } unless render_options.prerender
 
       react_component_name = render_options.react_component_name
-      props = render_options.props
+      props = render_options.server_props
 
       # On server `location` option is added (`location = request.fullpath`)
       # React Router needs this to match the current route

--- a/react_on_rails/lib/react_on_rails/react_component/render_options.rb
+++ b/react_on_rails/lib/react_on_rails/react_component/render_options.rb
@@ -27,6 +27,14 @@ module ReactOnRails
         options.fetch(:props) { NO_PROPS }
       end
 
+      def server_props
+        if ReactOnRails::Utils.react_on_rails_pro?
+          transformer = ReactOnRailsPro.configuration.props_transformer
+          return transformer.transform_props(react_component_name, props) if transformer
+        end
+        props
+      end
+
       def client_props
         props_extension = ReactOnRails.configuration.rendering_props_extension
         if props_extension.present?

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
@@ -78,6 +78,17 @@ module ReactOnRailsPro
                        ""
                      end
 
+        key_props_param = if ReactOnRailsPro.configuration.props_transformer &&
+                              ReactOnRailsPro.configuration.enable_rsc_support &&
+                              render_options.streaming?
+                            key_props_json = render_options.props.to_json
+                                                            .gsub("\u2028", '\u2028')
+                                                            .gsub("\u2029", '\u2029')
+                            "keyProps: #{key_props_json},"
+                          else
+                            ""
+                          end
+
         # This function is called with specific componentName and props when generateRSCPayload is invoked
         # In that case, it replaces the empty () with ('componentName', props) in the rendering request
         <<-JS
@@ -92,6 +103,7 @@ module ReactOnRailsPro
             name: componentName,
             domNodeId: #{render_options.dom_id.to_json},
             props: usedProps,
+            #{key_props_param}
             trace: #{render_options.trace},
             railsContext: railsContext,
             throwJsErrors: #{ReactOnRailsPro.configuration.throw_js_errors},

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -261,6 +261,37 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
       end
     end
 
+    describe ".props_transformer" do
+      it "is nil by default" do
+        ReactOnRailsPro.configure {} # rubocop:disable Lint/EmptyBlock
+
+        expect(ReactOnRailsPro.configuration.props_transformer).to be_nil
+      end
+
+      it "accepts a transformer that responds to transform_props" do
+        transformer = Module.new do
+          def self.transform_props(component_name, key_props)
+            key_props.merge(expanded: true)
+          end
+        end
+
+        ReactOnRailsPro.configure do |config|
+          config.props_transformer = transformer
+        end
+
+        expect(ReactOnRailsPro.configuration.props_transformer).to eq(transformer)
+      end
+
+      it "raises error if transformer does not respond to transform_props" do
+        expect do
+          ReactOnRailsPro.configure do |config|
+            config.props_transformer = Object.new
+          end
+        end.to raise_error(ReactOnRailsPro::Error,
+                           /must respond to `transform_props/)
+      end
+    end
+
     describe ".concurrent_component_streaming_buffer_size" do
       it "accepts positive integers" do
         ReactOnRailsPro.configure do |config|


### PR DESCRIPTION
## Summary
- Adds a `props_transformer` configuration option to ReactOnRailsPro that allows expanding compact "key props" into full rendering props on the server side
- Only the small key props appear in HTML output (RSC cache keys, hydration script), while full props are used for server-side rendering
- Reduces redundant prop data in HTML from ~112KB to a few hundred bytes for large-prop RSC components

## Test plan
- [x] RSCRequestTracker: keyPropsOverride set correctly, consumed-on-first-use, undefined when no override
- [x] injectRSCPayload: cache key uses keyProps when provided, falls back to props when undefined
- [x] Configuration: nil default, accepts valid transformer, rejects invalid transformer
- [x] All existing tests pass (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added props_transformer configuration option for customizing server-side props handling
  * Introduced keyProps support to optimize RSC payload caching by selectively including props in cache keys
  * Extended RSC streaming with per-request keyProps override mechanism for improved caching efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->