### PR TITLE
Fix generator CI SSR regression on main

### DIFF
--- a/packages/react-on-rails/src/scriptSanitizedVal.ts
+++ b/packages/react-on-rails/src/scriptSanitizedVal.ts
@@ -1,5 +1,7 @@
-export default (val: string): string => {
+const scriptSanitizedVal = (val: string): string => {
   // Replace closing
   const re = /<\/\W*script/gi;
   return val.replace(re, '(/script');
 };
+
+export default scriptSanitizedVal;

--- a/react_on_rails/rakelib/shakapacker_examples.rake
+++ b/react_on_rails/rakelib/shakapacker_examples.rake
@@ -162,6 +162,8 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
       # Use --legacy-peer-deps to avoid peer dependency conflicts when
       # react-on-rails expects newer React versions.
       sh_in_dir(example_type.dir, "npm install --legacy-peer-deps --install-links")
+      # Explicit re-install is required because npm install --install-links does not
+      # reliably copy a file: dependency that was just pinned in the same session.
       install_local_react_on_rails_package(example_type.dir, legacy_peer_deps: true)
       # Regenerate Shakapacker binstubs after downgrading from 9.x to 8.2.x
       # The binstub format may differ between major versions.
@@ -170,6 +172,8 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
       # Use --install-links to copy file: dependencies instead of symlinking,
       # preventing duplicate React instances from webpack resolving through symlinks.
       sh_in_dir(example_type.dir, "npm install --install-links")
+      # Explicit re-install is required because npm install --install-links does not
+      # reliably copy a file: dependency that was just pinned in the same session.
       install_local_react_on_rails_package(example_type.dir)
     end
   end

--- a/react_on_rails/rakelib/shakapacker_examples.rake
+++ b/react_on_rails/rakelib/shakapacker_examples.rake
@@ -64,6 +64,38 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
     fallback_match&.[](1)
   end
 
+  def local_react_on_rails_package_ref(dir)
+    package_dir = File.expand_path("../packages/react-on-rails", gem_root)
+    relative_package_dir = Pathname(package_dir).relative_path_from(Pathname(dir)).to_s
+    "file:#{relative_package_dir}"
+  end
+
+  # Makes generated examples use the local monorepo package for react-on-rails.
+  # This ensures CI validates the package code in this branch rather than a
+  # potentially stale published npm version.
+  def pin_react_on_rails_to_local_package(dir)
+    package_json_path = File.join(dir, "package.json")
+    return unless File.exist?(package_json_path)
+
+    begin
+      package_json = JSON.parse(File.read(package_json_path))
+    rescue JSON::ParserError => e
+      puts "  ERROR: Failed to parse #{package_json_path}: #{e.message}"
+      raise
+    end
+
+    deps = package_json["dependencies"]
+    return unless deps&.key?("react-on-rails")
+
+    local_package_ref = local_react_on_rails_package_ref(dir)
+
+    return if deps["react-on-rails"] == local_package_ref
+
+    puts "  Pinning react-on-rails npm dependency from #{deps['react-on-rails']} to #{local_package_ref}"
+    deps["react-on-rails"] = local_package_ref
+    File.write(package_json_path, "#{JSON.pretty_generate(package_json)}\n")
+  end
+
   # Updates React-related dependencies to a specific version
   def update_react_dependencies(deps, react_version)
     return unless deps
@@ -115,6 +147,33 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
     puts "    React: #{react_version}"
   end
 
+  def install_local_react_on_rails_package(dir, legacy_peer_deps: false)
+    legacy_peer_deps_flag = legacy_peer_deps ? "--legacy-peer-deps " : ""
+    sh_in_dir(dir,
+              "npm install react-on-rails@#{local_react_on_rails_package_ref(dir)} " \
+              "#{legacy_peer_deps_flag}--install-links")
+  end
+
+  def install_example_node_dependencies(example_type)
+    pin_shakapacker_npm_version(example_type.dir)
+    pin_react_on_rails_to_local_package(example_type.dir)
+
+    if example_type.pinned_react_version?
+      # Use --legacy-peer-deps to avoid peer dependency conflicts when
+      # react-on-rails expects newer React versions.
+      sh_in_dir(example_type.dir, "npm install --legacy-peer-deps --install-links")
+      install_local_react_on_rails_package(example_type.dir, legacy_peer_deps: true)
+      # Regenerate Shakapacker binstubs after downgrading from 9.x to 8.2.x
+      # The binstub format may differ between major versions.
+      unbundled_sh_in_dir(example_type.dir, "bundle exec rake shakapacker:binstubs")
+    else
+      # Use --install-links to copy file: dependencies instead of symlinking,
+      # preventing duplicate React instances from webpack resolving through symlinks.
+      sh_in_dir(example_type.dir, "npm install --install-links")
+      install_local_react_on_rails_package(example_type.dir)
+    end
+  end
+
   # Define tasks for each example type
   ExampleType.all[:shakapacker_examples].each do |example_type| # rubocop:disable Metrics/BlockLength
     relative_gem_root = Pathname(gem_root).relative_path_from(Pathname(example_type.dir))
@@ -158,29 +217,9 @@ namespace :shakapacker_examples do # rubocop:disable Metrics/BlockLength
         apply_react_version(example_type.dir, example_type.react_version_string)
         # Re-run bundle install to ensure dependencies are resolved correctly
         bundle_install_in(example_type.dir)
-        # Pin the npm shakapacker version to exactly match the installed gem version.
-        # shakapacker:install may add "^X.Y.Z" to package.json, which allows npm to
-        # resolve a newer minor version (e.g., 9.6.0 when gem is 9.5.0), causing
-        # Shakapacker's gem/npm version consistency check to fail.
-        pin_shakapacker_npm_version(example_type.dir)
-        # Use --legacy-peer-deps to avoid peer dependency conflicts when
-        # react-on-rails expects newer React versions
-        # Use --install-links to copy file: dependencies instead of symlinking,
-        # preventing duplicate React instances from webpack resolving through symlinks
-        sh_in_dir(example_type.dir, "npm install --legacy-peer-deps --install-links")
-        # Regenerate Shakapacker binstubs after downgrading from 9.x to 8.2.x
-        # The binstub format may differ between major versions
-        unbundled_sh_in_dir(example_type.dir, "bundle exec rake shakapacker:binstubs")
-      else
-        # Pin the npm shakapacker version to exactly match the installed gem version.
-        # shakapacker:install may add "^X.Y.Z" to package.json, which allows npm to
-        # resolve a newer minor version (e.g., 9.6.0 when gem is 9.5.0), causing
-        # Shakapacker's gem/npm version consistency check to fail.
-        pin_shakapacker_npm_version(example_type.dir)
-        # Use --install-links to copy file: dependencies instead of symlinking,
-        # preventing duplicate React instances from webpack resolving through symlinks
-        sh_in_dir(example_type.dir, "npm install --install-links")
       end
+      # Pin npm package versions and install node dependencies for generated example.
+      install_example_node_dependencies(example_type)
       # Generate the component packs after running the generator to ensure all
       # auto-bundled components have corresponding pack files created.
       # Use unbundled_sh_in_dir to ensure we're using the generated app's Gemfile


### PR DESCRIPTION
### Summary

Fixes the generator CI break on main by avoiding webpack's `__WEBPACK_DEFAULT_EXPORT__` runtime issue and ensuring example-app CI uses the local monorepo `react-on-rails` package instead of stale published tarballs. Updated `scriptSanitizedVal` export shape and refactored `shakapacker_examples` dependency install flow to pin/install `react-on-rails` from `file:` refs for both latest and pinned matrices.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Validated locally with `run_rspec:shakapacker_examples_latest` and `run_rspec:shakapacker_examples_pinned`, plus `rubocop`, `eslint`, and package build checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generator/CI dependency installation logic and npm package pinning, which can break example app builds/SSR if the `file:` install behavior differs across npm versions. No production runtime or security-sensitive code paths are changed beyond a small export refactor.
> 
> **Overview**
> Fixes an SSR/webpack regression by refactoring `scriptSanitizedVal` to a named const default export (avoiding runtime issues with default export handling).
> 
> Updates `shakapacker_examples` rake tasks to **pin `react-on-rails` to the local monorepo** via a `file:` dependency and centralizes node dependency installation, including explicit re-install of the local package and consistent `--install-links`/`--legacy-peer-deps` handling for pinned React matrices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e32dc6bf9095a16dda171525ec9091379a981ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for better maintainability.

* **Chores**
  * Enhanced dependency management and installation process for local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->