### PR TITLE
docs: modernize dependency update commands

### DIFF
--- a/docs/oss/misc/updating-dependencies.md
+++ b/docs/oss/misc/updating-dependencies.md
@@ -23,8 +23,13 @@ Check for outdated versions of packages:
 pnpm outdated
 ```
 
-Use the equivalent `npm outdated` or `yarn outdated` command if your app uses a different package
-manager. Read CHANGELOGs of major updated packages before you update. You might not be ready for
+Equivalents for other package managers:
+
+- npm: `npm outdated`
+- yarn: `yarn outdated`
+- bun: `bun outdated`
+
+Read CHANGELOGs of major updated packages before you update. You might not be ready for
 some updates.
 
 ### Updating All Dependencies
@@ -38,33 +43,48 @@ pnpm dlx npm-check-updates -u -a
 pnpm install
 ```
 
-Some combinations that I often run:
+To also remove old `node_modules` so you only get what corresponds to `package.json`:
 
-- Remove old installed `node_modules` so you only get what corresponds to `package.json`:
+```bash
+pnpm dlx npm-check-updates -u -a && rm -rf node_modules && pnpm install
+```
 
-  ```bash
-  pnpm dlx npm-check-updates -u -a && rm -rf node_modules && pnpm install
-  ```
+Equivalents for other package managers:
 
-Use the equivalent `npx npm-check-updates -u -a && npm install` or `npx npm-check-updates -u -a && yarn install` flow if your app does not use `pnpm`.
+- npm: `npx npm-check-updates -u -a && npm install`
+- yarn: `npx npm-check-updates -u -a && yarn install`
+- bun: `bunx npm-check-updates -u -a && bun install`
 
 **Option 2: Using your package manager's upgrade command**
 
-To update all dependencies:
+To update all dependencies within their existing semver ranges:
+
+```bash
+pnpm up
+```
+
+To ignore ranges and update everything to the absolute latest versions:
 
 ```bash
 pnpm up --latest
 ```
 
-To upgrade a specific package:
+To upgrade a specific package to its latest version:
 
 ```bash
 pnpm up [package] --latest
 ```
 
-Equivalent commands for other package managers are `npm install <package>@latest` and `yarn add <package>@latest`.
-Note that `npm update` is not the same as `pnpm up --latest` because it respects existing semver
-ranges instead of updating package.json to the latest available versions.
+Equivalents for other package managers:
+
+| Action                     | npm                        | yarn (v1)               | bun                    |
+| -------------------------- | -------------------------- | ----------------------- | ---------------------- |
+| Update within ranges       | `npm update`               | `yarn upgrade`          | `bun update`           |
+| Update to latest           | _(use ncu from Option 1)_  | `yarn upgrade --latest` | `bun update --latest`  |
+| Specific package to latest | `npm install <pkg>@latest` | `yarn add <pkg>@latest` | `bun add <pkg>@latest` |
+
+Note that `npm update` does not modify `package.json` by default (only the lockfile). Add `--save`
+if you want it to update version ranges. The other package managers update `package.json` by default.
 
 ### Adding New Dependencies
 
@@ -76,8 +96,11 @@ pnpm add module_name@version
 pnpm add -D module_name@version
 ```
 
-If your app uses `npm` or `yarn`, use the corresponding `npm install` or `yarn add` command in the
-same directory as `package.json`.
+Equivalents for other package managers:
+
+- npm: `npm install module_name@version` / `npm install -D module_name@version`
+- yarn: `yarn add module_name@version` / `yarn add --dev module_name@version`
+- bun: `bun add module_name@version` / `bun add -D module_name@version`
 
 ### Verify After Updates
 


### PR DESCRIPTION
## Summary

Refresh the dependency-updating guide so it matches current React on Rails app layout and package-manager guidance.

Changes in this PR:
- replace the stale `client/` + Yarn-only commands with root-level package-manager guidance
- use `pnpm` as the primary example, matching current project standards
- add npm and yarn equivalents so the page still works for apps using a different package manager

## Why

The published page is still an active contributor-facing guide, but it assumes JavaScript dependencies live under `client/` and that every app uses Yarn. Current React on Rails apps usually keep `package.json` at the app root, and this repo standardizes on `pnpm`.

## Test plan

- `/Users/justin/codex/react_on_rails/node_modules/.bin/prettier --check docs/oss/misc/updating-dependencies.md`
- `git diff --check`
- `lychee --offline --no-progress --format compact docs/oss/misc/updating-dependencies.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; updates command examples and guidance without affecting runtime code or dependencies.
> 
> **Overview**
> Updates `docs/oss/misc/updating-dependencies.md` to modernize Node dependency instructions: switches from Yarn + `client/`-directory examples to root `package.json` guidance with `pnpm` as the primary command set.
> 
> Adds explicit equivalent commands/notes for `npm` and `yarn`, including `npm-check-updates` usage, `pnpm up --latest` semantics vs `npm update`, and updated dev-dependency install examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e264e392a8fd152a36dab99952e7fd8b93f61f6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed "Node/Yarn" section to "Node Dependencies" and clarified running commands from the directory containing package.json (typically project/app root)
  * Made pnpm the primary package manager and replaced Yarn examples with pnpm equivalents for checking, updating, installing, and adding deps (including dev deps)
  * Added explicit npm, Yarn, and bun command equivalents
  * Clarified npm update behavior (updates lockfile by default; use flags to change package.json ranges)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->