### PR TITLE
Improve fresh Pro install docs and generator defaults

### DIFF
--- a/docs/getting-started/installation-into-an-existing-rails-app.md
+++ b/docs/getting-started/installation-into-an-existing-rails-app.md
@@ -21,9 +21,17 @@
    bundle add react_on_rails --version="<react_on_rails_gem_version>" --strict
    ```
 
+   Then install the matching npm packages (versions must stay in sync with the gems):
+
+   ```bash
+   # Use your preferred package manager
+   yarn add react-on-rails@<react_on_rails_npm_version> shakapacker@<shakapacker_version> --exact
+   # or: npm install react-on-rails@<react_on_rails_npm_version> shakapacker@<shakapacker_version> --save-exact
+   ```
+
 2. Run the following command to install Shakapacker with React. Note, if you are using an older version of
-   Rails than 5.1, you'll need to install Webpacker with React per the instructions
-   [here](https://github.com/rails/webpacker).
+   Rails than 5.1, you'll need to install Webpacker with React per the
+   [Webpacker React installation guide](https://github.com/rails/webpacker).
 
    ```bash
    bundle exec rails shakapacker:install

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -386,8 +386,15 @@ module ReactOnRails
 
         content = File.read(shakapacker_config_path)
 
-        # Any active key means the app already made an explicit choice.
-        return if content.match?(/^\s+private_output_path:/)
+        # A non-empty active value means the app already made an explicit choice.
+        return if content.match?(/^\s+private_output_path:\s*\S+/)
+
+        # Normalize an empty active key before falling back to insertion.
+        gsub_file(
+          shakapacker_config_path,
+          /^(\s*)private_output_path:\s*$/,
+          "\\1private_output_path: ssr-generated"
+        )
 
         # First try: uncomment an existing private_output_path placeholder line.
         gsub_file(

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/Procfile.dev
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/Procfile.dev
@@ -4,6 +4,6 @@
 # To run multiple worktrees simultaneously, set different ports in each worktree's .env:
 #   PORT=3001
 #   SHAKAPACKER_DEV_SERVER_PORT=3036
-rails: bundle exec rails s -p ${PORT}
+rails: bundle exec rails s -p ${PORT:-3000}
 dev-server: bin/shakapacker-dev-server
 server-bundle: SERVER_BUNDLE_ONLY=yes bin/shakapacker --watch

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/Procfile.dev-prod-assets
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/Procfile.dev-prod-assets
@@ -2,7 +2,7 @@
 # Uses production-optimized, precompiled assets with development environment
 # Uncomment additional processes as needed for your app
 
-rails: bundle exec rails s -p ${PORT}
+rails: bundle exec rails s -p ${PORT:-3001}
 # sidekiq: bundle exec sidekiq -C config/sidekiq.yml
 # redis: redis-server
 # mailcatcher: mailcatcher --foreground

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/Procfile.dev-static-assets
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/Procfile.dev-static-assets
@@ -1,2 +1,2 @@
-web: bin/rails server -p ${PORT}
+web: bin/rails server -p ${PORT:-3000}
 js: bin/shakapacker --watch

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -703,8 +703,8 @@ module ReactOnRails
 
         def configure_ports
           selected = PortSelector.select_ports
-          ENV["PORT"] = selected[:rails].to_s
-          ENV["SHAKAPACKER_DEV_SERVER_PORT"] = selected[:webpack].to_s
+          ENV["PORT"] ||= selected[:rails].to_s
+          ENV["SHAKAPACKER_DEV_SERVER_PORT"] ||= selected[:webpack].to_s
         rescue PortSelector::NoPortAvailable => e
           warn e.message
           exit 1

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       original_port = ENV.fetch("PORT", nil)
       ENV.delete("PORT")
       example.run
+    ensure
       if original_port.nil?
         ENV.delete("PORT")
       else
@@ -165,6 +166,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         ENV.delete("PORT")
         ENV.delete("SHAKAPACKER_DEV_SERVER_PORT")
         example.run
+      ensure
         ENV["PORT"] = old_port
         ENV["SHAKAPACKER_DEV_SERVER_PORT"] = old_webpack_port
       end
@@ -426,6 +428,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       old_port = ENV.fetch("PORT", nil)
       ENV.delete("PORT")
       example.run
+    ensure
       ENV["PORT"] = old_port
     end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -291,10 +291,11 @@ describe InstallGenerator, type: :generator do
     end
 
     it "does not insert duplicate private_output_path entries" do
+      skip "private_output_path requires Shakapacker >= 9.0.0" unless
+        ReactOnRails::PackerUtils.shakapacker_version_requirement_met?("9.0.0")
+
       assert_file "config/shakapacker.yml" do |content|
-        if ReactOnRails::PackerUtils.shakapacker_version_requirement_met?("9.0.0")
-          expect(content.scan(/^\s*private_output_path:/).size).to eq(1)
-        end
+        expect(content.scan(/^\s*private_output_path:/).size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## Summary
- update existing-app and Pro installation docs to remove stale version examples and use explicit version placeholders
- document the clean-git prerequisite for generator runs and add a short post-install validation checklist
- auto-configure `private_output_path: ssr-generated` in `config/shakapacker.yml` for Shakapacker 9+ during generator setup
- allow `PORT` overrides in generated Procfiles (`Procfile.dev`, `Procfile.dev-static-assets`, `Procfile.dev-prod-assets`)
- add generator specs covering the new `private_output_path` behavior

## Why
A real fresh-install run for `16.4.0.rc.5` exposed avoidable friction:
- docs referenced old versions and skipped a required clean-git precondition
- fresh installs emitted private bundle path warnings unless users manually edited `shakapacker.yml`
- generated Procfiles hardcoded ports, making documented `PORT=...` overrides ineffective

## Test Plan
- `mise exec ruby@3.4.3 -- bundle exec rubocop react_on_rails/lib/generators/react_on_rails/base_generator.rb react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`
- `mise exec ruby@3.4.3 -- bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb --tag type:generator`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes generator behavior that edits `config/shakapacker.yml` and modifies node-renderer VM build concurrency cleanup; both can affect SSR build/runtime if edge cases are missed. Documentation updates are low risk, but the generator and VM changes warrant review/testing across Shakapacker versions and failure paths.
> 
> **Overview**
> Improves install docs to use version placeholders (including pre-release formatting), consistently recommend `bundle exec`, call out the generator’s clean-git requirement, and document a quick post-install validation + `PORT=...` overrides.
> 
> Updates the Rails generator to auto-configure `private_output_path: ssr-generated` in `config/shakapacker.yml` for Shakapacker 9+ (keeping SSR bundle paths aligned) and changes generated Procfiles to honor the `PORT` environment variable.
> 
> Hardens the Pro node renderer’s `buildVM` concurrency tracking by ensuring `vmCreationPromises` cleanup happens via `.finally()` on the stored promise, and adds a regression test to confirm recovery after a failed VM build (e.g., missing bundle file).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e72bebd9e238f8f0b0024edc68bd88d7f55cb79e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic default port management for development and production workflows.

* **Documentation**
  * Installation instructions now use explicit commands and placeholders for simplified setup.
  * Port configuration guidance improved with clearer examples.
  * SSR installation steps clarified across standard and professional editions.
  * Validation workflow enhanced with new doctor commands.

* **Bug Fixes**
  * Improved stability in VM cleanup processes to prevent stale rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->