### PR TITLE
docs: standardize warning syntax to GFM alert format

### DIFF
--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -517,7 +517,8 @@ If you prefer to manually share output paths instead of using automatic detectio
    bundle exec rspec # Terminal 2
    ```
 
-> **Warning:** Do not share output paths with `bin/dev` (HMR mode) — HMR manifests will cause test failures.
+> [!WARNING]
+> Do not share output paths with `bin/dev` (HMR mode) — HMR manifests will cause test failures.
 
 ### Caching Strategies
 

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -277,7 +277,8 @@ spec:
 - **Secrets**: Use Kubernetes Secrets with `secretKeyRef` (as shown above) rather than hardcoding values directly in the `env` section. Never commit secret values to your manifest files.
 - **Migrations**: Run migrations as a Kubernetes Job or init container before the Deployment rolls out:
 
-  > **Warning:** With `replicas > 1`, each pod's init container runs concurrently. Prefer a Kubernetes Job for migrations unless every migration is idempotent.
+  > [!WARNING]
+  > With `replicas > 1`, each pod's init container runs concurrently. Prefer a Kubernetes Job for migrations unless every migration is idempotent.
 
   ```yaml
   initContainers:

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -404,7 +404,8 @@ For elements that intentionally differ between server and client:
 
 This suppresses the warning for **this element only** (not its descendants) and does not fix the mismatch -- use it only for non-critical content. If child elements also differ, each needs its own `suppressHydrationWarning`.
 
-> **Warning:** The `if (!mounted) return null` pattern causes **Cumulative Layout Shift (CLS)** -- the element occupies no space on first paint, then pops in after hydration. Only use it for small, positionally stable UI elements (icon buttons, toggles). For anything that affects page layout, read the preference from a server-readable cookie to render the correct value on first paint (see the [Theme Provider](rsc-context-and-state.md#theme-provider-no-flash-of-wrong-theme) section), or use `suppressHydrationWarning` on non-layout-critical elements.
+> [!WARNING]
+> The `if (!mounted) return null` pattern causes **Cumulative Layout Shift (CLS)** -- the element occupies no space on first paint, then pops in after hydration. Only use it for small, positionally stable UI elements (icon buttons, toggles). For anything that affects page layout, read the preference from a server-readable cookie to render the correct value on first paint (see the [Theme Provider](rsc-context-and-state.md#theme-provider-no-flash-of-wrong-theme) section), or use `suppressHydrationWarning` on non-layout-critical elements.
 
 ## Error Boundary Limitations
 


### PR DESCRIPTION
## Summary

- Converts 3 remaining `> **Warning:**` instances to `> [!WARNING]` GFM alert syntax for consistency with the 30+ GFM alerts already used across docs

### Files updated
- `docs/oss/building-features/testing-configuration.md`
- `docs/oss/deployment/docker-deployment.md`
- `docs/oss/migrating/rsc-troubleshooting.md`

Closes #3114

## Test plan

- [ ] Verify rendered warnings display correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only formatting changes with no code or behavior impact.
> 
> **Overview**
> Updates docs to replace remaining `> **Warning:**` blockquotes with GitHub alert callouts (`> [!WARNING]`) for consistent rendering across the guides, including testing configuration, Kubernetes migration guidance, and RSC troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c2ae5275f9e8a98519033cf87c665df64e1ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated warning callout formatting across testing configuration, Docker deployment, and Kubernetes migration guidance documentation to use admonition-style warnings for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->