### PR TITLE
docs: RSC + Rspack plugin implementation plan and findings (#3141)

### DIFF
--- a/.claude/docs/rsc-rspack-implementation-plan.md
+++ b/.claude/docs/rsc-rspack-implementation-plan.md
@@ -1,0 +1,644 @@
+# RSC + Rspack Implementation Plan
+
+Planning/investigation doc for issue [shakacode/react_on_rails#3141](https://github.com/shakacode/react_on_rails/issues/3141).
+
+**Audience:** React on Rails + Shakapacker maintainer with strong webpack knowledge and no deep rspack internals experience.
+
+**Goal:** Drive a decision on _how_ to make React Server Components (RSC) run end-to-end under rspack before a single line of production code is written.
+
+**Status tags used in this doc:**
+- **VERIFIED** — confirmed by source reading in this repo
+- **NEEDS VERIFICATION** — plausible but not runtime-tested
+- **UNKNOWN** — open question
+- **ASSUMED** — working assumption; flag before committing
+
+---
+
+## Table of Contents
+
+1. [Current Architecture Overview](#1-current-architecture-overview)
+2. [Compatibility Analysis (Webpack vs Rspack)](#2-compatibility-analysis-webpack-vs-rspack)
+3. [Critical Discussion Points](#3-critical-discussion-points-decide-before-coding)
+4. [Refactoring Opportunities](#4-refactoring-opportunities-before-implementation)
+5. [Implementation Plan (Phased)](#5-implementation-plan-phased)
+6. [Open Questions and Unknowns](#6-open-questions-and-unknowns)
+7. [Risk Matrix](#7-risk-matrix)
+8. [Related Links / References](#8-related-links--references)
+
+---
+
+## 1. Current Architecture Overview
+
+### 1.1 Three-bundle architecture
+
+RSC requires three separate bundles. Each is produced from the same monorepo source but with different loaders, conditions, and targets:
+
+| Bundle | Config file | Runtime | Purpose |
+|---|---|---|---|
+| Client | `config/webpack/clientWebpackConfig.js` | Browser | Ships `use client` components + hydration runtime |
+| Server (SSR) | `config/webpack/serverWebpackConfig.js` | VM sandbox via `vm.createContext` inside the Node renderer | Renders HTML (including server components) |
+| RSC | `config/webpack/rscWebpackConfig.js` | Full Node | Renders the RSC Flight payload (server components are real; client components are turned into `registerClientReference` stubs) |
+
+VERIFIED in the Pro dummy: `react_on_rails_pro/spec/dummy/config/webpack/{client,server,rsc}WebpackConfig.js`.
+
+Routing between the three is controlled by env vars (`CLIENT_BUNDLE_ONLY`, `SERVER_BUNDLE_ONLY`, `RSC_BUNDLE_ONLY`) inside `ServerClientOrBoth.js` — the single entrypoint invoked by `webpack.config.js` / `rspack.config.js`. See `react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/ServerClientOrBoth.js.tt`.
+
+### 1.2 Where the RSC webpack plugin/loader are wired
+
+The `react-on-rails-rsc` npm package ships two build-time hooks:
+
+| Hook | Attached to | What it does |
+|---|---|---|
+| `react-on-rails-rsc/WebpackLoader` | RSC bundle only | Runs `react-server-dom-webpack-node-loader.production.js#load()` over every JS/TS file. Files with a `"use client"` directive get every export rewritten to a `registerClientReference(…)` stub (see `docs/pro/react-server-components/how-react-server-components-work.md:9-73`) |
+| `RSCWebpackPlugin` (wrapping `react-server-dom-webpack/plugin`) | Client **and** Server (SSR) bundles; **intentionally NOT on the RSC bundle** | Discovers `"use client"` files, emits each as a webpack entry, and writes `react-client-manifest.json` + `react-ssr-manifest.json` |
+
+The RSC bundle opts out via `serverWebpackConfig(true)` (see `react_on_rails/lib/generators/react_on_rails/templates/rsc/base/config/webpack/rscWebpackConfig.js.tt:22-23`). That's why current docs say the RSC bundle itself "should work with rspack today" — it uses only a loader + `resolve.conditionNames + resolve.alias`, which are vanilla bundler features.
+
+The WebpackPlugin is the hard part. It is attached in both `clientWebpackConfig.js` and `serverWebpackConfig.js` templates (behind `<% if use_rsc? %>` blocks) and is the sole producer of the two manifest files that React's runtime needs.
+
+### 1.3 Webpack internals the plugin reaches into
+
+From `packages/react-on-rails-rsc/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js` (vendored copy inside the `react-on-rails-rsc` repo at `/mnt/ssd/react-on-rails-rsc/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js:12-19`, 409 lines total):
+
+```js
+var path = require("path"),
+    url = require("url"),
+    asyncLib = require("neo-async"),
+    acorn = require("acorn-loose"),
+    ModuleDependency = require("webpack/lib/dependencies/ModuleDependency"),
+    NullDependency = require("webpack/lib/dependencies/NullDependency"),
+    Template = require("webpack/lib/Template"),
+    webpack = require("webpack");
+```
+
+Specific webpack internals exercised:
+
+| Webpack API | File:line | What it does in the plugin |
+|---|---|---|
+| `webpack/lib/dependencies/ModuleDependency` | `react-server-dom-webpack-plugin.js:16, 87` | Base class for `ClientReferenceDependency` — a custom dependency type |
+| `webpack/lib/dependencies/NullDependency` | `react-server-dom-webpack-plugin.js:17, 161` | Template for rendering the dependency as nothing (just registering it) |
+| `webpack/lib/Template` | `react-server-dom-webpack-plugin.js:18, 177` | `Template.toPath()` to sanitize chunk names from user requests |
+| `webpack.AsyncDependenciesBlock` | `react-server-dom-webpack-plugin.js:178` | Creates a split chunk per `use client` file |
+| `webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT` | `react-server-dom-webpack-plugin.js:203` | Hooks into the final asset-emission stage |
+| `webpack.sources.RawSource` | `react-server-dom-webpack-plugin.js:300` | Emits the manifest JSON as an asset |
+| `webpack.WebpackError` | `react-server-dom-webpack-plugin.js:208` | Pushes a compilation warning |
+| Compiler hooks | `react-server-dom-webpack-plugin.js:134, 154, 199` | `beforeCompile` (resolve client references), `thisCompilation` (register dep factories + parser hooks), `make` (attach `processAssets`) |
+| Compilation hooks | `react-server-dom-webpack-plugin.js:200` | `processAssets` (emit the manifest) |
+| `compilation.dependencyFactories.set` | `react-server-dom-webpack-plugin.js:158` | Tell webpack how to resolve `ClientReferenceDependency` |
+| `compilation.dependencyTemplates.set` | `react-server-dom-webpack-plugin.js:159` | Tell webpack how to render the dep |
+| `normalModuleFactory.hooks.parser.for('javascript/{auto,esm,dynamic}').tap` | `react-server-dom-webpack-plugin.js:188-196` | Intercept parsing of the `react-on-rails-rsc/client.{browser,node}.js` modules to inject dependencies for every `use client` file |
+| `parser.hooks.program.tap` | `react-server-dom-webpack-plugin.js:164` | AST-level hook: fires at the top of every parsed module |
+| `parser.state.module.addBlock(asyncBlock)` | `react-server-dom-webpack-plugin.js:184` | Programmatically attach an async dep block to the registration module |
+| `compilation.chunkGraph.getChunkModulesIterable` | `react-server-dom-webpack-plugin.js:282` | Traverse every module in every chunk |
+| `compilation.chunkGraph.getModuleId` | `react-server-dom-webpack-plugin.js:284` | Resolve concrete module IDs |
+| `compilation.chunkGroups`, `entrypoint.getRuntimeChunk()` | `react-server-dom-webpack-plugin.js:235-241, 241` | Walk runtime chunks to build the manifest |
+| `compilation.emitAsset` | `react-server-dom-webpack-plugin.js:298` | Write the manifest file |
+
+This is _deep_ webpack — well past the public plugin surface. It is the hardest chunk of the compatibility story.
+
+### 1.4 What the two manifests do
+
+The plugin emits two JSON files into the public output dir (`public/packs/...` or equivalent):
+
+- **`react-client-manifest.json`** — consumed by the RSC bundle at render time. Maps `file:///absolute/path/to/Component.jsx` → `{ id, chunks: [chunkId, chunkFile, …], name }`. Read from disk by `buildServerRenderer` in `/mnt/ssd/react-on-rails-rsc/src/server.node.ts:16-27`. Its `filePathToModuleMetadata` is passed to React's `renderToPipeableStream` so the Flight payload can reference client components by module ID + chunk filenames.
+- **`react-ssr-manifest.json`** — consumed during SSR of the Flight payload in `buildClientRenderer` (`/mnt/ssd/react-on-rails-rsc/src/client.node.ts:4-33`). Cross-references `clientManifest.filePathToModuleMetadata[x].id` with the server bundle's module IDs so that the SSR pass can actually require the client component implementation.
+
+### 1.5 Runtime primitives baked into React's Flight client
+
+VERIFIED in `/mnt/ssd/react-on-rails-rsc/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js:58-112`:
+
+```js
+var promise = __webpack_require__(id);
+...
+chunkFilename = __webpack_chunk_load__(chunkId);
+...
+webpackGetChunkFilename = __webpack_require__.u;
+__webpack_require__.u = function (chunkId) { ... };
+```
+
+React's _runtime_ code (not just the build-time plugin) depends on:
+- `__webpack_require__(id)` — synchronous module access by ID
+- `__webpack_chunk_load__(chunkId)` — promise-returning chunk loader
+- `__webpack_require__.u` — chunk filename resolver (React monkey-patches it to inject `crossOrigin` / `moduleLoading.prefix`)
+
+Rspack v1+ emits webpack-compatible runtime code (`__webpack_require__` etc.) by design, so the runtime piece is NEEDS VERIFICATION but is substantially more likely to "just work" than the plugin. See §2.
+
+### 1.6 Generator integration
+
+The generator logic that wires all this up (VERIFIED):
+
+- `react_on_rails/lib/generators/react_on_rails/rsc_generator.rb` — thin wrapper calling `rsc_setup.rb`
+- `react_on_rails/lib/generators/react_on_rails/rsc_setup.rb` — 705 lines doing the orchestration:
+  - `create_rsc_webpack_config` (line 149) — copies `rscWebpackConfig.js.tt` to destination
+  - `update_server_webpack_config_for_rsc` (line 374) — injects `RSCWebpackPlugin` via regex
+  - `update_client_webpack_config_for_rsc` (line 413) — injects `RSCWebpackPlugin` via regex
+  - `update_server_client_or_both_for_rsc` (line 318) — wires the RSC bundle into the dispatcher
+- `generator_helper.rb:203-207` — `destination_config_path` remaps `config/webpack/` → `config/rspack/` for rspack projects
+- `generator_helper.rb:373-379` — `rspack_configured_in_project?` detects rspack via `shakapacker.yml`
+
+The generator already produces correct content for rspack projects today — the _generated output_ is bundler-agnostic. What's unverified is whether `RSCWebpackPlugin`, once installed, will _run_ under rspack.
+
+### 1.7 RSC runtime flow (for reference)
+
+From `docs/pro/react-server-components/rendering-flow.md:82-107`:
+
+1. View calls `stream_react_component` → Node renderer gets rendering request
+2. Server bundle calls `generateRSCPayload(name, props)` (global injected by the Node renderer; see `packages/react-on-rails-pro/src/RSCRequestTracker.ts:32-38`)
+3. RSC bundle runs → produces Flight payload stream
+4. Server bundle (via `react-on-rails-rsc/client.node` → `buildClientRenderer`) decodes the Flight payload back into React elements, rendering HTML + embedding the Flight payload into the response
+5. Client bundle hydrates from embedded Flight payload (no separate round-trip)
+
+The client/server bundle pair's ability to do step 4 depends entirely on `react-ssr-manifest.json` + `react-client-manifest.json`, which exist only if `RSCWebpackPlugin` ran successfully.
+
+---
+
+## 2. Compatibility Analysis (Webpack vs Rspack)
+
+### 2.1 Build time — what each component needs from the bundler
+
+Legend: ✅ works unchanged · ⚠️ expected to work, needs runtime verification · ❌ definitely won't work without rspack-side changes or our own adapter
+
+| Component | File | Webpack | Rspack v1 | Rspack v2 | Notes |
+|---|---|---|---|---|---|
+| RSC bundle config (loader chain, `resolve.conditionNames`, `resolve.alias`) | `rscWebpackConfig.js.tt` | ✅ | ✅ | ✅ | Vanilla bundler surface. Already covered by 9 generator specs added in #3120 |
+| `react-on-rails-rsc/WebpackLoader` | `src/WebpackLoader.ts` | ✅ | ⚠️ | ⚠️ | Uses `this.resourcePath` + async source transform (standard loader API). Almost certainly works. The `await import('./…-node-loader.production.js')` path ships ESM; rspack's ESM loader interop needs verification |
+| `extractLoader` helper (function vs array `rule.use`) | `rscWebpackConfig.js.tt:34-61` | ✅ | ✅ | ✅ | Covered by generator specs; handles SWC (function) and Babel (array) styles |
+| `resolve.alias: { 'react-dom/server': false }` | `rscWebpackConfig.js.tt:69-74` | ✅ | ✅ | ✅ | Rspack supports `alias: false` (VERIFIED in Rspack docs & existing shakapacker `resolve.fallback` usage) |
+| `conditionNames: ['react-server', '...']` | `rscWebpackConfig.js.tt:66-68` | ✅ | ✅ | ✅ | Rspack supports `conditionNames` and the `'...'` continuation token |
+| `LimitChunkCountPlugin` | `serverWebpackConfig.js.tt:84` | ✅ | ✅ | ✅ | Accessed via `bundler.optimize.LimitChunkCountPlugin` where `bundler = require('@rspack/core')` — rspack exports this |
+| `RSCWebpackPlugin` → `react-server-dom-webpack/plugin` | `react-on-rails-rsc/WebpackPlugin.ts` → vendored plugin | ✅ | ❌ most likely | ⚠️ | The nine specific internal APIs in §1.3 are the crux. Rspack's "webpack plugin compat layer" covers most public hooks but is known to not cover `webpack/lib/dependencies/ModuleDependency` direct imports. See §2.2 below |
+| Three-bundle env routing (`RSC_BUNDLE_ONLY`) | `ServerClientOrBoth.js.tt` | ✅ | ✅ | ✅ | Pure JS env var check; bundler-independent |
+
+### 2.2 `RSCWebpackPlugin` — the blocker in detail
+
+The plugin does four distinct things. Each has a different compatibility picture:
+
+#### (a) Discover `"use client"` files
+
+File: `react-server-dom-webpack-plugin.js:307-407`.
+
+Uses `compiler.resolverFactory.get('context')` and `contextModuleFactory.resolveDependencies()`. **VERIFIED to exist in rspack** (rspack exposes `resolverFactory` as part of its webpack-compat API). ASSUMED to work.
+
+#### (b) Register `ClientReferenceDependency` as a webpack dependency type
+
+File: `react-server-dom-webpack-plugin.js:87-94, 158-162`.
+
+```js
+class ClientReferenceDependency extends ModuleDependency { … }
+compilation.dependencyFactories.set(ClientReferenceDependency, normalModuleFactory);
+compilation.dependencyTemplates.set(ClientReferenceDependency, new NullDependency.Template());
+```
+
+This requires `require('webpack/lib/dependencies/ModuleDependency')` to resolve to a real class with the expected shape. Rspack does **not** provide `webpack/lib/…` deep paths. There are three possible outcomes:
+
+1. If `webpack` is also installed (common in a rspack project because shakapacker still has it as a devDep): `require('webpack/lib/…')` resolves to real webpack internals. But the _compiler_ passed to `apply()` is from rspack. Mixing a webpack-class-derived dependency with an rspack compilation is untested. — NEEDS VERIFICATION
+2. If `webpack` is not installed: `require` throws, and the plugin crashes on load before ever seeing the compiler. — VERIFIED via code inspection
+3. Rspack's webpack-compat layer might transparently aliasing `webpack/lib/dependencies/*` to rspack equivalents in v2. — UNKNOWN
+
+The Rspack team's public statement (see [#1828 comment from @SyMind](https://github.com/shakacode/react_on_rails/issues/1828#issuecomment-3350629010)) says rspack "already supports RSC with JavaScript API", citing Next.js. Next.js, however, uses its _own_ bundled RSC plugin, not `react-server-dom-webpack/plugin`. So this comment does not directly answer our question.
+
+#### (c) Attach async dependency blocks
+
+File: `react-server-dom-webpack-plugin.js:178-184`:
+
+```js
+chunkName = new webpack.AsyncDependenciesBlock({ name: chunkName }, null, dep.request);
+chunkName.addDependency(dep);
+module.addBlock(chunkName);
+```
+
+`webpack.AsyncDependenciesBlock` is available on the top-level `webpack` export. Rspack v2 ASSUMED to expose `AsyncDependenciesBlock` via `@rspack/core` for compat, but NEEDS VERIFICATION. Even if the class exists, calling `module.addBlock(asyncBlock)` on an rspack-originated `module` object assumes matching internal shape — a _behavioral_ compat question that can only be answered by runtime test.
+
+#### (d) Walk the chunk graph + emit the manifest asset
+
+File: `react-server-dom-webpack-plugin.js:235-301`:
+
+```js
+compilation.chunkGroups.forEach(…)
+chunkGroup.chunks.forEach(c => { ... })
+compilation.chunkGraph.getChunkModulesIterable(chunk)
+compilation.chunkGraph.getModuleId(module)
+compilation.emitAsset(name, new webpack.sources.RawSource(…))
+```
+
+`chunkGraph`, `chunkGroups`, `emitAsset`, and `sources.RawSource` are all standard webpack-compat APIs that rspack claims to support. ASSUMED to work. NEEDS VERIFICATION.
+
+### 2.3 Runtime (React's Flight client inside the browser bundle)
+
+`__webpack_require__(id)`, `__webpack_chunk_load__(chunkId)`, and `__webpack_require__.u` are emitted by both webpack and rspack in the generated runtime code. Rspack explicitly treats these globals as part of its compatibility contract. ASSUMED to work without modification. This is the strongest part of the compat story.
+
+### 2.4 Rspack v1 vs v2 summary
+
+| Feature | v1 | v2 |
+|---|---|---|
+| `peerDependencies: ^1.0.0` in shakapacker | Yes | Yes (shakapacker currently pins `^1.5.8` devDep) |
+| Webpack plugin compatibility layer | Partial | Improved |
+| Hooks coverage (`beforeCompile`, `thisCompilation`, `processAssets`, etc.) | High | Higher |
+| `webpack/lib/dependencies/*` deep imports | UNKNOWN | UNKNOWN |
+| Production-stable | Yes | Beta → RC as of 2026-04 |
+| Built-in RSC support | No | Being designed (per @chenjiahan, [rspack PR #5824 comment](https://github.com/web-infra-dev/rspack/pull/5824#issuecomment-3425376710), Oct 2025) |
+
+Per Justin's direction (#1828 comment 2026-04-01): target v2. Shakapacker upgrade path needed because its current peerDep is `^1.0.0`.
+
+---
+
+## 3. Critical Discussion Points (decide BEFORE coding)
+
+These are decisions that change the shape of the implementation. Resolve each one before Phase 2.
+
+### 3.1 Single plugin vs separate plugins?
+
+**Options:**
+
+- **A. Single `RSCBundlerPlugin`** that feature-detects the compiler at `apply(compiler)` time and dispatches to either a webpack or rspack implementation.
+- **B. Two separate exports:** `react-on-rails-rsc/WebpackPlugin` (unchanged) and `react-on-rails-rsc/RspackPlugin`. Generator picks the right one.
+- **C. Single export that abstracts over a `BundlerPlugin` interface**, with two backends behind it.
+
+**Trade-offs:**
+
+- A has the smallest user-facing change but forces all rspack-specific logic to live next to webpack logic — hard to review.
+- B makes the two paths explicit and easy to test independently. Users see "oh, this is the rspack one." More files to ship.
+- C looks clean but adds indirection. Only worth it if the _logic_ is mostly shared — and it won't be if we ever write a from-scratch rspack manifest plugin.
+
+**Recommendation placeholder:** Leaning toward **B**. Simpler to test and to evolve independently if rspack ships built-in RSC later.
+
+### 3.2 Does `react-server-dom-webpack` work with rspack, or do we need an rspack-specific alternative?
+
+This is the single biggest unknown. Three scenarios:
+
+- **3.2.a — It works.** Runtime test passes; manifests generate correctly. Minimal work required; update docs only.
+- **3.2.b — Build-time plugin fails, runtime works.** We need to write a replacement manifest plugin using rspack-native APIs (`Compilation.PROCESS_ASSETS_STAGE_REPORT` + `sources.RawSource` are supported). The replacement must produce identical JSON shape so `buildServerRenderer` / `buildClientRenderer` keep working unchanged.
+- **3.2.c — Runtime breaks too.** We need to either (i) use a bundled `react-server-dom-rspack` if/when it exists, or (ii) wait for rspack's built-in RSC support. There's no evidence a `react-server-dom-rspack` package exists as of 2026-04.
+
+**Action:** Phase 0 _must_ distinguish 3.2.a from 3.2.b before we commit to any architectural direction.
+
+### 3.3 Rspack v1 vs v2 target
+
+Justin's call: **v2**. v2 has better compatibility; shakapacker will need to bump its peerDep from `^1.0.0` to `^1.0.0 || ^2.0.0-0`. Potential downstream: users already on v1 get a supported config for longer if we DON'T bump. Decide:
+
+- Support both v1 and v2 during a transition window (generator detects version; RSC docs call out the minimum required)
+- Only support v2 for RSC (simpler; narrower surface to test)
+
+**Recommendation placeholder:** Only v2 for RSC. Users on rspack v1 stick with non-RSC setups (which already work today).
+
+### 3.4 How to handle `require('webpack')` inside `react-server-dom-webpack/plugin`?
+
+Line 19 of the vendored plugin: `webpack = require("webpack");`. Even if the compiler is rspack, this forces the _webpack_ npm package to be installed so the `require` resolves.
+
+Options:
+
+- **Leave as-is; require users to keep `webpack` as a devDep.** Fragile: dependency sprawl; the compiler and the `webpack` module are not in sync, so some globals (`webpack.AsyncDependenciesBlock`) come from webpack but the compiler is rspack.
+- **Module alias at install time:** Generator or install hook aliases `webpack` → `@rspack/core` in `package.json` (`resolutions` / `pnpm.overrides`). Brittle — rspack's top-level exports don't fully match webpack's.
+- **Fork/patch the vendored plugin** in `react-on-rails-rsc` to accept a bundler instance via its constructor options (`new RSCWebpackPlugin({ isServer, bundler: require('@rspack/core') })`). Then no top-level `require` of `webpack` is needed. Requires patching `react-server-dom-webpack-plugin.js` — but the file is already vendored, so this is an option.
+- **Use a Node `Module._resolveFilename` hook at install time** to redirect `webpack/lib/*` → rspack equivalents. Too hacky; reject.
+
+**Recommendation placeholder:** Fork + patch the vendored plugin to receive an explicit `bundler` handle. This is a one-time change, localized to the `react-on-rails-rsc` package, and keeps us out of monkey-patching Node.
+
+### 3.5 Rename `*WebpackConfig.js` → bundler-neutral names?
+
+Issue #2552 is an open RFC. The rename is a breaking change across 5 templates + 57 Ruby refs + 181 spec refs + 15 dummy files + 18 doc files.
+
+Options (abbreviated from #2552):
+- **A.** Rename to `commonConfig.js`, `clientConfig.js`, `serverConfig.js`, `rscConfig.js`
+- **B.** Keep names; add doc comment clarifying bundler-agnosticism
+- **C.** Bundler-specific names per bundler (`serverRspackConfig.js` for rspack installs)
+- **D.** Rename for new installs only; keep back-compat regex in the generator
+
+**Recommendation placeholder:** Option D bundled into the next major version. Not a blocker for RSC-rspack work. **Do this work _separately_ to avoid entangling a breaking rename with the runtime verification.** If we _are_ going to do it anyway, do it before or after, not mixed in.
+
+### 3.6 Testing strategy — separate CI job?
+
+The current CI matrix (see `.github/workflows/pro-integration-tests.yml`) runs the Pro dummy's full test suite. Adding an rspack permutation doubles runtime for every RSC test. Options:
+
+- **Dedicated smoke-test job:** `pro-rsc-rspack-smoke.yml` that only builds the three bundles + checks manifests exist + runs one E2E test. Fast.
+- **Parametric matrix:** Every pro-integration test runs on both webpack and rspack. Comprehensive but expensive.
+- **Separate dummy app:** `react_on_rails_pro/spec/dummy-rspack-rsc/` shadow app with identical specs. Maintainability nightmare.
+
+**Recommendation placeholder:** Start with the smoke-test job. Graduate to a matrix _after_ the smoke test has been green for a while.
+
+### 3.7 What to do about the two vendored pieces of React source?
+
+`react-on-rails-rsc` currently vendors:
+- `src/react-server-dom-webpack/cjs/` — compiled React runtime (client + server + static)
+- `src/react-server-dom-webpack/esm/react-server-dom-webpack-node-loader.production.js`
+- `src/react-server-dom-webpack/plugin.js` → `cjs/react-server-dom-webpack-plugin.js`
+
+Vendoring means:
+- We can patch (good for §3.4)
+- We must track React upstream carefully — version bumps are non-trivial
+- Users running the loader/plugin use OUR copy of React's internals
+
+Decision: Do we continue vendoring, or depend on the published `react-server-dom-webpack` npm package?
+
+**Recommendation placeholder:** Keep vendoring for now. Vendoring is what makes §3.4's "fork & patch the plugin" feasible. Revisit once React ships officially supported rspack variants.
+
+---
+
+## 4. Refactoring Opportunities (before implementation)
+
+Cheap, invisible-to-users refactors that make the rspack work safer, smaller, and more reviewable. **Do these first.**
+
+### 4.1 Extract the bundler-specific `require('webpack')` out of the plugin
+
+**Current:** `react-server-dom-webpack-plugin.js` top-of-file hardcodes every webpack import.
+
+**Proposed:** `WebpackPlugin.ts` already wraps the plugin. Change the wrapper to accept an injected `bundler` and re-export a constructor that reads from that bundler:
+
+```ts
+// react-on-rails-rsc/src/BundlerPlugin.ts (new name / new interface)
+export interface BundlerPluginOptions {
+  isServer: boolean;
+  bundler?: typeof import('webpack') | typeof import('@rspack/core');
+  // ...
+}
+```
+
+Make `bundler` default to `require('webpack')` for back-compat. Then the vendored plugin accesses its dependencies via this option instead of `require()`-ing webpack directly. Small API change; shippable as a non-breaking minor of `react-on-rails-rsc`.
+
+### 4.2 Normalize naming in `react-on-rails-rsc` package exports
+
+**Current exports:** `./WebpackPlugin`, `./WebpackLoader` (with the "Webpack" literal baked in).
+
+**Proposed:** Add `./BundlerPlugin` and `./BundlerLoader` as aliases. Keep the webpack-named exports for back-compat. Generator emits imports against the new names for new projects.
+
+Same philosophy as #2552 but localized to this npm package — no Ruby generator ripples.
+
+### 4.3 Lift the three-bundle awareness into a single module
+
+**Current:** `ServerClientOrBoth.js` is template-assembled via ERB branching (`<% if use_rsc? %>`), and the env-var dispatch logic is rewritten by `rsc_setup.rb#update_server_client_or_both_for_rsc` (four `gsub_file` calls, lines 318-372, fragile regex).
+
+**Proposed:** Ship a `buildBundleDispatcher(configs: { client, server, rsc? })` helper in `shakapacker` or in `react-on-rails`. The generated `ServerClientOrBoth.js` becomes:
+
+```js
+const { buildBundleDispatcher } = require('react-on-rails/bundler-dispatcher');
+module.exports = buildBundleDispatcher({
+  client: require('./clientConfig'),
+  server: require('./serverConfig'),
+  rsc: require('./rscConfig'), // omit for non-RSC installs
+});
+```
+
+Generator stops surgical-editing the file; it just re-emits it when RSC is added. This also fixes the brittle `gsub_file` patterns in `rsc_setup.rb:318-372`.
+
+Effort: medium. Risk: medium (changes a long-standing config layout). Not a blocker but a real gain.
+
+### 4.4 Consolidate `extractLoader` in one place
+
+Currently duplicated in:
+- `react_on_rails/lib/generators/react_on_rails/templates/rsc/base/config/webpack/rscWebpackConfig.js.tt:12-19`
+- `react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt:14-25`
+- `react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js:7-20`
+
+And the RSC template has a fallback inline version. Propose exporting `extractLoader` from a small utility module in the generated config tree (`config/webpack/utils/extractLoader.js`) so there's one copy.
+
+### 4.5 Move rspack-vs-webpack branching into a helper
+
+**Current:** `const bundler = config.assets_bundler === 'rspack' ? require('@rspack/core') : require('webpack');` is duplicated in `serverWebpackConfig.js.tt` and (potentially) other templates.
+
+**Proposed:** Export `resolveBundler()` from shakapacker (already exists under `shakapacker/webpack` and `shakapacker/rspack` sub-paths but not as a neutral resolver). Generated configs use that once.
+
+Discuss this with the shakapacker team — cross-repo change.
+
+### 4.6 Decouple generator regex rewrites from template shape
+
+`rsc_setup.rb` does 10+ `gsub_file` calls to inject RSC wiring into existing webpack configs. These regexes assume:
+
+- The exact string `const configureServer = () =>` exists in `serverWebpackConfig.js`
+- `serverWebpackConfig.plugins.unshift(new bundler.optimize.LimitChunkCountPlugin` appears exactly once
+- Import lines match specific shapes
+
+Any divergence (e.g., an rspack project that uses `@rspack/core` via a differently-named local helper) will silently fail. The `verify_rsc_webpack_transforms` check (line 441) catches _some_ failures but warns on others.
+
+**Proposed:** Convert these `gsub_file` rewrites to a single idempotent re-template step. I.e., instead of incremental patching, mark config files with a sentinel comment that the generator owns, and rewrite the whole section each time. Lower risk of silent rewrite failure.
+
+---
+
+## 5. Implementation Plan (Phased)
+
+### Phase 0 — Discovery (prerequisite for all other phases)
+
+**Goal:** Answer §3.2 definitively. Produce a runnable artifact that builds all three bundles using rspack v2 and demonstrates whether `RSCWebpackPlugin` works.
+
+**Scope:**
+- Create a fresh Pro dummy or a minimal repro in `react_on_rails_pro/spec/rsc-rspack-smoke/`
+- Configure it for rspack v2 (bump `@rspack/core` to `^2.0.0-0`)
+- Run `RSC_BUNDLE_ONLY=true bin/shakapacker` — expect ✅
+- Run `SERVER_BUNDLE_ONLY=true bin/shakapacker` — this is the critical one
+  - If plugin crashes on load (can't find `webpack/lib/...`) → confirms 3.2.b
+  - If plugin loads but the manifest is malformed/empty → confirms 3.2.b with a different fix
+  - If manifest matches the webpack-produced shape byte-for-byte → confirms 3.2.a
+- Run `CLIENT_BUNDLE_ONLY=true bin/shakapacker` — same
+- Run the Pro dummy's RSC E2E test against the rspack-built bundles — confirms runtime
+
+**Specific file changes:** None to production code. This is pure spike.
+
+**Risks:**
+- We don't have an rspack v2 in the lockfile today; may need temporary `@rspack/core@canary`
+- shakapacker may need patching to accept rspack v2 (peer dep says `^1.0.0`)
+
+**Effort:** Small (1-3 days assuming no surprises; medium if shakapacker bumps are needed)
+
+**Blockers:** shakapacker v2 peer-dep acceptance (may require a shakapacker PR)
+
+**Deliverable:** A short internal note with concrete findings — which of §3.2.a/b/c we're in.
+
+### Phase 1 — Refactoring (non-user-visible prep)
+
+**Goal:** Do §4.1, §4.4, §4.6 to make Phase 2 small and reviewable.
+
+**Specific file changes:**
+- `packages/react-on-rails-rsc/src/WebpackPlugin.ts` → Accept optional `bundler` option (4.1)
+- `packages/react-on-rails-rsc/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js` → Use an injected `bundler` handle instead of top-level `require('webpack')` (4.1)
+- Add `react-on-rails-rsc/BundlerPlugin` + `BundlerLoader` export aliases (4.2 — trivial)
+- `react_on_rails/lib/generators/react_on_rails/templates/rsc/base/config/webpack/rscWebpackConfig.js.tt` → Use shared `extractLoader` (4.4)
+- `react_on_rails/lib/generators/react_on_rails/rsc_setup.rb` → Replace `gsub_file` patching with full re-template where possible (4.6)
+
+**Risks:**
+- Changing the plugin wrapper signature could break existing users on webpack. Mitigate by keeping the old constructor shape as the default and making `bundler` option additive.
+- Refactoring `rsc_setup.rb` re-templating may clobber user-customized configs. Add a backup step and a prompt before overwriting.
+
+**Effort:** Medium
+
+**Blockers:** None
+
+### Phase 2 — Compatibility fixes
+
+**Goal:** Make RSC run end-to-end under rspack v2. Specifics depend on Phase 0 outcome.
+
+**If Phase 0 → 3.2.a (plugin works unchanged):**
+- Small: just flip on the generator path, update `rspack-compatibility.md` from "Experimental" → "Supported"
+- Effort: small
+
+**If Phase 0 → 3.2.b (plugin needs rewrite):**
+- Write `RSCRspackPlugin` in `react-on-rails-rsc` using only rspack-compatible APIs:
+  - `@rspack/core` top-level exports (`AsyncDependenciesBlock`, `Compilation`, `sources`) if they exist in v2
+  - If `dependencyFactories.set` is rspack-incompatible: use the `compilation.hooks.finishModules` → walk modules → inject a synthesized module technique that Parcel's RSC plugin uses (needs research)
+  - Emit identical JSON manifest shape so `buildClientRenderer`/`buildServerRenderer` keep working unchanged
+- Generator emits `RSCRspackPlugin` for rspack and `RSCWebpackPlugin` for webpack
+- Effort: large
+
+**If Phase 0 → 3.2.c (runtime breaks too):**
+- Stop. Wait for either:
+  - rspack's built-in RSC support to ship (timeline: UNKNOWN)
+  - a `react-server-dom-rspack` npm package from React/Rspack
+- Update `rspack-compatibility.md` to explicitly list "RSC + rspack = not supported, here's why, here's the tracking issue"
+- Effort: small (just docs)
+
+**Risks:**
+- If we take the rewrite path, the JSON manifest shape must stay identical or the `react-on-rails-rsc` client module breaks. Add a snapshot test of the manifest JSON shape before refactoring.
+- React's Flight runtime MIGHT emit chunk loading code that rspack's runtime doesn't satisfy. Hard to detect without E2E test.
+
+**Effort:** Range — small (a) → large (b) → small (c)
+
+**Blockers:** Phase 0 outcome. Also potentially: shakapacker upstream changes if rspack v2 isn't supported there yet (see shakapacker#984).
+
+### Phase 3 — Testing infrastructure
+
+**Goal:** Prevent regression once Phase 2 ships.
+
+**Specific file changes:**
+- `.github/workflows/pro-rsc-rspack-smoke.yml` — new. Minimal 3-bundle build + check manifests + one E2E navigation test
+- `react_on_rails_pro/spec/dummy/` — add an rspack-flavored config alongside the webpack one (behind an env var switch) OR create a sibling dummy
+- `react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb` — extend the existing "Rspack RSC runtime compatibility" block (added in PR #3120) with assertions that the _generated_ configs now reference the `BundlerPlugin` aliases
+- `packages/react-on-rails-rsc/tests/` — Jest tests for the refactored plugin wrapper (injection of bundler option, default webpack path)
+
+**Risks:**
+- Rspack binaries are native; CI image sizing / install time. Mitigate via caching.
+- Test flakiness due to rspack v2 beta churn. Pin exact version; bump deliberately.
+
+**Effort:** Medium
+
+**Blockers:** Phase 2 done
+
+### Phase 4 — Documentation
+
+**Specific file changes:**
+- `docs/pro/react-server-components/rspack-compatibility.md` — update status from "Experimental" → "Supported" (or "Limited" depending on Phase 2 outcome). Remove speculation. Add verified compatibility matrix.
+- `docs/pro/react-server-components/create-without-ssr.md` — add rspack-specific notes where needed
+- `docs/pro/react-server-components/index.md` — link to rspack-compatibility doc
+- `docs/oss/migrating/migrating-from-webpack-to-rspack.md` — add RSC section
+- `docs/oss/migrating/rsc-preparing-app.md` — callouts for rspack users
+- `CHANGELOG.md` — per `.claude/docs/changelog-guidelines.md`
+- `packages/react-on-rails-rsc/README.md` — document the new `bundler` option and BundlerPlugin exports
+- Generator output messages — print "Rspack" vs "Webpack" where applicable (already partly done)
+
+**Risks:** None meaningful. Docs-only.
+
+**Effort:** Small
+
+**Blockers:** Phases 2 and 3
+
+---
+
+## 6. Open Questions and Unknowns
+
+Items that require external input or runtime verification.
+
+| # | Question | Needs input from | Why it matters |
+|---|---|---|---|
+| Q1 | Does `compilation.dependencyFactories.set(ClientReferenceDependency, factory)` work when `ClientReferenceDependency` extends a webpack class but the compilation is rspack? | Rspack team / runtime test | Determines whether §3.2.a or §3.2.b is reality |
+| Q2 | Does rspack v2's top-level `@rspack/core` export include `AsyncDependenciesBlock`? | Rspack docs / source inspection | Governs §3.4 decision |
+| Q3 | Does rspack emit `__webpack_require__`, `__webpack_chunk_load__`, and `__webpack_require__.u` in an ABI-identical way to webpack 5? | Runtime test | If not, React's Flight client won't work |
+| Q4 | Is the Rspack team's built-in RSC support going to land in 2026? If so, when? Is there a public roadmap? | Rspack team (@SyMind, @chenjiahan) | Affects §3.2.c fallback; could obviate custom plugin work |
+| Q5 | Should `react-on-rails-rsc` depend on `react-server-dom-webpack` as an npm dependency instead of vendoring? (Vendoring makes §3.4 feasible but creates maintenance burden on every React release.) | shakacode internal | §3.7 decision |
+| Q6 | If we fork the plugin, how do we keep it in sync with upstream React? | React team or internal policy | Sustainability |
+| Q7 | Does Next.js's RSC + Rspack setup (cited by @SyMind) use `react-server-dom-webpack/plugin` or a fork/replacement? | Next.js source + Rspack team | Datapoint for Q1/Q2 |
+| Q8 | Is `react-server-dom-rspack` in anyone's roadmap? (Google search negative as of 2026-04-14) | React team | §3.2.c path |
+| Q9 | Is the shakapacker team OK with bumping rspack peer dep to `^1.0.0 \|\| ^2.0.0-0`? | shakapacker maintainers | Gates rspack v2 adoption |
+| Q10 | Should RSC support require a specific minimum shakapacker version? If so, which? | Internal | Generator prereq check |
+| Q11 | Does the `@rspack/core` bundle include working `sources.RawSource`? | Rspack source inspection | `emitAsset` path |
+| Q12 | How do rspack's `ContextModule` semantics compare to webpack's? The plugin uses `contextModuleFactory.resolveDependencies` to enumerate the app tree. | Runtime test | Plugin step (a) |
+| Q13 | Do we need to handle HMR / dev-server behavior differently? Rspack's dev server is compatible, but the RSC plugin's `beforeCompile` hook fires differently in watch mode. | Runtime test | Dev-mode usability |
+
+---
+
+## 7. Risk Matrix
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | `react-server-dom-webpack/plugin` fails on rspack v2 due to webpack internals incompatibility | High | High | Phase 0 discovery before committing; if it fails, write rspack-native plugin OR wait for rspack's built-in RSC |
+| R2 | Manifests produced by rspack have different JSON shape than webpack, breaking `buildServerRenderer` / `buildClientRenderer` | Medium | High | Add snapshot tests for manifest JSON shape; ensure any rspack-native plugin produces identical output |
+| R3 | React's Flight client runtime expects webpack-specific chunk loading ABI that rspack doesn't emit | Low | High | Validate at runtime in Phase 0; issue upstream to React if real |
+| R4 | Rspack v2 GA slips; shakapacker peer dep bump delays the whole feature | Medium | Medium | Gate RSC-rspack support on shakapacker shipping v2 compat; ship non-RSC rspack work independently |
+| R5 | React upstream releases a new `react-server-dom-webpack` internals shape before we finish, breaking our vendored fork | Medium | Medium | Version-pin vendored React pieces; treat bumps as code changes, not dependency bumps |
+| R6 | Generator regex rewrites in `rsc_setup.rb` silently fail when applied to rspack project configs that have drifted from templates | Medium | Medium | Convert to re-template approach (§4.6); expand `verify_rsc_webpack_transforms` coverage |
+| R7 | CI time doubles because RSC tests now run twice (webpack + rspack) | Low | Medium | Start with a single smoke-test job; add matrix later |
+| R8 | Breaking change to `react-on-rails-rsc` plugin constructor signature breaks existing webpack users | Low | High | Keep old constructor shape as default; make `bundler` option additive and back-compat |
+| R9 | Rspack built-in RSC support ships while we're mid-implementation, making our custom plugin obsolete | Medium | Low | Our plugin targets both v1 and v2; switching to rspack's built-in later is a docs-only change |
+| R10 | The fork-and-patch of the vendored React plugin diverges from upstream and accumulates drift | Medium | Medium | Minimal patches; annotate every change with upstream commit hash; document patch strategy in `react-on-rails-rsc/README.md` |
+| R11 | Users who already deployed `enable_rsc_support = true` with rspack hit a runtime error (because we said "Experimental" but it works for generator/doesn't work at runtime) | High (already shipped) | Medium | Ship a version bump that makes the failure mode explicit and actionable; update `rspack-compatibility.md` to reflect reality once Phase 0 is done |
+| R12 | Rename of `*WebpackConfig.js` (#2552) lands concurrently and invalidates all our generator regex patches | Medium | High | Coordinate with #2552 author; do not land #2552 during Phase 1/2 |
+| R13 | Phase 2 rewrite is large and slips, blocking a release train | Medium | Medium | Ship phases independently; Phase 0 is time-boxed; if Phase 2 grows, ship `rspack-compatibility.md` update first |
+| R14 | React's `renderToPipeableStream` behavior depends on exact module ID scheme used by the bundler; rspack module IDs might not match | Low | High | Validate in Phase 0; fall back to deterministic-ID config if needed |
+
+---
+
+## 8. Related Links / References
+
+### Tracking issues and PRs
+
+- [#1828](https://github.com/shakacode/react_on_rails/issues/1828) — Rspack support for RSC (P1, original tracker; @SyMind Rspack-team comment; Justin's "let's focus on rspack v2" directive 2026-04-01)
+- [#2552](https://github.com/shakacode/react_on_rails/issues/2552) — RFC: Rename bundler-agnostic config files from `*WebpackConfig.js`
+- [#2633](https://github.com/shakacode/react_on_rails/issues/2633) — Follow-up: tighten Doctor/SystemChecker webpack config diagnostics during Rspack migration
+- [#3120](https://github.com/shakacode/react_on_rails/pull/3120) — Add Rspack + RSC compatibility tests and documentation (merged; added 9 generator specs + `rspack-compatibility.md`)
+- [#3128](https://github.com/shakacode/react_on_rails/issues/3128) — Gumroad public comparison repo: React 19 + Rspack + RSC findings
+- [#3141](https://github.com/shakacode/react_on_rails/issues/3141) — THIS ISSUE: Revise Rspack support and plan RSC + Rspack compatibility
+- [#1862](https://github.com/shakacode/react_on_rails/issues/1862) — Rake task to generate and export reference webpack/rspack configurations
+- [#2410](https://github.com/shakacode/react_on_rails/issues/2410) — Generator creates rspack configs in deprecated `config/webpack/` (closed by #2417)
+- [#2417](https://github.com/shakacode/react_on_rails/pull/2417) — Generate `--rspack` configs under `config/rspack/` (merged)
+- [shakacode/shakapacker#984](https://github.com/shakacode/shakapacker/issues/984) — Switch to rspack drops compression plugin and optimization
+- [shakacode/shakapacker#1090](https://github.com/shakacode/shakapacker/issues/1090) — Doctor reports false SWC issues for hybrid setups (referenced by #3141)
+- [web-infra-dev/rspack#5824](https://github.com/web-infra-dev/rspack/pull/5824) — feat: rsc plugin (closed; superseded by future built-in support per @chenjiahan 2025-10)
+
+### Existing docs
+
+- `docs/pro/react-server-components/rspack-compatibility.md` — starting-point doc; compatibility matrix
+- `docs/pro/react-server-components/how-react-server-components-work.md` — the loader + plugin + manifest explainer
+- `docs/pro/react-server-components/rendering-flow.md` — three-bundle architecture + VM sandbox vs full Node distinction
+- `docs/pro/react-server-components/create-without-ssr.md` — step-by-step RSC setup
+- `docs/oss/migrating/migrating-from-webpack-to-rspack.md` — general rspack migration guide
+- `.claude/docs/analysis/RSPACK_IMPLEMENTATION.md` — historical notes on the `--rspack` flag rollout
+
+### Key source files in this repo
+
+- `react_on_rails/lib/generators/react_on_rails/rsc_setup.rb` — 705-line RSC generator orchestration
+- `react_on_rails/lib/generators/react_on_rails/rsc_generator.rb` — generator entry
+- `react_on_rails/lib/generators/react_on_rails/generator_helper.rb:190-207, 373-379` — rspack detection + path remap
+- `react_on_rails/lib/generators/react_on_rails/templates/rsc/base/config/webpack/rscWebpackConfig.js.tt`
+- `react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/{server,client,common}WebpackConfig.js.tt`
+- `react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/ServerClientOrBoth.js.tt`
+- `react_on_rails_pro/spec/dummy/config/webpack/{client,server,rsc}WebpackConfig.js` — reference working setup
+- `packages/react-on-rails-pro/src/RSCRoute.tsx`, `RSCProvider.tsx`, `RSCRequestTracker.ts`, `capabilities/proRSC.ts`, `getReactServerComponent.server.ts`, `ReactOnRailsRSC.ts` — Pro runtime
+
+### External source files (outside this repo)
+
+- `/mnt/ssd/react-on-rails-rsc/src/WebpackPlugin.ts` — `RSCWebpackPlugin` wrapper
+- `/mnt/ssd/react-on-rails-rsc/src/WebpackLoader.ts` — the `use client` transform loader
+- `/mnt/ssd/react-on-rails-rsc/src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js` — **the critical 409-line vendored React plugin** using all the webpack internals
+- `/mnt/ssd/react-on-rails-rsc/src/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.production.js:58-112` — proof that runtime uses `__webpack_require__` et al
+- `/mnt/ssd/react-on-rails-rsc/src/{client.node,client.browser,server.node}.ts` — the shakacode-owned API surface on top of React's internals
+- `/mnt/ssd/shakacode-related/shakapacker/package/plugins/rspack.ts`, `rules/rspack.ts` — reference for how shakapacker wires rspack today
+- `/mnt/ssd/shakacode-related/shakapacker/package.json:54-55, 102-103` — rspack peer-dep `^1.0.0` (needs bump for v2)
+
+### Rspack references
+
+- Rspack docs: https://rspack.dev/
+- Rspack webpack API compatibility: https://rspack.dev/guide/migration/webpack-compat
+- Rspack v2 release notes: (UNKNOWN — check https://rspack.dev/blog/ at implementation time)
+- Next.js Rspack integration (per @SyMind's reference): https://github.com/vercel/next.js
+
+### React RSC references
+
+- React docs — How to build support for Server Components: https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components
+- React source — `react-server-dom-webpack`: https://github.com/facebook/react/tree/main/packages/react-server-dom-webpack
+
+### Our own Claude-oriented docs (for Phase 3 context)
+
+- `.claude/docs/avoiding-ci-failure-cycles.md`
+- `.claude/docs/replicating-ci-failures.md`
+- `.claude/docs/playwright-e2e-testing.md`
+- `.claude/docs/project-architecture.md`
+- `.claude/docs/rails-engine-nuances.md`
+- `.claude/docs/debugging-webpack.md`
+- `.claude/docs/testing-build-scripts.md`
+- `.claude/docs/changelog-guidelines.md`

--- a/.claude/docs/rsc-rspack-plugin-implementation.md
+++ b/.claude/docs/rsc-rspack-plugin-implementation.md
@@ -1,0 +1,618 @@
+# RSC + Rspack: Plugin Implementation Plan
+
+**Status:** Design complete, ready for implementation
+**Related tracking issue:** [shakacode/react_on_rails#3141](https://github.com/shakacode/react_on_rails/issues/3141)
+**Related tests branch:** [shakacode/react_on_rails_rsc#test/rspack-compatibility](https://github.com/shakacode/react_on_rails_rsc/tree/test/rspack-compatibility) (31 tests proving runtime compat)
+**Companion docs:**
+- [`.claude/docs/rspack-rsc-support-state.md`](./rspack-rsc-support-state.md) — state of rspack's official RSC support
+- [`.claude/docs/rsc-rspack-implementation-plan.md`](./rsc-rspack-implementation-plan.md) — original high-level plan (superseded by this doc for plugin specifics)
+
+---
+
+## Executive Summary
+
+**Only ONE file in `react-on-rails-rsc` is incompatible with rspack: `RSCWebpackPlugin`.** Everything else (loader, server.node, client.node, client.browser) works with rspack unchanged — proven empirically by a 31-test suite that builds and runs all four components under rspack v1.7.11.
+
+**The plan:** dual-path plugin behind the existing `RSCWebpackPlugin` facade. Webpack projects keep the current code path (unchanged). Rspack projects get a new path that uses only standard rspack-compatible bundler APIs — no dependency on rspack's experimental RSC system, no configuration flags, no `react-server-dom-rspack`. The manifest JSON schemas stay identical, so `server.node.ts`, `client.node.ts`, and `client.browser.ts` require zero changes.
+
+**Open item to validate during implementation:** the `chunkCache` behavior in `react-server-dom-webpack`'s browser runtime. `react-server-dom-rspack` ships a 394-line patch removing the cache; likely needed for us too.
+
+---
+
+## Table of Contents
+
+1. [What We Verified Empirically](#1-what-we-verified-empirically)
+2. [Why Only the Plugin Needs Changing](#2-why-only-the-plugin-needs-changing)
+3. [What Rspack's Built-in RSC Does (and Why We Won't Use It)](#3-what-rspacks-built-in-rsc-does-and-why-we-wont-use-it)
+4. [Manifest Schema Comparison](#4-manifest-schema-comparison)
+5. [Plugin Architecture Decision](#5-plugin-architecture-decision)
+6. [Discovery Technique: FS Walk vs. Module Graph Walk](#6-discovery-technique-fs-walk-vs-module-graph-walk)
+7. [Chunk-Splitting Technique: Custom Dependency vs. AsyncDependenciesBlock](#7-chunk-splitting-technique-custom-dependency-vs-asyncdependenciesblock)
+8. [Runtime Compatibility Risks](#8-runtime-compatibility-risks)
+9. [Implementation Plan](#9-implementation-plan)
+10. [Known Unknowns to Validate in Prototype](#10-known-unknowns-to-validate-in-prototype)
+11. [References](#11-references)
+
+---
+
+## 1. What We Verified Empirically
+
+### 1.1 The 31-test compatibility suite
+
+Pushed to `shakacode/react_on_rails_rsc` on branch `test/rspack-compatibility`. Seven test suites:
+
+| Suite | Tests | Verifies |
+|---|---|---|
+| `static-analysis.test.ts` | 10 | No webpack internals imported in any of the 4 target files |
+| `rspack-runtime-abi.test.ts` | 6 | Rspack emits `__webpack_require__`, `__webpack_chunk_load__`, mutable `__webpack_require__.u` |
+| `webpack-loader.rspack.test.ts` | 3 | `RSCWebpackLoader` runs under rspack, produces `registerClientReference` stubs |
+| `server-node.rspack.test.ts` | 3 | `server.node` bundles with rspack; `renderToPipeableStream` works in the rspack-built output |
+| `client-node.rspack.test.ts` | 3 | `client.node` bundles with rspack; `buildClientRenderer` callable |
+| `client-browser.rspack.test.ts` | 5 | `client.browser` bundles for web target; `createFromFetch` / `createFromReadableStream` exported; `__webpack_require__.u` assignable |
+| `end-to-end.rspack.test.ts` | 1 | **Full pipeline:** rspack-bundled server encodes a React tree → rspack-bundled client decodes it → tree matches input |
+
+All 31 tests green in 5.9 seconds. The end-to-end test is the strongest evidence: a complete Flight-encode → Flight-decode round trip works when both sides are produced by rspack.
+
+### 1.2 A working pure-rspack RSC demo (no React on Rails)
+
+Location: `/mnt/ssd/demos/rspack-rsc-pure`. Runs at http://localhost:3000. Produces full HTML server-side with embedded Flight payload. Uses:
+- `@rspack/core@2.0.0-rc.2` (released 2026-04-14)
+- `react-server-dom-rspack@0.0.2` (maintained by SyMind / ByteDance)
+- `react@19.2.0` + Express 5 + `worker_threads`
+
+This proves RSC is buildable with rspack end-to-end today, outside React on Rails.
+
+### 1.3 Rspack's public runtime globals
+
+From direct inspection of `@rspack/core` v1.7.11 exports:
+
+| Needed by RoR's runtime | Rspack provides |
+|---|---|
+| `__webpack_require__(id)` | ✓ emitted identically |
+| `__webpack_chunk_load__(chunkId)` | ✓ emitted identically |
+| `__webpack_require__.u(chunkId)` | ✓ emitted as assignable property (React monkey-patches it) |
+| `AsyncDependenciesBlock` | ✓ `rspack.AsyncDependenciesBlock` (top-level export) |
+| `Compilation.PROCESS_ASSETS_STAGE_REPORT` | ✓ `rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT = 5000` |
+| `sources.RawSource` | ✓ `rspack.sources.RawSource` |
+| `Template.toPath` | ✓ `rspack.Template.toPath` |
+| `WebpackError` | ✓ `rspack.WebpackError` |
+
+Only the `webpack/lib/*` deep imports (`ModuleDependency`, `NullDependency`) are not exposed — these are the webpack-internals that make the current `RSCWebpackPlugin` rspack-incompatible.
+
+---
+
+## 2. Why Only the Plugin Needs Changing
+
+### 2.1 The complete compatibility scorecard for `react-on-rails-rsc`
+
+| File | Rspack-compatible? | Why |
+|---|---|---|
+| `src/WebpackLoader.ts` | ✅ | Only uses `this.resourcePath`. No webpack internals. |
+| `src/server.node.ts` | ✅ | Renders via `renderToPipeableStream`; only Node built-ins + `react-dom` needed. No `require('webpack')`. |
+| `src/client.node.ts` | ✅ | Uses `__webpack_require__` / `__webpack_chunk_load__` at runtime — rspack emits both. |
+| `src/client.browser.ts` | ✅ | Same — uses runtime globals only. |
+| `src/types.ts` | ✅ | Types only; no runtime code. |
+| **`src/WebpackPlugin.ts`** | ❌ | Wraps `react-server-dom-webpack/plugin` which imports `webpack/lib/dependencies/ModuleDependency`, `webpack/lib/dependencies/NullDependency`, `webpack/lib/Template`, and `webpack` itself. Also calls `contextModuleFactory.resolveDependencies()` which rspack doesn't expose. |
+| `src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js` (vendored, 409 lines) | ❌ | The actual file with the webpack-internal imports. |
+
+### 2.2 The first failure point (runtime-verified)
+
+I actually ran the current plugin with rspack. First thrown error:
+
+```
+TypeError: contextModuleFactory.resolveDependencies is not a function
+  at react-server-dom-webpack-plugin.js:345:38
+```
+
+This is in phase (a) of the plugin — the `"use client"` file discovery. Rspack's `ContextModuleFactory` doesn't expose `resolveDependencies`. We can't get past this without a rewrite of the discovery phase.
+
+### 2.3 Why `client.node`, `client.browser`, `server.node` all work
+
+Key architectural insight: the Flight wire protocol is self-describing. When the server encodes a React tree to Flight, each client reference appears in the payload as:
+
+```
+c:I["./src/Dialog.tsx",["src_Dialog_tsx","src_Dialog_tsx.js"],"Dialog"]
+```
+
+That `I` row contains `[moduleId, chunks, exportName]` inline. The browser-side decoder doesn't need a manifest — it reads the tuple out of the payload and calls `__webpack_require__(moduleId)` + `__webpack_chunk_load__(chunks[0])` directly. Proof from the compiled browser code:
+
+```js
+// dist/static/main.js:18599 — the browser passes NULL manifests to the decoder
+return new ResponseInstance(null, null, null, /* callbacks */, ...);
+```
+
+Server-side SSR decoder does need the manifest (to find the SSR-layer module ID and load the actual client component), but that manifest's shape is nearly identical between webpack and rspack (see §4).
+
+---
+
+## 3. What Rspack's Built-in RSC Does (and Why We Won't Use It)
+
+### 3.1 How rspack's native RSC support works
+
+Rspack v2 ships a built-in RSC system comprising:
+
+1. **Rust core at `crates/rspack_plugin_rsc/`** — 15 Rust files handling discovery, manifest build, chunk layout
+2. **SWC loader integration** — `rspackExperiments.reactServerComponents: true` enables `"use client"` / `"use server"` detection during parse
+3. **`rspack.experiments.rsc.createPlugins()` API** — returns `{ ServerPlugin, ClientPlugin }` JS handles
+4. **Layers machinery** — `Layers.rsc` / `Layers.ssr` for server-side layer tagging
+5. **Runtime module** at `crates/rspack_plugin_rsc/src/manifest_runtime_module.rs` — emits `__webpack_require__.rscM = JSON.parse("...")` into server bundles
+6. **JS-side `onManifest` callback** on `ServerPlugin` — exposes the manifest as a JSON string
+
+### 3.2 `react-server-dom-rspack` (the wrapper package)
+
+Maintained by SyMind (Cong-Cong Pan, ByteDance). Repo: https://github.com/SyMind/react-server-dom-rspack
+
+Architecture of the wrapper:
+- TypeScript source in `src/server.node.ts`, `src/client.node.ts`, etc. (thin wrappers, <700 lines total)
+- Vendors `react-server-dom-webpack` at build time via `cpx`
+- Applies a **394-line patch** to the vendored code removing `chunkCache` in 12 files
+- Wrapper calls into the vendored React code, substituting manifests read from `__rspack_rsc_manifest__` (aliased to `__webpack_require__.rscM` by rspack's runtime module)
+
+### 3.3 Why we're skipping this entire path
+
+**Decision: do NOT use rspack's built-in RSC system. Do NOT use `react-server-dom-rspack`.** Reasons:
+
+1. **Tight coupling** — rspack's ServerPlugin + ClientPlugin require the SWC loader flag + Layers machinery + specific plugin lifecycle. You can't pick one piece; it's all or nothing.
+2. **Experimental status** — `rspackExperiments.reactServerComponents` is behind an experiments flag. `@rspack/core@2.0.0-rc.2` (the first version with built-in RSC) was released 2026-04-14, still pre-stable.
+3. **React-on-rails-rsc has its own mental model** — three bundles (client, server, RSC), specific manifest file names, Ruby-side orchestration. Adopting rspack's built-in would require restructuring all of this OR running two parallel systems.
+4. **Coupling to `react-server-dom-rspack`** — ByteDance-maintained, not upstream React. Depending on it pins us to their release cadence.
+5. **Rsbuild direction** — the rspack team recommends `rsbuild-plugin-rsc` (which wraps their built-in RSC). RoR uses Shakapacker, not Rsbuild. Using rspack's built-in would pull us toward a parallel tooling stack.
+
+What we WILL do: write our own plugin using rspack's **standard public APIs** (the same APIs webpack provides). No `rspackExperiments` flag, no `experiments.rsc.createPlugins`, no Layers.
+
+---
+
+## 4. Manifest Schema Comparison
+
+### 4.1 `clientManifest` (passed to `renderToPipeableStream` server-side)
+
+**React on Rails (webpack):**
+```json
+{
+  "file:///path/to/Component.jsx": {
+    "id": "./app/javascript/components/Component.jsx",
+    "chunks": ["client25", "js/client25.js"],
+    "name": "*"
+  }
+}
+```
+
+**Rspack:**
+```json
+{
+  "/absolute/path/to/Dialog.tsx": {
+    "id": "./src/Dialog.tsx",
+    "name": "*",
+    "chunks": ["src_Dialog_tsx", "src_Dialog_tsx.js"],
+    "async": false
+  }
+}
+```
+
+**Differences:** RoR keys use `file://` URI prefix; rspack keys use raw paths. Rspack has an extra `async` field (defaults to `false`, harmless to RoR). Otherwise identical.
+
+### 4.2 SSR Manifest (passed to `createFromNodeStream` server-side)
+
+**React on Rails:**
+```json
+{
+  "moduleLoading": { "prefix": "/packs/...", "crossOrigin": null },
+  "moduleMap": {
+    "./app/javascript/components/Dialog.jsx": {
+      "*": { "id": "./app/javascript/...", "chunks": [...], "name": "*" }
+    }
+  }
+}
+```
+
+**Rspack:**
+```json
+{
+  "moduleMap": { "./src/Dialog.tsx": { "*": { ... } } },
+  "moduleLoading": { "prefix": "static/" },
+  "serverModuleMap": { "<hash>": { "id": "...", "chunks": [...] } }  // server actions
+}
+```
+
+**Differences:** Rspack adds a third `serverModuleMap` for server actions (RoR doesn't support server actions yet). Otherwise field names and shapes match.
+
+### 4.3 Decision: Keep RoR's schema unchanged
+
+The rspack plugin we write will emit JSON files with **RoR's existing schema** (`filePathToModuleMetadata` + `moduleLoading`). No changes to `server.node.ts`, `client.node.ts`, or `client.browser.ts`. No changes to Ruby-side code.
+
+This means we drop rspack's `async` field and `serverModuleMap` section. Server actions stay unsupported; that's an orthogonal feature to address later.
+
+---
+
+## 5. Plugin Architecture Decision
+
+### 5.1 Options considered
+
+**A. Single plugin, feature-detect at `apply()` time, dispatch to webpack/rspack path internally.**
+- One import path for users and generators
+- Two code paths internally
+- Simpler from outside; more complex inside
+
+**B. Two separate plugin exports (`RSCWebpackPlugin` and `RSCRspackPlugin`).**
+- Generator picks based on `assets_bundler` config
+- Cleaner internal separation
+- Breaks the "one import path" idiom
+
+**C. Unified interface, two backends.**
+- Most abstract; least code reuse since the two paths share very little
+
+### 5.2 Decision: Option A (dual-path, single facade)
+
+```ts
+// react-on-rails-rsc/src/WebpackPlugin.ts (renamed conceptually but export preserved)
+
+import createWebpackPlugin = require('./react-server-dom-webpack/plugin');
+import createRspackPlugin = require('./react-server-dom-rspack/plugin');
+
+export class RSCWebpackPlugin {
+  private plugin: { apply(compiler: any): void };
+
+  constructor(options: Options) {
+    const bundler = options.bundler || require('webpack');
+    const isRspack = typeof bundler.rspackVersion === 'string';
+
+    if (isRspack) {
+      this.plugin = new (createRspackPlugin(bundler))(options);
+    } else {
+      this.plugin = new (createWebpackPlugin(bundler))(options);
+    }
+  }
+
+  apply(compiler: any) { this.plugin.apply(compiler); }
+}
+
+// Optional alias for semantic clarity in new projects:
+export { RSCWebpackPlugin as RSCBundlerPlugin };
+```
+
+**Justification:**
+- Back-compat preserved (existing webpack users' generated configs continue to work)
+- One import path (generators don't need to branch at template level)
+- Rspack-specific code fully isolated in `react-server-dom-rspack/plugin.js` (new file)
+- Webpack path requires only a trivial wrapping change (factory function taking `bundler`)
+
+---
+
+## 6. Discovery Technique: FS Walk vs. Module Graph Walk
+
+### 6.1 Our current webpack plugin's approach (FS walk)
+
+```
+CONFIG: clientReferences = [{ directory: "./app/javascript", recursive: true,
+                              include: /\.(js|ts|jsx|tsx)$/ }]
+
+→ Walk filesystem
+→ For every matching file:
+    - Read file from disk
+    - Parse with acorn-loose
+    - Check for "use client" directive
+    - If found: create ClientReferenceDependency, register via AsyncDependenciesBlock
+
+MISSES:
+  ✗ node_modules/@lib/Client.tsx (outside configured dir)
+  ✗ Files resolved via TS path aliases outside directory
+  ✗ Virtual modules (no FS file)
+
+FALSE POSITIVES:
+  ✗ DeadFile.tsx — present in directory, matches regex, has "use client",
+                   but never imported → still ends up in manifest
+```
+
+### 6.2 Rspack's native approach (module graph walk)
+
+```
+→ SWC loader tags modules during parse (sets bit on module metadata)
+→ collect_component_info_from_entry_dependency starts from each entry
+→ Walks ESM/CJS import edges
+→ Uses visited set to handle cycles
+→ For each visited module, if SWC-tagged as "use client", record it
+
+FINDS:
+  ✓ Any file reachable via imports, anywhere — node_modules, aliases, virtual modules
+EXCLUDES:
+  ✓ Dead code (not parsed, not tagged)
+  ✓ Files not reachable from entry
+```
+
+### 6.3 Decision: module graph walk via loader-based tagging
+
+We adapt rspack's approach (minus the SWC integration, since we don't require rspack's experimental flags). The technique:
+
+1. **Small loader** — reads module source, checks for `"use client"` directive, records findings in a shared `Set<string>` keyed on module.resource path
+2. **Plugin reads the set in `compilation.hooks.finishModules`** — by that time, every module reachable from an entry has been loaded and (if a client component) tagged
+3. **Per-module chunk lookup** via `compilation.chunkGraph.getModuleChunks(module)` — simpler than walking all chunk groups
+
+Advantages over the current webpack plugin:
+- No `directory` / `include` regex — works with any rspack resolution (aliases, node_modules, conditional exports)
+- Dead code automatically excluded
+- Single pass (file read once by bundler, tagged by loader, used by plugin) — no double I/O
+- Per-entry accuracy available (we start simple with single-compilation-wide manifest, matching current webpack plugin behavior)
+
+We should apply the **same technique to the webpack path** eventually, since it's strictly better than the current FS walk. For this implementation we'll keep the webpack path unchanged (conservative) and use the new technique only on the rspack path.
+
+---
+
+## 7. Chunk-Splitting Technique: Custom Dependency vs. AsyncDependenciesBlock
+
+### 7.1 Webpack plugin's technique (today)
+
+```js
+class ClientReferenceDependency extends ModuleDependency { ... }
+compilation.dependencyFactories.set(ClientReferenceDependency, normalModuleFactory);
+compilation.dependencyTemplates.set(ClientReferenceDependency, new NullDependency.Template());
+
+// In parser hooks, for each client file:
+const asyncBlock = new webpack.AsyncDependenciesBlock({ name: chunkName }, null, dep.request);
+asyncBlock.addDependency(new ClientReferenceDependency(file));
+clientRegistrationModule.addBlock(asyncBlock);
+```
+
+**Works because:** webpack's `ModuleDependency` is a JS class you can extend from userland. Webpack's `dependencyFactories.set()` accepts arbitrary JS dep classes.
+
+**Doesn't work on rspack because:** rspack's `Dependency` base class is Rust-backed. Extending it from JS doesn't round-trip into rspack's Rust module graph.
+
+### 7.2 The rspack path (decision)
+
+Use `AsyncDependenciesBlock` attached to a registration module **without** a custom dependency subclass. Rspack's `AsyncDependenciesBlock` accepts standard built-in dependency types (`ImportDependency`, `EntryPlugin.createDependency`-style deps) as children.
+
+```js
+// Pseudocode for rspack path
+for (const file of tagged_client_files) {
+  const asyncBlock = new rspack.AsyncDependenciesBlock({ name: toChunkName(file) });
+  asyncBlock.addDependency(standardImportDep(file));  // use a built-in dep type
+  registrationModule.addBlock(asyncBlock);
+}
+```
+
+**Benefits:**
+- Same mechanism as the webpack plugin (familiar); different dependency shape
+- No custom subclass means no rspack internal-API coupling
+- Each client file ends up as a named async chunk (desired behavior)
+
+**To validate at prototype time:** the exact built-in dep type to use. Options:
+- `rspack.dependencies.ImportDependency` (if exposed)
+- `EntryPlugin.createDependency(file, options)` — already exposed; creates an entry dep
+- A built-in module-resolution dependency
+
+If none of the built-in deps work as-is, a fallback is to skip the `AsyncDependenciesBlock` entirely and use `compilation.addEntry()` with `entry.runtime: false` to create named runtime-less chunks per client file. Less elegant but well-supported.
+
+---
+
+## 8. Runtime Compatibility Risks
+
+### 8.1 The `react-server-dom-webpack` chunk-cache patch
+
+`react-server-dom-rspack@0.0.2` applies a uniform 394-line patch across 12 files in the vendored `react-server-dom-webpack`. The patch:
+
+```diff
+- var chunkId = chunks[i++],
+-   chunkFilename = chunks[i++],
+-   entry = chunkCache.get(chunkId);
+- void 0 === entry
+-   ? ((chunkFilename = loadChunk(chunkId, chunkFilename)),
+-     promises.push(chunkFilename),
+-     ...,
+-     chunkCache.set(chunkId, chunkFilename))
+-   : null !== entry && promises.push(entry);
++ var chunkId = chunks[i++];
++ i++;
++ var thenable = __webpack_chunk_load__(chunkId);
++ promises.push(thenable);
++ thenable.catch(ignoreReject);
+```
+
+**What it does:** removes the JS-level `chunkCache` and always calls `__webpack_chunk_load__(chunkId)` directly, relying on the bundler's own idempotency instead of React's JS cache.
+
+**Why it exists:** unclear from the patch file alone, but likely one of:
+- Rspack's `__webpack_chunk_load__` doesn't return the same Promise object on repeated calls (but still loads only once — i.e., idempotent but not referentially equal)
+- Rspack's module materialization timing differs, and React's cached promise resolves before the module is fully ready
+- Edge case with concurrent dynamic imports
+
+**Risk to RoR:** medium. Our vendored `react-server-dom-webpack` has the same chunkCache code. When rspack loads a chunk multiple times in quick succession (e.g., Suspense boundaries referencing the same client component), we may hit the same bug `react-server-dom-rspack` patched around.
+
+**Mitigation:** apply the same patch to our vendored copy at build time. The patch is uniform, mechanical, and small. Alternative: use `react-server-dom-rspack/client.browser` in place of our `client.browser.ts` when running on rspack (hybrid approach).
+
+**Action:** during prototype, build RoR's RSC test apps against an rspack project and watch for chunk-loading bugs. If none observed, defer the patch. If observed, port the patch.
+
+### 8.2 Module ID shape differences
+
+Rspack's SSR-layer module IDs include prefixes like `(server-side-rendering)/./src/Dialog.tsx`. Webpack's are plain like `./app/javascript/components/Dialog.jsx`.
+
+**Risk:** low. RoR's code doesn't compare these IDs; it passes them through to `__webpack_require__(id)`, and that's bundler-internal (rspack's IDs work with rspack's require). No expected issue.
+
+**Action:** test in prototype. If any code in `client.node.ts` or `server.node.ts` does string manipulation on IDs, review it.
+
+### 8.3 Missing `async` and `serverModuleMap` fields
+
+Our plugin will not emit these rspack-specific fields. React's Flight decoder accepts missing `async` (treats as `false`). `serverModuleMap` only matters for server actions (RoR doesn't support them). No risk.
+
+---
+
+## 9. Implementation Plan
+
+### Phase 0 — Prototype (validate assumptions)
+
+**Goal:** resolve the open items in §10 before writing production code.
+
+Tasks:
+1. Implement a minimal `RSCRspackPlugin` (single file) that:
+   - Registers a tiny loader that tags `"use client"` modules
+   - Hooks `compilation.hooks.finishModules` to iterate tagged modules
+   - Uses `compilation.chunkGraph.getModuleChunks(module)` to build chunks array
+   - Emits a single manifest matching RoR's format
+2. Wire into a test rspack project that builds server + client bundles
+3. Verify manifest shape matches RoR's expectations by hand
+4. Verify `renderToPipeableStream` (from RoR's unpatched `react-server-dom-webpack`) works with rspack-built output
+5. Verify `createFromNodeStream` works for SSR
+6. Verify the browser client works (watch for chunk-cache issue)
+
+Outputs:
+- Working prototype plugin (~200 lines)
+- Decision on which built-in dep type to use with `AsyncDependenciesBlock` (see §7.2)
+- Decision on whether to port the chunk-cache patch (see §8.1)
+
+Effort: small (~1-3 days)
+
+### Phase 1 — Refactor the webpack path for parameterization
+
+**Goal:** make the existing `RSCWebpackPlugin` accept a `bundler` parameter without changing behavior.
+
+Tasks:
+1. Convert `src/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js` from a module with hard-coded `require('webpack')` to a factory function that accepts `bundler`
+2. Update `src/WebpackPlugin.ts` to pass `bundler` through (defaults to `require('webpack')` for back-compat)
+3. Run all existing tests to verify no regression
+
+Outputs:
+- `react-server-dom-webpack/plugin` now exports a factory
+- `WebpackPlugin.ts` accepts optional `bundler` option, defaults to webpack
+
+Effort: small (~1 day)
+
+### Phase 2 — Implement the rspack path
+
+**Goal:** write `src/react-server-dom-rspack/plugin.js` and the companion loader.
+
+Tasks:
+1. Write the loader (`src/react-server-dom-rspack/loader.js`):
+   - Tiny file, reads source, checks for `"use client"` directive
+   - Records findings in a shared `Set` (module-level singleton or compilation-scoped)
+2. Write the plugin (`src/react-server-dom-rspack/plugin.js`):
+   - In `thisCompilation`, ensure the loader runs on all JS/TS
+   - Hook `finishModules` to collect tagged modules
+   - For each tagged module, attach an `AsyncDependenciesBlock` to a central registration module
+   - Hook `processAssets` at `PROCESS_ASSETS_STAGE_REPORT` to walk the chunk graph and emit the JSON
+3. Update `WebpackPlugin.ts` dispatcher to detect rspack via `bundler.rspackVersion` and route accordingly
+4. Add a `rspack` devDep to the `react-on-rails-rsc` package (already done for tests)
+
+Outputs:
+- New files: `src/react-server-dom-rspack/{plugin.js,loader.js,package.json}`
+- Updated dispatcher: `src/WebpackPlugin.ts`
+
+Effort: medium (~3-5 days, most of it in edge cases)
+
+### Phase 3 — Apply chunk-cache patch (conditional on Phase 0 findings)
+
+Only if Phase 0 confirms the bug:
+
+Tasks:
+1. Port the 394-line patch from `react-server-dom-rspack` to our vendored `react-server-dom-webpack`
+2. Apply via a build-time patch script OR inline into the vendored files
+3. Add a regression test that specifically triggers the original bug (concurrent client-component loads)
+
+Outputs:
+- Vendored files updated
+- Patch script in repo
+
+Effort: small (~1 day)
+
+### Phase 4 — Update `react-on-rails` generator
+
+**Goal:** generator produces correct rspack config when `assets_bundler: rspack`.
+
+Tasks:
+1. Generator emits new `*RspackConfig.js` templates (or shared templates that handle both) that:
+   - Pass `bundler: require('@rspack/core')` to `RSCWebpackPlugin` when on rspack
+   - Apply the loader to all JS/TS rules
+2. Update `rsc_setup.rb` to write the correct config for both bundlers
+3. Extend existing generator specs to cover rspack paths
+
+Outputs:
+- Generator changes
+- New template files
+
+Effort: medium (~3-5 days)
+
+### Phase 5 — Testing infrastructure
+
+**Goal:** CI catches rspack-specific regressions.
+
+Tasks:
+1. `.github/workflows/pro-rsc-rspack-smoke.yml` — builds three bundles + checks manifests exist + one E2E navigation test under rspack
+2. Add rspack permutation to the existing RSC dummy (behind env var switch)
+3. Snapshot test for the manifest JSON shape (must stay byte-compatible with the webpack path)
+
+Outputs:
+- New CI workflow
+- Extended dummy config
+- Snapshot tests
+
+Effort: medium (~2-3 days)
+
+### Phase 6 — Documentation
+
+Tasks:
+1. Update `docs/pro/react-server-components/rspack-compatibility.md` from "Experimental" to "Supported"
+2. Add rspack section to `docs/oss/migrating/migrating-from-webpack-to-rspack.md`
+3. Document the `bundler` option in `packages/react-on-rails-rsc/README.md`
+4. Changelog entry per `.claude/docs/changelog-guidelines.md`
+
+Effort: small (~1 day)
+
+### Total effort estimate
+
+| Phase | Size |
+|---|---|
+| 0 — Prototype | Small |
+| 1 — Webpack refactor | Small |
+| 2 — Rspack plugin | Medium |
+| 3 — Chunk-cache patch (conditional) | Small |
+| 4 — Generator | Medium |
+| 5 — Testing infra | Medium |
+| 6 — Docs | Small |
+
+---
+
+## 10. Known Unknowns to Validate in Prototype
+
+1. **Exact rspack built-in dep type for `AsyncDependenciesBlock.addDependency()`** (§7.2). Likely `EntryPlugin.createDependency(file, options)` or a module-resolution dep, but must be verified.
+
+2. **Whether the chunk-cache patch is required for RoR** (§8.1). Triggered by concurrent client-component loads; easy to test once the prototype runs.
+
+3. **Whether per-module chunk lookup (`chunkGraph.getModuleChunks`) returns the right chunks for `AsyncDependenciesBlock`-created chunks**. In webpack, the dep is materialized into a chunk; rspack may or may not use the same internal mapping.
+
+4. **Whether our `"use client"` detection loader can coexist with users' other SWC/Babel loaders**. Should run first in the chain (priority `pre` or via loader order).
+
+5. **Module ID format for the entries** — webpack uses relative paths (`./src/Dialog.tsx`); rspack sometimes includes layer prefixes (`(server-side-rendering)/...`). Need to confirm which format appears in the manifest we emit and whether it round-trips through `__webpack_require__(id)` at runtime.
+
+6. **`compilation.entrypoints.forEach` vs `compilation.chunkGroups.forEach` semantics** on rspack for walking client components. Should match webpack but worth verifying.
+
+7. **`configuredCrossOriginLoading` / `outputOptions.crossOriginLoading`** — webpack has this output option; rspack should too but with potentially different defaults.
+
+---
+
+## 11. References
+
+### In this repo
+- [`.claude/docs/rspack-rsc-support-state.md`](./rspack-rsc-support-state.md) — rspack's official RSC state
+- [`.claude/docs/rsc-rspack-implementation-plan.md`](./rsc-rspack-implementation-plan.md) — original high-level plan
+- [`docs/pro/react-server-components/rspack-compatibility.md`](../../docs/pro/react-server-components/rspack-compatibility.md) — current status doc
+
+### Tracking
+- [shakacode/react_on_rails#3141](https://github.com/shakacode/react_on_rails/issues/3141) — this investigation's parent issue
+- [shakacode/react_on_rails#1828](https://github.com/shakacode/react_on_rails/issues/1828) — original "rspack support for RSC" tracker
+- [shakacode/react_on_rails#2552](https://github.com/shakacode/react_on_rails/issues/2552) — RFC: rename `*WebpackConfig.js` (do NOT land concurrently with this work)
+- [shakacode/react_on_rails_rsc test/rspack-compatibility](https://github.com/shakacode/react_on_rails_rsc/tree/test/rspack-compatibility) — 31 verification tests
+
+### External
+- [web-infra-dev/rspack#12012](https://github.com/web-infra-dev/rspack/pull/12012) — rspack's built-in RSC landing PR
+- [SyMind/react-server-dom-rspack](https://github.com/SyMind/react-server-dom-rspack) — the wrapper; we're NOT using it but its patch file is our reference for the chunk-cache issue
+- [rstackjs/rspack-rsc-examples](https://github.com/rstackjs/rspack-rsc-examples) — working pure-rspack RSC example we validated
+- [Rspack runtime API docs](https://rspack.rs/api/runtime-api/module-variables) — documents `__webpack_*` global compatibility
+
+### Working prototype (for reference during Phase 0)
+- `/mnt/ssd/demos/rspack-rsc-pure/` — running pure-rspack RSC app
+- `/mnt/ssd/demos/ror-rspack-demo/` — React on Rails + rspack + no RSC (from earlier in this investigation)
+- `/mnt/ssd/react-on-rails-rsc/` on branch `test/rspack-compatibility` — 31 compat tests
+
+---
+
+## Revision History
+
+| Date | Change |
+|---|---|
+| 2026-04-14 | Initial draft after investigation |

--- a/.claude/docs/rspack-rsc-support-state.md
+++ b/.claude/docs/rspack-rsc-support-state.md
@@ -1,0 +1,533 @@
+# State of React Server Components (RSC) Support in Rspack
+
+**Research date:** 2026-04-14
+**Researcher:** Claude (Anthropic) for ShakaCode / React on Rails
+**Scope:** Rspack itself, independent of React on Rails. What the Rspack team ships, documents, and recommends for RSC as of April 2026.
+
+---
+
+## 1. Executive Summary
+
+As of April 2026, Rspack has **landed a first-class, built-in RSC implementation** on the v2 branch. The core was merged in [PR #12012 "feat: builtin react server component"](https://github.com/web-infra-dev/rspack/pull/12012) on 2026-01-23, shipped in [`v2.0.0-alpha.1`](https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-alpha.1) (2026-01-27), and has been iteratively improved across the subsequent 2.0 alpha, beta, and RC releases up to [`v2.0.0-rc.1`](https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-rc.1) (2026-04-08). A dedicated runtime package — [`react-server-dom-rspack`](https://www.npmjs.com/package/react-server-dom-rspack) — is published on npm by Rspack team member Cong-Cong Pan (`SyMind`, ByteDance), separate from `react-server-dom-webpack`. Official documentation lives at [`/guide/tech/rsc`](https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/guide/tech/rsc.mdx) (added via [PR #12919](https://github.com/web-infra-dev/rspack/pull/12919), 2026-02-06). A wrapper plugin for Rsbuild, [`rsbuild-plugin-rsc`](https://github.com/rstackjs/rsbuild-plugin-rsc), provides the ergonomic path.
+
+**Is it production-ready?** No. The feature is shipped behind `rspackExperiments.reactServerComponents`, only in Rspack v2 pre-releases (RC at time of writing, no stable v2 yet), and the wrapper plugin is at `v0.0.3` with a `react-server-dom-rspack` runtime at `v0.0.2`. The Rspack docs explicitly position this as requiring a custom dev server (the built-in dev server cannot host it). No stable Rspack 2.0 release exists as of 2026-04-14 — the first Rspack 2.0 "preview" was targeted at February 2026 per the roadmap, and the project is currently at `v2.0.0-rc.1`.
+
+## 2. Official Rspack Statement on RSC
+
+### 2.1 Roadmap
+
+The Rspack roadmap page lists built-in RSC among the stated goals of Rspack 2.0:
+
+> "Built-in RSC support: Inspired by tools like Parcel, offering built-in support for React Server Components."
+> — [`rspack.rs/misc/planning/roadmap`](https://rspack.rs/misc/planning/roadmap)
+
+Accompanying statement about timing:
+
+> "The first preview release is planned for February 2026. We will carefully review every breaking change to ensure a smooth upgrade path."
+> — same page
+
+### 2.2 Pre-v2 position (earlier statements, now superseded)
+
+Prior to the 2.0 work, Rspack's earlier public stance was framed as partial/experimental. From Rspack blog text that still surfaces in search results:
+
+> "At ByteDance, they have experimentally supported RSC based on Rspack and validated it in a large web application. In the future, Rspack will provide first-class support for RSC, with more core features to make RSC easier to implement. For example, Rspack now supports the layer feature, which allows to build for multiple environments in a single run."
+> — paraphrased from Rspack blog/FAQ surface; [`rspack.rs/blog/`](https://rspack.rs/blog/)
+
+### 2.3 Current confirmation (core PR)
+
+The merged core PR description is the clearest official statement of the current shape. From [PR #12012](https://github.com/web-infra-dev/rspack/pull/12012) (SyMind, merged 2026-01-23):
+
+> "This PR adds built-in RSC plugins to Rspack. We recommend using them via the Rsbuild plugin wrapper available at https://github.com/rstackjs/rsbuild-plugin-rsc."
+>
+> "The `builtin:swc-loader` has been enhanced to identify `"use client"` and `"use server"` directives. Within the RSC layer, it utilizes the `react-server-dom-rspack` package to transform these modules into the appropriate client and server references required by React."
+>
+> "Note: This feature must be enabled via rspackExperiments.reactServerComponents."
+>
+> "RSC requires separate compilation for Server and Client bundles. This PR introduces `ServerPlugin` and `ClientPlugin` (created via `rsc.createPlugins()`), which orchestrate the two compilers."
+
+From Rspack member `chenjiahan` on the predecessor PR [#5824](https://github.com/web-infra-dev/rspack/pull/5824) when it was closed in October 2025:
+
+> "@SyMind is currently designing the built-in RSC support for Rspack. We'll share more details soon."
+
+### 2.4 Relation to Next.js / Vercel partnership
+
+From the [Rspack joins the Next.js ecosystem](https://rspack.rs/blog/rspack-next-partner) blog post (2025-04-10):
+
+> "Rspack will deliver a similar API to bring first-class, high-performance RSC support to the ecosystem."
+
+Important caveat from the same post, re: Next.js App Router (which is where RSC lives in Next):
+
+> "The App Router implementation with next-rspack is slower than Turbopack, and may even be slower than webpack, due to JavaScript plugins that cause heavy Rust–JavaScript communication overhead. The Rspack team has experimentally ported these plugins to Rust, which dramatically improved performance — almost on par with Turbopack."
+
+The Next.js docs themselves flag Rspack as experimental:
+
+> "This feature is currently experimental and subject to change, it is not recommended for production."
+> — [Next.js community docs, Rspack integration](https://nextjs.org/docs/community/rspack), lastUpdated 2026-04-10
+
+## 3. The `react-server-dom-rspack` Question
+
+### 3.1 Does the package exist? Yes.
+
+The package `react-server-dom-rspack` exists and is published on npm:
+
+- **Package:** [`react-server-dom-rspack`](https://www.npmjs.com/package/react-server-dom-rspack)
+- **Latest version:** `0.0.2` (published 2026-03-14)
+- **First publish:** `0.0.1-alpha.1` on 2025-12-17
+- **Maintainer:** `symind <dacongsama@live.com>` (Cong-Cong Pan, ByteDance — same person who authored the core Rspack RSC PR)
+- **License:** MIT
+- **Description (verbatim from npm):** "React Server Components bindings for DOM using Rspack. This is intended to be integrated into meta-frameworks. It is not intended to be imported directly."
+- **Weekly downloads:** minimal — the package is not widely used outside Rspack-team example apps
+- **Peer dependencies:** `react ^19.1.0`, `react-dom ^19.1.0`, `@rspack/core ^2.0.0-0`
+
+Release timeline (from `npm view react-server-dom-rspack time`):
+
+| Version | Published |
+|---|---|
+| 0.0.1-alpha.1 | 2025-12-17 |
+| 0.0.1-alpha.2 | 2025-12-23 |
+| 0.0.1-alpha.3 | 2025-12-23 |
+| 0.0.1-alpha.4 | 2025-12-30 |
+| 0.0.1-alpha.5 | 2025-12-31 |
+| 0.0.1-alpha.6–0.0.1-alpha.8 | 2026-01-04 |
+| 0.0.1-alpha.9 | 2026-01-26 |
+| 0.0.1-alpha.10 | 2026-01-27 |
+| 0.0.1-beta.0 | 2026-02-03 |
+| 0.0.1-beta.1 | 2026-02-26 |
+| 0.0.2 | 2026-03-14 |
+
+### 3.2 Relationship to `react-server-dom-webpack`
+
+`react-server-dom-rspack` is **not** part of the [`facebook/react`](https://github.com/facebook/react) monorepo. The React team's monorepo ships `react-server-dom-webpack`, `react-server-dom-parcel`, `react-server-dom-turbopack`, `react-server-dom-esm`, `react-server-dom-fb`, and `react-server-dom-unbundled`, but **no `react-server-dom-rspack`** folder exists there (confirmed by [GitHub tree at facebook/react/packages](https://github.com/facebook/react/tree/main/packages), April 2026).
+
+The `react-server-dom-rspack` npm package is maintained independently by the Rspack team member SyMind. Its export map mirrors `react-server-dom-webpack` structurally — `./client`, `./server`, `./static` with `workerd`/`deno`/`worker`/`node`/`edge-light`/`browser` conditional subpaths — so from an API-surface perspective it is designed as a drop-in analog, but it is a separate publish under ByteDance/Rspack stewardship, not an upstream Meta-published package.
+
+### 3.3 Earlier community workaround (pre-package)
+
+Before `react-server-dom-rspack` existed, the only working path was patching `react-server-dom-webpack`. The demo repo [hyf0/server-components-demo-on-rspack](https://github.com/hyf0/server-components-demo-on-rspack) (created 2023-05, last touched 2024) is explicit:
+
+> "I patched the `react-server-dom-webpack` package, you need pnpm to make the patch works."
+
+The patch lives in `/patches/` and requires `npm install --legacy-peer-deps`. That repo pre-dates the Rspack built-in work and should be considered a historical reference, not a current recommendation.
+
+### 3.4 React team position
+
+No public statement from the React team (Sebastian Markbåge, Dan Abramov, Andrew Clark, etc.) blessing or vetoing `react-server-dom-rspack` surfaced in this research. The package is unilateral ByteDance/Rspack work published to npm by a non-`react-bot` maintainer. The React team accepted `react-server-dom-parcel` into the monorepo via [PR #31725 by devongovett](https://github.com/facebook/react/pull/31725) but has not made a similar move for Rspack — at least not publicly and not as of 2026-04-14.
+
+## 4. Rspack v1 vs v2 for RSC
+
+### 4.1 Rspack 1.x capabilities and limits
+
+Rspack 1.x does **not** ship built-in RSC support. The relevant 1.x milestones are supportive primitives rather than the feature itself:
+
+- **1.6 (2025-10-30):** Layer feature stabilized. Per [Announcing Rspack 1.6](https://rspack.rs/blog/announcing-1-6): "Layer is a feature for organizing modules into different layers, which can be useful in advanced scenarios such as React Server Components." The experimental flag `experiments.layers` was deprecated.
+- **1.7 (2025-12-31):** Final minor in the 1.x series; focused on stabilizing existing features. [Announcing Rspack 1.7](https://rspack.rs/blog/announcing-1-7) explicitly: "This marks the final minor release in the Rspack 1.x series and focuses on stabilizing existing features. Next, we'll be moving toward Rspack 2.0." No RSC-specific features.
+- **Tracking issue [#5318](https://github.com/web-infra-dev/rspack/issues/5318)** ("Blockers for React Server Components") was closed 2024-08-13 with an explicit punt to a full rewrite rather than API-compat fixes: "parser hook is not likely to be supported in near future for performance reason (we'll find a better way to support rsc), we're working [on] full rsc implementation in https://github.com/ScriptedAlchemy/rsnext".
+- **Issue [#8469](https://github.com/web-infra-dev/rspack/issues/8469)** (Modern.js team asking for `compilation.addInclude`, `moduleGraph.getExportsInfo`, `AsyncDependenciesBlock`, `chunkGraph.getModuleId`, etc.) was closed 2025-03-26 with "the API provided by Rspack can meet the support of RSC."
+
+So on v1, RSC is only possible by:
+- framework-level orchestration using webpack-ish compat APIs plus patches to `react-server-dom-webpack` (the hyf0 demo approach), or
+- reaching into the `dy-rsc` experimental branch referenced by `hardfist` in 2024, which never landed as a stable surface.
+
+There is no officially supported path to RSC on Rspack 1.x.
+
+### 4.2 Rspack 2.0 for RSC
+
+RSC is a flagship 2.0 feature. Release timeline of the 2.x pre-releases relevant to RSC:
+
+| Release | Date | RSC-relevant content |
+|---|---|---|
+| [v2.0.0-alpha.0](https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-alpha.0) | 2026-01-22 | Scaffolding |
+| [v2.0.0-alpha.1](https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-alpha.1) | 2026-01-27 | **PR #12012 lands** — `rspack_plugin_rsc` crate, `ServerPlugin`, `ClientPlugin`, `rspackExperiments.reactServerComponents`, `react-server-dom-rspack` integration |
+| v2.0.0-beta.0 | 2026-02-03 | — |
+| beta.1/2 | 2026-02-10/11 | |
+| beta.3/4 | 2026-02-25/27 | `feat: making RSC compatible with lazy compilation` (PR #13136) |
+| beta.5 | 2026-03-03 | |
+| beta.6 | 2026-03-10 | `feat: rsc support disable client api checks` (PR #13263) |
+| beta.7 | 2026-03-17 | `feat: support rsc manifest callback` (PR #13277) |
+| beta.8 | 2026-03-24 | `fix(rsc): should compile css without use server-entry` (PR #13402) |
+| beta.9 | 2026-03-27 | `fix(rsc): tree shaking client barrel` (PR #13472) |
+| v2.0.0-rc.0 | 2026-03-31 | |
+| [v2.0.0-rc.1](https://github.com/web-infra-dev/rspack/releases/tag/v2.0.0-rc.1) | 2026-04-08 | Latest available at time of writing; no stable 2.0 yet |
+
+As of 2026-04-14 there is **no stable Rspack 2.0 release** — the project is at RC. The `npm view` data confirms `v2.0.0-rc.1` is the newest tag.
+
+Still-open RSC-adjacent work (not yet merged as of research date):
+
+- [#12977](https://github.com/web-infra-dev/rspack/pull/12977) — `feat(mf): layer-aware sharing and runtime scope-array support`
+- [#12978](https://github.com/web-infra-dev/rspack/pull/12978) — `feat: add first-class module federation support for RSC`
+- [#13203](https://github.com/web-infra-dev/rspack/pull/13203) — `feat(rsbuild): add RSC federation host/remote example`
+- [#13204](https://github.com/web-infra-dev/rspack/pull/13204) — `feat(rsbuild): add RSC federation module patterns`
+- [#13208](https://github.com/web-infra-dev/rspack/pull/13208), [#13215](https://github.com/web-infra-dev/rspack/pull/13215) — RSC + Module Federation integration
+
+### 4.3 Which version to target
+
+If you intend to build an RSC app with Rspack directly today:
+
+- **Use Rspack 2.x pre-release** (`v2.0.0-rc.1` or later). Rspack 1.x has no supported path.
+- Accept the flag `rspackExperiments.reactServerComponents: true` in SWC loader options — it is explicitly experimental.
+- Accept the peer dep `react-server-dom-rspack@0.0.2` — described by its own README as "Experimental React Flight bindings for DOM using Rspack. Use it at your own risk."
+
+## 5. Building an RSC App with Rspack — What Works Today
+
+### 5.1 Required dependencies
+
+Taken from the [rsbuild-plugin-rsc react-router example](https://github.com/rstackjs/rsbuild-plugin-rsc/blob/main/examples/react-router/package.json):
+
+```json
+{
+  "dependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router": "^7.13.1",
+    "react-server-dom-rspack": "0.0.2"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "^2.0.0-rc.0",
+    "@rsbuild/plugin-react": "^1.4.6",
+    "rsbuild-plugin-rsc": "workspace:*"
+  }
+}
+```
+
+The Rspack docs require React 19.1.0+; the examples are actually pinned to 19.2.x. Rspack must be 2.x (via `@rsbuild/core ^2.0.0-0`).
+
+### 5.2 Minimal plugin setup (from official docs)
+
+From [`website/docs/en/guide/tech/rsc.mdx`](https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/guide/tech/rsc.mdx):
+
+```js
+import { experiments } from '@rspack/core';
+
+const { createPlugins, Layers } = experiments.rsc;
+const { ServerPlugin, ClientPlugin } = createPlugins();
+```
+
+One call to `createPlugins()` returns a paired `(ServerPlugin, ClientPlugin)` that share coordination state.
+
+### 5.3 Dual-compiler config
+
+Rspack's RSC architecture uses **two Compiler instances**, mirroring the webpack pattern but orchestrated by a shared coordinator:
+
+```js
+export default [
+  {
+    target: 'web',
+    entry: { main: { import: './src/entry.client.tsx' } },
+    plugins: [new ClientPlugin()],
+    module: { rules: [rscRule] }
+  },
+  {
+    target: 'node',
+    entry: { main: { import: './src/entry.rsc.tsx' } },
+    plugins: [new ServerPlugin()],
+    module: { rules: [rscRule] }
+  }
+];
+```
+
+Key doc-quoted constraint: "There must be an entry in the Client Compiler with the exact same name as the one in the Server Compiler." This is how manifests line up client references against server-emitted ids.
+
+### 5.4 SWC loader rule
+
+```js
+const rscRule = {
+  test: /\.(?:js|mjs|jsx|ts|tsx)$/,
+  use: {
+    loader: 'builtin:swc-loader',
+    options: { detectSyntax: 'auto' },
+    rspackExperiments: { reactServerComponents: true }
+  },
+  type: 'javascript/auto'
+};
+```
+
+The `builtin:swc-loader` detects `"use client"` and `"use server"` directives and, inside the RSC layer, rewrites modules into client-reference and server-reference stubs via `react-server-dom-rspack`.
+
+### 5.5 Layer rules on the server compiler
+
+The server compiler must separate the RSC layer from the SSR layer because they resolve `react` to different builds (the `react-server` export condition yields React's server-only runtime). From the docs:
+
+```js
+{
+  target: 'node',
+  module: {
+    rules: [
+      { resource: ssrEntry, layer: Layers.ssr },
+      {
+        resource: rscEntry,
+        layer: Layers.rsc,
+        resolve: { conditionNames: ['react-server', '...'] }
+      },
+      {
+        issuerLayer: Layers.rsc,
+        exclude: ssrEntry,
+        resolve: { conditionNames: ['react-server', '...'] }
+      }
+    ]
+  }
+}
+```
+
+Layer name constants (from [`crates/rspack_plugin_rsc/src/constants.rs`](https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_rsc/src/constants.rs)):
+
+- `Layers.rsc` → `"react-server-components"`
+- `Layers.ssr` → `"server-side-rendering"`
+
+### 5.6 Directives
+
+- **`"use client"`** — transformed to a client reference when imported from a module in the `react-server-components` layer.
+- **`"use server"`** — marks server actions; becomes a server reference when imported from the client layer.
+- **`"use server-entry"`** — Rspack-specific extension (not React-standard). Marks a Server Component as a "logical page entry point." The built plugin attaches `entryJsFiles` and `entryCssFiles` static properties to the exported component, for frameworks that need to hoist `<script>` / `<link>` tags into the SSR shell.
+
+### 5.7 Dev server
+
+The Rspack docs explicitly state:
+
+> "Rspack's built-in dev server cannot support these requirements."
+
+A custom dev server is required to (a) intercept RSC requests and stream renders, (b) manage per-request server runtime isolation, and (c) relay HMR via `ServerPlugin`'s `onServerComponentChanges` hook:
+
+```js
+new ServerPlugin({
+  onServerComponentChanges() {
+    // Notify client via WebSocket or similar
+  }
+})
+```
+
+### 5.8 The Rsbuild wrapper (recommended path)
+
+The direct Rspack RSC surface is low-level. The Rspack team explicitly recommends [`rsbuild-plugin-rsc`](https://github.com/rstackjs/rsbuild-plugin-rsc):
+
+```bash
+npm install rsbuild-plugin-rsc react-server-dom-rspack
+```
+
+```js
+import { pluginRSC, Layers } from 'rsbuild-plugin-rsc';
+
+export default {
+  plugins: [
+    pluginRSC({
+      layers: {
+        ssr: path.join(import.meta.dirname, './src/framework/entry.ssr.tsx'),
+      },
+    }),
+  ],
+};
+```
+
+Four example apps live in [`examples/`](https://github.com/rstackjs/rsbuild-plugin-rsc/tree/main/examples):
+
+- `client/` — client-driven RSC
+- `server/` — full server-rendered app with routing + Server Actions
+- `react-router/` — React Router 7 RSC Data Mode
+- `static/` — static site generation
+
+Repo stats (as of 2026-04-13): 12 stars, no license file at repo root (plugin is MIT per `package.json`), created 2025-12-23 (same week as `react-server-dom-rspack@0.0.1-alpha.1`).
+
+Plugin dependency versions (from [`packages/plugin-rsc/package.json`](https://github.com/rstackjs/rsbuild-plugin-rsc/blob/main/package.json)):
+
+- Plugin version: `0.0.3`
+- Peer deps: `@rsbuild/core ^2.0.0-0`, `react-server-dom-rspack *`
+- Declared: `react-server-dom-rspack 0.0.2`, `@rsbuild/core ^2.0.0-rc.2`, `@rslib/core 0.21.0`
+
+### 5.9 Three-bundle architecture equivalent
+
+The "three bundles" framing (RSC bundle / SSR bundle / client bundle) maps to Rspack like this:
+
+| Bundle | Rspack compiler | Layer | Entry example |
+|---|---|---|---|
+| RSC bundle (React.server runtime) | Server Compiler (`target: 'node'`) | `Layers.rsc` | `./src/entry.rsc.tsx` |
+| SSR bundle (React DOM server) | Same Server Compiler, different layer | `Layers.ssr` | `./src/entry.ssr.tsx` |
+| Client bundle (hydration) | Client Compiler (`target: 'web'`) | *(no layer needed)* | `./src/entry.client.tsx` |
+
+This is structurally the same as the webpack three-bundle layout Next.js and Waku historically used, but it runs as **two Compiler instances** (not three), with the server compiler internally bifurcated via the `layer` feature.
+
+## 6. Known Issues and Limitations
+
+Drawn from the PR history and docs:
+
+1. **No stable release.** Only available in `v2.0.0-alpha`/`beta`/`rc` pre-releases. Stable 2.0 has not shipped as of 2026-04-14.
+2. **Experiments flag required.** `rspackExperiments.reactServerComponents: true` — the feature is explicitly opt-in-experimental.
+3. **Built-in dev server does not work.** You must implement your own HTTP server that handles RSC request interception, runtime isolation, and HMR relays.
+4. **Module Federation integration is WIP.** Several RSC + MF PRs (#12977, #12978, #13203, #13204, #13208, #13215) remain open; first-class MF + RSC is not yet in RC.
+5. **Windows path bugs have existed.** [PR #12969](https://github.com/web-infra-dev/rspack/pull/12969) "fix: RSC fails to properly handle Windows paths" (2026-02-06) indicates path-handling regressions.
+6. **Lazy compilation compatibility was fixed only recently.** [PR #13136](https://github.com/web-infra-dev/rspack/pull/13136), 2026-02-27.
+7. **CSS handling in RSC layer had bugs.** [PR #13402](https://github.com/web-infra-dev/rspack/pull/13402) "should compile css without use server-entry" (2026-03-19).
+8. **Tree-shaking regressions on client barrels.** [PR #13472](https://github.com/web-infra-dev/rspack/pull/13472), 2026-03-26.
+9. **`react-server-dom-rspack` is pinned to `0.0.2`** with its README self-describing as experimental ("Use it at your own risk").
+10. **`rsbuild-plugin-rsc` is pinned to `0.0.3`** with only 12 GitHub stars — almost no external adoption yet.
+11. **Next.js App Router on Rspack is slow.** Per the Rspack+Vercel partnership blog, "App Router implementation with next-rspack is slower than Turbopack, and may even be slower than webpack." That means for Next.js users the RSC pipeline that *ships in production* today (Next App Router) is measurably degraded on Rspack unless the Rspack team's Rust port of the Next plugins is activated.
+12. **Documentation is thin.** The `rsc.mdx` guide is a single file (~287 lines for the English version, landed 2026-02-06); docs were being iterated as recently as [PR #13289](https://github.com/web-infra-dev/rspack/pull/13289) on 2026-03-11. Breadth and cookbook coverage do not approach Next.js or Parcel's RSC docs.
+13. **No React team blessing.** `react-server-dom-rspack` is not in `facebook/react`, unlike `react-server-dom-webpack`/`-parcel`/`-turbopack`. There is no upstream commitment to API stability paralleling the canary React renderers.
+
+## 7. Community Resources
+
+### 7.1 Official / Rspack-team
+
+- [rsbuild-plugin-rsc](https://github.com/rstackjs/rsbuild-plugin-rsc) — official wrapper, 4 examples
+- [Rspack 2.0 RSC guide (English)](https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/guide/tech/rsc.mdx)
+- [Core PR #12012 `feat: builtin react server component`](https://github.com/web-infra-dev/rspack/pull/12012)
+- [`react-server-dom-rspack` on npm](https://www.npmjs.com/package/react-server-dom-rspack)
+- [`crates/rspack_plugin_rsc`](https://github.com/web-infra-dev/rspack/tree/main/crates/rspack_plugin_rsc) — Rust source
+
+### 7.2 Historical / pre-built-in
+
+- [hyf0/server-components-demo-on-rspack](https://github.com/hyf0/server-components-demo-on-rspack) — 2023 patch-based demo. No SSR. Explicitly not production-ready. Fork of `reactjs/server-components-demo`.
+- [JiangWeixian/rspack-rsc-playground](https://github.com/JiangWeixian/rspack-rsc-playground) — referenced in 2024 by the author of the closed [PR #5824](https://github.com/web-infra-dev/rspack/pull/5824). That original PR proposal was closed on 2025-10-21 in favor of SyMind's redesign.
+- [ScriptedAlchemy/rsnext](https://github.com/ScriptedAlchemy/rsnext) — referenced by Rspack member `hardfist` in 2024 as "full rsc implementation" experiment. Pre-dates 2.0 built-in support.
+
+### 7.3 Frameworks that use Rspack for RSC (or could)
+
+- **Modern.js** (ByteDance, built on Rspack/Rsbuild) — was the original driver of the missing-APIs issue [#8469](https://github.com/web-infra-dev/rspack/issues/8469); confirmed "the API provided by Rspack can meet the support of RSC" at close (2025-03-26). Modern.js ships its own Rspack-based RSC integration, though public documentation of it is sparse.
+- **Next.js** — via the experimental [`next-rspack`](https://nextjs.org/docs/community/rspack) plugin. App Router RSC works functionally (≈96% integration test pass rate per [arewerspackyet.com](https://arewerspackyet.com)), but slower than both Turbopack and webpack on App Router today per the Rspack team's own admission.
+- **Waku** — uses Vite/Rolldown, not Rspack. [Waku blog: Introducing Waku](https://waku.gg/blog/introducing-waku).
+- **React Router 7 RSC Data Mode** — supported via `rsbuild-plugin-rsc` example; React Router's own canonical path remains Vite (`@vitejs/plugin-rsc`).
+
+### 7.4 ShakaCode / React on Rails context
+
+- [shakacode/gumroad-rsc](https://github.com/shakacode/gumroad-rsc) — public comparison repo Justin Gordon references in [react_on_rails#3128](https://github.com/shakacode/react_on_rails/issues/3128). Stack: Rails + React 19 + Shakapacker + Rspack + React on Rails Pro + RSC on one dashboard slice, Inertia control on another. Findings (per issue body, April 2026):
+  - Cold production build: `25.19s → 11.25s` (webpack → Rspack)
+  - Cold dev build: `16.24s → 5.28s`
+  - RSC route vs Inertia route: `-12.6%` navigation duration, `-8.9%` LCP, `-80%` client JS request count; but `+7.6%` `responseEnd` — RSC is winning user-visible metrics but still paying a server renderer/streaming cost.
+
+### 7.5 Noteworthy discussions and newsletters
+
+- [vercel/next.js discussion #77716 — "RSC and Build Tools: Should I Use Rspack or Wait for Turbopack?"](https://github.com/vercel/next.js/discussions/77716) — Next.js maintainer `icyJoseph`: "support for Rspack in Next.js is still an ongoing development."
+- [vercel/next.js discussion #77800 — "Rspack plugin feedback"](https://github.com/vercel/next.js/discussions/77800) — the official feedback thread for `next-rspack`.
+- [This Week In React #266](https://dev.to/sebastienlorber/this-week-in-react-266-dos-shadcn-skills-rspack-expo-55-beta-hermes-expo-router-tc39-2h0p) — contemporary coverage.
+
+## 8. Comparison with Webpack's RSC Support
+
+### 8.1 What webpack has that Rspack still doesn't
+
+1. **Upstream React-team-maintained runtime.** `react-server-dom-webpack` ships from `facebook/react` under Meta maintainership, with matched canaries pinned to React versions via `next`/`canary`/`experimental` dist-tags. `react-server-dom-rspack` is maintained by a single ByteDance engineer, with a `0.0.2` "stable" tag and 13 total published versions as of this writing.
+2. **Longer production track record.** Webpack's RSC plugin (`ReactFlightWebpackPlugin`) has been powering Next.js App Router in production since late 2022. Rspack's built-in RSC plugin is ~3 months old at this writing (merged January 2026).
+3. **Broader framework adoption.** Next.js (millions of prod apps), Remix's RSC experiments, and others historically targeted webpack. Rspack RSC has essentially zero public production deployments.
+4. **`ContextModuleFactory` and `NormalModuleFactory` parser hooks** — webpack's hooks used by `ReactFlightWebpackPlugin`. Per tracking issue [#5318](https://github.com/web-infra-dev/rspack/issues/5318): "parser hook is not likely to be supported in near future for performance reason." Rspack works around this with its own Rust-native implementation rather than exposing webpack-parity hooks.
+
+### 8.2 Where Rspack is already ahead
+
+1. **Native Rust implementation.** `rspack_plugin_rsc` is written in Rust (`ServerPlugin`, `ClientPlugin`, coordinator, manifest runtime, SWC-native directive detection). This sidesteps the JS-plugin RPC overhead that has hurt `next-rspack` App Router perf — once the plugin is Rust-native, it benefits from Rspack's parallelism.
+2. **Built-in coordination.** The paired-plugin model with a shared coordinator crate (see [`crates/rspack_plugin_rsc/src/coordinator.rs`](https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_rsc/src/coordinator.rs)) means server/client manifest alignment is handled by Rspack itself, whereas webpack leaves it to the framework.
+3. **Inherits Rspack's cold-build speed.** Per the Gumroad comparison ([#3128](https://github.com/shakacode/react_on_rails/issues/3128)), cold production builds went from ~25s to ~11s on a real Rails app just by swapping webpack → Rspack. RSC-specific throughput numbers are not yet published by the Rspack team.
+4. **`"use server-entry"` directive.** Rspack invented a third directive for entry-point metadata emission (attaching `entryJsFiles` / `entryCssFiles` to exported components). Not a React standard, but useful for framework authors. Webpack has no equivalent built-in.
+5. **Layer-aware chunking by default.** Rspack's stable `layer` feature (since 1.6) gives RSC a first-class primitive; webpack has layers via `experiments.layers` but with less ergonomic stability guarantees.
+
+### 8.3 Neither is ahead — both share
+
+- Dependence on the directive model (`"use client"`, `"use server"`).
+- Dependence on `react ^19.1.0` and compatible `react-dom` for RSC.
+- Need for a framework layer to produce a usable app; the bundler alone does not ship a dev server, router, streaming renderer, or server-action router.
+
+## 9. Outlook / Roadmap
+
+### 9.1 Immediate (Q2 2026)
+
+- Ship **Rspack 2.0 stable.** Currently at `v2.0.0-rc.1` (2026-04-08). [PR #13697 "chore(release): release 2.0.0-rc.2"](https://github.com/web-infra-dev/rspack/pull/13697) is open as of 2026-04-14.
+- Continue stabilizing `react-server-dom-rspack` (currently `0.0.2`). No public roadmap for hitting `1.0.0`; trajectory is about 1 version per 2–6 weeks since December 2025.
+- Iterate on documentation. The [rsc.mdx guide](https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/guide/tech/rsc.mdx) has been rewritten multiple times (PRs #12919, #13289, ongoing).
+
+### 9.2 Near-term (H2 2026, inferred from open PRs)
+
+- **First-class Module Federation + RSC.** Merge of PRs #12977, #12978, #13203, #13204, #13208, #13215. ByteDance's Module Federation team (`ScriptedAlchemy` et al.) is actively pushing this.
+- **Additional hooks for framework authors** — `onServerComponentChanges` is one; more will likely follow as framework consumers report gaps.
+
+### 9.3 Longer-term (unclear timeline)
+
+- **Upstream acceptance of `react-server-dom-rspack` into `facebook/react`.** No public signal this is planned or agreed. Compare with `react-server-dom-parcel` (upstreamed via devongovett's [PR #31725](https://github.com/facebook/react/pull/31725)) and `react-server-dom-turbopack` (in Vercel/React coordination).
+- **Production-grade adoption by a shipping framework.** Modern.js is the obvious candidate, but its public RSC positioning is quiet. Next.js's path forward is Turbopack, not Rspack, for RSC. Without a big framework shipping Rspack RSC in production, it will stay `experimental`.
+
+### 9.4 External dependencies
+
+- **React team direction.** If React's RSC API surface shifts (e.g., removing `"use server-entry"` extensions, changing reference IDs), `react-server-dom-rspack` must follow. Being out-of-tree in `facebook/react` is a structural risk.
+- **React 19 / 20 cadence.** `react-server-dom-rspack` has `peerDependencies.react ^19.1.0`. Any React 20 RSC changes will require a new major.
+- **Next.js's Turbopack-vs-Rspack balance.** Vercel's preferred RSC path is Turbopack. Rspack + Next App Router is degraded today per the Rspack team's own post. This caps "how much Next work it's worth Rspack doing" until/unless the Rust-plugin port lands stably.
+
+## 10. References
+
+All URLs consulted, grouped by type. Dates show the content's "as of" when known; accessed 2026-04-14 unless otherwise stated.
+
+### 10.1 Rspack official
+
+- [rspack.rs — homepage](https://rspack.rs/)
+- [rspack.rs/misc/planning/roadmap — Roadmap](https://rspack.rs/misc/planning/roadmap)
+- [rspack.rs/guide/tech/react — React guide](https://rspack.rs/guide/tech/react)
+- [rspack.rs/guide/features/layer — Layer guide](https://rspack.rs/guide/features/layer)
+- [rspack.rs/config/experiments — Experiments config](https://rspack.rs/config/experiments)
+- [rspack.rs/blog/ — Blog index](https://rspack.rs/blog/)
+- [rspack.rs/blog/announcing-1-6 — Rspack 1.6 announcement, 2025-10-30](https://rspack.rs/blog/announcing-1-6)
+- [rspack.rs/blog/announcing-1-7 — Rspack 1.7 announcement, 2025-12-31](https://rspack.rs/blog/announcing-1-7)
+- [rspack.rs/blog/rspack-next-partner — Rspack joins Next.js ecosystem, 2025-04-10](https://rspack.rs/blog/rspack-next-partner)
+- [v2.rspack.rs/ — Rspack 2 docs](https://v2.rspack.rs/)
+- [github.com/web-infra-dev/rspack — main repo](https://github.com/web-infra-dev/rspack)
+- [github.com/web-infra-dev/rspack/releases — all releases](https://github.com/web-infra-dev/rspack/releases)
+- [github.com/web-infra-dev/rspack/blob/main/website/docs/en/guide/tech/rsc.mdx — RSC guide source](https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/guide/tech/rsc.mdx)
+- [github.com/web-infra-dev/rspack/tree/main/crates/rspack_plugin_rsc — Rust plugin source](https://github.com/web-infra-dev/rspack/tree/main/crates/rspack_plugin_rsc)
+
+### 10.2 Rspack PRs and Issues
+
+- [PR #5824 — feat: rsc plugin (closed 2025-10-21)](https://github.com/web-infra-dev/rspack/pull/5824)
+- [PR #12012 — feat: builtin react server component (merged 2026-01-23)](https://github.com/web-infra-dev/rspack/pull/12012)
+- [PR #12919 — docs: add guide for React Server Components (merged 2026-02-06)](https://github.com/web-infra-dev/rspack/pull/12919)
+- [PR #13136 — feat: making RSC compatible with lazy compilation (merged 2026-02-27)](https://github.com/web-infra-dev/rspack/pull/13136)
+- [PR #13263 — feat: rsc support disable client api checks (merged 2026-03-09)](https://github.com/web-infra-dev/rspack/pull/13263)
+- [PR #13277 — feat: support rsc manifest callback (merged 2026-03-11)](https://github.com/web-infra-dev/rspack/pull/13277)
+- [PR #13289 — chore: docs for config rsc build entries (merged 2026-03-11)](https://github.com/web-infra-dev/rspack/pull/13289)
+- [PR #13402 — fix(rsc): should compile css without use server-entry (merged 2026-03-19)](https://github.com/web-infra-dev/rspack/pull/13402)
+- [PR #13472 — fix(rsc): tree shaking client barrel (merged 2026-03-26)](https://github.com/web-infra-dev/rspack/pull/13472)
+- [Issue #5318 — [Tracking] Blockers for React Server Components (closed 2024-08-13)](https://github.com/web-infra-dev/rspack/issues/5318)
+- [Issue #8469 — missing APIs for RSC framework support (closed 2025-03-26)](https://github.com/web-infra-dev/rspack/issues/8469)
+- [Discussion #9270 — Planned breaking changes for Rspack 2.0](https://github.com/web-infra-dev/rspack/discussions/9270)
+
+### 10.3 npm packages
+
+- [react-server-dom-rspack on npm](https://www.npmjs.com/package/react-server-dom-rspack) — maintainer: `symind`, latest `0.0.2` (2026-03-14)
+- [react-server-dom-webpack on npm](https://www.npmjs.com/package/react-server-dom-webpack) — maintainer: `react-bot@meta.com`, latest `19.2.5` (2026-04-08)
+- [@rspack/core on npm](https://www.npmjs.com/package/@rspack/core)
+
+### 10.4 Related projects
+
+- [rstackjs/rsbuild-plugin-rsc — official Rsbuild wrapper](https://github.com/rstackjs/rsbuild-plugin-rsc), stars: 12, created 2025-12-23
+- [rstackjs/rsbuild-plugin-rsc/tree/main/examples — 4 examples](https://github.com/rstackjs/rsbuild-plugin-rsc/tree/main/examples)
+- [hyf0/server-components-demo-on-rspack — 2023 patch-based demo](https://github.com/hyf0/server-components-demo-on-rspack)
+- [JiangWeixian/rspack-rsc-playground — 2024 playground](https://github.com/JiangWeixian/rspack-rsc-playground)
+- [ScriptedAlchemy/rsnext — 2024 full RSC experiment](https://github.com/ScriptedAlchemy/rsnext)
+
+### 10.5 Next.js / Vercel
+
+- [Next.js community docs on Rspack](https://nextjs.org/docs/community/rspack) — lastUpdated 2026-04-10
+- [Discussion #77716 — RSC and Build Tools: Should I Use Rspack or Wait for Turbopack?](https://github.com/vercel/next.js/discussions/77716)
+- [Discussion #77800 — Rspack plugin feedback](https://github.com/vercel/next.js/discussions/77800)
+- [arewerspackyet.com — next-rspack test progress (99.3% as of access)](https://arewerspackyet.com)
+
+### 10.6 Competitor bundler RSC approaches
+
+- [Parcel RSC recipe](https://parceljs.org/recipes/rsc/)
+- [Parcel v2.14.0 blog — beta RSC](https://parceljs.org/blog/v2-14-0/)
+- [PR #31725 — Implement react-server-dom-parcel (facebook/react)](https://github.com/facebook/react/pull/31725)
+- [@vitejs/plugin-rsc on npm](https://www.npmjs.com/package/@vitejs/plugin-rsc)
+- [vitejs/vite-plugin-react/tree/main/packages/plugin-rsc](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc)
+- [facebook/react packages dir — no react-server-dom-rspack](https://github.com/facebook/react/tree/main/packages)
+
+### 10.7 ShakaCode / React on Rails context
+
+- [shakacode/react_on_rails issue #3128 — Gumroad comparison](https://github.com/shakacode/react_on_rails/issues/3128)
+- [shakacode/gumroad-rsc — public comparison repo](https://github.com/shakacode/gumroad-rsc)
+
+### 10.8 People cited
+
+- **SyMind / Cong-Cong Pan** (ByteDance) — author of Rspack's built-in RSC and of `react-server-dom-rspack`. [GitHub profile](https://github.com/SyMind).
+- **chenjiahan** — Rspack team member, confirmed RSC design direction on PR #5824.
+- **hardfist** — Rspack team member, originally triaged blocker issue #5318.
+- **yimingjfe (Ming)** — Modern.js / ByteDance, opened missing-APIs issue #8469.
+
+---
+
+**Flagged uncertainties (as of 2026-04-14):**
+
+- It is not clear from public documentation whether the Rspack team intends to upstream `react-server-dom-rspack` into `facebook/react`. No PR or public proposal has been observed.
+- No benchmark data has been published by the Rspack team specifically comparing their built-in RSC vs webpack's `ReactFlightWebpackPlugin` on RSC-specific workloads (manifest generation, streaming, HMR). Performance claims so far are general Rspack-vs-webpack, not RSC-specific.
+- The stable Rspack 2.0 release date is not locked — February 2026 was the "first preview" target per the roadmap, and the project is at RC as of April 2026. A firm GA date has not been publicly committed.
+- `react-server-dom-rspack`'s API stability guarantees are undocumented; the README is ~1 line of "Use it at your own risk."


### PR DESCRIPTION
## Summary

Captures the investigation of [#3141](https://github.com/shakacode/react_on_rails/issues/3141) and a concrete plan for implementing rspack support in the RSC plugin. **Docs only — no code changes.** Adds three documents under `.claude/docs/` that together answer: what rspack's RSC story looks like today, which parts of `react-on-rails-rsc` are already compatible, and exactly how to make the remaining part (the plugin) work.

## Key findings

- **Only `RSCWebpackPlugin` needs rewriting.** The other four components in `react-on-rails-rsc` — `WebpackLoader`, `server.node`, `client.node`, `client.browser` — work with rspack as-is. Proven empirically by a 31-test suite on [`shakacode/react_on_rails_rsc#test/rspack-compatibility`](https://github.com/shakacode/react_on_rails_rsc/tree/test/rspack-compatibility) including a full encode→decode round trip with both sides bundled by rspack.
- **We will NOT adopt rspack's built-in RSC system** (`rspackExperiments.reactServerComponents` + `experiments.rsc.createPlugins()` + `react-server-dom-rspack`). It's too coupled to rspack's experimental Layers + Rsbuild path. Instead, write our own plugin using standard bundler-compatible APIs.
- **Runtime compatibility is solid.** Rspack emits `__webpack_require__`, `__webpack_chunk_load__`, and a mutable `__webpack_require__.u` — the three globals React's Flight client relies on — with identical semantics.
- **Manifest schema stays unchanged.** Rspack's native manifest is nearly identical to RoR's (minor field name differences, one extra `async` field). Our rspack plugin emits RoR's existing schema; no changes to `server.node.ts`, `client.node.ts`, or `client.browser.ts`.
- **One known risk:** `react-server-dom-rspack@0.0.2` ships a 394-line chunk-cache patch over `react-server-dom-webpack`. May or may not affect RoR — decide in prototype.

## Documents added

1. **`rspack-rsc-support-state.md`** (533 lines) — state of official rspack RSC support as of 2026-04-14: verified `react-server-dom-rspack` exists, rspack v2 built-in RSC is live (PR [web-infra-dev/rspack#12012](https://github.com/web-infra-dev/rspack/pull/12012)), working pure-rspack demo built and validated.

2. **`rsc-rspack-implementation-plan.md`** (46KB, 8 sections) — original high-level investigation: current architecture, compatibility matrix, 7 critical discussion points, 6 refactoring opportunities, 4-phase plan, 14-row risk matrix.

3. **`rsc-rspack-plugin-implementation.md`** (NEW, 618 lines) — focused plugin plan; the decision doc for implementation. Covers:
   - What we verified empirically (31-test suite + pure-rspack demo)
   - Why only the plugin needs changing
   - Manifest schema comparison
   - Architecture decision (dual-path behind existing facade)
   - Discovery technique (loader-tag + module graph walk, not FS walk)
   - Chunk-splitting technique (`AsyncDependenciesBlock` without custom dep subclass)
   - Runtime compatibility risks (the chunk-cache patch)
   - 6-phase implementation plan
   - 7 known unknowns to validate in prototype

## Why this is docs-only

The implementation work itself is blocked on Phase 0 (prototype) to validate seven specific unknowns (rspack dep-type for `AsyncDependenciesBlock.addDependency`, the chunk-cache issue, module ID formats, etc.). Rather than guess at these, the plan commits them to a short prototype and defers implementation until we have answers.

## Test plan

- [x] Run `yarn test` locally — no code changes, nothing to run
- [x] Verify all three docs render correctly on GitHub
- [x] Confirm linked issues and PRs exist:
  - [#3141 (parent issue)](https://github.com/shakacode/react_on_rails/issues/3141)
  - [#1828 (original RSC+rspack tracker)](https://github.com/shakacode/react_on_rails/issues/1828)
  - [#2552 (rename `*WebpackConfig.js`)](https://github.com/shakacode/react_on_rails/issues/2552) — must NOT land concurrently
  - [web-infra-dev/rspack#12012](https://github.com/web-infra-dev/rspack/pull/12012)
  - [shakacode/react_on_rails_rsc#test/rspack-compatibility](https://github.com/shakacode/react_on_rails_rsc/tree/test/rspack-compatibility)

## Next steps after merge

1. Start Phase 0 (prototype) from the plan in `rsc-rspack-plugin-implementation.md`
2. Validate the seven open unknowns
3. Proceed with phases 1-6 (webpack refactor → rspack plugin → optional chunk-cache patch → generator → tests → docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three comprehensive planning documents detailing React Server Components support with rspack, including architecture analysis, compatibility assessment, implementation phases, configuration guidance, and risk evaluation for future development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->