### PR TITLE
Add checks/statuses read permissions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,8 @@ jobs:
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      checks: read
+      statuses: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,17 +36,11 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+            checks: read
+            statuses: read


### PR DESCRIPTION
## Summary
- Adds `checks: read` and `statuses: read` to both job-level permissions and `additional_permissions`, so Claude can fully read CI check results on PRs
- Adds explicit `github_token` pass-through
- Aligns with the default claude-code-action install (as seen in shakacode/backstopjs)
- Removes unused boilerplate comments

## Test plan
- [ ] Verify Claude can still respond to `@claude` mentions in issues/PRs
- [ ] Verify Claude can read CI check status on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance automation and access permissions for improved pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission tweaks that add read access to checks/statuses and a token pass-through; no application code changes.
> 
> **Overview**
> Updates the `Claude Code` GitHub Actions workflow to grant additional read-only access to CI metadata by adding `checks: read` and `statuses: read` at both the job `permissions` level and in `additional_permissions` passed to `claude-code-action`.
> 
> Also explicitly passes `github_token` into the action and removes unused commented boilerplate from the workflow configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e568c1c9e31d8ba3add974c6c3c5431ae5215b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->