### PR TITLE
docs: fix JWT claim name in Pro license setup

### DIFF
--- a/react_on_rails_pro/LICENSE_SETUP.md
+++ b/react_on_rails_pro/LICENSE_SETUP.md
@@ -148,7 +148,7 @@ The task exits with code 0 on success and code 1 if the license is missing, inva
 | Field                  | Type            | Description                                         |
 | ---------------------- | --------------- | --------------------------------------------------- |
 | `status`               | string          | `"valid"`, `"expired"`, `"invalid"`, or `"missing"` |
-| `organization`         | string or null  | Organization name from the license                  |
+| `organization`         | string or null  | Organization name from the JWT `org` claim          |
 | `plan`                 | string or null  | License plan (`"paid"`, `"startup"`, etc.)          |
 | `expiration`           | string or null  | ISO 8601 expiration date                            |
 | `attribution_required` | boolean         | Whether attribution is required                     |
@@ -302,10 +302,12 @@ The license is a JWT (JSON Web Token) signed with RSA-256, containing:
   "iat": 1234567890, // Issued at timestamp (REQUIRED)
   "exp": 1234567890, // Expiration timestamp (REQUIRED)
   "plan": "paid", // License plan (Optional — only "paid" is valid for production)
-  "organization": "Your Company", // Organization name (Optional)
+  "org": "Your Company", // Organization name (Optional)
   "iss": "api" // Issuer identifier (Optional, standard JWT claim)
 }
 ```
+
+> Note: The JWT claim is `org`. The verify task output uses the field name `organization` for readability.
 
 ### Security
 


### PR DESCRIPTION
## Summary
- update JWT payload example to use the runtime-supported `org` claim
- clarify that `organization` is the verify-task output field name, not the JWT input claim
- align JSON field table wording with the validator behavior

Fixes #2451

## Test Plan
- docs-only change; no runtime code paths changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that corrects a claim name in examples and descriptions; no runtime behavior is modified.
> 
> **Overview**
> Clarifies React on Rails Pro license documentation by correcting the JWT payload example to use the `org` claim and updating the verify-task JSON field table to state that `organization` is derived from `org`.
> 
> Adds a brief note explaining the naming mismatch between the JWT claim (`org`) and the verifier output field (`organization`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59ff666a3ec5095274b7632199623caa580dd197. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license setup documentation to clarify how organization information is sourced from JWT authentication claims and improved explanations of field naming conventions in license verification outputs for enhanced user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->