### PR TITLE
Consolidate docs comparison pages into single evaluation entry

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,7 @@ React on Rails is one product with two tiers: open source for Rails + React inte
 ### Evaluating Rails + React options
 
 - [Examples and migration references](https://reactonrails.com/examples)
-- [Compare with alternatives (narrative overview)](./oss/getting-started/comparing-react-on-rails-to-alternatives.md)
-- [Detailed feature matrix and benchmarks](./oss/getting-started/comparison-with-alternatives.md)
+- [Compare with alternatives](./oss/getting-started/comparing-react-on-rails-to-alternatives.md) — decision guide covering Hotwire, Inertia, Next.js, and more
 - [Migrate from react-rails](./oss/migrating/migrating-from-react-rails.md)
 - [Published migration example repo (Rails 7)](https://github.com/shakacode/react-on-rails-migration-example)
 

--- a/docs/oss/introduction.md
+++ b/docs/oss/introduction.md
@@ -45,7 +45,7 @@ Unlike a separate SPA approach, React on Rails lets you leverage Rails conventio
 - ❌ You mainly want Rails-rendered HTML plus minimal JavaScript enhancements
 - ❌ You want a page-oriented SPA shell instead of embedding React into Rails views
 
-If you're evaluating the tradeoffs, start with **[Comparing React on Rails to alternatives](./getting-started/comparing-react-on-rails-to-alternatives.md)** for a narrative overview, or jump to the **[feature comparison table](./getting-started/comparison-with-alternatives.md)** for a side-by-side matrix with benchmarks.
+If you're evaluating the tradeoffs, see **[Comparing React on Rails to alternatives](./getting-started/comparing-react-on-rails-to-alternatives.md)** for a decision guide covering Hotwire, Inertia, Next.js, and more.
 
 ## Getting Started
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -23,15 +23,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/using-react-on-rails',
         'getting-started/oss-vs-pro',
         'getting-started/pro-quick-start',
-        {
-          type: 'category',
-          label: 'Compare Alternatives',
-          items: [
-            'getting-started/comparison-with-alternatives',
-            'getting-started/comparing-react-on-rails-to-alternatives',
-          ],
-        },
-        'getting-started/nextjs-with-separate-rails-backend',
+        'getting-started/comparing-react-on-rails-to-alternatives',
         'getting-started/common-issues',
       ],
     },


### PR DESCRIPTION
## Summary

- Promotes the **Decision Guide** (`comparing-react-on-rails-to-alternatives`) as the single canonical comparison entry in the sidebar
- Removes the **Feature Matrix & Benchmarks** page and **Next.js + Separate Rails Backend** page from the sidebar (both stay published as supporting material, still linked from within other docs)
- Updates `docs/README.md` and `docs/oss/introduction.md` to point to one comparison page instead of two
- `quick-start.md` already pointed only to the Decision Guide — no change needed

Fixes #2927

## Test plan

- [ ] Verify the sidebar shows a single "Comparing React on Rails to Alternatives" link under Getting Started (no "Compare Alternatives" subcategory)
- [ ] Verify `comparison-with-alternatives` and `nextjs-with-separate-rails-backend` are still accessible via direct URL
- [ ] Verify cross-links from the Decision Guide to the Feature Matrix still work
- [ ] Verify `docs/README.md` evaluation section has one comparison link
- [ ] Verify `docs/oss/introduction.md` evaluation paragraph has one comparison link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts navigation and cross-links; main risk is broken or less discoverable links in the docs sidebar/README.
> 
> **Overview**
> **Docs navigation is simplified to a single canonical comparison entry.** The “compare alternatives” section in `docs/README.md` and the evaluation guidance in `docs/oss/introduction.md` now point only to `getting-started/comparing-react-on-rails-to-alternatives`.
> 
> **Sidebar structure is streamlined.** `docs/sidebars.ts` removes the “Compare Alternatives” subcategory and drops sidebar links to `getting-started/comparison-with-alternatives` and `getting-started/nextjs-with-separate-rails-backend`, leaving only the decision guide under Getting Started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb98b17672b108cc7d3328c801d6568d5bbf71f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Reorganized comparison documentation**: Consolidated React on Rails alternatives comparison into a single decision guide covering Hotwire, Inertia, Next.js, and more.
* **Improved navigation structure**: Streamlined sidebar organization by moving comparison content to the Getting Started section for better discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->