### PR TITLE
Document small-PR AI review workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,19 @@ Prettier handles all formatting. Never manually format — run `rake autofix` in
 
 **PR creation**: Use `gh pr create` with a clear title, summary, and test plan.
 
+## Review Workflow
+
+For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
+
+- Use at most one AI reviewer that leaves inline comments. Additional AI tools should be summary-only or used manually.
+- Wait for the first full review pass to finish before pushing follow-up commits.
+- Batch review fixes into one follow-up push when practical. Do not create a new commit for each minor comment.
+- Treat as blocking only: correctness bugs, failing tests, regressions, and clear inconsistencies with adjacent code. Nits and style suggestions are optional unless a maintainer asks for them.
+- Verify language, runtime, and library claims locally before changing code in response to AI review comments.
+- Deduplicate repeated bot comments before acting on them. Fix the underlying issue once, then resolve the duplicates.
+- Rebase or merge `master` once, near the end of the review cycle. For `CHANGELOG.md` conflicts, prefer resolving them as the final step before merge.
+- When asking an agent to address review comments, instruct it to classify comments into `blocking`, `optional`, and `noise`, then apply only the `blocking` items plus any explicitly selected optional items.
+
 ## Boundaries
 
 ### Always


### PR DESCRIPTION
## Summary
- add a small-PR review workflow section to `AGENTS.md`
- document batching, blocking-vs-optional triage, bot deduplication, and end-of-cycle `master` sync
- clarify how agents should handle review comments to avoid unnecessary review churn

## Test Plan
- docs only; no code or test changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime, build, or test impact.
> 
> **Overview**
> Adds a new **Review Workflow** section to `AGENTS.md` documenting how to handle *small, focused PRs*, including limiting inline AI reviewers, batching fixes after a full review pass, and triaging comments as `blocking` vs `optional` vs `noise`.
> 
> Also codifies guidance to verify AI claims locally, deduplicate bot comments, and delay syncing with `master` (with a note on `CHANGELOG.md` conflict resolution) until late in the review cycle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1db35f4137c24f6d0b035d8363f2f961f2118ccc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Review Workflow guidelines covering reviewer usage, review pacing, fix batching, and issue classification standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->