### PR TITLE
Sync address-review command with shakapacker improvements

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -102,7 +102,7 @@ Present the triage to the user - **DO NOT automatically start addressing items**
 - Wait for the user to tell you which items to address
 - Always offer an explicit optional follow-up to post rationale replies on selected `SKIPPED` or declined `DISCUSS` items
 - Never post those rationale replies unless the user explicitly selects which items to reply to
-- Ask two things when relevant:
+- Ask two things when there are `SKIPPED` or declined `DISCUSS` items:
   - Which items to address in code/tests/docs
   - Which skipped/declined items (if any) should receive a rationale reply
 
@@ -184,6 +184,8 @@ SKIPPED (3):
 Which items would you like me to address? (e.g., "1", "1,2", or "all must-fix")
 Optional: I can also post rationale replies for skipped/declined items (e.g., "reply 3,5" or "reply all skipped").
 ```
+
+Note: Only show the "Optional: rationale replies" line when there are `SKIPPED` or declined `DISCUSS` items. Omit it when every item is `MUST-FIX`.
 
 # Important Notes
 


### PR DESCRIPTION
## Summary
- Syncs the `.claude/commands/address-review.md` command with the latest version from shakacode/shakapacker
- Adds improved rationale-reply UX: after triage, explicitly offers to post rationale replies for skipped/declined items (only when user selects them)
- Preserves the sequential numbering instruction unique to this repo

Closes #2656

## Test plan
- [ ] Verify `/address-review` command works correctly with a PR that has review comments
- [ ] Confirm triage output includes the "Optional: rationale replies" prompt
- [ ] Confirm sequential numbering across categories still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts the command’s interaction guidance without affecting production code paths.
> 
> **Overview**
> Updates `.claude/commands/address-review.md` to add an explicit, *opt-in* workflow for posting rationale replies on `SKIPPED` or declined `DISCUSS` items after triage.
> 
> The triage prompt and examples now ask separately which items to address vs. which items (if any) should receive rationale replies, and clarify that the optional rationale line should only appear when applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 553cc35d90449f031394d8fd657ff72e7a0fd277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced rationale reply workflow: always offer optional rationale replies for selected SKIPPED or declined items; rationales are posted only with explicit user selection.
  * Improved prompts and post-triage presentation clarifying which items to address and which should receive rationale replies.
* **Documentation**
  * Updated instructions and examples to show the optional rationale-reply line only when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->