### PR TITLE
Doctor: accept TS/TSX server bundle suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Fixed
+
+- **Doctor accepts TypeScript server bundle entrypoints**: `react_on_rails:doctor` now resolves common source entrypoint suffixes (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning that the server bundle is missing, preventing false positives when apps use `server-bundle.ts`. [PR 3111](https://github.com/shakacode/react_on_rails/pull/3111) by [justin808](https://github.com/justin808).
+
 ### [16.6.0] - 2026-04-09
 
 #### Removed

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -55,6 +55,7 @@ module ReactOnRails
     MINITEST_HELPER_FILE = "test/test_helper.rb"
     DEFAULT_BUILD_TEST_COMMAND = 'config.build_test_command = "RAILS_ENV=test bin/shakapacker"'
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
+    SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
 
     def initialize(verbose: false, fix: false)
       @verbose = verbose
@@ -1535,11 +1536,12 @@ module ReactOnRails
         source_entry_path = source_entry_path.sub("#{source_path}/", "")
       end
 
-      File.join(source_path, source_entry_path, bundle_filename)
+      bundle_path = File.join(source_path, source_entry_path, bundle_filename)
+      resolve_server_bundle_source_path(bundle_path)
     rescue LoadError, StandardError
       # Handle missing Shakapacker gem or other configuration errors
       bundle_filename = server_bundle_filename
-      "app/javascript/packs/#{bundle_filename}"
+      resolve_server_bundle_source_path("app/javascript/packs/#{bundle_filename}")
     end
 
     def server_bundle_filename
@@ -1560,6 +1562,27 @@ module ReactOnRails
 
       # Default filename
       "server-bundle.js"
+    end
+
+    def resolve_server_bundle_source_path(bundle_path)
+      return bundle_path if File.exist?(bundle_path)
+
+      base_path = bundle_path.sub(%r{\.[^./]+\z}, "")
+
+      candidate_extensions = server_bundle_source_extensions_for(bundle_path)
+      candidate_extensions.each do |extension|
+        candidate_path = "#{base_path}#{extension}"
+        return candidate_path if File.exist?(candidate_path)
+      end
+
+      bundle_path
+    end
+
+    def server_bundle_source_extensions_for(bundle_path)
+      extension = File.extname(bundle_path)
+      return SERVER_BUNDLE_SOURCE_EXTENSIONS if extension.empty?
+
+      ([extension] + SERVER_BUNDLE_SOURCE_EXTENSIONS).uniq
     end
 
     def exit_with_status
@@ -1612,6 +1635,7 @@ module ReactOnRails
         if (prerender_set || uses_prerender) && !server_bundle_set
           checker.add_warning("  ⚠️  Server rendering is enabled but server_bundle_js_file is not configured")
           checker.add_info("  💡 Set config.server_bundle_js_file = 'server-bundle.js' to enable SSR")
+          checker.add_info("  💡 Source entrypoint can use .js/.jsx/.ts/.tsx suffixes")
           checker.add_info("  💡 See: https://reactonrails.com/docs/core-concepts/react-server-rendering/")
         elsif server_bundle_set && !prerender_set && !uses_prerender
           checker.add_info("  ℹ️  server_bundle_js_file is configured but prerender doesn't appear to be used")

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1582,7 +1582,7 @@ module ReactOnRails
       extension = File.extname(bundle_path)
       return SERVER_BUNDLE_SOURCE_EXTENSIONS if extension.empty?
 
-      ([extension] + SERVER_BUNDLE_SOURCE_EXTENSIONS).uniq
+      SERVER_BUNDLE_SOURCE_EXTENSIONS.reject { |candidate_extension| candidate_extension == extension }
     end
 
     def exit_with_status
@@ -1635,7 +1635,6 @@ module ReactOnRails
         if (prerender_set || uses_prerender) && !server_bundle_set
           checker.add_warning("  ⚠️  Server rendering is enabled but server_bundle_js_file is not configured")
           checker.add_info("  💡 Set config.server_bundle_js_file = 'server-bundle.js' to enable SSR")
-          checker.add_info("  💡 Source entrypoint can use .js/.jsx/.ts/.tsx suffixes")
           checker.add_info("  💡 See: https://reactonrails.com/docs/core-concepts/react-server-rendering/")
         elsif server_bundle_set && !prerender_set && !uses_prerender
           checker.add_info("  ℹ️  server_bundle_js_file is configured but prerender doesn't appear to be used")

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -294,6 +294,10 @@ RSpec.describe ReactOnRails::Doctor do
           stub_const("Shakapacker", shakapacker_module)
           allow(doctor).to receive(:require).with("shakapacker").and_return(true)
           allow(doctor).to receive(:server_bundle_filename).and_return("server-bundle.js")
+          allow(File).to receive(:exist?).and_call_original
+          %w[.js .jsx .ts .tsx .mjs .cjs].each do |extension|
+            allow(File).to receive(:exist?).with("client/app/packs/server-bundle#{extension}").and_return(false)
+          end
         end
 
         it "uses Shakapacker API configuration with relative paths" do
@@ -302,8 +306,6 @@ RSpec.describe ReactOnRails::Doctor do
         end
 
         it "accepts a TypeScript server bundle source file when the configured filename is .js" do
-          allow(File).to receive(:exist?).and_call_original
-          allow(File).to receive(:exist?).with("client/app/packs/server-bundle.js").and_return(false)
           allow(File).to receive(:exist?).with("client/app/packs/server-bundle.ts").and_return(true)
 
           path = doctor.send(:determine_server_bundle_path)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -327,6 +327,10 @@ RSpec.describe ReactOnRails::Doctor do
           allow(doctor).to receive(:require).with("shakapacker").and_return(true)
           allow(doctor).to receive(:server_bundle_filename).and_return("server-bundle.js")
           allow(Dir).to receive(:pwd).and_return(rails_root)
+          allow(File).to receive(:exist?).and_call_original
+          %w[.js .jsx .ts .tsx .mjs .cjs].each do |ext|
+            allow(File).to receive(:exist?).with("client/app/packs/server-bundle#{ext}").and_return(false)
+          end
         end
 
         it "converts absolute paths to relative paths" do
@@ -348,6 +352,10 @@ RSpec.describe ReactOnRails::Doctor do
           allow(doctor).to receive(:require).with("shakapacker").and_return(true)
           allow(doctor).to receive(:server_bundle_filename).and_return("server-bundle.js")
           allow(Dir).to receive(:pwd).and_return(rails_root)
+          allow(File).to receive(:exist?).and_call_original
+          %w[.js .jsx .ts .tsx .mjs .cjs].each do |ext|
+            allow(File).to receive(:exist?).with("client/app/packs/server-bundle#{ext}").and_return(false)
+          end
         end
 
         it "handles nested absolute paths correctly" do
@@ -360,11 +368,23 @@ RSpec.describe ReactOnRails::Doctor do
         before do
           allow(doctor).to receive(:require).with("shakapacker").and_raise(LoadError)
           allow(doctor).to receive(:server_bundle_filename).and_return("server-bundle.js")
+          allow(File).to receive(:exist?).and_call_original
+          %w[.js .jsx .ts .tsx .mjs .cjs].each do |ext|
+            allow(File).to receive(:exist?).with("app/javascript/packs/server-bundle#{ext}").and_return(false)
+          end
         end
 
         it "uses default path" do
           path = doctor.send(:determine_server_bundle_path)
           expect(path).to eq("app/javascript/packs/server-bundle.js")
+        end
+
+        it "accepts a TypeScript server bundle source file" do
+          allow(File).to receive(:exist?).with("app/javascript/packs/server-bundle.ts").and_return(true)
+
+          path = doctor.send(:determine_server_bundle_path)
+
+          expect(path).to eq("app/javascript/packs/server-bundle.ts")
         end
       end
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -300,6 +300,16 @@ RSpec.describe ReactOnRails::Doctor do
           path = doctor.send(:determine_server_bundle_path)
           expect(path).to eq("client/app/packs/server-bundle.js")
         end
+
+        it "accepts a TypeScript server bundle source file when the configured filename is .js" do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with("client/app/packs/server-bundle.js").and_return(false)
+          allow(File).to receive(:exist?).with("client/app/packs/server-bundle.ts").and_return(true)
+
+          path = doctor.send(:determine_server_bundle_path)
+
+          expect(path).to eq("client/app/packs/server-bundle.ts")
+        end
       end
 
       context "when Shakapacker gem is available with absolute paths" do


### PR DESCRIPTION
### Summary

`react_on_rails:doctor` could report a false warning when `server_bundle_js_file` was `server-bundle.js` but the Shakapacker source entrypoint file was `server-bundle.ts`.
This PR makes doctor resolve common source suffixes (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning, and updates doctor messaging to clarify TS/TSX source entrypoints are valid.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

Issue searches in `shakacode/react_on_rails` did not find an existing issue for this exact suffix false-positive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust `react_on_rails:doctor` path detection to reduce false warnings; no runtime rendering or security-sensitive logic is modified.
> 
> **Overview**
> **Doctor now accepts non-`.js` server bundle source entrypoints.** When `react_on_rails:doctor` determines the server bundle path, it now tries common source extensions (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning that the configured bundle is missing, avoiding false positives for apps using `server-bundle.ts`.
> 
> Adds focused specs for the new extension-resolution behavior and documents the fix in the `CHANGELOG`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75708573641e0e549e70b39c0beb0d1d5c794139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `react_on_rails:doctor` now correctly resolves server bundle files with alternate extensions (.js, .jsx, .ts, .tsx, .mjs, .cjs), preventing false warnings for missing bundles when using TypeScript configurations.

* **Tests**
  * Added comprehensive test coverage for server bundle path resolution across multiple configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->