### PR TITLE
Fix doctor false positives for Pro/SWC setups

### DIFF
--- a/react_on_rails/lib/react_on_rails/system_checker.rb
+++ b/react_on_rails/lib/react_on_rails/system_checker.rb
@@ -495,7 +495,8 @@ module ReactOnRails
 
       raw_content = File.read(shakapacker_config_path)
       rendered_content = ERB.new(raw_content).result
-      YAML.safe_load(rendered_content, aliases: true) || {}
+      parsed = YAML.safe_load(rendered_content, aliases: true)
+      parsed.is_a?(Hash) ? parsed : nil
     rescue StandardError, ScriptError
       nil
     end

--- a/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
@@ -597,6 +597,20 @@ RSpec.describe ReactOnRails::SystemChecker do
       end
     end
 
+    context "when shakapacker.yml has non-hash YAML content" do
+      before do
+        allow(File).to receive(:exist?).with("config/shakapacker.yml").and_return(true)
+        allow(File).to receive(:read).with("config/shakapacker.yml").and_return("- item1\n- item2")
+      end
+
+      it "does not crash and defaults to requiring @babel/preset-react" do
+        expect { checker.check_react_dependencies }.not_to raise_error
+        expect(checker.messages.any? do |msg|
+          msg[:type] == :warning && msg[:content].include?("@babel/preset-react")
+        end).to be true
+      end
+    end
+
     context "when shakapacker.yml has broken ERB" do
       before do
         allow(File).to receive(:exist?).with("config/shakapacker.yml").and_return(true)


### PR DESCRIPTION
## Summary

Fixes `rails react_on_rails:doctor` emitting false warnings for Pro + SWC setups:

1. **Recognise `react-on-rails-pro` npm package** — doctor now detects both `react-on-rails` and `react-on-rails-pro` in package.json for NPM package presence and version sync checks. Pro package is checked first since it's a superset.

2. **Skip `@babel/preset-react` when transpiler is SWC** — reads `javascript_transpiler` from `config/shakapacker.yml` and only requires `@babel/preset-react` when using Babel. Rescues both `StandardError` and `ScriptError` (covers `SyntaxError` from broken ERB) and shows a diagnostic message when config parsing fails.

3. **Fix pre-existing `&.merge` nil-safety bug** — the pattern `package_json["dependencies"]&.merge(...)` silently dropped all devDependencies when the `"dependencies"` key was absent. Replaced with `(package_json["dependencies"] || {}).merge(...)` at all 6 locations.

Closes #2432

## Context

Extracted and improved from the doctor-related portion of [#2478](https://github.com/shakacode/react_on_rails/pull/2478). See [review comment](https://github.com/shakacode/react_on_rails/pull/2478#issuecomment-4026486636) for details on what was changed vs the original PR.

## Test plan

- [x] 49 specs passing (8 new: Pro detection, devDependencies-only, SWC/Babel transpiler, broken ERB fallback)
- [x] Rubocop clean
- [x] Verified on fresh RSC test app: both false positives eliminated
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better detection of react-on-rails and react-on-rails-pro packages and clearer messages referencing the resolved package.
  * Detects whether Babel is used from packer config and adjusts required dependency checks and guidance.
  * More robust parsing of package and packer config files with graceful warnings and improved dependency reporting.

* **Tests**
  * Expanded coverage for package detection, version sync, packer (shakapacker) transpiler scenarios, devDependencies-only reporting, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->