### PR TITLE
Fix changelog version stamping header to mention explicit version support

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -150,7 +150,7 @@ Entries should be organized under these section headings **in the following orde
 
 ### Version Stamping with Rake Task
 
-When this command is invoked with `release`, `rc`, or `beta`, **use the rake task to stamp the version header** after adding entries:
+When this command is invoked with `release`, `rc`, `beta`, or an explicit version (e.g., `16.5.0.rc.10`), **use the rake task to stamp the version header** after adding entries:
 
 ```bash
 bundle exec rake "update_changelog[release]"   # stamp next stable version


### PR DESCRIPTION
## Summary
- Updates the Version Stamping section header in `.claude/commands/update-changelog.md` to mention explicit version support (e.g., `16.5.0.rc.10`), aligning it with Step 4 and the "Before a release" summary which already documented this correctly.

Fixes #2806

## Test plan
- [x] Verified the updated line matches the suggested fix in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying that the changelog stamping rake task can be invoked with an explicit version string. No runtime or release logic was modified.
> 
> **Overview**
> Updates `.claude/commands/update-changelog.md` to explicitly document that version stamping via the rake task applies not only to `release`/`rc`/`beta` modes but also when an explicit version (e.g., `16.5.0.rc.10`) is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 283793b359d2f40a260ec7ca7da136e0250c785d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on when to use the version-stamping rake task, now including scenarios with explicit version arguments in addition to release modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->