### PR TITLE
Fix sidebar navigation issues from #2886 review

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -66,7 +66,7 @@ const sidebars: SidebarsConfig = {
         'core-concepts/webpack-configuration',
         'core-concepts/execjs-limitations',
         'core-concepts/performance-benchmarks',
-        { type: 'ref', id: 'pro/react-on-rails-pro' },
+        { type: 'ref', id: 'pro/react-on-rails-pro', label: 'React on Rails Pro (Overview)' },
       ],
     },
     {
@@ -181,11 +181,7 @@ const sidebars: SidebarsConfig = {
       label: 'Upgrading',
       items: [
         'upgrading/upgrading-react-on-rails',
-        {
-          type: 'link',
-          label: 'Full Changelog',
-          href: 'https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md',
-        },
+        { type: 'doc', id: 'upgrading/changelog', label: 'Full Changelog' },
         {
           type: 'category',
           label: 'Release Notes',
@@ -210,8 +206,10 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Migrating',
+      link: { type: 'generated-index', title: 'Migrating' },
       items: [
         'migrating/migrating-from-react-rails',
+        { type: 'ref', id: 'migrating/migrating-to-rsc' },
         'migrating/migrating-from-vite-rails',
         'migrating/migrating-from-webpack-to-rspack',
         'migrating/babel-to-swc-migration',


### PR DESCRIPTION
## Summary

Addresses 4 remaining review items from https://github.com/shakacode/react_on_rails/pull/2886:

- **Migrating section discoverability**: Added `type: 'ref'` link to `migrating-to-rsc` in the top-level Migrating category so users browsing "Migrating" can find the RSC migration series (previously only nested under React Server Components)
- **Migrating generated-index**: Added `link: { type: 'generated-index' }` to the Migrating category for consistency with Getting Started, Core Concepts, and Building Features
- **Changelog as in-repo doc**: Replaced the external GitHub link to `CHANGELOG.md` with the in-repo `upgrading/changelog` doc reference, giving readers Docusaurus rendering and search
- **Pro ref label**: Added explicit label `"React on Rails Pro (Overview)"` to the `type: 'ref'` entry in Core Concepts so it's clear this links to a Pro feature

Fixes #2886

## Test plan

- [ ] Run `npm run prepare && npm run build:full` on site repo to verify sidebar generates correctly
- [ ] Verify Migrating section shows the RSC migration entry point
- [ ] Verify changelog renders in Docusaurus instead of linking externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only adjusts Docusaurus sidebar configuration (navigation labels/links) with no runtime or data/security impact; main risk is broken doc IDs causing missing sidebar entries.
> 
> **Overview**
> Improves Docusaurus sidebar navigation by clarifying the `React on Rails Pro` reference label in **Core Concepts**, adding a generated index and top-level entry for `migrating/migrating-to-rsc` under **Migrating**, and switching **Upgrading → Full Changelog** from an external GitHub URL to the in-repo `upgrading/changelog` doc so it renders and is searchable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d8b7ffce3830afc1511da4db43f14c41938f87b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation navigation structure for better organization
  * Full Changelog now accessible directly from documentation instead of external link
  * Added new guide for migrating to RSC
  * Improved Pro overview documentation labeling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->