### PR TITLE
Fix Pro generator multiline and template-literal rewrites

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/pro_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_generator.rb
@@ -473,7 +473,7 @@ module ReactOnRails
                   pending_multiline_static_import_specifier
                 ) { |line_fragment| yield line_fragment }
               in_multiline_template_literal = updated_template_literal_state
-              in_block_comment = true if unclosed_block_comment_starts?(rewritten_line)
+              in_block_comment = unclosed_block_comment_starts?(rewritten_line)
               rewritten_line
             elsif line_contains_unescaped_backtick
               rewritten_line, pending_multiline_module_call_depth, pending_multiline_static_import_specifier =
@@ -484,7 +484,7 @@ module ReactOnRails
                   in_block_comment: in_block_comment
                 ) { |line_fragment| yield line_fragment }
               in_multiline_template_literal = updated_template_literal_state
-              in_block_comment = true if unclosed_block_comment_starts?(rewritten_line)
+              in_block_comment = unclosed_block_comment_starts?(rewritten_line)
               rewritten_line
             else
               in_multiline_template_literal = updated_template_literal_state
@@ -760,7 +760,7 @@ module ReactOnRails
       end
 
       def first_unescaped_backtick_index(line)
-        unescaped_backtick_indexes(line).first
+        unescaped_backtick_indexes(line, skip_comments: true).first
       end
 
       def opening_backtick_index_for_multiline_start(line, in_block_comment: false)
@@ -771,7 +771,7 @@ module ReactOnRails
       end
 
       # rubocop:disable Metrics/CyclomaticComplexity
-      def unescaped_backtick_indexes(line, in_block_comment: false)
+      def unescaped_backtick_indexes(line, in_block_comment: false, skip_comments: false)
         quote_state = nil
         backtick_indexes = []
 
@@ -793,12 +793,14 @@ module ReactOnRails
             next
           end
 
-          break if line[scan_index, 2] == "//"
+          unless skip_comments
+            break if line[scan_index, 2] == "//"
 
-          if line[scan_index, 2] == "/*"
-            in_block_comment = true
-            scan_index += 2
-            next
+            if line[scan_index, 2] == "/*"
+              in_block_comment = true
+              scan_index += 2
+              next
+            end
           end
 
           backtick_indexes << scan_index if char == "`" && !character_escaped?(line, scan_index)

--- a/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
@@ -1038,6 +1038,31 @@ describe ProGenerator, type: :generator do
       expect(rewritten).to include('odd backtick ` still comment */ import("react-on-rails-pro"); `multiline-start')
     end
 
+    it "rewrites imports after a block-comment-to-template-literal transition closes" do
+      source = <<~JS
+        /*
+         odd backtick ` still comment */ import("react-on-rails"); `multiline-start
+        content
+        `; import("react-on-rails");
+      JS
+
+      rewritten = generator.send(:rewrite_react_on_rails_module_specifiers, source)
+
+      expect(rewritten).to include('import("react-on-rails-pro"); `multiline-start')
+      expect(rewritten).to include('`; import("react-on-rails-pro");')
+    end
+
+    it "finds the closing backtick when template literal content contains /* on the same line" do
+      source = <<~JS
+        const x = `multiline-start
+        content /* with embedded `; import("react-on-rails");
+      JS
+
+      rewritten = generator.send(:rewrite_react_on_rails_module_specifiers, source)
+
+      expect(rewritten).to include('`; import("react-on-rails-pro");')
+    end
+
     it "rewrites all matching specifiers on a pending continuation line" do
       source = <<~JS
         import {


### PR DESCRIPTION
### Summary

Improve the Pro install generator rewrite logic so multiline non-parenthesized `gem "react_on_rails"` declarations keep trailing options while replacing the base gem entry. Harden module-specifier rewriting around template literals by preserving escaped sequences and correctly detecting multiline template-literal starts after a closed inline template.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Validated with `bundle exec rspec react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb:219 react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb:1007 react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb:1019`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Pro install generator’s Gemfile and JS source rewriting logic; subtle parsing/state bugs could cause incorrect dependency swaps or missed/over-eager import rewrites in real-world edge cases.
> 
> **Overview**
> Improves the Pro generator’s Gemfile swap to correctly consume *non-parenthesized multiline* `gem "react_on_rails"` declarations and carry forward trailing options/guards while stripping only version constraints, avoiding orphaned lines and stray/trailing commas.
> 
> Hardens JS module-specifier rewriting around template literals by restoring inline template placeholders without altering escaped sequences, and by more accurately detecting multiline template-literal boundaries across inline literals and block-comment transitions (so imports between these regions are rewritten correctly). Adds focused specs for these multiline Gemfile and template-literal edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a6e361f2001539a0239a259282b835d5e755636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve non-version gem options during upgrade without leaving trailing commas, extra whitespace, or blank-line artifacts.
  * More robust template-literal handling across inline and multiline cases, including escaped sequences, correct backtick detection, and block-comment boundary transitions.

* **Tests**
  * Added unit tests for non-parenthesized multiline gem declarations.
  * Added tests for template-literal edge cases: placeholder restoration, imports between literals, and comment-boundary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->