### PR TITLE
Add test for empty async_props_block (fixes #2269)

### DIFF
--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -48,6 +48,10 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     stream_view_containing_react_components(template: "/pages/test_incremental_rendering")
   end
 
+  def test_empty_async_props_block
+    stream_view_containing_react_components(template: "/pages/test_empty_async_props_block")
+  end
+
   def cached_stream_async_components_for_testing
     stream_view_containing_react_components(template: "/pages/cached_stream_async_components_for_testing")
   end

--- a/react_on_rails_pro/spec/dummy/app/views/pages/test_empty_async_props_block.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/pages/test_empty_async_props_block.html.erb
@@ -1,0 +1,8 @@
+<h1>Empty Async Props Block Test</h1>
+<p>Testing stream_react_component_with_async_props with an empty block (issue #2269)</p>
+
+<%= stream_react_component_with_async_props("AsyncPropsComponent", props: { name: "John Doe", age: 30, description: "Software Engineer" }) do |_emit|
+  # Empty block - no async props emitted
+  # This reproduces the scenario from issue #2269 where passing an empty block
+  # caused the stream to hang or return nil before the fix in PR #2297
+end %>

--- a/react_on_rails_pro/spec/dummy/config/routes.rb
+++ b/react_on_rails_pro/spec/dummy/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   get "cached_stream_async_components_for_testing" => "pages#cached_stream_async_components_for_testing",
       as: :cached_stream_async_components_for_testing
   get "test_incremental_rendering" => "pages#test_incremental_rendering", as: :test_incremental_rendering
+  get "test_empty_async_props_block" => "pages#test_empty_async_props_block", as: :test_empty_async_props_block
   get "stream_async_components_for_testing_client_render" => "pages#stream_async_components_for_testing_client_render",
       as: :stream_async_components_for_testing_client_render
   get "rsc_posts_page_over_http" => "pages#rsc_posts_page_over_http", as: :rsc_posts_page_over_http

--- a/react_on_rails_pro/spec/dummy/spec/requests/incremental_rendering_integration_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/incremental_rendering_integration_spec.rb
@@ -111,6 +111,41 @@ describe "Incremental Rendering Integration", :integration do
     end
   end
 
+  describe "render_code_with_incremental_updates with empty block" do
+    it "completes without hanging when async_props_block emits nothing (issue #2269)" do
+      # Upload bundles first
+      ReactOnRailsPro::Request.upload_assets
+
+      # Construct the incremental render path
+      js_code = "ReactOnRails.getStreamValues()"
+      request_digest = Digest::MD5.hexdigest(js_code)
+      render_path = "/bundles/#{server_bundle_hash}/incremental-render/#{request_digest}"
+
+      # Wrap in timeout to catch deadlocks - the original bug caused infinite hang
+      Timeout.timeout(10) do
+        # Perform incremental rendering with an EMPTY block (no props emitted)
+        # Before the fix in PR #2297, this would deadlock because the Node handler
+        # used fire-and-forget (void) for onResponseStart/onRequestEnded
+        stream = ReactOnRailsPro::Request.render_code_with_incremental_updates(
+          render_path,
+          js_code,
+          async_props_block: proc { |_emitter| }
+        )
+
+        # Collect all chunks from the stream - should complete without hanging
+        chunks = []
+        stream.each_chunk do |chunk|
+          chunks << chunk
+        end
+
+        # The stream should have returned at least some response (even if error message)
+        # The key assertion is that we reached this point without deadlocking
+        response_text = chunks.join
+        expect(response_text).not_to be_empty
+      end
+    end
+  end
+
   describe "render_code_with_incremental_updates" do
     it "sends stream values and receives them in the response" do
       # Upload bundles first


### PR DESCRIPTION
## Summary
- Adds a minimum reproduction test for issue #2269 where `stream_react_component_with_async_props` with an empty block caused a streaming deadlock
- Adds test view, controller action, route, and integration test for the empty block scenario
- This issue was already fixed by PR #2297 which changed fire-and-forget (`void`) calls to `await`ed promises in `handleIncrementalRenderStream.ts`

## Context

Issue #2269 reported that passing an empty block to `stream_react_component_with_async_props` would cause the stream to hang or return `nil`. The root cause was in `handleIncrementalRenderStream.ts` where `void onResponseStart()` and `void onRequestEnded()` were fire-and-forget — with an empty block, `request.close` fires immediately (END_STREAM) before the response was fully set up.

PR #2297 fixed this by changing to `await onRequestEnded()` and `await onResponseStartPromise`. This PR adds a regression test to ensure this scenario continues to work.

Closes #2269

## Test plan
- [ ] Integration test `completes without hanging when async_props_block emits nothing` passes with node renderer running
- [ ] Existing incremental rendering tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)