### PR TITLE
Fix ci-changes-detector skipping pro jobs for node renderer changes

### DIFF
--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -283,7 +283,7 @@ if [ "$PRO_RUBY_CORE_CHANGED" = true ] || [ "$PRO_RSPEC_CHANGED" = true ] || [ "
   RUN_PRO_TESTS=true
 fi
 
-if [ "$PRO_DUMMY_CHANGED" = true ] || [ "$PRO_RUBY_CORE_CHANGED" = true ] || [ "$PRO_JS_CHANGED" = true ] || [ "$RUBY_CORE_CHANGED" = true ]; then
+if [ "$PRO_DUMMY_CHANGED" = true ] || [ "$PRO_RUBY_CORE_CHANGED" = true ] || [ "$PRO_JS_CHANGED" = true ] || [ "$PRO_NODE_RENDERER_CHANGED" = true ] || [ "$RUBY_CORE_CHANGED" = true ]; then
   RUN_PRO_DUMMY_TESTS=true
 fi
 


### PR DESCRIPTION
## Summary
- Add `PRO_NODE_RENDERER_CHANGED` to the `RUN_PRO_LINT` and `RUN_PRO_TESTS` conditions in `script/ci-changes-detector` so that PRs touching only `packages/react-on-rails-pro-node-renderer/` correctly trigger pro lint, pro package tests, and pro integration tests
- Add `PRO_NODE_RENDERER_CHANGED=true` to the CI infrastructure catch-all for consistency
- Add `run_pro_node_renderer_tests:false` to the docs-only output path for consistency

## Test plan
- [x] Verified bash syntax passes (`bash -n`)
- [x] Simulated node-renderer-only change locally — `RUN_PRO_LINT`, `RUN_PRO_TESTS`, and `RUN_PRO_NODE_RENDERER_TESTS` all correctly set to `true`
- [ ] CI workflows on this PR should demonstrate correct detection (this PR changes `script/ci-changes-detector` which is CI infrastructure, so all jobs trigger)

Fixes #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects changes to the Pro Node Renderer and exposes a dedicated change flag.
  * CI decision logic was extended so Pro Node Renderer changes gate and trigger the appropriate Pro Node Renderer test runs.
  * Test run decisions and summaries now include the Pro Node Renderer flag and appear in CI outputs and final summaries (including JSON/GitHub outputs).
  * Change-detection categories and reporting were expanded to cover Node Renderer updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->