### PR TITLE
Add workflow to trigger docs site rebuild on docs changes

### DIFF
--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -1,0 +1,24 @@
+name: Trigger docs site rebuild
+
+on:
+  push:
+    branches: [master]
+    paths: ['docs/**']
+
+jobs:
+  notify-docs-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.DOCS_DISPATCH_APP_KEY }}
+          owner: shakacode
+          repositories: reactonrails.com
+
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: shakacode/reactonrails.com
+          event-type: docs-updated


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/trigger-docs-site.yml` that fires on pushes to `master` when files under `docs/**` change
- Uses a GitHub App token (`actions/create-github-app-token`) scoped to `shakacode/reactonrails.com` for secure cross-repo auth
- Sends a `repository-dispatch` event (`docs-updated`) to `shakacode/reactonrails.com` to trigger a docs site rebuild

## Prerequisites

Before merging, a shakacode org admin needs to:
1. Create a GitHub App with `contents: write` permission, installed on only `reactonrails.com`
2. Add `DOCS_DISPATCH_APP_ID` and `DOCS_DISPATCH_APP_KEY` secrets to the `react_on_rails` repo

## Test plan

- [ ] Verify secrets are configured in repo settings
- [ ] Merge and push a change to `docs/` on master — confirm the workflow runs and dispatches the event
- [ ] Confirm `reactonrails.com` receives the `docs-updated` event and triggers a rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cross-repo automation that uses GitHub App secrets and `repository_dispatch`, which could fail or misfire if secrets/permissions are misconfigured but does not change runtime application code.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `trigger-docs-site.yml`, that runs on pushes to `master` affecting `docs/**`.
> 
> The job mints a GitHub App token from `DOCS_DISPATCH_APP_ID`/`DOCS_DISPATCH_APP_KEY` and sends a `repository_dispatch` (`docs-updated`) event to `shakacode/reactonrails.com` to trigger a docs site rebuild.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1084725d473e07b88e11be736ae4de20b326e8f1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to rebuild the documentation site when updates are made to documentation files on the master branch, ensuring the documentation site stays current with recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->