### PR TITLE
ci: exclude bot-blocking URLs from lychee link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -29,8 +29,10 @@ exclude = [
   '^https://careersatdoordash\.com',  # Cloudflare bot challenge returns 403
   '^https://www\.linkedin\.com',
   '^https://reactrails\.slack\.com',
+  '^https://invite\.reactrails\.com/?$',  # Slack invite endpoint returns 403 for automated requests
   '^https://docs\.google\.com',  # Private docs require auth
   '^https://claude\.ai',  # Returns 403 for automated requests
+  '^https://(www\.)?110grill\.com/?$',  # Returns 403 for automated requests
 
   # ============================================================================
   # KNOWN DEAD OR PROBLEMATIC URLS


### PR DESCRIPTION
## Summary

The Check Markdown Links workflow has been failing because `lychee` receives **403 Forbidden** responses from two URLs that block automated requests:

- `https://invite.reactrails.com/` (referenced from `README.md`, `docs/oss/getting-started/common-issues.md`, `docs/oss/deployment/troubleshooting.md`)
- `https://www.110grill.com/` (referenced from `docs/oss/migrating/migrating-from-vite-rails.md`)

`.lychee.toml` only accepts `200`/`301`/`308`, and the workflow uses `fail: true`, so any 403 fails the job.

## Fix

Add both URLs to the `exclude` list in `.lychee.toml`, alongside the existing bot-blocking exclusions (`npmjs`, `medium.com`, `claude.ai`, etc.).

Patterns:
- `^https://invite\.reactrails\.com/?$`
- `^https://(www\.)?110grill\.com/?$`

Verified locally that both regexes correctly match all URL variants used in the docs.

## Test plan

- [ ] `Check Markdown Links` CI job passes on this PR
- [ ] No other regressions on `lychee` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 409a03c8f7a4584b901429b7089be00e53000872. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link checking configuration to exclude additional URL patterns from validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->