### PR TITLE
Exclude .lychee.toml from triggering code test workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -54,11 +54,13 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
 # Cancel stale PR benchmark runs when new commits are pushed.
 # Main runs are never cancelled so every merge is measured.
 concurrency:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
   workflow_dispatch:
     inputs:
       force_run:

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'packages/**'
       - 'react_on_rails_pro/**'
   workflow_dispatch:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails_pro/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails_pro/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails/lib/**'
       - 'react_on_rails/spec/react_on_rails/**'
       - 'react_on_rails_pro/**'

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails_pro/**'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails/lib/**'
       - 'react_on_rails/spec/**'
       - 'packages/react_on_rails/**'

--- a/.github/workflows/pro-lint.yml
+++ b/.github/workflows/pro-lint.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails/lib/**'
       - 'react_on_rails/spec/**'
       - 'packages/react_on_rails/**'

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+      - '.lychee.toml'
       - 'react_on_rails/lib/**'
       - 'react_on_rails/spec/**'
       - 'packages/react_on_rails/**'

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -72,7 +72,7 @@ UNCATEGORIZED_CHANGED=false
 while IFS= read -r file; do
   case "$file" in
     # Documentation files
-    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|docs/**/*)
+    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|docs/**/*|.lychee.toml)
       # Don't change DOCS_ONLY flag, just continue
       ;;
 


### PR DESCRIPTION
## Summary

Fixes the issue where PR #2876 (docs-only changes including `.lychee.toml`) triggered all code test workflows.

**Root cause**: `.lychee.toml` is a docs-infrastructure config file (for the markdown link checker) but it wasn't excluded from code test workflows in two places:

1. **Workflow `paths-ignore`**: `.lychee.toml` doesn't match `**.md` or `docs/**`, so all code workflows triggered
2. **`ci-changes-detector` script**: `.lychee.toml` hit the catch-all `*` pattern, which set `UNCATEGORIZED_CHANGED=true` and ran the **entire** test suite

**Fix**:
- Added `.lychee.toml` to `paths-ignore` in all 10 code test workflow files so they don't trigger at all
- Added `.lychee.toml` to the documentation pattern in `ci-changes-detector` so it's classified as docs-only (defense in depth)

The `check-markdown-links.yml` workflow already correctly includes `.lychee.toml` in its `paths:` trigger — that's the only workflow that should care about it.

## Test plan
- [ ] Verify this PR itself only triggers `detect-changes`, `markdown-link-check`, and `claude-review` — not code tests
- [ ] Confirm `check-markdown-links.yml` still triggers when `.lychee.toml` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to CI trigger/changed-file classification logic, with no runtime/app behavior changes; primary risk is inadvertently skipping intended CI runs when `.lychee.toml` changes.
> 
> **Overview**
> Prevents docs-infra changes to `.lychee.toml` from triggering the main code test suite.
> 
> Adds `.lychee.toml` to `paths-ignore` across code-related GitHub Actions workflows (including benchmarks) and updates `script/ci-changes-detector` to classify `.lychee.toml` as documentation-only so it no longer falls into the catch-all “run everything” path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 869d5d46310d64bde585b26ea4649bbccfec4036. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflows to treat `.lychee.toml` as a documentation-only file, preventing unnecessary test suite triggers when only this configuration file is modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->