### PR TITLE
Fix doctor prerender check and ExecJS display for Pro/RSC apps

### DIFF
--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -672,13 +672,15 @@ module ReactOnRails
 
       begin
         uses_node_renderer = ReactOnRails::Utils.react_on_rails_pro? &&
-                             defined?(ReactOnRailsPro) &&
-                             ReactOnRailsPro.configuration.node_renderer?
+                             pro_initializer_has_node_renderer?
 
         if uses_node_renderer
           checker.add_info("  Pro uses NodeRenderer for server rendering")
           if defined?(ExecJS) && ExecJS.runtime
             checker.add_info("  ExecJS available as fallback: #{ExecJS.runtime.name}")
+          else
+            checker.add_warning("  ⚠️  ExecJS fallback is enabled but ExecJS is not available")
+            checker.add_info("  💡 Install mini_racer or set renderer_use_fallback_exec_js = false")
           end
         elsif defined?(ExecJS)
           runtime_name = ExecJS.runtime.name if ExecJS.runtime
@@ -1262,6 +1264,15 @@ module ReactOnRails
         content.match?(/prerender:\s*true/) ||
           content.match?(/stream_react_component|cached_stream_react_component|rsc_payload_react_component/)
       end
+    rescue StandardError
+      false
+    end
+
+    def pro_initializer_has_node_renderer?
+      config_path = "config/initializers/react_on_rails_pro.rb"
+      return false unless File.exist?(config_path)
+
+      File.read(config_path).match?(/server_renderer\s*=\s*["']NodeRenderer["']/)
     rescue StandardError
       false
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1187,11 +1187,25 @@ RSpec.describe ReactOnRails::Doctor do
     let(:execjs_runtime) { Struct.new(:name).new("Node.js (V8)") }
     let(:execjs_module) { Struct.new(:runtime).new(execjs_runtime) }
 
-    context "when Pro gem is installed with NodeRenderer" do
+    around do |example|
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(tmpdir) { example.run }
+      end
+    end
+
+    def write_project_file(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end
+
+    context "when Pro initializer has NodeRenderer" do
       before do
         allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
-        pro_config = Struct.new(:node_renderer?).new(true)
-        stub_const("ReactOnRailsPro", Struct.new(:configuration).new(pro_config))
+        write_project_file("config/initializers/react_on_rails_pro.rb", <<~RUBY)
+          ReactOnRailsPro.configure do |config|
+            config.server_renderer = "NodeRenderer"
+          end
+        RUBY
       end
 
       it "labels ExecJS as fallback" do
@@ -1206,27 +1220,37 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
-    context "when Pro gem is installed with NodeRenderer and ExecJS is absent" do
+    context "when Pro initializer has NodeRenderer and ExecJS is absent" do
       before do
         allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
-        pro_config = Struct.new(:node_renderer?).new(true)
-        stub_const("ReactOnRailsPro", Struct.new(:configuration).new(pro_config))
+        write_project_file("config/initializers/react_on_rails_pro.rb", <<~RUBY)
+          ReactOnRailsPro.configure do |config|
+            config.server_renderer = "NodeRenderer"
+          end
+        RUBY
         hide_const("ExecJS")
       end
 
-      it "only shows the NodeRenderer message" do
+      it "warns about missing ExecJS fallback" do
         doctor.send(:check_server_rendering_engine)
+
         info_messages = checker.messages.select { |m| m[:type] == :info }.map { |m| m[:content] }
+        warning_messages = checker.messages.select { |m| m[:type] == :warning }.map { |m| m[:content] }
         expect(info_messages).to include(a_string_including("Pro uses NodeRenderer"))
-        expect(info_messages).not_to include(a_string_including("ExecJS"))
+        expect(warning_messages).to include(
+          a_string_including("ExecJS fallback is enabled but ExecJS is not available")
+        )
       end
     end
 
-    context "when Pro gem is installed with ExecJS (default renderer)" do
+    context "when Pro initializer does not have NodeRenderer" do
       before do
         allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
-        pro_config = Struct.new(:node_renderer?).new(false)
-        stub_const("ReactOnRailsPro", Struct.new(:configuration).new(pro_config))
+        write_project_file("config/initializers/react_on_rails_pro.rb", <<~RUBY)
+          ReactOnRailsPro.configure do |config|
+            config.prerender_caching = true
+          end
+        RUBY
       end
 
       it "reports ExecJS as primary engine" do
@@ -1237,6 +1261,21 @@ RSpec.describe ReactOnRails::Doctor do
         info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
         expect(info_messages).to include(a_string_including("ExecJS Runtime:"))
         expect(info_messages).not_to include(a_string_including("Pro uses NodeRenderer"))
+      end
+    end
+
+    context "when no Pro initializer exists" do
+      before do
+        allow(ReactOnRails::Utils).to receive(:react_on_rails_pro?).and_return(true)
+      end
+
+      it "reports ExecJS as primary engine" do
+        stub_const("ExecJS", execjs_module)
+
+        doctor.send(:check_server_rendering_engine)
+
+        info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+        expect(info_messages).to include(a_string_including("ExecJS Runtime:"))
       end
     end
 


### PR DESCRIPTION
## Summary

- **Fix prerender consistency check (#2770):** `uses_prerender_in_views?` now detects Pro streaming helpers (`stream_react_component`, `cached_stream_react_component`, `rsc_payload_react_component`) that implicitly enable prerender. Previously, the doctor only scanned for `prerender: true` in views, missing RSC/streaming patterns and recommending removal of `server_bundle_js_file` — which crashes RSC apps.
- **Fix server rendering engine display:** `check_server_rendering_engine` now regex-parses the Pro initializer to detect `server_renderer = "NodeRenderer"`. When detected, shows "Pro uses NodeRenderer" with ExecJS as fallback. When NodeRenderer is configured but ExecJS is absent, warns about the missing fallback dependency. Pro apps using the default ExecJS renderer correctly see ExecJS as their primary engine.

## Test plan

- [x] 4 integration tests for prerender consistency (3 streaming helpers + negative case)
- [x] 5 tests for server rendering engine display (NodeRenderer + ExecJS, NodeRenderer + no ExecJS, Pro with default ExecJS, no Pro initializer, no Pro gem)
- [x] Full doctor spec passes (80 examples, 0 failures)
- [x] Reproduced both issues in test apps on main — confirmed broken behavior
- [x] Verified both fixes in test apps on branch — confirmed correct behavior

Closes #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)