### PR TITLE
test: enable RSpec --profile to surface slowest package tests

### DIFF
--- a/react_on_rails/spec/react_on_rails/spec_helper.rb
+++ b/react_on_rails/spec/react_on_rails/spec_helper.rb
@@ -113,10 +113,10 @@ RSpec.configure do |config|
   #     config.default_formatter = 'doc'
   #   end
   #
-  #   # Print the 10 slowest examples and example groups at the
-  #   # end of the spec run, to help surface which specs are running
-  #   # particularly slow.
-  #   config.profile_examples = 10
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
   #
   #   # Run specs in random order to surface order dependencies. If you find an
   #   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
## Summary
- Uncomments `config.profile_examples = 10` in `react_on_rails/spec/react_on_rails/spec_helper.rb` so each run prints the 10 slowest examples.
- Enables data-driven optimization of the ~24 minute package test suite — prerequisite for targeted perf work on generator tests, redundant `before(:all)` blocks, etc.

Fixes #3132

## Test plan
- [x] `bundle exec rubocop react_on_rails/spec/react_on_rails/spec_helper.rb` — no offenses
- [x] Ran a sample spec file (`utils_spec.rb`) locally; confirmed "Top 10 slowest examples" block appears at the end of the run
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only configuration change that only affects RSpec output and adds minor runtime overhead from collecting timings.
> 
> **Overview**
> Enables RSpec profiling in `react_on_rails/spec/react_on_rails/spec_helper.rb` by turning on `config.profile_examples = 10`, so each spec run reports the 10 slowest examples/example groups to help target test-suite performance work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82417ab510cbd3666f59384091f9b2b04ac7d209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test performance profiling to identify and report the slowest test cases during spec runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->