### PR TITLE
Sync release docs with recent changelog automation changes

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -206,7 +206,7 @@ After adding an entry to the `### [Unreleased]` section, ensure the version diff
 The format at the bottom should be:
 
 ```markdown
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.2.0.beta.19...master
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.2.0.beta.19...main
 [16.2.0.beta.19]: https://github.com/shakacode/react_on_rails/compare/v16.1.1...v16.2.0.beta.19
 ```
 
@@ -220,7 +220,7 @@ When a new version is released:
    ### [16.2.0.beta.20] - 2025-12-12
    ```
 
-2. Update the `[unreleased]:` link to compare from the new version to master
+2. Update the `[unreleased]:` link to compare from the new version to main
 3. Add a new version link comparing the previous version to the new version
 
 ## Process
@@ -229,8 +229,8 @@ When a new version is released:
 
 #### Step 1: Fetch and read current state
 
-- **CRITICAL**: Run `git fetch origin master` to ensure you have the latest commits
-- After fetching, use `origin/master` for all comparisons, NOT local `master` branch
+- **CRITICAL**: Run `git fetch origin main` to ensure you have the latest commits
+- After fetching, use `origin/main` for all comparisons, NOT local `main` branch
 - Read the current CHANGELOG.md to understand the existing structure
 
 #### Step 2: Reconcile tags with changelog sections (DO THIS FIRST)
@@ -257,16 +257,16 @@ When a new version is released:
    e. **Move** matching entries from Unreleased into the new section
    f. **Add** any new entries for PRs in that tag that aren't in the changelog at all
    g. **Update version diff links** at the bottom of the file:
-   - Update `[unreleased]:` to compare from the newest tag to master
+   - Update `[unreleased]:` to compare from the newest tag to main
    - Add a link for each new version section
 
 5. Get the tag date with: `git log -1 --format="%Y-%m-%d" TAG_NAME`
 
 #### Step 3: Add new entries for post-tag commits
 
-1. Run `git log --oneline LATEST_TAG..origin/master` to find commits after the latest tag (LATEST_TAG is the most recent git tag, i.e., the same one identified in Step 2)
-2. Extract PR numbers: `git log --oneline LATEST_TAG..origin/master | grep -oE "#[0-9]+" | sort -u`
-3. If Step 2 found no missing tagged versions, verify no tag is ahead of master: `git log --oneline origin/master..LATEST_TAG` should be empty. If not, entries in "Unreleased" may belong to that tagged version — Step 2 should have caught this, so re-check.
+1. Run `git log --oneline LATEST_TAG..origin/main` to find commits after the latest tag (LATEST_TAG is the most recent git tag, i.e., the same one identified in Step 2)
+2. Extract PR numbers: `git log --oneline LATEST_TAG..origin/main | grep -oE "#[0-9]+" | sort -u`
+3. If Step 2 found no missing tagged versions, verify no tag is ahead of main: `git log --oneline origin/main..LATEST_TAG` should be empty. If not, entries in "Unreleased" may belong to that tagged version — Step 2 should have caught this, so re-check.
 4. For each PR number, check if it's already in CHANGELOG.md: `grep "PR XXX" CHANGELOG.md`
 5. For PRs not yet in the changelog:
    - Get PR details: `gh pr view NUMBER --json title,body,author --repo shakacode/react_on_rails`

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -225,9 +225,10 @@ The task automatically converts Ruby gem format to npm semver format:
 
    **Option A - Use Claude Code (recommended):**
 
-   Run `/update-changelog 16.5.0` (using the already-released version) to analyze commits, write entries, and automatically open a PR. After the PR merges, sync the GitHub release:
+   Run `/update-changelog 16.5.0` (using the already-released version) to analyze commits, write entries, and automatically open a PR. After the PR merges, pull the updated changelog and sync the GitHub release:
 
    ```bash
+   git pull --rebase
    bundle exec rake "sync_github_release[16.5.0]"
    ```
 


### PR DESCRIPTION
## Summary

Recent commits (15f6cfc, 078a8b0, 97f4625) updated `update_changelog.rake` and `update-changelog.md` with significant improvements (orphaned prerelease link cleanup, v prefix fix for compare links, consolidate/deduplicate blocks, explicit version support, auto-commit/push/PR). However `releasing.md` was not updated to match, leaving stale instructions.

- **releasing.md**: Update step 1 to reflect `/update-changelog` now supports explicit versions, collapses prereleases with dedup, and auto-commits/pushes/opens a PR (removes manual "commit and push CHANGELOG.md" step)
- **releasing.md**: Add note about `v` prefix requirement in CHANGELOG compare links (per #2628 fix)
- **releasing.md**: Update Option A post-release instructions to match new auto-PR behavior
- **update-changelog.md**: Fix stale description saying version computed from "changelog headings and git tags" -- prerelease index is now determined solely from git tags

No changes to `release.rake` -- it was not affected by the recent changes.

## Test plan

- [ ] Verify `releasing.md` step 1 accurately describes current `/update-changelog` behavior
- [ ] Verify compare link `v` prefix note matches actual `update_changelog_links()` behavior
- [ ] Verify `update-changelog.md` description matches `compute_auto_version()` logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that align release/changelog instructions with current automation behavior; no runtime code paths or release tooling logic changed.
> 
> **Overview**
> Aligns release and changelog docs with the updated `/update-changelog` automation: explicit version support, skipping auto-versioning when provided, prerelease section collapse/dedup, and auto commit/push/PR creation.
> 
> Clarifies versioning/link rules (prerelease index derived from git tags only; CHANGELOG compare links must use `v`-prefixed tags), updates instructions from `master` to `main`, and refreshes post-release catch-up steps to use the new auto-PR flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a48394ab3d6cd3475fc21194c42fbbf2d73cb82c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added support for explicit prerelease/versions (e.g., 16.5.0.rc.10); auto-version computation is skipped when explicit version provided
  * Clarified prerelease changelog handling: collapse prior prerelease sections, deduplicate entries, and derive prerelease index from git tags
  * Documented automated workflow: command can automatically commit, push, and open a PR (now requires working on main)
  * Require changelog compare links to use v-prefixed tag names and compare against main
<!-- end of auto-generated comment: release notes by coderabbit.ai -->