### PR TITLE
Docs: fix RSC migration gaps found during real-world migration

### DIFF
--- a/docs/oss/core-concepts/render-functions-and-railscontext.md
+++ b/docs/oss/core-concepts/render-functions-and-railscontext.md
@@ -113,6 +113,8 @@ The `railsContext` has: (see the implementation in [ReactOnRails::Helper](https:
 
 Plus, you can add your customizations to this. See "rendering extension" below.
 
+> **RSC Note:** When using React on Rails Pro with RSC, `railsContext` also includes functions like `addPostSSRHook` and `getRSCPayloadStream`. These **cannot** be passed from Server Components to Client Components across the RSC boundary. Strip them before passing: `const { addPostSSRHook, getRSCPayloadStream, ...serializableContext } = railsContext;`. See [RSC Troubleshooting](../migrating/rsc-troubleshooting.md#common-error-railscontext-contains-functions).
+
 ## Rails Context
 
 The `railsContext` is a second param passed to your render-functions for React components. This is in addition to the props that are passed from the `react_component` Rails helper. For example:

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -448,6 +448,28 @@ import { Provider } from 'react-redux';
 >
 > For more on this distinction, see [File Suffixes vs. RSC Directive](https://github.com/shakacode/react_on_rails/pull/2406).
 
+### Transpiled languages (ReScript, Reason, etc.)
+
+If you use ReScript or other transpiled languages, the compiled `.bs.js` files don't preserve directives. Add `'use client'` to the **wrapper `.jsx` files** in `ror_components/`, not to the `.res` source files.
+
+For example, with `.client.jsx` / `.server.jsx` pairs:
+
+```jsx
+// ListingsShow.client.jsx — add 'use client' here
+'use client';
+import ListingsShow from '../ListingsShow';
+export default ListingsShow;
+```
+
+```jsx
+// ListingsShow.server.jsx — add 'use client' here too
+'use client';
+import ListingsShow from '../ListingsShow';
+export default ListingsShow;
+```
+
+> **Common mistake:** Developers often add `'use client'` to JS/JSX entry points but forget the ReScript ones. The pack generator will **silently** register components without `'use client'` as server components via `registerServerComponent`. There is no warning — the component just breaks at runtime. After adding the directive, verify with `bin/rails react_on_rails:generate_packs` and check that the output shows all components as "Client components."
+
 ### What about the bundle entry files?
 
 Adding `'use client'` to `client-bundle.js` or `server-bundle.js` would technically work -- it would make all imported components Client Components, achieving the same immediate effect. However, we recommend placing the directive on **individual component files** instead. The reason is forward-looking: when you later want to convert a specific component to a Server Component (by removing `'use client'`), you need granular control per component. If the directive is only on the bundle entry file, you'd have to move it to every individual component file at that point anyway.
@@ -459,6 +481,8 @@ After adding `'use client'` to all entry points, rebuild all three bundles and v
 ## Step 6: Switch to Streaming Rendering
 
 Replace synchronous view helpers and controller rendering with their streaming equivalents.
+
+> **Warning: Compression middleware.** If your app uses `Rack::Deflater`, `Rack::Brotli`, or similar compression middleware, streaming responses will deadlock. The middleware calls `body.each` to check the response size, which blocks on `ActionController::Live::Buffer`. See [Compression Middleware Compatibility](../building-features/streaming-server-rendering.md#compression-middleware-compatibility) for the fix.
 
 ### 6a. Update controllers
 

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -102,6 +102,27 @@ export default function ClientForm() {
 <%= stream_react_component("ClientForm") %>
 ```
 
+### Common Error: railsContext Contains Functions
+
+When using React on Rails Pro with RSC, the `railsContext` object includes non-serializable functions (`addPostSSRHook`, `getRSCPayloadStream`). Passing the entire `railsContext` to a Client Component causes:
+
+```
+Functions cannot be passed directly to Client Components
+unless you explicitly expose it by marking it with "use server".
+```
+
+**Fix:** Strip non-serializable properties before passing to Client Components:
+
+```jsx
+// Server Component (render function)
+const MyPage = (props, railsContext) => {
+  const { addPostSSRHook, getRSCPayloadStream, ...serializableContext } = railsContext;
+  return () => (
+    <ClientComponent {...props} railsContext={serializableContext} />
+  );
+};
+```
+
 > **Note:** React on Rails does **not** support Server Actions (`'use server'`). Server Actions run on the Node renderer, which has no access to Rails models, sessions, cookies, or CSRF protection. Use Rails controller endpoints for all mutations.
 
 ### Common Error: Passing Class Instances
@@ -712,6 +733,8 @@ end
 | SSR hangs indefinitely / request timeout on large RSC payloads                                                               | Stream backpressure deadlock when RSC payload exceeds 16 KB                                                                                                                                        | Update to latest React on Rails Pro. See [Stream Backpressure Deadlock](#stream-backpressure-deadlock)                                                                                                                                                                 |
 | `"The 'react-on-rails' package version does not match the gem version"`                                                      | Gem and npm package installed at different versions                                                                                                                                                | Install the npm package version matching your gem. See [Gem and npm Package Version Mismatch](#gem-and-npm-package-version-mismatch)                                                                                                                                   |
 | `"The 'react-on-rails' package version is not an exact version"`                                                             | Using semver ranges (`^`, `~`, `*`) instead of an exact version in package.json                                                                                                                    | Pin to the exact version without range operators. See [Gem and npm Package Version Mismatch](#gem-and-npm-package-version-mismatch)                                                                                                                                    |
+| RSC payload returns `ServerComponentFetchError: Error parsing JSON` or `SyntaxError` in development                          | Rails' `annotate_rendered_view_with_filenames` wraps the RSC payload JSON in `<!-- BEGIN -->` / `<!-- END -->` HTML comments                                                                       | Upgrade to React on Rails Pro 16.4.0+ which renders RSC templates with `formats: [:text]`. For older versions, disable `config.action_view.annotate_rendered_view_with_filenames` for the RSC controller.                                                              |
+| `railsContext` causes "Functions cannot be passed directly to Client Components"                                             | `railsContext` includes non-serializable functions (`addPostSSRHook`, `getRSCPayloadStream`) added by Pro                                                                                          | Destructure and exclude function properties before passing to Client Components. See [railsContext Contains Functions](#common-error-railscontext-contains-functions)                                                                                                   |
 
 ## Environment Variable Access
 


### PR DESCRIPTION
## Summary

Fixes documentation gaps discovered during a real-world RSC migration (HiChee). These caused silent failures that were difficult to debug.

Closes #2841

## Changes

### `rsc-preparing-app.md`
- **Step 5:** Added guidance for ReScript/transpiled languages — wrapper `.jsx` files in `ror_components/` need `'use client'`, not the compiled `.bs.js` files. Includes warning about silent misclassification when the directive is missing.
- **Step 6:** Added compression middleware warning — `Rack::Deflater`/`Rack::Brotli` deadlocks with `ActionController::Live` streaming. Cross-references the existing streaming SSR docs.

### `rsc-troubleshooting.md`
- Added "railsContext Contains Functions" section — `railsContext` includes `addPostSSRHook` and `getRSCPayloadStream` which can't cross the RSC boundary. Shows the destructuring fix.
- Added two entries to the Error Message Catalog:
  - View annotations breaking RSC JSON in development
  - railsContext function serialization error

### `render-functions-and-railscontext.md`
- Added RSC note about non-serializable functions in `railsContext`

## Test plan
- [ ] Verify links between docs are correct
- [ ] Review that the ReScript example matches the actual wrapper pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced React Server Components documentation with guidance on context serialization across component boundaries and practical examples
  * Expanded troubleshooting section with solutions for common configuration issues, error diagnostics, and compatibility concerns
  * Added streaming middleware compatibility notes and support for transpiled languages in RSC implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->