### PR TITLE
Unify incremental rendering to use length-prefixed protocol

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -79,8 +79,10 @@ module ReactOnRailsPro
         # Determine bundle timestamp based on RSC support
         pool = ReactOnRailsPro::ServerRenderingPool::NodeRenderingPool
 
-        # Incremental rendering streams raw text from the VM without length-prefixed envelope
-        ReactOnRailsPro::StreamRequest.create(length_prefixed: false) do |send_bundle, barrier|
+        # Incremental rendering goes through the same `streamServerRenderedReactComponent`
+        # transform as one-shot streaming, so each response chunk arrives in the
+        # length-prefixed wire format. `StreamRequest` always parses length-prefixed.
+        ReactOnRailsPro::StreamRequest.create do |send_bundle, barrier|
           if send_bundle
             Rails.logger.info { "[ReactOnRailsPro] Sending bundle to the node renderer" }
             upload_assets

--- a/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/stream_request.rb
@@ -86,9 +86,8 @@ module ReactOnRailsPro
   end
 
   class StreamRequest
-    def initialize(length_prefixed: true, &request_block)
+    def initialize(&request_block)
       @request_executor = request_block
-      @length_prefixed = length_prefixed
     end
 
     private_class_method :new
@@ -104,10 +103,13 @@ module ReactOnRailsPro
         loop do
           stream_response = @request_executor.call(send_bundle, barrier)
 
-          # Chunks can be merged during streaming, so we separate them by newlines
-          # Also, we check the status code inside the loop block because calling `status` outside the loop block
-          # is blocking, it will wait for the response to be fully received
-          # Look at the spec of `status` in `spec/react_on_rails_pro/stream_spec.rb` for more details
+          # The Node renderer always emits the length-prefixed wire format
+          # (`<metadata JSON>\t<content byte length hex>\n<raw content bytes>`)
+          # for every response chunk — both the one-shot streaming path and the
+          # incremental-rendering path. We check the status code inside the loop
+          # block because calling `status` outside of it blocks until the full
+          # response has been received. See the `status` spec in
+          # `spec/react_on_rails_pro/stream_spec.rb` for more details.
           process_response_chunks(stream_response, error_body, &block)
           break
         rescue HTTPX::HTTPError => e
@@ -122,21 +124,13 @@ module ReactOnRailsPro
     end
 
     # Method to start the decoration
-    def self.create(length_prefixed: true, &request_block)
-      StreamDecorator.new(new(length_prefixed: length_prefixed, &request_block))
+    def self.create(&request_block)
+      StreamDecorator.new(new(&request_block))
     end
 
     private
 
     def process_response_chunks(stream_response, error_body, &block)
-      if @length_prefixed
-        process_length_prefixed_chunks(stream_response, error_body, &block)
-      else
-        process_line_based_chunks(stream_response, error_body, &block)
-      end
-    end
-
-    def process_length_prefixed_chunks(stream_response, error_body, &block)
       parser = ReactOnRails::LengthPrefixedParser.new
       stream_response.each do |chunk|
         stream_response.instance_variable_set(:@react_on_rails_received_first_chunk, true)
@@ -147,22 +141,6 @@ module ReactOnRailsPro
         end
 
         parser.feed(chunk, &block)
-      end
-    end
-
-    def process_line_based_chunks(stream_response, error_body)
-      stream_response.each do |chunk|
-        stream_response.instance_variable_set(:@react_on_rails_received_first_chunk, true)
-
-        if response_has_error_status?(stream_response)
-          error_body << chunk
-          next
-        end
-
-        chunk.split("\n").each do |line|
-          stripped = line.strip
-          yield stripped unless stripped.empty?
-        end
       end
     end
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -387,7 +387,7 @@ describe ReactOnRailsPro::Request do
       allow(mock_request).to receive(:close)
       allow(mock_request).to receive(:<<)
       allow(mock_response).to receive(:is_a?).with(HTTPX::ErrorResponse).and_return(false)
-      allow(mock_response).to receive(:each).and_yield("chunk\n")
+      allow(mock_response).to receive(:each).and_yield(to_length_prefixed("chunk"))
       allow(described_class).to receive(:connection).and_return(mock_connection)
 
       # Stub AsyncPropsEmitter to return a mock with end_stream_chunk
@@ -449,7 +449,7 @@ describe ReactOnRailsPro::Request do
       # Track when chunks are yielded during streaming
       allow(mock_response).to receive(:each) do |&block|
         execution_order << :chunk_yielded
-        block.call("chunk\n")
+        block.call(to_length_prefixed("chunk"))
       end
 
       # Allow real emitter to be created for this test


### PR DESCRIPTION
## Summary
- Removes the `length_prefixed` flag from `StreamRequest`, making it always parse the length-prefixed wire format
- Removes the dead `process_line_based_chunks` method since the incremental rendering path now uses the same `streamServerRenderedReactComponent` transform as one-shot streaming
- Updates incremental rendering tests to use `to_length_prefixed("chunk")` instead of raw `"chunk\n"`

## Test plan
- [ ] Pro gem unit tests pass (`cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/`)
- [ ] Pro integration tests pass (`cd react_on_rails_pro/spec/dummy && bundle exec rspec spec/`)
- [ ] Verify incremental rendering (async props) works end-to-end with streaming components

🤖 Generated with [Claude Code](https://claude.com/claude-code)