### PR TITLE
Docs: clean up directory structure and normalize filenames (#2780)

### DIFF
--- a/docs/DIRECTORY_LICENSING.md
+++ b/docs/DIRECTORY_LICENSING.md
@@ -134,4 +134,4 @@ Each phase includes mandatory license compliance verification before proceeding 
 
 ---
 
-_This document is maintained as part of the React on Rails monorepo merger plan. For implementation details, see [MONOREPO_MERGER_PLAN_REF.md](./MONOREPO_MERGER_PLAN_REF.md)_
+_This document is maintained as part of the React on Rails monorepo merger plan. For implementation details, see [MONOREPO_MERGER_PLAN_REF.md](../internal/planning/MONOREPO_MERGER_PLAN_REF.md)_

--- a/docs/LICENSING_FAQ.md
+++ b/docs/LICENSING_FAQ.md
@@ -31,7 +31,7 @@
 import ReactOnRails from 'react-on-rails-pro';
 ```
 
-See the [Installation Guide](../../docs/pro/installation.md) for details.
+See the [Installation Guide](./pro/installation.md) for details.
 
 ### Q: How will the monorepo structure maintain license separation?
 
@@ -86,7 +86,7 @@ react_on_rails/ (monorepo root)
 
 ### Q: When will this happen?
 
-**A:** The merger is planned as a 7-phase process. Each phase maintains full functionality and CI compliance. See [MONOREPO_MERGER_PLAN_REF.md](./MONOREPO_MERGER_PLAN_REF.md) for details.
+**A:** The merger is planned as a 7-phase process. Each phase maintains full functionality and CI compliance. See [MONOREPO_MERGER_PLAN_REF.md](../internal/planning/MONOREPO_MERGER_PLAN_REF.md) for details.
 
 ### Q: What if something goes wrong during the merger?
 
@@ -142,4 +142,4 @@ Production use requires a valid subscription.
 
 ---
 
-_For more information about the monorepo merger, see [MONOREPO_MERGER_PLAN_REF.md](./MONOREPO_MERGER_PLAN_REF.md)_
+_For more information about the monorepo merger, see [MONOREPO_MERGER_PLAN_REF.md](../internal/planning/MONOREPO_MERGER_PLAN_REF.md)_


### PR DESCRIPTION
## Summary

- Move planning artifacts (`DIRECTORY_LICENSING.md`, `LICENSING_FAQ.md`) from `docs/` to `internal/planning/` — these are monorepo merger planning docs, not user-facing documentation
- Rename `rails_view_rendering_from_inline_javascript.md` → `rails-view-rendering-from-inline-javascript.md` (kebab-case)
- Rename `code_of_conduct.md` → `code-of-conduct.md` (kebab-case)
- Fix internal cross-references in moved files

Closes #2780

## Test plan

- [ ] Verify no broken links in docs (no existing references pointed to the renamed/moved files)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only (moves/renames and link fixes) with no impact on runtime code; main risk is broken internal links if any references were missed.
> 
> **Overview**
> Moves monorepo-merger planning/licensing docs (e.g., `DIRECTORY_LICENSING.md`, `LICENSING_FAQ.md`) out of `docs/` into `internal/planning/` to keep user-facing docs clean.
> 
> Normalizes doc filenames to kebab-case (e.g., `rails_view_rendering_from_inline_javascript.md` → `rails-view-rendering-from-inline-javascript.md`, `code_of_conduct.md` → `code-of-conduct.md`) and updates internal links/cross-references to match the new locations/names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc8f430cb7f888c4b89c66c535561f846209eb72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated relative links across internal planning documentation to fix path resolution for merger plan references and installation guide links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->