### PR TITLE
Update spec/dummy Gemfile.lock for async >= 2.29

### DIFF
--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
   specs:
     react_on_rails_pro (16.5.0)
       addressable
-      async (>= 2.6)
+      async (>= 2.29)
       connection_pool
       execjs (~> 2.9)
       http-2 (>= 1.1.1)


### PR DESCRIPTION
## Summary
- Regenerates `react_on_rails_pro/spec/dummy/Gemfile.lock` to reflect the `async >= 2.29` constraint added in #2832 (Async::Variable → Async::Promise migration)
- The gemspec was updated but the dummy app lock file was not regenerated, causing a mismatch

Fixes the Gemfile.lock drift introduced by #2832.

## Test plan
- [ ] CI passes — this is a lock file update only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only `spec/dummy/Gemfile.lock` to align dependency constraints; no runtime code changes.
> 
> **Overview**
> Regenerates `react_on_rails_pro/spec/dummy/Gemfile.lock` so the dummy app’s `react_on_rails_pro` dependency now requires `async (>= 2.29)` (previously `>= 2.6`), eliminating lockfile drift from the gemspec update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 496be260a60c8888476e5e451a9eedf6936d70b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->