### PR TITLE
Fix broken doc links after Pro docs consolidation

### DIFF
--- a/react_on_rails_pro/CONTRIBUTING.md
+++ b/react_on_rails_pro/CONTRIBUTING.md
@@ -47,7 +47,7 @@ From [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/
 ## Doc Changes
 
 When making doc changes, we want the change to work on both [the React on Rails docs site](https://reactonrails.com/docs/pro/react-on-rails-pro/) and when browsing the GitHub repo.
-The issue is that the ShakaCode site is generated only from files in [`../docs/pro`](../docs/pro), so any references from them to non-doc files must use the full GitHub URL.
+For links from docs pages to non-doc files, use full GitHub URLs so links resolve correctly in both contexts.
 
 ### Links to other docs:
 


### PR DESCRIPTION
## Summary

Fixes broken internal markdown links left over from #2627 (Pro docs consolidation):

- **`docs/pro/upgrading-to-pro.md`** — 7 broken `./` relative links still pointing to files that were moved from `docs/pro/` to `docs/oss/building-features/` and `docs/oss/configuration/`
- **`docs/oss/getting-started/oss-vs-pro.md`** — 6 broken `../../pro/` links in the feature comparison table pointing to moved files
- **`react_on_rails_pro/CONTRIBUTING.md`** — Stale wording about "ShakaCode site is generated only from files in `../docs/pro`" which no longer reflects the consolidated docs structure

Fixes #2627 (follow-up)

## Test plan

- [ ] Verify all updated links resolve to existing files
- [ ] Check docs site renders correctly with new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to documentation link updates and minor wording tweaks, with no code or runtime behavior changes.
> 
> **Overview**
> Fixes broken documentation links caused by the Pro docs consolidation by repointing references in `docs/oss/getting-started/oss-vs-pro.md` and `docs/pro/upgrading-to-pro.md` to the new `docs/oss/building-features`/`docs/oss/configuration` locations.
> 
> Also updates `react_on_rails_pro/CONTRIBUTING.md` to clarify the rule for using full GitHub URLs when linking from docs to non-doc files so links resolve on both the docs site and GitHub.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6193eeaafc74c3de7491f1c7e608c63e7c52ed. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to use full GitHub URLs for consistent link resolution across different contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->