### PR TITLE
Document compression middleware compatibility with streaming SSR

### DIFF
--- a/docs/building-features/streaming-server-rendering.md
+++ b/docs/building-features/streaming-server-rendering.md
@@ -157,6 +157,37 @@ For example, with our `MyStreamingComponent`, the sequence might be:
 </script>
 ```
 
+## Compression Middleware Compatibility
+
+Streaming responses use `ActionController::Live`, which writes chunks to a `SizedQueue` (a destructive, non-idempotent data structure). Standard Rack compression middleware (`Rack::Deflater`, `Rack::Brotli`) works correctly with streaming **by default** — each chunk is compressed and flushed immediately, preserving low TTFB.
+
+However, if you pass an `:if` condition that calls `body.each` to check the response size, **streaming responses will deadlock**. The `:if` callback destructively consumes all chunks from the queue, leaving nothing for the compressor to read.
+
+```ruby
+# BAD — causes deadlocks with streaming responses
+config.middleware.use Rack::Deflater, if: lambda { |*, body|
+  sum = 0
+  body.each { |i| sum += i.length }  # destructive — drains the queue
+  sum > 512
+}
+```
+
+The [Rack SPEC](https://github.com/rack/rack/blob/main/SPEC.rdoc) states that `each` must only be called once and middleware must not call `each` directly unless the body responds to `to_ary`. Streaming bodies explicitly do not support `to_ary`.
+
+**Correct pattern** — check `to_ary` before iterating:
+
+```ruby
+config.middleware.use Rack::Deflater, if: lambda { |*, body|
+  # Streaming bodies don't support to_ary — always compress them.
+  # Rack::Deflater handles streaming correctly with sync flush per chunk.
+  return true unless body.respond_to?(:to_ary)
+
+  body.to_ary.sum(&:bytesize) > 512
+}
+```
+
+The same applies to `Rack::Brotli` or any middleware that accepts an `:if` callback.
+
 ## When to Use Streaming
 
 Streaming SSR is particularly valuable in specific scenarios. Here's when to consider it:

--- a/docs/deployment/server-rendering-tips.md
+++ b/docs/deployment/server-rendering-tips.md
@@ -18,6 +18,7 @@ For the best performance with Server Rendering, consider using [React on Rails P
 
 1. First make sure your code works with server rendering disabled (`prerender: false`).
 2. Set `config.trace` to true. You will get the server invocation code that renders your component. If you're not using Shakapacker, you will also get the whole file used to set up the JavaScript context.
+3. If streaming SSR requests hang indefinitely, check whether your compression middleware (`Rack::Deflater`, `Rack::Brotli`) has an `:if` condition that calls `body.each`. This causes deadlocks with streaming responses. See the [Compression Middleware Compatibility](../building-features/streaming-server-rendering.md#compression-middleware-compatibility) section in the Streaming Server Rendering guide.
 
 ## CSS
 

--- a/react_on_rails_pro/docs/streaming-server-rendering.md
+++ b/react_on_rails_pro/docs/streaming-server-rendering.md
@@ -155,6 +155,37 @@ For example, with our `MyStreamingComponent`, the sequence might be:
 </script>
 ```
 
+## Compression Middleware Compatibility
+
+Streaming responses use `ActionController::Live`, which writes chunks to a `SizedQueue` (a destructive, non-idempotent data structure). Standard Rack compression middleware (`Rack::Deflater`, `Rack::Brotli`) works correctly with streaming **by default** — each chunk is compressed and flushed immediately, preserving low TTFB.
+
+However, if you pass an `:if` condition that calls `body.each` to check the response size, **streaming responses will deadlock**. The `:if` callback destructively consumes all chunks from the queue, leaving nothing for the compressor to read.
+
+```ruby
+# BAD — causes deadlocks with streaming responses
+config.middleware.use Rack::Deflater, if: lambda { |*, body|
+  sum = 0
+  body.each { |i| sum += i.length }  # destructive — drains the queue
+  sum > 512
+}
+```
+
+The [Rack SPEC](https://github.com/rack/rack/blob/main/SPEC.rdoc) states that `each` must only be called once and middleware must not call `each` directly unless the body responds to `to_ary`. Streaming bodies explicitly do not support `to_ary`.
+
+**Correct pattern** — check `to_ary` before iterating:
+
+```ruby
+config.middleware.use Rack::Deflater, if: lambda { |*, body|
+  # Streaming bodies don't support to_ary — always compress them.
+  # Rack::Deflater handles streaming correctly with sync flush per chunk.
+  return true unless body.respond_to?(:to_ary)
+
+  body.to_ary.sum(&:bytesize) > 512
+}
+```
+
+The same applies to `Rack::Brotli` or any middleware that accepts an `:if` callback.
+
 ## When to Use Streaming
 
 Streaming SSR is particularly valuable in specific scenarios. Here's when to consider it:

--- a/react_on_rails_pro/docs/troubleshooting.md
+++ b/react_on_rails_pro/docs/troubleshooting.md
@@ -1,3 +1,11 @@
 # Troubleshooting
 
 For issues related to upgrading from GitHub Packages to public distribution, see the [Upgrading Guide](./updating.md).
+
+## Streaming SSR request hangs indefinitely
+
+**Symptom**: Requests to streaming pages (or RSC payload endpoints) hang forever and never complete.
+
+**Cause**: A compression middleware (`Rack::Deflater`, `Rack::Brotli`) is configured with an `:if` condition that calls `body.each` to check the response size. This destructively consumes streaming chunks from the `SizedQueue`, causing a deadlock.
+
+**Fix**: See the "Compression Middleware Compatibility" section in the [Streaming Server Rendering guide](./streaming-server-rendering.md).


### PR DESCRIPTION
## Summary
- Add "Compression Middleware Compatibility" section to both streaming SSR guides (open-source and Pro) explaining the `Rack::Deflater`/`Rack::Brotli` deadlock when `:if` conditions call `body.each` on streaming responses
- Add troubleshooting entry to Pro troubleshooting docs for the "streaming hangs indefinitely" symptom
- Add a note to the server rendering tips troubleshooting section with a cross-reference

The root cause is that streaming bodies use `ActionController::Live::Buffer` backed by a `SizedQueue`, where `each` is destructive (pops items). When a middleware `:if` condition calls `body.each` to check response size, it drains the queue, leaving nothing for the compressor. The fix is to check `body.respond_to?(:to_ary)` first — streaming bodies don't support `to_ary`, so the condition should return `true` (always compress) for them and only check size for buffered responses.

Closes #2519

## Test plan
- [x] Documentation-only change, no code changes
- [x] Verified markdown renders correctly
- [x] Cross-references between docs use correct relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive guidance on compression middleware compatibility with streaming server-side rendering, including common deadlock scenarios and correct implementation patterns.
* Enhanced troubleshooting documentation with new section addressing streaming server-side rendering request hangs and resolution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->