### PR TITLE
Docs: link published Rails 7 react-rails migration example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ React on Rails is one product with two tiers: open source for Rails + React inte
 - [Compare with alternatives (narrative overview)](./oss/getting-started/comparing-react-on-rails-to-alternatives.md)
 - [Detailed feature matrix and benchmarks](./oss/getting-started/comparison-with-alternatives.md)
 - [Migrate from react-rails](./oss/migrating/migrating-from-react-rails.md)
+- [Published migration example repo (Rails 7)](https://github.com/shakacode/react-on-rails-migration-example)
 
 ## Dive deeper when you need it
 

--- a/docs/oss/migrating/migrating-from-react-rails.md
+++ b/docs/oss/migrating/migrating-from-react-rails.md
@@ -46,6 +46,8 @@ bundle _2.3.26_ install
 
 You can also check [react-rails-to-react-on-rails](https://github.com/shakacode/react-rails-example-app/tree/react-rails-to-react-on-rails) branch on [react-rails example app](https://github.com/shakacode/react-rails-example-app) for an example of migration from `react-rails` v3 to `react_on_rails` v13.4.
 
+For a more recent Rails 7-era migration example (published under ShakaCode), see [react-on-rails-migration-example](https://github.com/shakacode/react-on-rails-migration-example), based on [ganchdev/react-rails-example](https://github.com/ganchdev/react-rails-example).
+
 ## Practical checklist for Webpacker-era apps
 
 If your app looks like this:


### PR DESCRIPTION
## Summary
- add a direct link to the published Rails 7 migration example repo in docs/README.md
- add the same reference to docs/oss/migrating/migrating-from-react-rails.md

## Context
The new example repo is:
- https://github.com/shakacode/react-on-rails-migration-example

This gives users a current, public migration artifact in addition to the older branch-based example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds external reference links with no runtime or API impact.
> 
> **Overview**
> Adds a new documentation link to the published Rails 7 migration example repo (`react-on-rails-migration-example`) in the main docs index under evaluation resources.
> 
> Updates the `Migrate From react-rails` guide to also point readers to this newer, public migration example (in addition to the older branch-based example).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe09f6280e12ecd7501746350b3027426f57566a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added external references to Rails 7 migration example repositories to provide additional resources and guidance for users migrating React Rails projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->