### PR TITLE
docs: remove fabricated DevConsole reference, link verified RSC tools (#2527)

### DIFF
--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -704,7 +704,7 @@ end
 
 | Tool                                                                                                                          | Purpose                                                          |
 | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **webpack-bundle-analyzer**                                                                                                   | Analyze client bundle composition and module sizes               |
+| **[webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer)**                                     | Analyze client bundle composition and module sizes               |
 | **[RSC Devtools](https://chromewebstore.google.com/detail/rsc-devtools/jcejahepddjnppkhomnidalpnnnemomn)** (Chrome extension) | Visualize RSC streaming data, server vs client rendering         |
 | **[RSC Parser](https://rsc-parser.vercel.app/)**                                                                              | Parse the React Flight wire format to inspect the component tree |
 | **[webpack-stats-explorer](https://github.com/erykpiast/webpack-stats-explorer)**                                             | Interactive exploration of webpack stats for chunk analysis      |

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -702,13 +702,12 @@ end
 
 ## Bundle Analysis Tools
 
-| Tool                                | Purpose                                                          |
-| ----------------------------------- | ---------------------------------------------------------------- |
-| **webpack-bundle-analyzer**         | Analyze client bundle composition and module sizes               |
-| **RSC Devtools** (Chrome extension) | Visualize RSC streaming data, server vs client rendering         |
-| **DevConsole**                      | Color-coded component boundaries (green = client, blue = server) |
-| **RSC Parser**                      | Parse the React Flight wire format to inspect the component tree |
-| **`webpack-stats-explorer`**        | Interactive exploration of webpack stats for chunk analysis      |
+| Tool                                                                                                                          | Purpose                                                          |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **webpack-bundle-analyzer**                                                                                                   | Analyze client bundle composition and module sizes               |
+| **[RSC Devtools](https://chromewebstore.google.com/detail/rsc-devtools/jcejahepddjnppkhomnidalpnnnemomn)** (Chrome extension) | Visualize RSC streaming data, server vs client rendering         |
+| **[RSC Parser](https://rsc-parser.vercel.app/)**                                                                              | Parse the React Flight wire format to inspect the component tree |
+| **[webpack-stats-explorer](https://github.com/erykpiast/webpack-stats-explorer)**                                             | Interactive exploration of webpack stats for chunk analysis      |
 
 ### Key Metrics to Track
 


### PR DESCRIPTION
## Summary

Addresses [#2527](https://github.com/shakacode/react_on_rails/issues/2527) — minor unverified references in the RSC migration docs.

The Bundle Analysis Tools table in `rsc-troubleshooting.md` listed a tool called **DevConsole** with the description "Color-coded component boundaries (green = client, blue = server)". After verification, DevConsole is a Next.js-specific in-app debug overlay (the `devconsole-package` npm package, integrated via a `DebugProvider` in `app/layout.tsx`), not a bundle analysis tool, and not applicable to React on Rails.

- Remove the DevConsole row.
- Add direct links to the remaining third-party tools (RSC Devtools, RSC Parser, webpack-stats-explorer) so readers can verify and install them without searching.

## Verification of the other items in #2527

- **E1 (`WithAsyncProps` import path)** — already removed from `rsc-data-fetching.md` in [#2803](https://github.com/shakacode/react_on_rails/pull/2803). No action needed.
- **E2 (RSC Devtools Chrome extension)** — verified: real tool by Alvar Lagerlöf, listed at https://chromewebstore.google.com/detail/rsc-devtools/jcejahepddjnppkhomnidalpnnnemomn. Linked in this PR.
- **E3 (DevConsole)** — fixed (removed) by this PR.
- **E4 (`react-on-rails-rsc` 19.0.4 minimum)** — verified: 19.0.4 is the current latest published version on npm. The recommendation in `rsc-preparing-app.md` is correct.

Closes #2527

## Test plan

- [x] Local prettier passes
- [x] lefthook pre-commit hooks pass (markdown-links, trailing-newlines, prettier)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an unverified tool reference and adds outbound links; no runtime/code behavior is affected.
> 
> **Overview**
> Updates the RSC migration troubleshooting docs to **remove the incorrect `DevConsole` entry** from the “Bundle Analysis Tools” table.
> 
> Also **adds direct links** to the remaining recommended third-party tools (`webpack-bundle-analyzer`, `RSC Devtools`, `RSC Parser`, `webpack-stats-explorer`) to make verification and installation easier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57382a921cd53005df2eb30407aab704aa7fbea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved the bundle analysis tools table in the RSC troubleshooting guide for clearer formatting and spacing.
  * Replaced plain tool names with direct external links for webpack-bundle-analyzer, RSC Devtools, RSC Parser, and webpack-stats-explorer, and removed the DevConsole entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->