### PR TITLE
Update docs links to reactonrails.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # React on Rails Documentation
 
-> For the best experience, visit our **[documentation website](https://www.shakacode.com/react-on-rails/docs/)**.
+> For the best experience, visit our **[documentation website](https://reactonrails.com/docs/)**.
 
 Browsing on GitHub? This guide will help you navigate the documentation.
 

--- a/docs/oss/api-reference/javascript-api.md
+++ b/docs/oss/api-reference/javascript-api.md
@@ -34,7 +34,7 @@ The best source of docs is the `interface ReactOnRails` in [types/index.ts](http
  * Your Ruby code with get this object as a Hash containing keys componentHtml and any other
  * custom keys that you added:
  * { renderedHtml: { componentHtml, customKey1, customKey2 } }
- * See the example in https://www.shakacode.com/react-on-rails/docs/javascript/react-helmet
+ * See the example in https://reactonrails.com/docs/building-features/react-helmet
  * @param components (key is component name, value is component)
  */
 register(components);
@@ -78,7 +78,7 @@ setOptions(options);
  * Allow directly calling the page loaded script in case the default events that trigger React
  * rendering are not sufficient, such as when loading JavaScript asynchronously with TurboLinks:
  * More details can be found here:
- * https://www.shakacode.com/react-on-rails/docs/building-features/turbolinks
+ * https://reactonrails.com/docs/building-features/turbolinks
  */
 reactOnRailsPageLoaded();
 

--- a/docs/oss/building-features/how-to-conditionally-server-render-based-on-device-type.md
+++ b/docs/oss/building-features/how-to-conditionally-server-render-based-on-device-type.md
@@ -35,6 +35,6 @@ ReactOnRails.configure do |config|
 end
 ```
 
-Note, full details of the React on Rails configuration are [available here](https://www.shakacode.com/react-on-rails/docs/configuration/).
+Note, full details of the React on Rails configuration are [available here](https://reactonrails.com/docs/configuration/).
 
 See the doc file [render-functions-and-railscontext.md](../core-concepts/render-functions-and-railscontext.md#rails-context) for how your client-side code uses the device information

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -611,5 +611,5 @@ When running tests in Docker, consider:
 ## Need Help?
 
 - **Forum:** [ShakaCode Forum](https://forum.shakacode.com/)
-- **Docs:** [React on Rails Guides](https://www.shakacode.com/react-on-rails/docs/)
+- **Docs:** [React on Rails Guides](https://reactonrails.com/docs/)
 - **Support:** [justin@shakacode.com](mailto:justin@shakacode.com)

--- a/docs/oss/configuration/README.md
+++ b/docs/oss/configuration/README.md
@@ -988,7 +988,7 @@ Access methods:
 
 ## Need Help?
 
-- **Documentation:** [React on Rails Guides](https://www.shakacode.com/react-on-rails/docs/)
+- **Documentation:** [React on Rails Guides](https://reactonrails.com/docs/)
 - **Pro Features:** [React on Rails Pro](https://www.shakacode.com/react-on-rails-pro/)
 - **Support:** [ShakaCode Forum](https://forum.shakacode.com/)
 - **Consulting:** [justin@shakacode.com](mailto:justin@shakacode.com)

--- a/docs/oss/configuration/configuration-deprecated.md
+++ b/docs/oss/configuration/configuration-deprecated.md
@@ -47,6 +47,6 @@ See [CHANGELOG.md](https://github.com/shakacode/react_on_rails/blob/master/CHANG
 
 ## Need Help?
 
-- **Documentation:** [React on Rails Guides](https://www.shakacode.com/react-on-rails/docs/)
+- **Documentation:** [React on Rails Guides](https://reactonrails.com/docs/)
 - **Support:** [ShakaCode Forum](https://forum.shakacode.com/)
 - **Consulting:** [justin@shakacode.com](mailto:justin@shakacode.com)

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -254,7 +254,7 @@ It's super important to exclude certain directories from RubyMine or else it wil
 
 ## Conclusion
 
-- Browse the docs on [our documentation website](https://www.shakacode.com/react-on-rails/docs/)
+- Browse the docs on [our documentation website](https://reactonrails.com/docs/)
 
 Feedback is greatly appreciated! As are stars on github!
 

--- a/docs/pro/bundle-caching.md
+++ b/docs/pro/bundle-caching.md
@@ -115,7 +115,7 @@ A much better approach than accessing `process.env` is to use the
 `config/initializers/react_on_rails.rb` setting for the`config.rendering_extension` to always
 pass some values into the rendering props.
 
-See [our railsContext docs](https://www.shakacode.com/react-on-rails/docs/basics/render-functions-and-railscontext/#customization-of-the-railscontext) for more details.
+See [our railsContext docs](https://reactonrails.com/docs/core-concepts/render-functions-and-railscontext/#customization-of-the-railscontext) for more details.
 
 Also, if your webpack build process depends on any ENV values, then you will also need to add those
 to return value of the `cache_keys` method.

--- a/docs/pro/caching.md
+++ b/docs/pro/caching.md
@@ -132,7 +132,7 @@ i18nLocale = I18n.locale
 
 ### How: API
 
-Here is the doc for helpers `cached_react_component` and `cached_react_component_hash`. Consult the [docs in React on Rails](https://www.shakacode.com/react-on-rails/docs/api/view-helpers-api/) for the non-cached analogies `react_component` and `react_component_hash`. These docs only show the differences.
+Here is the doc for helpers `cached_react_component` and `cached_react_component_hash`. Consult the [docs in React on Rails](https://reactonrails.com/docs/api-reference/view-helpers-api/) for the non-cached analogies `react_component` and `react_component_hash`. These docs only show the differences.
 
 ```ruby
   # Provide caching support for react_component in a manner akin to Rails fragment caching.


### PR DESCRIPTION
## Summary
- update docs links that still point to `shakacode.com/react-on-rails/docs` so they point to `reactonrails.com/docs`
- update related Pro docs references to use the new docs domain paths

## Why
The canonical docs destination is now `reactonrails.com`. Keeping old domain links inside markdown causes confusing round-trips and stale references.

## Validation
- searched docs for remaining `shakacode.com/react-on-rails/docs` references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that update external URLs and should not affect runtime behavior.
> 
> **Overview**
> Updates documentation markdown to point to the new canonical docs domain `https://reactonrails.com/docs/` instead of the legacy `shakacode.com/react-on-rails/docs` URLs, including a few updated deep-link paths in both OSS and Pro guides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e8fecfc59956fe26245ad99c4f98cdbd5b59515. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links across multiple guides to point to the new reactonrails.com domain for consistent access to current documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->