### PR TITLE
Fix empty-string plan mismatch between Ruby and Node (#2452)

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/licenseValidator.ts
@@ -102,7 +102,7 @@ function decodeLicense(licenseString: string): LicenseData | undefined {
  */
 function checkPlan(decodedData: LicenseData): LicenseStatus {
   const { plan } = decodedData;
-  if (!plan) {
+  if (plan == null) {
     return 'valid'; // No plan field = valid (backwards compat with old paid licenses)
   }
   if (VALID_PLANS.includes(plan as ValidPlan)) {
@@ -260,7 +260,7 @@ function determineLicensePlan(): ValidPlan | undefined {
   }
 
   const { plan } = decodedData;
-  if (!plan || !VALID_PLANS.includes(plan as ValidPlan)) {
+  if (plan == null || !VALID_PLANS.includes(plan as ValidPlan)) {
     return undefined;
   }
 

--- a/packages/react-on-rails-pro-node-renderer/tests/licenseValidator.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/licenseValidator.test.ts
@@ -261,7 +261,7 @@ describe('LicenseValidator', () => {
       expect(module.getLicenseStatus()).toBe('valid');
     });
 
-    it('returns valid for empty string plan (treated as absent for backwards compat)', () => {
+    it('returns invalid for empty string plan (aligned with Ruby: "" is not a valid plan)', () => {
       const payload = {
         sub: 'test@example.com',
         iat: Math.floor(Date.now() / 1000),
@@ -274,7 +274,7 @@ describe('LicenseValidator', () => {
       process.env.REACT_ON_RAILS_PRO_LICENSE = token;
 
       const module = jest.requireActual<LicenseValidatorModule>('../src/shared/licenseValidator');
-      expect(module.getLicenseStatus()).toBe('valid');
+      expect(module.getLicenseStatus()).toBe('invalid');
     });
 
     it('returns valid for null plan (treated as absent)', () => {

--- a/react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb
@@ -211,6 +211,27 @@ RSpec.describe ReactOnRailsPro::LicenseValidator do
       end
     end
 
+    context "when plan is empty string" do
+      let(:empty_plan_payload) do
+        {
+          sub: "test@example.com",
+          iat: Time.now.to_i,
+          exp: Time.now.to_i + 3600,
+          plan: "",
+          org: "Acme Corp"
+        }
+      end
+
+      before do
+        token = JWT.encode(empty_plan_payload, test_private_key, "RS256")
+        ENV["REACT_ON_RAILS_PRO_LICENSE"] = token
+      end
+
+      it "returns :invalid (empty string is not a valid plan)" do
+        expect(described_class.license_status).to eq(:invalid)
+      end
+    end
+
     context "when plan field is absent" do
       let(:no_plan_payload) do
         {


### PR DESCRIPTION
## Summary
- Align Node `checkPlan` with Ruby `check_plan` so `plan: ""` yields `:invalid` in both runtimes
- Use `plan == null` instead of `!plan` in Node — only `null`/`undefined` count as absent (backwards compat), while `""` falls through to the VALID_PLANS check
- Add Ruby spec for `plan: ""` to document existing behavior

## Test plan
- [x] Node `licenseValidator.test.ts` passes (empty string now expects `'invalid'`)
- [x] Ruby `license_validator_spec.rb` passes (60 examples, 0 failures, including new empty-string test)
- [x] `null` and `undefined` plan still return `'valid'` (backwards compat preserved)

Closes #2452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated license validation to consistently treat empty string plans as invalid.
  * Enhanced null and undefined handling in plan validation to ensure more predictable licensing status determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->