### PR TITLE
fix: merge setup-gem-tests-matrix job into detect-changes

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -51,6 +51,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
             # Pinned fallback used when the GitHub API call fails (rate limit / outage)
             # so the cache key stays stable and the download step still has a version to pin to.
+            echo "::warning::GitHub API unavailable; falling back to pinned actionlint $fallback_version. Consider updating this pin."
             fallback_version="v1.7.7"
             if response=$(curl -sf -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/rhysd/actionlint/releases/latest); then
               actionlint_version=$(echo "$response" | jq -r .tag_name)

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -49,14 +49,20 @@ jobs:
           
           if git diff --name-only "$DIFF_BASE" ${{ github.sha }} 2>/dev/null | grep -q '^.github/workflows'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            # Pinned fallback used when the GitHub API call fails (rate limit / outage)
+            # so the cache key stays stable and the download step still has a version to pin to.
+            fallback_version="v1.7.7"
             if response=$(curl -sf -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/rhysd/actionlint/releases/latest); then
               actionlint_version=$(echo "$response" | jq -r .tag_name)
-              if [ -z "$actionlint_version" ]; then
-                echo "Failed to parse Actionlint version"
-                exit 1
+              if [ -z "$actionlint_version" ] || [ "$actionlint_version" = "null" ]; then
+                echo "Failed to parse Actionlint version; using pinned fallback $fallback_version"
+                actionlint_version="$fallback_version"
               fi
-              echo "actionlint_version=\"$actionlint_version\"" >> "$GITHUB_OUTPUT"
+            else
+              echo "curl to GitHub API failed; using pinned fallback $fallback_version"
+              actionlint_version="$fallback_version"
             fi
+            echo "actionlint_version=\"$actionlint_version\"" >> "$GITHUB_OUTPUT"
           fi
       - name: Setup Actionlint
         if: steps.check-workflows.outputs.changed == 'true'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -49,8 +49,7 @@ jobs:
           
           if git diff --name-only "$DIFF_BASE" ${{ github.sha }} 2>/dev/null | grep -q '^.github/workflows'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            response=$(curl -sf https://api.github.com/repos/rhysd/actionlint/releases/latest)
-            if [ $? -eq 0 ]; then
+            if response=$(curl -sf -H "Authorization: token ${{ github.token }}" https://api.github.com/repos/rhysd/actionlint/releases/latest); then
               actionlint_version=$(echo "$response" | jq -r .tag_name)
               if [ -z "$actionlint_version" ]; then
                 echo "Failed to parse Actionlint version"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -62,7 +62,7 @@ jobs:
               echo "curl to GitHub API failed; using pinned fallback $fallback_version"
               actionlint_version="$fallback_version"
             fi
-            echo "actionlint_version=\"$actionlint_version\"" >> "$GITHUB_OUTPUT"
+            echo "actionlint_version=$actionlint_version" >> "$GITHUB_OUTPUT"
           fi
       - name: Setup Actionlint
         if: steps.check-workflows.outputs.changed == 'true'

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -44,6 +44,7 @@ jobs:
       run_dummy_tests: ${{ steps.detect.outputs.run_dummy_tests }}
       run_generators: ${{ steps.detect.outputs.run_generators }}
       has_full_ci_label: ${{ steps.check-label.outputs.result }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,21 +77,15 @@ jobs:
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
           previous-sha: ${{ github.event.before }}
-
-  setup-gem-tests-matrix:
-    needs: detect-changes
-    runs-on: ubuntu-22.04
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
+      - name: Set gem tests matrix
+        id: set-matrix
         run: |
           # Determine if we should run full matrix (main or full-ci label)
           # Each Ruby version / dependency level is split into two shards:
           #   generators – spec/react_on_rails/generators (heavy filesystem I/O)
           #   unit       – everything else under spec/react_on_rails
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
-             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+             [[ "${{ steps.check-label.outputs.result }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions × 2 shards
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> $GITHUB_OUTPUT
           else
@@ -99,7 +94,7 @@ jobs:
           fi
 
   rspec-package-tests:
-    needs: [detect-changes, setup-gem-tests-matrix]
+    needs: detect-changes
     # Skip only if: main push AND docs-only changes
     # Otherwise run if: on main OR Ruby tests needed
     # This allows docs-only commits to skip heavy jobs while ensuring full CI on main for code changes
@@ -114,7 +109,7 @@ jobs:
       )
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup-gem-tests-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
     env:
       BUNDLE_FROZEN: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -85,7 +85,8 @@ jobs:
           #   generators – spec/react_on_rails/generators (heavy filesystem I/O)
           #   unit       – everything else under spec/react_on_rails
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
-             [[ "${{ steps.check-label.outputs.result }}" == "true" ]]; then
+             [[ "${{ steps.check-label.outputs.result }}" == "true" ]] || \
+             [[ "${{ inputs.force_run }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions × 2 shards
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -85,7 +85,7 @@ jobs:
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> $GITHUB_OUTPUT
           else
             # PR matrix: test only latest versions for fast feedback × 2 shards
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"}]}' >> "$GITHUB_OUTPUT"
           fi
       - name: Guard docs-only main pushes
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -71,12 +71,6 @@ jobs:
           BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
-      - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: ./.github/actions/ensure-main-docs-safety
-        with:
-          docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
       - name: Set gem tests matrix
         id: set-matrix
         run: |
@@ -93,6 +87,12 @@ jobs:
             # PR matrix: test only latest versions for fast feedback × 2 shards
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"}]}' >> $GITHUB_OUTPUT
           fi
+      - name: Guard docs-only main pushes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/ensure-main-docs-safety
+        with:
+          docs-only: ${{ steps.detect.outputs.docs_only }}
+          previous-sha: ${{ github.event.before }}
 
   rspec-package-tests:
     needs: detect-changes


### PR DESCRIPTION
## Summary
- Moves the `setup-gem-tests-matrix` job's 3-line matrix setup logic into the `detect-changes` job as an additional step
- Eliminates one runner queue hop, saving 2-10 minutes per CI run
- `rspec-package-tests` now depends only on `detect-changes` instead of both jobs

Closes #3130

## Test plan
- [ ] Verify CI runs successfully on this PR (the gem-tests workflow should trigger)
- [ ] Confirm `rspec-package-tests` picks up the matrix from `detect-changes` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only changes, but could affect CI execution if the new matrix output wiring or API fallback logic is incorrect.
> 
> **Overview**
> **CI workflow reliability and speed improvements.** The `actionlint` workflow now uses an authenticated GitHub API call to resolve the latest `rhysd/actionlint` release and falls back to a pinned version (`v1.7.7`) when the API fails or returns an invalid tag.
> 
> In `gem-tests`, the Ruby test matrix generation is moved into `detect-changes` (exported via job outputs) and the separate `setup-gem-tests-matrix` job is removed; `rspec-package-tests` now depends only on `detect-changes` and consumes `needs.detect-changes.outputs.matrix`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec338e8f6412f7607e2072ef9053f5fbfe7d4a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability for tool version lookup by consolidating request/response handling, using authenticated requests, and falling back to a pinned version on failure.
  * Streamlined CI test orchestration by generating and exporting test matrices within a single job, removing intermediate jobs and simplifying downstream job dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->