### PR TITLE
Fix brittle positional assertions in create-app tests

### DIFF
--- a/packages/create-react-on-rails-app/tests/create-app.test.ts
+++ b/packages/create-react-on-rails-app/tests/create-app.test.ts
@@ -274,10 +274,21 @@ describe('createApp', () => {
   }
 
   // Returns only the "step" commands (rails, bundle, pnpm, etc.) — excludes
-  // educational git operations (add, commit) so the count is resilient to
+  // educational git operations (add, commit) so assertions are resilient to
   // changes in the educational-commit interleaving.
   function stepCalls(): Array<[string, ...unknown[]]> {
     return mockedExecLiveArgs.mock.calls.filter(([cmd]) => cmd !== 'git');
+  }
+
+  function stepCallSummaries(): string[] {
+    return stepCalls().map(([cmd, args]) => {
+      const subArgs = args as string[];
+      if (cmd === 'rails') return `rails ${subArgs[0]}`;
+      if (cmd === 'bundle' && subArgs[0] === 'add') return `bundle add ${subArgs[1]}`;
+      if (cmd === 'bundle' && subArgs.includes('generate')) return 'bundle generate';
+      if (cmd === 'pnpm') return `pnpm ${subArgs[0]}`;
+      return `${cmd} ${subArgs[0]}`;
+    });
   }
 
   function expectFallbackGitIdentityOnCommits(): void {
@@ -354,7 +365,12 @@ describe('createApp', () => {
       appPath,
       expect.objectContaining({ REACT_ON_RAILS_PACKAGE_MANAGER: 'npm' }),
     );
-    expect(stepCalls()).toHaveLength(4);
+    expect(stepCallSummaries()).toEqual([
+      'rails new',
+      'bundle add react_on_rails',
+      'bundle add react_on_rails_pro',
+      'bundle generate',
+    ]);
     expect(mockedLogStepDone).toHaveBeenCalledWith('react_on_rails gem added');
     expect(mockedLogStepDone).toHaveBeenCalledWith('react_on_rails_pro gem added');
     expect(mockedLogInfo).toHaveBeenCalledWith('Then visit http://localhost:3000');
@@ -400,7 +416,12 @@ describe('createApp', () => {
       appPath,
       expect.objectContaining({ REACT_ON_RAILS_PACKAGE_MANAGER: 'npm' }),
     );
-    expect(stepCalls()).toHaveLength(4);
+    expect(stepCallSummaries()).toEqual([
+      'rails new',
+      'bundle add react_on_rails',
+      'bundle add react_on_rails_pro',
+      'bundle generate',
+    ]);
     expect(mockedLogStepDone).toHaveBeenCalledWith('react_on_rails gem added');
     expect(mockedLogStepDone).toHaveBeenCalledWith('react_on_rails_pro gem added');
     expect(mockedLogInfo).toHaveBeenCalledWith('Then visit http://localhost:3000');
@@ -565,7 +586,7 @@ describe('createApp', () => {
       appPath,
       expect.objectContaining({ REACT_ON_RAILS_PACKAGE_MANAGER: 'npm' }),
     );
-    expect(stepCalls()).toHaveLength(3);
+    expect(stepCallSummaries()).toEqual(['rails new', 'bundle add react_on_rails', 'bundle generate']);
     expect(mockedExecLiveArgs).not.toHaveBeenCalledWith(
       'bundle',
       ['add', 'react_on_rails_pro'],
@@ -615,6 +636,13 @@ describe('createApp', () => {
       expect.stringContaining('system!("pnpm install")'),
       'utf8',
     );
+    expect(stepCallSummaries()).toEqual([
+      'rails new',
+      'bundle add react_on_rails',
+      'bundle generate',
+      'pnpm import',
+      'pnpm install',
+    ]);
     expect(gitCommitSubjects()).toEqual([
       'Create Rails app with PostgreSQL',
       'Add react_on_rails gem',


### PR DESCRIPTION
## Summary
- Replace `toHaveBeenNthCalledWith` ordinals with `toHaveBeenCalledWith` (semantic argument matching)
- Replace `mockImplementationOnce` chains with command-matching `mockImplementation`
- Replace `toHaveBeenCalledTimes` with `stepCallSummaries()` — a filtered sequence assertion on non-git commands that verifies ordering, count, and argument correctness in one check
- Add `stepCallSummaries()` helper (mirrors the existing `gitCommitSubjects()` pattern for commit ordering)

## Context

PR #2849 added educational git commits to the `create-react-on-rails-app` scaffold flow, interleaving `git add` + `git commit` calls between each real step. The existing tests were updated to use new ordinal positions (1→4→7→10) and counts (9, 12), but a reviewer flagged this as brittle and it was deferred as item 1 of #2888.

The brittleness was verified: adding a single `execLiveArgs` call to `create-app.ts` broke 13 of 78 tests — 7 from shifted ordinals, 5 from `mockImplementationOnce` chain off-by-one, and 1 from a count mismatch.

## Approach

The test file already had `gitCommitSubjects().toEqual([...])` which verifies commit ordering through `mock.calls` filtering — the [standard Jest community pattern](https://github.com/jestjs/jest/issues/4402) for asserting call order on a subset of calls. This PR extends that pattern to step commands via `stepCallSummaries()`, which filters out educational git operations and asserts on the exact sequence of real steps:

```typescript
expect(stepCallSummaries()).toEqual([
  'rails new',
  'bundle add react_on_rails',
  'bundle add react_on_rails_pro',
  'bundle generate',
]);
```

This provides ordering verification (via `toEqual` on an ordered array), count verification (exact array length), and resilience to educational-commit interleaving — without the positional coupling of the original ordinal assertions.

Partially addresses #2888.

## Test plan
- [x] All 78 existing tests pass
- [x] Adding an extra `git` command to `create-app.ts` → 0 test failures (correctly tolerant of git interleaving)
- [x] Adding an extra non-git command to `create-app.ts` → `stepCallSummaries()` catches the sequence mismatch
- [x] Inserting a command at the wrong position → `stepCallSummaries()` catches the ordering violation
- [x] Pre-commit hooks pass (prettier, eslint, trailing-newlines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and maintainability for the app-creation flow by adding helpers to summarize and verify ordered setup steps, shifting assertions from strict call-count/order to presence and expected step sequences, and consolidating failure-path mocks for clearer, more robust error simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->