### PR TITLE
Fix h2c probe compatibility guidance for Node Renderer

### DIFF
--- a/docs/oss/building-features/node-renderer/container-deployment.md
+++ b/docs/oss/building-features/node-renderer/container-deployment.md
@@ -493,7 +493,7 @@ spec:
             - containerPort: 3800
           env:
             - name: RENDERER_HOST
-              value: '0.0.0.0' # Required for Kubernetes HTTP probes
+              value: '0.0.0.0' # Bind to all interfaces for pod-network access
             - name: NODE_OPTIONS
               value: '--max-old-space-size=512'
             - name: RENDERER_WORKERS_COUNT

--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -165,14 +165,13 @@ export default function run(config: Partial<Config>) {
   // The renderer uses cleartext HTTP/2 (h2c). Node's `allowHTTP1` option only
   // applies to TLS servers (http2.createSecureServer), so it cannot enable
   // HTTP/1.1 Kubernetes httpGet probes on this listener.
-  const fastifyOptions: Record<string, unknown> = {
-    http2: useHttp2,
+  const app = fastify({
+    http2: useHttp2 as true,
     bodyLimit: 104857600, // 100 MB
     logger:
       logHttpLevel !== 'silent' ? { name: 'RORP HTTP', level: logHttpLevel, ...sharedLoggerOptions } : false,
     ...fastifyServerOptions,
-  };
-  const app = fastify(fastifyOptions as Parameters<typeof fastify>[0]);
+  });
 
   handleGracefulShutdown(app);
 


### PR DESCRIPTION
## Summary

- Clarifies that the Node Renderer runs as cleartext HTTP/2 (h2c); Node's `allowHTTP1` does not enable HTTP/1.1 fallback on this listener.
- Updates Kubernetes probe guidance to h2c-compatible options:
  - `startupProbe` and `livenessProbe`: `tcpSocket`
  - `readinessProbe`: prefer `exec` with `curl --http2-prior-knowledge http://localhost:3800/info` (with `tcpSocket` as a minimal fallback)
- Adds explicit startup-ordering guidance to wait for TCP accept or query `/info` with an h2c-aware client.
- Keeps the Rails gem SSR path unchanged (still HTTP/2).

**Context:** We validated that Kubernetes `httpGet` probes (HTTP/1.1) are incompatible with the renderer's h2c listener. The docs now reflect that behavior and provide probe configurations that work in practice.

Related to https://github.com/shakacode/react_on_rails/pull/2876

## Test plan

- [x] `pnpm exec eslint packages/react-on-rails-pro-node-renderer/src/worker.ts`
- [x] `pnpm exec prettier --check packages/react-on-rails-pro-node-renderer/src/worker.ts docs/oss/building-features/node-renderer/container-deployment.md`
- [x] `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/worker.test.ts --runInBand`
- [x] Re-run docs formatting after follow-up review fixes: `pnpm exec prettier --check docs/oss/building-features/node-renderer/container-deployment.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a clarifying comment; no runtime behavior or protocol handling is modified.
> 
> **Overview**
> Clarifies that the Node Renderer serves **cleartext HTTP/2 (h2c)**, so Kubernetes `httpGet` probes (HTTP/1.1) won’t work and Node’s `allowHTTP1` can’t provide HTTP/1.1 fallback on this listener.
> 
> Updates container deployment examples to use h2c-compatible checks: installs `curl` in the Dockerfile, changes Docker Compose healthchecks to `curl -sf --http2-prior-knowledge`, and revises Kubernetes `startupProbe`/`livenessProbe` to `tcpSocket` with `readinessProbe` preferring `exec` + h2c-aware `curl` (with notes/fallback guidance).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31bc052a6d953b6acfd6030cd89450bc5d473c8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated container deployment and troubleshooting guidance for Node Renderer: revised healthcheck and probe recommendations for cleartext HTTP/2 endpoints, added TCP and exec-based probe examples, noted requirement for an HTTP/2-capable client with TCP fallback, and clarified init/wait guidance.

* **Chores**
  * Clarified server behavior around cleartext HTTP/2 to prevent probe compatibility issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->