### PR TITLE
Exclude broken external URLs from markdown link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -46,16 +46,20 @@ exclude = [
   '^https://(www\.)?localwise\.com',    # SSL verification failed
   '^https://(www\.)?mycfsapp\.com',     # SSL hostname mismatch
   '^https://(www\.)?scoutapp\.com',     # SSL hostname mismatch
+  '^https://solargraph\.org',           # SSL HandshakeFailure
 
   # ============================================================================
-  # BADGE SERVICES
+  # BADGE AND CI SERVICES
   # ============================================================================
   '^https://badge\.fury\.io',  # Returns 403 for automated requests
+  '^https://coveralls\.io',    # Returns 503 for automated requests
 
   # ============================================================================
-  # SITES THAT RETURN 504 FROM CI
+  # SITES THAT RETURN 5xx FROM CI
   # ============================================================================
-  '^https://reactrails\.com',  # Works locally but 504s from CI
+  '^https://reactrails\.com',              # Works locally but 504s from CI
+  '^https://shakacode\.controlplane\.com', # Connection refused from CI
+  '^https://storybook\.js\.org',           # Intermittent connection resets from CI
 
   # ============================================================================
   # PLANNED DEPLOYMENTS NOT YET LIVE


### PR DESCRIPTION
## Summary

- Exclude 4 external URLs that have been causing the markdown link checker CI job to fail on **every single run**
- `solargraph.org` — SSL HandshakeFailure
- `coveralls.io` — Returns 503 for automated requests
- `shakacode.controlplane.com` — Connection refused from CI
- `storybook.js.org` — Intermittent connection resets from CI

These follow the existing pattern in `.lychee.toml` for excluding unreliable external sites that are not under our control.

## Test plan

- [ ] Verify the markdown link checker CI job passes after merge
- [ ] Confirm no legitimate link breakage is being masked (all 4 URLs are third-party sites with known CI-unfriendly behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; the main downside is potentially masking future breakage for the newly excluded third-party domains.
> 
> **Overview**
> Updates `.lychee.toml` to expand the Lychee exclude list with several CI-unreliable third-party domains (SSL handshake failure, 503s, connection refused, intermittent resets) so the markdown link checker workflow stops failing on those external URLs.
> 
> Also tweaks/clarifies comment grouping (e.g., **badge/CI services** and **5xx from CI**) to reflect the broader set of excluded sites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 526ac0c6114a208b239f42775f08505aa802317a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link validation configuration to exclude additional services from checks, including coveralls.io, shakacode.controlplane.com, and storybook.js.org.
  * Reorganized service categorization headers for improved clarity in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->