### PR TITLE
fix: Doctor no longer fails custom projects for missing bin/dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **Doctor accepts TypeScript server bundle entrypoints**: `react_on_rails:doctor` now resolves common source entrypoint suffixes (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning that the server bundle is missing, preventing false positives when apps use `server-bundle.ts`. [PR 3111](https://github.com/shakacode/react_on_rails/pull/3111) by [justin808](https://github.com/justin808).
-- **Doctor no longer fails custom projects for a missing generated `bin/dev`**: `react_on_rails:doctor` now downgrades a missing official React on Rails `bin/dev` launcher from an error to a warning and adds explicit guidance when a custom `./dev` or `Procfile` workflow is detected, so custom projects can pass diagnostics when their development setup is intentional. Fixes [Issue 3103](https://github.com/shakacode/react_on_rails/issues/3103). PR attribution pending.
+- **Doctor no longer fails custom projects for a missing generated `bin/dev`**: `react_on_rails:doctor` now downgrades a missing official React on Rails `bin/dev` launcher from an error to a warning and adds explicit guidance when a custom `./dev` or `Procfile.dev` workflow is detected, so custom projects can pass diagnostics when their development setup is intentional. Fixes [Issue 3103](https://github.com/shakacode/react_on_rails/issues/3103). [PR #3117](https://github.com/shakacode/react_on_rails/pull/3117) by [justin808](https://github.com/justin808).
 
 ### [16.6.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **Doctor accepts TypeScript server bundle entrypoints**: `react_on_rails:doctor` now resolves common source entrypoint suffixes (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning that the server bundle is missing, preventing false positives when apps use `server-bundle.ts`. [PR 3111](https://github.com/shakacode/react_on_rails/pull/3111) by [justin808](https://github.com/justin808).
-- **Doctor no longer fails custom projects for a missing generated `bin/dev`**: `react_on_rails:doctor` now downgrades a missing official React on Rails `bin/dev` launcher from an error to a warning and adds explicit guidance when a custom `./dev` or `Procfile.dev` workflow is detected, so custom projects can pass diagnostics when their development setup is intentional. Fixes [Issue 3103](https://github.com/shakacode/react_on_rails/issues/3103). [PR #3117](https://github.com/shakacode/react_on_rails/pull/3117) by [justin808](https://github.com/justin808).
+- **Doctor no longer fails custom projects for a missing generated `bin/dev`**: `react_on_rails:doctor` now downgrades a missing official React on Rails `bin/dev` launcher from an error to a warning and adds explicit guidance when a custom `./dev` script is detected, so custom projects can pass diagnostics when their development setup is intentional. Fixes [Issue 3103](https://github.com/shakacode/react_on_rails/issues/3103). [PR 3117](https://github.com/shakacode/react_on_rails/pull/3117) by [justin808](https://github.com/justin808).
 
 ### [16.6.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **Doctor accepts TypeScript server bundle entrypoints**: `react_on_rails:doctor` now resolves common source entrypoint suffixes (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`) before warning that the server bundle is missing, preventing false positives when apps use `server-bundle.ts`. [PR 3111](https://github.com/shakacode/react_on_rails/pull/3111) by [justin808](https://github.com/justin808).
+- **Doctor no longer fails custom projects for a missing generated `bin/dev`**: `react_on_rails:doctor` now downgrades a missing official React on Rails `bin/dev` launcher from an error to a warning and adds explicit guidance when a custom `./dev` or `Procfile` workflow is detected, so custom projects can pass diagnostics when their development setup is intentional. Fixes [Issue 3103](https://github.com/shakacode/react_on_rails/issues/3103). PR attribution pending.
 
 ### [16.6.0] - 2026-04-09
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -56,7 +56,7 @@ module ReactOnRails
     DEFAULT_BUILD_TEST_COMMAND = 'config.build_test_command = "RAILS_ENV=test bin/shakapacker"'
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
-    CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev Procfile.dev].freeze
+    CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev].freeze
 
     def initialize(verbose: false, fix: false)
       @verbose = verbose

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -56,6 +56,7 @@ module ReactOnRails
     DEFAULT_BUILD_TEST_COMMAND = 'config.build_test_command = "RAILS_ENV=test bin/shakapacker"'
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
+    CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev Procfile].freeze
 
     def initialize(verbose: false, fix: false)
       @verbose = verbose
@@ -1428,7 +1429,9 @@ module ReactOnRails
       bin_dev_path = "bin/dev"
 
       unless File.exist?(bin_dev_path)
-        checker.add_error("  🚫 bin/dev script not found")
+        checker.add_warning("  ⚠️  Official React on Rails bin/dev launcher not found")
+        report_custom_launcher_guidance
+        checker.add_info("    💡 Generate the official launcher with: rails generate react_on_rails:install")
         return
       end
 
@@ -1466,6 +1469,24 @@ module ReactOnRails
         checker.add_success("  ✅ All Launcher Procfiles available")
       else
         checker.add_info("  💡 Run: rails generate react_on_rails:install")
+      end
+    end
+
+    def report_custom_launcher_guidance
+      custom_launcher_paths = detected_custom_launcher_paths
+      return if custom_launcher_paths.empty?
+
+      checker.add_info(
+        "    ℹ️  Custom launcher detected (#{custom_launcher_paths.join(', ')}). " \
+        "This is OK if your project intentionally manages its own dev workflow."
+      )
+    end
+
+    def detected_custom_launcher_paths
+      CUSTOM_LAUNCHER_INDICATOR_FILES.filter_map do |path|
+        next unless File.exist?(path)
+
+        path == "dev" ? "./dev" : path
       end
     end
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -56,7 +56,7 @@ module ReactOnRails
     DEFAULT_BUILD_TEST_COMMAND = 'config.build_test_command = "RAILS_ENV=test bin/shakapacker"'
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
-    CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev Procfile].freeze
+    CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev Procfile.dev].freeze
 
     def initialize(verbose: false, fix: false)
       @verbose = verbose
@@ -182,7 +182,7 @@ module ReactOnRails
 
     def check_bin_dev_launcher
       checker.add_info("🚀 bin/dev Launcher:")
-      check_bin_dev_launcher_setup
+      return unless check_bin_dev_launcher_setup
 
       checker.add_info("\n📄 Launcher Procfiles:")
       check_launcher_procfiles
@@ -1425,6 +1425,8 @@ module ReactOnRails
       checker.add_info("  • Modern React patterns recommended")
     end
 
+    # Returns true if bin/dev exists, false otherwise.
+    # Used by check_bin_dev_launcher to decide whether to check Procfiles.
     def check_bin_dev_launcher_setup
       bin_dev_path = "bin/dev"
 
@@ -1432,7 +1434,7 @@ module ReactOnRails
         checker.add_warning("  ⚠️  Official React on Rails bin/dev launcher not found")
         report_custom_launcher_guidance
         checker.add_info("    💡 Generate the official launcher with: rails generate react_on_rails:install")
-        return
+        return false
       end
 
       content = File.read(bin_dev_path)
@@ -1445,6 +1447,8 @@ module ReactOnRails
         checker.add_warning("  ⚠️  bin/dev exists but doesn't use ReactOnRails Launcher")
         checker.add_info("    💡 Consider upgrading: rails generate react_on_rails:install")
       end
+
+      true
     end
 
     def check_launcher_procfiles

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -1432,8 +1432,16 @@ module ReactOnRails
 
       unless File.exist?(bin_dev_path)
         checker.add_warning("  ⚠️  Official React on Rails bin/dev launcher not found")
-        report_custom_launcher_guidance
-        checker.add_info("    💡 Generate the official launcher with: rails generate react_on_rails:install")
+        custom_launchers = detected_custom_launcher_paths
+        if custom_launchers.any?
+          checker.add_info(
+            "    ℹ️  Custom launcher detected (#{custom_launchers.join(', ')}). " \
+            "This is OK if your project intentionally manages its own dev workflow."
+          )
+          checker.add_info("    💡 To use the official launcher instead, run: rails generate react_on_rails:install")
+        else
+          checker.add_info("    💡 Generate the official launcher with: rails generate react_on_rails:install")
+        end
         return false
       end
 
@@ -1476,19 +1484,9 @@ module ReactOnRails
       end
     end
 
-    def report_custom_launcher_guidance
-      custom_launcher_paths = detected_custom_launcher_paths
-      return if custom_launcher_paths.empty?
-
-      checker.add_info(
-        "    ℹ️  Custom launcher detected (#{custom_launcher_paths.join(', ')}). " \
-        "This is OK if your project intentionally manages its own dev workflow."
-      )
-    end
-
     def detected_custom_launcher_paths
       CUSTOM_LAUNCHER_INDICATOR_FILES.filter_map do |path|
-        next unless File.exist?(path)
+        next unless File.file?(path)
 
         path == "dev" ? "./dev" : path
       end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1691,6 +1691,53 @@ RSpec.describe ReactOnRails::Doctor do
     end
   end
 
+  describe "#check_bin_dev_launcher_setup" do
+    let(:doctor) { described_class.new(verbose: false, fix: false) }
+    let(:checker) { doctor.instance_variable_get(:@checker) }
+
+    around do |example|
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(tmpdir) { example.run }
+      end
+    end
+
+    def write_project_file(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end
+
+    it "warns instead of erroring when the generated launcher is missing" do
+      doctor.send(:check_bin_dev_launcher_setup)
+
+      error_messages = checker.messages.select { |msg| msg[:type] == :error }
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+
+      expect(error_messages).to be_empty
+      expect(warning_messages).to include(a_string_including("Official React on Rails bin/dev launcher not found"))
+      expect(info_messages).to include(a_string_including("rails generate react_on_rails:install"))
+    end
+
+    it "acknowledges custom launchers when bin/dev is missing" do
+      write_project_file("dev", <<~SH)
+        #!/usr/bin/env bash
+        bundle exec overmind start -f Procfile
+      SH
+      write_project_file("Procfile", <<~PROCFILE)
+        web: bundle exec rails server
+        assets: bin/shakapacker --watch
+      PROCFILE
+
+      doctor.send(:check_bin_dev_launcher_setup)
+
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+
+      expect(info_messages).to include(a_string_including("Custom launcher detected"))
+      expect(info_messages).to include(a_string_including("./dev"))
+      expect(info_messages).to include(a_string_including("Procfile"))
+    end
+  end
+
   describe "server bundle path Shakapacker integration" do
     let(:doctor) { described_class.new }
     let(:checker) { doctor.instance_variable_get(:@checker) }

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1723,10 +1723,6 @@ RSpec.describe ReactOnRails::Doctor do
         #!/usr/bin/env bash
         bundle exec overmind start -f Procfile.dev
       SH
-      write_project_file("Procfile.dev", <<~PROCFILE)
-        web: bundle exec rails server
-        assets: bin/shakapacker --watch
-      PROCFILE
 
       doctor.send(:check_bin_dev_launcher_setup)
 
@@ -1736,7 +1732,6 @@ RSpec.describe ReactOnRails::Doctor do
       expect(error_messages).to be_empty
       expect(info_messages).to include(a_string_including("Custom launcher detected"))
       expect(info_messages).to include(a_string_including("./dev"))
-      expect(info_messages).to include(a_string_including("Procfile.dev"))
     end
 
     it "skips Procfile checks for custom projects via check_bin_dev_launcher" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1732,6 +1732,17 @@ RSpec.describe ReactOnRails::Doctor do
       expect(error_messages).to be_empty
       expect(info_messages).to include(a_string_including("Custom launcher detected"))
       expect(info_messages).to include(a_string_including("./dev"))
+      expect(info_messages).to include(a_string_including("To use the official launcher instead"))
+    end
+
+    it "does not detect a dev/ directory as a custom launcher" do
+      FileUtils.mkdir_p("dev")
+
+      doctor.send(:check_bin_dev_launcher_setup)
+
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+
+      expect(info_messages).not_to include(a_string_including("Custom launcher detected"))
     end
 
     it "skips Procfile checks for custom projects via check_bin_dev_launcher" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -1721,20 +1721,39 @@ RSpec.describe ReactOnRails::Doctor do
     it "acknowledges custom launchers when bin/dev is missing" do
       write_project_file("dev", <<~SH)
         #!/usr/bin/env bash
-        bundle exec overmind start -f Procfile
+        bundle exec overmind start -f Procfile.dev
       SH
-      write_project_file("Procfile", <<~PROCFILE)
+      write_project_file("Procfile.dev", <<~PROCFILE)
         web: bundle exec rails server
         assets: bin/shakapacker --watch
       PROCFILE
 
       doctor.send(:check_bin_dev_launcher_setup)
 
+      error_messages = checker.messages.select { |msg| msg[:type] == :error }
       info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
 
+      expect(error_messages).to be_empty
       expect(info_messages).to include(a_string_including("Custom launcher detected"))
       expect(info_messages).to include(a_string_including("./dev"))
-      expect(info_messages).to include(a_string_including("Procfile"))
+      expect(info_messages).to include(a_string_including("Procfile.dev"))
+    end
+
+    it "skips Procfile checks for custom projects via check_bin_dev_launcher" do
+      write_project_file("dev", <<~SH)
+        #!/usr/bin/env bash
+        bundle exec overmind start -f Procfile.dev
+      SH
+
+      doctor.send(:check_bin_dev_launcher)
+
+      all_messages = checker.messages.map { |msg| msg[:content] }
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+
+      expect(warning_messages).not_to include(a_string_including("Missing Procfile.dev"))
+      expect(warning_messages).not_to include(a_string_including("Missing Procfile.dev-static-assets"))
+      expect(warning_messages).not_to include(a_string_including("Missing Procfile.dev-prod-assets"))
+      expect(all_messages).not_to include(a_string_including("Launcher Procfiles"))
     end
   end
 


### PR DESCRIPTION
### Summary

`react_on_rails:doctor` previously raised a hard error when `bin/dev` was missing, causing custom projects that intentionally manage their own dev workflow (e.g. `./dev` script) to fail diagnostics unnecessarily.

This PR downgrades the missing `bin/dev` check from an error to a warning, detects custom launcher files (`./dev`), and provides guidance for generating the official launcher when desired.

Fixes [#3103](https://github.com/shakacode/react_on_rails/issues/3103).

### Pull Request checklist

- [x] Add/update test to cover these changes
- [ ] Update documentation
- [x] Update CHANGELOG file

### Other Information

Two new specs cover the downgraded warning behavior and custom launcher detection.