### PR TITLE
Revert "Eliminate double JSON.stringify in RSC payload embedding (#2835)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,17 +24,6 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
-#### Performance
-
-- **[Pro]** **Reduce RSC payload overhead by eliminating double JSON.stringify**: RSC Flight data embedded in
-  HTML stream script tags was being JSON.stringified twice — once when wrapping in the result object envelope,
-  and again when embedding in the `<script>` tag's `.push()` call. The second stringify is now eliminated by
-  embedding JSON directly as a JavaScript expression (JSON is a strict subset of JS). This saves ~38KB (~24%
-  of raw Flight data) on a typical product search page with 36 results.
-  [PR 2835](https://github.com/shakacode/react_on_rails/pull/2835) by
-  [justin808](https://github.com/justin808).
-  Fixes [Issue 2522](https://github.com/shakacode/react_on_rails/issues/2522).
-
 ### [16.5.1] - 2026-03-27
 
 #### Fixed

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -14,20 +14,13 @@
 
 import * as React from 'react';
 import { createFromReadableStream } from 'react-on-rails-rsc/client.browser';
-import { RailsContext, RSCPayloadChunk } from 'react-on-rails/types';
-import {
-  createRSCPayloadKey,
-  fetch,
-  wrapInNewPromise,
-  extractErrorMessage,
-  sanitizeNonce,
-  replayConsoleLog,
-} from './utils.ts';
+import { RailsContext } from 'react-on-rails/types';
+import { createRSCPayloadKey, fetch, wrapInNewPromise, extractErrorMessage } from './utils.ts';
 import transformRSCStreamAndReplayConsoleLogs from './transformRSCStreamAndReplayConsoleLogs.ts';
 
 declare global {
   interface Window {
-    REACT_ON_RAILS_RSC_PAYLOADS?: Record<string, RSCPayloadChunk[]>;
+    REACT_ON_RAILS_RSC_PAYLOADS?: Record<string, string[]>;
   }
 }
 
@@ -98,36 +91,20 @@ const fetchRSC = ({
   }
 };
 
-/**
- * Creates a ReadableStream of raw Flight data from preloaded RSC payload objects.
- *
- * The payloads are objects (not strings) because injectRSCPayload embeds JSON
- * directly as JavaScript expressions, avoiding the double JSON.stringify overhead.
- * This function extracts the html field and replays console logs from each chunk.
- */
-const createRSCStreamFromPreloadedPayloads = (payloads: RSCPayloadChunk[], cspNonce?: string) => {
-  const encoder = new TextEncoder();
-  const sanitizedNonceValue = sanitizeNonce(cspNonce);
-  let streamController: ReadableStreamController<Uint8Array> | undefined;
-  let closed = false;
-  const stream = new ReadableStream<Uint8Array>({
+const createRSCStreamFromArray = (payloads: string[]) => {
+  let streamController: ReadableStreamController<string> | undefined;
+  const stream = new ReadableStream<string>({
     start(controller) {
-      // Browser-only by design (callers read from window.REACT_ON_RAILS_RSC_PAYLOADS).
-      // If called outside the browser, close immediately to avoid hanging streams.
       if (typeof window === 'undefined') {
-        closed = true;
-        controller.close();
         return;
       }
-      const handleChunk = (chunk: RSCPayloadChunk) => {
-        if (closed) return;
-        controller.enqueue(encoder.encode(chunk.html ?? ''));
-        replayConsoleLog(chunk.consoleReplayScript, sanitizedNonceValue);
+      const handleChunk = (chunk: string) => {
+        controller.enqueue(chunk);
       };
 
       payloads.forEach(handleChunk);
       // eslint-disable-next-line no-param-reassign
-      payloads.push = (...chunks: RSCPayloadChunk[]) => {
+      payloads.push = (...chunks) => {
         chunks.forEach(handleChunk);
         return chunks.length;
       };
@@ -137,13 +114,9 @@ const createRSCStreamFromPreloadedPayloads = (payloads: RSCPayloadChunk[], cspNo
 
   if (typeof document !== 'undefined' && document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-      closed = true;
       streamController?.close();
     });
   } else {
-    // Once parsing is past "loading", all inline <script> tags that push into this array
-    // have already executed, so the preloaded payload list is complete and can be closed now.
-    closed = true;
     streamController?.close();
   }
 
@@ -151,18 +124,23 @@ const createRSCStreamFromPreloadedPayloads = (payloads: RSCPayloadChunk[], cspNo
 };
 
 /**
- * Creates React elements from preloaded RSC payloads embedded in the page.
+ * Creates React elements from preloaded RSC payloads in the page.
  *
- * The payloads are RSCPayloadChunk objects pushed to the global array by
- * injectRSCPayload's script tags. This processes them directly without
- * JSON.parse overhead (the objects are already parsed by the JS engine).
+ * This function:
+ * 1. Creates a ReadableStream from the array of payload chunks
+ * 2. Transforms the stream to handle console logs and other processing
+ * 3. Uses React's createFromReadableStream to process the payload
  *
- * @param payloads - Array of RSC payload chunk objects from the global array
+ * This is used during hydration to avoid making HTTP requests when
+ * the payload is already embedded in the page.
+ *
+ * @param payloads - Array of RSC payload chunks from the global array
  * @returns A Promise resolving to the rendered React element
  */
-const createFromPreloadedPayloads = (payloads: RSCPayloadChunk[], cspNonce?: string) => {
-  const stream = createRSCStreamFromPreloadedPayloads(payloads, cspNonce);
-  const renderPromise = createFromReadableStream<React.ReactNode>(stream);
+const createFromPreloadedPayloads = (payloads: string[], cspNonce?: string) => {
+  const stream = createRSCStreamFromArray(payloads);
+  const transformedStream = transformRSCStreamAndReplayConsoleLogs(stream, cspNonce);
+  const renderPromise = createFromReadableStream<React.ReactNode>(transformedStream);
   return wrapInNewPromise(renderPromise);
 };
 

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -46,17 +46,8 @@ function createRSCPayloadInitializationScript(cacheKey: string, sanitizedNonce?:
   return createScriptTag(cacheKeyJSArray(cacheKey), sanitizedNonce);
 }
 
-function createRSCPayloadChunk(jsonLine: string, cacheKey: string, sanitizedNonce?: string) {
-  // Embed the JSON line directly as a JavaScript expression instead of re-stringifying it.
-  // Valid JSON is a strict subset of JavaScript expressions, so parseable JSON is safe to embed.
-  // createScriptTag's escapeScript() handles HTML-unsafe sequences (</script>, <!--)
-  // using JS-compatible escape sequences that preserve the parsed value.
-  try {
-    JSON.parse(jsonLine);
-  } catch {
-    throw new Error(`Malformed NDJSON line in RSC stream: ${jsonLine.slice(0, 100)}`);
-  }
-  return createScriptTag(`(${cacheKeyJSArray(cacheKey)}).push(${jsonLine})`, sanitizedNonce);
+function createRSCPayloadChunk(chunk: string, cacheKey: string, sanitizedNonce?: string) {
+  return createScriptTag(`(${cacheKeyJSArray(cacheKey)}).push(${JSON.stringify(chunk)})`, sanitizedNonce);
 }
 
 /**
@@ -97,6 +88,7 @@ export default function injectRSCPayload(
   safePipe(pipeableHtmlStream, htmlStream, (err) => {
     resultStream.emit('error', err);
   });
+  const decoder = new TextDecoder();
   let rscPromise: Promise<void> | null = null;
 
   // ========================================
@@ -259,37 +251,12 @@ export default function injectRSCPayload(
         const initializationScript = createRSCPayloadInitializationScript(rscPayloadKey, sanitizedNonce);
         rscInitializationBuffers.push(Buffer.from(initializationScript));
 
-        // Process RSC payload stream asynchronously.
-        // Chunks may not align with JSON object boundaries, so we buffer
-        // incomplete lines (same approach as transformRSCStream).
+        // Process RSC payload stream asynchronously
         rscPromises.push(
           (async () => {
-            let lastIncompleteLine = '';
-            const decoder = new TextDecoder();
             for await (const chunk of stream ?? []) {
-              const decodedChunk =
-                lastIncompleteLine +
-                (typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true }));
-              const lines = decodedChunk.split('\n');
-              lastIncompleteLine = lines.pop() ?? '';
-
-              // Contract: upstream stream emits NDJSON (one payload object per line).
-              let bufferedPayloadInThisChunk = false;
-              for (const line of lines) {
-                const normalizedLine = line.trim();
-                if (normalizedLine !== '') {
-                  const payloadScript = createRSCPayloadChunk(normalizedLine, rscPayloadKey, sanitizedNonce);
-                  rscPayloadBuffers.push(Buffer.from(payloadScript));
-                  bufferedPayloadInThisChunk = true;
-                }
-              }
-              if (bufferedPayloadInThisChunk) {
-                scheduleFlush();
-              }
-            }
-            const finalChunk = (lastIncompleteLine + decoder.decode()).trim();
-            if (finalChunk !== '') {
-              const payloadScript = createRSCPayloadChunk(finalChunk, rscPayloadKey, sanitizedNonce);
+              const decodedChunk = typeof chunk === 'string' ? chunk : decoder.decode(chunk);
+              const payloadScript = createRSCPayloadChunk(decodedChunk, rscPayloadKey, sanitizedNonce);
               rscPayloadBuffers.push(Buffer.from(payloadScript));
               scheduleFlush();
             }

--- a/packages/react-on-rails-pro/src/transformRSCStreamAndReplayConsoleLogs.ts
+++ b/packages/react-on-rails-pro/src/transformRSCStreamAndReplayConsoleLogs.ts
@@ -13,7 +13,7 @@
  */
 
 import { RSCPayloadChunk } from 'react-on-rails/types';
-import { sanitizeNonce, replayConsoleLog } from './utils.ts';
+import { sanitizeNonce } from './utils.ts';
 
 /**
  * Transforms an RSC stream and replays console logs on the client.
@@ -45,46 +45,48 @@ export default function transformRSCStreamAndReplayConsoleLogs(
       let { value, done } = await reader.read();
 
       const handleJsonChunk = (chunk: RSCPayloadChunk) => {
-        const { html, consoleReplayScript } = chunk;
+        const { html, consoleReplayScript = '' } = chunk;
         controller.enqueue(encoder.encode(html ?? ''));
-        replayConsoleLog(consoleReplayScript, sanitizedNonce);
-      };
 
-      const parseAndHandleLines = (lines: string[]) => {
-        const jsonChunks = lines
-          .filter((line) => line.trim() !== '')
-          .map((line) => {
-            try {
-              return JSON.parse(line) as RSCPayloadChunk;
-            } catch (error) {
-              console.error('Error parsing JSON:', line, error);
-              throw error;
-            }
-          });
-
-        for (const jsonChunk of jsonChunks) {
-          handleJsonChunk(jsonChunk);
+        const replayConsoleCode = consoleReplayScript
+          .trim()
+          .replace(/^<script[^>]*>/i, '')
+          .replace(/<\/script>$/i, '');
+        if (replayConsoleCode?.trim() !== '') {
+          const scriptElement = document.createElement('script');
+          if (sanitizedNonce) {
+            scriptElement.nonce = sanitizedNonce;
+          }
+          scriptElement.textContent = replayConsoleCode;
+          document.body.appendChild(scriptElement);
         }
       };
 
       try {
         while (!done) {
-          const decodedValue = typeof value === 'string' ? value : decoder.decode(value, { stream: true });
+          const decodedValue = typeof value === 'string' ? value : decoder.decode(value);
           const decodedChunks = lastIncompleteChunk + decodedValue;
           const chunks = decodedChunks.split('\n');
           lastIncompleteChunk = chunks.pop() ?? '';
 
-          parseAndHandleLines(chunks);
+          const jsonChunks = chunks
+            .filter((line) => line.trim() !== '')
+            .map((line) => {
+              try {
+                return JSON.parse(line) as RSCPayloadChunk;
+              } catch (error) {
+                console.error('Error parsing JSON:', line, error);
+                throw error;
+              }
+            });
+
+          for (const jsonChunk of jsonChunks) {
+            handleJsonChunk(jsonChunk);
+          }
 
           // eslint-disable-next-line no-await-in-loop
           ({ value, done } = await reader.read());
         }
-
-        const finalDecodedValue = lastIncompleteChunk + decoder.decode();
-        if (finalDecodedValue.trim() !== '') {
-          parseAndHandleLines(finalDecodedValue.split('\n'));
-        }
-
         controller.close();
       } catch (error) {
         console.error('Error transforming RSC stream:', error);

--- a/packages/react-on-rails-pro/src/utils.ts
+++ b/packages/react-on-rails-pro/src/utils.ts
@@ -49,22 +49,3 @@ export const sanitizeNonce = (nonce?: string) => {
   const nonceWithAllowedCharsOnly = nonce?.replace(/[^a-zA-Z0-9+/=_-]/g, '');
   return nonceWithAllowedCharsOnly?.match(/^[a-zA-Z0-9+/_-]+={0,2}$/)?.[0];
 };
-
-export function replayConsoleLog(consoleReplayScript: string | undefined, sanitizedNonce?: string) {
-  if (typeof document === 'undefined') {
-    return;
-  }
-
-  const replayConsoleCode = (consoleReplayScript ?? '')
-    .trim()
-    .replace(/^<script[^>]*>/i, '')
-    .replace(/<\/script>$/i, '');
-  if (replayConsoleCode?.trim() !== '') {
-    const scriptElement = document.createElement('script');
-    if (sanitizedNonce) {
-      scriptElement.nonce = sanitizedNonce;
-    }
-    scriptElement.textContent = replayConsoleCode;
-    document.body.appendChild(scriptElement);
-  }
-}

--- a/packages/react-on-rails-pro/tests/RSCRequestTracker.test.ts
+++ b/packages/react-on-rails-pro/tests/RSCRequestTracker.test.ts
@@ -222,10 +222,10 @@ describe('RSCRequestTracker', () => {
       expect(result).toContain('<html><body>');
       expect(result).toContain('</body></html>');
 
-      // Output must contain the RSC payload initialization and data scripts.
-      // The payload JSON is embedded directly as a JS expression (not re-stringified).
+      // Output must contain the RSC payload initialization and data scripts
       expect(result).toContain('REACT_ON_RAILS_RSC_PAYLOADS');
-      expect(result).toContain(`.push(${payload})`);
+      expect(result).toContain('.push(');
+      expect(result).toContain(JSON.stringify(payload));
     });
 
     it('does not deadlock with large multi-chunk payloads exceeding the default highWaterMark', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -48,7 +48,7 @@ const setupTest = (mockRSC: Readable) => {
 
 describe('injectRSCPayload', () => {
   it('should inject RSC payload as script tags', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n']);
+    const mockRSC = createMockStream(['{"test": "data"}']);
     const mockHTML = createMockStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
@@ -56,12 +56,12 @@ describe('injectRSCPayload', () => {
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data"})</script>`,
+      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data\\"}")</script>`,
     );
   });
 
   it('should handle multiple RSC payloads', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n', '{"test": "data2"}\n']);
+    const mockRSC = createMockStream(['{"test": "data"}', '{"test": "data2"}']);
     const mockHTML = createMockStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
@@ -69,15 +69,15 @@ describe('injectRSCPayload', () => {
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data"})</script>`,
+      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data\\"}")</script>`,
     );
     expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data2"})</script>`,
+      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data2\\"}")</script>`,
     );
   });
 
   it('should add all ready html chunks before adding RSC payloads', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n', '{"test": "data2"}\n']);
+    const mockRSC = createMockStream(['{"test": "data"}', '{"test": "data2"}']);
     const mockHTML = createMockStream([
       '<html><body><div>Hello, world!</div></body></html>',
       '<div>Next chunk</div>',
@@ -91,13 +91,13 @@ describe('injectRSCPayload', () => {
       '<script>(self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]</script>' +
         '<html><body><div>Hello, world!</div></body></html>' +
         '<div>Next chunk</div>' +
-        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data"})</script>' +
-        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data2"})</script>',
+        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data\\"}")</script>' +
+        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data2\\"}")</script>',
     );
   });
 
   it('adds delayed html chunks after RSC payloads', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n', '{"test": "data2"}\n']);
+    const mockRSC = createMockStream(['{"test": "data"}', '{"test": "data2"}']);
     const mockHTML = createMockStream({
       0: '<html><body><div>Hello, world!</div></body></html>',
       100: '<div>Next chunk</div>',
@@ -110,16 +110,16 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toEqual(
       '<script>(self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]</script>' +
         '<html><body><div>Hello, world!</div></body></html>' +
-        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data"})</script>' +
-        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data2"})</script>' +
+        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data\\"}")</script>' +
+        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data2\\"}")</script>' +
         '<div>Next chunk</div>',
     );
   });
 
   it('handles the case when html is delayed', async () => {
     const mockRSC = createMockStream({
-      0: '{"test": "data"}\n',
-      150: '{"test": "data2"}\n',
+      0: '{"test": "data"}',
+      150: '{"test": "data2"}',
     });
     const mockHTML = createMockStream({
       100: ['<html><body><div>Hello, world!</div></body></html>', '<div>Next chunk</div>'],
@@ -134,15 +134,15 @@ describe('injectRSCPayload', () => {
       '<script>(self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]</script>' +
         '<html><body><div>Hello, world!</div></body></html>' +
         '<div>Next chunk</div>' +
-        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data"})</script>' +
-        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data2"})</script>' +
+        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data\\"}")</script>' +
+        '<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"test\\": \\"data2\\"}")</script>' +
         '<div>Third chunk</div>',
     );
   });
 
   it('should include RSC payload that arrives after HTML stream finishes', async () => {
     const mockRSC = createMockStream({
-      300: '{"late": "rsc_data"}\n',
+      300: '{"late": "rsc_data"}',
     });
     const mockHTML = createMockStream({
       0: '<html><body>Hello</body></html>',
@@ -154,14 +154,14 @@ describe('injectRSCPayload', () => {
 
     expect(resultStr).toContain('<html><body>Hello</body></html>');
     expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"late": "rsc_data"})</script>`,
+      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"late\\": \\"rsc_data\\"}")</script>`,
     );
   });
 
   it('should include all RSC payloads arriving at different times after HTML stream finishes', async () => {
     const mockRSC = createMockStream({
-      200: '{"first": "chunk"}\n',
-      400: '{"second": "chunk"}\n',
+      200: '{"first": "chunk"}',
+      400: '{"second": "chunk"}',
     });
     const mockHTML = createMockStream({
       0: '<div>content</div>',
@@ -173,86 +173,15 @@ describe('injectRSCPayload', () => {
 
     expect(resultStr).toContain('<div>content</div>');
     expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"first": "chunk"})</script>`,
+      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"first\\": \\"chunk\\"}")</script>`,
     );
     expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"second": "chunk"})</script>`,
+      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push("{\\"second\\": \\"chunk\\"}")</script>`,
     );
-  });
-
-  it('handles chunks that split across JSON object boundaries', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n{"test": "dat', 'a2"}\n']);
-    const mockHTML = createMockStream(['<html><body>Hello</body></html>']);
-    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
-    const resultStr = await collectStreamData(result);
-
-    expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data"})</script>`,
-    );
-    expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test": "data2"})</script>`,
-    );
-  });
-
-  it('handles chunks that split a multibyte UTF-8 character', async () => {
-    const mockRSC = createMockStream([
-      Buffer.from('{"test":"'),
-      Buffer.from([0xf0, 0x9f]),
-      Buffer.from([0x98, 0x80]),
-      Buffer.from('"}\n'),
-    ]);
-    const mockHTML = createMockStream(['<html><body>Hello</body></html>']);
-    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
-    const resultStr = await collectStreamData(result);
-
-    expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test":"😀"})</script>`,
-    );
-  });
-
-  it('normalizes CRLF on the final buffered payload chunk', async () => {
-    const mockRSC = createMockStream(['{"test":"data"}\r\n', '{"final":"chunk"}\r']);
-    const mockHTML = createMockStream(['<html><body>Hello</body></html>']);
-    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
-    const resultStr = await collectStreamData(result);
-
-    expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test":"data"})</script>`,
-    );
-    expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"final":"chunk"})</script>`,
-    );
-    expect(resultStr).not.toContain('\r');
-  });
-
-  it('emits an error instead of embedding malformed NDJSON as invalid JavaScript', async () => {
-    const mockRSC = createMockStream(['{"test":"data"}\n', '{"broken": }\n']);
-    const mockHTML = createMockStream(['<html><body>Hello</body></html>']);
-    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-
-    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
-    const errorPromise = new Promise<Error>((resolve) => {
-      result.once('error', (error) => resolve(error as Error));
-    });
-    const resultStr = await collectStreamData(result);
-    const error = await errorPromise;
-
-    expect(resultStr).toContain('<html><body>Hello</body></html>');
-    expect(resultStr).toContain(
-      `<script>((self.REACT_ON_RAILS_RSC_PAYLOADS||={})["test-{}-test-node"]||=[]).push({"test":"data"})</script>`,
-    );
-    expect(resultStr).not.toContain('{"broken": }');
-    expect(error.message).toContain('Malformed NDJSON line in RSC stream');
   });
 
   it('adds sanitized nonce attribute to injected RSC script tags', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n']);
+    const mockRSC = createMockStream(['{"test": "data"}']);
     const mockHTML = createMockStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 
@@ -264,7 +193,7 @@ describe('injectRSCPayload', () => {
   });
 
   it('adds valid nonce attribute to injected RSC script tags', async () => {
-    const mockRSC = createMockStream(['{"test": "data"}\n']);
+    const mockRSC = createMockStream(['{"test": "data"}']);
     const mockHTML = createMockStream(['<html><body><div>Hello, world!</div></body></html>']);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
 

--- a/packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx
@@ -152,21 +152,20 @@ enableFetchMocks();
   });
 
   describe('preloaded RSC payloads', () => {
-    let chunk1Obj;
-    let chunk2Obj;
+    let chunk1;
+    let chunk2;
     let railsContext;
 
     beforeEach(() => {
-      // Setup test fixtures — preloaded payloads are objects (not strings)
-      // because injectRSCPayload embeds JSON directly as JS expressions
+      // Setup test fixtures
       const chunksDirectory = path.join(
         __dirname,
         'fixtures',
         'rsc-payloads',
         'simple-shell-with-async-component',
       );
-      chunk1Obj = JSON.parse(fs.readFileSync(path.join(chunksDirectory, 'chunk1.json'), 'utf8'));
-      chunk2Obj = JSON.parse(fs.readFileSync(path.join(chunksDirectory, 'chunk2.json'), 'utf8'));
+      chunk1 = JSON.stringify(JSON.parse(fs.readFileSync(path.join(chunksDirectory, 'chunk1.json'), 'utf8')));
+      chunk2 = JSON.stringify(JSON.parse(fs.readFileSync(path.join(chunksDirectory, 'chunk2.json'), 'utf8')));
 
       registerServerComponent('TestComponent');
       railsContext = {
@@ -183,9 +182,9 @@ enableFetchMocks();
     });
 
     it('uses preloaded RSC payloads without making a fetch request', async () => {
-      // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS with objects
+      // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS
       window.REACT_ON_RAILS_RSC_PAYLOADS = {
-        'TestComponent-{}-test-container': [chunk1Obj, chunk2Obj],
+        'TestComponent-{}-test-container': [`${chunk1}\n`, `${chunk2}\n`],
       };
 
       await act(async () => {
@@ -209,7 +208,7 @@ enableFetchMocks();
 
       // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS with only the first chunk initially
       window.REACT_ON_RAILS_RSC_PAYLOADS = {
-        'TestComponent-{}-test-container': [chunk1Obj],
+        'TestComponent-{}-test-container': [`${chunk1}\n`],
       };
 
       await act(async () => {
@@ -225,9 +224,9 @@ enableFetchMocks();
       expect(screen.getByText('Loading AsyncComponent...')).toBeInTheDocument();
       expect(screen.queryByText('AsyncComponent')).not.toBeInTheDocument();
 
-      // Now push the second chunk object to the preloaded array and set document to complete
+      // Now push the second chunk to the preloaded array and set document to complete
       await act(async () => {
-        window.REACT_ON_RAILS_RSC_PAYLOADS['TestComponent-{}-test-container'].push(chunk2Obj);
+        window.REACT_ON_RAILS_RSC_PAYLOADS['TestComponent-{}-test-container'].push(`${chunk2}\n`);
 
         // Set document.readyState to 'complete' and dispatch readystatechange event
         Object.defineProperty(document, 'readyState', { value: 'complete', writable: true });


### PR DESCRIPTION
## Summary
- Reverts merge commit `d1d8e6f9` from PR #2835.
- Restores `main` to the state before "Eliminate double JSON.stringify in RSC payload embedding".

## Why
- PR #2835 was merged accidentally and needs to be backed out.
- A fresh follow-up PR can be opened afterward with any remaining fixes.

## Test Plan
- Not run (pure git revert of previously reviewed code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pro RSC streaming/hydration by changing how payload chunks are embedded, decoded, and replayed, which could reintroduce payload overhead and affect progressive hydration/stream correctness. Mostly a revert, but it alters client/server stream contracts and related tests.
> 
> **Overview**
> Reverts the prior Pro RSC optimization that embedded parsed JSON payload objects directly into the HTML stream.
> 
> RSC payload injection now pushes **stringified chunks** into `window.REACT_ON_RAILS_RSC_PAYLOADS` again (with the client updated to expect `string[]`), and `injectRSCPayload` drops the NDJSON line-buffering/validation logic in favor of embedding each incoming stream chunk as-is.
> 
> Console replay handling is moved out of `utils.ts` (removing `replayConsoleLog`) and is performed inside `transformRSCStreamAndReplayConsoleLogs`, with tests and the changelog updated to reflect the revert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 123d474d0e1416e8bf874131fac9d6335263b775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Simplified RSC payload serialization and stream processing logic
  * Consolidated console output handling for improved code maintainability
  * Reduced complexity in stream decoding and payload injection mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->