### PR TITLE
docs: document RSC HTTP response ownership

### DIFF
--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -146,7 +146,7 @@ Tailored for React on Rails' multi-root architecture:
 1. **[Prepare your app](rsc-preparing-app.md)** -- set up the RSC infrastructure, add `'use client'` to all component entry points, and switch to streaming rendering. The app works identically -- nothing changes yet.
 2. **Pick a component and push the boundary down** -- move `'use client'` from the root component to its interactive children, letting parent components become Server Components.
 3. **Adopt advanced patterns** -- add Suspense boundaries, [`stream_react_component`](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for streaming SSR, and server-side data fetching.
-4. **[Keep route policy in Rails](rsc-http-response-patterns.md)** -- decide redirects, status codes, and cache headers before streaming commits the response.
+4. **[Keep route policy in Rails](rsc-http-response-patterns.md)** -- for each route, decide redirects, status codes, and cache headers before streaming commits the response.
 5. **Repeat for each registered component** -- migrate components one at a time, in any order.
 
 This approach lets you migrate incrementally, one component at a time, without ever breaking your app.

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -72,7 +72,17 @@ How to migrate from client-side data fetching to server component patterns. Cove
 - Streaming data with the `use()` hook and Suspense
 - When to keep client-side data fetching
 
-### 5. [Third-Party Library Compatibility](rsc-third-party-libs.md)
+### 5. [HTTP Response Ownership](rsc-http-response-patterns.md)
+
+How to keep HTTP response semantics in Rails while rendering the UI with RSC. Covers:
+
+- Preflight patterns for controller/service decisions before streaming
+- Route-level `404` and not-found UI patterns
+- Redirect ownership and why it should stay in Rails
+- Cache header strategy for public and personalized RSC responses
+- Passing response policy into the RSC tree as serializable props
+
+### 6. [Third-Party Library Compatibility](rsc-third-party-libs.md)
 
 How to handle libraries that aren't RSC-compatible. Covers:
 
@@ -83,7 +93,7 @@ How to handle libraries that aren't RSC-compatible. Covers:
 - The barrel file problem and direct imports
 - Using `server-only` and `client-only` packages
 
-### 6. [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md)
+### 7. [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md)
 
 How to debug and avoid common problems. Covers:
 
@@ -96,7 +106,7 @@ How to debug and avoid common problems. Covers:
 - Performance monitoring and bundle analysis tools
 - Common error messages and their solutions
 
-### 7. [Flight Payload Optimization](rsc-flight-payload.md)
+### 8. [Flight Payload Optimization](rsc-flight-payload.md)
 
 How to optimize RSC Flight payload size for better performance. Covers:
 
@@ -136,7 +146,8 @@ Tailored for React on Rails' multi-root architecture:
 1. **[Prepare your app](rsc-preparing-app.md)** -- set up the RSC infrastructure, add `'use client'` to all component entry points, and switch to streaming rendering. The app works identically -- nothing changes yet.
 2. **Pick a component and push the boundary down** -- move `'use client'` from the root component to its interactive children, letting parent components become Server Components.
 3. **Adopt advanced patterns** -- add Suspense boundaries, [`stream_react_component`](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for streaming SSR, and server-side data fetching.
-4. **Repeat for each registered component** -- migrate components one at a time, in any order.
+4. **Keep route policy in Rails** -- decide redirects, status codes, and cache headers before streaming commits the response.
+5. **Repeat for each registered component** -- migrate components one at a time, in any order.
 
 This approach lets you migrate incrementally, one component at a time, without ever breaking your app.
 
@@ -191,6 +202,7 @@ These mistakes account for the majority of setup failures:
 
 - [Upgrading an Existing Pro App to RSC](../../pro/react-server-components/upgrading-existing-pro-app.md) — generator-based runbook for adding RSC to an existing Pro app, including legacy webpack compatibility and verification checklist
 - [React 19 Native Metadata](../building-features/react-19-native-metadata.md) — replace react-helmet and `react_component_hash` with React 19's built-in `<title>`, `<meta>`, and `<link>` hoisting. Native metadata works with streaming and RSC out of the box.
+- [HTTP Response Ownership](rsc-http-response-patterns.md) -- keep `404`, redirects, and cache policy in Rails while rendering route UI with RSC.
 
 ## References
 

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -202,7 +202,7 @@ These mistakes account for the majority of setup failures:
 
 - [Upgrading an Existing Pro App to RSC](../../pro/react-server-components/upgrading-existing-pro-app.md) — generator-based runbook for adding RSC to an existing Pro app, including legacy webpack compatibility and verification checklist
 - [React 19 Native Metadata](../building-features/react-19-native-metadata.md) — replace react-helmet and `react_component_hash` with React 19's built-in `<title>`, `<meta>`, and `<link>` hoisting. Native metadata works with streaming and RSC out of the box.
-- [HTTP Response Ownership](rsc-http-response-patterns.md) -- keep `404`, redirects, and cache policy in Rails while rendering route UI with RSC.
+- [HTTP Response Ownership](rsc-http-response-patterns.md) — keep `404`, redirects, and cache policy in Rails while rendering route UI with RSC.
 
 ## References
 

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -146,7 +146,7 @@ Tailored for React on Rails' multi-root architecture:
 1. **[Prepare your app](rsc-preparing-app.md)** -- set up the RSC infrastructure, add `'use client'` to all component entry points, and switch to streaming rendering. The app works identically -- nothing changes yet.
 2. **Pick a component and push the boundary down** -- move `'use client'` from the root component to its interactive children, letting parent components become Server Components.
 3. **Adopt advanced patterns** -- add Suspense boundaries, [`stream_react_component`](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for streaming SSR, and server-side data fetching.
-4. **Keep route policy in Rails** -- decide redirects, status codes, and cache headers before streaming commits the response.
+4. **[Keep route policy in Rails](rsc-http-response-patterns.md)** -- decide redirects, status codes, and cache headers before streaming commits the response.
 5. **Repeat for each registered component** -- migrate components one at a time, in any order.
 
 This approach lets you migrate incrementally, one component at a time, without ever breaking your app.

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -2,7 +2,7 @@
 
 This guide covers how to migrate your data fetching from client-side patterns (`useEffect` + `fetch`, React Query, SWR) to Server Component patterns. In React on Rails, data flows from Rails to your components as props — eliminating the need for loading states, error handling boilerplate, and client-side caching in many cases.
 
-> **Part 4 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Context and State Management](rsc-context-and-state.md) | Next: [Third-Party Library Compatibility](rsc-third-party-libs.md)
+> **Part 4 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Context and State Management](rsc-context-and-state.md) | Next: [HTTP Response Ownership](rsc-http-response-patterns.md)
 
 ## The Core Shift: From Client-Side Fetching to Server-Side Data
 
@@ -890,5 +890,6 @@ For each component that fetches data:
 
 ## Next Steps
 
+- [HTTP Response Ownership](rsc-http-response-patterns.md) -- status codes, redirects, and cache headers
 - [Third-Party Library Compatibility](rsc-third-party-libs.md) -- dealing with incompatible libraries
 - [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md) -- debugging and avoiding problems

--- a/docs/oss/migrating/rsc-flight-payload.md
+++ b/docs/oss/migrating/rsc-flight-payload.md
@@ -2,7 +2,7 @@
 
 This guide covers a critical and counterintuitive RSC performance nuance: not all non-interactive, stateless components should be Server Components. When presentational components produce element trees much larger than their data props, moving them to Client Components can dramatically reduce page weight.
 
-> **Part 7 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md)
+> **Part 8 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md)
 
 ## What's in the Flight Payload
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -30,8 +30,10 @@ class StoriesController < ApplicationController
     preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
     if preflight.redirect_reason
-      # .fetch raises KeyError if a new redirect_reason is added without a matching path here.
-      redirect_path = { unauthenticated: sign_in_path }.fetch(preflight.redirect_reason)
+      redirect_path = { unauthenticated: sign_in_path }.fetch(preflight.redirect_reason) do |reason|
+        Rails.logger.error("Unknown redirect_reason: #{reason.inspect}")
+        root_path
+      end
       return redirect_to(redirect_path, status: preflight.redirect_status || :see_other)
     end
 
@@ -45,6 +47,8 @@ end
 ```
 
 The preflight object can expose a small, serializable result:
+
+These examples use placeholder serializer classes that return plain Ruby hashes; substitute your app's serializer or presenter as needed.
 
 ```ruby
 class StoryPagePreflight
@@ -218,7 +222,8 @@ If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` r
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy before streaming or keep the response private:
 
 ```ruby
-response.headers["Vary"] = "Accept-Language"
+existing_vary = response.headers["Vary"].presence
+response.headers["Vary"] = [existing_vary, "Accept-Language"].compact.join(", ")
 ```
 
 Every `Vary` header expands the cache key; avoid high-cardinality headers for public caches unless that extra cache storage is intentional.
@@ -240,8 +245,10 @@ Pass decisions as data, not as hidden HTTP side effects:
 ```
 
 ```tsx
+type StoryData = { id: number; title: string };
+type ViewerData = { id: number; name: string };
 type ResponsePolicy = { canonicalUrl: string };
-type StoryPageProps = { story: Story; viewer: Viewer; responsePolicy: ResponsePolicy };
+type StoryPageProps = { story: StoryData; viewer: ViewerData; responsePolicy: ResponsePolicy };
 
 export default function StoryPage({ story, viewer, responsePolicy }: StoryPageProps) {
   return (

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -30,6 +30,7 @@ class StoriesController < ApplicationController
     preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
     if preflight.redirect_reason
+      # .fetch raises KeyError if a new redirect_reason is added without a matching path here.
       redirect_path = { unauthenticated: sign_in_path }.fetch(preflight.redirect_reason)
       return redirect_to(redirect_path, status: preflight.redirect_status || :see_other)
     end
@@ -80,7 +81,7 @@ Keep the props serializable and intentional. A good preflight result usually con
 
 Avoid making React responsible for route outcomes. React can render a "not found" UI, but Rails should decide whether the response is actually a `404`.
 
-Set cookies and mutate session state before calling `stream_view_containing_react_components`, for the same reason you set status and cache headers first. Once streaming commits the headers, `Set-Cookie` changes and session writes can no longer be added reliably to the HTTP response.
+> **Important:** Set cookies and mutate session state before calling `stream_view_containing_react_components`, for the same reason you set status and cache headers first. Once streaming commits the headers, `Set-Cookie` changes and session writes can no longer be added reliably to the HTTP response.
 
 ## 404 and Not-Found Routes
 
@@ -139,7 +140,6 @@ def show
   story = Story.find_by(slug: params[:slug])
 
   if story&.removed?
-    response.status = :gone
     response.headers["Cache-Control"] = "public, max-age=86400"
     return render(template: "errors/gone", status: :gone)
   end
@@ -207,7 +207,7 @@ end
 
 If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected.
 
-When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy or keep the response private:
+When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy before streaming or keep the response private:
 
 ```ruby
 response.headers["Vary"] = "Accept-Language"

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -77,7 +77,7 @@ class StoryPagePreflight
 
   def self.call(story_id, current_user:)
     unless current_user
-      return Result.new(props: {}, redirect_reason: :unauthenticated)
+      return Result.new(redirect_reason: :unauthenticated)
     end
 
     story = Story.find_by(id: story_id)
@@ -273,7 +273,9 @@ change whenever any rendered input changes. For example, models for comments or 
 declare `belongs_to :story, touch: true`, while author/profile data may need an explicit composite cache key or a manual
 touch when it changes. Otherwise Rails can return `304 Not Modified` for content that should be regenerated.
 
-When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy before streaming or keep the response private:
+When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary`
+policy before streaming or keep the response private. Replace `Accept-Language` with the headers your app actually
+varies on, such as `Accept-Encoding`, `X-Device-Class`, or an application-specific header:
 
 ```ruby
 # Merge with any existing Vary tokens set upstream, then deduplicate.

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -74,7 +74,7 @@ def show
 
   if story.nil?
     response.status = :not_found
-    @story_props = { notFound: true, story: nil, requestedId: params[:id].to_i }
+    @story_props = { notFound: true, story: nil, requestedId: params[:id]&.to_i }
   else
     @story_props = { story: StorySerializer.render_as_hash(story) }
   end
@@ -86,7 +86,12 @@ end
 Then keep the React component purely presentational:
 
 ```tsx
-export default function StoryPage({ notFound, story }) {
+type StoryPageProps = {
+  notFound?: boolean;
+  story: Story | null;
+};
+
+export default function StoryPage({ notFound, story }: StoryPageProps) {
   if (notFound) {
     return <NotFoundMessage />;
   }
@@ -133,7 +138,9 @@ For public pages, let Rails decide freshness before rendering:
 
 ```ruby
 def show
-  story = Story.published.find_by!(slug: params[:slug])
+  story = Story.published.find_by(slug: params[:slug])
+  return render(template: "errors/not_found", status: :not_found) unless story
+
   return unless stale?(
     story,
     public: true,
@@ -144,6 +151,8 @@ def show
   stream_view_containing_react_components(template: "stories/show")
 end
 ```
+
+Rails 7.1+ supports `cache_control:` on `stale?`. On older Rails versions, set the full `Cache-Control` header directly and keep the explicit freshness guard before streaming.
 
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy or keep the response private:
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -59,6 +59,9 @@ One possible preflight implementation is:
 ```ruby
 class StoryPagePreflight
   # redirect_reason is nil when no redirect is needed.
+  # redirect_status is only meaningful when redirect_reason is set; the override
+  # below ignores it otherwise so callers cannot accidentally produce a status
+  # without a reason.
   Result = Struct.new(
     :props,
     :status,
@@ -99,7 +102,7 @@ class StoryPagePreflight
     end
 
     Result.new(
-      props: { story: StorySerializer.render_as_hash(story) },
+      props: { notFound: false, story: StorySerializer.render_as_hash(story) },
       cache_control: "private, no-cache"
     )
   end
@@ -151,18 +154,18 @@ def show
     response.status = :not_found
     @story_props = { notFound: true, story: nil }
   else
-    @story_props = { story: StorySerializer.render_as_hash(story) }
+    @story_props = { notFound: false, story: StorySerializer.render_as_hash(story) }
   end
 
   stream_view_containing_react_components(template: "stories/show")
 end
 ```
 
-Then keep the React component purely presentational. The happy path omits `notFound`, so `notFound?: false` models the absent key as the non-error branch. Keep `props` whole until after the guard so TypeScript narrows `story` correctly:
+Then keep the React component purely presentational. Set `notFound` explicitly on every branch so the discriminated union is fully exhaustive and TypeScript narrows `story` correctly. Keep `props` whole until after the guard so the narrowing flows through:
 
 ```tsx
 type StoryData = { id: number; title: string };
-type StoryPageProps = { notFound: true; story: null } | { notFound?: false; story: StoryData };
+type StoryPageProps = { notFound: true; story: null } | { notFound: false; story: StoryData };
 
 export default function StoryPage(props: StoryPageProps) {
   if (props.notFound) {
@@ -206,6 +209,9 @@ responses. Cache a `410` only when the removal is durable enough for clients and
 With `max-age=3600`, a shared cache may keep serving the `410` for up to one hour after the origin restores the
 resource unless you purge that cache explicitly. Choose the TTL based on how confident you are that the removal is
 permanent and whether your CDN supports on-demand purging; longer TTLs are appropriate only for irreversible removals.
+Without on-demand CDN purging, the only way to recover before `s-maxage` expires is to wait out the full TTL, so use
+a short `s-maxage` (such as 300–600 seconds) when you are not certain the resource is gone permanently and your CDN
+does not support instant purging.
 
 ## Redirects
 
@@ -277,17 +283,39 @@ touch when it changes. Otherwise Rails can return `304 Not Modified` for content
 
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary`
 policy before streaming or keep the response private. Replace `Accept-Language` with the headers your app actually
-varies on, such as `Accept-Encoding`, `X-Device-Class`, or an application-specific header:
+varies on, such as `Accept-Encoding`, `X-Device-Class`, or an application-specific header.
+
+When the controller is the only place setting `Vary` for this response, assign it directly:
 
 ```ruby
-# Merge with any existing Vary tokens set upstream, then deduplicate case-insensitively.
-existing_vary = response.headers["Vary"].presence
-
-unless existing_vary == "*"
-  vary_tokens = [existing_vary, "Accept-Language"].compact.flat_map { |value| value.split(",") }.map(&:strip)
-  response.headers["Vary"] = vary_tokens.reject(&:empty?).uniq { |token| token.downcase }.join(", ")
-end
+response.headers["Vary"] = "Accept-Language"
 ```
+
+> **Advanced: merging with an upstream `Vary`.** If Rack middleware, a `before_action`, or a parent layout may have
+> already set `Vary`, append new tokens with a small helper that deduplicates case-insensitively and short-circuits on
+> `Vary: *` (which already varies on everything):
+>
+> ```ruby
+> # Call this before streaming, e.g. in a before_action or inline in the action.
+> def merge_vary_header(*tokens)
+>   existing = response.headers["Vary"].presence
+>   return if existing == "*"
+>
+>   merged = [existing, *tokens]
+>     .compact
+>     .flat_map { |value| value.split(",") }
+>     .map(&:strip)
+>     .reject(&:empty?)
+>     .uniq { |token| token.downcase }
+>   response.headers["Vary"] = merged.join(", ")
+> end
+> ```
+>
+> Then the call site stays readable:
+>
+> ```ruby
+> merge_vary_header("Accept-Language")
+> ```
 
 Every `Vary` header expands the cache key; avoid high-cardinality headers for public caches unless that extra cache storage is intentional.
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -34,8 +34,10 @@ class StoriesController < ApplicationController
 
     if preflight.redirect_reason
       # Map every possible redirect_reason StoryPagePreflight can return.
+      # Extend this hash whenever the preflight gains a new redirect branch.
       redirect_path = {
         unauthenticated: sign_in_path,
+        # moved_permanently: story_path(preflight.canonical_slug),
       }.fetch(preflight.redirect_reason) do |reason|
         raise ArgumentError, "Unknown redirect_reason: #{reason.inspect}"
       end
@@ -94,6 +96,7 @@ class StoryPagePreflight
     end
 
     unless StoryPolicy.new(current_user, story).read?
+      # Return 404 instead of 403 to avoid revealing that this record exists.
       return Result.new(
         props: { notFound: true, story: nil },
         status: :not_found,
@@ -195,6 +198,8 @@ def show
 
   if story.removed?
     # Use this branch only when removed stories are truly permanent in your app.
+    # max-age=0 makes browsers always revalidate; s-maxage=3600 lets shared caches
+    # (such as a CDN) serve the 410 for up to an hour without hitting the origin.
     response.headers["Cache-Control"] = "public, max-age=0, s-maxage=3600"
     return render(template: "errors/gone", status: :gone)
   end
@@ -293,7 +298,8 @@ response.headers["Vary"] = "Accept-Language"
 
 > **Advanced: merging with an upstream `Vary`.** If Rack middleware, a `before_action`, or a parent layout may have
 > already set `Vary`, append new tokens with a small helper that deduplicates case-insensitively and short-circuits on
-> `Vary: *` (which already varies on everything):
+> `Vary: *` (which already varies on everything). Define this helper on `ApplicationController` or a shared concern so
+> every streaming action can call it before streaming:
 >
 > ```ruby
 > # Call this before streaming, e.g. in a before_action or inline in the action.

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -161,7 +161,7 @@ def show
   story = Story.find_by(slug: params[:slug])
 
   if story&.removed?
-    response.headers["Cache-Control"] = "public, max-age=3600" # Raise only for truly permanent removals.
+    response.headers["Cache-Control"] = "public, max-age=3600" # Cache only for truly permanent removals.
     return render(template: "errors/gone", status: :gone)
   end
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -46,9 +46,8 @@ class StoriesController < ApplicationController
 end
 ```
 
-The preflight object can expose a small, serializable result:
-
-These examples use placeholder serializer classes that return plain Ruby hashes; substitute your app's serializer or presenter as needed.
+The preflight object can expose a small, serializable result. These examples use placeholder serializer
+classes that return plain Ruby hashes; substitute your app's serializer or presenter as needed:
 
 ```ruby
 class StoryPagePreflight
@@ -172,7 +171,7 @@ Use Rails redirects before streaming. Replace `can?` with your app's authorizati
 ```ruby
 def show
   story = Story.find_by(id: params[:id])
-  return redirect_to(stories_path, alert: "Story not found", status: :see_other) unless story
+  return render(template: "errors/not_found", status: :not_found) unless story
 
   return redirect_to(sign_in_path, status: :see_other) unless can?(:read, story)
 
@@ -271,6 +270,7 @@ React can render metadata, route chrome, empty states, and branded error UI from
 - Decide redirects before rendering.
 - Decide `404`, `410`, and authorization statuses before rendering.
 - Set cache headers before the first streamed chunk.
+- Set cookies and mutate session state before the first streamed chunk.
 - Pass route decisions into RSC as serializable props.
 - Keep Rails controllers, policies, and services responsible for authentication, authorization, and response policy.
 - Use Client Component navigation only for browser-side transitions after a valid HTTP response exists.

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -59,7 +59,7 @@ For simple not-found cases, return a Rails response before streaming:
 ```ruby
 def show
   story = Story.find_by(id: params[:id])
-  return render("errors/not_found", status: :not_found) unless story
+  return render(template: "errors/not_found", status: :not_found) unless story
 
   @story_props = { story: StorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
@@ -74,7 +74,7 @@ def show
 
   if story.nil?
     response.status = :not_found
-    @story_props = { notFound: true, story: nil, requestedId: params[:id] }
+    @story_props = { notFound: true, story: nil, requestedId: params[:id].to_i }
   else
     @story_props = { story: StorySerializer.render_as_hash(story) }
   end
@@ -127,7 +127,7 @@ For personalized pages, prefer private browser caching with revalidation:
 response.set_header("Cache-Control", "private, no-cache")
 ```
 
-Use `no-store` instead when sensitive responses must never be cached.
+`no-cache` allows the browser to store the response but forces revalidation before reuse. Use `no-store` instead when sensitive responses must never be cached.
 
 For public pages, let Rails decide freshness before rendering:
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -74,7 +74,7 @@ def show
 
   if story.nil?
     response.status = :not_found
-    @story_props = { notFound: true, story: nil, requestedId: params[:id]&.to_i }
+    @story_props = { notFound: true, story: nil }
   else
     @story_props = { story: StorySerializer.render_as_hash(story) }
   end
@@ -86,10 +86,7 @@ end
 Then keep the React component purely presentational:
 
 ```tsx
-type StoryPageProps = {
-  notFound?: boolean;
-  story: Story | null;
-};
+type StoryPageProps = { notFound: true; story: null } | { notFound?: false; story: Story };
 
 export default function StoryPage({ notFound, story }: StoryPageProps) {
   if (notFound) {
@@ -177,7 +174,10 @@ Pass decisions as data, not as hidden HTTP side effects:
 ```
 
 ```tsx
-export default function StoryPage({ story, viewer, responsePolicy }) {
+type ResponsePolicy = { canonicalUrl: string };
+type StoryPageProps = { story: Story; viewer: Viewer; responsePolicy: ResponsePolicy };
+
+export default function StoryPage({ story, viewer, responsePolicy }: StoryPageProps) {
   return (
     <>
       <link rel="canonical" href={responsePolicy.canonicalUrl} />

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -21,8 +21,9 @@ With streaming, this boundary matters even more. Once Rails writes the first res
 ## Preflight Pattern
 
 Use a controller or service object to gather data and choose the response policy before rendering the RSC tree.
-The preflight object exposes a small, serializable result. `StorySerializer`, `PublicStorySerializer`, and
-`ViewerSerializer` are placeholder names in these examples; substitute your app's serializer or presenter as needed.
+The preflight object exposes a small, serializable result. `StorySerializer`, `PublicStorySerializer`,
+`ViewerSerializer`, and `StoryPolicy` are placeholder names in these examples; substitute your app's serializer,
+presenter, or authorization helper as needed.
 
 ```ruby
 class StoriesController < ApplicationController
@@ -52,6 +53,9 @@ class StoriesController < ApplicationController
 end
 ```
 
+`stream_view_containing_react_components` commits the response status that was set before streaming begins. For example,
+a pre-set `:not_found` status remains a real `404` in the HTTP response line.
+
 One possible preflight implementation is:
 
 ```ruby
@@ -78,6 +82,14 @@ class StoryPagePreflight
     story = Story.find_by(id: story_id)
 
     unless story
+      return Result.new(
+        props: { notFound: true, story: nil },
+        status: :not_found,
+        cache_control: "no-store"
+      )
+    end
+
+    unless StoryPolicy.new(current_user, story).read?
       return Result.new(
         props: { notFound: true, story: nil },
         status: :not_found,
@@ -171,12 +183,12 @@ Use `410 Gone` when the route identifies a permanently removed resource and you 
 def show
   story = Story.find_by(slug: params[:slug])
 
-  if story&.removed?
+  return render(template: "errors/not_found", status: :not_found) unless story
+
+  if story.removed?
     response.headers["Cache-Control"] = "public, max-age=3600" # Cache only for truly permanent removals.
     return render(template: "errors/gone", status: :gone)
   end
-
-  return render(template: "errors/not_found", status: :not_found) unless story
 
   @story_props = { story: StorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
@@ -239,7 +251,7 @@ def show
   return unless stale?(
     story,
     public: true,
-    cache_control: { max_age: 300, stale_while_revalidate: 300 }
+    cache_control: { max_age: 60, stale_while_revalidate: 300 }
   )
 
   @story_props = { story: PublicStorySerializer.render_as_hash(story) }

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -24,18 +24,38 @@ Use a controller or service object to gather data and choose the response policy
 
 ```ruby
 class StoriesController < ApplicationController
-  include ReactOnRailsPro::Stream
+  include ReactOnRailsPro::Stream # Requires React on Rails Pro
 
   def show
     preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
     return redirect_to(preflight.redirect_path, status: :see_other) if preflight.redirect_path
 
-    response.status = preflight.status if preflight.status
+    response.status = preflight.status unless preflight.status.nil?
     response.set_header("Cache-Control", preflight.cache_control) if preflight.cache_control
 
     @story_props = preflight.props
     stream_view_containing_react_components(template: "stories/show")
+  end
+end
+```
+
+The preflight object can expose a small, serializable result:
+
+```ruby
+class StoryPagePreflight
+  Result = Struct.new(:props, :status, :redirect_path, :cache_control, keyword_init: true)
+
+  def self.call(story_id, current_user:)
+    story = Story.find_by(id: story_id)
+
+    return Result.new(props: { notFound: true, story: nil }, status: :not_found) unless story
+    return Result.new(redirect_path: "/sign_in") unless current_user
+
+    Result.new(
+      props: { story: StorySerializer.render_as_hash(story) },
+      cache_control: "private, no-cache"
+    )
   end
 end
 ```
@@ -55,6 +75,8 @@ Keep the props serializable and intentional. A good preflight result usually con
 Avoid making React responsible for route outcomes. React can render a "not found" UI, but Rails should decide whether the response is actually a `404`.
 
 ## 404 And Not-Found Routes
+
+The following controller snippets assume the controller includes `ReactOnRailsPro::Stream`, as shown in the preflight example.
 
 For simple not-found cases, return a Rails response before streaming:
 
@@ -131,7 +153,7 @@ For personalized pages, prefer private HTTP caching with revalidation:
 response.set_header("Cache-Control", "private, no-cache")
 ```
 
-`no-cache` allows HTTP caches to store the response but requires revalidation with the origin before each reuse. Use `no-store` instead when sensitive responses must never be cached by anyone.
+`private` prevents CDNs and shared proxies from storing the response; `no-cache` allows the browser to store it but requires revalidation with the origin before each reuse. Use `no-store` instead when sensitive responses must never be cached by anyone.
 
 For public pages, let Rails decide freshness before rendering:
 
@@ -169,20 +191,20 @@ Pass decisions as data, not as hidden HTTP side effects:
 @story_props = {
   story: StorySerializer.render_as_hash(story),
   viewer: ViewerSerializer.render_as_hash(current_user),
-  responsePolicy: {
-    canonicalUrl: story_url(story)
+  response_policy: {
+    canonical_url: story_url(story)
   }
 }
 ```
 
 ```tsx
-type ResponsePolicy = { canonicalUrl: string };
-type StoryPageProps = { story: Story; viewer: Viewer; responsePolicy: ResponsePolicy };
+type ResponsePolicy = { canonical_url: string };
+type StoryPageProps = { story: Story; viewer: Viewer; response_policy: ResponsePolicy };
 
-export default function StoryPage({ story, viewer, responsePolicy }: StoryPageProps) {
+export default function StoryPage({ story, viewer, response_policy }: StoryPageProps) {
   return (
     <>
-      <link rel="canonical" href={responsePolicy.canonicalUrl} />
+      <link rel="canonical" href={response_policy.canonical_url} />
       <Story story={story} viewer={viewer} />
     </>
   );

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -33,10 +33,10 @@ class StoriesController < ApplicationController
     preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
     if preflight.redirect_reason
+      # Map every possible redirect_reason StoryPagePreflight can return.
+      # Unknown reasons fall back to root_path and log an error.
       redirect_path = {
         unauthenticated: sign_in_path,
-        # Add a key here for every redirect_reason StoryPagePreflight can return.
-        # Unknown reasons fall back to root_path and log an error.
       }.fetch(preflight.redirect_reason) do |reason|
         Rails.logger.error("Unknown redirect_reason: #{reason.inspect}")
         root_path
@@ -69,6 +69,7 @@ class StoryPagePreflight
     :cache_control,
     keyword_init: true
   ) do
+    # Override the Struct-generated accessor to supply a default when the field is nil.
     def redirect_status
       self[:redirect_status] || :see_other
     end
@@ -173,6 +174,9 @@ export default function StoryPage({ notFound, story }: StoryPageProps) {
 
 Use this pattern when the branded not-found UI benefits from the same RSC layout as the rest of the route. Use a plain Rails error template when you need the smallest, most reliable failure path.
 
+Rails normalizes `response.status` values through Rack, so both integer codes such as `404` and Rails symbols such as
+`:not_found` are valid.
+
 Cache `404` responses publicly only when the route is truly missing, such as typo-driven URLs that repeat often. Prefer
 `no-store` for user-specific or permission-sensitive misses, and use `410 Gone` for durable removals where caches should
 reuse the response as a permanent absence.
@@ -248,6 +252,8 @@ def show
   story = Story.published.find_by(slug: params[:slug])
   return render(template: "errors/not_found", status: :not_found) unless story
 
+  # If request validators still match, stale? sends 304 Not Modified and returns false.
+  # The explicit return avoids opening a stream for that already-selected response.
   return unless stale?(
     story,
     public: true,

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -61,7 +61,7 @@ def show
   story = Story.find_by(id: params[:id])
   return render("errors/not_found", status: :not_found) unless story
 
-  @story_props = StorySerializer.render_as_hash(story)
+  @story_props = { story: StorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
 end
 ```
@@ -74,9 +74,9 @@ def show
 
   if story.nil?
     response.status = 404
-    @story_props = { notFound: true, requestedId: params[:id] }
+    @story_props = { notFound: true, story: nil, requestedId: params[:id] }
   else
-    @story_props = StorySerializer.render_as_hash(story)
+    @story_props = { story: StorySerializer.render_as_hash(story) }
   end
 
   stream_view_containing_react_components(template: "stories/show")
@@ -104,11 +104,11 @@ Use Rails redirects before streaming:
 ```ruby
 def show
   story = Story.find_by(id: params[:id])
-  return redirect_to(stories_path, alert: "Story not found") unless story
+  return redirect_to(stories_path, alert: "Story not found", status: :see_other) unless story
 
   return redirect_to(sign_in_path, status: :see_other) unless can?(:read, story)
 
-  @story_props = StorySerializer.render_as_hash(story)
+  @story_props = { story: StorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
 end
 ```
@@ -132,10 +132,10 @@ For public pages, let Rails decide freshness before rendering:
 ```ruby
 def show
   story = Story.published.find_by!(slug: params[:slug])
+  response.set_header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
   return unless stale?(story, public: true)
 
-  response.set_header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
-  @story_props = PublicStorySerializer.render_as_hash(story)
+  @story_props = { story: PublicStorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
 end
 ```

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -67,8 +67,10 @@ class StoryPagePreflight
     :cache_control,
     keyword_init: true
   ) do
-    # Override the Struct-generated accessor to supply a default when the field is nil.
+    # Supply a default only for redirect results.
     def redirect_status
+      return unless redirect_reason
+
       self[:redirect_status] || :see_other
     end
   end
@@ -190,7 +192,7 @@ def show
 
   if story.removed?
     # Use this branch only when removed stories are truly permanent in your app.
-    response.headers["Cache-Control"] = "public, max-age=3600"
+    response.headers["Cache-Control"] = "public, max-age=0, s-maxage=3600"
     return render(template: "errors/gone", status: :gone)
   end
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -113,7 +113,7 @@ def show
 end
 ```
 
-Do not model route redirects as Server Component return values. React on Rails render-functions may expose redirect metadata for client routers, but React on Rails does not turn that metadata into an actual HTTP redirect for the page response. See [Redirect Information](../core-concepts/render-functions.md#8-redirect-information).
+Do not model route redirects as Server Component return values. React on Rails render-functions may expose redirect metadata for client routers, but React on Rails does not turn that metadata into an actual HTTP redirect for the page response. See [Redirect Information](../core-concepts/render-functions.md#8-redirect-information-legacy).
 
 If a streamed response has already started and an error forces navigation, the fallback is client-side navigation or an error shell, not a true HTTP redirect. Treat that as an exception path, not the normal route design.
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -34,12 +34,10 @@ class StoriesController < ApplicationController
 
     if preflight.redirect_reason
       # Map every possible redirect_reason StoryPagePreflight can return.
-      # Unknown reasons fall back to root_path and log an error.
       redirect_path = {
         unauthenticated: sign_in_path,
       }.fetch(preflight.redirect_reason) do |reason|
-        Rails.logger.error("Unknown redirect_reason: #{reason.inspect}")
-        root_path
+        raise ArgumentError, "Unknown redirect_reason: #{reason.inspect}"
       end
       return redirect_to(redirect_path, status: preflight.redirect_status)
     end
@@ -107,6 +105,7 @@ end
 ```
 
 ```erb
+<%# app/views/stories/show.html.erb %>
 <%= stream_react_component("StoryPage", props: @story_props) %>
 ```
 
@@ -190,7 +189,8 @@ def show
   return render(template: "errors/not_found", status: :not_found) unless story
 
   if story.removed?
-    response.headers["Cache-Control"] = "public, max-age=3600" # Cache only for truly permanent removals.
+    # Use this branch only when removed stories are truly permanent in your app.
+    response.headers["Cache-Control"] = "public, max-age=3600"
     return render(template: "errors/gone", status: :gone)
   end
 
@@ -278,12 +278,19 @@ policy before streaming or keep the response private. Replace `Accept-Language` 
 varies on, such as `Accept-Encoding`, `X-Device-Class`, or an application-specific header:
 
 ```ruby
-# Merge with any existing Vary tokens set upstream, then deduplicate.
+# Merge with any existing Vary tokens set upstream, then deduplicate case-insensitively.
 existing_vary = response.headers["Vary"].presence
 
 unless existing_vary == "*"
   vary_tokens = [existing_vary, "Accept-Language"].compact.join(", ")
-  response.headers["Vary"] = vary_tokens.split(",").map(&:strip).uniq.join(", ")
+  seen_tokens = {}
+  response.headers["Vary"] = vary_tokens.split(",").map(&:strip).reject do |token|
+    normalized_token = token.downcase
+    next true if seen_tokens[normalized_token]
+
+    seen_tokens[normalized_token] = true
+    false
+  end.join(", ")
 end
 ```
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -4,6 +4,8 @@ This guide covers status codes, redirects, and cache headers when Rails owns the
 
 > **Part 5 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Data Fetching Migration](rsc-data-fetching.md) | Next: [Third-Party Library Compatibility](rsc-third-party-libs.md)
 
+> **Note:** The streaming helpers shown in this guide (`ReactOnRailsPro::Stream`, `stream_view_containing_react_components`, and `stream_react_component`) require React on Rails Pro. The same HTTP ownership rules apply to non-streaming Rails responses; use the rendering helper that matches your app.
+
 ## Core Rule: Rails Decides Before Rendering
 
 React Server Components decide what UI to render. Rails still decides the HTTP response:
@@ -123,13 +125,13 @@ If a streamed response has already started and an error forces navigation, the f
 
 Set cache headers in Rails before streaming. The streamed HTML can include serialized props and embedded RSC payloads, so cache it with the same care you would use for any Rails response that contains user-specific data.
 
-For personalized pages, prefer private browser caching with revalidation:
+For personalized pages, prefer private HTTP caching with revalidation:
 
 ```ruby
 response.set_header("Cache-Control", "private, no-cache")
 ```
 
-`no-cache` allows the browser to store the response but forces revalidation before reuse. Use `no-store` instead when sensitive responses must never be cached.
+`no-cache` allows HTTP caches to store the response but requires revalidation with the origin before each reuse. Use `no-store` instead when sensitive responses must never be cached by anyone.
 
 For public pages, let Rails decide freshness before rendering:
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -57,7 +57,13 @@ class StoryPagePreflight
 
     story = Story.find_by(id: story_id)
 
-    return Result.new(props: { notFound: true, story: nil }, status: :not_found) unless story
+    unless story
+      return Result.new(
+        props: { notFound: true, story: nil },
+        status: :not_found,
+        cache_control: "no-store"
+      )
+    end
 
     Result.new(
       props: { story: StorySerializer.render_as_hash(story) },
@@ -98,6 +104,8 @@ def show
   stream_view_containing_react_components(template: "stories/show")
 end
 ```
+
+Create `app/views/errors/not_found.html.erb` or use another existing error template before copying this pattern. For quick local testing, `render(plain: "Not Found", status: :not_found)` is a minimal stand-in.
 
 If you want the not-found page itself to be rendered by RSC, set the status before streaming:
 
@@ -151,7 +159,7 @@ def show
 end
 ```
 
-Cache a `410` only when the removal is durable enough for clients and CDNs to reuse that response.
+Create `app/views/errors/gone.html.erb` if your app does not already have a generic template for `410` responses. Cache a `410` only when the removal is durable enough for clients and CDNs to reuse that response.
 
 ## Redirects
 
@@ -187,7 +195,7 @@ response.headers["Cache-Control"] = "private, no-cache"
 
 For public pages, let Rails decide freshness before rendering:
 
-> **Rails 7.1+:** The `cache_control:` keyword on `stale?` requires Rails 7.1 or later. On earlier Rails versions, set the full `Cache-Control` header directly with `response.headers["Cache-Control"] = "public, max-age=60"` and keep the explicit freshness guard before streaming. `stale_while_revalidate` only helps caches that support that extension; unsupported browsers, proxies, and CDNs fall back to normal `max-age` behavior.
+> **Rails 7.1+:** The `cache_control:` keyword on `stale?` requires Rails 7.1 or later. On earlier Rails versions, set the full `Cache-Control` header directly with `response.headers["Cache-Control"] = "public, max-age=300"` and keep the explicit freshness guard before streaming. `stale_while_revalidate` only helps caches that support that extension; unsupported browsers, proxies, and CDNs fall back to normal `max-age` behavior.
 
 ```ruby
 def show
@@ -197,7 +205,7 @@ def show
   return unless stale?(
     story,
     public: true,
-    cache_control: { max_age: 60, stale_while_revalidate: 300 }
+    cache_control: { max_age: 300, stale_while_revalidate: 300 }
   )
 
   @story_props = { story: PublicStorySerializer.render_as_hash(story) }
@@ -245,7 +253,7 @@ export default function StoryPage({ story, viewer, responsePolicy }: StoryPagePr
 }
 ```
 
-Use the same serialized key names that the TypeScript component consumes. React on Rails passes prop keys through by default, so choose one casing convention for the route props and keep both sides aligned.
+Use the same serialized key names that the TypeScript component consumes. React on Rails passes prop keys through by default, so these example props are already in camelCase for TypeScript. If your app uses `config.rendering_props_extension` or another custom serializer to change key casing, use the Ruby-side key names that your serializer expects and keep both sides aligned.
 
 Native `<link>` hoisting requires React 19. On React 18, use `react-helmet` or emit canonical URLs from the Rails layout instead. See [React 19 Native Metadata](../building-features/react-19-native-metadata.md).
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -40,7 +40,7 @@ class StoriesController < ApplicationController
         Rails.logger.error("Unknown redirect_reason: #{reason.inspect}")
         root_path
       end
-      return redirect_to(redirect_path, status: preflight.redirect_status || :see_other)
+      return redirect_to(redirect_path, status: preflight.redirect_status)
     end
 
     response.status = preflight.status if preflight.status
@@ -57,11 +57,22 @@ One possible preflight implementation is:
 ```ruby
 class StoryPagePreflight
   # redirect_reason is nil when no redirect is needed.
-  Result = Struct.new(:props, :status, :redirect_reason, :redirect_status, :cache_control, keyword_init: true)
+  Result = Struct.new(
+    :props,
+    :status,
+    :redirect_reason,
+    :redirect_status,
+    :cache_control,
+    keyword_init: true
+  ) do
+    def redirect_status
+      self[:redirect_status] || :see_other
+    end
+  end
 
   def self.call(story_id, current_user:)
     unless current_user
-      return Result.new(props: {}, redirect_reason: :unauthenticated, redirect_status: :see_other)
+      return Result.new(props: {}, redirect_reason: :unauthenticated)
     end
 
     story = Story.find_by(id: story_id)
@@ -172,23 +183,33 @@ def show
 end
 ```
 
-Create `app/views/errors/gone.html.erb` if your app does not already have a generic template for `410` responses. Cache a `410` only when the removal is durable enough for clients and CDNs to reuse that response.
+Create `app/views/errors/gone.html.erb` if your app does not already have a generic template for `410`
+responses. Cache a `410` only when the removal is durable enough for clients and CDNs to reuse that response.
+With `max-age=3600`, a shared cache may keep serving the `410` for up to one hour after the origin restores the
+resource unless you purge that cache explicitly. Choose the TTL based on how confident you are that the removal is
+permanent and whether your CDN supports on-demand purging; longer TTLs are appropriate only for irreversible removals.
 
 ## Redirects
 
-Use Rails redirects before streaming. Replace `can?` with your app's authorization helper:
+Use Rails redirects before streaming. Keep authentication redirects separate from authorization decisions so signed-in
+users are not sent back to sign-in and private resources do not reveal that a record exists. Replace `can?` with your
+app's authorization helper:
 
 ```ruby
 def show
+  return redirect_to(sign_in_path, status: :see_other) unless current_user
+
   story = Story.find_by(id: params[:id])
   return render(template: "errors/not_found", status: :not_found) unless story
-
-  return redirect_to(sign_in_path, status: :see_other) unless can?(:read, story)
+  return render(template: "errors/not_found", status: :not_found) unless can?(:read, story)
 
   @story_props = { story: StorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
 end
 ```
+
+Use `:forbidden` for unauthorized users only when the route is allowed to reveal that the resource exists. For private
+resources, returning the same `404` for missing and unauthorized records is usually safer.
 
 Do not model route redirects as Server Component return values. React on Rails render-functions may expose redirect metadata for client routers, but React on Rails does not turn that metadata into an actual HTTP redirect for the page response. See [Redirect Information](../core-concepts/render-functions.md#8-redirect-information-legacy).
 
@@ -227,6 +248,12 @@ end
 ```
 
 If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected.
+
+`stale?` compares Rails' response validators, such as the generated `ETag` and `Last-Modified`, with request headers
+such as `If-None-Match` and `If-Modified-Since`. Before relying on this for public caching, make sure those validators
+change whenever any rendered input changes. For example, models for comments or join records that affect the page can
+declare `belongs_to :story, touch: true`, while author/profile data may need an explicit composite cache key or a manual
+touch when it changes. Otherwise Rails can return `304 Not Modified` for content that should be regenerated.
 
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy before streaming or keep the response private:
 
@@ -291,3 +318,8 @@ React can render metadata, route chrome, empty states, and branded error UI from
 - Pass route decisions into RSC as serializable props.
 - Keep Rails controllers, policies, and services responsible for authentication, authorization, and response policy.
 - Use Client Component navigation only for browser-side transitions after a valid HTTP response exists.
+
+## Next Steps
+
+- [Third-Party Library Compatibility](rsc-third-party-libs.md) -- dealing with incompatible libraries
+- [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md) -- debugging and avoiding problems

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -37,7 +37,6 @@ class StoriesController < ApplicationController
       # Extend this hash whenever the preflight gains a new redirect branch.
       redirect_path = {
         unauthenticated: sign_in_path,
-        # moved_permanently: story_path(preflight.canonical_slug),
       }.fetch(preflight.redirect_reason) do |reason|
         raise ArgumentError, "Unknown redirect_reason: #{reason.inspect}"
       end
@@ -76,6 +75,10 @@ class StoryPagePreflight
     def redirect_status
       return unless redirect_reason
 
+      # 303 (:see_other) forces GET on the redirect target, which is correct
+      # when the original request might be POST (for example, a sign-in flow
+      # that follows a form submission). Override with :found (302) when both
+      # legs are GET, matching Rails' redirect_to default.
       self[:redirect_status] || :see_other
     end
   end
@@ -164,12 +167,29 @@ def show
 end
 ```
 
-Then keep the React component purely presentational. Set `notFound` explicitly on every branch so the discriminated union is fully exhaustive and TypeScript narrows `story` correctly. Keep `props` whole until after the guard so the narrowing flows through:
+Then keep the React component purely presentational. Set `notFound` explicitly on every branch so the discriminated union is fully exhaustive and TypeScript narrows `story` correctly. Keep `props` whole until after the guard — destructuring upfront collapses the union and loses the narrowing.
 
 ```tsx
 type StoryData = { id: number; title: string };
 type StoryPageProps = { notFound: true; story: null } | { notFound: false; story: StoryData };
+```
 
+What not to do — destructuring before the guard loses narrowing:
+
+```tsx
+export default function StoryPage(props: StoryPageProps) {
+  const { notFound, story } = props; // story widens to StoryData | null — TypeScript can't narrow it further
+  if (notFound) {
+    return <NotFoundMessage />;
+  }
+
+  return <Story story={story} />; // TS error: story is still StoryData | null here
+}
+```
+
+Keep `props` intact through the guard so the discriminated union narrows correctly:
+
+```tsx
 export default function StoryPage(props: StoryPageProps) {
   if (props.notFound) {
     return <NotFoundMessage />;
@@ -304,6 +324,10 @@ response.headers["Vary"] = "Accept-Language"
 > ```ruby
 > # Call this before streaming, e.g. in a before_action or inline in the action.
 > def merge_vary_header(*tokens)
+>   # Per RFC 7231, "*" must not appear alongside named fields, so collapse to
+>   # "*" whenever any caller passes it.
+>   return response.headers["Vary"] = "*" if tokens.map(&:strip).include?("*")
+>
 >   existing = response.headers["Vary"].presence
 >   return if existing == "*"
 >

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -73,7 +73,7 @@ def show
   story = Story.find_by(id: params[:id])
 
   if story.nil?
-    response.status = 404
+    response.status = :not_found
     @story_props = { notFound: true, story: nil, requestedId: params[:id] }
   else
     @story_props = { story: StorySerializer.render_as_hash(story) }
@@ -121,19 +121,24 @@ If a streamed response has already started and an error forces navigation, the f
 
 Set cache headers in Rails before streaming. The streamed HTML can include serialized props and embedded RSC payloads, so cache it with the same care you would use for any Rails response that contains user-specific data.
 
-For personalized pages, prefer private or no-store policies:
+For personalized pages, prefer private browser caching with revalidation:
 
 ```ruby
-response.set_header("Cache-Control", "private, no-store")
+response.set_header("Cache-Control", "private, no-cache")
 ```
+
+Use `no-store` instead when sensitive responses must never be cached.
 
 For public pages, let Rails decide freshness before rendering:
 
 ```ruby
 def show
   story = Story.published.find_by!(slug: params[:slug])
-  response.set_header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
-  return unless stale?(story, public: true)
+  return unless stale?(
+    story,
+    public: true,
+    cache_control: { max_age: 60, stale_while_revalidate: 300 }
+  )
 
   @story_props = { story: PublicStorySerializer.render_as_hash(story) }
   stream_view_containing_react_components(template: "stories/show")
@@ -157,7 +162,6 @@ Pass decisions as data, not as hidden HTTP side effects:
   story: StorySerializer.render_as_hash(story),
   viewer: ViewerSerializer.render_as_hash(current_user),
   responsePolicy: {
-    cache: "private",
     canonicalUrl: story_url(story)
   }
 }
@@ -173,6 +177,8 @@ export default function StoryPage({ story, viewer, responsePolicy }) {
   );
 }
 ```
+
+Native `<link>` hoisting requires React 19. On React 18, use `react-helmet` or emit canonical URLs from the Rails layout instead. See [React 19 Native Metadata](../building-features/react-19-native-metadata.md).
 
 React can render metadata, route chrome, empty states, and branded error UI from these props. Rails remains the source of truth for the actual HTTP semantics.
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -29,7 +29,9 @@ class StoriesController < ApplicationController
   def show
     preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
-    return redirect_to(preflight.redirect_path, status: :see_other) if preflight.redirect_path
+    if preflight.redirect_path
+      return redirect_to(preflight.redirect_path, status: preflight.redirect_status || :see_other)
+    end
 
     response.status = preflight.status unless preflight.status.nil?
     response.set_header("Cache-Control", preflight.cache_control) if preflight.cache_control
@@ -44,13 +46,16 @@ The preflight object can expose a small, serializable result:
 
 ```ruby
 class StoryPagePreflight
-  Result = Struct.new(:props, :status, :redirect_path, :cache_control, keyword_init: true)
+  Result = Struct.new(:props, :status, :redirect_path, :redirect_status, :cache_control, keyword_init: true)
 
   def self.call(story_id, current_user:)
+    unless current_user
+      return Result.new(props: {}, redirect_path: "/sign_in", redirect_status: :see_other)
+    end
+
     story = Story.find_by(id: story_id)
 
     return Result.new(props: { notFound: true, story: nil }, status: :not_found) unless story
-    return Result.new(redirect_path: "/sign_in") unless current_user
 
     Result.new(
       props: { story: StorySerializer.render_as_hash(story) },
@@ -74,7 +79,7 @@ Keep the props serializable and intentional. A good preflight result usually con
 
 Avoid making React responsible for route outcomes. React can render a "not found" UI, but Rails should decide whether the response is actually a `404`.
 
-## 404 And Not-Found Routes
+## 404 and Not-Found Routes
 
 The following controller snippets assume the controller includes `ReactOnRailsPro::Stream`, as shown in the preflight example.
 
@@ -173,7 +178,7 @@ def show
 end
 ```
 
-If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected. Rails 7.1+ supports `cache_control:` on `stale?`. On older Rails versions, set the full `Cache-Control` header directly and keep the explicit freshness guard before streaming.
+If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected. Rails 7.1+ supports `cache_control:` on `stale?`. On older Rails versions, set the full `Cache-Control` header directly and keep the explicit freshness guard before streaming. `stale_while_revalidate` only helps caches that support that extension; unsupported browsers, proxies, and CDNs fall back to the normal `max-age` behavior.
 
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy or keep the response private:
 
@@ -191,25 +196,27 @@ Pass decisions as data, not as hidden HTTP side effects:
 @story_props = {
   story: StorySerializer.render_as_hash(story),
   viewer: ViewerSerializer.render_as_hash(current_user),
-  response_policy: {
-    canonical_url: story_url(story)
+  responsePolicy: {
+    canonicalUrl: story_url(story)
   }
 }
 ```
 
 ```tsx
-type ResponsePolicy = { canonical_url: string };
-type StoryPageProps = { story: Story; viewer: Viewer; response_policy: ResponsePolicy };
+type ResponsePolicy = { canonicalUrl: string };
+type StoryPageProps = { story: Story; viewer: Viewer; responsePolicy: ResponsePolicy };
 
-export default function StoryPage({ story, viewer, response_policy }: StoryPageProps) {
+export default function StoryPage({ story, viewer, responsePolicy }: StoryPageProps) {
   return (
     <>
-      <link rel="canonical" href={response_policy.canonical_url} />
+      <link rel="canonical" href={responsePolicy.canonicalUrl} />
       <Story story={story} viewer={viewer} />
     </>
   );
 }
 ```
+
+Use the same serialized key names that the TypeScript component consumes. React on Rails passes prop keys through by default, so choose one casing convention for the route props and keep both sides aligned.
 
 Native `<link>` hoisting requires React 19. On React 18, use `react-helmet` or emit canonical URLs from the Rails layout instead. See [React 19 Native Metadata](../building-features/react-19-native-metadata.md).
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -1,0 +1,186 @@
+# RSC Migration: HTTP Response Ownership
+
+This guide covers status codes, redirects, and cache headers when Rails owns the HTTP request and React Server Components own the rendered UI.
+
+> **Part 5 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Data Fetching Migration](rsc-data-fetching.md) | Next: [Third-Party Library Compatibility](rsc-third-party-libs.md)
+
+## Core Rule: Rails Decides Before Rendering
+
+React Server Components decide what UI to render. Rails still decides the HTTP response:
+
+- Status codes (`200`, `404`, `410`, etc.)
+- Redirects
+- Cache headers
+- Cookies and session policy
+- Authentication and authorization failures
+
+With streaming, this boundary matters even more. Once Rails writes the first response chunk, headers are committed. After that point the app can no longer turn the response into a real HTTP redirect, change `200` to `404`, or revise cache policy. Make these route-level decisions in the controller or a Ruby preflight object before calling `stream_view_containing_react_components`.
+
+## Preflight Pattern
+
+Use a controller or service object to gather data and choose the response policy before rendering the RSC tree.
+
+```ruby
+class StoriesController < ApplicationController
+  include ReactOnRailsPro::Stream
+
+  def show
+    preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
+
+    return redirect_to(preflight.redirect_path, status: :see_other) if preflight.redirect_path
+
+    response.status = preflight.status if preflight.status
+    response.set_header("Cache-Control", preflight.cache_control) if preflight.cache_control
+
+    @story_props = preflight.props
+    stream_view_containing_react_components(template: "stories/show")
+  end
+end
+```
+
+```erb
+<%= stream_react_component("StoryPage", props: @story_props) %>
+```
+
+Keep the props serializable and intentional. A good preflight result usually contains:
+
+- The data the RSC tree needs to render
+- The selected HTTP status
+- Any redirect target
+- Cache policy metadata
+- Small route-level flags such as `notFound: true`
+
+Avoid making React responsible for route outcomes. React can render a "not found" UI, but Rails should decide whether the response is actually a `404`.
+
+## 404 And Not-Found Routes
+
+For simple not-found cases, return a Rails response before streaming:
+
+```ruby
+def show
+  story = Story.find_by(id: params[:id])
+  return render("errors/not_found", status: :not_found) unless story
+
+  @story_props = StorySerializer.render_as_hash(story)
+  stream_view_containing_react_components(template: "stories/show")
+end
+```
+
+If you want the not-found page itself to be rendered by RSC, set the status before streaming:
+
+```ruby
+def show
+  story = Story.find_by(id: params[:id])
+
+  if story.nil?
+    response.status = 404
+    @story_props = { notFound: true, requestedId: params[:id] }
+  else
+    @story_props = StorySerializer.render_as_hash(story)
+  end
+
+  stream_view_containing_react_components(template: "stories/show")
+end
+```
+
+Then keep the React component purely presentational:
+
+```tsx
+export default function StoryPage({ notFound, story }) {
+  if (notFound) {
+    return <NotFoundMessage />;
+  }
+
+  return <Story story={story} />;
+}
+```
+
+Use this pattern when the branded not-found UI benefits from the same RSC layout as the rest of the route. Use a plain Rails error template when you need the smallest, most reliable failure path.
+
+## Redirects
+
+Use Rails redirects before streaming:
+
+```ruby
+def show
+  story = Story.find_by(id: params[:id])
+  return redirect_to(stories_path, alert: "Story not found") unless story
+
+  return redirect_to(sign_in_path, status: :see_other) unless can?(:read, story)
+
+  @story_props = StorySerializer.render_as_hash(story)
+  stream_view_containing_react_components(template: "stories/show")
+end
+```
+
+Do not model route redirects as Server Component return values. React on Rails render-functions may expose redirect metadata for client routers, but React on Rails does not turn that metadata into an actual HTTP redirect for the page response. See [Redirect Information](../core-concepts/render-functions.md#8-redirect-information).
+
+If a streamed response has already started and an error forces navigation, the fallback is client-side navigation or an error shell, not a true HTTP redirect. Treat that as an exception path, not the normal route design.
+
+## Cache Headers
+
+Set cache headers in Rails before streaming. The streamed HTML can include serialized props and embedded RSC payloads, so cache it with the same care you would use for any Rails response that contains user-specific data.
+
+For personalized pages, prefer private or no-store policies:
+
+```ruby
+response.set_header("Cache-Control", "private, no-store")
+```
+
+For public pages, let Rails decide freshness before rendering:
+
+```ruby
+def show
+  story = Story.published.find_by!(slug: params[:slug])
+  return unless stale?(story, public: true)
+
+  response.set_header("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
+  @story_props = PublicStorySerializer.render_as_hash(story)
+  stream_view_containing_react_components(template: "stories/show")
+end
+```
+
+When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy or keep the response private:
+
+```ruby
+response.set_header("Vary", "Accept-Language")
+```
+
+Do not bury cache decisions inside Server Components. By the time React is rendering, the controller should already know whether the response is public, private, stale, or not cacheable.
+
+## What To Pass Into RSC
+
+Pass decisions as data, not as hidden HTTP side effects:
+
+```ruby
+@story_props = {
+  story: StorySerializer.render_as_hash(story),
+  viewer: ViewerSerializer.render_as_hash(current_user),
+  responsePolicy: {
+    cache: "private",
+    canonicalUrl: story_url(story)
+  }
+}
+```
+
+```tsx
+export default function StoryPage({ story, viewer, responsePolicy }) {
+  return (
+    <>
+      <link rel="canonical" href={responsePolicy.canonicalUrl} />
+      <Story story={story} viewer={viewer} />
+    </>
+  );
+}
+```
+
+React can render metadata, route chrome, empty states, and branded error UI from these props. Rails remains the source of truth for the actual HTTP semantics.
+
+## Checklist
+
+- Decide redirects before rendering.
+- Decide `404`, `410`, and authorization statuses before rendering.
+- Set cache headers before the first streamed chunk.
+- Pass route decisions into RSC as serializable props.
+- Keep Rails controllers, policies, and services responsible for authentication, authorization, and response policy.
+- Use Client Component navigation only for browser-side transitions after a valid HTTP response exists.

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -37,7 +37,7 @@ class StoriesController < ApplicationController
       return redirect_to(redirect_path, status: preflight.redirect_status || :see_other)
     end
 
-    response.status = preflight.status unless preflight.status.nil?
+    response.status = preflight.status if preflight.status
     response.headers["Cache-Control"] = preflight.cache_control if preflight.cache_control
 
     @story_props = preflight.props
@@ -51,6 +51,7 @@ classes that return plain Ruby hashes; substitute your app's serializer or prese
 
 ```ruby
 class StoryPagePreflight
+  # redirect_reason is nil when no redirect is needed.
   Result = Struct.new(:props, :status, :redirect_reason, :redirect_status, :cache_control, keyword_init: true)
 
   def self.call(story_id, current_user:)

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -156,18 +156,18 @@ def show
 end
 ```
 
-Then keep the React component purely presentational. The happy path omits `notFound`, so `notFound?: false` models the absent key as the non-error branch while still narrowing `story` after the guard:
+Then keep the React component purely presentational. The happy path omits `notFound`, so `notFound?: false` models the absent key as the non-error branch. Keep `props` whole until after the guard so TypeScript narrows `story` correctly:
 
 ```tsx
 type StoryData = { id: number; title: string };
 type StoryPageProps = { notFound: true; story: null } | { notFound?: false; story: StoryData };
 
-export default function StoryPage({ notFound, story }: StoryPageProps) {
-  if (notFound) {
+export default function StoryPage(props: StoryPageProps) {
+  if (props.notFound) {
     return <NotFoundMessage />;
   }
 
-  return <Story story={story} />;
+  return <Story story={props.story} />;
 }
 ```
 
@@ -282,15 +282,8 @@ varies on, such as `Accept-Encoding`, `X-Device-Class`, or an application-specif
 existing_vary = response.headers["Vary"].presence
 
 unless existing_vary == "*"
-  vary_tokens = [existing_vary, "Accept-Language"].compact.join(", ")
-  seen_tokens = {}
-  response.headers["Vary"] = vary_tokens.split(",").map(&:strip).reject do |token|
-    normalized_token = token.downcase
-    next true if seen_tokens[normalized_token]
-
-    seen_tokens[normalized_token] = true
-    false
-  end.join(", ")
+  vary_tokens = [existing_vary, "Accept-Language"].compact.flat_map { |value| value.split(",") }.map(&:strip)
+  response.headers["Vary"] = vary_tokens.reject(&:empty?).uniq { |token| token.downcase }.join(", ")
 end
 ```
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -21,6 +21,8 @@ With streaming, this boundary matters even more. Once Rails writes the first res
 ## Preflight Pattern
 
 Use a controller or service object to gather data and choose the response policy before rendering the RSC tree.
+The preflight object exposes a small, serializable result. `StorySerializer`, `PublicStorySerializer`, and
+`ViewerSerializer` are placeholder names in these examples; substitute your app's serializer or presenter as needed.
 
 ```ruby
 class StoriesController < ApplicationController
@@ -30,7 +32,11 @@ class StoriesController < ApplicationController
     preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
     if preflight.redirect_reason
-      redirect_path = { unauthenticated: sign_in_path }.fetch(preflight.redirect_reason) do |reason|
+      redirect_path = {
+        unauthenticated: sign_in_path,
+        # Add a key here for every redirect_reason StoryPagePreflight can return.
+        # Unknown reasons fall back to root_path and log an error.
+      }.fetch(preflight.redirect_reason) do |reason|
         Rails.logger.error("Unknown redirect_reason: #{reason.inspect}")
         root_path
       end
@@ -46,8 +52,7 @@ class StoriesController < ApplicationController
 end
 ```
 
-The preflight object can expose a small, serializable result. These examples use placeholder serializer
-classes that return plain Ruby hashes; substitute your app's serializer or presenter as needed:
+One possible preflight implementation is:
 
 ```ruby
 class StoryPagePreflight
@@ -65,7 +70,7 @@ class StoryPagePreflight
       return Result.new(
         props: { notFound: true, story: nil },
         status: :not_found,
-        cache_control: "no-store" # or "public, max-age=30" to absorb repeat 404s at the CDN
+        cache_control: "no-store"
       )
     end
 
@@ -145,6 +150,10 @@ export default function StoryPage({ notFound, story }: StoryPageProps) {
 
 Use this pattern when the branded not-found UI benefits from the same RSC layout as the rest of the route. Use a plain Rails error template when you need the smallest, most reliable failure path.
 
+Cache `404` responses publicly only when the route is truly missing, such as typo-driven URLs that repeat often. Prefer
+`no-store` for user-specific or permission-sensitive misses, and use `410 Gone` for durable removals where caches should
+reuse the response as a permanent absence.
+
 Use `410 Gone` when the route identifies a permanently removed resource and you want caches to treat that response differently from a temporary `404`:
 
 ```ruby
@@ -152,7 +161,7 @@ def show
   story = Story.find_by(slug: params[:slug])
 
   if story&.removed?
-    response.headers["Cache-Control"] = "public, max-age=86400"
+    response.headers["Cache-Control"] = "public, max-age=3600" # Raise only for truly permanent removals.
     return render(template: "errors/gone", status: :gone)
   end
 
@@ -222,9 +231,13 @@ If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` r
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy before streaming or keep the response private:
 
 ```ruby
+# Merge with any existing Vary tokens set upstream, then deduplicate.
 existing_vary = response.headers["Vary"].presence
-vary_tokens = [existing_vary, "Accept-Language"].compact.join(", ")
-response.headers["Vary"] = vary_tokens.split(",").map(&:strip).uniq.join(", ")
+
+unless existing_vary == "*"
+  vary_tokens = [existing_vary, "Accept-Language"].compact.join(", ")
+  response.headers["Vary"] = vary_tokens.split(",").map(&:strip).uniq.join(", ")
+end
 ```
 
 Every `Vary` header expands the cache key; avoid high-cardinality headers for public caches unless that extra cache storage is intentional.

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -27,10 +27,11 @@ class StoriesController < ApplicationController
   include ReactOnRailsPro::Stream # Requires React on Rails Pro
 
   def show
-    preflight = StoryPagePreflight.call(params[:id], current_user: current_user, sign_in_path: sign_in_path)
+    preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
 
-    if preflight.redirect_path
-      return redirect_to(preflight.redirect_path, status: preflight.redirect_status || :see_other)
+    if preflight.redirect_reason
+      redirect_path = { unauthenticated: sign_in_path }.fetch(preflight.redirect_reason)
+      return redirect_to(redirect_path, status: preflight.redirect_status || :see_other)
     end
 
     response.status = preflight.status unless preflight.status.nil?
@@ -46,11 +47,11 @@ The preflight object can expose a small, serializable result:
 
 ```ruby
 class StoryPagePreflight
-  Result = Struct.new(:props, :status, :redirect_path, :redirect_status, :cache_control, keyword_init: true)
+  Result = Struct.new(:props, :status, :redirect_reason, :redirect_status, :cache_control, keyword_init: true)
 
-  def self.call(story_id, current_user:, sign_in_path:)
+  def self.call(story_id, current_user:)
     unless current_user
-      return Result.new(props: {}, redirect_path: sign_in_path, redirect_status: :see_other)
+      return Result.new(props: {}, redirect_reason: :unauthenticated, redirect_status: :see_other)
     end
 
     story = Story.find_by(id: story_id)
@@ -73,11 +74,13 @@ Keep the props serializable and intentional. A good preflight result usually con
 
 - The data the RSC tree needs to render
 - The selected HTTP status
-- Any redirect target
+- Any redirect reason and status
 - Cache policy metadata
 - Small route-level flags such as `notFound: true`
 
 Avoid making React responsible for route outcomes. React can render a "not found" UI, but Rails should decide whether the response is actually a `404`.
+
+Set cookies and mutate session state before calling `stream_view_containing_react_components`, for the same reason you set status and cache headers first. Once streaming commits the headers, `Set-Cookie` changes and session writes can no longer be added reliably to the HTTP response.
 
 ## 404 and Not-Found Routes
 
@@ -115,7 +118,8 @@ end
 Then keep the React component purely presentational. The happy path omits `notFound`, so `notFound?: false` models the absent key as the non-error branch while still narrowing `story` after the guard:
 
 ```tsx
-type StoryPageProps = { notFound: true; story: null } | { notFound?: false; story: Story };
+type StoryData = { id: number; title: string };
+type StoryPageProps = { notFound: true; story: null } | { notFound?: false; story: StoryData };
 
 export default function StoryPage({ notFound, story }: StoryPageProps) {
   if (notFound) {
@@ -127,6 +131,27 @@ export default function StoryPage({ notFound, story }: StoryPageProps) {
 ```
 
 Use this pattern when the branded not-found UI benefits from the same RSC layout as the rest of the route. Use a plain Rails error template when you need the smallest, most reliable failure path.
+
+Use `410 Gone` when the route identifies a permanently removed resource and you want caches to treat that response differently from a temporary `404`:
+
+```ruby
+def show
+  story = Story.find_by(slug: params[:slug])
+
+  if story&.removed?
+    response.status = :gone
+    response.headers["Cache-Control"] = "public, max-age=86400"
+    return render(template: "errors/gone", status: :gone)
+  end
+
+  return render(template: "errors/not_found", status: :not_found) unless story
+
+  @story_props = { story: StorySerializer.render_as_hash(story) }
+  stream_view_containing_react_components(template: "stories/show")
+end
+```
+
+Cache a `410` only when the removal is durable enough for clients and CDNs to reuse that response.
 
 ## Redirects
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -64,7 +64,7 @@ class StoryPagePreflight
       return Result.new(
         props: { notFound: true, story: nil },
         status: :not_found,
-        cache_control: "no-store"
+        cache_control: "no-store" # or "public, max-age=30" to absorb repeat 404s at the CDN
       )
     end
 
@@ -222,7 +222,8 @@ When the response varies by locale, device class, authentication state, or featu
 
 ```ruby
 existing_vary = response.headers["Vary"].presence
-response.headers["Vary"] = [existing_vary, "Accept-Language"].compact.join(", ")
+vary_tokens = [existing_vary, "Accept-Language"].compact.join(", ")
+response.headers["Vary"] = vary_tokens.split(",").map(&:strip).uniq.join(", ")
 ```
 
 Every `Vary` header expands the cache key; avoid high-cardinality headers for public caches unless that extra cache storage is intentional.
@@ -242,6 +243,8 @@ Pass decisions as data, not as hidden HTTP side effects:
   }
 }
 ```
+
+Keep viewer props minimal. They are embedded in the streamed response and visible to browser DevTools, logs, and any permitted cache, so include only fields the component actually reads rather than a full user representation.
 
 ```tsx
 type StoryData = { id: number; title: string };

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -27,14 +27,14 @@ class StoriesController < ApplicationController
   include ReactOnRailsPro::Stream # Requires React on Rails Pro
 
   def show
-    preflight = StoryPagePreflight.call(params[:id], current_user: current_user)
+    preflight = StoryPagePreflight.call(params[:id], current_user: current_user, sign_in_path: sign_in_path)
 
     if preflight.redirect_path
       return redirect_to(preflight.redirect_path, status: preflight.redirect_status || :see_other)
     end
 
     response.status = preflight.status unless preflight.status.nil?
-    response.set_header("Cache-Control", preflight.cache_control) if preflight.cache_control
+    response.headers["Cache-Control"] = preflight.cache_control if preflight.cache_control
 
     @story_props = preflight.props
     stream_view_containing_react_components(template: "stories/show")
@@ -48,9 +48,9 @@ The preflight object can expose a small, serializable result:
 class StoryPagePreflight
   Result = Struct.new(:props, :status, :redirect_path, :redirect_status, :cache_control, keyword_init: true)
 
-  def self.call(story_id, current_user:)
+  def self.call(story_id, current_user:, sign_in_path:)
     unless current_user
-      return Result.new(props: {}, redirect_path: "/sign_in", redirect_status: :see_other)
+      return Result.new(props: {}, redirect_path: sign_in_path, redirect_status: :see_other)
     end
 
     story = Story.find_by(id: story_id)
@@ -112,7 +112,7 @@ def show
 end
 ```
 
-Then keep the React component purely presentational:
+Then keep the React component purely presentational. The happy path omits `notFound`, so `notFound?: false` models the absent key as the non-error branch while still narrowing `story` after the guard:
 
 ```tsx
 type StoryPageProps = { notFound: true; story: null } | { notFound?: false; story: Story };
@@ -130,7 +130,7 @@ Use this pattern when the branded not-found UI benefits from the same RSC layout
 
 ## Redirects
 
-Use Rails redirects before streaming:
+Use Rails redirects before streaming. Replace `can?` with your app's authorization helper:
 
 ```ruby
 def show
@@ -155,12 +155,14 @@ Set cache headers in Rails before streaming. The streamed HTML can include seria
 For personalized pages, prefer private HTTP caching with revalidation:
 
 ```ruby
-response.set_header("Cache-Control", "private, no-cache")
+response.headers["Cache-Control"] = "private, no-cache"
 ```
 
-`private` prevents CDNs and shared proxies from storing the response; `no-cache` allows the browser to store it but requires revalidation with the origin before each reuse. Use `no-store` instead when sensitive responses must never be cached by anyone.
+`private` prevents CDNs and shared proxies from storing the response; `no-cache` allows permitted HTTP caches to store it but requires revalidation with the origin before each reuse. For a private response, that permitted cache is usually the browser. Use `no-store` instead when sensitive responses must never be cached by anyone.
 
 For public pages, let Rails decide freshness before rendering:
+
+> **Rails 7.1+:** The `cache_control:` keyword on `stale?` requires Rails 7.1 or later. On earlier Rails versions, set the full `Cache-Control` header directly with `response.headers["Cache-Control"] = "public, max-age=60"` and keep the explicit freshness guard before streaming. `stale_while_revalidate` only helps caches that support that extension; unsupported browsers, proxies, and CDNs fall back to normal `max-age` behavior.
 
 ```ruby
 def show
@@ -178,13 +180,15 @@ def show
 end
 ```
 
-If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected. Rails 7.1+ supports `cache_control:` on `stale?`. On older Rails versions, set the full `Cache-Control` header directly and keep the explicit freshness guard before streaming. `stale_while_revalidate` only helps caches that support that extension; unsupported browsers, proxies, and CDNs fall back to the normal `max-age` behavior.
+If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected.
 
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy or keep the response private:
 
 ```ruby
-response.set_header("Vary", "Accept-Language")
+response.headers["Vary"] = "Accept-Language"
 ```
+
+Every `Vary` header expands the cache key; avoid high-cardinality headers for public caches unless that extra cache storage is intentional.
 
 Do not bury cache decisions inside Server Components. By the time React is rendering, the controller should already know whether the response is public, private, stale, or not cacheable.
 

--- a/docs/oss/migrating/rsc-http-response-patterns.md
+++ b/docs/oss/migrating/rsc-http-response-patterns.md
@@ -173,7 +173,7 @@ def show
 end
 ```
 
-Rails 7.1+ supports `cache_control:` on `stale?`. On older Rails versions, set the full `Cache-Control` header directly and keep the explicit freshness guard before streaming.
+If `stale?` returns `false`, Rails has already prepared the `304 Not Modified` response; the early return keeps the controller from starting a streamed render after that response has been selected. Rails 7.1+ supports `cache_control:` on `stale?`. On older Rails versions, set the full `Cache-Control` header directly and keep the explicit freshness guard before streaming.
 
 When the response varies by locale, device class, authentication state, or feature flag, set the corresponding `Vary` policy or keep the response private:
 

--- a/docs/oss/migrating/rsc-third-party-libs.md
+++ b/docs/oss/migrating/rsc-third-party-libs.md
@@ -2,7 +2,7 @@
 
 Most third-party React libraries were built before Server Components existed. Many rely on hooks, Context, or browser APIs that are unavailable in Server Components. This guide covers how to identify incompatible libraries, create wrapper patterns, and choose RSC-compatible alternatives.
 
-> **Part 5 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Data Fetching Migration](rsc-data-fetching.md) | Next: [Troubleshooting](rsc-troubleshooting.md)
+> **Part 6 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [HTTP Response Ownership](rsc-http-response-patterns.md) | Next: [Troubleshooting](rsc-troubleshooting.md)
 
 ## Why Libraries Break in Server Components
 
@@ -423,3 +423,4 @@ Styled-components and Emotion work inside `'use client'` boundaries, but they pr
 
 - [Troubleshooting and Common Pitfalls](rsc-troubleshooting.md) -- debugging and avoiding problems
 - [Data Fetching Migration](rsc-data-fetching.md) -- migrating from useEffect to server-side fetching
+- [HTTP Response Ownership](rsc-http-response-patterns.md) -- status codes, redirects, and cache headers

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -2,7 +2,7 @@
 
 This guide covers the most common problems you'll encounter when migrating to React Server Components, with concrete solutions for each. Use it as a reference when you hit errors or unexpected behavior.
 
-> **Part 6 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Third-Party Library Compatibility](rsc-third-party-libs.md) | Next: [Flight Payload Optimization](rsc-flight-payload.md)
+> **Part 7 of the [RSC Migration Series](migrating-to-rsc.md)** | Previous: [Third-Party Library Compatibility](rsc-third-party-libs.md) | Next: [Flight Payload Optimization](rsc-flight-payload.md)
 
 ## Diagnostic Quick-Reference
 
@@ -1087,4 +1087,5 @@ For these cases, keep components as Client Components and adopt Server Component
 - [Component Tree Restructuring Patterns](rsc-component-patterns.md) -- how to restructure your component tree
 - [Context, Providers, and State Management](rsc-context-and-state.md) -- how to handle Context and global state
 - [Data Fetching Migration](rsc-data-fetching.md) -- migrating from useEffect to server-side fetching
+- [HTTP Response Ownership](rsc-http-response-patterns.md) -- status codes, redirects, and cache headers
 - [Third-Party Library Compatibility](rsc-third-party-libs.md) -- dealing with incompatible libraries

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -227,6 +227,7 @@ const sidebars: SidebarsConfig = {
                 'migrating/rsc-component-patterns',
                 'migrating/rsc-context-and-state',
                 'migrating/rsc-data-fetching',
+                'migrating/rsc-http-response-patterns',
                 'migrating/rsc-third-party-libs',
                 'migrating/rsc-troubleshooting',
                 'migrating/rsc-flight-payload',


### PR DESCRIPTION
## Summary
- add a new RSC migration guide for Rails-owned status codes, redirects, and cache headers
- document controller/service preflight patterns before streaming commits headers
- wire the new guide into the migration series navigation

Fixes #3180

## Test plan
- `pnpm exec prettier --check docs/oss/migrating/rsc-http-response-patterns.md docs/oss/migrating/migrating-to-rsc.md docs/oss/migrating/rsc-data-fetching.md docs/oss/migrating/rsc-third-party-libs.md docs/oss/migrating/rsc-troubleshooting.md docs/oss/migrating/rsc-flight-payload.md`
- `pnpm start format.listDifferent`
- pre-commit hook: offline Markdown links, trailing newlines, Prettier
- pre-push hook: branch-lint, online Markdown links

## Notes
- Full `bundle exec rubocop` is not a meaningful docs-only gate on current `origin/main`; it reports pre-existing Pro dummy/script offenses unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds a new migration article and rewires navigation/part numbering; no runtime or API behavior changes.
> 
> **Overview**
> Adds a new **RSC migration guide** (`rsc-http-response-patterns.md`) documenting how to keep *HTTP status codes, redirects, cookies/session, and cache headers* owned by Rails when using streaming RSC, including a preflight/service-object pattern and not-found/redirect/cache strategies.
> 
> Updates the RSC migration series to insert this as **Part 5**, renumber subsequent parts, add it to the quick-start checklist and “Next steps” cross-links, and include the page in the Docusaurus sidebar navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79470ae5f1dc5fd4b9d0899e2d5a519bb1aaf269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "HTTP Response Ownership" guide for RSC migrations covering status codes, redirects, not-found UI strategies, cache headers, and passing response policy into the RSC render path.
  * Introduced a Rails preflight pattern and checklist for ordering response decisions before streaming.
  * Updated migration series: renumbered parts, inserted a route-policy step in Quick‑Start, expanded "Next Steps" links, and added the page to sidebar/navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->