### PR TITLE
Consolidate changelog to keep only rc6 prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1281,6 +1281,36 @@ _Note: 8.0.4 skipped._
 - For an example of migration, see: [react-webpack-rails-tutorial PR #395](https://github.com/shakacode/react-webpack-rails-tutorial/pull/395)
 - For a simple example of the webpacker_lite setup, run the basic generator.
 
+### 8.0.0-beta.3 - 2017-05-27
+
+#### Changed
+
+- Major updates for WebpackerLite 2.0.2. [#844](https://github.com/shakacode/react_on_rails/pull/845) by [justin808](https://github.com/justin808) with help from [robwise](https://github.com/robwise)
+- Logging no longer occurs when trace is turned to false. [#845](https://github.com/shakacode/react_on_rails/pull/845) by [conturbo](https://github.com/Conturbo)
+
+### 8.0.0-beta.2 - 2017-05-08
+
+#### Changed
+
+Removed unnecessary values in default paths.yml files for generators. [#834](https://github.com/shakacode/react_on_rails/pull/834) by [justin808](https://github.com/justin808).
+
+### 8.0.0-beta.1 - 2017-05-03
+
+#### Added
+
+Support for WebpackerLite in the generators. [#822](https://github.com/shakacode/react_on_rails/pull/822) by [kaizencodes](https://github.com/kaizencodes) and [justin808](https://github.com/justin808).
+
+#### Changed
+
+Breaking change is that the default value of symlink_non_digested_assets_regex has changed from this
+old value to nil. This is a breaking change if you didn't have this value set in your
+config/initializers/react_on_rails.rb file and you need this because you're using webpack's CSS
+features and you have not switched to webpacker lite.
+
+```
+symlink_non_digested_assets_regex: /\.(png|jpg|jpeg|gif|tiff|woff|ttf|eot|svg|map)/,
+```
+
 ## [7.0.4] - 2017-04-27
 
 - Return empty json when nil in json_safe_and_pretty [#824](https://github.com/shakacode/react_on_rails/pull/824) by [dzirtusss](https://github.com/dzirtusss)


### PR DESCRIPTION
### Summary

This PR cleans up `CHANGELOG.md` so `16.4.0.rc.6` is the only non-final release section remaining. It removes older non-final sections (`16.4.0.rc.5`, `16.4.0.rc.3`, and `8.0.0-beta.*`) and updates compare links to point from `16.3.0` to `16.4.0.rc.6`.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

`bundle exec rubocop` was run and failed due pre-existing offenses in unrelated files; this PR only modifies `CHANGELOG.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes confined to `CHANGELOG.md` with no impact on runtime behavior.
> 
> **Overview**
> Updates `CHANGELOG.md` to keep only a single active prerelease section (`16.4.0.rc.6`), moving the relevant fixes (including the streaming SSR/RSC fix) under that version and removing older prerelease/beta sections.
> 
> Cleans up historical noise by deleting legacy `8.0.0-beta.*` entries and updates the compare links at the bottom to point `unreleased` at `v16.4.0.rc.6...master` (and adds the new `16.4.0.rc.6` compare link).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6185a694169c2b7f5c5c85b823e522090a3bfe07. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming SSR reliability and payload handling to prevent hangs and ensure proper error visibility.
  * Ensured consistent instrumentation initialization for reliable performance monitoring.
  * Restored RSC support for SWC-based projects and fixed RSC generator layout wiring for fresh installs.
  * Fixed unsafe string interpolation in generated JS to prevent breakage.
  * Made precompile hook detection and self-guarding more robust to avoid duplicate runs in multi-process/HMR setups.

* **Changelog**
  * Updated release notes and anchors to rc.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->