### PR TITLE
test(dummy): enable StrictMode in OSS and Pro dummies

### DIFF
--- a/react_on_rails/spec/dummy/client/app-react16/startup/ManualRenderApp.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ManualRenderApp.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+// Intentional cross-tree import: the React 16 dummy entries reuse the StrictMode helper from the
+// React 19 `app/` tree. Keep the import path in sync if `app/strictModeSupport` is moved.
 import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 
 export default (props, _railsContext, domNodeId) => {

--- a/react_on_rails/spec/dummy/client/app-react16/startup/ManualRenderApp.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ManualRenderApp.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 
 export default (props, _railsContext, domNodeId) => {
-  const reactElement = (
+  const reactElement = wrapElementInStrictMode(
     <div>
       <h1 id="manual-render">Manual Render Example</h1>
       <p>If you can see this, you can register renderer functions.</p>
-    </div>
+    </div>,
   );
 
   const domNode = document.getElementById(domNodeId);

--- a/react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx
@@ -12,6 +12,8 @@ import reducers from '../../app/reducers/reducersIndex';
 import composeInitialState from '../../app/store/composeInitialState';
 
 import HelloWorldContainer from '../../app/components/HelloWorldContainer';
+// Intentional cross-tree import: the React 16 dummy entries reuse the StrictMode helper from the
+// React 19 `app/` tree. Keep the import path in sync if `app/strictModeSupport` is moved.
 import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 
 /*

--- a/react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx
@@ -12,6 +12,7 @@ import reducers from '../../app/reducers/reducersIndex';
 import composeInitialState from '../../app/store/composeInitialState';
 
 import HelloWorldContainer from '../../app/components/HelloWorldContainer';
+import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 
 /*
  *  Export a function that takes the props and returns a ReactComponent.
@@ -37,10 +38,10 @@ export default (props, railsContext, domNodeId) => {
   // Provider uses this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
   const renderApp = (Komponent) => {
-    const element = (
+    const element = wrapElementInStrictMode(
       <Provider store={store}>
         <Komponent />
-      </Provider>
+      </Provider>,
     );
 
     render(element, document.getElementById(domNodeId));

--- a/react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx
@@ -7,6 +7,8 @@ import ReactOnRails from 'react-on-rails/client';
 import ReactDOM from 'react-dom';
 
 import HelloWorldContainer from '../../app/components/HelloWorldContainer';
+// Intentional cross-tree import: the React 16 dummy entries reuse the StrictMode helper from the
+// React 19 `app/` tree. Keep the import path in sync if `app/strictModeSupport` is moved.
 import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 
 /*

--- a/react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx
@@ -7,6 +7,7 @@ import ReactOnRails from 'react-on-rails/client';
 import ReactDOM from 'react-dom';
 
 import HelloWorldContainer from '../../app/components/HelloWorldContainer';
+import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 
 /*
  *  Export a function that returns a ReactComponent, depending on a store named SharedReduxStore.
@@ -27,10 +28,10 @@ export default (props, _railsContext, domNodeId) => {
   // Provider uses this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
   const renderApp = (Component) => {
-    const element = (
+    const element = wrapElementInStrictMode(
       <Provider store={store}>
         <Component />
-      </Provider>
+      </Provider>,
     );
     render(element, document.getElementById(domNodeId));
   };

--- a/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
@@ -11,9 +11,16 @@ import ManualRenderComponent from '../startup/ManualRenderComponent';
 import SharedReduxStore from '../stores/SharedReduxStore';
 import { wrapRegisteredComponentsWithStrictMode } from '../strictModeSupport';
 
-const originalRegister = ReactOnRails.register.bind(ReactOnRails);
+const STRICT_MODE_PATCHED = '__reactOnRailsDummyStrictModePatched';
 
-ReactOnRails.register = (components) => originalRegister(wrapRegisteredComponentsWithStrictMode(components));
+if (!ReactOnRails[STRICT_MODE_PATCHED]) {
+  const originalRegister = ReactOnRails.register.bind(ReactOnRails);
+
+  // Covers this bundle and inline ERB register calls, which run after the bundle has loaded.
+  ReactOnRails.register = (components) =>
+    originalRegister(wrapRegisteredComponentsWithStrictMode(components));
+  Object.defineProperty(ReactOnRails, STRICT_MODE_PATCHED, { value: true });
+}
 
 ReactOnRails.setOptions({
   traceTurbolinks: true,

--- a/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
@@ -13,10 +13,20 @@ import { wrapRegisteredComponentsWithStrictMode } from '../strictModeSupport';
 
 const STRICT_MODE_PATCHED = '__reactOnRailsDummyStrictModePatched';
 
-// Scope: this patch only affects `ReactOnRails.register` calls that share this bundle's module
-// instance (this pack and inline ERB views that run after it). Separate entry-point packs that
-// import `react-on-rails/client` independently get their own unpatched module and would skip
-// StrictMode wrapping.
+// Scope: this patch only affects `ReactOnRails.register` calls that share this bundle's
+// `react-on-rails/client` module instance. Coverage today:
+//   - This pack and its imports (HelloTurboStream, ManualRenderComponent, SharedReduxStore).
+//   - The auto-generated `packs/generated/*.js` entries — they share this `ReactOnRails` instance
+//     because shakapacker's webpack build produces one runtime per compilation, and they run
+//     after `client-bundle.js` on every page that loads them.
+//   - Inline ERB views that call `ReactOnRails.register` after this pack has run.
+//   - Manual-render trees in `startup/` and `app-react16/startup/` already wrap with
+//     `wrapElementInStrictMode` directly (they don't need this `register` patch).
+//
+// What's NOT covered: any future pack that imports `react-on-rails/client` from a separate
+// webpack compilation (e.g., a standalone bundle config) would get its own unpatched module
+// instance. When adding a pack like that, either fold it into this compilation or duplicate
+// this `STRICT_MODE_PATCHED` block at the top of the new pack before any `register` calls.
 if (!ReactOnRails[STRICT_MODE_PATCHED]) {
   const originalRegister = ReactOnRails.register.bind(ReactOnRails);
 

--- a/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
@@ -9,6 +9,11 @@ import ReactOnRails from 'react-on-rails/client';
 import HelloTurboStream from '../startup/HelloTurboStream';
 import ManualRenderComponent from '../startup/ManualRenderComponent';
 import SharedReduxStore from '../stores/SharedReduxStore';
+import { wrapRegisteredComponentsWithStrictMode } from '../strictModeSupport';
+
+const originalRegister = ReactOnRails.register.bind(ReactOnRails);
+
+ReactOnRails.register = (components) => originalRegister(wrapRegisteredComponentsWithStrictMode(components));
 
 ReactOnRails.setOptions({
   traceTurbolinks: true,

--- a/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
@@ -13,10 +13,13 @@ import { wrapRegisteredComponentsWithStrictMode } from '../strictModeSupport';
 
 const STRICT_MODE_PATCHED = '__reactOnRailsDummyStrictModePatched';
 
+// Scope: this patch only affects `ReactOnRails.register` calls that share this bundle's module
+// instance (this pack and inline ERB views that run after it). Separate entry-point packs that
+// import `react-on-rails/client` independently get their own unpatched module and would skip
+// StrictMode wrapping.
 if (!ReactOnRails[STRICT_MODE_PATCHED]) {
   const originalRegister = ReactOnRails.register.bind(ReactOnRails);
 
-  // Covers this bundle and inline ERB register calls, which run after the bundle has loaded.
   ReactOnRails.register = (components) =>
     originalRegister(wrapRegisteredComponentsWithStrictMode(components));
   Object.defineProperty(ReactOnRails, STRICT_MODE_PATCHED, { value: true });

--- a/react_on_rails/spec/dummy/client/app/startup/ManualRenderApp.jsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ManualRenderApp.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOMClient from 'react-dom/client';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 export default (props, _railsContext, domNodeId) => {
-  const reactElement = (
+  const reactElement = wrapElementInStrictMode(
     <div>
       <h1 id="manual-render">Manual Render Example</h1>
       <p>If you can see this, you can register renderer functions.</p>
-    </div>
+    </div>,
   );
 
   const domNode = document.getElementById(domNodeId);

--- a/react_on_rails/spec/dummy/client/app/startup/ReduxApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ReduxApp.client.jsx
@@ -12,6 +12,7 @@ import reducers from '../reducers/reducersIndex';
 import composeInitialState from '../store/composeInitialState';
 
 import HelloWorldContainer from '../components/HelloWorldContainer';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 /*
  *  Export a function that takes the props and returns a ReactComponent.
@@ -42,10 +43,10 @@ export default (props, railsContext, domNodeId) => {
   // Provider uses this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
   const renderApp = (Komponent) => {
-    const element = (
+    const element = wrapElementInStrictMode(
       <Provider store={store}>
         <Komponent />
-      </Provider>
+      </Provider>,
     );
 
     render(document.getElementById(domNodeId), element);

--- a/react_on_rails/spec/dummy/client/app/startup/ReduxSharedStoreApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ReduxSharedStoreApp.client.jsx
@@ -7,6 +7,7 @@ import ReactOnRails from 'react-on-rails/client';
 import ReactDOMClient from 'react-dom/client';
 
 import HelloWorldContainer from '../components/HelloWorldContainer';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 /*
  *  Export a function that returns a ReactComponent, depending on a store named SharedReduxStore.
@@ -32,10 +33,10 @@ export default (props, _railsContext, domNodeId) => {
   // Provider uses this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
   const renderApp = (Component) => {
-    const element = (
+    const element = wrapElementInStrictMode(
       <Provider store={store}>
         <Component />
-      </Provider>
+      </Provider>,
     );
     render(document.getElementById(domNodeId), element);
   };

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+const wrappedFunctionComponents = new WeakMap();
+const wrappedOtherComponents = new Map();
+
+const isRenderFunction = (component) => {
+  if (typeof component !== 'function') {
+    return false;
+  }
+
+  if (component.prototype?.isReactComponent) {
+    return false;
+  }
+
+  if (component.renderFunction) {
+    return true;
+  }
+
+  return component.length >= 2;
+};
+
+const createStrictModeWrapper = (Component) => {
+  function StrictModeWrapper(props) {
+    return (
+      <React.StrictMode>
+        {typeof Component === 'function' ? <Component {...props} /> : React.createElement(Component, props)}
+      </React.StrictMode>
+    );
+  }
+
+  const componentName =
+    typeof Component === 'string'
+      ? Component
+      : Component.displayName || Component.name || 'AnonymousComponent';
+  StrictModeWrapper.displayName = `StrictMode(${componentName})`;
+
+  return StrictModeWrapper;
+};
+
+const wrapComponentInStrictMode = (component) => {
+  if (typeof component === 'function') {
+    const cachedComponent = wrappedFunctionComponents.get(component);
+    if (cachedComponent) {
+      return cachedComponent;
+    }
+
+    const wrappedComponent = createStrictModeWrapper(component);
+    wrappedFunctionComponents.set(component, wrappedComponent);
+    return wrappedComponent;
+  }
+
+  const cachedComponent = wrappedOtherComponents.get(component);
+  if (cachedComponent) {
+    return cachedComponent;
+  }
+
+  const wrappedComponent = createStrictModeWrapper(component);
+  wrappedOtherComponents.set(component, wrappedComponent);
+  return wrappedComponent;
+};
+
+export const wrapElementInStrictMode = (reactElement) => <React.StrictMode>{reactElement}</React.StrictMode>;
+
+export const wrapRegisteredComponentsWithStrictMode = (components) =>
+  Object.fromEntries(
+    Object.entries(components).map(([name, component]) => [
+      name,
+      isRenderFunction(component) ? component : wrapComponentInStrictMode(component),
+    ]),
+  );

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 const wrappedFunctionComponents = new WeakMap();
-const wrappedOtherComponents = new Map();
+const wrappedOtherComponents = new Map(); // Map, not WeakMap: string component names are valid keys.
 
+// Mirrors the public react-on-rails/isRenderFunction convention for this dummy-only wrapper.
 const isRenderFunction = (component) => {
   if (typeof component !== 'function') {
     return false;
@@ -21,11 +22,7 @@ const isRenderFunction = (component) => {
 
 const createStrictModeWrapper = (Component) => {
   function StrictModeWrapper(props) {
-    return (
-      <React.StrictMode>
-        {typeof Component === 'function' ? <Component {...props} /> : React.createElement(Component, props)}
-      </React.StrictMode>
-    );
+    return <React.StrictMode>{React.createElement(Component, props)}</React.StrictMode>;
   }
 
   const componentName =
@@ -65,6 +62,7 @@ export const wrapRegisteredComponentsWithStrictMode = (components) =>
   Object.fromEntries(
     Object.entries(components).map(([name, component]) => [
       name,
+      // OSS dummy registered render functions own their root; manual renderer entries wrap explicitly.
       isRenderFunction(component) ? component : wrapComponentInStrictMode(component),
     ]),
   );

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -1,16 +1,36 @@
 import React from 'react';
 
+const REACT_OBJECT_COMPONENT_TYPES = new Set([
+  Symbol.for('react.forward_ref'),
+  Symbol.for('react.lazy'),
+  Symbol.for('react.memo'),
+]);
+
 const wrappedFunctionComponents = new WeakMap();
+const wrappedRenderFunctions = new WeakMap();
 // Object-typed React components (memo, forwardRef, lazy) are GC-safe in a WeakMap.
 const wrappedObjectComponents = new WeakMap();
 // Strings are primitives and cannot key a WeakMap, so registered string component names live here.
 const wrappedStringComponents = new Map();
 
-// Mirrors the public react-on-rails/isRenderFunction convention for this dummy-only wrapper.
-// Note: the `length >= 2` heuristic intentionally classifies any 2-arg function as a render
-// function. Legacy 2-arg components that use the (props, context) signature must opt back in by
-// setting `fn.renderFunction = false` (or, for class components, are detected via the prototype
-// check). Set `fn.renderFunction = true` to flag a 1-arg render function explicitly.
+const isPromiseLike = (value) =>
+  typeof value === 'object' && value !== null && typeof value.then === 'function';
+
+const isFunctionWithMetadata = (component) => typeof component === 'function';
+
+const isObjectComponent = (component) =>
+  typeof component === 'object' &&
+  component !== null &&
+  REACT_OBJECT_COMPONENT_TYPES.has(component.$$typeof ?? 0);
+
+const isReactComponent = (component) =>
+  typeof component === 'string' || isFunctionWithMetadata(component) || isObjectComponent(component);
+
+// Mirrors the public react-on-rails/isRenderFunction convention while extending it with an
+// explicit `renderFunction = false` opt-out (the public helper only checks for truthiness; this
+// dummy honors `false` so legacy 2-arg `(props, context)` components can be wrapped via the
+// component path rather than the render-function path). Set `fn.renderFunction = true` to flag a
+// 1-arg render function explicitly. Class components are detected via the prototype check.
 const isRenderFunction = (component) => {
   if (typeof component !== 'function') {
     return false;
@@ -20,12 +40,15 @@ const isRenderFunction = (component) => {
     return false;
   }
 
-  if (component.renderFunction) {
-    return true;
+  if (typeof component.renderFunction === 'boolean') {
+    return component.renderFunction;
   }
 
   return component.length >= 2;
 };
+
+// A 3-arg renderer controls its own root, so direct renderer files wrap their root elements explicitly.
+const isRendererFunction = (component) => isRenderFunction(component) && component.length === 3;
 
 const createStrictModeWrapper = (Component) => {
   function StrictModeWrapper(props) {
@@ -76,11 +99,63 @@ const wrapComponentInStrictMode = (component) => {
 
 export const wrapElementInStrictMode = (reactElement) => <React.StrictMode>{reactElement}</React.StrictMode>;
 
+const wrapRenderFunctionResult = (result) => {
+  if (isPromiseLike(result)) {
+    return result.then(wrapRenderFunctionResult);
+  }
+
+  if (React.isValidElement(result)) {
+    return wrapElementInStrictMode(result);
+  }
+
+  if (isReactComponent(result)) {
+    return wrapComponentInStrictMode(result);
+  }
+
+  return result;
+};
+
+// The wrapped function below has `length === 2`, so `isRenderFunction` would re-classify it as a
+// render function if it ever flowed back through `wrapRegisteredComponentsWithStrictMode`. The
+// `STRICT_MODE_PATCHED` guard on the patched `register` call (in `client-bundle.js`) keeps that
+// re-entry path unreachable. Note: when called directly (outside the registry path), the wrapper's
+// hardcoded `length === 2` does not reflect the original function's arity.
+const wrapRenderFunctionInStrictMode = (renderFunction) => {
+  const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
+  if (cachedRenderFunction) {
+    return cachedRenderFunction;
+  }
+
+  const wrappedRenderFunction = function StrictModeRenderFunction(props, railsContext) {
+    return wrapRenderFunctionResult(renderFunction(props, railsContext));
+  };
+  wrappedRenderFunction.displayName = `StrictMode(${
+    renderFunction.displayName || renderFunction.name || 'AnonymousRenderFunction'
+  })`;
+
+  if (renderFunction.renderFunction) {
+    wrappedRenderFunction.renderFunction = true;
+  }
+
+  wrappedRenderFunctions.set(renderFunction, wrappedRenderFunction);
+  return wrappedRenderFunction;
+};
+
 export const wrapRegisteredComponentsWithStrictMode = (components) =>
   Object.fromEntries(
-    Object.entries(components).map(([name, component]) => [
-      name,
-      // OSS dummy registered render functions own their root; manual renderer entries wrap explicitly.
-      isRenderFunction(component) ? component : wrapComponentInStrictMode(component),
-    ]),
+    Object.entries(components).map(([name, component]) => {
+      if (isRendererFunction(component)) {
+        return [name, component];
+      }
+
+      if (isRenderFunction(component)) {
+        return [name, wrapRenderFunctionInStrictMode(component)];
+      }
+
+      if (!isReactComponent(component)) {
+        return [name, component];
+      }
+
+      return [name, wrapComponentInStrictMode(component)];
+    }),
   );

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -10,8 +10,6 @@ const wrappedFunctionComponents = new WeakMap();
 const wrappedRenderFunctions = new WeakMap();
 // Object-typed React components (memo, forwardRef, lazy) are GC-safe in a WeakMap.
 const wrappedObjectComponents = new WeakMap();
-// Strings are primitives and cannot key a WeakMap, so registered string component names live here.
-const wrappedStringComponents = new Map();
 
 const isPromiseLike = (value) =>
   typeof value === 'object' && value !== null && typeof value.then === 'function';
@@ -23,8 +21,7 @@ const isObjectComponent = (component) =>
   component !== null &&
   REACT_OBJECT_COMPONENT_TYPES.has(component.$$typeof ?? 0);
 
-const isReactComponent = (component) =>
-  typeof component === 'string' || isFunctionWithMetadata(component) || isObjectComponent(component);
+const isReactComponent = (component) => isFunctionWithMetadata(component) || isObjectComponent(component);
 
 // Mirrors the public react-on-rails/isRenderFunction convention while extending it with an
 // explicit `renderFunction = false` opt-out (the public helper only checks for truthiness; this
@@ -55,11 +52,7 @@ const createStrictModeWrapper = (Component) => {
     return <React.StrictMode>{React.createElement(Component, props)}</React.StrictMode>;
   }
 
-  const componentName =
-    typeof Component === 'string'
-      ? Component
-      : Component.displayName || Component.name || 'AnonymousComponent';
-  StrictModeWrapper.displayName = `StrictMode(${componentName})`;
+  StrictModeWrapper.displayName = `StrictMode(${Component.displayName || Component.name || 'AnonymousComponent'})`;
 
   return StrictModeWrapper;
 };
@@ -73,17 +66,6 @@ const wrapComponentInStrictMode = (component) => {
 
     const wrappedComponent = createStrictModeWrapper(component);
     wrappedFunctionComponents.set(component, wrappedComponent);
-    return wrappedComponent;
-  }
-
-  if (typeof component === 'string') {
-    const cachedComponent = wrappedStringComponents.get(component);
-    if (cachedComponent) {
-      return cachedComponent;
-    }
-
-    const wrappedComponent = createStrictModeWrapper(component);
-    wrappedStringComponents.set(component, wrappedComponent);
     return wrappedComponent;
   }
 

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 
 const wrappedFunctionComponents = new WeakMap();
-const wrappedOtherComponents = new Map(); // Map, not WeakMap: string component names are valid keys.
+// Object-typed React components (memo, forwardRef, lazy) are GC-safe in a WeakMap.
+const wrappedObjectComponents = new WeakMap();
+// Strings are primitives and cannot key a WeakMap, so registered string component names live here.
+const wrappedStringComponents = new Map();
 
 // Mirrors the public react-on-rails/isRenderFunction convention for this dummy-only wrapper.
+// Note: the `length >= 2` heuristic intentionally classifies any 2-arg function as a render
+// function. Legacy 2-arg components that use the (props, context) signature must opt back in by
+// setting `fn.renderFunction = false` (or, for class components, are detected via the prototype
+// check). Set `fn.renderFunction = true` to flag a 1-arg render function explicitly.
 const isRenderFunction = (component) => {
   if (typeof component !== 'function') {
     return false;
@@ -46,13 +53,24 @@ const wrapComponentInStrictMode = (component) => {
     return wrappedComponent;
   }
 
-  const cachedComponent = wrappedOtherComponents.get(component);
+  if (typeof component === 'string') {
+    const cachedComponent = wrappedStringComponents.get(component);
+    if (cachedComponent) {
+      return cachedComponent;
+    }
+
+    const wrappedComponent = createStrictModeWrapper(component);
+    wrappedStringComponents.set(component, wrappedComponent);
+    return wrappedComponent;
+  }
+
+  const cachedComponent = wrappedObjectComponents.get(component);
   if (cachedComponent) {
     return cachedComponent;
   }
 
   const wrappedComponent = createStrictModeWrapper(component);
-  wrappedOtherComponents.set(component, wrappedComponent);
+  wrappedObjectComponents.set(component, wrappedComponent);
   return wrappedComponent;
 };
 

--- a/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
+++ b/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
@@ -47,34 +47,94 @@ describe('strictModeSupport', () => {
     expect(wrappedElement.props.children.type).toBe(HelloWorld);
   });
 
-  it('does not wrap render functions or renderer functions', () => {
-    const renderFunction = (props, railsContext) => ({ props, railsContext });
+  it('skips 3-arg renderer functions (they manage their own DOM root)', () => {
     const rendererFunction = (props, railsContext, domNodeId) => ({ props, railsContext, domNodeId });
-    const flaggedRenderFunction = () => () => <div>Hello</div>;
-    flaggedRenderFunction.renderFunction = true;
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ rendererFunction });
 
-    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({
-      flaggedRenderFunction,
-      renderFunction,
-      rendererFunction,
-    });
-
-    expect(wrappedComponents.flaggedRenderFunction).toBe(flaggedRenderFunction);
-    expect(wrappedComponents.renderFunction).toBe(renderFunction);
     expect(wrappedComponents.rendererFunction).toBe(rendererFunction);
   });
 
-  it('treats a 2-arg functional component as a render function (arity heuristic)', () => {
-    // A 2-arg component looks like a render function to isRenderFunction; this test pins down
-    // the heuristic so a future change has to update the test alongside the behavior.
+  it('wraps 2-arg render functions and intercepts React element results in StrictMode', () => {
+    const renderFunction = (props, _railsContext) => <div>{props.greeting}</div>;
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ renderFunction });
+
+    expect(wrappedComponents.renderFunction).not.toBe(renderFunction);
+    const result = wrappedComponents.renderFunction({ greeting: 'hello' }, {});
+    expect(result.type).toBe(React.StrictMode);
+    expect(result.props.children.type).toBe('div');
+    expect(result.props.children.props.children).toBe('hello');
+  });
+
+  it('wraps render functions flagged with renderFunction = true', () => {
+    const flaggedRenderFunction = (props) => <div>{props.greeting}</div>;
+    flaggedRenderFunction.renderFunction = true;
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ flaggedRenderFunction });
+
+    expect(wrappedComponents.flaggedRenderFunction).not.toBe(flaggedRenderFunction);
+    const result = wrappedComponents.flaggedRenderFunction({ greeting: 'hello' });
+    expect(result.type).toBe(React.StrictMode);
+    expect(result.props.children.type).toBe('div');
+  });
+
+  it('passes through non-element results from render functions unchanged', () => {
+    const renderFunction = (props, railsContext) => ({ props, railsContext });
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ renderFunction });
+
+    const result = wrappedComponents.renderFunction({ a: 1 }, { b: 2 });
+    expect(result).toEqual({ props: { a: 1 }, railsContext: { b: 2 } });
+  });
+
+  it('wraps a component result returned from a render function via the component path', () => {
+    const ResultComponent = ({ greeting }) => <span>{greeting}</span>;
+    ResultComponent.propTypes = {
+      greeting: PropTypes.string.isRequired,
+    };
+    const renderFunction = (_props, _railsContext) => ResultComponent;
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ renderFunction });
+
+    const wrappedResult = wrappedComponents.renderFunction({}, {});
+    expect(wrappedResult).not.toBe(ResultComponent);
+    const wrappedElement = wrappedResult({ greeting: 'hello' });
+    expect(wrappedElement.type).toBe(React.StrictMode);
+    expect(wrappedElement.props.children.type).toBe(ResultComponent);
+  });
+
+  it('respects explicit renderFunction = false on 2-arg components (component path)', () => {
     const TwoArgComponent = ({ greeting }, _legacyContext) => <div>{greeting}</div>;
     TwoArgComponent.propTypes = {
       greeting: PropTypes.string.isRequired,
     };
+    TwoArgComponent.renderFunction = false;
 
     const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ TwoArgComponent });
 
-    expect(wrappedComponents.TwoArgComponent).toBe(TwoArgComponent);
+    expect(wrappedComponents.TwoArgComponent).not.toBe(TwoArgComponent);
+    const wrappedElement = wrappedComponents.TwoArgComponent({ greeting: 'hello' });
+    expect(wrappedElement.type).toBe(React.StrictMode);
+    expect(wrappedElement.props.children.type).toBe(TwoArgComponent);
+  });
+
+  it('treats a 2-arg functional component as a render function by default (arity heuristic)', () => {
+    // Without the explicit `renderFunction = false` opt-out, a 2-arg signature is classified as
+    // a render function and its return value is intercepted (wrapped in StrictMode) rather than
+    // the component itself wrapped via the component path.
+    const TwoArgComponent = ({ greeting }, _legacyContext) => <div>{greeting}</div>;
+    TwoArgComponent.propTypes = {
+      greeting: PropTypes.string.isRequired,
+    };
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ TwoArgComponent });
+
+    expect(wrappedComponents.TwoArgComponent).not.toBe(TwoArgComponent);
+    const result = wrappedComponents.TwoArgComponent({ greeting: 'hello' }, {});
+    expect(result.type).toBe(React.StrictMode);
+    expect(result.props.children.type).toBe('div');
+  });
+
+  it('passes plain objects (non-React components) through unchanged', () => {
+    const plainObject = { world: () => 'hello' };
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ plainObject });
+
+    expect(wrappedComponents.plainObject).toBe(plainObject);
   });
 
   it('wraps manual render trees in StrictMode', () => {

--- a/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
+++ b/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
@@ -64,6 +64,19 @@ describe('strictModeSupport', () => {
     expect(wrappedComponents.rendererFunction).toBe(rendererFunction);
   });
 
+  it('treats a 2-arg functional component as a render function (arity heuristic)', () => {
+    // A 2-arg component looks like a render function to isRenderFunction; this test pins down
+    // the heuristic so a future change has to update the test alongside the behavior.
+    const TwoArgComponent = ({ greeting }, _legacyContext) => <div>{greeting}</div>;
+    TwoArgComponent.propTypes = {
+      greeting: PropTypes.string.isRequired,
+    };
+
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({ TwoArgComponent });
+
+    expect(wrappedComponents.TwoArgComponent).toBe(TwoArgComponent);
+  });
+
   it('wraps manual render trees in StrictMode', () => {
     const innerElement = <div>hello</div>;
     const wrappedElement = wrapElementInStrictMode(innerElement);

--- a/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
+++ b/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
@@ -31,15 +31,35 @@ describe('strictModeSupport', () => {
     expect(firstWrappedComponent).toBe(secondWrappedComponent);
   });
 
+  it('wraps class components and preserves useful display names', () => {
+    // eslint-disable-next-line react/prefer-stateless-function
+    class HelloWorld extends React.Component {
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+
+    const wrappedComponent = wrapRegisteredComponentsWithStrictMode({ HelloWorld }).HelloWorld;
+    const wrappedElement = wrappedComponent({});
+
+    expect(wrappedComponent.displayName).toBe('StrictMode(HelloWorld)');
+    expect(wrappedElement.type).toBe(React.StrictMode);
+    expect(wrappedElement.props.children.type).toBe(HelloWorld);
+  });
+
   it('does not wrap render functions or renderer functions', () => {
     const renderFunction = (props, railsContext) => ({ props, railsContext });
     const rendererFunction = (props, railsContext, domNodeId) => ({ props, railsContext, domNodeId });
+    const flaggedRenderFunction = () => () => <div>Hello</div>;
+    flaggedRenderFunction.renderFunction = true;
 
     const wrappedComponents = wrapRegisteredComponentsWithStrictMode({
+      flaggedRenderFunction,
       renderFunction,
       rendererFunction,
     });
 
+    expect(wrappedComponents.flaggedRenderFunction).toBe(flaggedRenderFunction);
     expect(wrappedComponents.renderFunction).toBe(renderFunction);
     expect(wrappedComponents.rendererFunction).toBe(rendererFunction);
   });

--- a/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
+++ b/react_on_rails/spec/dummy/tests/strict-mode-support.test.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {
+  wrapElementInStrictMode,
+  wrapRegisteredComponentsWithStrictMode,
+} from '../client/app/strictModeSupport';
+
+describe('strictModeSupport', () => {
+  it('wraps registered React components in StrictMode', () => {
+    const HelloWorld = ({ greeting }) => <div>{greeting}</div>;
+    HelloWorld.propTypes = {
+      greeting: PropTypes.string.isRequired,
+    };
+    const wrappedComponent = wrapRegisteredComponentsWithStrictMode({ HelloWorld }).HelloWorld;
+
+    expect(wrappedComponent).not.toBe(HelloWorld);
+
+    const wrappedElement = wrappedComponent({ greeting: 'hello' });
+    expect(wrappedElement.type).toBe(React.StrictMode);
+    expect(wrappedElement.props.children.type).toBe(HelloWorld);
+    expect(wrappedElement.props.children.props.greeting).toBe('hello');
+  });
+
+  it('reuses the same wrapper for repeated registrations of the same component', () => {
+    const HelloWorld = () => <div>Hello</div>;
+
+    const firstWrappedComponent = wrapRegisteredComponentsWithStrictMode({ HelloWorld }).HelloWorld;
+    const secondWrappedComponent = wrapRegisteredComponentsWithStrictMode({ HelloWorld }).HelloWorld;
+
+    expect(firstWrappedComponent).toBe(secondWrappedComponent);
+  });
+
+  it('does not wrap render functions or renderer functions', () => {
+    const renderFunction = (props, railsContext) => ({ props, railsContext });
+    const rendererFunction = (props, railsContext, domNodeId) => ({ props, railsContext, domNodeId });
+
+    const wrappedComponents = wrapRegisteredComponentsWithStrictMode({
+      renderFunction,
+      rendererFunction,
+    });
+
+    expect(wrappedComponents.renderFunction).toBe(renderFunction);
+    expect(wrappedComponents.rendererFunction).toBe(rendererFunction);
+  });
+
+  it('wraps manual render trees in StrictMode', () => {
+    const innerElement = <div>hello</div>;
+    const wrappedElement = wrapElementInStrictMode(innerElement);
+
+    expect(wrappedElement.type).toBe(React.StrictMode);
+    expect(wrappedElement.props.children).toBe(innerElement);
+  });
+});

--- a/react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx
@@ -5,16 +5,17 @@ import { loadableReady } from '@loadable/component';
 import { HelmetProvider } from '@dr.pogodin/react-helmet';
 
 import ClientApp from './LoadableApp';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 const App = (props, railsContext, domNodeId) => {
   loadableReady(() => {
     const el = document.getElementById(domNodeId);
-    hydrateRoot(
-      el,
+    const reactElement = wrapElementInStrictMode(
       <HelmetProvider>
         {React.createElement(ClientApp, { ...props, path: railsContext.pathname })}
       </HelmetProvider>,
     );
+    hydrateRoot(el, reactElement);
   });
 };
 

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ApolloGraphQLApp.client.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ApolloGraphQLApp.client.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { ApolloProvider, ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
 import { hydrateRoot } from 'react-dom/client';
 import ApolloGraphQL from '../components/ApolloGraphQL';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 export default (_props, _railsContext, domNodeId) => {
   const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
@@ -22,10 +23,10 @@ export default (_props, _railsContext, domNodeId) => {
     ssrForceFetchDelay: 100,
   });
   const el = document.getElementById(domNodeId);
-  const App = (
+  const App = wrapElementInStrictMode(
     <ApolloProvider client={client}>
       <ApolloGraphQL />
-    </ApolloProvider>
+    </ApolloProvider>,
   );
   hydrateRoot(el, App);
 };

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/LazyApolloGraphQLApp.client.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/LazyApolloGraphQLApp.client.tsx
@@ -5,6 +5,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { setSSRCache } from '@shakacode/use-ssr-computation.runtime';
 import { RailsContext } from 'react-on-rails-pro';
 import ApolloGraphQL from '../components/LazyApolloGraphQL';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 export default (_props: unknown, _railsContext: RailsContext, domNodeId: string) => {
   if (!window.__SSR_COMPUTATION_CACHE) {
@@ -18,6 +19,6 @@ export default (_props: unknown, _railsContext: RailsContext, domNodeId: string)
   console.log('window.__SSR_COMPUTATION_CACHE', window.__SSR_COMPUTATION_CACHE);
   const ssrComputationCache = window.__SSR_COMPUTATION_CACHE;
   setSSRCache(ssrComputationCache);
-  const App = <ApolloGraphQL />;
+  const App = wrapElementInStrictMode(<ApolloGraphQL />);
   hydrateRoot(el, App);
 };

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ManualRenderApp.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ManualRenderApp.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 const hydrateOrRender = (domEl, reactEl, prerender) => {
   if (prerender) {
@@ -16,11 +17,11 @@ const hydrateOrRender = (domEl, reactEl, prerender) => {
 export default (props, _railsContext, domNodeId) => {
   const { prerender } = props;
 
-  const reactElement = (
+  const reactElement = wrapElementInStrictMode(
     <div>
       <h1 id="manual-render">Manual Render Example</h1>
       <p>If you can see this, you can register renderer functions.</p>
-    </div>
+    </div>,
   );
 
   hydrateOrRender(document.getElementById(domNodeId), reactElement, prerender);

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ReduxApp.client.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ReduxApp.client.jsx
@@ -14,6 +14,7 @@ import reducers from '../reducers/reducersIndex';
 import composeInitialState from '../store/composeInitialState';
 
 import HelloWorldContainer from '../components/HelloWorldContainer';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 const hydrateOrRender = (domEl, reactEl, prerender) => {
   if (prerender) {
@@ -43,10 +44,10 @@ export default (props, railsContext, domNodeId) => {
 
   // Provider uses this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
-  const element = (
+  const element = wrapElementInStrictMode(
     <Provider store={store}>
       <HelloWorldContainer />
-    </Provider>
+    </Provider>,
   );
 
   hydrateOrRender(document.getElementById(domNodeId), element, prerender);

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ReduxSharedStoreApp.client.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ReduxSharedStoreApp.client.jsx
@@ -9,6 +9,7 @@ import ReactOnRails from 'react-on-rails-pro';
 import { hydrateRoot, createRoot } from 'react-dom/client';
 
 import HelloWorldContainer from '../components/HelloWorldContainer';
+import { wrapElementInStrictMode } from '../strictModeSupport';
 
 const hydrateOrRender = (domEl, reactEl, prerender) => {
   if (prerender) {
@@ -33,10 +34,10 @@ export default (props, _railsContext, domNodeId) => {
 
   // Provider uses this.props.children, so we're not typical React syntax.
   // This allows redux to add additional props to the HelloWorldContainer.
-  const element = (
+  const element = wrapElementInStrictMode(
     <Provider store={store}>
       <HelloWorldContainer />
-    </Provider>
+    </Provider>,
   );
 
   hydrateOrRender(document.getElementById(domNodeId), element, prerender);

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
@@ -1,0 +1,5 @@
+import ReactOnRails from 'react-on-rails-pro/ReactOnRails.full';
+import { enableStrictModeForReactOnRails } from './strictModeSupport';
+
+export * from 'react-on-rails-pro/ReactOnRails.full';
+export default enableStrictModeForReactOnRails(ReactOnRails);

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
@@ -1,5 +1,4 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.client';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-export * from 'react-on-rails-pro/ReactOnRails.client';
 export default enableStrictModeForReactOnRails(ReactOnRails);

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
@@ -1,0 +1,5 @@
+import ReactOnRails from 'react-on-rails-pro/ReactOnRails.client';
+import { enableStrictModeForReactOnRails } from './strictModeSupport';
+
+export * from 'react-on-rails-pro/ReactOnRails.client';
+export default enableStrictModeForReactOnRails(ReactOnRails);

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
@@ -1,3 +1,10 @@
+// `<React.StrictMode>` is a client-only construct: its double-invocation, deprecated-API, and
+// ref-validation checks do not run during server-side rendering. Wrapping `register` here is
+// effectively a no-op at SSR time. We keep the patch in place so client and server `register`
+// call sites resolve through the same shim (uniformity across Pro entry points), and so that
+// hot-reload paths or shared code that registers once and renders both client- and server-side
+// continues to work without divergence. Per-call cost is bounded by the WeakMap caches in
+// `strictModeSupport.tsx` (repeated registrations are O(1)).
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.node';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
@@ -1,4 +1,4 @@
-import ReactOnRails from 'react-on-rails-pro/ReactOnRails.full';
+import ReactOnRails from 'react-on-rails-pro/ReactOnRails.node';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
 export default enableStrictModeForReactOnRails(ReactOnRails);

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -4,31 +4,39 @@ type ReactClassPrototype = {
   isReactComponent?: boolean;
 };
 
-type ComponentWithMetadata = React.ComponentType<Record<string, unknown>> & {
+type ComponentMetadata = {
   displayName?: string;
   name?: string;
   prototype?: ReactClassPrototype;
 };
 
-type RenderFunction = ((props?: unknown, railsContext?: unknown) => unknown) & {
-  renderFunction?: true;
-  displayName?: string;
-  name?: string;
-  prototype?: ReactClassPrototype;
+type CallableComponent = React.ComponentType<Record<string, unknown>> & ComponentMetadata;
+type ObjectComponent = ComponentMetadata & {
+  $$typeof?: symbol | number;
 };
+type ComponentWithMetadata = string | CallableComponent | ObjectComponent;
+type RenderFunction = ((props?: unknown, railsContext?: unknown) => unknown) &
+  ComponentMetadata & {
+    renderFunction?: true;
+  };
 
-type RegisteredComponent = string | ComponentWithMetadata | RenderFunction;
-type ComponentRegistry = Record<string, RegisteredComponent>;
+type ComponentRegistry = Record<string, unknown>;
 type ReactOnRailsWithRegister = {
   register: (components: ComponentRegistry) => void;
   [key: string]: unknown;
 };
 
 const STRICT_MODE_PATCHED = '__reactOnRailsProDummyStrictModePatched';
+const REACT_OBJECT_COMPONENT_TYPES = new Set<symbol | number>([
+  Symbol.for('react.forward_ref'),
+  Symbol.for('react.lazy'),
+  Symbol.for('react.memo'),
+]);
 
-const wrappedFunctionComponents = new WeakMap<ComponentWithMetadata | RenderFunction, RegisteredComponent>();
+const wrappedFunctionComponents = new WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata>();
 const wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
-const wrappedOtherComponents = new Map<RegisteredComponent, RegisteredComponent>();
+const wrappedObjectComponents = new WeakMap<ObjectComponent, ComponentWithMetadata>();
+const wrappedStringComponents = new Map<string, ComponentWithMetadata>();
 
 const isPromiseLike = (value: unknown): value is Promise<unknown> =>
   typeof value === 'object' &&
@@ -36,12 +44,25 @@ const isPromiseLike = (value: unknown): value is Promise<unknown> =>
   'then' in value &&
   typeof (value as { then?: unknown }).then === 'function';
 
-const isRenderFunction = (component: RegisteredComponent): component is RenderFunction => {
+const isFunctionWithMetadata = (component: unknown): component is CallableComponent | RenderFunction =>
+  typeof component === 'function';
+
+const isObjectComponent = (component: unknown): component is ObjectComponent =>
+  typeof component === 'object' &&
+  component !== null &&
+  REACT_OBJECT_COMPONENT_TYPES.has((component as ObjectComponent).$$typeof ?? 0);
+
+const isReactComponent = (component: unknown): component is ComponentWithMetadata =>
+  typeof component === 'string' || isFunctionWithMetadata(component) || isObjectComponent(component);
+
+// Mirrors React on Rails' render-function convention while keeping class components wrappable.
+const isRenderFunction = (component: unknown): component is RenderFunction => {
   if (typeof component !== 'function') {
     return false;
   }
 
-  if (component.prototype?.isReactComponent) {
+  const reactPrototype = (component as { prototype?: ReactClassPrototype }).prototype;
+  if (reactPrototype?.isReactComponent) {
     return false;
   }
 
@@ -52,15 +73,13 @@ const isRenderFunction = (component: RegisteredComponent): component is RenderFu
   return component.length >= 2;
 };
 
-const isRendererFunction = (component: RegisteredComponent): component is RenderFunction =>
+// A 3-arg renderer controls its own root, so direct renderer files wrap their root elements explicitly.
+const isRendererFunction = (component: unknown): component is RenderFunction =>
   isRenderFunction(component) && component.length === 3;
 
-const createStrictModeWrapper = (Component: RegisteredComponent): React.FC<Record<string, unknown>> => {
+const createStrictModeWrapper = (Component: ComponentWithMetadata): React.FC<Record<string, unknown>> => {
   function StrictModeWrapper(props: Record<string, unknown>) {
-    const childElement =
-      typeof Component === 'string'
-        ? React.createElement(Component, props)
-        : React.createElement(Component as ComponentWithMetadata, props);
+    const childElement = React.createElement(Component as React.ElementType<Record<string, unknown>>, props);
 
     return <React.StrictMode>{childElement}</React.StrictMode>;
   }
@@ -74,7 +93,7 @@ const createStrictModeWrapper = (Component: RegisteredComponent): React.FC<Recor
   return StrictModeWrapper;
 };
 
-const wrapComponentInStrictMode = (component: RegisteredComponent): RegisteredComponent => {
+const wrapComponentInStrictMode = (component: ComponentWithMetadata): ComponentWithMetadata => {
   if (typeof component === 'function') {
     const cachedComponent = wrappedFunctionComponents.get(component);
     if (cachedComponent) {
@@ -86,13 +105,23 @@ const wrapComponentInStrictMode = (component: RegisteredComponent): RegisteredCo
     return wrappedComponent;
   }
 
-  const cachedComponent = wrappedOtherComponents.get(component);
+  if (typeof component === 'string') {
+    const cachedComponent = wrappedStringComponents.get(component);
+    if (cachedComponent) {
+      return cachedComponent;
+    }
+
+    const wrappedComponent = createStrictModeWrapper(component);
+    wrappedStringComponents.set(component, wrappedComponent);
+    return wrappedComponent;
+  }
+
+  const cachedComponent = wrappedObjectComponents.get(component);
   if (cachedComponent) {
     return cachedComponent;
   }
-
   const wrappedComponent = createStrictModeWrapper(component);
-  wrappedOtherComponents.set(component, wrappedComponent);
+  wrappedObjectComponents.set(component, wrappedComponent);
   return wrappedComponent;
 };
 
@@ -109,8 +138,8 @@ const wrapRenderFunctionResult = (result: unknown): unknown => {
     return wrapElementInStrictMode(result);
   }
 
-  if (typeof result === 'function') {
-    return wrapComponentInStrictMode(result as RegisteredComponent);
+  if (isReactComponent(result)) {
+    return wrapComponentInStrictMode(result);
   }
 
   return result;
@@ -125,6 +154,9 @@ const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderF
   const wrappedRenderFunction: RenderFunction = function StrictModeRenderFunction(props, railsContext) {
     return wrapRenderFunctionResult(renderFunction(props, railsContext));
   };
+  wrappedRenderFunction.displayName = `StrictMode(${
+    renderFunction.displayName || renderFunction.name || 'AnonymousRenderFunction'
+  })`;
 
   if (renderFunction.renderFunction) {
     wrappedRenderFunction.renderFunction = true;
@@ -145,6 +177,10 @@ export const wrapRegisteredComponentsWithStrictMode = (components: ComponentRegi
         return [name, wrapRenderFunctionInStrictMode(component)];
       }
 
+      if (!isReactComponent(component)) {
+        return [name, component];
+      }
+
       return [name, wrapComponentInStrictMode(component)];
     }),
   );
@@ -154,14 +190,14 @@ export const enableStrictModeForReactOnRails = <T extends ReactOnRailsWithRegist
     return reactOnRails;
   }
 
-  const originalRegister = reactOnRails.register.bind(reactOnRails);
-  const patchedReactOnRails = reactOnRails;
-
-  patchedReactOnRails.register = (components: ComponentRegistry) => {
+  // Mutate the singleton in place so every default-import consumer observes the patch.
+  const reactOnRailsSingleton = reactOnRails;
+  const originalRegister = reactOnRailsSingleton.register.bind(reactOnRailsSingleton);
+  reactOnRailsSingleton.register = (components: ComponentRegistry) => {
     originalRegister(wrapRegisteredComponentsWithStrictMode(components));
   };
 
-  Object.defineProperty(patchedReactOnRails, STRICT_MODE_PATCHED, { value: true });
+  Object.defineProperty(reactOnRailsSingleton, STRICT_MODE_PATCHED, { value: true });
 
-  return patchedReactOnRails;
+  return reactOnRailsSingleton;
 };

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -145,6 +145,10 @@ const wrapRenderFunctionResult = (result: unknown): unknown => {
   return result;
 };
 
+// The wrapped function below has `length === 2`, so `isRenderFunction` would re-classify it as a
+// render function if it ever flowed back through `wrapRegisteredComponentsWithStrictMode`. The
+// STRICT_MODE_PATCHED guard on `enableStrictModeForReactOnRails` ensures the patched `register`
+// runs only once per singleton, which keeps that re-entry path unreachable.
 const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderFunction => {
   const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
   if (cachedRenderFunction) {

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -17,7 +17,7 @@ type ObjectComponent = ComponentMetadata & {
 type ComponentWithMetadata = string | CallableComponent | ObjectComponent;
 type RenderFunction = ((props?: unknown, railsContext?: unknown) => unknown) &
   ComponentMetadata & {
-    renderFunction?: true;
+    renderFunction?: boolean;
   };
 
 type ComponentRegistry = Record<string, unknown>;
@@ -36,7 +36,14 @@ const REACT_OBJECT_COMPONENT_TYPES = new Set<symbol | number>([
 const wrappedFunctionComponents = new WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata>();
 const wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
 const wrappedObjectComponents = new WeakMap<ObjectComponent, ComponentWithMetadata>();
+// Strings are primitives and cannot key a WeakMap, so registered string component names live here.
 const wrappedStringComponents = new Map<string, ComponentWithMetadata>();
+
+// TODO: Pro-only logic (`enableStrictModeForReactOnRails`, `wrapRenderFunctionResult` Promise
+// handling, `wrapRenderFunctionInStrictMode`) has no dedicated test suite. The OSS dummy's Jest
+// config doesn't cover Pro-specific paths; consider a small Vitest/Jest harness inside
+// `react_on_rails_pro/spec/dummy/tests/` (mirroring the OSS `strict-mode-support.test.jsx`) to
+// pin the async Promise-result path and the singleton-patch idempotency.
 
 const isPromiseLike = (value: unknown): value is Promise<unknown> =>
   typeof value === 'object' &&
@@ -55,7 +62,11 @@ const isObjectComponent = (component: unknown): component is ObjectComponent =>
 const isReactComponent = (component: unknown): component is ComponentWithMetadata =>
   typeof component === 'string' || isFunctionWithMetadata(component) || isObjectComponent(component);
 
-// Mirrors React on Rails' render-function convention while keeping class components wrappable.
+// Mirrors React on Rails' render-function convention while extending it with an explicit
+// `renderFunction = false` opt-out (the public helper only checks for truthiness; this dummy
+// honors `false` so legacy 2-arg `(props, context)` components can be wrapped via the component
+// path rather than the render-function path). Class components are detected via the prototype
+// check.
 const isRenderFunction = (component: unknown): component is RenderFunction => {
   if (typeof component !== 'function') {
     return false;
@@ -66,8 +77,9 @@ const isRenderFunction = (component: unknown): component is RenderFunction => {
     return false;
   }
 
-  if (component.renderFunction) {
-    return true;
+  const renderFunctionFlag = (component as { renderFunction?: unknown }).renderFunction;
+  if (typeof renderFunctionFlag === 'boolean') {
+    return renderFunctionFlag;
   }
 
   return component.length >= 2;
@@ -148,7 +160,11 @@ const wrapRenderFunctionResult = (result: unknown): unknown => {
 // The wrapped function below has `length === 2`, so `isRenderFunction` would re-classify it as a
 // render function if it ever flowed back through `wrapRegisteredComponentsWithStrictMode`. The
 // STRICT_MODE_PATCHED guard on `enableStrictModeForReactOnRails` ensures the patched `register`
-// runs only once per singleton, which keeps that re-entry path unreachable.
+// runs only once per singleton, which keeps that re-entry path unreachable. Note: when called
+// directly (outside the registry path) with a 3-arg renderer, the wrapper's hardcoded
+// `length === 2` would not reflect the original arity. `wrapRegisteredComponentsWithStrictMode`
+// orders the renderer check before the render-function check so a 3-arg renderer never reaches
+// this helper through the registry, but direct callers should treat this as a precondition.
 const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderFunction => {
   const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
   if (cachedRenderFunction) {

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+
+type ReactClassPrototype = {
+  isReactComponent?: boolean;
+};
+
+type ComponentWithMetadata = React.ComponentType<Record<string, unknown>> & {
+  displayName?: string;
+  name?: string;
+  prototype?: ReactClassPrototype;
+};
+
+type RenderFunction = ((props?: unknown, railsContext?: unknown) => unknown) & {
+  renderFunction?: true;
+  displayName?: string;
+  name?: string;
+  prototype?: ReactClassPrototype;
+};
+
+type RegisteredComponent = string | ComponentWithMetadata | RenderFunction;
+type ComponentRegistry = Record<string, RegisteredComponent>;
+type ReactOnRailsWithRegister = {
+  register: (components: ComponentRegistry) => void;
+  [key: string]: unknown;
+};
+
+const STRICT_MODE_PATCHED = '__reactOnRailsProDummyStrictModePatched';
+
+const wrappedFunctionComponents = new WeakMap<ComponentWithMetadata | RenderFunction, RegisteredComponent>();
+const wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
+const wrappedOtherComponents = new Map<RegisteredComponent, RegisteredComponent>();
+
+const isPromiseLike = (value: unknown): value is Promise<unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  'then' in value &&
+  typeof (value as { then?: unknown }).then === 'function';
+
+const isRenderFunction = (component: RegisteredComponent): component is RenderFunction => {
+  if (typeof component !== 'function') {
+    return false;
+  }
+
+  if (component.prototype?.isReactComponent) {
+    return false;
+  }
+
+  if (component.renderFunction) {
+    return true;
+  }
+
+  return component.length >= 2;
+};
+
+const isRendererFunction = (component: RegisteredComponent): component is RenderFunction =>
+  isRenderFunction(component) && component.length === 3;
+
+const createStrictModeWrapper = (Component: RegisteredComponent): React.FC<Record<string, unknown>> => {
+  function StrictModeWrapper(props: Record<string, unknown>) {
+    const childElement =
+      typeof Component === 'string'
+        ? React.createElement(Component, props)
+        : React.createElement(Component as ComponentWithMetadata, props);
+
+    return <React.StrictMode>{childElement}</React.StrictMode>;
+  }
+
+  const componentName =
+    typeof Component === 'string'
+      ? Component
+      : Component.displayName || Component.name || 'AnonymousComponent';
+  StrictModeWrapper.displayName = `StrictMode(${componentName})`;
+
+  return StrictModeWrapper;
+};
+
+const wrapComponentInStrictMode = (component: RegisteredComponent): RegisteredComponent => {
+  if (typeof component === 'function') {
+    const cachedComponent = wrappedFunctionComponents.get(component);
+    if (cachedComponent) {
+      return cachedComponent;
+    }
+
+    const wrappedComponent = createStrictModeWrapper(component);
+    wrappedFunctionComponents.set(component, wrappedComponent);
+    return wrappedComponent;
+  }
+
+  const cachedComponent = wrappedOtherComponents.get(component);
+  if (cachedComponent) {
+    return cachedComponent;
+  }
+
+  const wrappedComponent = createStrictModeWrapper(component);
+  wrappedOtherComponents.set(component, wrappedComponent);
+  return wrappedComponent;
+};
+
+export const wrapElementInStrictMode = (reactElement: React.ReactElement): React.ReactElement => (
+  <React.StrictMode>{reactElement}</React.StrictMode>
+);
+
+const wrapRenderFunctionResult = (result: unknown): unknown => {
+  if (isPromiseLike(result)) {
+    return result.then(wrapRenderFunctionResult);
+  }
+
+  if (React.isValidElement(result)) {
+    return wrapElementInStrictMode(result);
+  }
+
+  if (typeof result === 'function') {
+    return wrapComponentInStrictMode(result as RegisteredComponent);
+  }
+
+  return result;
+};
+
+const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderFunction => {
+  const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
+  if (cachedRenderFunction) {
+    return cachedRenderFunction;
+  }
+
+  const wrappedRenderFunction: RenderFunction = function StrictModeRenderFunction(props, railsContext) {
+    return wrapRenderFunctionResult(renderFunction(props, railsContext));
+  };
+
+  if (renderFunction.renderFunction) {
+    wrappedRenderFunction.renderFunction = true;
+  }
+
+  wrappedRenderFunctions.set(renderFunction, wrappedRenderFunction);
+  return wrappedRenderFunction;
+};
+
+export const wrapRegisteredComponentsWithStrictMode = (components: ComponentRegistry): ComponentRegistry =>
+  Object.fromEntries(
+    Object.entries(components).map(([name, component]) => {
+      if (isRendererFunction(component)) {
+        return [name, component];
+      }
+
+      if (isRenderFunction(component)) {
+        return [name, wrapRenderFunctionInStrictMode(component)];
+      }
+
+      return [name, wrapComponentInStrictMode(component)];
+    }),
+  );
+
+export const enableStrictModeForReactOnRails = <T extends ReactOnRailsWithRegister>(reactOnRails: T): T => {
+  if (reactOnRails[STRICT_MODE_PATCHED]) {
+    return reactOnRails;
+  }
+
+  const originalRegister = reactOnRails.register.bind(reactOnRails);
+  const patchedReactOnRails = reactOnRails;
+
+  patchedReactOnRails.register = (components: ComponentRegistry) => {
+    originalRegister(wrapRegisteredComponentsWithStrictMode(components));
+  };
+
+  Object.defineProperty(patchedReactOnRails, STRICT_MODE_PATCHED, { value: true });
+
+  return patchedReactOnRails;
+};

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -14,7 +14,7 @@ type CallableComponent = React.ComponentType<Record<string, unknown>> & Componen
 type ObjectComponent = ComponentMetadata & {
   $$typeof?: symbol | number;
 };
-type ComponentWithMetadata = string | CallableComponent | ObjectComponent;
+type ComponentWithMetadata = CallableComponent | ObjectComponent;
 type RenderFunction = ((props?: unknown, railsContext?: unknown) => unknown) &
   ComponentMetadata & {
     renderFunction?: boolean;
@@ -36,14 +36,6 @@ const REACT_OBJECT_COMPONENT_TYPES = new Set<symbol | number>([
 const wrappedFunctionComponents = new WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata>();
 const wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
 const wrappedObjectComponents = new WeakMap<ObjectComponent, ComponentWithMetadata>();
-// Strings are primitives and cannot key a WeakMap, so registered string component names live here.
-const wrappedStringComponents = new Map<string, ComponentWithMetadata>();
-
-// TODO: Pro-only logic (`enableStrictModeForReactOnRails`, `wrapRenderFunctionResult` Promise
-// handling, `wrapRenderFunctionInStrictMode`) has no dedicated test suite. The OSS dummy's Jest
-// config doesn't cover Pro-specific paths; consider a small Vitest/Jest harness inside
-// `react_on_rails_pro/spec/dummy/tests/` (mirroring the OSS `strict-mode-support.test.jsx`) to
-// pin the async Promise-result path and the singleton-patch idempotency.
 
 const isPromiseLike = (value: unknown): value is Promise<unknown> =>
   typeof value === 'object' &&
@@ -60,7 +52,7 @@ const isObjectComponent = (component: unknown): component is ObjectComponent =>
   REACT_OBJECT_COMPONENT_TYPES.has((component as ObjectComponent).$$typeof ?? 0);
 
 const isReactComponent = (component: unknown): component is ComponentWithMetadata =>
-  typeof component === 'string' || isFunctionWithMetadata(component) || isObjectComponent(component);
+  isFunctionWithMetadata(component) || isObjectComponent(component);
 
 // Mirrors React on Rails' render-function convention while extending it with an explicit
 // `renderFunction = false` opt-out (the public helper only checks for truthiness; this dummy
@@ -96,11 +88,7 @@ const createStrictModeWrapper = (Component: ComponentWithMetadata): React.FC<Rec
     return <React.StrictMode>{childElement}</React.StrictMode>;
   }
 
-  const componentName =
-    typeof Component === 'string'
-      ? Component
-      : Component.displayName || Component.name || 'AnonymousComponent';
-  StrictModeWrapper.displayName = `StrictMode(${componentName})`;
+  StrictModeWrapper.displayName = `StrictMode(${Component.displayName || Component.name || 'AnonymousComponent'})`;
 
   return StrictModeWrapper;
 };
@@ -114,17 +102,6 @@ const wrapComponentInStrictMode = (component: ComponentWithMetadata): ComponentW
 
     const wrappedComponent = createStrictModeWrapper(component);
     wrappedFunctionComponents.set(component, wrappedComponent);
-    return wrappedComponent;
-  }
-
-  if (typeof component === 'string') {
-    const cachedComponent = wrappedStringComponents.get(component);
-    if (cachedComponent) {
-      return cachedComponent;
-    }
-
-    const wrappedComponent = createStrictModeWrapper(component);
-    wrappedStringComponents.set(component, wrappedComponent);
     return wrappedComponent;
   }
 

--- a/react_on_rails_pro/spec/dummy/config/webpack/alias.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/alias.js
@@ -14,6 +14,15 @@ module.exports = {
       'react-dom': resolve(rootNodeModules, 'react-dom'),
       'react-dom/client': resolve(rootNodeModules, 'react-dom', 'client'),
       'react-dom/server': resolve(rootNodeModules, 'react-dom', 'server'),
+      'react-on-rails-pro$': resolve(__dirname, '..', '..', 'client', 'app', 'strictModeReactOnRailsPro.js'),
+      'react-on-rails-pro/client$': resolve(
+        __dirname,
+        '..',
+        '..',
+        'client',
+        'app',
+        'strictModeReactOnRailsProClient.js',
+      ),
     },
   },
 };

--- a/react_on_rails_pro/spec/dummy/config/webpack/rscWebpackConfig.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/rscWebpackConfig.js
@@ -36,6 +36,9 @@ const configureRsc = () => {
   const rootNodeModules = resolve(__dirname, '..', '..', '..', '..', '..', 'node_modules');
   const rscAliases = { ...(rscConfig.resolve?.alias || {}) };
   delete rscAliases['react-on-rails-pro$'];
+  // Drop the client-only StrictMode shim so RSC imports of `react-on-rails-pro/client` don't pull
+  // in a browser entry point inside the React server bundle.
+  delete rscAliases['react-on-rails-pro/client$'];
   rscConfig.resolve = {
     ...rscConfig.resolve,
     conditionNames: ['react-server', '...'],

--- a/react_on_rails_pro/spec/dummy/config/webpack/rscWebpackConfig.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/rscWebpackConfig.js
@@ -34,11 +34,13 @@ const configureRsc = () => {
   // For the RSC bundle, we must override these aliases to point to the react-server
   // entry files directly, so that React's server-specific code is bundled correctly.
   const rootNodeModules = resolve(__dirname, '..', '..', '..', '..', '..', 'node_modules');
+  const rscAliases = { ...(rscConfig.resolve?.alias || {}) };
+  delete rscAliases['react-on-rails-pro$'];
   rscConfig.resolve = {
     ...rscConfig.resolve,
     conditionNames: ['react-server', '...'],
     alias: {
-      ...rscConfig.resolve?.alias,
+      ...rscAliases,
       // Override React aliases to use react-server entry points
       react: resolve(rootNodeModules, 'react', 'react.react-server.js'),
       'react/jsx-runtime': resolve(rootNodeModules, 'react', 'jsx-runtime.react-server.js'),

--- a/react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js
@@ -25,10 +25,15 @@ const configureServer = (rscBundle = false) => {
   // entry value will result in changing the client config!
   // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
+  const serverAliases = { ...(serverWebpackConfig.resolve?.alias || {}) };
+  // Drop the client-only StrictMode shim — same reason as the RSC config:
+  // the SSR bundle must not pull a browser entry point if anything resolves
+  // `react-on-rails-pro/client` server-side.
+  delete serverAliases['react-on-rails-pro/client$'];
   serverWebpackConfig.resolve = {
     ...serverWebpackConfig.resolve,
     alias: {
-      ...(serverWebpackConfig.resolve?.alias || {}),
+      ...serverAliases,
       'react-on-rails-pro$': path.resolve(
         __dirname,
         '..',

--- a/react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js
@@ -25,6 +25,14 @@ const configureServer = (rscBundle = false) => {
   // entry value will result in changing the client config!
   // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
+  serverWebpackConfig.resolve.alias['react-on-rails-pro$'] = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'client',
+    'app',
+    'strictModeReactOnRailsProNode.js',
+  );
 
   // We just want the single server bundle entry
   const serverEntry = {

--- a/react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js
+++ b/react_on_rails_pro/spec/dummy/config/webpack/serverWebpackConfig.js
@@ -25,14 +25,20 @@ const configureServer = (rscBundle = false) => {
   // entry value will result in changing the client config!
   // Using webpack-merge into an empty object avoids this issue.
   const serverWebpackConfig = commonWebpackConfig();
-  serverWebpackConfig.resolve.alias['react-on-rails-pro$'] = path.resolve(
-    __dirname,
-    '..',
-    '..',
-    'client',
-    'app',
-    'strictModeReactOnRailsProNode.js',
-  );
+  serverWebpackConfig.resolve = {
+    ...serverWebpackConfig.resolve,
+    alias: {
+      ...(serverWebpackConfig.resolve?.alias || {}),
+      'react-on-rails-pro$': path.resolve(
+        __dirname,
+        '..',
+        '..',
+        'client',
+        'app',
+        'strictModeReactOnRailsProNode.js',
+      ),
+    },
+  };
 
   // We just want the single server bundle entry
   const serverEntry = {

--- a/react_on_rails_pro/spec/dummy/jest.config.cjs
+++ b/react_on_rails_pro/spec/dummy/jest.config.cjs
@@ -1,0 +1,28 @@
+// Jest config for the Pro dummy app.
+//
+// Pins behaviors of `client/app/strictModeSupport.tsx` that aren't exercised by the OSS dummy's
+// Jest suite (Pro's `enableStrictModeForReactOnRails` singleton patch and the async Promise path
+// in `wrapRenderFunctionResult`).
+//
+// Uses ts-jest directly rather than the dummy's `babel.config.js`, which carries webpack-specific
+// plugins (macros, loadable, react-refresh) that aren't safe to run inside the test runner.
+
+const { createJsWithTsPreset } = require('ts-jest');
+
+const tsJestPreset = createJsWithTsPreset({
+  tsconfig: {
+    jsx: 'react',
+    esModuleInterop: true,
+    module: 'ESNext',
+    target: 'ES2020',
+  },
+});
+
+module.exports = {
+  ...tsJestPreset,
+  testEnvironment: 'jsdom',
+  testMatch: ['<rootDir>/tests/**/?(*.)+(spec|test).[jt]s?(x)'],
+  moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx', 'json'],
+  clearMocks: true,
+  rootDir: '.',
+};

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -95,6 +95,7 @@
   },
   "scripts": {
     "test": "pnpm run build:test && pnpm run lint && rspec",
+    "test:js": "jest ./tests",
     "lint": "cd ../.. && nps lint",
     "e2e-test": "npx playwright test",
     "postinstall": "test -f post-pnpm-install.local && ./post-pnpm-install.local || true",

--- a/react_on_rails_pro/spec/dummy/tests/strict-mode-support.test.tsx
+++ b/react_on_rails_pro/spec/dummy/tests/strict-mode-support.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import {
+  enableStrictModeForReactOnRails,
+  wrapElementInStrictMode,
+  wrapRegisteredComponentsWithStrictMode,
+} from '../client/app/strictModeSupport';
+
+type RegisteredComponents = Record<string, unknown>;
+
+const buildFakeReactOnRails = () => {
+  const registered: RegisteredComponents = {};
+  return {
+    register: (components: RegisteredComponents) => {
+      Object.assign(registered, components);
+    },
+    registered,
+  };
+};
+
+describe('Pro strictModeSupport', () => {
+  it('wraps registered React components in StrictMode via the patched register', () => {
+    const fakeReactOnRails = buildFakeReactOnRails();
+    enableStrictModeForReactOnRails(fakeReactOnRails);
+
+    const HelloWorld = ({ greeting }: { greeting: string }) => <div>{greeting}</div>;
+    fakeReactOnRails.register({ HelloWorld });
+
+    const wrapped = fakeReactOnRails.registered.HelloWorld as React.FC<{ greeting: string }>;
+    expect(wrapped).not.toBe(HelloWorld);
+    const rendered = wrapped({ greeting: 'hi' }) as React.ReactElement;
+    expect(rendered.type).toBe(React.StrictMode);
+  });
+
+  it('is idempotent — calling enableStrictMode twice does not double-wrap registrations', () => {
+    const fakeReactOnRails = buildFakeReactOnRails();
+    const originalRegister = fakeReactOnRails.register;
+
+    enableStrictModeForReactOnRails(fakeReactOnRails);
+    const patchedRegister = fakeReactOnRails.register;
+    expect(patchedRegister).not.toBe(originalRegister);
+
+    // Second call is a no-op: register reference must not change.
+    enableStrictModeForReactOnRails(fakeReactOnRails);
+    expect(fakeReactOnRails.register).toBe(patchedRegister);
+
+    const Component = () => <div>hi</div>;
+    fakeReactOnRails.register({ Component });
+    const wrapped = fakeReactOnRails.registered.Component as React.FC;
+    const rendered = wrapped({}) as React.ReactElement;
+    // Single StrictMode wrapper, not nested.
+    expect(rendered.type).toBe(React.StrictMode);
+    const inner = rendered.props.children as React.ReactElement;
+    expect(inner.type).toBe(Component);
+  });
+
+  it('wraps the resolved value of a render function that returns a Promise<ReactElement>', async () => {
+    const renderFunction = (props: { greeting: string }) => Promise.resolve(<div>{props.greeting}</div>);
+    // Render function detection uses arity; this single-arg function needs the explicit flag.
+    (renderFunction as unknown as { renderFunction: boolean }).renderFunction = true;
+
+    const wrapped = wrapRegisteredComponentsWithStrictMode({ renderFunction }).renderFunction as (props: {
+      greeting: string;
+    }) => Promise<React.ReactElement>;
+    const result = await wrapped({ greeting: 'hello' });
+
+    expect(result.type).toBe(React.StrictMode);
+    const inner = result.props.children as React.ReactElement;
+    expect(inner.type).toBe('div');
+    expect(inner.props.children).toBe('hello');
+  });
+
+  it('skips 3-arg renderer functions (they own their root and wrap manually)', () => {
+    const rendererFunction = (props: unknown, railsContext: unknown, domNodeId: unknown) => ({
+      props,
+      railsContext,
+      domNodeId,
+    });
+    const wrapped = wrapRegisteredComponentsWithStrictMode({ rendererFunction });
+    expect(wrapped.rendererFunction).toBe(rendererFunction);
+  });
+
+  it('exposes wrapElementInStrictMode for manual-render entry points', () => {
+    const element = <span>hi</span>;
+    const wrapped = wrapElementInStrictMode(element);
+    expect(wrapped.type).toBe(React.StrictMode);
+    expect(wrapped.props.children).toBe(element);
+  });
+});

--- a/react_on_rails_pro/spec/dummy/tsconfig.json
+++ b/react_on_rails_pro/spec/dummy/tsconfig.json
@@ -12,6 +12,8 @@
     "client/**/*.tsx",
     "client/**/*.d.ts",
     "e2e-tests/*",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
     "./playwright.config.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- Enables React StrictMode in the OSS `spec/dummy` startup paths by wrapping normal `ReactOnRails.register` registrations and direct manual renderer roots.
- Covers both OSS dummy variants: the React 19 `client/app/` path and the React 16 `client/app-react16/` path.
- Extends the same coverage to the Pro dummy with webpack aliases for the Pro package entrypoints, so async/generated registrations are patched before startup imports run.
- Leaves 3-argument renderer functions in control of their own roots and wraps those manual roots explicitly.
- Adds Jest coverage for the OSS StrictMode helper's wrapping, caching, and render-function skip behavior.

Closes #1465

## Test plan

- [x] `pnpm --dir react_on_rails/spec/dummy run test:js`
- [x] `pnpm --dir react_on_rails/spec/dummy run build:test` (passes with existing DefinePlugin warnings)
- [x] `pnpm exec eslint --no-ignore react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js react_on_rails_pro/spec/dummy/config/webpack/alias.js react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ManualRenderApp.jsx react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ReduxApp.client.jsx react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ReduxSharedStoreApp.client.jsx`
- [x] `pnpm --dir react_on_rails_pro/spec/dummy run build:test` (passes with existing DefinePlugin warnings)
- [x] pre-commit hook: trailing-newlines, Prettier, ESLint on Pro changed files
- [x] pre-push hook: branch-lint, markdown-links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable React Strict Mode consistently for client render/hydration flows, registered components, and pro/auto-loaded entry points; add bundler/alias updates so client/server bundles resolve strict-mode-aware implementations.

* **Tests**
  * Add comprehensive tests validating strict-mode wrapping behavior, wrapper caching, render-function exemptions, and opt-out handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to `spec/dummy` apps and webpack configs used for dummy/test builds; main risk is unexpected StrictMode double-invocation effects causing flaky dummy tests or examples.
> 
> **Overview**
> **Enables React `StrictMode` across the OSS and Pro dummy apps** by adding shared helpers to wrap rendered element trees and to automatically wrap registered components.
> 
> In OSS `spec/dummy`, startup entrypoints (including the React 16 variant) now wrap manual render roots and Redux provider trees via `wrapElementInStrictMode`, and `client-bundle.js` monkey-patches `ReactOnRails.register` to StrictMode-wrap non-render-function registrations.
> 
> In Pro `spec/dummy`, a TypeScript `strictModeSupport` adds component/render-function wrapping (including async render results), webpack aliases redirect `react-on-rails-pro` imports to StrictMode-enabled shims for client/server builds (with RSC config explicitly removing that alias), and several startup apps wrap their roots explicitly; Jest coverage is added for the OSS helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45da8decfd0217962e4778fbfc9fbd138a304061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->