### PR TITLE
Normalize Pro Gemfile.lock platforms

### DIFF
--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -140,9 +140,8 @@ GEM
     cgi (0.5.1)
     childprocess (5.0.0)
     coderay (1.1.3)
-    commonmarker (1.1.4-arm64-darwin)
-    commonmarker (1.1.4-x86_64-darwin)
-    commonmarker (1.1.4-x86_64-linux)
+    commonmarker (1.1.4)
+      rb_sys (~> 0.9)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     console (1.34.2)
@@ -171,9 +170,7 @@ GEM
     fakefs (2.8.0)
     faker (3.4.1)
       i18n (>= 1.8.11, < 2)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0)
     fiber-annotation (0.2.0)
     fiber-local (1.1.0)
       fiber-storage
@@ -231,6 +228,7 @@ GEM
     method_source (1.1.0)
     metrics (0.15.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -327,9 +325,12 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
+    rake-compiler-dock (1.11.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rb_sys (0.9.124)
+      rake-compiler-dock (= 1.11.0)
     rbs (3.9.5)
       logger
     rdoc (7.2.0)
@@ -440,9 +441,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3-arm64-darwin)
-    sqlite3 (1.7.3-x86_64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     stringio (3.2.0)
     sync (0.5.0)
     term-ansicolor (1.10.2)
@@ -489,6 +489,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-darwin-24
   x86_64-linux
 


### PR DESCRIPTION
### Summary

Standardize lockfile resolution for the Pro gem by normalizing platform-specific native gem entries in `react_on_rails_pro/Gemfile.lock` and adding `arm64-darwin-25` to supported platforms. This keeps setup-driven lockfile churn contained and reproducible.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

I ran `bundle install` and `bundle check` in all Gemfile roots (root, OSS gem, OSS dummy, Pro gem, Pro dummy, Pro execjs dummy); only `react_on_rails_pro/Gemfile.lock` changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only updates the Pro gem lockfile for more consistent cross-platform resolution; runtime behavior should be unchanged aside from bundler choosing the generic native gem builds.
> 
> **Overview**
> **Normalizes `react_on_rails_pro/Gemfile.lock` platform resolution** by replacing platform-pinned native gem entries (e.g., `commonmarker`, `ffi`, `sqlite3`) with generic versions and recording their build-time dependencies (e.g., `rb_sys`, `rake-compiler-dock`, `mini_portile2`).
> 
> Adds `arm64-darwin-25` to the lockfile `PLATFORMS` list to reduce platform-driven lockfile churn when running `bundle install` on newer macOS/Ruby setups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2155e76fc2fd80e02d5562cba7897b5cc261caab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->