### PR TITLE
Fix RSC WebpackLoader not added when using SWC transpiler

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/config/webpack/rscWebpackConfig.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/rsc/base/config/webpack/rscWebpackConfig.js.tt
@@ -37,7 +37,8 @@ const configureRsc = () => {
       // SWC transpiler defines rule.use as a function: use: ({resource}) => getSwcLoaderConfig(resource)
       // Wrap it to append the RSC WebpackLoader to the returned loader(s).
       const originalUse = rule.use;
-      rule.use = function (data) {
+      // Must use `function` (not arrow) so `.call(this, data)` forwards webpack's context.
+      rule.use = function rscLoaderWrapper(data) {
         const result = originalUse.call(this, data);
         const resultArray = Array.isArray(result) ? result : result ? [result] : [];
         const resolvedRule = { use: resultArray };


### PR DESCRIPTION
## Summary

- Fix RSC WebpackLoader never being injected when using SWC (Shakapacker's default transpiler)
- Handle function-based `rule.use` by wrapping it to append the WebpackLoader to the dynamically resolved loader chain
- Preserves existing Babel (array-based `rule.use`) behavior unchanged

## Root Cause

Shakapacker defines `rule.use` differently depending on the transpiler:

- **Babel**: `use: [{ loader: 'babel-loader', ... }]` — a static **array**
- **SWC**: `use: ({ resource }) => getSwcLoaderConfig(resource)` — a **function** (needs per-file parser config for `.ts` vs `.tsx` vs `.js`)

The RSC config template checked `Array.isArray(rule.use)` which returned `false` for SWC's function, so the RSC WebpackLoader was never added. This caused `'use client'` files to pass through untransformed into the RSC bundle.

## Test plan

- [ ] Verify RSC bundle correctly replaces `'use client'` files with `registerClientReference` proxies when using SWC transpiler
- [ ] Verify existing Babel transpiler behavior is unchanged
- [ ] CI passes

Closes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Webpack configuration handling for React Server Components loaders.
  * Now supports both array- and function-style loader declarations while preserving behavior.
  * Ensures the RSC loader is consistently appended when a JS loader is detected.
  * Expanded inline comments and formatting for clarity and maintainability.
  * No changes to public/exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->