### PR TITLE
Keep address-review triage aligned with latest actionable feedback

### DIFF
--- a/.agents/workflows/address-review.md
+++ b/.agents/workflows/address-review.md
@@ -66,7 +66,7 @@ Execution flow when terminal access is available:
 
 4. Filter comments:
    - Skip resolved threads.
-   - Skip replies where `in_reply_to_id` is set.
+   - Do not create standalone triage items from comments where `in_reply_to_id` is set, but use reply text as the latest thread context when it updates or narrows the unresolved concern.
    - Keep bot comments by default, but deduplicate duplicates and skip status-only bot posts.
    - Focus on correctness bugs, regressions, security issues, missing tests that hide bugs, and clear adjacent-code inconsistencies.
    - Skip style nits, speculative suggestions, documentation nits, changelog wording, duplicate comments, and "could consider" feedback unless I ask for polish work.
@@ -77,11 +77,12 @@ Execution flow when terminal access is available:
 5. Triage every remaining comment:
    - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a bug, and clear inconsistencies with adjacent code that would likely block merge.
    - `DISCUSS`: reasonable scope-expanding suggestions, architectural opinions, and comments that need a decision.
-   - `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, summaries, and factually incorrect suggestions.
+   - `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, non-actionable summaries, and factually incorrect suggestions.
    - Deduplicate overlapping comments before classifying them.
    - Verify reviewer claims locally before calling something `MUST-FIX`.
    - If a claim is wrong, classify it as `SKIPPED` and say why.
    - Preserve comment IDs and thread IDs for later replies and thread resolution.
+   - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
    - Track only `MUST-FIX` items as your working checklist.
    - Use one checklist entry per must-fix item or deduplicated issue.
    - Use the subject format: `"{file}:{line} - {comment_summary} (@{username})"`.

--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -82,7 +82,7 @@ gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER
 **Filtering comments:**
 
 - Skip comments belonging to already-resolved threads (match via `thread_id` and `is_resolved` from the GraphQL response)
-- Skip comments where `in_reply_to_id` is set (these are replies, not top-level comments)
+- Do not create standalone triage items from comments where `in_reply_to_id` is set, but use reply text as the latest thread context when it updates or narrows the unresolved concern
 - Do not skip bot-generated comments by default. Many actionable review comments in this repository come from bots.
 - Deduplicate repeated bot comments and skip bot status posts, summaries, and acknowledgments that do not require a code or documentation change
 - Treat as actionable by default only: correctness bugs, regressions, security issues, missing tests, and clear inconsistencies with adjacent code
@@ -101,7 +101,7 @@ Before creating any todos, classify every review comment into one of three categ
 
 - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a real bug, and clear inconsistencies with adjacent code that would likely block merge
 - `DISCUSS`: reasonable suggestions that expand scope, architectural opinions that are not clearly right or wrong, and comments where the reviewer claim may be correct but needs a user decision
-- `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, summaries, and factually incorrect suggestions
+- `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, non-actionable summaries, and factually incorrect suggestions
 
 Triage rules:
 
@@ -109,6 +109,7 @@ Triage rules:
 - Verify factual claims locally before classifying a comment as `MUST-FIX`.
 - If a claim appears wrong, classify it as `SKIPPED` and note briefly why.
 - Preserve the original review comment ID and thread ID when available so the command can reply to the correct place and resolve the correct thread later.
+- Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
 
 ## Step 5: Create Todo List
 


### PR DESCRIPTION
## Summary
- update reply filtering guidance so replies are not standalone triage items, but still update unresolved thread context
- classify actionable review summary bodies as normal feedback and only skip non-actionable summaries
- mirror the same behavior in both `.agents/workflows/address-review.md` and `.claude/commands/address-review.md` to keep Claude and non-Claude workflows aligned

## Testing
- pnpm exec prettier --check .agents/workflows/address-review.md .claude/commands/address-review.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

* Review workflow now intelligently handles threaded reply comments, using them to refine issue context rather than creating separate items.
* Feedback classification refined to better distinguish actionable review input from non-actionable boilerplate or status-only summaries, improving triage accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->