### PR TITLE
docs: fix profiling node renderer command

### DIFF
--- a/docs/pro/profiling-server-side-rendering-code.md
+++ b/docs/pro/profiling-server-side-rendering-code.md
@@ -5,6 +5,9 @@ Renderer so you can find slow paths and bottlenecks.
 
 The examples below use the sample app in `react_on_rails_pro/spec/dummy`.
 
+**Prerequisite:** This guide assumes you have [Overmind](https://github.com/DarthSim/overmind)
+installed. On macOS, you can install it with `brew install overmind`.
+
 ## Profiling Server-Side Code Running On Node Renderer
 
 1. Start the sample app with Overmind.


### PR DESCRIPTION
## Summary

Update the Pro profiling guide so its Node Renderer debugging instructions match the current dummy app and generator output.

Changes in this PR:
- remove the stale `yarn run node-renderer` Procfile example
- document the current `node --inspect client/node-renderer.js` form used by the dummy app
- clarify that apps still using a package script can temporarily switch to the direct `node --inspect` command while profiling

## Why

The old instructions told readers to replace a `yarn run node-renderer` line that no longer exists in `react_on_rails_pro/spec/dummy/Procfile.dev` or the current generator output. That makes the first profiling step look wrong before the reader even starts.

## Test plan

- `/Users/justin/codex/react_on_rails/node_modules/.bin/prettier --check docs/pro/profiling-server-side-rendering-code.md`
- `git diff --check`
- `lychee --offline --no-progress --format compact docs/pro/profiling-server-side-rendering-code.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to profiling instructions with no runtime or API changes.
> 
> **Overview**
> Updates the SSR profiling guide to match the current React on Rails Pro sample app workflow: start the dummy app via Overmind, stop the managed `node-renderer`, and restart it manually with `node --inspect client/node-renderer.js`.
> 
> Clarifies prerequisites, sample-app paths/URLs, adds guidance for apps that normally start the renderer via a package script, and tightens wording for the high-load `ab` profiling section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eddaf2c7c4427f64d18d4017dd7dd2c95ca3a8c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated profiling guide to target the Pro Node renderer with clearer, step-by-step developer workflows and sample-app context.
  * Added an Overmind-driven flow for starting/stopping the managed renderer and instructions to restart the renderer with the debugger attached during profiling.
  * Guidance added for temporarily bypassing normal package-script startup.
  * Clarified how to visit the sample app and generalized the load-testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->