### PR TITLE
docs: remove defunct guavapass.com reference

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -80,7 +80,6 @@ exclude = [
   # ============================================================================
   '^https://blog\.shakacode\.com',  # May block automated requests
   '^https?://(www\.)?foxford\.ru',  # Russian site, often blocks bots
-  '^https://(www\.)?guavapass\.com',  # TLS handshake fails from GitHub Actions (bot filter)
   '^https://(www\.)?airgoat\.com',  # Returns 403
   '^https://(www\.)?first\.io',     # Returns 403
   '^https://(www\.)?estately\.com', # Returns 403

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -20,7 +20,6 @@ _Please support the project by [emailing Justin Gordon](mailto:justin@shakacode.
 - **[OppenheimerFunds](https://www.oppenheimerfunds.com/)**, investment site.
 - **[KissKissBankBank](https://www.kisskissbankbank.com/)**, large French crowdfunding platform.
 - **HVMN**: Web ecommerce site for "biohacking" products.
-- **[GuavaPass](https://guavapass.com/)**: Coaching client of [ShakaCode](https://www.shakacode.com) and React on Rails fan!
 - **[Pivotal Tracker](http://www.pivotaltracker.com/)**: The first (and most-loved) agile project management tool built on Rails. React on Rails has greatly simplified integration and workflow for our React components in Rails!
 - **[Estately](https://www.estately.com)**: Home search.
 - **[Blink Inc](https://www.blinkinc.com)**: Website and more built by [ShakaCode](https://www.shakacode.com).


### PR DESCRIPTION
## Summary
- Remove GuavaPass entry from `PROJECTS.md` — the site is no longer reachable and was breaking the markdown link checker.
- Drop the companion `guavapass.com` exclusion from `.lychee.toml`, which is no longer needed.

## Test plan
- [x] `lefthook` pre-push markdown link check passes (0 errors)
- [ ] Check Markdown Links CI workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change plus a small update to `.lychee.toml` exclusions; no runtime code paths affected.
> 
> **Overview**
> Removes the **GuavaPass** entry from `PROJECTS.md` because the site is no longer reachable.
> 
> Cleans up `.lychee.toml` by dropping the `guavapass.com` exclude pattern that was only needed to silence link-check failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f84806b9d7f87a6ee5cbe4995b65c68785ef9b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed GuavaPass reference from the commercial products section.

* **Chores**
  * Updated link checking configuration to include GuavaPass URLs in validation scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->