### PR TITLE
fix(pro-dummy): make manual node-renderer validation reliable

### DIFF
--- a/.claude/docs/manual-dev-environment-testing.md
+++ b/.claude/docs/manual-dev-environment-testing.md
@@ -2,7 +2,7 @@
 
 Automated tests can pass while the development environment is completely broken. CI starts services explicitly and runs in a controlled environment — it does not exercise `bin/dev`, Procfile orchestration, or the actual browser experience. This guide ensures agents verify the dev environment works end-to-end before submitting a PR.
 
-**Related:** [PR Testing Guide](pr-testing-guide.md), [Testing Build Scripts](testing-build-scripts.md)
+**Related:** [PR Testing Guide](pr-testing-guide.md), [Testing Build Scripts](testing-build-scripts.md), [Validating Node Renderer Changes](validating-node-renderer-changes.md)
 
 ## The Rule
 

--- a/.claude/docs/validating-node-renderer-changes.md
+++ b/.claude/docs/validating-node-renderer-changes.md
@@ -21,14 +21,18 @@ If your PR touches **any** of these, run through the checklist below:
 
 ## Pre-flight: Toolchain
 
-The Pro dummy app requires Ruby 3.3.x. If you are on a newer Ruby (3.5+), the dummy's
-Gemfile already pulls in `ostruct`, `logger`, and `benchmark` as explicit gems to silence
-warnings, but you may still hit unrelated incompatibilities. When in doubt, switch to the
-documented Ruby version:
+Ruby 3.3.x is the documented baseline for the Pro dummy app, and this workflow
+has also been verified on Ruby 3.4.8. On Ruby 3.5+, the dummy's Gemfile pulls in
+`ostruct`, `logger`, and `benchmark` as explicit gems for stdlib compatibility.
+If a newer Ruby hits unrelated incompatibilities, fall back to the documented
+Ruby version.
 
 ```bash
-mise use ruby@3.3.7  # or rbenv/asdf equivalent
 cd react_on_rails_pro/spec/dummy
+bundle install
+
+# Optional fallback if your local Ruby fails:
+mise shell ruby@3.3.7  # or rbenv/asdf equivalent
 bundle install
 ```
 
@@ -97,9 +101,10 @@ For each route:
 
 It is easy to validate stale lib output without realizing it. Confirm:
 
-- [ ] `lib/` mtime is newer than the `src/` file you changed (compare
-      `ls -la packages/react-on-rails-pro-node-renderer/lib/` against
-      `ls -la packages/react-on-rails-pro-node-renderer/src/`)
+- [ ] The built `lib/` file corresponding to your edit is newer than the `src/`
+      file you changed. Compare the specific files with `stat` or use a
+      per-file freshness check, for example:
+      `find packages/react-on-rails-pro-node-renderer/lib -newer packages/react-on-rails-pro-node-renderer/src/<changed-file>.ts | head`
 - [ ] If you used watch mode, you saw a rebuild line in the watcher output after your
       most recent edit
 - [ ] Restart the `node-renderer` Procfile process after the rebuild — `node` does not
@@ -111,7 +116,7 @@ It is easy to validate stale lib output without realizing it. Confirm:
 ## Node Renderer Validation
 
 - [x] Rebuilt `react-on-rails-pro-node-renderer` package
-- [x] Verified `lib/` mtime newer than `src/` after edit
+- [x] Verified the rebuilt `lib/` file is newer than the changed `src/` file
 - [x] `bin/dev` starts cleanly
 - [x] `/stream_native_metadata` renders without errors
 - [x] `/hybrid_metadata_streaming` renders without errors

--- a/.claude/docs/validating-node-renderer-changes.md
+++ b/.claude/docs/validating-node-renderer-changes.md
@@ -1,0 +1,122 @@
+# Validating Node Renderer Changes
+
+Manual validation checklist for changes under `packages/react-on-rails-pro-node-renderer/src/**`.
+
+**Why this exists:** the Pro dummy app consumes the _built_ renderer at
+`packages/react-on-rails-pro-node-renderer/lib/**`. Editing TypeScript under `src/` does
+nothing until that lib output is regenerated, so a correct fix can look broken (or worse,
+a regression can look fine because the dummy is still running stale lib output).
+
+**Related:** [Manual Dev Environment Testing](manual-dev-environment-testing.md)
+
+## When This Applies
+
+If your PR touches **any** of these, run through the checklist below:
+
+- `packages/react-on-rails-pro-node-renderer/src/**`
+- `packages/react-on-rails-pro-node-renderer/package.json` (especially `protocolVersion`,
+  `exports`, or runtime dependencies)
+- Any worker pool, JWT auth, integrations (Sentry/Honeybadger), or VM-context code in the
+  renderer
+
+## Pre-flight: Toolchain
+
+The Pro dummy app requires Ruby 3.3.x. If you are on a newer Ruby (3.5+), the dummy's
+Gemfile already pulls in `ostruct`, `logger`, and `benchmark` as explicit gems to silence
+warnings, but you may still hit unrelated incompatibilities. When in doubt, switch to the
+documented Ruby version:
+
+```bash
+mise use ruby@3.3.7  # or rbenv/asdf equivalent
+cd react_on_rails_pro/spec/dummy
+bundle install
+```
+
+## Step 1: Rebuild the Renderer Package
+
+Pick **one** of these depending on how you plan to iterate:
+
+**One-shot rebuild (recommended for a single validation pass):**
+
+```bash
+pnpm --filter react-on-rails-pro-node-renderer run build
+```
+
+**Or use the dummy's convenience script:**
+
+```bash
+cd react_on_rails_pro/spec/dummy
+pnpm run node-renderer:fresh   # builds the package, then starts the renderer
+```
+
+**Watch mode (recommended when iterating on the renderer source):**
+
+Either uncomment the `node-renderer-build` line in `react_on_rails_pro/spec/dummy/Procfile.dev`,
+or in a separate terminal run:
+
+```bash
+pnpm --filter react-on-rails-pro-node-renderer run build-watch
+```
+
+> If you skip this step, the dummy app will silently keep using the previous lib build.
+> Symptoms: a fix you just applied does not change behavior, or a regression you expected
+> to see does not appear.
+
+## Step 2: Start the Dummy App
+
+```bash
+cd react_on_rails_pro/spec/dummy
+bin/dev
+```
+
+Verify:
+
+- [ ] `bin/dev` starts without `overlay.sockPort should be a number` (webpack-dev-server)
+- [ ] `bin/dev` starts without `cannot load such file -- ostruct` (Rails precompile)
+- [ ] All Procfile.dev processes are healthy after 30 seconds
+- [ ] The `node-renderer` process logs that it bound to port 3800
+
+## Step 3: Exercise the SSR Endpoints
+
+For PRs touching streaming, hydration, RSC, or VM-context code, hit the routes that
+actually exercise the renderer (not just static pages):
+
+- [ ] `http://localhost:3000/stream_native_metadata` — renders without `ReferenceError`
+      (e.g. `performance is not defined`) in the renderer logs
+- [ ] `http://localhost:3000/hybrid_metadata_streaming` — same
+- [ ] Any route specifically related to your change
+
+For each route:
+
+- [ ] Page returns 200 and renders SSR content (view-source shows component markup)
+- [ ] No errors in the `node-renderer` Procfile pane
+- [ ] No errors in the Rails server log
+- [ ] No errors in the browser console
+
+## Step 4: Confirm You Tested the New Code
+
+It is easy to validate stale lib output without realizing it. Confirm:
+
+- [ ] `lib/` mtime is newer than the `src/` file you changed (compare
+      `ls -la packages/react-on-rails-pro-node-renderer/lib/` against
+      `ls -la packages/react-on-rails-pro-node-renderer/src/`)
+- [ ] If you used watch mode, you saw a rebuild line in the watcher output after your
+      most recent edit
+- [ ] Restart the `node-renderer` Procfile process after the rebuild — `node` does not
+      hot-reload required modules
+
+## Reporting Results in the PR
+
+```markdown
+## Node Renderer Validation
+
+- [x] Rebuilt `react-on-rails-pro-node-renderer` package
+- [x] Verified `lib/` mtime newer than `src/` after edit
+- [x] `bin/dev` starts cleanly
+- [x] `/stream_native_metadata` renders without errors
+- [x] `/hybrid_metadata_streaming` renders without errors
+- [x] No errors in node-renderer logs
+```
+
+If you cannot validate manually (e.g. no local Ruby toolchain), say so explicitly and
+note that the change is type-checked / unit-tested only.

--- a/.claude/docs/validating-node-renderer-changes.md
+++ b/.claude/docs/validating-node-renderer-changes.md
@@ -50,8 +50,13 @@ pnpm --filter react-on-rails-pro-node-renderer run build
 
 ```bash
 cd react_on_rails_pro/spec/dummy
-pnpm run node-renderer:fresh   # builds the package, then starts the renderer
+pnpm run node-renderer:fresh   # builds, then starts the renderer standalone
 ```
+
+This starts the renderer in the foreground on port 3800. For a full-stack dummy
+run, either stop it before Step 2 and let `bin/dev` start the renderer, or leave
+it running and comment out the `node-renderer:` line in `Procfile.dev` before
+running `bin/dev`.
 
 **Watch mode (recommended when iterating on the renderer source):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,5 +45,6 @@ Use these docs for Claude-oriented operational guidance:
 - `.claude/docs/docs-competitive-landscape.md`
 - `.claude/docs/docs-templates.md`
 - `.claude/docs/manual-dev-environment-testing.md`
+- `.claude/docs/validating-node-renderer-changes.md`
 
 For Pro-package specifics, also read `react_on_rails_pro/CLAUDE.md`.

--- a/docs/oss/building-features/node-renderer/debugging.md
+++ b/docs/oss/building-features/node-renderer/debugging.md
@@ -42,7 +42,7 @@ Use this when you need full control over the renderer process — different flag
 1. If you want to attach a debugger instead, run:
    ```bash
    cd react_on_rails_pro/spec/dummy
-   pnpm run node-renderer-debug
+   pnpm run node-renderer:debug
    ```
 1. Reload the page that triggers the SSR issue and reproduce the problem.
 1. If you change Ruby code in loaded gems, restart the Rails server.

--- a/docs/oss/building-features/node-renderer/debugging.md
+++ b/docs/oss/building-features/node-renderer/debugging.md
@@ -14,7 +14,7 @@ It is a `pnpm` workspace app and already points at the local packages in this mo
 
 ### Quick start: debugging with the full stack running
 
-If you already have the dummy app running via `bin/dev` (which uses `Procfile.dev`), the node renderer is already listening on port 3800 with `--inspect` enabled. To debug:
+If you already have the dummy app running via `bin/dev` (which uses `Procfile.dev`), the node renderer is listening on port 3800 but without `--inspect`. To attach a debugger you first need to restart it with `--inspect` — either stop the renderer process and run `pnpm run node-renderer:debug`, or temporarily add `--inspect` to the `node-renderer:` entry in `Procfile.dev` and `overmind restart node-renderer`. Then:
 
 1. Open `chrome://inspect` in Chrome and connect to the renderer process.
 2. Use overmind to isolate renderer logs: `overmind connect node-renderer` (Ctrl-B to detach).

--- a/react_on_rails_pro/CLAUDE.md
+++ b/react_on_rails_pro/CLAUDE.md
@@ -58,6 +58,16 @@ The node renderer is a standalone Fastify HTTP server (separate Node.js process)
 - Integrations: Sentry, Honeybadger (optional peer deps)
 - Protocol versioning: `protocolVersion` in package.json must match gem expectations
 
+**Validating source changes against the dummy app:** the dummy consumes the _built_
+`packages/react-on-rails-pro-node-renderer/lib/**`, so edits under `src/**` are not
+picked up until the package is rebuilt. Use one of:
+
+- `pnpm --filter react-on-rails-pro-node-renderer run build` (one-shot)
+- `cd react_on_rails_pro/spec/dummy && pnpm run node-renderer:fresh` (rebuild + start)
+- `pnpm --filter react-on-rails-pro-node-renderer run build-watch` (watch in another shell)
+
+See `.claude/docs/validating-node-renderer-changes.md` for the full checklist.
+
 ### Yalc Dependency Chain
 
 Pro dummy's preinstall builds and links packages in this order:

--- a/react_on_rails_pro/Gemfile.development_dependencies
+++ b/react_on_rails_pro/Gemfile.development_dependencies
@@ -55,8 +55,8 @@ group :development, :test do
   gem "scss_lint", require: false
   gem "fakefs", require: "fakefs/safe"
 
-  # Added for Ruby 3.5+ compatibility to silence warnings.
-  # jbuilder and other gems lazy-require these stdlib bits that became default gems in 3.5.
+  # Ruby 3.5+ removed these from the default gem set; they must now be declared explicitly
+  # to avoid `cannot load such file` errors from gems that lazy-require them (e.g. jbuilder).
   gem "benchmark", require: false
   gem "logger", require: false
   gem "ostruct", require: false

--- a/react_on_rails_pro/Gemfile.development_dependencies
+++ b/react_on_rails_pro/Gemfile.development_dependencies
@@ -54,6 +54,12 @@ group :development, :test do
   gem "rbs", require: false
   gem "scss_lint", require: false
   gem "fakefs", require: "fakefs/safe"
+
+  # Added for Ruby 3.5+ compatibility to silence warnings.
+  # jbuilder and other gems lazy-require these stdlib bits that became default gems in 3.5.
+  gem "benchmark", require: false
+  gem "logger", require: false
+  gem "ostruct", require: false
 end
 
 group :test do

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    ostruct (0.6.3)
     package_json (0.2.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -475,6 +476,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
+  benchmark
   bootsnap
   bundler
   capybara (>= 3.38.0)
@@ -490,9 +492,11 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen
+  logger
   net-http
   net-imap
   net-smtp
+  ostruct
   pg
   pry (>= 0.14.1)
   pry-byebug!

--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
+    ostruct (0.6.3)
     package_json (0.2.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -524,6 +525,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
+  benchmark
   bootsnap
   capybara (>= 3.38.0)
   capybara-screenshot
@@ -538,9 +540,11 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen
+  logger
   net-http
   net-imap
   net-smtp
+  ostruct
   pg
   prism-rails
   pry (>= 0.14.1)

--- a/react_on_rails_pro/spec/dummy/Procfile.dev
+++ b/react_on_rails_pro/spec/dummy/Procfile.dev
@@ -15,7 +15,10 @@ rails-rsc-assets: HMR=true RSC_BUNDLE_ONLY=true bin/shakapacker --watch
 # When validating source changes under `packages/react-on-rails-pro-node-renderer/src/**`,
 # either rebuild once (`pnpm --filter react-on-rails-pro-node-renderer run build`) or
 # uncomment the `node-renderer-build` line below to watch and rebuild on every save.
-# Foreman/overmind starts processes concurrently, so on first use wait for the initial
-# build-watch compile or restart `node-renderer` before trusting renderer output.
+# WARNING: build-watch runs `pnpm run clean && tsc --watch`, which deletes `lib/` on
+# startup before the first compile completes. Foreman/overmind starts processes
+# concurrently, so the `node-renderer` process will fail with module-not-found errors
+# until the initial build finishes. On first use, wait for the watcher to emit "Found 0
+# errors" and then restart the `node-renderer` process before trusting renderer output.
 # node-renderer-build: pnpm --filter react-on-rails-pro-node-renderer run build-watch
 node-renderer: RENDERER_PORT=3800 node renderer/node-renderer.js

--- a/react_on_rails_pro/spec/dummy/Procfile.dev
+++ b/react_on_rails_pro/spec/dummy/Procfile.dev
@@ -18,4 +18,4 @@ rails-rsc-assets: HMR=true RSC_BUNDLE_ONLY=true bin/shakapacker --watch
 # Foreman/overmind starts processes concurrently, so on first use wait for the initial
 # build-watch compile or restart `node-renderer` before trusting renderer output.
 # node-renderer-build: pnpm --filter react-on-rails-pro-node-renderer run build-watch
-node-renderer: RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js
+node-renderer: RENDERER_PORT=3800 node renderer/node-renderer.js

--- a/react_on_rails_pro/spec/dummy/Procfile.dev
+++ b/react_on_rails_pro/spec/dummy/Procfile.dev
@@ -11,4 +11,9 @@ rails-server-assets: HMR=true SERVER_BUNDLE_ONLY=true bin/shakapacker --watch
 rails-rsc-assets: HMR=true RSC_BUNDLE_ONLY=true bin/shakapacker --watch
 
 # Start Node server for server rendering.
+# NOTE: This consumes the *built* `packages/react-on-rails-pro-node-renderer/lib/**`.
+# When validating source changes under `packages/react-on-rails-pro-node-renderer/src/**`,
+# either rebuild once (`pnpm --filter react-on-rails-pro-node-renderer run build`) or
+# uncomment the `node-renderer-build` line below to watch and rebuild on every save.
+# node-renderer-build: pnpm --filter react-on-rails-pro-node-renderer run build-watch
 node-renderer: RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js

--- a/react_on_rails_pro/spec/dummy/Procfile.dev
+++ b/react_on_rails_pro/spec/dummy/Procfile.dev
@@ -15,5 +15,7 @@ rails-rsc-assets: HMR=true RSC_BUNDLE_ONLY=true bin/shakapacker --watch
 # When validating source changes under `packages/react-on-rails-pro-node-renderer/src/**`,
 # either rebuild once (`pnpm --filter react-on-rails-pro-node-renderer run build`) or
 # uncomment the `node-renderer-build` line below to watch and rebuild on every save.
+# Foreman/overmind starts processes concurrently, so on first use wait for the initial
+# build-watch compile or restart `node-renderer` before trusting renderer output.
 # node-renderer-build: pnpm --filter react-on-rails-pro-node-renderer run build-watch
 node-renderer: RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js

--- a/react_on_rails_pro/spec/dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/development.js
@@ -15,6 +15,8 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
           // surfaces unchanged on devServer.port. The plugin schema requires a number.
           // `|| 3035` falls back to Shakapacker's default if devServer.port is missing,
           // so a misconfiguration surfaces as a wrong port rather than silent NaN.
+          // Note: port `0` (OS-assigned) would also fall back to 3035, but Shakapacker
+          // does not use `0` as a dev server port — do not copy this pattern where `0` is valid.
           sockPort: parseInt(devServer.port, 10) || 3035,
         },
       }),

--- a/react_on_rails_pro/spec/dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/development.js
@@ -13,7 +13,7 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
         overlay: {
           // bin/dev sets SHAKAPACKER_DEV_SERVER_PORT as a string, which Shakapacker
           // surfaces unchanged on devServer.port. The plugin schema requires a number.
-          sockPort: Number(devServer.port),
+          sockPort: parseInt(devServer.port, 10),
         },
       }),
     );

--- a/react_on_rails_pro/spec/dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/development.js
@@ -13,7 +13,9 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
         overlay: {
           // bin/dev sets SHAKAPACKER_DEV_SERVER_PORT as a string, which Shakapacker
           // surfaces unchanged on devServer.port. The plugin schema requires a number.
-          sockPort: parseInt(devServer.port, 10),
+          // `|| 3035` falls back to Shakapacker's default if devServer.port is missing,
+          // so a misconfiguration surfaces as a wrong port rather than silent NaN.
+          sockPort: parseInt(devServer.port, 10) || 3035,
         },
       }),
     );

--- a/react_on_rails_pro/spec/dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/development.js
@@ -11,7 +11,9 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
     clientWebpackConfig.plugins.push(
       new ReactRefreshWebpackPlugin({
         overlay: {
-          sockPort: devServer.port,
+          // bin/dev sets SHAKAPACKER_DEV_SERVER_PORT as a string, which Shakapacker
+          // surfaces unchanged on devServer.port. The plugin schema requires a number.
+          sockPort: Number(devServer.port),
         },
       }),
     );

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -106,8 +106,9 @@
     "build:server": "RAILS_ENV=production NODE_ENV=production SERVER=true bin/shakapacker",
     "build:clean": "rm -rf public/webpack && rm -rf ssr-generated || true",
     "node-renderer-debug": "RENDERER_PORT=3800 ndb renderer/node-renderer.js",
+    "node-renderer:debug": "RENDERER_PORT=3800 ndb renderer/node-renderer.js",
     "node-renderer": "RENDERER_PORT=3800 node renderer/node-renderer.js",
-    "node-renderer:fresh": "pnpm --filter react-on-rails-pro-node-renderer run build && RENDERER_PORT=3800 node renderer/node-renderer.js",
+    "node-renderer:fresh": "pnpm --filter react-on-rails-pro-node-renderer run build && RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js",
     "node-renderer:build-watch": "pnpm --filter react-on-rails-pro-node-renderer run build-watch"
   },
   "license": "UNLICENSED",

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -106,7 +106,9 @@
     "build:server": "RAILS_ENV=production NODE_ENV=production SERVER=true bin/shakapacker",
     "build:clean": "rm -rf public/webpack && rm -rf ssr-generated || true",
     "node-renderer-debug": "RENDERER_PORT=3800 ndb renderer/node-renderer.js",
-    "node-renderer": "RENDERER_PORT=3800 node renderer/node-renderer.js"
+    "node-renderer": "RENDERER_PORT=3800 node renderer/node-renderer.js",
+    "node-renderer:fresh": "pnpm --filter react-on-rails-pro-node-renderer run build && RENDERER_PORT=3800 node renderer/node-renderer.js",
+    "node-renderer:build-watch": "pnpm --filter react-on-rails-pro-node-renderer run build-watch"
   },
   "license": "UNLICENSED",
   "repository": {

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -107,7 +107,7 @@
     "build:clean": "rm -rf public/webpack && rm -rf ssr-generated || true",
     "node-renderer:debug": "RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js",
     "node-renderer": "RENDERER_PORT=3800 node renderer/node-renderer.js",
-    "node-renderer:fresh": "pnpm --filter react-on-rails-pro-node-renderer run build && RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js",
+    "node-renderer:fresh": "pnpm --filter react-on-rails-pro-node-renderer run build && RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node renderer/node-renderer.js",
     "node-renderer:build-watch": "pnpm --filter react-on-rails-pro-node-renderer run build-watch"
   },
   "license": "UNLICENSED",

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -105,8 +105,7 @@
     "build:client": "RAILS_ENV=production NODE_ENV=production bin/shakapacker",
     "build:server": "RAILS_ENV=production NODE_ENV=production SERVER=true bin/shakapacker",
     "build:clean": "rm -rf public/webpack && rm -rf ssr-generated || true",
-    "node-renderer-debug": "RENDERER_PORT=3800 ndb renderer/node-renderer.js",
-    "node-renderer:debug": "RENDERER_PORT=3800 ndb renderer/node-renderer.js",
+    "node-renderer:debug": "RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js",
     "node-renderer": "RENDERER_PORT=3800 node renderer/node-renderer.js",
     "node-renderer:fresh": "pnpm --filter react-on-rails-pro-node-renderer run build && RENDERER_LOG_LEVEL=debug RENDERER_PORT=3800 node --inspect renderer/node-renderer.js",
     "node-renderer:build-watch": "pnpm --filter react-on-rails-pro-node-renderer run build-watch"

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
@@ -40,6 +40,12 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]
+
+  # Ruby 3.5+ removed these from the default gem set; they must now be declared explicitly
+  # to avoid `cannot load such file` errors from gems that lazy-require them (e.g. jbuilder).
+  gem "benchmark", require: false
+  gem "logger", require: false
+  gem "ostruct", require: false
 end
 
 group :development do

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
+    ostruct (0.6.3)
     package_json (0.2.0)
     pp (0.6.3)
       prettyprint
@@ -334,10 +335,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  benchmark
   bootsnap
   capybara
   debug
   jbuilder
+  logger
+  ostruct
   pry
   pry-nav
   puma (>= 5.0)

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
@@ -16,7 +16,9 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
     clientWebpackConfig.plugins.push(
       new ReactRefreshWebpackPlugin({
         overlay: {
-          sockPort: devServer.port,
+          // bin/dev sets SHAKAPACKER_DEV_SERVER_PORT as a string, which Shakapacker
+          // surfaces unchanged on devServer.port. The plugin schema requires a number.
+          sockPort: Number(devServer.port),
         },
       }),
     );

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
@@ -20,6 +20,8 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
           // surfaces unchanged on devServer.port. The plugin schema requires a number.
           // `|| 3035` falls back to Shakapacker's default if devServer.port is missing,
           // so a misconfiguration surfaces as a wrong port rather than silent NaN.
+          // Note: port `0` (OS-assigned) would also fall back to 3035, but Shakapacker
+          // does not use `0` as a dev server port — do not copy this pattern where `0` is valid.
           sockPort: parseInt(devServer.port, 10) || 3035,
         },
       }),

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
@@ -18,7 +18,9 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
         overlay: {
           // bin/dev sets SHAKAPACKER_DEV_SERVER_PORT as a string, which Shakapacker
           // surfaces unchanged on devServer.port. The plugin schema requires a number.
-          sockPort: parseInt(devServer.port, 10),
+          // `|| 3035` falls back to Shakapacker's default if devServer.port is missing,
+          // so a misconfiguration surfaces as a wrong port rather than silent NaN.
+          sockPort: parseInt(devServer.port, 10) || 3035,
         },
       }),
     );

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/config/webpack/development.js
@@ -18,7 +18,7 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
         overlay: {
           // bin/dev sets SHAKAPACKER_DEV_SERVER_PORT as a string, which Shakapacker
           // surfaces unchanged on devServer.port. The plugin schema requires a number.
-          sockPort: Number(devServer.port),
+          sockPort: parseInt(devServer.port, 10),
         },
       }),
     );


### PR DESCRIPTION
## Summary

Addresses three independent breakages in the Pro dummy app that surfaced during review of #3158, where validating a renderer fix locally required repo-specific workarounds. Each one could cause a correct fix to look broken or silently validate stale build artifacts.

- **`bin/dev` `overlay.sockPort should be a number`** — `bin/dev` exports `SHAKAPACKER_DEV_SERVER_PORT` as a string, Shakapacker forwards it unchanged on `devServer.port`, and the Pro dummy passed it straight to `@pmmmwh/react-refresh-webpack-plugin`, whose schema requires a number. Coerced with `parseInt(devServer.port, 10) || 3035` in both Pro dummy and execjs dummy webpack configs (the fallback surfaces a misconfiguration as a wrong port instead of silent `NaN`).
- **Rails precompile hook `cannot load such file -- ostruct`** — Pro Gemfile was missing the explicit `ostruct`/`logger`/`benchmark` declarations that the open-source Gemfile already had for Ruby 3.5+ compatibility. Added them.
- **Stale node-renderer lib silently consumed** — the dummy consumes the _built_ `react-on-rails-pro-node-renderer/lib/`, not the TS source. Added `node-renderer:fresh` (rebuild + start) and `node-renderer:build-watch` scripts, documented the rebuild requirement inline in `Procfile.dev`, expanded `react_on_rails_pro/CLAUDE.md`, and added a dedicated `.claude/docs/validating-node-renderer-changes.md` checklist for reviewers.

### Notes for reviewers

- `node-renderer:fresh` intentionally hardcodes `RENDERER_LOG_LEVEL=debug`. The script exists for one-shot manual validation runs, where verbose logging is valuable; the base `node-renderer` script (used by `Procfile.dev`/`bin/dev`) deliberately stays at the default level. JSON has no comments, so this callout lives here instead of inline.
- `node-renderer:fresh` does **not** include `--inspect`. It's a clean rebuild + start; `node-renderer:debug` is the dedicated debug-mode entry point. Keeping the two contracts orthogonal is intentional.

Fixes #3177

## Test plan

- [x] Verified the bug: `new ReactRefreshWebpackPlugin({ overlay: { sockPort: '3035' } })` throws the exact error message from the issue (`options.overlay.sockPort should be a number`); `sockPort: 3035` succeeds.
- [x] Verified `parseInt(devServer.port, 10) || 3035` correctly converts string-typed env-var input to a number, and falls back to `3035` (Shakapacker's default) on undefined/empty input.
- [x] `bundle install` resolves cleanly with the added `ostruct`/`logger`/`benchmark` gems on Ruby 3.4.8.
- [x] `require 'jbuilder'; require 'ostruct'; require 'logger'; require 'benchmark'` succeeds.
- [x] `node --check` passes on both updated webpack configs.
- [x] Prettier passes on all changed files.
- [x] No new RuboCop offenses on changed Gemfile lines.
- [ ] Reviewer to run through `.claude/docs/validating-node-renderer-changes.md` against `bin/dev` to confirm the `overlay.sockPort` and `ostruct` errors no longer occur on a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes dev startup orchestration (`Procfile.dev`/scripts), webpack dev-server config, and Ruby dependency sets/lockfiles, which can break local workflows if misconfigured.
> 
> **Overview**
> Improves Pro dummy app manual validation of the node renderer by adding a dedicated checklist (`.claude/docs/validating-node-renderer-changes.md`), linking it from existing agent docs, and documenting the built-`lib/` consumption/rebuild requirement in `react_on_rails_pro/CLAUDE.md` and the dummy `Procfile.dev`.
> 
> Fixes `bin/dev` startup breakages by coercing the React Refresh overlay `sockPort` to a number in both dummy webpack development configs, and by explicitly adding stdlib-removed gems (`benchmark`, `logger`, `ostruct`) to Pro development/test Gemfiles with corresponding lockfile updates.
> 
> Updates renderer run/debug ergonomics by renaming/adding dummy `package.json` scripts (`node-renderer:debug`, `node-renderer:fresh`, `node-renderer:build-watch`) and aligning the OSS debugging docs with the new workflow; also removes `--inspect`/debug logging defaults from the `Procfile.dev` `node-renderer` command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb01670fc024d4d1a15b639521935e6b2ebb867e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a node-renderer validation checklist and updated doc indexes and dummy-app guidance.

- **Bug Fixes**
  - Ensure dev-server port is treated as a numeric value so the React Refresh overlay behaves reliably.

- **Chores**
  - Added gems to silence Ruby 3.5+ stdlib warnings.
  - Introduced clearer debug/fresh-build/build-watch runner scripts and clarified dev startup/watch guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
