### PR TITLE
fix: update CHANGELOG for 16.4.0.rc.9 and fix orphaned prerelease link cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2071,8 +2071,7 @@ such as:
 - Fix several generator-related issues.
 
 [unreleased]: https://github.com/shakacode/react_on_rails/compare/16.4.0.rc.9...master
-[16.4.0.rc.9]: https://github.com/shakacode/react_on_rails/compare/16.4.0.rc.8...16.4.0.rc.9
-[16.4.0.rc.8]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...16.4.0.rc.8
+[16.4.0.rc.9]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...16.4.0.rc.9
 [16.3.0]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...v16.3.0
 [16.2.1]: https://github.com/shakacode/react_on_rails/compare/v16.2.0...v16.2.1
 [16.2.0]: https://github.com/shakacode/react_on_rails/compare/16.1.1...v16.2.0

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -194,7 +194,32 @@ def prepare_changelog_for_auto_version(changelog, monorepo_root)
   active_base_version = active_prerelease_base_version(monorepo_root, changelog)
   return changelog unless active_base_version
 
-  collapse_prerelease_series(changelog, active_base_version)
+  changelog = collapse_prerelease_series(changelog, active_base_version)
+  cleanup_collapsed_prerelease_links(changelog, active_base_version)
+end
+
+# After collapsing prerelease sections, remove their orphaned compare links
+# and update [unreleased] to compare from the last stable version.
+def cleanup_collapsed_prerelease_links(changelog, base_version)
+  compare_prefix = Regexp.escape("https://github.com/shakacode/react_on_rails/compare/")
+  prerelease_pattern = /#{Regexp.escape(base_version)}\.(?:test|beta|alpha|rc|pre)\.\d+/i
+
+  # Find the "from" version in prerelease links that points to a non-prerelease (stable) version
+  stable_from = nil
+  changelog.scan(/^\[#{prerelease_pattern}\]:\s*#{compare_prefix}(\S+)\.\.\./i) do |from_version,|
+    stable_from = from_version unless from_version.match?(prerelease_pattern)
+  end
+
+  if stable_from
+    # Update [unreleased] link to compare from the stable version instead of the old prerelease
+    changelog = changelog.sub(
+      /^(\[unreleased\]:\s*#{compare_prefix})\S+(\.\.\.master)/i,
+      "\\1#{stable_from}\\2"
+    )
+  end
+
+  # Remove all prerelease compare link lines for this base version
+  changelog.gsub(/^\[#{prerelease_pattern}\]:.*\n/i, "")
 end
 
 def changelog_section_blocks(section_body)

--- a/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
@@ -104,6 +104,62 @@ RSpec.describe "update_changelog.rake helper methods" do
     end
   end
 
+  describe "#cleanup_collapsed_prerelease_links" do
+    it "removes orphaned prerelease compare links and updates [unreleased] to point to stable" do
+      changelog = <<~CHANGELOG
+        ### [Unreleased]
+
+        #### Added
+        - Merged content from rc.1 and rc.0
+
+        ### [16.3.0] - 2026-02-01
+        #### Fixed
+        - Older fix
+
+        [unreleased]: https://github.com/shakacode/react_on_rails/compare/16.4.0.rc.1...master
+        [16.4.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/16.4.0.rc.0...16.4.0.rc.1
+        [16.4.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...16.4.0.rc.0
+        [16.3.0]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...v16.3.0
+      CHANGELOG
+
+      result = cleanup_collapsed_prerelease_links(changelog, "16.4.0")
+
+      expect(result).to include("[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...master")
+      expect(result).not_to include("[16.4.0.rc.1]:")
+      expect(result).not_to include("[16.4.0.rc.0]:")
+      expect(result).to include("[16.3.0]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...v16.3.0")
+    end
+
+    it "handles a single prerelease link" do
+      changelog = <<~CHANGELOG
+        ### [Unreleased]
+
+        [unreleased]: https://github.com/shakacode/react_on_rails/compare/16.4.0.rc.8...master
+        [16.4.0.rc.8]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...16.4.0.rc.8
+        [16.3.0]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...v16.3.0
+      CHANGELOG
+
+      result = cleanup_collapsed_prerelease_links(changelog, "16.4.0")
+
+      expect(result).to include("[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...master")
+      expect(result).not_to include("[16.4.0.rc.8]:")
+      expect(result).to include("[16.3.0]:")
+    end
+
+    it "returns changelog unchanged when no prerelease links exist" do
+      changelog = <<~CHANGELOG
+        ### [Unreleased]
+
+        [unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...master
+        [16.3.0]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...v16.3.0
+      CHANGELOG
+
+      result = cleanup_collapsed_prerelease_links(changelog, "16.4.0")
+
+      expect(result).to eq(changelog)
+    end
+  end
+
   describe "#fetch_git_tags!" do
     it "refreshes local tags from origin when a remote exists" do
       Dir.mktmpdir do |dir|


### PR DESCRIPTION
## Summary
- Added missing changelog entries for PRs #2439, #2477, #2554
- Stamped version header for 16.4.0.rc.9 (collapsed rc.8 into rc.9)
- **Fixed rake task bug**: `collapse_prerelease_sections` removed section headers but left behind orphaned compare links at the bottom of CHANGELOG.md. Added `cleanup_collapsed_prerelease_links` to remove these links and update `[unreleased]` to compare from the last stable version.

## Changes
1. **CHANGELOG.md**: New entries + rc.9 stamp + removed orphaned `[16.4.0.rc.8]` link
2. **update_changelog.rake**: Added `cleanup_collapsed_prerelease_links` function, called from `prepare_changelog_for_auto_version`
3. **update_changelog_rake_helpers_spec.rb**: 3 new tests covering link cleanup (multi-prerelease chain, single prerelease, no prereleases)

## Skipped PRs (not user-visible)
- #2593 — test only (lock instrumentation)
- #2591 — test only (Jest clearMocks)
- #2588 — internal refactoring (Thor shell output)
- #2584 — docs restructuring
- #2587 — internal tooling (release script)
- #2589 — docs fix (JWT claim name)
- #2586 — docs/CI (dead link removal)

## Test plan
- [x] All 13 rake helper tests pass (3 new)
- [ ] CI passes
- [ ] After merge, run `rake release` to publish 16.4.0.rc.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bin/setup failing in pnpm workspace member directories.

* **New Features**
  * Added host configuration option for the Node Renderer Fastify worker.

* **Improvements / Changed**
  * Automatic installation of react_on_rails_pro enabled for --rsc/--pro flags.
  * Clarified Pro-installation signaling related to immediate hydration warnings.
  * Updated changelog to include RC9 entries and ensure Unreleased links point to the correct base.

* **Documentation**
  * Added startup warning and remediation guidance for unsafe compression middleware callbacks.

* **Tests**
  * Added tests covering changelog prerelease-link cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->