### PR TITLE
docs: restore absolute URL for node-renderer testing example

### DIFF
--- a/docs/oss/building-features/node-renderer/js-configuration.md
+++ b/docs/oss/building-features/node-renderer/js-configuration.md
@@ -58,7 +58,7 @@ Deprecated options:
 
 ### Testing example:
 
-[react_on_rails_pro/spec/dummy/renderer/node-renderer.js](../../../../react_on_rails_pro/spec/dummy/renderer/node-renderer.js)
+[react_on_rails_pro/spec/dummy/renderer/node-renderer.js](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/dummy/renderer/node-renderer.js)
 
 ### Simple example:
 


### PR DESCRIPTION
## Summary

Follow-up to #3165. Now that `react_on_rails_pro/spec/dummy/renderer/node-renderer.js` exists on `main`, switches the testing-example link in `docs/oss/building-features/node-renderer/js-configuration.md` from a cross-package relative path back to an absolute GitHub URL.

The relative path was a temporary workaround so the lychee link check would pass before the file existed at its new location. Absolute URLs render correctly on the published documentation site (Docusaurus / `reactonrails.com/docs`), where cross-package relative links may not resolve.

## Test plan

- [x] Lychee pre-commit hook passes on the changed file
- [x] Prettier passes
- [x] `curl https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/dummy/renderer/node-renderer.js` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single link target with no runtime or API impact.
> 
> **Overview**
> Restores the **testing example** link in `docs/oss/building-features/node-renderer/js-configuration.md` to an absolute GitHub URL (instead of a cross-package relative path), so the link resolves correctly on the published documentation site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10da4a96e037a97d66d8f92bcb969bb077395211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a testing example reference link to point to an external GitHub repository, enhancing documentation accessibility while preserving the reference material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->