### PR TITLE
fix: add concurrency groups to long-running CI workflows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,6 +3,10 @@ name: Generator tests # TODO needs to be duplicated for RoR Pro
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,8 +4,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event.pull_request.number && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -4,8 +4,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event.pull_request.number && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -3,6 +3,10 @@ name: Rspec test for gem
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,8 +4,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event.pull_request.number && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,10 @@ name: Integration Tests
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,10 @@ name: Playwright E2E Tests
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,8 +4,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event.pull_request.number && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:


### PR DESCRIPTION
## Summary

Closes #3129

- Adds `concurrency` groups with `cancel-in-progress: true` to four long-running CI workflows: `gem-tests.yml`, `integration-tests.yml`, `examples.yml`, and `playwright.yml`
- When multiple commits push to the same PR branch, stale runs are cancelled automatically, reducing runner pool contention and queue times (~5-10 minutes saved during peak activity)
- Uses the standard GitHub pattern: `group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Push a second commit to this PR branch while CI is running to confirm old runs get cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that primarily affects CI scheduling; main risk is inadvertently canceling desired parallel runs within the same PR if grouping is too broad.
> 
> **Overview**
> Adds **workflow-level `concurrency`** to `examples.yml`, `gem-tests.yml`, `integration-tests.yml`, and `playwright.yml` so that **new commits on the same PR cancel prior in-progress runs**.
> 
> Concurrency grouping keys off the PR number (or falls back to the commit SHA), with `cancel-in-progress` enabled only for `pull_request` events to avoid canceling main-branch runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b33ddc612e9ef4244062dcdebe8d9cf79f6c3061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added workflow concurrency configuration across multiple CI/CD pipelines to automatically cancel redundant runs when new commits are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->