### PR TITLE
chore: harden claude autofix hook execution

### DIFF
--- a/bin/claude-hooks/autofix-file
+++ b/bin/claude-hooks/autofix-file
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code PostToolUse hook: auto-fix a single file after Edit/Write.
-# Runs Prettier (JS/TS/JSON/MD/YAML) or RuboCop -A (Ruby) depending on extension.
+# Runs Prettier (JS/TS/JSON/MD/YAML) or RuboCop -a (Ruby) depending on extension.
 #
 # Claude Code pipes a JSON object on stdin with tool_input.file_path.
 # Falls back to $1 for manual testing.
@@ -14,7 +14,10 @@ if [ -t 0 ]; then
   FILE="${1:-}"
 else
   INPUT="$(cat)"
-  FILE="$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null || true)"
+  FILE="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+  if [ -z "$FILE" ] && ! command -v jq > /dev/null 2>&1; then
+    echo "autofix-file: jq not found, skipping auto-fix" >&2
+  fi
 fi
 
 if [ -z "$FILE" ]; then
@@ -32,14 +35,14 @@ REL_PATH="${FILE#"$REPO_ROOT/"}"
 
 case "$REL_PATH" in
   *.rb|*.rake|*.ru)
-    bundle exec rubocop -A --force-exclusion -- "$REL_PATH" 2>&1 | tail -3
+    (cd "$REPO_ROOT" && bundle exec rubocop -a --force-exclusion -- "$REL_PATH" 2>&1 | tail -3 || true)
     ;;
   *.js|*.jsx|*.ts|*.tsx|*.json|*.md|*.yml|*.yaml)
     if [[ "$REL_PATH" == react_on_rails_pro/* ]]; then
       PRO_REL="${REL_PATH#react_on_rails_pro/}"
-      (cd react_on_rails_pro && pnpm exec prettier --write "$PRO_REL" 2>&1 | tail -1)
+      (cd "$REPO_ROOT/react_on_rails_pro" && pnpm exec prettier --write -- "$PRO_REL" 2>&1 | tail -1 || true)
     else
-      pnpm exec prettier --write "$REL_PATH" 2>&1 | tail -1
+      (cd "$REPO_ROOT" && pnpm exec prettier --write -- "$REL_PATH" 2>&1 | tail -1 || true)
     fi
     ;;
 esac


### PR DESCRIPTION
## Summary\n- split out the  portion from #2415\n- switch file-path extraction to  with safe fallback behavior\n- run formatter/linter commands from repo-root paths and make hook best-effort\n\n## Testing\n- \n\n## Context\n- extracted from #2415 to break that large draft into smaller reviewable PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a developer hook script and mainly improve robustness (path parsing, working directory, and best-effort formatter execution) without affecting runtime application code.
> 
> **Overview**
> Hardens the `bin/claude-hooks/autofix-file` post-tool hook by switching stdin JSON parsing from Python to `jq`, with a safe no-op when the file path can’t be extracted or `jq` is missing.
> 
> Formatter/linter invocations are now run from explicit repo-root directories, pass paths safely via `--`, and are made best-effort (`|| true`) so formatting failures don’t break the hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5934e8f1c64443a6ffa07db37cbc84feb2b07954. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved error handling and resilience in code formatting and linting hooks
  * Enhanced dependency management with graceful fallbacks when tools are unavailable
  * Optimized script execution with better working directory context for consistency
  * Made formatter processes non-fatal to prevent interruption of development workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->