### PR TITLE
docs: refresh generator and helper URLs

### DIFF
--- a/react_on_rails/lib/generators/USAGE
+++ b/react_on_rails/lib/generators/USAGE
@@ -20,4 +20,4 @@ Then you may run
 
 More Details:
 
-    `https://github.com/shakacode/react_on_rails/blob/master/docs/additional-details/generator-details.md`
+    `https://reactonrails.com/docs/api-reference/generator-details/`

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # React on Rails configuration
-# See https://github.com/shakacode/react_on_rails/blob/master/docs/oss/configuration/README.md
+# See https://reactonrails.com/docs/configuration/
 # for complete documentation of all configuration options.
 
 ReactOnRails.configure do |config|
@@ -44,7 +44,7 @@ ReactOnRails.configure do |config|
   # ALTERNATIVE APPROACH: Set `compile: true` in config/shakapacker.yml test section
   # - Simpler setup, but less explicit control
   # - Can be slower due to on-demand recompilation
-  # - See: https://github.com/shakacode/react_on_rails/blob/master/docs/oss/building-features/testing-configuration.md
+  # - See: https://reactonrails.com/docs/building-features/testing-configuration/
   #
   # RSpec apps should also add to spec/rails_helper.rb (inside RSpec.configure):
   #   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
@@ -66,5 +66,5 @@ ReactOnRails.configure do |config|
   # - Custom rendering extensions
   # - And more...
   #
-  # See: https://github.com/shakacode/react_on_rails/blob/master/docs/oss/configuration/README.md
+  # See: https://reactonrails.com/docs/configuration/
 end

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -74,7 +74,7 @@ module ReactOnRails
       when Hash
         msg = <<~MSG
           Use react_component_hash (not react_component) to return a Hash to your ruby view code. See
-          https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReactHelmetServerApp.jsx
+          https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/client/app/startup/ReactHelmetApp.server.jsx
           for an example of the necessary javascript configuration.
         MSG
         raise ReactOnRails::Error, msg
@@ -88,7 +88,7 @@ module ReactOnRails
 
           If you're trying to use a Render-Function to return a Hash to your ruby view code, then use
           react_component_hash instead of react_component and see
-          https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReactHelmetServerApp.jsx
+          https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/client/app/startup/ReactHelmetApp.server.jsx
           for an example of the JavaScript code.
         MSG
         raise ReactOnRails::Error, msg
@@ -135,7 +135,7 @@ module ReactOnRails
       else
         msg = <<~MSG
           Render-Function used by react_component_hash for #{component_name} is expected to return
-          an Object. See https://github.com/shakacode/react_on_rails/blob/master/spec/dummy/client/app/startup/ReactHelmetServerApp.jsx
+          an Object. See https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/client/app/startup/ReactHelmetApp.server.jsx
           for an example of the JavaScript code.
           Note, your Render-Function must either take 2 params or have the property
           `.renderFunction = true` added to it to distinguish it from a React Function Component.

--- a/react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb
+++ b/react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb
@@ -5,8 +5,7 @@
 module ReactOnRails
   module TestHelper
     class WebpackAssetsCompiler
-      TESTING_DOCS_URL = "https://github.com/shakacode/react_on_rails/blob/master/" \
-                         "docs/oss/building-features/dev-server-and-testing.md"
+      TESTING_DOCS_URL = "https://reactonrails.com/docs/building-features/dev-server-and-testing/"
 
       def compile_assets
         if ReactOnRails.configuration.build_test_command.blank?

--- a/react_on_rails/spec/dummy/app/views/pages/client_side_manual_render.html.erb
+++ b/react_on_rails/spec/dummy/app/views/pages/client_side_manual_render.html.erb
@@ -50,5 +50,5 @@
 
 <p>
   One possible use case for this is
-  <a href="https://github.com/shakacode/react_on_rails/blob/master/docs/pro/code-splitting-loadable-components.md"> Code Splitting</a>.
+  <a href="https://reactonrails.com/docs/building-features/code-splitting/">Code Splitting</a>.
 </p>


### PR DESCRIPTION
## Summary

- replace stale generator/help links that still point at moved docs or `blob/master` paths
- update scaffolded initializer comments to the current published configuration/testing docs
- refresh the manual-render example page so its code-splitting link points at the live docs page

## Scope notes

- Limited to generator/help/example URLs only
- Intentionally separate from #2850 and #2851 to keep review small
- No runtime behavior changes

## Validation

Passed:
- `bundle exec rubocop react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb react_on_rails/lib/react_on_rails/helper.rb react_on_rails/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt`
- `git diff --check`
- `curl -I -L` checks showing `200` for:
  - `https://reactonrails.com/docs/api-reference/generator-details/`
  - `https://reactonrails.com/docs/building-features/dev-server-and-testing/`
  - `https://reactonrails.com/docs/building-features/testing-configuration/`
  - `https://reactonrails.com/docs/building-features/code-splitting/`
  - `https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/client/app/startup/ReactHelmetApp.server.jsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only documentation links in generator templates, helper error messages, and dummy/example views, with no runtime logic changes.
> 
> **Overview**
> Refreshes several stale documentation URLs to point at the current `reactonrails.com` docs, including generator usage output and the scaffolded `config/initializers/react_on_rails.rb` template comments.
> 
> Also updates in-code guidance links in `ReactOnRails::Helper` error messages and `TestHelper::WebpackAssetsCompiler`, plus the dummy manual-render example page’s code-splitting link, to avoid `blob/master` and moved-doc paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1afee932b4309d048491f05dfa954806b980b7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->