### PR TITLE
Add Rspack + RSC compatibility tests and documentation (#1828)

### DIFF
--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -1,0 +1,100 @@
+# Rspack Compatibility with React Server Components
+
+> **Status**: Experimental — generator support is complete; runtime verification is in progress.
+
+This page documents the compatibility status of [Rspack](https://rspack.dev/) with React on Rails Pro's React Server Components (RSC) implementation.
+
+## Overview
+
+React on Rails Pro's RSC implementation uses a three-bundle architecture (client, server, RSC).
+The generator already supports Rspack — when `assets_bundler: rspack` is detected in `shakapacker.yml`, all RSC config files are created in `config/rspack/` instead of `config/webpack/`.
+
+The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides:
+
+- **WebpackPlugin** — generates client/server component manifest files
+- **WebpackLoader** — transforms `'use client'` files into client reference proxies in the RSC bundle
+
+## Compatibility Matrix
+
+| Component                                                        | Rspack Compatible  | Notes                                                                           |
+| ---------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| **RSC bundle config** (`rscWebpackConfig.js`)                    | Yes                | Does not use WebpackPlugin; only uses loader + resolve settings                 |
+| **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`)           | Yes                | Standard loader interface (`this.resourcePath`, source transform)               |
+| **`conditionNames: ['react-server', '...']`**                    | Yes                | Rspack supports conditional exports resolution                                  |
+| **`resolve.alias`** (`react-dom/server: false`)                  | Yes                | Rspack supports alias to `false`                                                |
+| **`LimitChunkCountPlugin`**                                      | Yes                | Generated configs use bundler-agnostic `bundler.optimize.LimitChunkCountPlugin` |
+| **Loader chain (SWC + Babel)**                                   | Yes                | Generated config handles both `function` and `Array` `rule.use` styles          |
+| **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`)           | Needs verification | Uses webpack internal APIs (see below)                                          |
+| **Three-bundle build** (`RSC_BUNDLE_ONLY`, `SERVER_BUNDLE_ONLY`) | Yes                | Environment variable routing is bundler-agnostic                                |
+
+## WebpackPlugin Compatibility Details
+
+The `RSCWebpackPlugin` is the critical compatibility question. It wraps React's
+`react-server-dom-webpack/plugin`, which uses these webpack internal APIs:
+
+- `webpack/lib/dependencies/ModuleDependency` — base class for dependency tracking
+- `webpack/lib/dependencies/NullDependency` — null dependency template
+- `webpack/lib/Template` — template utilities
+- `webpack.AsyncDependenciesBlock` — async dependency blocks
+- `webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT` — asset processing hooks
+- `webpack.sources.RawSource` — source output
+- Compiler hooks: `beforeCompile`, `thisCompilation`, `make`
+- Compilation hooks: `processAssets`
+- Parser hooks: `program`
+- `compilation.chunkGraph` — chunk/module graph traversal
+
+**Why this matters**: The plugin generates `react-client-manifest.json` and
+`react-ssr-manifest.json`, which map client component file paths to their chunk
+IDs and bundle filenames. Without these manifests, the RSC runtime cannot resolve
+`'use client'` component references during streaming.
+
+**Rspack v2 compatibility**: Rspack v2 has significantly improved webpack plugin
+compatibility. The [Rspack team has confirmed](https://github.com/shakacode/react_on_rails/issues/1828#issuecomment-3350629010)
+that Rspack supports RSC with the JavaScript API. However, runtime verification
+with the specific `react-on-rails-rsc` plugin is still needed.
+
+## How the RSC Bundle Avoids the Plugin
+
+The RSC bundle config (`rscWebpackConfig.js`) calls `serverWebpackConfig(true)`,
+which skips adding `RSCWebpackPlugin`. The RSC bundle only uses:
+
+1. The **WebpackLoader** to transform `'use client'` files into client reference proxies
+2. **`conditionNames: ['react-server', '...']`** to resolve React's server entry points
+3. **Aliases** to exclude `react-dom/server` from the RSC bundle
+
+This means the RSC bundle itself should work with Rspack today. The plugin is only
+added to the **server** and **client** bundles for manifest generation.
+
+## Testing with Rspack
+
+To test RSC with Rspack in your project:
+
+1. Ensure `assets_bundler: rspack` is set in `config/shakapacker.yml`
+2. Run the RSC generator: `rails generate react_on_rails:rsc`
+3. Verify configs are in `config/rspack/`
+4. Build all three bundles and check for:
+   - `rsc-bundle.js` in the output
+   - `react-client-manifest.json` and `react-ssr-manifest.json` (from the plugin)
+   - No webpack/Rspack compilation errors
+
+## Known Limitations
+
+1. **No `react-server-dom-rspack` package**: React does not ship a dedicated Rspack
+   variant of the RSC wire protocol. The `react-server-dom-webpack` package is used,
+   relying on Rspack's webpack compatibility layer.
+
+2. **Plugin `require('webpack')` call**: The `react-server-dom-webpack/plugin`
+   internally calls `require('webpack')`, which loads webpack even in Rspack projects.
+   Rspack's compatibility layer must intercept the compiler/compilation interactions
+   for the plugin to function correctly.
+
+3. **No official React Rspack support**: The React team has not officially tested or
+   endorsed `react-server-dom-webpack` with Rspack. Compatibility is provided by
+   Rspack's webpack API compatibility layer.
+
+## Related Resources
+
+- [Issue #1828: Rspack support for RSC](https://github.com/shakacode/react_on_rails/issues/1828)
+- [Rspack RSC support PR](https://github.com/web-infra-dev/rspack/pull/5824)
+- [Three-bundle architecture](./how-react-server-components-work.md)
+- [Upgrading an existing Pro app to RSC](./upgrading-existing-pro-app.md)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -211,6 +211,7 @@ const sidebars: SidebarsConfig = {
             'pro/react-server-components/selective-hydration-in-streamed-components',
             'pro/react-server-components/flight-protocol-syntax',
             'pro/react-server-components/upgrading-existing-pro-app',
+            'pro/react-server-components/rspack-compatibility',
             'pro/react-server-components/glossary',
             {
               type: 'category',

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -666,6 +666,9 @@ describe RscGenerator, type: :generator do
 
     # Rspack RSC compatibility — verifies that the generated RSC config uses
     # bundler-agnostic patterns that work with both webpack and Rspack runtimes.
+    # Some assertions below overlap with the "RSC webpack config transforms" block
+    # above but use more specific matchers (e.g. verifying the `false` value, not
+    # just the key name). The duplication is intentional.
     # See: https://github.com/shakacode/react_on_rails/issues/1828
 
     describe "Rspack RSC runtime compatibility" do
@@ -678,7 +681,7 @@ describe RscGenerator, type: :generator do
 
       it "rscWebpackConfig.js aliases react-dom/server to false for RSC bundle" do
         assert_file "config/rspack/rscWebpackConfig.js" do |content|
-          expect(content).to include("react-dom/server")
+          expect(content).to include("'react-dom/server': false")
         end
       end
 
@@ -701,7 +704,7 @@ describe RscGenerator, type: :generator do
         end
       end
 
-      it "rscWebpackConfig.js handles both function-based (SWC) and array-based (Babel) loader chains" do
+      it "rscWebpackConfig.js contains conditional loader-chain handling for function-based and array-based rule.use" do
         assert_file "config/rspack/rscWebpackConfig.js" do |content|
           # Must handle both loader styles since Rspack projects often use SWC
           expect(content).to include("typeof rule.use === 'function'")
@@ -709,10 +712,10 @@ describe RscGenerator, type: :generator do
         end
       end
 
-      it "serverWebpackConfig.js uses bundler-agnostic require for LimitChunkCountPlugin" do
+      it "serverWebpackConfig.js (from Pro generator) uses bundler-agnostic LimitChunkCountPlugin" do
         assert_file "config/rspack/serverWebpackConfig.js" do |content|
-          # Verify the server config uses the bundler variable (not hardcoded webpack)
-          # for plugin instantiation — critical for Rspack compatibility
+          # This content comes from the Pro generator, not the RSC generator.
+          # Verified here to ensure the full Rspack server config is bundler-agnostic.
           expect(content).to include("bundler.optimize.LimitChunkCountPlugin")
         end
       end

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -663,6 +663,76 @@ describe RscGenerator, type: :generator do
         end
       end
     end
+
+    # Rspack RSC compatibility — verifies that the generated RSC config uses
+    # bundler-agnostic patterns that work with both webpack and Rspack runtimes.
+    # See: https://github.com/shakacode/react_on_rails/issues/1828
+
+    describe "Rspack RSC runtime compatibility" do
+      it "rscWebpackConfig.js uses react-server conditionNames for module resolution" do
+        assert_file "config/rspack/rscWebpackConfig.js" do |content|
+          expect(content).to include("conditionNames")
+          expect(content).to include("react-server")
+        end
+      end
+
+      it "rscWebpackConfig.js aliases react-dom/server to false for RSC bundle" do
+        assert_file "config/rspack/rscWebpackConfig.js" do |content|
+          expect(content).to include("react-dom/server")
+        end
+      end
+
+      it "rscWebpackConfig.js adds RSC WebpackLoader to the loader chain" do
+        assert_file "config/rspack/rscWebpackConfig.js" do |content|
+          expect(content).to include("react-on-rails-rsc/WebpackLoader")
+        end
+      end
+
+      it "rscWebpackConfig.js passes true to skip RSCWebpackPlugin in RSC bundle" do
+        assert_file "config/rspack/rscWebpackConfig.js" do |content|
+          expect(content).to include("serverWebpackConfig(true)")
+        end
+      end
+
+      it "rscWebpackConfig.js renames entry to rsc-bundle" do
+        assert_file "config/rspack/rscWebpackConfig.js" do |content|
+          expect(content).to include("'rsc-bundle'")
+          expect(content).to include("rsc-bundle.js")
+        end
+      end
+
+      it "rscWebpackConfig.js handles both function-based (SWC) and array-based (Babel) loader chains" do
+        assert_file "config/rspack/rscWebpackConfig.js" do |content|
+          # Must handle both loader styles since Rspack projects often use SWC
+          expect(content).to include("typeof rule.use === 'function'")
+          expect(content).to include("Array.isArray(rule.use)")
+        end
+      end
+
+      it "serverWebpackConfig.js uses bundler-agnostic require for LimitChunkCountPlugin" do
+        assert_file "config/rspack/serverWebpackConfig.js" do |content|
+          # Verify the server config uses the bundler variable (not hardcoded webpack)
+          # for plugin instantiation — critical for Rspack compatibility
+          expect(content).to include("bundler.optimize.LimitChunkCountPlugin")
+        end
+      end
+
+      it "serverWebpackConfig.js conditionally skips RSCWebpackPlugin when rscBundle is true" do
+        assert_file "config/rspack/serverWebpackConfig.js" do |content|
+          expect(content).to include("if (!rscBundle)")
+          expect(content).to include("RSCWebpackPlugin({ isServer: true })")
+        end
+      end
+
+      it "ServerClientOrBoth.js includes RSC_BUNDLE_ONLY env var handling for isolated RSC builds" do
+        assert_file "config/rspack/ServerClientOrBoth.js" do |content|
+          expect(content).to include("process.env.RSC_BUNDLE_ONLY")
+          expect(content).to include("rscConfig")
+          # Verify three-bundle default (client + server + RSC)
+          expect(content).to include("[clientConfig, serverConfig, rscConfig]")
+        end
+      end
+    end
   end
 
   # Rspack + legacy Pro variant — same as the legacy webpack exports context below,

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -694,6 +694,7 @@ describe RscGenerator, type: :generator do
       it "rscWebpackConfig.js passes true to skip RSCWebpackPlugin in RSC bundle" do
         assert_file "config/rspack/rscWebpackConfig.js" do |content|
           expect(content).to include("serverWebpackConfig(true)")
+          expect(content).not_to match(/new\s+RSCWebpackPlugin/)
         end
       end
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/shakacode/react_on_rails/issues/1828 — researches and documents whether Rspack works with React on Rails Pro's RSC implementation.

- Adds 9 new RSpec tests verifying the generated RSC config content is correct for Rspack runtime compatibility (conditionNames, aliases, loader chain, bundler-agnostic plugins, three-bundle routing)
- Creates `docs/pro/react-server-components/rspack-compatibility.md` with a compatibility matrix, analysis of `react-server-dom-webpack` internal API usage, and known limitations

### Key Findings

| Component | Compatible | Notes |
|---|---|---|
| RSC bundle config | **Yes** | Skips WebpackPlugin; uses only loader + resolve |
| WebpackLoader | **Yes** | Standard loader interface |
| conditionNames / aliases | **Yes** | Rspack supports both |
| LimitChunkCountPlugin | **Yes** | Bundler-agnostic via `bundler.optimize` variable |
| Loader chain (SWC + Babel) | **Yes** | Handles both function and array `rule.use` |
| Three-bundle env routing | **Yes** | `RSC_BUNDLE_ONLY` is bundler-agnostic |
| **WebpackPlugin** | **Needs verification** | Uses webpack internal APIs (`ModuleDependency`, `AsyncDependenciesBlock`, compiler hooks) |

The RSC **bundle** itself should work with Rspack today — it only uses the loader and resolve settings. The `RSCWebpackPlugin` (added to server/client configs for manifest generation) is the one component requiring runtime verification with Rspack v2's compatibility layer.

## Test plan

- [x] `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb` — 76 examples, 0 failures
- [x] `bundle exec rubocop` passes on changed files
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and RSpec coverage of generated config output, with no runtime or production code modifications.
> 
> **Overview**
> Adds a new Pro RSC doc, `rspack-compatibility.md`, summarizing the current Rspack compatibility status, what parts rely on `react-on-rails-rsc`, and what still needs runtime verification (notably the manifest-generating plugin).
> 
> Expands `rsc_generator_spec.rb` with a dedicated Rspack runtime-compatibility spec block asserting the generated `config/rspack/*` RSC configs use bundler-agnostic patterns (e.g., `conditionNames`, `react-dom/server: false`, loader-chain handling, skipping `RSCWebpackPlugin` for the RSC bundle, and `RSC_BUNDLE_ONLY` routing), and links the new doc into `docs/sidebars.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17708eff584bde947cf4eb0bfed537ef8783c08c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Pro guide on React Server Components compatibility with Rspack, describing generator integration, three-bundle architecture, environment routing, compatibility notes, testing checklist, and known limitations.

* **Tests**
  * Added specs validating generated Rspack RSC configuration, loader-chain handling, conditional plugin behavior, bundler-agnostic runtime arrangements, and runtime entry/bundle naming outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->