### PR TITLE
Docs: replace legacy Pro docs URLs with local docs/pro links

### DIFF
--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -95,7 +95,7 @@ A "renderer function" is a Render-Function that accepts three arguments (rather 
 
 Why would you want to call `ReactDOM.hydrate` yourself? One possible use case is code splitting. In a nutshell, you don't want to load the React component on the DOM node yet. So you want to install some handler that will call `ReactDOM.hydrate` at a later time. In the case of code splitting with server rendering, the server-rendered code has any async code loaded and used to server render. Thus, the client code must also fully load any async code before server rendering. Otherwise, the client code would first render partially, not matching the server rendering, and then a second later, the full code would render, resulting in an unpleasant flashing on the screen.
 
-For modern code splitting with server-side rendering, see the [React on Rails Pro loadable-components guide](https://www.shakacode.com/react-on-rails-pro/docs/code-splitting-loadable-components).
+For modern code splitting with server-side rendering, see the [React on Rails Pro loadable-components guide](../../pro/code-splitting-loadable-components.md).
 
 Renderer functions are not meant to be used on the server since there's no DOM on the server. Instead, use a Render-Function. Attempting to server render with a renderer function will throw an error.
 
@@ -107,7 +107,7 @@ Renderer functions are not meant to be used on the server since there's no DOM o
 
 1. [React on Rails docs for React Router](../building-features/react-router.md)
 2. Examples in [spec/dummy/app/views/react_router](https://github.com/shakacode/react_on_rails/tree/master/react_on_rails/spec/dummy/app/views/react_router) and follow to the JavaScript code in the [spec/dummy/client/app/startup/RouterApp.server.jsx](https://github.com/shakacode/react_on_rails/tree/master/react_on_rails/spec/dummy/client/app/startup/RouterApp.server.jsx).
-3. [React on Rails Pro loadable-components guide](https://www.shakacode.com/react-on-rails-pro/docs/code-splitting-loadable-components) for modern code splitting with server-side rendering.
+3. [React on Rails Pro loadable-components guide](../../pro/code-splitting-loadable-components.md) for modern code splitting with server-side rendering.
 
 ### TanStack Router
 

--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -15,7 +15,7 @@ Visit [http://localhost:3000/hello_world](http://localhost:3000/hello_world) to 
 This creates a TypeScript app by default. For JavaScript, use `--template javascript`.
 For React Server Components (RSC), add `--rsc` and visit `/hello_server` after setup.
 `--rsc` requires `react_on_rails_pro` to be installable in your environment
-([Pro setup docs](https://www.shakacode.com/react-on-rails-pro/docs/installation/)).
+([Pro setup docs](../../pro/installation.md)).
 RSC supports both JavaScript (`.jsx`) and TypeScript (`.tsx`) templates.
 
 ## Options

--- a/docs/oss/getting-started/pro-quick-start.md
+++ b/docs/oss/getting-started/pro-quick-start.md
@@ -150,15 +150,15 @@ Or for a fresh app with RSC from the start:
 rails generate react_on_rails:install --rsc
 ```
 
-See the [RSC tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/) for details.
+See the [RSC tutorial](../../pro/react-server-components/tutorial.md) for details.
 
 ## Next Steps
 
-- [Configuration Reference](https://www.shakacode.com/react-on-rails-pro/docs/configuration/) — All Pro config options
-- [Node Renderer Configuration](https://www.shakacode.com/react-on-rails-pro/docs/node-renderer/js-configuration/) — All Node Renderer options
-- [Caching Guide](https://www.shakacode.com/react-on-rails-pro/docs/caching/) — Fragment and prerender caching
-- [Streaming SSR](https://www.shakacode.com/react-on-rails-pro/docs/streaming-server-rendering/) — Progressive rendering
-- [Code Splitting](https://www.shakacode.com/react-on-rails-pro/docs/code-splitting-loadable-components/) — Loadable components with SSR
+- [Configuration Reference](../../pro/configuration.md) — All Pro config options
+- [Node Renderer Configuration](../../pro/node-renderer/js-configuration.md) — All Node Renderer options
+- [Caching Guide](../../pro/caching.md) — Fragment and prerender caching
+- [Streaming SSR](../../pro/streaming-server-rendering.md) — Progressive rendering
+- [Code Splitting](../../pro/code-splitting-loadable-components.md) — Loadable components with SSR
 
 ## Troubleshooting
 

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -2,7 +2,7 @@
 
 This guide covers the React-side challenges of migrating an existing React on Rails application to React Server Components (RSC). It focuses on how to restructure your component tree, handle Context and state management, migrate data fetching patterns, deal with third-party library compatibility, and avoid common pitfalls.
 
-> **React on Rails Pro required:** RSC support requires [React on Rails Pro](https://www.shakacode.com/react-on-rails-pro/) 4+ with the node renderer. The Pro gem provides the streaming view helpers (`stream_react_component`, `rsc_payload_react_component`), the RSC webpack plugin and loader, and the `registerServerComponent` API. For setup, see the [RSC tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/). For upgrade steps, see the [performance breakthroughs guide](../../pro/major-performance-breakthroughs-upgrade-guide.md).
+> **React on Rails Pro required:** RSC support requires [React on Rails Pro](https://www.shakacode.com/react-on-rails-pro/) 4+ with the node renderer. The Pro gem provides the streaming view helpers (`stream_react_component`, `rsc_payload_react_component`), the RSC webpack plugin and loader, and the `registerServerComponent` API. For setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). For upgrade steps, see the [performance breakthroughs guide](../../pro/major-performance-breakthroughs-upgrade-guide.md).
 
 ## Why Migrate?
 
@@ -104,7 +104,7 @@ Before diving into the React patterns, understand how RSC maps to React on Rails
 - **Server bundle** -- wraps the component for streaming SSR
 - **Client bundle** -- registers a placeholder that fetches the RSC payload from the server
 
-> **Setup instructions:** For webpack configuration, bundle structure, route setup, and step-by-step instructions, see the [React on Rails Pro RSC tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/). This guide focuses on the **React-side patterns** you'll need after setup is complete.
+> **Setup instructions:** For webpack configuration, bundle structure, route setup, and step-by-step instructions, see the [React on Rails Pro RSC tutorial](../../pro/react-server-components/tutorial.md). This guide focuses on the **React-side patterns** you'll need after setup is complete.
 
 ## Quick-Start Migration Strategy
 
@@ -132,7 +132,7 @@ Before you start, audit your components using this classification:
 - React 19+
 - [React on Rails Pro](https://www.shakacode.com/react-on-rails-pro/) 4+ with React on Rails 15+
 - Node renderer configured (RSC requires server-side JavaScript execution)
-- RSC webpack bundle configured (see [RSC tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/))
+- RSC webpack bundle configured (see [RSC tutorial](../../pro/react-server-components/tutorial.md))
 - Node.js 20+
 - Understanding of the [server vs client component mental model](https://react.dev/reference/rsc/server-components)
 
@@ -144,5 +144,5 @@ Before you start, audit your components using this classification:
 
 - [React Server Components RFC](https://react.dev/reference/rsc/server-components)
 - [React `'use client'` directive](https://react.dev/reference/rsc/use-client)
-- [React on Rails Pro RSC tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/)
-- [React on Rails Pro RSC purpose and benefits](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/purpose-and-benefits/)
+- [React on Rails Pro RSC tutorial](../../pro/react-server-components/tutorial.md)
+- [React on Rails Pro RSC purpose and benefits](../../pro/react-server-components/purpose-and-benefits.md)

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -88,7 +88,7 @@ This is the recommended data fetching pattern for React on Rails because:
 end %>
 ```
 
-> **See also:** [`stream_react_component_with_async_props` RSC tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/) for setup instructions and configuration options.
+> **See also:** [`stream_react_component_with_async_props` RSC tutorial](../../pro/react-server-components/tutorial.md) for setup instructions and configuration options.
 
 **React component (Server Component):**
 
@@ -181,7 +181,7 @@ type Props = WithAsyncProps<AsyncProps, SyncProps>;
 
 `getReactOnRailsAsyncProp` is fully typed -- calling `getReactOnRailsAsyncProp('users')` returns `Promise<User[]>`, and passing an invalid key is a compile-time error.
 
-> **More details:** For setup instructions, configuration options, and the RSC payload variant (`rsc_payload_react_component_with_async_props`), see the [React on Rails Pro RSC documentation](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/).
+> **More details:** For setup instructions, configuration options, and the RSC payload variant (`rsc_payload_react_component_with_async_props`), see the [React on Rails Pro RSC documentation](../../pro/react-server-components/tutorial.md).
 
 ## Migrating from React Query / TanStack Query
 

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -23,7 +23,7 @@ Before starting, ensure you have:
 
 - **React on Rails Pro 4+** with **React on Rails 15+**
 - **React 19** (`react` and `react-dom` both at 19.x)
-- **Node renderer** configured and running (RSC requires server-side JavaScript execution via the node renderer, not ExecJS). If you're still using ExecJS, migrate to the node renderer first -- see [Node Renderer Basics](https://www.shakacode.com/react-on-rails-pro/docs/node-renderer/basics/).
+- **Node renderer** configured and running (RSC requires server-side JavaScript execution via the node renderer, not ExecJS). If you're still using ExecJS, migrate to the node renderer first -- see [Node Renderer Basics](../../pro/node-renderer/basics.md).
 - **Shakapacker** (or webpack configured via Shakapacker)
 - **Node.js 20+**
 
@@ -134,7 +134,7 @@ Create `config/webpack/rscWebpackConfig.js`:
 ```js
 // React Server Components webpack configuration
 // Creates the RSC bundle based on the server webpack config
-// See: https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/
+// See: ../../pro/react-server-components/how-react-server-components-work.md
 
 const serverWebpackModule = require('./serverWebpackConfig');
 
@@ -341,7 +341,7 @@ rails-rsc-assets: HMR=true RSC_BUNDLE_ONLY=yes bin/shakapacker --watch
 node-renderer: node client/node-renderer.js
 ```
 
-> **For full webpack configuration details**, including the technical background on how the RSC loader, plugin, and manifests work together, see [How React Server Components Work](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/how-react-server-components-work/).
+> **For full webpack configuration details**, including the technical background on how the RSC loader, plugin, and manifests work together, see [How React Server Components Work](../../pro/react-server-components/how-react-server-components-work.md).
 
 ## Step 5: Add `'use client'` to All Registered Component Entry Points
 

--- a/docs/oss/upgrading/release-notes/16.0.0.md
+++ b/docs/oss/upgrading/release-notes/16.0.0.md
@@ -13,7 +13,7 @@ Experience the future of React with full RSC integration in your Rails apps:
 - Seamlessly use React Server Components
 - Reduce client bundle sizes
 - Enable powerful new patterns for data fetching
-- ⚡️ Requires React on Rails Pro - [See the full tutorial](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/)
+- ⚡️ Requires React on Rails Pro - [See the full tutorial](../../../pro/react-server-components/tutorial.md)
 
 ### 🚀 Major Performance Breakthrough: Early Hydration
 

--- a/docs/pro/configuration.md
+++ b/docs/pro/configuration.md
@@ -3,7 +3,7 @@
 `config/initializers/react_on_rails_pro.rb`
 
 1. You don't need to create a initializer if you are satisfied with the defaults as described below.
-1. Values beginning with `renderer` pertain only to using an external rendering server. You will need to ensure these values are consistent with your configuration for the external rendering server, as given in [JS configuration](https://www.shakacode.com/react-on-rails-pro/docs/node-renderer/js-configuration/)
+1. Values beginning with `renderer` pertain only to using an external rendering server. You will need to ensure these values are consistent with your configuration for the external rendering server, as given in [JS configuration](./node-renderer/js-configuration.md)
 1. `config.prerender_caching` works for standard mini_racer server rendering and using an external rendering server.
 
 ## Example of Configuration

--- a/docs/pro/major-performance-breakthroughs-upgrade-guide.md
+++ b/docs/pro/major-performance-breakthroughs-upgrade-guide.md
@@ -104,7 +104,7 @@ Adopting these features in React on Rails Pro v4 and React on Rails v15 will hel
 
 1. Update to React on Rails v15
 2. Update to React on Rails Pro v4
-3. Follow our [RSC & SSR Streaming migration guide](https://www.shakacode.com/react-on-rails-pro/docs/react-server-components/tutorial/)
+3. Follow our [RSC & SSR Streaming migration guide](./react-server-components/tutorial.md)
 
 Let's make your apps faster—together.
 


### PR DESCRIPTION
## Summary
- replace legacy `https://www.shakacode.com/react-on-rails-pro/docs/...` links with local `docs/pro/...` links across OSS and Pro docs
- keep scope to link hygiene from issue #2601
- intentionally defer landing-page files (`README.md` and `docs/pro/react-on-rails-pro.md`) to the separate landing-page PR

## Verification
- `rg -n "https://www.shakacode.com/react-on-rails-pro/docs/" README.md docs -g "*.md"` now reports only the two intentionally deferred landing-page links
- `lychee --config .lychee.toml docs/oss/api-reference/view-helpers-api.md docs/oss/getting-started/create-react-on-rails-app.md docs/oss/getting-started/pro-quick-start.md docs/oss/migrating/migrating-to-rsc.md docs/oss/migrating/rsc-data-fetching.md docs/oss/migrating/rsc-preparing-app.md docs/oss/upgrading/release-notes/16.0.0.md docs/pro/configuration.md docs/pro/major-performance-breakthroughs-upgrade-guide.md`

Refs #2601


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external documentation links to internal relative paths across multiple guides, including React Server Components setup, Pro configuration, migration guides, and code-splitting documentation. Users can now navigate documentation more seamlessly within the local documentation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->