### PR TITLE
Add React on Rails-specific troubleshooting to RSC migration docs

### DIFF
--- a/docs/migrating/rsc-troubleshooting.md
+++ b/docs/migrating/rsc-troubleshooting.md
@@ -674,38 +674,6 @@ When using **yalc** for local development:
 2. Ensure both packages resolve to the same version source
 3. Run `yalc installations show` to verify no stale installations exist
 
-### RSC WebpackLoader with SWC
-
-**Symptoms:** The RSC webpack loader silently fails to transform modules. Server Components work without React Server Components directives being processed. The RSC bundle builds without errors but components aren't correctly split between server and client.
-
-**Root cause:** Shakapacker may configure `swc-loader` using a non-array format (a function or a single object), so the RSC configuration helper `extractLoader()` -- which checks `Array.isArray(rule.use)` -- returns `null` and never finds the loader:
-
-```js
-// What extractLoader() expects:
-rule.use = [{ loader: 'swc-loader', options: {...} }]; // Array -- works
-
-// What Shakapacker may generate:
-rule.use = (info) => [{ loader: 'swc-loader', options: {...} }]; // Function -- not found
-rule.use = { loader: 'swc-loader', options: {...} };             // Object -- not found
-```
-
-**Fix:** Instead of trying to append the RSC loader to the existing rule, add it as a separate `enforce: 'post'` rule:
-
-```js
-// config/webpack/rscWebpackConfig.js
-const rscConfig = require('./serverWebpackConfig');
-
-// Add RSC loader as a separate post-processing rule
-rscConfig.module.rules.push({
-  test: /\.(js|jsx|ts|tsx)$/,
-  enforce: 'post',
-  exclude: /node_modules/,
-  use: [{ loader: 'react-on-rails-rsc/WebpackLoader' }],
-});
-```
-
-This approach is more robust because it doesn't depend on the structure of existing loader rules. The `enforce: 'post'` ensures the RSC loader runs after SWC/Babel transformation.
-
 ### Duplicate Package Detection
 
 **Symptoms:** Boot-time error: `"Both 'react-on-rails' and 'react-on-rails-pro' packages are installed."` This prevents the Rails application from starting.


### PR DESCRIPTION
## Summary
- Adds six React on Rails-specific troubleshooting sections: stream backpressure deadlock, GOAWAY connection reset, node renderer VM context missing globals, version mismatch "global object mismatch", RSC WebpackLoader with SWC, and `validate_no_duplicate_packages!`
- Updates the Error Boundary section with the `refetchComponent` pattern from `useRSC()` as a finer-grained alternative to full page reload
- Adds four RoR-specific entries to the Error Message Catalog table

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all internal anchor links resolve (e.g., `#stream-backpressure-deadlock`, `#node-renderer-vm-context----missing-globals`)
- [ ] Review code examples for accuracy against actual codebase (`RSCRequestTracker.ts`, `vm.ts`, `request.rb`, `RSCProvider.tsx`)
- [ ] Confirm the `refetchComponent` API matches the actual `useRSC()` interface

Closes #2504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for React 19 native metadata with migration strategies from react-helmet.
  * Added React Server Components (RSC) migration series covering patterns, context management, data fetching, third-party library compatibility, and troubleshooting.
  * Updated existing documentation with React 19 alternatives and recommendations.

* **New Features**
  * Added example pages demonstrating React 19 native metadata handling in sync SSR, streaming, and RSC scenarios with side-by-side comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->