### PR TITLE
generators: point Pro install fallback to upgrade guide

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
@@ -67,7 +67,6 @@ module ReactOnRails
                          "This generator requires the react_on_rails_pro gem."
                        end
 
-        # TODO(#2575): Replace temporary email CTA after react-unrails.com flow is live.
         GeneratorMessages.add_error(<<~MSG.strip)
           🚫 Failed to auto-install #{PRO_GEM_NAME} gem.
 
@@ -80,7 +79,7 @@ module ReactOnRails
 
           No license needed for evaluation or non-production use.
           Free or low-cost production licenses available for startups and small companies.
-          Get started: https://pro.reactonrails.com/
+          See the upgrade guide: https://reactonrails.com/docs/pro/upgrading-to-pro/
         MSG
         true
       end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -2500,7 +2500,7 @@ describe InstallGenerator, type: :generator do
       expect(error_text).to include("--pro")
       expect(error_text).to include("react_on_rails_pro")
       expect(error_text).to include("~> #{expected_pro_version}")
-      expect(error_text).to include("https://pro.reactonrails.com/")
+      expect(error_text).to include("https://reactonrails.com/docs/pro/upgrading-to-pro/")
     end
   end
 


### PR DESCRIPTION
Closes #2575

## Summary
- replace the stale fallback CTA in `pro_setup.rb` with the canonical upgrade-guide destination
- update the generator spec to match the new CTA output

## Verification
- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/pro_setup.rb react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb:2494`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes generator error messaging and updates a spec assertion; no behavior changes beyond the displayed URL.
> 
> **Overview**
> Updates the Pro-install fallback error message in `pro_setup.rb` to point users to the canonical Pro upgrade guide URL instead of the old `pro.reactonrails.com` CTA.
> 
> Adjusts `install_generator_spec.rb` to assert the new URL in the `missing_pro_gem?` error output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adea9c4cffdb7d30d1cfe2fc85306f31ddfd63eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the documentation link in the pro installation error message to direct users to the correct upgrading guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->