### PR TITLE
Update address-review command to use sequential numbering

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -95,6 +95,7 @@ Create a todo list with TodoWrite containing **only the `MUST-FIX` items**:
 
 Present the triage to the user - **DO NOT automatically start addressing items**:
 
+- Use a single sequential numbering across all categories (1, 2, 3, ...) so every item has a unique number the user can reference. Do not restart numbering at 1 for each category.
 - `MUST-FIX ({count})`: list the todos created
 - `DISCUSS ({count})`: list items needing user choice, with a short reason
 - `SKIPPED ({count})`: list skipped comments with a short reason, including duplicates and factually incorrect suggestions


### PR DESCRIPTION
### Summary

Updated the address-review command's triage presentation to use a single sequential numbering system across all categories (MUST-FIX, DISCUSS, SKIPPED). This makes it easier for users to reference specific items when directing which comments to address.

### Pull Request checklist

- [x] Documentation updated (command documentation)
- [~] Add/update test to cover these changes (N/A - documentation-only)
- [~] Update CHANGELOG file (N/A - documentation-only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts the output formatting guidance for triage lists; no runtime or data-handling code is affected.
> 
> **Overview**
> Updates the `address-review` command documentation to require a **single sequential numbering scheme** across `MUST-FIX`, `DISCUSS`, and `SKIPPED` triage sections, so each item has a unique reference number (instead of restarting numbering per category).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf21d73bfc697360b9b195e64f0523a6a130443d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated triage results presentation format to use sequential global numbering for improved clarity and easier reference across all categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->