### PR TITLE
Add script to publish built JS packages to dist repo

### DIFF
--- a/scripts/publish-to-builds-repo.sh
+++ b/scripts/publish-to-builds-repo.sh
@@ -220,32 +220,32 @@ echo ""
 cd "$DIST_DIR/repo"
 git add -A
 
+SOURCE_SHA=$(cd "$MONOREPO_ROOT" && git rev-parse --short HEAD)
+SOURCE_BRANCH=$(cd "$MONOREPO_ROOT" && git rev-parse --abbrev-ref HEAD)
+
 if git diff --cached --quiet; then
-  echo "==> No changes to commit."
+  echo "==> No file changes to commit."
 else
-  SOURCE_SHA=$(cd "$MONOREPO_ROOT" && git rev-parse --short HEAD)
-  SOURCE_BRANCH=$(cd "$MONOREPO_ROOT" && git rev-parse --abbrev-ref HEAD)
-
   git commit -m "Build packages $VERSION from $SOURCE_BRANCH ($SOURCE_SHA)"
+fi
 
-  if [[ "$DRY_RUN" == "true" ]]; then
-    echo "==> [DRY RUN] Would push to $DIST_REPO branch $DIST_BRANCH"
-    echo "==> [DRY RUN] Would create tag $DIST_TAG"
-    echo ""
-    echo "==> Contents of dist repo:"
-    find . -not -path './.git/*' -not -path './.git' | sort
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "==> [DRY RUN] Would push to $DIST_REPO branch $DIST_BRANCH"
+  echo "==> [DRY RUN] Would create tag $DIST_TAG"
+  echo ""
+  echo "==> Contents of dist repo:"
+  find . -not -path './.git/*' -not -path './.git' | sort
+else
+  echo "==> Pushing to $DIST_REPO branch $DIST_BRANCH..."
+  git push -u origin "$DIST_BRANCH"
+
+  # Create and push tag
+  if git rev-parse "$DIST_TAG" &>/dev/null; then
+    echo "==> Tag $DIST_TAG already exists, skipping tag creation."
   else
-    echo "==> Pushing to $DIST_REPO branch $DIST_BRANCH..."
-    git push -u origin "$DIST_BRANCH"
-
-    # Create and push tag
-    if git rev-parse "$DIST_TAG" &>/dev/null; then
-      echo "==> Tag $DIST_TAG already exists, skipping tag creation."
-    else
-      git tag "$DIST_TAG"
-      git push origin "$DIST_TAG"
-      echo "==> Tag $DIST_TAG pushed."
-    fi
+    git tag "$DIST_TAG"
+    git push origin "$DIST_TAG"
+    echo "==> Tag $DIST_TAG pushed."
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Adds `scripts/publish-to-builds-repo.sh` that builds all JS packages and pushes the compiled output to [shakacode/react-on-rails-builds](https://github.com/shakacode/react-on-rails-builds)
- The builds repo contains pre-built `package.json` + `lib/` for each package, ready for consumption as pnpm git dependencies — no TypeScript compilation needed during install
- The script defaults to pushing to a branch matching the current react_on_rails branch name (overridable with `--branch`)

### What the script does
1. Runs `pnpm build` for all packages
2. Copies `package.json` + `lib/` to the builds repo
3. Replaces `workspace:*` references with the actual version
4. Strips `devDependencies` and build-related scripts
5. Commits, pushes, and tags (e.g., `v16.4.0`)

### Usage
```bash
./scripts/publish-to-builds-repo.sh              # build + push + tag
./scripts/publish-to-builds-repo.sh --dry-run     # preview without pushing
./scripts/publish-to-builds-repo.sh --tag v1.2.3  # custom tag
./scripts/publish-to-builds-repo.sh --branch main # override branch
```

### Consumer usage (pnpm)
```json
{
  "react-on-rails": "github:shakacode/react-on-rails-builds#v16.4.0&path:react-on-rails",
  "react-on-rails-pro": "github:shakacode/react-on-rails-builds#v16.4.0&path:react-on-rails-pro",
  "react-on-rails-pro-node-renderer": "github:shakacode/react-on-rails-builds#v16.4.0&path:react-on-rails-pro-node-renderer"
}
```

## Test plan
- [x] Dry run completes successfully
- [x] Real run pushes to `shakacode/react-on-rails-builds` with correct structure
- [x] Verified `workspace:*` replaced with actual version in dist `package.json`
- [x] Verified `devDependencies` and build scripts stripped
- [x] Verified consumer `pnpm install` resolves correct packages in ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)