### PR TITLE
DO NOT MERGE: Document view helper pattern for disabling SSR in CI (#2786)

### DIFF
--- a/docs/oss/deployment/server-rendering-tips.md
+++ b/docs/oss/deployment/server-rendering-tips.md
@@ -20,6 +20,31 @@ For the best performance with Server Rendering, consider using [React on Rails P
 2. Set `config.trace` to true. You will get the server invocation code that renders your component. If you're not using Shakapacker, you will also get the whole file used to set up the JavaScript context.
 3. If streaming SSR requests hang indefinitely, check whether your compression middleware (`Rack::Deflater`, `Rack::Brotli`) has an `:if` condition that calls `body.each`. This causes deadlocks with streaming responses. See the [Compression Middleware Compatibility](../building-features/streaming-server-rendering.md#compression-middleware-compatibility) section in the Streaming Server Rendering guide.
 
+## Disabling SSR in CI or Test Environments
+
+If your CI or test environment lacks an SSR server (e.g., no Node.js runtime available), components with `prerender: true` will throw errors. Rather than adding gem-level configuration, use a standard Rails view helper to control prerendering per-environment:
+
+```ruby
+# app/helpers/prerender_helper.rb
+module PrerenderHelper
+  def use_prerendering
+    return false if ENV["DISABLE_SSR"].present?
+
+    true
+  end
+end
+```
+
+Then replace hardcoded `prerender: true` calls with the helper:
+
+```erb
+<%= react_component("MyComponent", prerender: use_prerendering) %>
+```
+
+Set `DISABLE_SSR=1` in your CI environment to skip server rendering.
+
+This approach gives you per-component granularity (SEO-critical components can still hardcode `prerender: true`), and you can customize the logic however you like — for example, checking `Rails.env.test?` or reading a different env var.
+
 ## CSS
 
 Server bundles must always have CSS extracted.

--- a/docs/oss/deployment/troubleshooting.md
+++ b/docs/oss/deployment/troubleshooting.md
@@ -370,6 +370,12 @@ rule.use = rule.use.filter((item) => {
 
 3. **No browser-only code in component?** (see "window is not defined" above)
 
+### "SSR errors in CI or test environments"
+
+**Symptoms:** Components with `prerender: true` throw errors because no SSR server is available
+
+**Solution:** Use a view helper to conditionally disable prerendering. See [Disabling SSR in CI or Test Environments](server-rendering-tips.md#disabling-ssr-in-ci-or-test-environments).
+
 ### "Hydration mismatch warnings"
 
 **Symptoms:** React warnings about server/client content differences


### PR DESCRIPTION
## Summary

**This PR is kept open for reference only — do not merge.**

Documents a view helper pattern for conditionally disabling SSR in CI/test environments, as described in #2786. After further discussion, we decided this is an anti-pattern (disabling SSR hides SSR-specific bugs), so we're not merging this into the docs. The PR is left open so stakeholders can see the proposed approach.

- Adds a "Disabling SSR in CI or Test Environments" section to `server-rendering-tips.md`
- Adds a cross-reference in `troubleshooting.md`

See #2786 for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for conditionally disabling SSR when no runtime is available in CI/test.
> 
> **Overview**
> Adds a new docs section describing how to *conditionally disable* SSR per environment by replacing hardcoded `prerender: true` with a Rails view helper and an env var (e.g. `DISABLE_SSR`).
> 
> Updates the troubleshooting guide with a new “SSR errors in CI or test environments” entry that links to the new guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c948a9e89a8a51c782242bfffda4d2a603f2b11d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on disabling server-side rendering in CI and test environments to prevent failures when an SSR runtime is unavailable.
  * Added a troubleshooting subsection describing symptoms of SSR failures in CI/test and recommending a conditional, environment-aware approach to disable prerendering, with links to the guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->