### PR TITLE
Update mise docs: prefer shell-level shims over conductor-exec

### DIFF
--- a/.claude/docs/conductor-compatibility.md
+++ b/.claude/docs/conductor-compatibility.md
@@ -97,7 +97,7 @@ When `mise` is available, it runs `mise exec --` (which prepends the correct too
 If `mise` is not on PATH, it falls back to running the command directly:
 
 ```bash
-bin/conductor-exec bundle exec ruby --version
+bin/conductor-exec ruby --version
 bin/conductor-exec bundle exec rubocop
 bin/conductor-exec pnpm install
 bin/conductor-exec git commit -m "message"  # Pre-commit hooks work correctly


### PR DESCRIPTION
## Summary

- Updated conductor-compatibility docs to reflect that shell-level mise shim activation (`.zshenv`/`.bashrc`/`.profile` + `BASH_ENV`/`ENV` exports) is the preferred approach
- Demoted `bin/conductor-exec` wrapper to a fallback for users who haven't configured shell-level shims
- Added reference to [justin808-dotfiles](https://github.com/justin808/justin808-dotfiles) for implementation example
- Added caveat about system binaries that can shadow mise shims on PATH

## Context

With mise shims activated in `.zshenv` (which runs for all zsh shells, including non-interactive ones used by Conductor and coding agents), the `conductor-exec` wrapper becomes unnecessary. The `BASH_ENV`/`ENV` exports ensure child bash/sh processes also get shims.

## Test plan

- [ ] Verify docs render correctly in CLAUDE.md (auto-included via `@` reference)
- [ ] Confirm conductor-exec still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust recommended setup and add guidance; no runtime or build logic is modified.
> 
> **Overview**
> Updates `conductor-compatibility.md` to recommend enabling mise shims at the shell level (`.zshenv`/`.bashrc`/`.profile` plus `BASH_ENV`/`ENV`) as the primary fix for non-interactive Conductor/agent shells using system tool versions.
> 
> Demotes `bin/conductor-exec` to a documented fallback, adds a dotfiles reference implementation, and notes a PATH-shadowing caveat when system binaries override mise shims.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0554d9bc1e63ef1a77a30da82f4d26d4e57d590c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Recommend shell-level shim activation as the preferred setup for both interactive and non-interactive shells, with step-by-step per-shell guidance.
  * Clarified environment export behavior, PATH shadowing risks, and compatibility caveats across shell variants and modes.
  * Added extensive user-facing examples and retained a documented fallback wrapper-based execution option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->