### PR TITLE
Skip flaky external URLs in lychee checks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -60,6 +60,9 @@ exclude = [
   '^https://reactrails\.com',              # Works locally but 504s from CI
   '^https://shakacode\.controlplane\.com', # Connection refused from CI
   '^https://storybook\.js\.org',           # Intermittent connection resets from CI
+  '^https://redux\.js\.org/?$',            # Intermittent connection resets from CI
+  '^https://angularjs\.org/?$',            # Connection failed from CI
+  '^https://frigade\.com/blog/bundle-size-reduction-with-rsc-and-frigade/?$', # Connection failed from CI
 
   # ============================================================================
   # PLANNED DEPLOYMENTS NOT YET LIVE


### PR DESCRIPTION
### Summary

Add exact-match `lychee` exclusions for external URLs that intermittently fail from CI, so markdown link checks stop failing on third-party network issues unrelated to repo content. This covers `redux.js.org`, `angularjs.org`, and the referenced `frigade.com` article.

### Pull Request checklist

~[ ] Add/update test to cover these changes~
~[ ] Update documentation~
~[ ] Update CHANGELOG file~

### Other Information

Verified locally with `bin/check-links` (`1590 OK`, `0 Errors`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects CI link-check coverage by skipping a few unstable external URLs.
> 
> **Overview**
> Updates `.lychee.toml` to **exclude additional flaky third-party URLs** from CI link checking by adding exact-match patterns for `redux.js.org`, `angularjs.org`, and a specific `frigade.com` blog post, reducing CI failures caused by intermittent external connectivity/5xx errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 330cd3de90dc59444447a369fb2250b4fd31ad1b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to exclude certain external resources from automated link verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->