### PR TITLE
Update CHANGELOG.md for 16.5.0.rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,29 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [16.5.0.rc.0] - 2026-03-25
+
 #### Added
 
-- **`create-react-on-rails-app --pro` support**: Added explicit `--pro` mode to the CLI, including
-  `react_on_rails_pro` gem installation and generator wiring for Pro-only setup (without requiring `--rsc`).
-  [PR 2818](https://github.com/shakacode/react_on_rails/pull/2818) by
-- **Global prerender env override**: Added `REACT_ON_RAILS_PRERENDER_OVERRIDE=true|false` to force prerender behavior
-  globally (env > component option > initializer default), useful for CI/test environments without an SSR server.
-  [PR 2816](https://github.com/shakacode/react_on_rails/pull/2816) by
-  [justin808](https://github.com/justin808).
+- **`create-react-on-rails-app --pro` support**: Added explicit `--pro` mode to the CLI, including `react_on_rails_pro` gem installation and generator wiring for Pro-only setup (without requiring `--rsc`). [PR 2818](https://github.com/shakacode/react_on_rails/pull/2818) by [justin808](https://github.com/justin808).
+- **Global prerender env override**: Added `REACT_ON_RAILS_PRERENDER_OVERRIDE=true|false` to force prerender behavior globally (env > component option > initializer default), useful for CI/test environments without an SSR server. [PR 2816](https://github.com/shakacode/react_on_rails/pull/2816) by [justin808](https://github.com/justin808).
+- **`react_on_rails:sync_versions` rake task**: Added a version synchronizer that aligns npm package versions (`react-on-rails`, `react-on-rails-pro`, `react-on-rails-pro-node-renderer`) with loaded gem versions. Runs in dry-run mode by default; use `WRITE=true` to apply changes. [PR 2797](https://github.com/shakacode/react_on_rails/pull/2797) by [justin808](https://github.com/justin808).
+- **Pro/RSC setup checks in `react_on_rails:doctor`**: Extended doctor diagnostics with Pro Setup (initializer, renderer mode, base-package import scanning) and RSC checks (renderer mode, payload route, bundler config, React version, Procfile RSC watcher). Sections are skipped for OSS-only installs. [PR 2674](https://github.com/shakacode/react_on_rails/pull/2674) by [ihabadham](https://github.com/ihabadham).
+
+#### Changed
+
+- **[Pro]** **Canonical env var for worker count is now `RENDERER_WORKERS_COUNT`**. The previous `NODE_RENDERER_CONCURRENCY` is still supported as a fallback. Worker count validation now accepts explicit `0` for single-process mode and warns on invalid values. [PR 2611](https://github.com/shakacode/react_on_rails/pull/2611) by [justin808](https://github.com/justin808).
+
+#### Improved
+
+- **Smoother `create-react-on-rails-app` and install generator flows**: Fresh app scaffolding now runs non-interactively with `--force`, preserves the selected package manager, normalizes pnpm projects, auto-replaces stock `bin/dev`, and warns (instead of failing) on dirty worktrees. Post-install output updated with `db:prepare` step and current docs URL. [PR 2650](https://github.com/shakacode/react_on_rails/pull/2650) by [justin808](https://github.com/justin808).
+- **Pro upgrade hint after install**: Running `rails g react_on_rails:install` now prints a Pro upgrade hint with docs link. Suppressed when `--pro` or `--rsc` flags are used. [PR 2642](https://github.com/shakacode/react_on_rails/pull/2642) by [justin808](https://github.com/justin808).
+
+#### Fixed
+
+- **Preserve runtime env vars across `Bundler.with_unbundled_env`**: Fixed `PORT` and `SHAKAPACKER_DEV_SERVER_PORT` being lost when `ProcessManager` runs foreman/overmind inside `Bundler.with_unbundled_env`, breaking auto-detected ports from `PortSelector`. Env vars are now captured before the unbundled block and passed explicitly to `system()`. [PR 2836](https://github.com/shakacode/react_on_rails/pull/2836) by [ihabadham](https://github.com/ihabadham).
+- **Fix doctor prerender check and ExecJS display for Pro/RSC apps**: `uses_prerender_in_views?` now detects Pro streaming helpers (`stream_react_component`, `cached_stream_react_component`, `rsc_payload_react_component`) that implicitly enable prerender. Server rendering engine display now correctly detects NodeRenderer configuration from the Pro initializer. [PR 2773](https://github.com/shakacode/react_on_rails/pull/2773) by [ihabadham](https://github.com/ihabadham).
+- **Fix doctor false positives for custom layouts**: `react_on_rails:doctor` now resolves `package.json` from `node_modules_location` config (instead of assuming repo root) and discovers webpack/rspack configs across common custom locations. Missing bundler config downgraded from error to contextual warning. [PR 2612](https://github.com/shakacode/react_on_rails/pull/2612) by [justin808](https://github.com/justin808).
 
 ### [16.4.0] - 2026-03-16
 
@@ -2028,7 +2042,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.4.0...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.5.0.rc.0...main
+[16.5.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v16.4.0...v16.5.0.rc.0
 [16.4.0]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...v16.4.0
 [16.3.0]: https://github.com/shakacode/react_on_rails/compare/v16.2.1...v16.3.0
 [16.2.1]: https://github.com/shakacode/react_on_rails/compare/v16.2.0...v16.2.1


### PR DESCRIPTION
## Summary

- Stamp `### [16.5.0.rc.0]` version header with today's date
- Add 10 new changelog entries for PRs merged since v16.4.0
- Fix incomplete PR 2818 entry (missing author link)

### New entries added

**Added:**
- `create-react-on-rails-app --pro` support (PR 2818)
- Global prerender env override `REACT_ON_RAILS_PRERENDER_OVERRIDE` (PR 2816)
- `react_on_rails:sync_versions` rake task (PR 2797)
- Pro/RSC setup checks in `react_on_rails:doctor` (PR 2674)

**Changed:**
- [Pro] Canonical env var for worker count is now `RENDERER_WORKERS_COUNT` (PR 2611)

**Improved:**
- Smoother `create-react-on-rails-app` and install generator flows (PR 2650)
- Pro upgrade hint after install (PR 2642)

**Fixed:**
- Preserve runtime env vars across `Bundler.with_unbundled_env` (PR 2836)
- Fix doctor prerender check and ExecJS display for Pro/RSC apps (PR 2773)
- Fix doctor false positives for custom layouts (PR 2612)

### Skipped PRs (not user-visible)

Docs-only: #2845, #2842, #2826, #2830, #2820, #2809, #2803, #2785, #2801, #2791, #2789, #2788, #2772, #2778, #2780, #2784, #2671, #2676, #2662, #2657, #2669
CI/internal tooling: #2825, #2817, #2819, #2812, #2815, #2810, #2808, #2807, #2634, #2798, #2761, #2760, #2658, #2639, #2667, #2656

## Test plan

- [x] Verified version header and diff links are correct
- [x] Verified all entries follow changelog formatting conventions
- [x] Verified file ends with newline
- [ ] After merge, run `rake release` to publish 16.5.0.rc.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating `CHANGELOG.md` with a new `16.5.0.rc.0` section and compare links; no runtime code is modified.
> 
> **Overview**
> Adds a new `16.5.0.rc.0` (2026-03-25) section to `CHANGELOG.md`, consolidating recent PR entries under **Added/Changed/Improved/Fixed** and correcting the previously incomplete `--pro` CLI entry author attribution.
> 
> Updates the bottom compare links so `[unreleased]` now compares from `v16.5.0.rc.0` and adds a link definition for `[16.5.0.rc.0]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 481a71c876907ea40d166c2246dcafee635fb2f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v16.5.0.rc.0

* **New Features**
  * Added sync_versions task for streamlined version management
  * Expanded doctor checks for Pro and RSC support

* **Improvements**
  * Enhanced generator workflow and Pro upgrade guidance
  * Improved environment variable handling and preservation

* **Bug Fixes**
  * Fixed detection issues with doctor tools and ExecJS/prerender functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->