### PR TITLE
Fix placeholder text in docs

### DIFF
--- a/docs/oss/building-features/how-to-use-different-files-for-client-and-server-rendering.md
+++ b/docs/oss/building-features/how-to-use-different-files-for-client-and-server-rendering.md
@@ -46,9 +46,9 @@ function setResolve(builderConfig, webpackConfig) {
 
  const resolve = {
     alias: {
-      ... // blah blah
+      // ... other aliases
       SomeJsFile,
-      ... // blah blah
+      // ... other aliases
     },
 ```
 
@@ -75,9 +75,9 @@ function setResolve(builderConfig, webpackConfig) {
 
  const resolve = {
     alias: {
-      ... // blah blah
-      variant
-      ... // blah blah
+      // ... other aliases
+      variant,
+      // ... other aliases
     },
 ```
 

--- a/docs/oss/building-features/images.md
+++ b/docs/oss/building-features/images.md
@@ -1,8 +1,6 @@
 # Configuring Images and Assets with Webpack
 
-1. leading slash necessary on the
-   a. Option name for the file-loader and url-loader (todo reference)
-   b. Option publicPath for the output (todo reference)
+A leading slash is necessary on the `name` option for file-loader/url-loader and the `publicPath` option for output.
 
 ```
 const assetLoaderRules = [


### PR DESCRIPTION
## Summary
- Replace `// blah blah` placeholder comments with `// ... other aliases` in webpack alias code examples
- Rewrite incomplete `(todo reference)` notes into proper documentation in images.md

Fixes #2648

## Test plan
- [x] Verified `/\b(blah blah|TODO|TBD|xxx)\b/i` no longer matches any lines in the two files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits that clarify webpack alias examples and replace incomplete placeholder/TODO text; no runtime code paths are affected.
> 
> **Overview**
> Cleans up OSS docs examples by replacing `// blah blah` placeholders in webpack `resolve.alias` snippets with clearer `// ... other aliases` comments.
> 
> Also rewrites the opening note in `images.md` to a complete sentence clarifying when a leading slash is required for `file-loader`/`url-loader` `name` and webpack output `publicPath` options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93b9600e8105db70d532df5db85fd67958e029fc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined in-code comments in the feature building documentation to enhance clarity and consistency across the guides.
  * Consolidated and clarified documentation related to file-loader and url-loader configuration requirements, specifically improving guidance on the necessary leading slash specifications for both the name option and publicPath settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->