### PR TITLE
Allow Dependabot to trigger claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: "dependabot[bot]"` to the `claude-code-action` step in `.github/workflows/claude-code-review.yml`
- Without this, the action explicitly rejects non-human actors, causing the `claude-review` job to fail on every Dependabot PR

## Remaining step (requires admin access)

`CLAUDE_CODE_OAUTH_TOKEN` also needs to be added to Dependabot secrets in repo settings, otherwise the token will still be empty for Dependabot-triggered runs. See #2498 for full details.

> Settings → Secrets and variables → Dependabot → New repository secret
> 
> The token is generated by running `claude setup-token` locally (requires a Claude Pro or Max account).

Closes #2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow configuration to restrict bot contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->