### PR TITLE
docs: address RSC pitfalls review follow-ups (#3155)

### DIFF
--- a/docs/oss/building-features/node-renderer/basics.md
+++ b/docs/oss/building-features/node-renderer/basics.md
@@ -157,6 +157,7 @@ The Node Renderer must be started as a background process before running tests. 
 # .github/workflows/test.yml (GitHub Actions example)
 jobs:
   test:
+    runs-on: ubuntu-latest
     env:
       # Job-level: both the renderer and Rails test steps need this
       RENDERER_PASSWORD: ${{ secrets.RENDERER_PASSWORD }}

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -862,7 +862,7 @@ externals: {
 **Correct approach:**
 
 ```js
-// In serverWebpackConfig.js -- tells webpack to provide empty modules
+// In serverWebpackConfig.js -- tells webpack to omit these modules (no require() call emitted)
 resolve: {
   fallback: {
     path: false,
@@ -880,7 +880,19 @@ resolve: {
 
 **Root cause:** `react-dom/server.browser.js` (used for SSR streaming) instantiates `MessageChannel` at **module load time** for React's internal scheduler. The VM sandbox does not provide `MessageChannel` as a global, and `supportModules` does not include it.
 
-**Fix:** Use webpack's `BannerPlugin` to inject a minimal `MessageChannel` polyfill at the top of the server bundle. The polyfill only needs to support `port2.postMessage` triggering `port1.onmessage`, which is all React's scheduler requires:
+**Fix (recommended):** Use `additionalContext` in the node renderer config to inject Node.js' native `MessageChannel` into the VM sandbox. Node.js has had a native `MessageChannel` since Node 15, and passing it through `additionalContext` gives React's scheduler correct async scheduling (macrotask delivery), which is what it depends on:
+
+```js
+// In your node-renderer.js config
+const { MessageChannel } = require('node:worker_threads');
+
+const config = {
+  // ... other options
+  additionalContext: { MessageChannel },
+};
+```
+
+**Fallback:** If you cannot change the renderer config (e.g., a build-only setup without renderer config control), inject a minimal `MessageChannel` polyfill at the top of the server bundle using webpack's `BannerPlugin`. The polyfill only needs to support `port2.postMessage` triggering `port1.onmessage`, which is all React's scheduler requires:
 
 ```js
 // In serverWebpackConfig.js
@@ -913,9 +925,7 @@ plugins: [
 ];
 ```
 
-This injects the polyfill as raw JavaScript at the top of the bundle output, ensuring `MessageChannel` is defined before any module code executes.
-
-**Recommended approach:** Use `additionalContext` in the renderer config to inject Node.js' native `MessageChannel` into the VM sandbox. This provides correct async scheduling (macrotask delivery), which React's scheduler depends on. The `BannerPlugin` polyfill above delivers messages synchronously — this works for current SSR streaming scenarios but may cause subtle rendering bugs if React yields mid-render and re-enters the scheduler.
+This injects the polyfill as raw JavaScript at the top of the bundle output, ensuring `MessageChannel` is defined before any module code executes. Note: this polyfill delivers messages synchronously, which works for current SSR streaming scenarios but may cause subtle rendering bugs if React yields mid-render and re-enters the scheduler. Prefer the `additionalContext` approach above whenever possible.
 
 > **When to use the `BannerPlugin` polyfill:** Use it only when the renderer config's `additionalContext` is not accessible (e.g., in a build-only setup without renderer config control). If you encounter recursive stack-overflow errors or unexpected rendering behavior with the synchronous polyfill, switch to the `additionalContext` approach.
 

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -862,7 +862,7 @@ externals: {
 **Correct approach:**
 
 ```js
-// In serverWebpackConfig.js -- tells webpack to omit these modules (no require() call emitted)
+// In serverWebpackConfig.js -- tells webpack not to polyfill these modules (imports resolve to nothing; no shim bundled)
 resolve: {
   fallback: {
     path: false,
@@ -872,7 +872,7 @@ resolve: {
 }
 ```
 
-`resolve.fallback: false` tells webpack to omit the module at build time — no fallback shim is bundled and no `require()` call is emitted. The RSC bundle does not need this workaround because it runs in full Node.js where `require()` is available and Node builtins work normally.
+`resolve.fallback: false` tells webpack not to provide a polyfill for the module — the import resolves to an empty module at build time and no fallback shim is bundled. The RSC bundle does not need this workaround because it runs in full Node.js where `require()` is available and Node builtins work normally.
 
 ### MessageChannel Not Defined
 
@@ -890,7 +890,11 @@ const config = {
   // ... other options
   additionalContext: { MessageChannel },
 };
+
+module.exports = config; // export from node-renderer.js
 ```
+
+See the [node renderer JS configuration reference](../building-features/node-renderer/js-configuration.md) for where `config` is consumed.
 
 **Fallback:** If you cannot change the renderer config (e.g., a build-only setup without renderer config control), inject a minimal `MessageChannel` polyfill at the top of the server bundle using webpack's `BannerPlugin`. The polyfill only needs to support `port2.postMessage` triggering `port1.onmessage`, which is all React's scheduler requires:
 

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -71,7 +71,7 @@ There is no warning when a component is auto-classified as a server component. I
 
 Before proceeding to Step 1:
 
-- [ ] Search your component source files for `useState`, `useEffect`, `useLayoutEffect`, `useInsertionEffect`, `useContext`, `useRef`, `useImperativeHandle`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useSyncExternalStore`, `useOptimistic`, `useFormStatus`, `useSelector`, `useDispatch`, `useNavigate`, `useLocation`, `useParams`, `ReactOnRails.getStore`, `ReactOnRails.authenticityToken`
+- [ ] Search your component source files for `useState`, `useEffect`, `useLayoutEffect`, `useInsertionEffect`, `useContext`, `useRef`, `useImperativeHandle`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useSyncExternalStore`, `useOptimistic`, `useFormStatus`, `useSelector`, `useDispatch`, `connect(`, `useNavigate`, `useLocation`, `useParams`, `ReactOnRails.getStore`, `ReactOnRails.authenticityToken`
 - [ ] Check all `.server.jsx` files -- these almost certainly need `'use client'`
 - [ ] Check components that use `StaticRouter` (SSR wrapper, not a client API — but the file likely uses other client APIs)
 - [ ] Verify no component relies on browser globals (`window`, `document`) without `'use client'`

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -45,7 +45,7 @@ Components that use any of the following **must** have `'use client'`:
 - **Router client APIs**: `useNavigate`, `useLocation`, `useParams`
 - **SSR entry-point files** using `StaticRouter`: these are SSR wrappers, not RSC server components — see the `.server.jsx` naming collision below
 - **Event handlers**: `onClick`, `onChange`, `onSubmit`, etc.
-- **Browser APIs**: `window`, `document`, `localStorage`, `fetch` in effects
+- **Browser APIs**: `window`, `document`, `localStorage` (note: `fetch` is a Node.js global since v18 and works in Server Components — calling it directly in server context is an encouraged RSC pattern; only flag `fetch` if it is called inside a `useEffect`, which is already covered by the hooks list above)
 
 ### The `.server.jsx` naming collision
 
@@ -71,7 +71,7 @@ There is no warning when a component is auto-classified as a server component. I
 
 Before proceeding to Step 1:
 
-- [ ] Search your component source files for `useState`, `useEffect`, `useContext`, `useSelector`, `useDispatch`, `useTransition`, `useDeferredValue`, `useNavigate`, `useLocation`, `useParams`, `ReactOnRails.getStore`
+- [ ] Search your component source files for `useState`, `useEffect`, `useContext`, `useRef`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useOptimistic`, `useFormStatus`, `useSelector`, `useDispatch`, `useNavigate`, `useLocation`, `useParams`, `ReactOnRails.getStore`, `ReactOnRails.authenticityToken`
 - [ ] Check all `.server.jsx` files -- these almost certainly need `'use client'`
 - [ ] Check components that use `StaticRouter` (SSR wrapper, not a client API — but the file likely uses other client APIs)
 - [ ] Verify no component relies on browser globals (`window`, `document`) without `'use client'`

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -38,7 +38,7 @@ Before running the generator, audit your existing components to identify which o
 
 Components that use any of the following **must** have `'use client'`:
 
-- **React hooks** (`import { ... } from 'react'`): `useState`, `useEffect`, `useContext`, `useRef`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useOptimistic`
+- **React hooks** (`import { ... } from 'react'`): `useState`, `useEffect`, `useLayoutEffect`, `useInsertionEffect`, `useContext`, `useRef`, `useImperativeHandle`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useSyncExternalStore`, `useOptimistic`
 - **React DOM hooks** (`import { ... } from 'react-dom'`): `useFormStatus`
 - **React on Rails client APIs**: `ReactOnRails.getStore()`, `ReactOnRails.authenticityToken()`
 - **Redux**: `useSelector`, `useDispatch`, `connect()`, `<Provider>`
@@ -71,7 +71,7 @@ There is no warning when a component is auto-classified as a server component. I
 
 Before proceeding to Step 1:
 
-- [ ] Search your component source files for `useState`, `useEffect`, `useContext`, `useRef`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useOptimistic`, `useFormStatus`, `useSelector`, `useDispatch`, `useNavigate`, `useLocation`, `useParams`, `ReactOnRails.getStore`, `ReactOnRails.authenticityToken`
+- [ ] Search your component source files for `useState`, `useEffect`, `useLayoutEffect`, `useInsertionEffect`, `useContext`, `useRef`, `useImperativeHandle`, `useReducer`, `useCallback`, `useMemo`, `useTransition`, `useDeferredValue`, `useId`, `useSyncExternalStore`, `useOptimistic`, `useFormStatus`, `useSelector`, `useDispatch`, `useNavigate`, `useLocation`, `useParams`, `ReactOnRails.getStore`, `ReactOnRails.authenticityToken`
 - [ ] Check all `.server.jsx` files -- these almost certainly need `'use client'`
 - [ ] Check components that use `StaticRouter` (SSR wrapper, not a client API — but the file likely uses other client APIs)
 - [ ] Verify no component relies on browser globals (`window`, `document`) without `'use client'`


### PR DESCRIPTION
## Summary

Applies the five documentation review comments from PR #3087 that were triaged to issue #3155:

- `docs/oss/building-features/node-renderer/basics.md` — Add missing `runs-on: ubuntu-latest` to the GitHub Actions workflow example so the snippet is copy-paste valid.
- `docs/oss/migrating/rsc-troubleshooting.md` — Correct the `resolve.fallback: false` inline comment to say "omit these modules (no require() call emitted)", matching the paragraph below it (no empty-module shim is generated).
- `docs/pro/react-server-components/upgrading-existing-pro-app.md` — Expand the audit checklist to include the React hooks (`useRef`, `useReducer`, `useCallback`, `useMemo`, `useId`, `useOptimistic`), React DOM hooks (`useFormStatus`), and `ReactOnRails.authenticityToken` that were listed under "What to look for" but missing from the checklist.
- `docs/oss/migrating/rsc-troubleshooting.md` — Reorder the MessageChannel Not Defined section to lead with the recommended `additionalContext` fix (injecting Node's native `MessageChannel` from `node:worker_threads`) and demote BannerPlugin to a labeled fallback, so readers encounter the preferred approach first.
- `docs/pro/react-server-components/upgrading-existing-pro-app.md` — Clarify `fetch` under "Browser APIs": it's a Node.js global since v18 and works in Server Components. The list now only flags `fetch` calls inside `useEffect`, which are already captured by the hooks list above.

Fixes #3155

## Test plan

- [x] Prettier check (`npx prettier --check`) passes on all three modified docs
- [x] Lefthook hooks (trailing-newlines, markdown-links, prettier) passed on commit
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust examples and recommended fixes; no runtime behavior changes, so risk is low aside from potential reader confusion if guidance is misapplied.
> 
> **Overview**
> Updates RSC/Node Renderer docs to make setup and troubleshooting guidance more accurate and copy/paste-ready.
> 
> The CI workflow snippet now includes `runs-on: ubuntu-latest`, the webpack `resolve.fallback: false` explanation is clarified, and the `MessageChannel is not defined` section is reordered to recommend injecting Node’s native `MessageChannel` via `additionalContext` (with `BannerPlugin` polyfill as an explicit fallback). The Pro RSC upgrade guide expands the client-API audit checklist to cover additional hooks/APIs and clarifies that `fetch` is usable in Server Components (flag it only when used in `useEffect`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba62952c1de4cd9d8c785bbaaa009426e5ea569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Specified explicit runner environment for Node Renderer test workflow
  * Updated MessageChannel troubleshooting to recommend injecting Node’s MessageChannel at the renderer level, with the webpack polyfill noted as a fallback
  * Clarified that fetch is usable in Server Components and expanded the audit checklist to include additional React hooks and related APIs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->