### PR TITLE
Fix pro glossary markdown for MDX compatibility

### DIFF
--- a/docs/pro/react-server-components/glossary.md
+++ b/docs/pro/react-server-components/glossary.md
@@ -9,8 +9,6 @@ A React architecture that allows components to execute exclusively on the server
 - Improved initial page load
 - Better SEO
 
-<!-- H2 is intentional here: this callout must stand out above the H3 glossary entries to prevent confusion -->
-
 ## Important: `.client.` / `.server.` File Suffixes Are Unrelated
 
 React on Rails has a separate, older concept where files can have `.client.jsx` or `.server.jsx` suffixes. These control **which webpack bundle** imports the file (client bundle vs. server bundle for SSR) and have nothing to do with React Server Components.


### PR DESCRIPTION
Remove the HTML comment in docs/pro/react-server-components/glossary.md so legacy Gatsby/MDX builds do not fail while parsing this page. This unblocks sc-website deploys that still ingest docs from react_on_rails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an HTML comment to avoid legacy Gatsby/MDX parsing/build failures.
> 
> **Overview**
> Removes an inline HTML comment from `docs/pro/react-server-components/glossary.md` so the glossary renders cleanly in MDX/Gatsby-based pipelines.
> 
> No behavior or API changes; content and headings remain the same aside from dropping the comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a071b5aa5f37ec1e4d87a9c7476822842e3ec429. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Minor formatting cleanup in React Server Components documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->