### PR TITLE
Enhance address-review with parallel fixes, self-review, and Greptile verification

### DIFF
--- a/.agents/workflows/address-review.md
+++ b/.agents/workflows/address-review.md
@@ -112,6 +112,7 @@ Execution flow when terminal access is available:
    - If a claim is wrong, classify it as `SKIPPED` and say why.
    - Preserve comment IDs and thread IDs for later replies and thread resolution.
    - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
+   - **Claim verification**: Before finalizing `MUST-FIX` classification, verify the reviewer's factual claims against the actual codebase. If the code already handles the concern, or the reviewer's claim is based on outdated context, downgrade to `DISCUSS` and note the discrepancy. If you have access to AI-powered codebase search tools (e.g., Greptile), use them to cross-reference claims for additional confidence.
    - Track only `MUST-FIX` items as your working checklist.
    - Use one checklist entry per must-fix item or deduplicated issue.
    - Use the subject format: `"{file}:{line} - {comment_summary} (@{username})"`.
@@ -152,6 +153,8 @@ Execution flow when terminal access is available:
      `gh api graphql -f query='mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }' -f threadId="<THREAD_ID>"`
    - Do not resolve anything still in progress or uncertain.
    - Ask for push confirmation before running `git push`.
+   - **Parallel fixes**: When there are 2+ items to fix that touch different files with no logical dependencies, process them in parallel if your environment supports concurrent execution (e.g., sub-agents, background tasks). Items in the same file or with cross-file dependencies must be fixed sequentially. After parallel fixes complete, verify no conflicts exist between the changes.
+   - **Self-review gate**: After making all code changes but before committing, review the diff for issues introduced by the fixes themselves. Check for correctness bugs, style violations, and inconsistencies with surrounding code. Fix critical issues immediately. This prevents new review cycles caused by the fixes. If you have access to a code-review agent or tool, use it; otherwise, do a manual diff review.
 
 9. Create follow-up issue (when `f+i` or `m` is chosen):
    - Use `gh issue create --repo "${REPO}"` with title "Follow-up: Review feedback from PR #N"

--- a/.agents/workflows/address-review.md
+++ b/.agents/workflows/address-review.md
@@ -112,7 +112,7 @@ Execution flow when terminal access is available:
    - If a claim is wrong, classify it as `SKIPPED` and say why.
    - Preserve comment IDs and thread IDs for later replies and thread resolution.
    - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
-   - **Claim verification**: Before finalizing `MUST-FIX` classification, verify the reviewer's factual claims against the actual codebase. If the code already handles the concern, or the reviewer's claim is based on outdated context, downgrade to `DISCUSS` and note the discrepancy. If you have access to AI-powered codebase search tools (e.g., Greptile), use them to cross-reference claims for additional confidence.
+   - **Claim verification**: Before finalizing `MUST-FIX` classification, verify the reviewer's factual claims against the actual codebase. If local code inspection confirms the code already handles the concern (claim is demonstrably wrong), classify as `SKIPPED` per the rule above. If the evidence is ambiguous or you have only partial confidence the claim is wrong, downgrade to `DISCUSS` and note the discrepancy. If you have access to AI-powered codebase search tools (e.g., Greptile), use them to cross-reference claims for additional confidence, but treat their output as a signal — corroborated claims stay `MUST-FIX`, clearly contradicted claims go to `SKIPPED`, and inconclusive results go to `DISCUSS`.
    - Track only `MUST-FIX` items as your working checklist.
    - Use one checklist entry per must-fix item or deduplicated issue.
    - Use the subject format: `"{file}:{line} - {comment_summary} (@{username})"`.
@@ -152,9 +152,9 @@ Execution flow when terminal access is available:
    - Resolve threads only when the issue is actually handled or explicitly declined with my approval:
      `gh api graphql -f query='mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }' -f threadId="<THREAD_ID>"`
    - Do not resolve anything still in progress or uncertain.
-   - Ask for push confirmation before running `git push`.
-   - **Parallel fixes**: When there are 2+ items to fix that touch different files with no logical dependencies, process them in parallel if your environment supports concurrent execution (e.g., sub-agents, background tasks). Items in the same file or with cross-file dependencies must be fixed sequentially. After parallel fixes complete, verify no conflicts exist between the changes.
    - **Self-review gate**: After making all code changes but before committing, review the diff for issues introduced by the fixes themselves. Check for correctness bugs, style violations, and inconsistencies with surrounding code. Fix critical issues immediately. This prevents new review cycles caused by the fixes. If you have access to a code-review agent or tool, use it; otherwise, do a manual diff review.
+   - Ask for push confirmation before running `git push`.
+   - **Parallel fixes**: When there are 2+ items to fix that touch different files with no logical dependencies, process them in parallel if your environment supports concurrent execution (e.g., sub-agents, background tasks). Items in the same file or with cross-file dependencies must be fixed sequentially. Instruct each sub-agent **not to commit** — all changes must remain unstaged so the self-review gate can run on the combined diff. After parallel fixes complete, verify no conflicts exist between the changes by checking whether any sub-agents touched the same files (`git diff --name-only`).
 
 9. Create follow-up issue (when `f+i` or `m` is chosen):
    - Use `gh issue create --repo "${REPO}"` with title "Follow-up: Review feedback from PR #N"

--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -151,6 +151,18 @@ Triage rules:
 - Preserve the original review comment ID and thread ID when available so the command can reply to the correct place and resolve the correct thread later.
 - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
 
+**Greptile claim verification:**
+
+When Greptile MCP tools are available (`mcp__plugin_greptile_greptile__*`), cross-reference reviewer claims against Greptile's codebase analysis before finalizing triage classifications:
+
+1. For each reviewer comment that asserts a factual claim about the codebase (e.g., "this function doesn't handle null", "this breaks the existing API contract"), query Greptile to verify the claim:
+   - Use `search_greptile_comments` to find prior Greptile analysis of the same code area
+   - Use `search_custom_context` to check project-specific context that may confirm or contradict the claim
+2. If Greptile's analysis contradicts the reviewer's claim or confirms the current code is correct, downgrade from `MUST-FIX` to `DISCUSS` and note the discrepancy (e.g., "Greptile analysis suggests current handling is correct — reviewer claim needs verification").
+3. If Greptile's analysis corroborates the reviewer's claim, keep the `MUST-FIX` classification with higher confidence.
+4. If Greptile has no relevant data, fall back to local verification only.
+5. Do not block triage on Greptile availability — if the tools are not configured or the API fails, proceed with local verification alone.
+
 ## Step 6: Create Todo List
 
 Create a task list with TodoWrite containing **only the `MUST-FIX` items**:
@@ -249,6 +261,32 @@ Users can chain actions: e.g., `f+i` then `r7-9`. After the first action complet
 When addressing items, after completing each selected item (whether `MUST-FIX` or `DISCUSS`), reply to the original review comment explaining how it was addressed.
 If the user selects `DISCUSS` items to address, treat them the same as `MUST-FIX`: make the code change, reply, and resolve the thread.
 If the user selects skipped/declined items for rationale replies, post those replies too.
+
+**Parallel sub-agents for independent fixes:**
+
+When there are 2+ items to fix that touch different files with no logical dependencies between them, use the Task tool to spawn parallel sub-agents for faster execution:
+
+1. Group items by file path. Items in different files with no cross-file dependencies (e.g., a type change in file A that affects callers in file B) are independent.
+2. For each independent group, spawn a sub-agent via the Task tool with:
+   - The full review comment text and context
+   - The file path and line number
+   - Instructions to make the specific fix and run any relevant file-level checks
+   - A reminder not to modify files outside the assigned scope
+3. After all sub-agents complete, verify there are no conflicts between their changes (e.g., two agents editing the same shared import or config file).
+4. If conflicts exist, resolve them sequentially before proceeding.
+5. Items that touch the same file or have logical dependencies must be fixed sequentially, not in parallel.
+6. If only 1 item needs fixing or all items are in the same file, skip parallel dispatch and fix sequentially as before.
+
+**Self-review gate before pushing:**
+
+After making all code changes but before committing, run a self-review on the diff to prevent new review cycles caused by the fixes themselves:
+
+1. Use the Task tool to launch a code-review sub-agent (e.g., `pr-review-toolkit:code-reviewer` if available, or a general-purpose review agent) against the uncommitted changes (`git diff`).
+2. The self-review should check for: correctness bugs introduced by the fixes, style violations against project standards (CLAUDE.md, linter rules), missing error handling, and inconsistencies with surrounding code.
+3. If the self-review finds critical issues (bugs, security problems, or clear correctness errors), fix them immediately before committing. These are issues that would likely trigger a new review round.
+4. If the self-review finds only minor issues (style nits, naming suggestions), note them but proceed — do not block the push for optional improvements.
+5. If the self-review catches and fixes additional issues, mention this in the commit message (e.g., "also fixed: null check in adjacent error path caught by self-review").
+6. Skip the self-review gate for non-code actions (rationale replies, follow-up issue creation, thread resolution).
 
 **For issue comments (general PR comments):**
 

--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -156,9 +156,9 @@ Triage rules:
 When Greptile MCP tools are available (`mcp__plugin_greptile_greptile__*`), cross-reference reviewer claims against Greptile's codebase analysis before finalizing triage classifications:
 
 1. For each reviewer comment that asserts a factual claim about the codebase (e.g., "this function doesn't handle null", "this breaks the existing API contract"), query Greptile to verify the claim:
-   - Use `search_greptile_comments` to find prior Greptile analysis of the same code area
-   - Use `search_custom_context` to check project-specific context that may confirm or contradict the claim
-2. If Greptile's analysis contradicts the reviewer's claim or confirms the current code is correct, downgrade from `MUST-FIX` to `DISCUSS` and note the discrepancy (e.g., "Greptile analysis suggests current handling is correct — reviewer claim needs verification").
+   - Use `mcp__plugin_greptile_greptile__search_greptile_comments` to find prior Greptile analysis of the same code area
+   - Use `mcp__plugin_greptile_greptile__search_custom_context` to check project-specific context that may confirm or contradict the claim
+2. If Greptile's analysis clearly contradicts the reviewer's claim and local code inspection confirms the code already handles the concern, classify as `SKIPPED` per the existing triage rule (claim is demonstrably wrong). If the analysis is inconclusive or only partially contradicts the claim, downgrade to `DISCUSS` and note the discrepancy (e.g., "Greptile analysis suggests current handling may be correct — needs verification").
 3. If Greptile's analysis corroborates the reviewer's claim, keep the `MUST-FIX` classification with higher confidence.
 4. If Greptile has no relevant data, fall back to local verification only.
 5. Do not block triage on Greptile availability — if the tools are not configured or the API fails, proceed with local verification alone.
@@ -272,10 +272,12 @@ When there are 2+ items to fix that touch different files with no logical depend
    - The file path and line number
    - Instructions to make the specific fix and run any relevant file-level checks
    - A reminder not to modify files outside the assigned scope
-3. After all sub-agents complete, verify there are no conflicts between their changes (e.g., two agents editing the same shared import or config file).
+   - An explicit instruction **not to commit** the changes — leave all modifications unstaged so the orchestrator can run the self-review gate on the combined diff before committing
+3. After all sub-agents complete, verify there are no conflicts between their changes by checking whether any sub-agents touched the same files (e.g., `git diff --name-only` to list changed files, then check for overlaps).
 4. If conflicts exist, resolve them sequentially before proceeding.
-5. Items that touch the same file or have logical dependencies must be fixed sequentially, not in parallel.
-6. If only 1 item needs fixing or all items are in the same file, skip parallel dispatch and fix sequentially as before.
+5. If a sub-agent fails (crashes, hits a tool error, or produces an incorrect edit), fall back to fixing that item sequentially in the parent agent before proceeding.
+6. Items that touch the same file or have logical dependencies must be fixed sequentially, not in parallel.
+7. If only 1 item needs fixing or all items are in the same file, skip parallel dispatch and fix sequentially as before.
 
 **Self-review gate before pushing:**
 


### PR DESCRIPTION
## Summary

- **Parallel sub-agents**: When 2+ MUST-FIX items touch different files with no dependencies, spawn parallel sub-agents via Task tool for faster execution instead of fixing sequentially
- **Self-review gate**: After making fixes but before committing, run `pr-review-toolkit:code-reviewer` on the diff to catch issues introduced by the fixes themselves — prevents new review cycles
- **Greptile claim verification**: Cross-reference reviewer claims against Greptile's codebase analysis before finalizing MUST-FIX triage, reducing false-positive classifications
- **pr-review-toolkit integration**: The self-review gate uses the code-reviewer agent when available

Updates both `.claude/commands/address-review.md` (Claude Code) and `.agents/workflows/address-review.md` (portable prompt) with tool-agnostic equivalents where applicable.

Inspired by research into the open-source PR review tool landscape (corylanou, gjoranv, kieranklaassen, dfed, tilomitra, solberg, OpenAI Codex babysit-pr).

## Test plan

- [ ] Run `/address-review` on a PR with 3+ MUST-FIX items in different files — verify parallel sub-agents are spawned
- [ ] Run `/address-review` on a PR with MUST-FIX items in the same file — verify sequential fixing
- [ ] Verify self-review gate catches an intentionally introduced bug in a fix
- [ ] Verify Greptile verification downgrades a false-positive reviewer claim to DISCUSS
- [ ] Verify graceful fallback when Greptile MCP tools are not available
- [ ] Test the portable `.agents/workflows/` prompt in a non-Claude-Code assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only updates workflow/prompt documentation and command guidance, with no production code or runtime behavior changes.
> 
> **Overview**
> Updates the `address-review` workflow docs to **tighten triage correctness** by adding explicit claim-verification guidance (including optional Greptile cross-checks) before labeling items `MUST-FIX`.
> 
> Adds execution safeguards and speedups: a **self-review gate** before committing/pushing, and guidance to run **independent fixes in parallel** (with no commits in sub-agents and a post-run conflict check) in both the portable `.agents/workflows` prompt and the Claude command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f582502fd4281f31a3369654b862a51c7e807d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->