### PR TITLE
fix: preserve runtime env vars across Bundler.with_unbundled_env

### DIFF
--- a/react_on_rails/lib/react_on_rails/dev/process_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/process_manager.rb
@@ -8,6 +8,14 @@ module ReactOnRails
       # Timeout for version check operations to prevent hanging
       VERSION_CHECK_TIMEOUT = 5
 
+      # Env vars set after Bundler.setup that must survive with_unbundled_env.
+      # with_unbundled_env restores the pre-Bundler env snapshot, so any var
+      # set at runtime (e.g. PORT by PortSelector) is lost. We capture them
+      # before entering the block and pass them explicitly to system().
+      # This follows the same pattern used by Rails' bundle_command (railties),
+      # Spring's process spawning, and this codebase's own PackGenerator.
+      ENV_KEYS_TO_PRESERVE = %w[PORT SHAKAPACKER_DEV_SERVER_PORT].freeze
+
       class << self
         # Check if a process is available and usable in the current execution context
         # This accounts for bundler context where system commands might be intercepted
@@ -98,14 +106,6 @@ module ReactOnRails
           # Process not available in either context
           nil
         end
-
-        # Env vars set after Bundler.setup that must survive with_unbundled_env.
-        # with_unbundled_env restores the pre-Bundler env snapshot, so any var
-        # set at runtime (e.g. PORT by PortSelector) is lost. We capture them
-        # before entering the block and pass them explicitly to system().
-        # This follows the same pattern used by Rails' bundle_command (railties),
-        # Spring's process spawning, and this codebase's own PackGenerator.
-        ENV_KEYS_TO_PRESERVE = %w[PORT SHAKAPACKER_DEV_SERVER_PORT].freeze
 
         # Run a process outside of bundler context
         # This allows using system-installed processes even when they're not in the Gemfile

--- a/react_on_rails/sig/react_on_rails/dev/process_manager.rbs
+++ b/react_on_rails/sig/react_on_rails/dev/process_manager.rbs
@@ -2,6 +2,7 @@ module ReactOnRails
   module Dev
     class ProcessManager
       VERSION_CHECK_TIMEOUT: Integer
+      ENV_KEYS_TO_PRESERVE: Array[String]
 
       def self.installed?: (String) -> bool
       def self.ensure_procfile: (String) -> void
@@ -16,6 +17,7 @@ module ReactOnRails
       def self.process_available_in_system?: (String) -> bool
       def self.with_unbundled_context: () { () -> untyped } -> untyped
       def self.show_process_manager_installation_help: () -> void
+      def self.preserve_runtime_env_vars: () -> Hash[String, String]
       def self.valid_procfile_path?: (String) -> bool
     end
   end

--- a/react_on_rails/spec/react_on_rails/dev/process_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/process_manager_spec.rb
@@ -179,6 +179,30 @@ RSpec.describe ReactOnRails::Dev::ProcessManager do
       described_class.send(:run_process_outside_bundle, "foreman", ["start", "-f", "Procfile.dev"])
     end
 
+    it "preserves PORT and SHAKAPACKER_DEV_SERVER_PORT in env hash" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("PORT").and_return("3001")
+      allow(ENV).to receive(:[]).with("SHAKAPACKER_DEV_SERVER_PORT").and_return("3036")
+
+      expect(described_class).to receive(:with_unbundled_context).and_yield
+      expect_any_instance_of(Kernel).to receive(:system)
+        .with({ "PORT" => "3001", "SHAKAPACKER_DEV_SERVER_PORT" => "3036" }, "foreman", "start", "-f", "Procfile.dev")
+
+      described_class.send(:run_process_outside_bundle, "foreman", ["start", "-f", "Procfile.dev"])
+    end
+
+    it "omits unset env vars from the hash" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("PORT").and_return("3001")
+      allow(ENV).to receive(:[]).with("SHAKAPACKER_DEV_SERVER_PORT").and_return(nil)
+
+      expect(described_class).to receive(:with_unbundled_context).and_yield
+      expect_any_instance_of(Kernel).to receive(:system)
+        .with({ "PORT" => "3001" }, "foreman", "start", "-f", "Procfile.dev")
+
+      described_class.send(:run_process_outside_bundle, "foreman", ["start", "-f", "Procfile.dev"])
+    end
+
     it "falls back to direct system call when Bundler is not available" do
       hide_const("Bundler")
       expect_any_instance_of(Kernel).to receive(:system).with("foreman", "start", "-f", "Procfile.dev")


### PR DESCRIPTION
## Summary

- Fix `ProcessManager#run_process_outside_bundle` losing `PORT` and `SHAKAPACKER_DEV_SERVER_PORT` env vars when running foreman/overmind inside `Bundler.with_unbundled_env`

## Problem

When foreman is system-installed (recommended by foreman docs — "Don't Bundle Foreman"), `ProcessManager` runs it inside `Bundler.with_unbundled_env`. This restores the pre-Bundler env snapshot, wiping any env vars set **after** `Bundler.setup` — including `PORT` and `SHAKAPACKER_DEV_SERVER_PORT` set by `PortSelector.configure_ports`.

**Result:** Auto-detected ports from `PortSelector` never reach foreman's child processes:
- Foreman injects its default `PORT=5000`, overriding the selected port
- Webpack dev server falls back to hardcoded `3035` from `shakapacker.yml`

This breaks the zero-config automatic port selection added in #2539.

## Root Cause

`Bundler.with_unbundled_env` restores a snapshot of `ENV` captured **before** `Bundler.setup` ran. Any env var set at runtime after that point is `nil` inside the block. This is [documented Bundler behavior](https://bundler.io/man/bundle-exec.1.html) and a [known issue](https://github.com/rails/spring/issues/669) across the ecosystem.

## Fix

Capture the port env vars **before** entering the unbundled block and pass them explicitly to `system()` as an env hash — using Ruby's `Kernel#system(env, command, *args)` signature.

This is the same pattern used by:
- **Rails' `bundle_command`** in railties ([8.0](https://github.com/rails/rails/blob/v8.0.2/railties/lib/rails/generators/app_base.rb#L657), [8.1](https://github.com/rails/rails/blob/v8.1.2/railties/lib/rails/generators/bundle_helper.rb))
- **Spring's** process spawning with `Process.spawn(env_hash, ...)`
- **Puma's** `BundlePruner` (captures `GEM_HOME`/`BUNDLE_GEMFILE` before `with_unbundled_env`)
- **This codebase's own `PackGenerator`** (`run_via_bundle_exec` passes env hash to `system()` inside `with_unbundled_context`)

## Test plan

Tested manually with a Rails app where foreman is system-installed (not in Gemfile):
- [x] Occupied ports 3000/3035 with dummy listeners
- [x] Ran `bin/dev` — `PortSelector` detected conflict, selected 3001/3036
- [x] **Before fix:** Rails bound to :5000 (foreman default), webpack crashed on :3035
- [x] **After fix:** Rails bound to :3001, webpack to :3036 — both correct

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development environment variables for the app server PORT and the dev-server port are now preserved when launching local development processes, so custom port settings persist across restarts.

* **Tests**
  * Updated tests to accept an environment/options hash when asserting the launched process, and to verify that the relevant port variables are included only when set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->