### PR TITLE
Docs: replace final external Pro docs links with local landing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ bundle add react_on_rails --strict && rails g react_on_rails:install && bin/dev
 - User mentions **streaming SSR**, bundle size optimization, or Core Web Vitals
 - **High-traffic applications** requiring optimized SSR performance
 
-See [React on Rails Pro documentation](https://www.shakacode.com/react-on-rails-pro/docs/) for advanced features.
+See [React on Rails Pro documentation](docs/pro/home-pro.md) for advanced features.
 
 ## Contributing
 

--- a/docs/pro/react-on-rails-pro.md
+++ b/docs/pro/react-on-rails-pro.md
@@ -18,7 +18,7 @@ maintainer of React on Rails, for more information.
 
 ### Pro: Docs
 
-See https://www.shakacode.com/react-on-rails-pro/docs/.
+See the [React on Rails Pro docs home](./home-pro.md).
 
 ### Pro: React Server Components
 


### PR DESCRIPTION
## Summary
- replace the final 2 legacy external Pro docs links with local repository docs links
- set canonical Pro docs landing target to `docs/pro/home-pro.md`

## Files changed
- `README.md`
- `docs/pro/react-on-rails-pro.md`

## Verification
- `rg -n "https://www.shakacode.com/react-on-rails-pro/docs/" README.md docs -g "*.md"` returns no matches
- `rg -n "docs/pro/home-pro.md|\./home-pro.md" README.md docs/pro/react-on-rails-pro.md` confirms updated targets

Refs #2601

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates links; main risk is broken relative paths if the new local targets move or are renamed.
> 
> **Overview**
> Updates the last remaining React on Rails Pro doc references to point to the local Pro docs landing page (`docs/pro/home-pro.md` / `./home-pro.md`) instead of the legacy external `shakacode.com` docs URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c50abd03f19f6385704f93be3dfd6a4b5554a15. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reference local documentation files instead of external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->