### PR TITLE
Bump Rspack dependencies to v2 (^2.0.0-0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **Doctor accepts TypeScript server bundle entrypoints**: `react_on_rails:doctor` now resolves common source entrypoint suffixes (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning that the server bundle is missing, preventing false positives when apps use `server-bundle.ts`. [PR 3111](https://github.com/shakacode/react_on_rails/pull/3111) by [justin808](https://github.com/justin808).
 - **Doctor no longer fails custom projects for a missing generated `bin/dev`**: `react_on_rails:doctor` now downgrades a missing official React on Rails `bin/dev` launcher from an error to a warning and adds explicit guidance when a custom `./dev` script is detected, so custom projects can pass diagnostics when their development setup is intentional. Fixes [Issue 3103](https://github.com/shakacode/react_on_rails/issues/3103). [PR 3117](https://github.com/shakacode/react_on_rails/pull/3117) by [justin808](https://github.com/justin808).
 
+#### Changed
+
+- **Rspack install scaffolding now targets Rspack v2**: `react_on_rails:install --rspack` and `bin/switch-bundler` now generate the Rspack v2 package line (`@rspack/core@^2.0.0-0`, `@rspack/cli@^2.0.0-0`, `@rspack/plugin-react-refresh@^2.0.0`) while keeping `rspack-manifest-plugin@^5.0.0`, which is already compatible. The `-0` prerelease suffix on `@rspack/core` and `@rspack/cli` keeps RC builds installable until stable 2.0.0 lands. Closes [Issue 3082](https://github.com/shakacode/react_on_rails/issues/3082). [PR 3084](https://github.com/shakacode/react_on_rails/pull/3084) by [justin808](https://github.com/justin808).
+
 ### [16.6.0] - 2026-04-09
 
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
-- **Rspack install scaffolding now targets Rspack v2**: `react_on_rails:install --rspack` and `bin/switch-bundler` now generate the Rspack v2 package line (`@rspack/core@^2.0.0-0`, `@rspack/cli@^2.0.0-0`, `@rspack/plugin-react-refresh@^2.0.0`) while keeping `rspack-manifest-plugin@^5.0.0`, which is already compatible. The `-0` prerelease suffix on `@rspack/core` and `@rspack/cli` keeps RC builds installable until stable 2.0.0 lands. Closes [Issue 3082](https://github.com/shakacode/react_on_rails/issues/3082). [PR 3084](https://github.com/shakacode/react_on_rails/pull/3084) by [justin808](https://github.com/justin808).
+- **Rspack install scaffolding now targets Rspack v2**: `react_on_rails:install --rspack` and `bin/switch-bundler` now generate the Rspack v2 package line (`@rspack/core@^2.0.0-0`, `@rspack/cli@^2.0.0-0`, `@rspack/plugin-react-refresh@^2.0.0`) while keeping `rspack-manifest-plugin@^5.0.0`, which is already compatible. Closes [Issue 3082](https://github.com/shakacode/react_on_rails/issues/3082). [PR 3084](https://github.com/shakacode/react_on_rails/pull/3084) by [justin808](https://github.com/justin808).
 
 ### [16.6.0] - 2026-04-09
 

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -91,16 +91,19 @@ module ReactOnRails
       ].freeze
 
       # Rspack core dependencies (only installed when --rspack flag is used)
+      # @rspack/core uses ^2.0.0-0 (with -0 prerelease suffix) to include RC/beta prereleases
+      # of 2.0.0 until the stable 2.0.0 release lands.
       RSPACK_DEPENDENCIES = %w[
-        @rspack/core@^1.0.0
+        @rspack/core@^2.0.0-0
         rspack-manifest-plugin@^5.0.0
       ].freeze
 
       # Rspack development dependencies for hot reloading
       # react-refresh is pre-1.0, so left bare (see pinning note above).
+      # @rspack/cli uses ^2.0.0-0 to match @rspack/core's prerelease range.
       RSPACK_DEV_DEPENDENCIES = %w[
-        @rspack/cli@^1.0.0
-        @rspack/plugin-react-refresh@^1.0.0
+        @rspack/cli@^2.0.0-0
+        @rspack/plugin-react-refresh@^2.0.0
         react-refresh
       ].freeze
 

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/switch-bundler
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/switch-bundler
@@ -15,8 +15,8 @@ class BundlerSwitcher
   }.freeze
 
   RSPACK_DEPS = {
-    dependencies: %w[@rspack/core@^1.0.0 rspack-manifest-plugin@^5.0.0],
-    dev_dependencies: %w[@rspack/cli@^1.0.0 @rspack/plugin-react-refresh@^1.0.0]
+    dependencies: %w[@rspack/core@^2.0.0-0 rspack-manifest-plugin@^5.0.0],
+    dev_dependencies: %w[@rspack/cli@^2.0.0-0 @rspack/plugin-react-refresh@^2.0.0]
   }.freeze
 
   def initialize(target_bundler)

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -667,7 +667,7 @@ describe InstallGenerator, type: :generator do
     it "switch-bundler has version-pinned deps and strips versions before deletion" do
       assert_file "bin/switch-bundler" do |content|
         # Version pins are present in the constants
-        expect(content).to include("@rspack/core@^1.0.0")
+        expect(content).to include("@rspack/core@^2.0.0-0")
         expect(content).to include("webpack@^5.0.0")
         # Version-stripping regex is used for package.json key deletion
         expect(content).to include('dep[%r{\A(@[^/]+/[^@]+|[^@]+)}]')

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -668,6 +668,8 @@ describe InstallGenerator, type: :generator do
       assert_file "bin/switch-bundler" do |content|
         # Version pins are present in the constants
         expect(content).to include("@rspack/core@^2.0.0-0")
+        expect(content).to include("@rspack/cli@^2.0.0-0")
+        expect(content).to include("@rspack/plugin-react-refresh@^2.0.0")
         expect(content).to include("webpack@^5.0.0")
         # Version-stripping regex is used for package.json key deletion
         expect(content).to include('dep[%r{\A(@[^/]+/[^@]+|[^@]+)}]')

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -140,14 +140,14 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
     it "defines RSPACK_DEPENDENCIES" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSPACK_DEPENDENCIES).to eq(%w[
-                                                                                         @rspack/core@^1.0.0
+                                                                                         @rspack/core@^2.0.0-0
                                                                                          rspack-manifest-plugin@^5.0.0
                                                                                        ])
     end
 
     it "defines RSPACK_DEV_DEPENDENCIES" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSPACK_DEV_DEPENDENCIES).to(
-        eq(%w[@rspack/cli@^1.0.0 @rspack/plugin-react-refresh@^1.0.0 react-refresh])
+        eq(%w[@rspack/cli@^2.0.0-0 @rspack/plugin-react-refresh@^2.0.0 react-refresh])
       )
     end
 


### PR DESCRIPTION
## Summary

- Updates generator and `bin/switch-bundler` Rspack dependencies from v1 to v2
- `@rspack/core@^2.0.0-0` and `@rspack/cli@^2.0.0-0` — the `-0` prerelease suffix ensures RC builds (currently `2.0.0-rc.1`) are included until stable 2.0.0 lands
- `@rspack/plugin-react-refresh@^2.0.0` — already stable at 2.0.0
- `rspack-manifest-plugin@^5.0.0` — unchanged, already compatible with Rspack v2

Closes #3082

## Test plan

- [x] `js_dependency_manager_spec.rb` passes
- [x] RuboCop passes on all changed files
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Upgraded Rspack bundler support from version 1 to version 2. Updated dependency configurations in the installation generator and bundler switching utility to use Rspack v2 packages, enabling support for prerelease and release candidate builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->