### PR TITLE
Remove broad Pro URL exclusions from lychee config

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -70,8 +70,6 @@ exclude = [
   # PLANNED DEPLOYMENTS NOT YET LIVE
   # ============================================================================
   '^https://ror-spec-dummy\.reactrails\.com',  # spec/dummy demo - deployment pending
-  '^https://pro\.reactonrails\.com/docs/',     # Pro docs site - pages being deployed incrementally
-  '^https://reactonrails\.com/pro',            # Pro page - deployment pending
 
   # ============================================================================
   # SITES FROM PROJECTS.MD THAT BLOCK BOTS OR ARE UNRELIABLE


### PR DESCRIPTION
## Summary
- remove broad lychee exclusions for `https://pro.reactonrails.com/docs/` and `https://reactonrails.com/pro`
- keep the demo pending-deployment exclusion (`ror-spec-dummy.reactrails.com`) intact
- restore link-check coverage for the migrated Pro URL targets

Closes #2673

## Validation
- `lychee --config .lychee.toml README.md docs/oss/getting-started/comparison-with-alternatives.md docs/oss/getting-started/oss-vs-pro.md`
- confirmed `https://reactonrails.com/pro` returns HTTP 200
- confirmed `https://pro.reactonrails.com/docs/` returns HTTP 404 (legacy host; no in-repo links currently target it)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Lychee link-checker exclusions, affecting CI link validation behavior but not runtime code.
> 
> **Overview**
> Restores link-check coverage by removing the broad Lychee `exclude` patterns for `https://pro.reactonrails.com/docs/` and `https://reactonrails.com/pro`.
> 
> Keeps the existing planned-deployment exclusion for `https://ror-spec-dummy.reactrails.com` intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f1e89e3e5300406b87108d55a095bc1da1dc504. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Link-checking configuration updated so Pro-related documentation URLs are now included in validation (previous exclude rules removed).

* **Documentation**
  * Minor whitespace and Markdown formatting adjustments across several docs to improve spacing and rendering of excerpts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->