### PR TITLE
docs: clarify AGENTS internal docs directory map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,20 +84,22 @@ cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb
 
 ## Project Structure
 
-| Directory                            | Purpose                                                                                                  |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `react_on_rails/lib/react_on_rails/` | Ruby gem source — helpers, configuration, SSR pool, engine                                               |
-| `react_on_rails/lib/generators/`     | Rails generators for `react_on_rails:install`                                                            |
-| `react_on_rails/spec/`               | RSpec tests (unit + integration via dummy app)                                                           |
-| `react_on_rails/spec/dummy/`         | Full Rails app for integration testing and E2E                                                           |
-| `packages/react-on-rails/src/`       | TypeScript source — client-side React integration                                                        |
-| `packages/react-on-rails/tests/`     | Jest tests for the npm package                                                                           |
-| `react_on_rails_pro/`                | Pro package (separate gem + npm, own lint config)                                                        |
-| `rakelib/`                           | Rake task definitions                                                                                    |
-| `docs/oss/`                          | OSS documentation — published to the [ShakaCode website](https://www.shakacode.com/react-on-rails/docs/) |
-| `docs/pro/`                          | Pro documentation — installation, configuration, RSC, node renderer, caching                             |
-| `analysis/`                          | Investigation and analysis documents (kebab-case `.md` files)                                            |
-| `internal/`                          | Contributor guides, planning docs, and testimonials (not published to the website)                       |
+| Directory                                        | Purpose                                                                                                  |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `react_on_rails/lib/react_on_rails/`             | Ruby gem source — helpers, configuration, SSR pool, engine                                               |
+| `react_on_rails/lib/generators/`                 | Rails generators for `react_on_rails:install`                                                            |
+| `react_on_rails/spec/`                           | RSpec tests (unit + integration via dummy app)                                                           |
+| `react_on_rails/spec/dummy/`                     | Full Rails app for integration testing and E2E                                                           |
+| `packages/react-on-rails/src/`                   | TypeScript source — client-side React integration                                                        |
+| `packages/react-on-rails/tests/`                 | Jest tests for the npm package                                                                           |
+| `react_on_rails_pro/`                            | Pro package (separate gem + npm, own lint config)                                                        |
+| `rakelib/`                                       | Rake task definitions                                                                                    |
+| `docs/oss/`                                      | OSS documentation — published to the [ShakaCode website](https://www.shakacode.com/react-on-rails/docs/) |
+| `docs/pro/`                                      | Pro documentation — installation, configuration, RSC, node renderer, caching                             |
+| `internal/contributor-info/`                     | Internal contributor docs (not published to the website)                                                 |
+| `internal/planning/`                             | Internal planning docs, drafts, and historical analysis                                                  |
+| `internal/react_on_rails_pro/contributors-info/` | Internal Pro contributor docs (not published to the website)                                             |
+| `analysis/`                                      | Investigation and analysis documents (kebab-case `.md` files)                                            |
 
 ## Code Style
 


### PR DESCRIPTION
## Summary\n- split out the AGENTS.md-only portion from #2415\n- clarify internal docs directory mapping in the Project Structure table\n- keep this PR focused to one file for easier review\n\n## Testing\n- docs-only change (no runtime impact)\n\n## Context\n- extracted from #2415 to break that large draft into smaller reviewable PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates the `AGENTS.md` project structure table with more specific internal directory entries; no runtime behavior is affected.
> 
> **Overview**
> Updates `AGENTS.md`’s **Project Structure** table to clarify the internal documentation layout by replacing the generic `internal/` entry with specific subdirectories (e.g., `internal/contributor-info/`, `internal/planning/`, and `internal/react_on_rails_pro/contributors-info/`).
> 
> Also adjusts the table formatting/alignment while keeping the rest of the agent guidance unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61d95d716096f47b33bede7a99e5d7df33198dce. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project structure documentation with improved table formatting and organization for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->