### PR TITLE
Fix factual errors in RSC migration docs

### DIFF
--- a/docs/migrating/rsc-third-party-libs.md
+++ b/docs/migrating/rsc-third-party-libs.md
@@ -10,9 +10,12 @@ Server Components cannot use:
 
 - `useState`, `useEffect`, `useRef`, `useReducer`, and most React hooks
 - `createContext` / `useContext`
-- `forwardRef`, `memo`
 - Browser APIs (`window`, `localStorage`, `document`)
 - Event handlers (`onClick`, `onChange`)
+
+> **Note on `React.memo` and `forwardRef`:** These wrappers don't cause errors in Server Components -- the React Flight renderer silently unwraps them. However, their functionality has no effect: `memo` can't memoize (Server Components don't re-render), and `forwardRef` can't forward refs (the `ref` prop is explicitly rejected by the Flight serializer). Libraries that use these wrappers can still render as Server Components, unlike libraries that call hooks. `forwardRef` is deprecated in React 19 in favor of `ref` as a regular prop.
+>
+> **Note on `ref` in Server Components:** `React.createRef()` is available in the server runtime (it's a plain function, not a hook), but the resulting ref cannot be attached to any element. The Flight serializer explicitly rejects the `ref` prop on any element -- including Client Components -- with: _"Refs cannot be used in Server Components, nor passed to Client Components."_ Refs are inherently a client-side concept -- if a Client Component needs a ref, it should create one itself with `useRef()`.
 
 Any library that relies on these features must be used within a `'use client'` boundary. The React Working Group maintains a [canonical tracking list](https://github.com/reactwg/server-components/discussions/6) of library RSC support status.
 

--- a/docs/migrating/rsc-troubleshooting.md
+++ b/docs/migrating/rsc-troubleshooting.md
@@ -282,7 +282,8 @@ Error Boundaries do **not** catch errors thrown in Server Components. Errors fro
 ```jsx
 'use client';
 
-import { useRouter, startTransition } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import { startTransition } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 function ErrorFallback({ error, resetErrorBoundary }) {
@@ -525,6 +526,7 @@ export async function createUser(formData: FormData) {
 | RSC page downloads unexpectedly large chunks | A shared component with `'use client'` appears in multiple chunk groups; webpack's manifest may map it to a heavy chunk group containing unrelated dependencies (depends on chunk group iteration order) | Inspect `react-client-manifest.json` for oversized chunk mappings. If found, create a thin `'use client'` wrapper file for the RSC import. See [Chunk Contamination](#chunk-contamination) above |
 | `"Text content does not match server-rendered HTML"` | Hydration mismatch | Ensure identical rendering on server and client; use `suppressHydrationWarning` for intentional differences |
 | `"Route used params.id. params should be awaited before using its properties"` | Next.js 15 changed params to async | Await params: `const { id } = await params;` |
+| `"Refs cannot be used in Server Components, nor passed to Client Components"` | Using the `ref` prop on any element inside a Server Component -- including on Client Components. The Flight serializer rejects the literal `ref` prop before checking the target type. | Remove the `ref` prop. Refs are a client-side concept -- if a Client Component needs a ref, it should create one itself with `useRef()`. While `React.createRef()` is callable on the server, the result cannot be attached to any element. |
 
 ## Environment Variable Access
 


### PR DESCRIPTION
## Summary
- **Fix `startTransition` import** in `rsc-troubleshooting.md`: was incorrectly imported from `next/navigation`, now correctly imported from `react`
- **Remove `memo`/`forwardRef` from "cannot use" list** in `rsc-third-party-libs.md`: these wrappers don't cause errors in Server Components (the Flight renderer silently unwraps them), unlike hooks which throw. Added accurate notes explaining their behavior.
- **Add `ref` behavior note**: `React.createRef()` is callable on the server but the `ref` prop is explicitly rejected by the Flight serializer on all elements. Refs are a client-side concept.
- **Add error catalog entry** for `"Refs cannot be used in Server Components, nor passed to Client Components"`

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review technical accuracy of memo/forwardRef/ref notes against React 19 behavior

Closes #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)