### PR TITLE
docs: sharpen minimum acceptable evidence for example migrations (#3127)

### DIFF
--- a/docs/oss/migrating/example-migrations.md
+++ b/docs/oss/migrating/example-migrations.md
@@ -72,28 +72,40 @@ The safest approach is:
 2. Replace one helper-backed component boundary first
 3. Treat the wrapper removal as a later step
 
-## What counts as proof
+## Minimum acceptable evidence
 
-Not every good migration example is performance-first.
+Every example migration PR listed on this page must carry proof a reader can inspect without local setup. Pick one of the two lanes below based on the honest win for the slice. Do not force a weak benchmark onto a maintainability-first example.
 
-When the change is performance-first, compare the same route on the baseline branch and the migration branch. At minimum, record:
+### Performance-first lane
 
-1. Response timing
-2. HTML size
-3. Route JavaScript bytes
-4. Number of JS assets needed for the route
-5. Hydration warnings or client boot errors
+Required for every performance-first example PR:
 
-If possible, also record browser metrics such as FCP, LCP, CLS, and TBT or INP.
+1. **Baseline and target** named explicitly: the commit SHA or branch on the baseline (pre-migration) side and the migration side, plus the route or mount point being compared
+2. **Response timing** on the same route, same environment, same warmup protocol, reported as a median over a stated sample size
+3. **HTML size** for the rendered route
+4. **Route JavaScript bytes** shipped to the browser for that route
+5. **Number of JS assets** needed for the route
+6. **Hydration warnings or client boot errors** observed, or an explicit "none" with how that was checked
 
-When the change is maintainability-first, record:
+Recommended when the environment allows: FCP, LCP, CLS, and TBT or INP.
 
-1. The custom bridge, oversized mount, or repo-specific contract that existed before the migration
-2. The standardized React on Rails helper or smaller boundary that replaced it
-3. What got easier to review, test, or evolve afterward
-4. The validation that supports the claim
+### Maintainability-first lane
 
-Use maintainability notes when that is the honest win. Do not force a weak benchmark onto an example whose real value is simpler ownership or a narrower integration boundary.
+Required for every maintainability-first example PR:
+
+1. **Before contract**: the specific custom bridge, oversized mount, or repo-specific helper that existed before the migration, named with file paths
+2. **After contract**: the React on Rails helper or smaller boundary that replaced it, named with file paths
+3. **What got easier**: one concrete reviewable, testable, or evolvable improvement, not a general claim
+4. **Validation**: the test, lint, compile, or runner step that confirms the new boundary works, linked or quoted from the PR
+
+### Where the evidence must live
+
+Proof that only exists in a local note is not proof for this page. It must be:
+
+1. In the PR description of the public migration PR, or
+2. In a linked gist, doc, or issue comment that anyone can read without credentials
+
+The [example-migrations meta issue](https://github.com/shakacode/react_on_rails/issues/3125) is the right place for working notes while a PR is still in flight. Once the migration lands or stabilizes, move the proof into the migration PR description or a linked writeup, then this page can add it as a stable reference.
 
 ## Contribute an example
 


### PR DESCRIPTION
## Summary

Sharpens the existing "What counts as proof" section in `docs/oss/migrating/example-migrations.md` into an explicit **Minimum acceptable evidence** policy that new example-migration PRs can be held to.

## What changed

- Renamed the section to `## Minimum acceptable evidence`
- Split it into `### Performance-first lane` and `### Maintainability-first lane`, each with a numbered REQUIRED checklist
- Added an explicit **baseline and target** requirement (commit SHA or branch for before/after, plus the route/mount being compared)
- Tightened the timing requirement to specify same environment, same warmup protocol, and a median over a stated sample size
- Added **Where the evidence must live**: proof must be in the public PR description or a linked gist/issue comment; in-flight working notes belong in the meta issue (#3125)

## Why

Addresses **deliverable 4** from #3127 ("Define the minimum acceptable evidence for future example PRs").

The previous "What counts as proof" text was descriptive ("at minimum, record...") but didn't clearly state what makes an example PR acceptance-ready, what counts as a reproducible baseline, or where the evidence must live. The sharpened version gives contributors a concrete checklist and explicitly rejects "local note" style proof as a credibility artifact.

## Scope note

This PR only advances deliverable 4. The other three from #3127 are intentionally out of scope here:

- **Deliverables 1 and 2** (publish the ACP benchmark and the `demarche` / `search-gov` / `worldcubeassociation` maintainability notes): the local notes don't exist in this repo. Best path is to paste them as comments on the meta issue (#3125) or into the public migration PR descriptions, which is what this policy now requires.
- **Deliverable 3** (add one more benchmarked example beyond ACP): requires a new migration + benchmark run, separate from a docs-only change.

## Dependency

Stacked on top of #3126 (base: `codex/example-migrations-docs`). This keeps the diff scoped to the 27-line policy change rather than pulling in #3126's content. When #3126 merges, this PR's base will auto-retarget to `main`.

## Validation

- `pnpm exec prettier --check docs/oss/migrating/example-migrations.md` passes
- Pre-commit hooks (trailing-newlines, markdown-links, prettier) passed at commit time

Refs #3127.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that tighten contribution requirements and do not affect runtime code.
> 
> **Overview**
> Replaces the vague "What counts as proof" guidance in `docs/oss/migrating/example-migrations.md` with a stricter **Minimum acceptable evidence** policy for example migration PRs.
> 
> Defines two required checklists (*performance-first* vs *maintainability-first*), adds explicit baseline/target and timing methodology requirements for benchmarks, and clarifies that evidence must be publicly inspectable (in the PR description or a link) rather than local notes, with in-flight artifacts directed to the meta issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c38a1cc565ceb824a7d761d4b8ee3a9d2c11b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->