### PR TITLE
docs: document RSC node renderer test setup

### DIFF
--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -129,7 +129,8 @@ module RscNodeRenderer
     loop do
       Socket.tcp(host, port, connect_timeout: 1).close
       break
-    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, SocketError
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT,
+           Errno::EHOSTUNREACH, SocketError
       if pid
         begin
           Process.kill(0, pid)
@@ -184,6 +185,9 @@ RSpec.configure do |config|
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
     }
 
+    # These lines mirror the Step 1 preamble. This support file is required as a
+    # standalone file, so it cannot share locals with rails_helper.rb and must re-derive
+    # test_worker_id itself.
     test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
     test_worker = "0" if test_worker.empty?
     test_worker_id = test_worker.gsub(/[^0-9]/, "")
@@ -224,6 +228,9 @@ RSpec.configure do |config|
     rsc_node_renderer_waiter&.join(5)
   rescue Errno::ESRCH
     # Already stopped.
+  rescue Errno::EPERM
+    warn "No permission to stop node renderer process group #{pid}; " \
+         "it may need manual cleanup."
   ensure
     rsc_node_renderer_pid = nil
     rsc_node_renderer_waiter = nil

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -145,7 +145,8 @@ module RscNodeRenderer
 
       if pid
         begin
-          # This process was spawned above, so EPERM is not expected here; ESRCH means it exited early.
+          # This checks the spawned command process. For `pnpm run <script>`, pnpm usually stays resident while the
+          # renderer is alive; if your launcher daemonizes Node, replace this with an app-specific health check.
           Process.kill(0, pid)
         rescue Errno::ESRCH
           hint = log_path ? " Check #{log_path} for startup errors." : ""
@@ -253,7 +254,9 @@ end
 
 Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
-The explicit `ensure_assets_compiled` call above is intentional: the renderer needs bundles before it boots. Step 2 still wires compilation to `:rsc` examples for suites that do not start the renderer.
+The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed
+examples run. If your suite starts the renderer before any `:rsc` example can trigger that hook, compile assets in your CI
+job before running the spec process.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -111,7 +111,7 @@ end
 require_relative "support/rsc_node_renderer"
 ```
 
-Passing any metatags replaces the TestHelper defaults, so include the default `:js`, `:server_rendering`, and `:controller` tags alongside `:rsc` if your suite mixes RSC and non-RSC specs.
+> **Warning:** Passing any metatags replaces the TestHelper defaults. Include `:js`, `:server_rendering`, and `:controller` alongside `:rsc` if your suite mixes RSC and non-RSC specs, or those tag groups will no longer trigger compilation.
 
 The derived metadata block intentionally tags every system and feature spec so the first browser request cannot race ahead of RSC bundle compilation. If only some directories exercise RSC, narrow the regex (for example, `spec/(system/rsc|features/rsc)`) or tag those examples manually to avoid compiling for unrelated system tests.
 
@@ -120,6 +120,18 @@ Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. If y
 ### 3. Start One Test Renderer Per Worker
 
 Start the renderer in `before(:suite)` after assets are compiled and stop it in `after(:suite)`. The example below assumes your app has a `node-renderer` package script that launches the node-renderer server, reads `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH` from ENV, and serves the RSC test bundle cache. See [Node Renderer JavaScript Configuration](node-renderer/js-configuration.md#example-launch-files) for launch-file and `package.json` script examples. Replace the package-manager command with the one your project uses.
+
+> **Warning:** The generated `renderer/node-renderer.js` template hardcodes `serverBundleCachePath` to `path.resolve(__dirname, '../.node-renderer-bundles')`, so it ignores `RENDERER_SERVER_BUNDLE_CACHE_PATH` until you change it. Without this edit every parallel worker shares the same cache directory and you will see stale-bundle and missing-bundle flakes that look like RSC timeouts. Update the launch file to read the env var:
+>
+> ```js
+> // renderer/node-renderer.js
+> const config = {
+>   serverBundleCachePath:
+>     process.env.RENDERER_SERVER_BUNDLE_CACHE_PATH || path.resolve(__dirname, '../.node-renderer-bundles'),
+>   port: Number(process.env.RENDERER_PORT) || 3800,
+>   // ...
+> };
+> ```
 
 ```ruby
 # spec/support/rsc_node_renderer.rb
@@ -132,6 +144,7 @@ module RscNodeRenderer
 
   def wait_until_ready!(host:, port:, timeout_seconds: 30, log_path: nil, pid: nil)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+    saw_reset = false
 
     loop do
       begin
@@ -140,8 +153,11 @@ module RscNodeRenderer
       rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
         # Port not yet open; renderer still booting.
       rescue Errno::ECONNRESET
-        # Connection reset: renderer may have bound the port and crashed.
-        # The PID check below catches a dead process and raises before the deadline.
+        # Connection reset: renderer bound the port but closed the connection before accepting.
+        # Fall through — the PID check below will detect a dead process and raise before the deadline.
+        # If the deadline expires without a successful connect, the deadline error mentions the reset
+        # so a port already used by another service is easier to diagnose than a generic timeout.
+        saw_reset = true
       rescue Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError => e
         raise "Cannot reach node renderer at #{host}:#{port}. " \
               "Check the host configuration (#{e.class}: #{e.message})."
@@ -163,7 +179,8 @@ module RscNodeRenderer
 
       if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         hint = log_path ? " Check #{log_path} for startup errors." : ""
-        raise "Node renderer did not boot on #{host}:#{port} within #{timeout_seconds}s.#{hint}"
+        reset_hint = saw_reset ? " (TCP connections were reset — another process may already be using this port)" : ""
+        raise "Node renderer did not boot on #{host}:#{port} within #{timeout_seconds}s.#{hint}#{reset_hint}"
       end
 
       sleep 0.1
@@ -225,6 +242,8 @@ RSpec.configure do |config|
     rescue Errno::ECONNRESET
       raise "RENDERER_PORT #{renderer_env['RENDERER_PORT']} accepted and reset a connection. " \
             "Another service may already be using it."
+    rescue Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError => e
+      raise "Cannot probe RENDERER_PORT #{renderer_env['RENDERER_PORT']}: #{e.class}: #{e.message}"
     end
 
     renderer_log_path = Rails.root.join("log/node-renderer-test-#{RscTestWorker::ID}.log").to_s
@@ -258,8 +277,9 @@ RSpec.configure do |config|
     rescue StandardError
       begin
         Process.kill("-TERM", rsc_node_renderer_pid)
-      rescue Errno::ESRCH
-        # Already stopped.
+      rescue Errno::ESRCH, Errno::EPERM
+        # Already stopped or no permission to signal the process group; matches the after(:suite)
+        # cleanup so the original startup failure isn't masked by an EPERM here.
       end
       rsc_node_renderer_waiter&.join(2)
       rsc_node_renderer_pid = nil
@@ -276,12 +296,11 @@ RSpec.configure do |config|
     # Raises Errno::ESRCH if the group is already gone; caught by rescue below.
     Process.kill("-TERM", pid)
     # Thread#join returns the waiter thread when the process exits, and nil on timeout.
-    # Skip SIGKILL only when TERM worked and the waiter reaped the process.
-    # `next` exits only this hook block; Ruby still runs the ensure below, so cleanup always fires.
-    next if rsc_node_renderer_waiter&.join(5)
-
-    Process.kill("-KILL", pid)
-    rsc_node_renderer_waiter&.join(5)
+    # SIGKILL only fires when SIGTERM did not stop the process within the join window.
+    unless rsc_node_renderer_waiter&.join(5)
+      Process.kill("-KILL", pid)
+      rsc_node_renderer_waiter&.join(5)
+    end
   rescue Errno::ESRCH
     # Already stopped.
   rescue Errno::EPERM

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -54,10 +54,7 @@ The Pro initializer reads renderer settings while Rails boots. Set test renderer
 module RscTestWorker
   TEST_ENV_NUMBER = ENV.fetch("TEST_ENV_NUMBER", "0")
   NORMALIZED_ENV_NUMBER = TEST_ENV_NUMBER.empty? ? "0" : TEST_ENV_NUMBER
-  ID = begin
-    worker_id = NORMALIZED_ENV_NUMBER.gsub(/[^0-9]/, "")
-    worker_id.empty? ? "0" : worker_id
-  end
+  ID = NORMALIZED_ENV_NUMBER.gsub(/[^0-9]/, "").then { |worker_id| worker_id.empty? ? "0" : worker_id }
 end
 ```
 
@@ -175,7 +172,7 @@ RSpec.configure do |config|
             "gets a unique renderer bundle cache directory."
     end
     expanded_cache_path = File.expand_path(cache_path)
-    tmp_root = File.expand_path(Rails.root.join("tmp").to_s)
+    tmp_root = File.realpath(Rails.root.join("tmp").to_s)
     unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH must be inside Rails.root/tmp " \
             "(got: #{expanded_cache_path})"
@@ -210,7 +207,7 @@ RSpec.configure do |config|
     renderer_timeout = ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30").to_i
     RscNodeRenderer.wait_until_ready!(
       host: "127.0.0.1",
-      port: ENV.fetch("RENDERER_PORT").to_i,
+      port: renderer_env["RENDERER_PORT"].to_i,
       timeout_seconds: renderer_timeout,
       log_path: renderer_log_path,
       pid: rsc_node_renderer_pid
@@ -240,7 +237,7 @@ RSpec.configure do |config|
 end
 ```
 
-Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The explicit `ensure_assets_compiled` call above is intentional: the renderer needs bundles before it boots. Step 2 still wires compilation to `:rsc` examples for suites that do not start the renderer.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -136,8 +136,11 @@ module RscNodeRenderer
       begin
         Socket.tcp(host, port, connect_timeout: 1).close
         break
-      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
-        # The renderer is still booting or has not bound the port yet; keep retrying until the deadline.
+      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
+        # Port not yet open; renderer still booting.
+      rescue Errno::ECONNRESET
+        # Connection reset: renderer may have bound the port and crashed.
+        # The PID check below catches a dead process and raises before the deadline.
       rescue Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError => e
         raise "Cannot reach node renderer at #{host}:#{port}. " \
               "Check the host configuration (#{e.class}: #{e.message})."
@@ -181,7 +184,8 @@ RSpec.configure do |config|
             "Follow Step 1 of this guide to set it before Rails boots so every parallel worker " \
             "gets a unique renderer bundle cache directory."
     end
-    raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is empty." if cache_path.strip.empty?
+    cache_path = cache_path.strip
+    raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is empty." if cache_path.empty?
 
     expanded_cache_path = File.expand_path(cache_path, Rails.root.to_s)
     FileUtils.mkdir_p(Rails.root.join("tmp"))
@@ -235,7 +239,7 @@ RSpec.configure do |config|
     Process.kill("-TERM", pid)
     # Thread#join returns the waiter thread when the process exits, and nil on timeout.
     # Skip SIGKILL only when TERM worked and the waiter reaped the process.
-    # Ruby still runs the block-level ensure below when next exits the hook early.
+    # `next` exits only this hook block; Ruby still runs the ensure below, so cleanup always fires.
     next if rsc_node_renderer_waiter&.join(5)
 
     Process.kill("-KILL", pid)
@@ -255,8 +259,10 @@ end
 Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed
-examples run. If your suite starts the renderer before any `:rsc` example can trigger that hook, compile assets in your CI
-job before running the spec process.
+examples run. The renderer starts in `before(:suite)`, and compilation runs in a second `before(:suite)` registered by
+`configure_rspec_to_compile_assets`; RSpec runs both hooks before any example executes, so the renderer has no bundles to
+serve until compilation has completed. If your suite starts the renderer before any `:rsc` example can trigger that hook,
+compile assets in your CI job before running the spec process.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -56,13 +56,15 @@ test_worker = "0" if test_worker.empty?
 
 ENV["RENDERER_PORT"] ||= (3900 + test_worker.to_i).to_s
 renderer_url = "http://127.0.0.1:#{ENV.fetch('RENDERER_PORT')}"
-ENV["REACT_RENDERER_URL"] ||= renderer_url
-ENV["RENDERER_URL"] ||= renderer_url
+ENV["REACT_RENDERER_URL"] ||= renderer_url # used by config.renderer_url = ENV["REACT_RENDERER_URL"]
+ENV["RENDERER_URL"] ||= renderer_url       # used by some older/custom initializers
 ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
   File.expand_path("../tmp/node-renderer-bundles-test-#{test_worker}", __dir__)
 
 require_relative "../config/environment"
 ```
+
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -84,13 +86,13 @@ require "react_on_rails/test_helper"
 RSpec.configure do |config|
   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config, :rsc)
 
-  config.define_derived_metadata(file_path: %r{spec/(system|features|requests)}) do |metadata|
+  config.define_derived_metadata(file_path: %r{spec/(system|features)}) do |metadata|
     metadata[:rsc] = true
   end
 end
 ```
 
-You can keep the default `:js`, `:server_rendering`, and `:controller` tags instead if that already matches your suite. The important part is that the build runs before the first request that can upload bundles to the node renderer.
+Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. You can keep the default `:js`, `:server_rendering`, and `:controller` tags instead if that already matches your suite. The important part is that the build runs before the first request that can upload bundles to the node renderer.
 
 ### 3. Start One Test Renderer Per Worker
 
@@ -109,8 +111,10 @@ module RscNodeRenderer
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
-      TCPSocket.open(host, port) { return }
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      TCPSocket.open(host, port).close
+      break
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
+           Errno::ECONNRESET, Errno::ENETUNREACH
       raise "Node renderer did not boot on #{host}:#{port}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
       sleep 0.1
@@ -179,6 +183,7 @@ Keep the first system test boring: visit a route that streams one Server Compone
 ```ruby
 RSpec.describe "Story page", :rsc, :js, type: :system do
   it "renders the streamed RSC page and hydrates client controls" do
+    # Replace story_path and selectors with your app's RSC route and content.
     visit story_path("ruby-rails-react")
 
     expect(page).to have_css("h1", text: "Ruby, Rails, and React")

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -107,7 +107,7 @@ require "timeout"
 module RscNodeRenderer
   module_function
 
-  def wait_until_ready!(host:, port:, timeout_seconds: 15)
+  def wait_until_ready!(host:, port:, timeout_seconds: 30)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
@@ -130,14 +130,18 @@ RSpec.configure do |config|
 
     ReactOnRails::TestHelper.ensure_assets_compiled
 
-    cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH")
+    cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH") do
+      raise "Set RENDERER_SERVER_BUNDLE_CACHE_PATH before starting the test renderer (see Step 1)."
+    end
     FileUtils.rm_rf(cache_path)
     FileUtils.mkdir_p(cache_path)
 
     renderer_env = {
       "NODE_ENV" => "test",
       "RAILS_ENV" => "test",
-      "RENDERER_PORT" => ENV.fetch("RENDERER_PORT"),
+      "RENDERER_PORT" => ENV.fetch("RENDERER_PORT") do
+        raise "Set RENDERER_PORT before starting the test renderer (see Step 1)."
+      end,
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => cache_path
     }
 
@@ -204,7 +208,9 @@ RSpec.describe "RSC payload endpoint", :rsc, type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.media_type).to eq("application/x-ndjson")
-    expect(response.body).to include("html")
+
+    chunks = response.body.lines.map { |line| JSON.parse(line) }
+    expect(chunks.any? { |chunk| chunk.key?("html") }).to be(true)
   end
 end
 ```

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -43,7 +43,7 @@ React Server Components add one more moving part to the standard test setup: sys
 
 Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
 
-This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails. The full lifecycle example is RSpec-focused because it uses `before(:suite)` and `after(:suite)` hooks; Minitest suites can reuse the ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled` call, but must start and stop the renderer from their own suite-level harness. See [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation) for the underlying compilation tradeoffs.
+This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails. The full lifecycle example is RSpec-focused because it uses `before(:suite)` and `after(:suite)` hooks; Minitest suites can reuse the ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled` call, but must start and stop the renderer from their own suite-level harness such as `Minitest.after_run { ... }` plus a suite-level startup helper. See [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation) for the underlying compilation tradeoffs.
 
 ### 1. Set Renderer ENV Before Rails Boots
 
@@ -209,6 +209,24 @@ RSpec.configure do |config|
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
     }
 
+    renderer_port = begin
+      Integer(renderer_env["RENDERER_PORT"])
+    rescue ArgumentError
+      raise "RENDERER_PORT must be an integer port number " \
+            "(got: #{renderer_env['RENDERER_PORT'].inspect})"
+    end
+    begin
+      Socket.tcp("127.0.0.1", renderer_port, connect_timeout: 1).close
+      raise "RENDERER_PORT #{renderer_env['RENDERER_PORT']} is already in use. " \
+            "A previous test run may have left an orphaned node renderer. " \
+            "Kill it manually or restart the CI job."
+    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
+      # Port is free; safe to spawn.
+    rescue Errno::ECONNRESET
+      raise "RENDERER_PORT #{renderer_env['RENDERER_PORT']} accepted and reset a connection. " \
+            "Another service may already be using it."
+    end
+
     renderer_log_path = Rails.root.join("log/node-renderer-test-#{RscTestWorker::ID}.log").to_s
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
@@ -222,11 +240,17 @@ RSpec.configure do |config|
     )
     rsc_node_renderer_waiter = Process.detach(rsc_node_renderer_pid)
 
-    renderer_timeout = Integer(ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30"))
+    renderer_timeout_value = ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30")
+    renderer_timeout = begin
+      Integer(renderer_timeout_value)
+    rescue ArgumentError
+      raise "RSC_NODE_RENDERER_BOOT_TIMEOUT must be an integer number of seconds " \
+            "(got: #{ENV['RSC_NODE_RENDERER_BOOT_TIMEOUT'].inspect})"
+    end
     begin
       RscNodeRenderer.wait_until_ready!(
         host: "127.0.0.1",
-        port: Integer(renderer_env["RENDERER_PORT"]),
+        port: renderer_port,
         timeout_seconds: renderer_timeout,
         log_path: renderer_log_path,
         pid: rsc_node_renderer_pid
@@ -248,7 +272,8 @@ RSpec.configure do |config|
     pid = rsc_node_renderer_pid
     next unless pid
 
-    # Signal the process group so pnpm and the Node child both stop.
+    # Sends SIGTERM to the entire process group so pnpm and the Node child both stop.
+    # Raises Errno::ESRCH if the group is already gone; caught by rescue below.
     Process.kill("-TERM", pid)
     # Thread#join returns the waiter thread when the process exits, and nil on timeout.
     # Skip SIGKILL only when TERM worked and the waiter reaped the process.
@@ -269,7 +294,7 @@ RSpec.configure do |config|
 end
 ```
 
-Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized. A reset during the pre-spawn probe usually means another service is already using the port and closing connections immediately. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed
 examples run. Load `support/rsc_node_renderer` after registering `configure_rspec_to_compile_assets` so modern RSpec can

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -52,9 +52,9 @@ The Pro initializer reads renderer settings while Rails boots. Set test renderer
 ```ruby
 # spec/support/rsc_test_worker.rb
 module RscTestWorker
-  TEST_ENV_NUMBER = ENV.fetch("TEST_ENV_NUMBER", "0")
-  NORMALIZED_ENV_NUMBER = TEST_ENV_NUMBER.empty? ? "0" : TEST_ENV_NUMBER
-  ID = NORMALIZED_ENV_NUMBER.gsub(/[^0-9]/, "").then { |worker_id| worker_id.empty? ? "0" : worker_id }
+  ID = ENV.fetch("TEST_ENV_NUMBER", "")
+          .gsub(/[^0-9]/, "")
+          .then { |worker_id| worker_id.empty? ? "0" : worker_id }
 end
 ```
 
@@ -172,6 +172,7 @@ RSpec.configure do |config|
             "gets a unique renderer bundle cache directory."
     end
     expanded_cache_path = File.expand_path(cache_path)
+    FileUtils.mkdir_p(Rails.root.join("tmp"))
     tmp_root = File.realpath(Rails.root.join("tmp").to_s)
     unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH must be inside Rails.root/tmp " \

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -174,8 +174,8 @@ module RscNodeRenderer
           hint = log_path ? " Check #{log_path} for startup errors." : ""
           raise "Node renderer process (pid #{pid}) exited before binding to #{host}:#{port}.#{hint}"
         rescue Errno::EPERM
-          hint = log_path ? " Check #{log_path} for startup errors." : ""
-          raise "Cannot inspect node renderer process (pid #{pid}) while waiting for #{host}:#{port}.#{hint}"
+          # Process exists but we lack permission to signal it (different UID, seccomp, container boundary).
+          # Continue waiting for the TCP port — the port probe is authoritative for readiness.
         end
       end
 
@@ -248,6 +248,7 @@ RSpec.configure do |config|
       raise "Cannot probe RENDERER_PORT #{renderer_env['RENDERER_PORT']}: #{e.class}: #{e.message}"
     end
 
+    FileUtils.mkdir_p(Rails.root.join("log"))
     renderer_log_path = Rails.root.join("log/node-renderer-test-#{RscTestWorker::ID}.log").to_s
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
@@ -300,10 +301,15 @@ RSpec.configure do |config|
     # Thread#join returns the waiter thread when the process exits, and nil on timeout.
     # SIGKILL only fires when SIGTERM did not stop the process within the join window.
     unless rsc_node_renderer_waiter&.join(5)
-      Process.kill("-KILL", pid)
-      unless rsc_node_renderer_waiter&.join(5)
-        warn "Node renderer process group #{pid} did not stop after SIGKILL; " \
-             "it may still occupy the renderer port for the next CI retry."
+      begin
+        Process.kill("-KILL", pid)
+      rescue Errno::ESRCH
+        # Process stopped between the join timeout and the SIGKILL; nothing more to do.
+      else
+        unless rsc_node_renderer_waiter&.join(5)
+          warn "Node renderer process group #{pid} did not stop after SIGKILL; " \
+               "it may still occupy the renderer port for the next CI retry."
+        end
       end
     end
   rescue Errno::ESRCH

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -109,7 +109,6 @@ Start the renderer in `before(:suite)` after assets are compiled and stop it in 
 # spec/support/rsc_node_renderer.rb
 require "fileutils"
 require "socket"
-require "timeout"
 
 module RscNodeRenderer
   module_function
@@ -129,6 +128,7 @@ module RscNodeRenderer
 end
 
 rsc_node_renderer_pid = nil # Closure shared by before(:suite) and after(:suite).
+rsc_node_renderer_waiter = nil # Process.detach thread for reaping abnormal exits.
 
 RSpec.configure do |config|
   config.before(:suite) do
@@ -142,8 +142,14 @@ RSpec.configure do |config|
             "Set it before requiring config/environment so every parallel worker " \
             "gets a unique renderer bundle cache directory."
     end
-    FileUtils.rm_rf(cache_path)
-    FileUtils.mkdir_p(cache_path)
+    expanded_cache_path = File.expand_path(cache_path)
+    tmp_root = File.expand_path(Rails.root.join("tmp").to_s)
+    unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
+      raise "RENDERER_SERVER_BUNDLE_CACHE_PATH must be inside Rails.root/tmp " \
+            "(got: #{expanded_cache_path})"
+    end
+    FileUtils.rm_rf(expanded_cache_path)
+    FileUtils.mkdir_p(expanded_cache_path)
 
     renderer_env = {
       "NODE_ENV" => "test",
@@ -153,7 +159,7 @@ RSpec.configure do |config|
               "Set it before requiring config/environment so every parallel worker " \
               "gets a unique renderer port."
       end,
-      "RENDERER_SERVER_BUNDLE_CACHE_PATH" => cache_path
+      "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
     }
 
     rsc_node_renderer_pid = Process.spawn(
@@ -165,6 +171,7 @@ RSpec.configure do |config|
       out: Rails.root.join("log/node-renderer-test.log").to_s,
       err: [:child, :out]
     )
+    rsc_node_renderer_waiter = Process.detach(rsc_node_renderer_pid)
 
     renderer_timeout = ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30").to_i
     RscNodeRenderer.wait_until_ready!(
@@ -179,18 +186,15 @@ RSpec.configure do |config|
     next unless pid
 
     Process.kill("TERM", pid)
-    Timeout.timeout(5) { Process.wait(pid) }
-  rescue Errno::ESRCH, Errno::ECHILD
+    next if rsc_node_renderer_waiter&.join(5)
+
+    Process.kill("KILL", pid)
+    rsc_node_renderer_waiter&.join(5)
+  rescue Errno::ESRCH
     # Already stopped.
-  rescue Timeout::Error
-    begin
-      Process.kill("KILL", pid)
-      Process.wait(pid)
-    rescue Errno::ESRCH, Errno::ECHILD
-      # Already stopped.
-    end
   ensure
     rsc_node_renderer_pid = nil
+    rsc_node_renderer_waiter = nil
   end
 end
 ```

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -119,14 +119,17 @@ require "socket"
 module RscNodeRenderer
   module_function
 
-  def wait_until_ready!(host:, port:, timeout_seconds: 30)
+  def wait_until_ready!(host:, port:, timeout_seconds: 30, log_path: nil)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
-      TCPSocket.open(host, port).close
+      TCPSocket.open(host, port) {}
       break
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET, Errno::ETIMEDOUT
-      raise "Node renderer did not boot on #{host}:#{port}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        hint = log_path ? " Check #{log_path} for startup errors." : ""
+        raise "Node renderer did not boot on #{host}:#{port} within #{timeout_seconds}s.#{hint}"
+      end
 
       sleep 0.1
     end
@@ -168,13 +171,14 @@ RSpec.configure do |config|
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
     }
 
+    renderer_log_path = Rails.root.join("log/node-renderer-test.log").to_s
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
       "pnpm", # replace with "npm", "yarn", or "bun" if that is your package manager
       "run",
       "node-renderer",
       chdir: Rails.root.to_s,
-      out: Rails.root.join("log/node-renderer-test.log").to_s,
+      out: renderer_log_path,
       err: [:child, :out]
     )
     rsc_node_renderer_waiter = Process.detach(rsc_node_renderer_pid)
@@ -183,7 +187,8 @@ RSpec.configure do |config|
     RscNodeRenderer.wait_until_ready!(
       host: "127.0.0.1",
       port: ENV.fetch("RENDERER_PORT").to_i,
-      timeout_seconds: renderer_timeout
+      timeout_seconds: renderer_timeout,
+      log_path: renderer_log_path
     )
   end
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -43,7 +43,7 @@ React Server Components add one more moving part to the standard test setup: sys
 
 Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
 
-This recipe builds on the TestHelper and `build_test_command` approach described in [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation). The full lifecycle example is RSpec-focused because it uses `before(:suite)` and `after(:suite)` hooks; Minitest suites can reuse the ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled` call, but must start and stop the renderer from their own suite-level harness.
+This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails. The full lifecycle example is RSpec-focused because it uses `before(:suite)` and `after(:suite)` hooks; Minitest suites can reuse the ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled` call, but must start and stop the renderer from their own suite-level harness. See [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation) for the underlying compilation tradeoffs.
 
 ### 1. Set Renderer ENV Before Rails Boots
 
@@ -66,7 +66,7 @@ ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on, so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -89,7 +89,13 @@ require "react_on_rails/test_helper"
 require_relative "support/rsc_node_renderer"
 
 RSpec.configure do |config|
-  ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config, :rsc)
+  ReactOnRails::TestHelper.configure_rspec_to_compile_assets(
+    config,
+    :rsc,
+    :js,
+    :server_rendering,
+    :controller
+  )
 
   config.define_derived_metadata(file_path: %r{spec/(system|features)}) do |metadata|
     metadata[:rsc] = true
@@ -97,9 +103,9 @@ RSpec.configure do |config|
 end
 ```
 
-The optional `:rsc` argument is a TestHelper metatag filter. It tells `configure_rspec_to_compile_assets` to compile before `:rsc` examples instead of every example.
+Passing any metatags replaces the TestHelper defaults, so include the default `:js`, `:server_rendering`, and `:controller` tags alongside `:rsc` if your suite mixes RSC and non-RSC specs.
 
-Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. You can keep the default `:js`, `:server_rendering`, and `:controller` tags instead if that already matches your suite. The important part is that the build runs before the first request that can upload bundles to the node renderer.
+Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. If your suite uses a different tag scheme, pass the complete list of tags that should trigger compilation. The important part is that the build runs before the first request that can upload bundles to the node renderer.
 
 ### 3. Start One Test Renderer Per Worker
 
@@ -119,7 +125,7 @@ module RscNodeRenderer
     loop do
       TCPSocket.open(host, port).close
       break
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET, Errno::ETIMEDOUT
       raise "Node renderer did not boot on #{host}:#{port}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
       sleep 0.1
@@ -164,7 +170,7 @@ RSpec.configure do |config|
 
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
-      "pnpm", # replace with "npm" or "yarn" if that is your package manager
+      "pnpm", # replace with "npm", "yarn", or "bun" if that is your package manager
       "run",
       "node-renderer",
       chdir: Rails.root.to_s,

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -55,7 +55,9 @@ test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
 test_worker = "0" if test_worker.empty?
 
 ENV["RENDERER_PORT"] ||= (3900 + test_worker.to_i).to_s
-ENV["RENDERER_URL"] ||= "http://127.0.0.1:#{ENV.fetch('RENDERER_PORT')}"
+renderer_url = "http://127.0.0.1:#{ENV.fetch('RENDERER_PORT')}"
+ENV["REACT_RENDERER_URL"] ||= renderer_url
+ENV["RENDERER_URL"] ||= renderer_url
 ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
   File.expand_path("../tmp/node-renderer-bundles-test-#{test_worker}", __dir__)
 
@@ -154,7 +156,12 @@ RSpec.configure do |config|
   rescue Errno::ESRCH, Errno::ECHILD
     # Already stopped.
   rescue Timeout::Error
-    Process.kill("KILL", @rsc_node_renderer_pid)
+    begin
+      Process.kill("KILL", @rsc_node_renderer_pid)
+      Process.wait(@rsc_node_renderer_pid)
+    rescue Errno::ESRCH, Errno::ECHILD
+      # Already stopped.
+    end
   end
 end
 ```

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -118,6 +118,8 @@ module RscNodeRenderer
   end
 end
 
+rsc_node_renderer_pid = nil
+
 RSpec.configure do |config|
   config.before(:suite) do
     next unless ENV["RSC_NODE_RENDERER_TESTS"] == "1"
@@ -135,7 +137,7 @@ RSpec.configure do |config|
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => cache_path
     }
 
-    @rsc_node_renderer_pid = Process.spawn(
+    rsc_node_renderer_pid = Process.spawn(
       renderer_env,
       "pnpm",
       "run",
@@ -149,19 +151,21 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    next unless @rsc_node_renderer_pid
+    next unless rsc_node_renderer_pid
 
-    Process.kill("TERM", @rsc_node_renderer_pid)
-    Timeout.timeout(5) { Process.wait(@rsc_node_renderer_pid) }
+    Process.kill("TERM", rsc_node_renderer_pid)
+    Timeout.timeout(5) { Process.wait(rsc_node_renderer_pid) }
   rescue Errno::ESRCH, Errno::ECHILD
     # Already stopped.
   rescue Timeout::Error
     begin
-      Process.kill("KILL", @rsc_node_renderer_pid)
-      Process.wait(@rsc_node_renderer_pid)
+      Process.kill("KILL", rsc_node_renderer_pid)
+      Process.wait(rsc_node_renderer_pid)
     rescue Errno::ESRCH, Errno::ECHILD
       # Already stopped.
     end
+  ensure
+    rsc_node_renderer_pid = nil
   end
 end
 ```

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -132,6 +132,8 @@ Start the renderer in `before(:suite)` after assets are compiled and stop it in 
 >   // ...
 > };
 > ```
+>
+> The renderer package's built-in default chain is `RENDERER_SERVER_BUNDLE_CACHE_PATH || RENDERER_BUNDLE_PATH || '/tmp/react-on-rails-pro-node-renderer-bundles'`. The middle term is intentionally omitted here because `RENDERER_BUNDLE_PATH` is deprecated; if your existing renderer config relies on it, migrate to `RENDERER_SERVER_BUNDLE_CACHE_PATH` before adopting this snippet so the per-worker cache path actually takes effect.
 
 ```ruby
 # spec/support/rsc_node_renderer.rb
@@ -299,7 +301,10 @@ RSpec.configure do |config|
     # SIGKILL only fires when SIGTERM did not stop the process within the join window.
     unless rsc_node_renderer_waiter&.join(5)
       Process.kill("-KILL", pid)
-      rsc_node_renderer_waiter&.join(5)
+      unless rsc_node_renderer_waiter&.join(5)
+        warn "Node renderer process group #{pid} did not stop after SIGKILL; " \
+             "it may still occupy the renderer port for the next CI retry."
+      end
     end
   rescue Errno::ESRCH
     # Already stopped.
@@ -313,13 +318,16 @@ RSpec.configure do |config|
 end
 ```
 
-Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized. A reset during the pre-spawn probe usually means another service is already using the port and closing connections immediately. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps.
 
-The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed
-examples run. Load `support/rsc_node_renderer` after registering `configure_rspec_to_compile_assets` so modern RSpec can
-trigger compilation with `when_first_matching_example_defined` before suite hooks start the renderer. Older RSpec falls back
-to `before(:example, metatag)`, so compile assets in your CI job before running the spec process if your launcher validates
-bundles at boot or your suite starts renderer-backed requests outside examples tagged for compilation.
+**Caveats:**
+
+- The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized.
+- A reset during the pre-spawn probe usually means another service is already using the port and closing connections immediately.
+- The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately. If you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout.
+- The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout.
+- If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+- The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed examples run. Load `support/rsc_node_renderer` after registering `configure_rspec_to_compile_assets` so modern RSpec can trigger compilation with `when_first_matching_example_defined` before suite hooks start the renderer. Older RSpec falls back to `before(:example, metatag)`, so compile assets in your CI job before running the spec process if your launcher validates bundles at boot or your suite starts renderer-backed requests outside examples tagged for compilation.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -145,6 +145,7 @@ module RscNodeRenderer
 
       if pid
         begin
+          # This process was spawned above, so EPERM is not expected here; ESRCH means it exited early.
           Process.kill(0, pid)
         rescue Errno::ESRCH
           hint = log_path ? " Check #{log_path} for startup errors." : ""
@@ -181,7 +182,7 @@ RSpec.configure do |config|
     end
     expanded_cache_path = File.expand_path(cache_path)
     FileUtils.mkdir_p(Rails.root.join("tmp"))
-    tmp_root = File.expand_path(Rails.root.join("tmp").to_s)
+    tmp_root = Rails.root.join("tmp").to_s
     unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH must be inside Rails.root/tmp " \
             "(got: #{expanded_cache_path})"
@@ -231,6 +232,7 @@ RSpec.configure do |config|
     Process.kill("-TERM", pid)
     # Thread#join returns the waiter thread when the process exits, and nil on timeout.
     # Skip SIGKILL only when TERM worked and the waiter reaped the process.
+    # Ruby still runs the block-level ensure below when next exits the hook early.
     next if rsc_node_renderer_waiter&.join(5)
 
     Process.kill("-KILL", pid)
@@ -247,7 +249,7 @@ RSpec.configure do |config|
 end
 ```
 
-Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The explicit `ensure_assets_compiled` call above is intentional: the renderer needs bundles before it boots. Step 2 still wires compilation to `:rsc` examples for suites that do not start the renderer.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -167,8 +167,12 @@ module RscNodeRenderer
 
       if pid
         begin
-          # This checks the spawned command process. For `pnpm run <script>`, pnpm usually stays resident while the
-          # renderer is alive; if your launcher daemonizes Node, replace this with an app-specific health check.
+          # Heuristic early-exit check: if the launcher process has already died, raise now rather than
+          # waiting for the deadline. For `pnpm run <script>`, pnpm typically stays resident while Node
+          # is alive, but process managers that exec directly into Node (or daemonize) will exit here even
+          # though the renderer is still starting, surfacing a misleading ESRCH. The TCP probe above is
+          # the authoritative readiness signal; this check is only a fast-fail shortcut for the common
+          # pnpm/npm/yarn case. Replace it with an app-specific health check if your launcher daemonizes.
           Process.kill(0, pid)
         rescue Errno::ESRCH
           hint = log_path ? " Check #{log_path} for startup errors." : ""
@@ -212,7 +216,9 @@ RSpec.configure do |config|
     tmp_root = Rails.root.join("tmp").to_s
     unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH must be inside Rails.root/tmp " \
-            "(got: #{expanded_cache_path})"
+            "(got: #{expanded_cache_path}). " \
+            "This path is deleted and recreated on every test run, so only paths " \
+            "inside Rails.root/tmp are permitted to prevent accidental data loss."
     end
     FileUtils.rm_rf(expanded_cache_path)
     FileUtils.mkdir_p(expanded_cache_path)
@@ -239,8 +245,12 @@ RSpec.configure do |config|
       raise "RENDERER_PORT #{renderer_env['RENDERER_PORT']} is already in use. " \
             "A previous test run may have left an orphaned node renderer. " \
             "Kill it manually or restart the CI job."
-    rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      # Port is free; safe to spawn.
+    rescue Errno::ECONNREFUSED
+      # Port refused immediately — nothing is listening; safe to spawn.
+    rescue Errno::ETIMEDOUT
+      # SYN was silently dropped (firewall/throttle); assume nothing is listening and proceed.
+      # Less certain than ECONNREFUSED on loopback, but treating it as fatal would block tests
+      # whenever a stray DROP rule is present.
     rescue Errno::ECONNRESET
       raise "RENDERER_PORT #{renderer_env['RENDERER_PORT']} accepted and reset a connection. " \
             "Another service may already be using it."
@@ -331,8 +341,9 @@ Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test
 - The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized.
 - A reset during the pre-spawn probe usually means another service is already using the port and closing connections immediately.
 - The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately. If you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout.
-- The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout.
+- The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to `connect_timeout + sleep` per iteration (roughly 1.1 s with the defaults above).
 - If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+- `pgroup: true` and the negative-PID `Process.kill("-TERM", pid)` / `Process.kill("-KILL", pid)` calls are POSIX-only. On Windows they raise `NotImplementedError`, so adapt the spawn options and shutdown calls (for example, kill only the spawned PID and rely on the renderer to clean up its child) if you need to run this guide on a native Windows host. CI on Linux/macOS and WSL is unaffected.
 - The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed examples run. Load `support/rsc_node_renderer` after registering `configure_rspec_to_compile_assets` so modern RSpec can trigger compilation with `when_first_matching_example_defined` before suite hooks start the renderer. Older RSpec falls back to `before(:example, metatag)`, so compile assets in your CI job before running the spec process if your launcher validates bundles at boot or your suite starts renderer-backed requests outside examples tagged for compilation.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -93,7 +93,6 @@ The Quick Start command only sets `RAILS_ENV` for the minimal browser-bundle cas
 ```ruby
 # spec/rails_helper.rb
 require "react_on_rails/test_helper"
-require_relative "support/rsc_node_renderer"
 
 RSpec.configure do |config|
   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(
@@ -108,6 +107,8 @@ RSpec.configure do |config|
     metadata[:rsc] = true
   end
 end
+
+require_relative "support/rsc_node_renderer"
 ```
 
 Passing any metatags replaces the TestHelper defaults, so include the default `:js`, `:server_rendering`, and `:controller` tags alongside `:rsc` if your suite mixes RSC and non-RSC specs.
@@ -222,13 +223,25 @@ RSpec.configure do |config|
     rsc_node_renderer_waiter = Process.detach(rsc_node_renderer_pid)
 
     renderer_timeout = Integer(ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30"))
-    RscNodeRenderer.wait_until_ready!(
-      host: "127.0.0.1",
-      port: Integer(renderer_env["RENDERER_PORT"]),
-      timeout_seconds: renderer_timeout,
-      log_path: renderer_log_path,
-      pid: rsc_node_renderer_pid
-    )
+    begin
+      RscNodeRenderer.wait_until_ready!(
+        host: "127.0.0.1",
+        port: Integer(renderer_env["RENDERER_PORT"]),
+        timeout_seconds: renderer_timeout,
+        log_path: renderer_log_path,
+        pid: rsc_node_renderer_pid
+      )
+    rescue StandardError
+      begin
+        Process.kill("-TERM", rsc_node_renderer_pid)
+      rescue Errno::ESRCH
+        # Already stopped.
+      end
+      rsc_node_renderer_waiter&.join(2)
+      rsc_node_renderer_pid = nil
+      rsc_node_renderer_waiter = nil
+      raise
+    end
   end
 
   config.after(:suite) do
@@ -256,14 +269,13 @@ RSpec.configure do |config|
 end
 ```
 
-Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed
-examples run. On RSpec 3.5 and newer, `configure_rspec_to_compile_assets` uses
-`when_first_matching_example_defined`, so compilation is triggered as soon as RSpec defines a matching example; older RSpec
-falls back to `before(:example, metatag)`. The renderer may already be running, but it does not need to serve an RSC request
-until a matching example executes. If your launcher validates bundles at boot, or your suite starts renderer-backed requests
-outside examples tagged for compilation, compile assets in your CI job before running the spec process.
+examples run. Load `support/rsc_node_renderer` after registering `configure_rspec_to_compile_assets` so modern RSpec can
+trigger compilation with `when_first_matching_example_defined` before suite hooks start the renderer. Older RSpec falls back
+to `before(:example, metatag)`, so compile assets in your CI job before running the spec process if your launcher validates
+bundles at boot or your suite starts renderer-backed requests outside examples tagged for compilation.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -73,7 +73,7 @@ ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, update `spec/support/rsc_test_worker.rb` to normalize that tool's worker ID to a stable, path-safe `RscTestWorker::ID` so every worker gets a unique port, cache path, and renderer log.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. That unused 3901 port is expected; keeping the normalized worker ID stable matters more than filling every port number. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, update `spec/support/rsc_test_worker.rb` to normalize that tool's worker ID to a stable, path-safe `RscTestWorker::ID` so every worker gets a unique port, cache path, and renderer log.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -133,10 +133,16 @@ module RscNodeRenderer
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
-      Socket.tcp(host, port, connect_timeout: 1).close
-      break
-    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT,
-           Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError
+      begin
+        Socket.tcp(host, port, connect_timeout: 1).close
+        break
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
+        # The renderer is still booting or has not bound the port yet; keep retrying until the deadline.
+      rescue Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError => e
+        raise "Cannot reach node renderer at #{host}:#{port}. " \
+              "Check the host configuration (#{e.class}: #{e.message})."
+      end
+
       if pid
         begin
           Process.kill(0, pid)
@@ -156,8 +162,10 @@ module RscNodeRenderer
   end
 end
 
-rsc_node_renderer_pid = nil # Closure shared by before(:suite) and after(:suite).
-rsc_node_renderer_waiter = nil # Process.detach thread for reaping abnormal exits.
+# Intentional suite-level closure state shared by before(:suite) and after(:suite).
+# This avoids relying on RSpec hook instance variables while keeping mutation local to this support file.
+rsc_node_renderer_pid = nil
+rsc_node_renderer_waiter = nil
 
 RSpec.configure do |config|
   config.before(:suite) do
@@ -221,8 +229,8 @@ RSpec.configure do |config|
 
     # Signal the process group so pnpm and the Node child both stop.
     Process.kill("-TERM", pid)
-    # join returns the Thread when TERM reaped the process; nil means the process is still alive.
-    # Skip KILL only when TERM already reaped the process.
+    # Thread#join returns the waiter thread when the process exits, and nil on timeout.
+    # Skip SIGKILL only when TERM worked and the waiter reaped the process.
     next if rsc_node_renderer_waiter&.join(5)
 
     Process.kill("-KILL", pid)

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -123,7 +123,7 @@ module RscNodeRenderer
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
-      TCPSocket.open(host, port) {}
+      TCPSocket.new(host, port).close
       break
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
       if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
@@ -171,7 +171,9 @@ RSpec.configure do |config|
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
     }
 
-    renderer_log_path = Rails.root.join("log/node-renderer-test.log").to_s
+    test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
+    test_worker = "0" if test_worker.empty?
+    renderer_log_path = Rails.root.join("log/node-renderer-test-#{test_worker}.log").to_s
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
       "pnpm", # replace with "npm", "yarn", or "bun" if that is your package manager

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -66,7 +66,7 @@ ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on, so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -123,7 +123,7 @@ module RscNodeRenderer
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
-      TCPSocket.new(host, port).close
+      Socket.tcp(host, port, connect_timeout: 1).close
       break
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
       if pid
@@ -190,7 +190,8 @@ RSpec.configure do |config|
       "node-renderer",
       chdir: Rails.root.to_s,
       out: renderer_log_path,
-      err: [:child, :out]
+      err: [:child, :out],
+      pgroup: true # place pnpm and its child Node process in a new process group
     )
     rsc_node_renderer_waiter = Process.detach(rsc_node_renderer_pid)
 
@@ -208,10 +209,11 @@ RSpec.configure do |config|
     pid = rsc_node_renderer_pid
     next unless pid
 
-    Process.kill("TERM", pid)
+    # Signal the process group so pnpm and the Node child both stop.
+    Process.kill("-TERM", pid)
     next if rsc_node_renderer_waiter&.join(5)
 
-    Process.kill("KILL", pid)
+    Process.kill("-KILL", pid)
     rsc_node_renderer_waiter&.join(5)
   rescue Errno::ESRCH
     # Already stopped.

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -150,6 +150,9 @@ module RscNodeRenderer
         rescue Errno::ESRCH
           hint = log_path ? " Check #{log_path} for startup errors." : ""
           raise "Node renderer process (pid #{pid}) exited before binding to #{host}:#{port}.#{hint}"
+        rescue Errno::EPERM
+          hint = log_path ? " Check #{log_path} for startup errors." : ""
+          raise "Cannot inspect node renderer process (pid #{pid}) while waiting for #{host}:#{port}.#{hint}"
         end
       end
 
@@ -171,9 +174,6 @@ rsc_node_renderer_waiter = nil
 RSpec.configure do |config|
   config.before(:suite) do
     next unless ENV["RSC_NODE_RENDERER_TESTS"] == "1"
-
-    # Compile before spawning the renderer; tagged examples would compile too late.
-    ReactOnRails::TestHelper.ensure_assets_compiled
 
     cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH") do
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is not set. " \

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -173,7 +173,7 @@ RSpec.configure do |config|
     end
     expanded_cache_path = File.expand_path(cache_path)
     FileUtils.mkdir_p(Rails.root.join("tmp"))
-    tmp_root = File.realpath(Rails.root.join("tmp").to_s)
+    tmp_root = File.expand_path(Rails.root.join("tmp").to_s)
     unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH must be inside Rails.root/tmp " \
             "(got: #{expanded_cache_path})"
@@ -221,7 +221,8 @@ RSpec.configure do |config|
 
     # Signal the process group so pnpm and the Node child both stop.
     Process.kill("-TERM", pid)
-    # Thread#join(timeout) returns nil on timeout; skip KILL if TERM already reaped the process.
+    # join returns the Thread when TERM reaped the process; nil means the process is still alive.
+    # Skip KILL only when TERM already reaped the process.
     next if rsc_node_renderer_waiter&.join(5)
 
     Process.kill("-KILL", pid)

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -136,7 +136,7 @@ module RscNodeRenderer
       begin
         Socket.tcp(host, port, connect_timeout: 1).close
         break
-      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ECONNABORTED
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
         # The renderer is still booting or has not bound the port yet; keep retrying until the deadline.
       rescue Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError => e
         raise "Cannot reach node renderer at #{host}:#{port}. " \
@@ -183,7 +183,7 @@ RSpec.configure do |config|
     end
     raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is empty." if cache_path.strip.empty?
 
-    expanded_cache_path = File.expand_path(cache_path)
+    expanded_cache_path = File.expand_path(cache_path, Rails.root.to_s)
     FileUtils.mkdir_p(Rails.root.join("tmp"))
     tmp_root = Rails.root.join("tmp").to_s
     unless expanded_cache_path.start_with?("#{tmp_root}#{File::SEPARATOR}")
@@ -220,7 +220,7 @@ RSpec.configure do |config|
     renderer_timeout = Integer(ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30"))
     RscNodeRenderer.wait_until_ready!(
       host: "127.0.0.1",
-      port: renderer_env["RENDERER_PORT"].to_i,
+      port: Integer(renderer_env["RENDERER_PORT"]),
       timeout_seconds: renderer_timeout,
       log_path: renderer_log_path,
       pid: rsc_node_renderer_pid

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -259,10 +259,11 @@ end
 Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately; if you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout. The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to the one-second connect timeout. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The helper relies on the Step 2 `configure_rspec_to_compile_assets` setup so bundles are available before renderer-backed
-examples run. The renderer starts in `before(:suite)`, and compilation runs in a second `before(:suite)` registered by
-`configure_rspec_to_compile_assets`; RSpec runs both hooks before any example executes, so the renderer has no bundles to
-serve until compilation has completed. If your suite starts the renderer before any `:rsc` example can trigger that hook,
-compile assets in your CI job before running the spec process.
+examples run. On RSpec 3.5 and newer, `configure_rspec_to_compile_assets` uses
+`when_first_matching_example_defined`, so compilation is triggered as soon as RSpec defines a matching example; older RSpec
+falls back to `before(:example, metatag)`. The renderer may already be running, but it does not need to serve an RSC request
+until a matching example executes. If your launcher validates bundles at boot, or your suite starts renderer-backed requests
+outside examples tagged for compilation, compile assets in your CI job before running the spec process.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -47,28 +47,36 @@ This recipe uses the React on Rails TestHelper with `build_test_command`: Rails 
 
 ### 1. Set Renderer ENV Before Rails Boots
 
-The Pro initializer reads renderer settings while Rails boots. Set test renderer ENV values before requiring `config/environment` in `spec/rails_helper.rb`. Generated Pro apps read `REACT_RENDERER_URL`; some older or custom initializers read `RENDERER_URL`, so the example sets both names.
+The Pro initializer reads renderer settings while Rails boots. Set test renderer ENV values before requiring `config/environment` in `spec/rails_helper.rb`. Generated Pro apps read `REACT_RENDERER_URL`; some older or custom initializers read `RENDERER_URL`, so the example sets both names. Keep the worker ID normalization in a small support file so the Rails boot preamble and renderer lifecycle code cannot drift apart.
+
+```ruby
+# spec/support/rsc_test_worker.rb
+module RscTestWorker
+  TEST_ENV_NUMBER = ENV.fetch("TEST_ENV_NUMBER", "0")
+  NORMALIZED_ENV_NUMBER = TEST_ENV_NUMBER.empty? ? "0" : TEST_ENV_NUMBER
+  ID = begin
+    worker_id = NORMALIZED_ENV_NUMBER.gsub(/[^0-9]/, "")
+    worker_id.empty? ? "0" : worker_id
+  end
+end
+```
 
 ```ruby
 # spec/rails_helper.rb
 ENV["RAILS_ENV"] ||= "test"
+require_relative "support/rsc_test_worker"
 
-test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
-test_worker = "0" if test_worker.empty?
-test_worker_id = test_worker.gsub(/[^0-9]/, "")
-test_worker_id = "0" if test_worker_id.empty?
-
-ENV["RENDERER_PORT"] ||= (3900 + test_worker_id.to_i).to_s
+ENV["RENDERER_PORT"] ||= (3900 + RscTestWorker::ID.to_i).to_s
 renderer_url = "http://127.0.0.1:#{ENV["RENDERER_PORT"]}"
 ENV["REACT_RENDERER_URL"] ||= renderer_url # used by config.renderer_url = ENV["REACT_RENDERER_URL"]
 ENV["RENDERER_URL"] ||= renderer_url       # used by some older/custom initializers
 ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
-  File.expand_path("../tmp/node-renderer-bundles-test-#{test_worker_id}", __dir__)
+  File.expand_path("../tmp/node-renderer-bundles-test-#{RscTestWorker::ID}", __dir__)
 
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID and normalize it to a stable, path-safe `test_worker_id` so every worker gets a unique port and cache path.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, update `spec/support/rsc_test_worker.rb` to normalize that tool's worker ID to a stable, path-safe `RscTestWorker::ID` so every worker gets a unique port, cache path, and renderer log.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -119,6 +127,7 @@ Start the renderer in `before(:suite)` after assets are compiled and stop it in 
 # spec/support/rsc_node_renderer.rb
 require "fileutils"
 require "socket"
+require_relative "rsc_test_worker"
 
 module RscNodeRenderer
   module_function
@@ -130,7 +139,7 @@ module RscNodeRenderer
       Socket.tcp(host, port, connect_timeout: 1).close
       break
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT,
-           Errno::EHOSTUNREACH, SocketError
+           Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError
       if pid
         begin
           Process.kill(0, pid)
@@ -185,14 +194,7 @@ RSpec.configure do |config|
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
     }
 
-    # These lines mirror the Step 1 preamble. This support file is required as a
-    # standalone file, so it cannot share locals with rails_helper.rb and must re-derive
-    # test_worker_id itself.
-    test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
-    test_worker = "0" if test_worker.empty?
-    test_worker_id = test_worker.gsub(/[^0-9]/, "")
-    test_worker_id = "0" if test_worker_id.empty?
-    renderer_log_path = Rails.root.join("log/node-renderer-test-#{test_worker_id}.log").to_s
+    renderer_log_path = Rails.root.join("log/node-renderer-test-#{RscTestWorker::ID}.log").to_s
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
       "pnpm", # replace with "npm", "yarn", or "bun" if that is your package manager
@@ -277,7 +279,7 @@ RSpec.describe "RSC payload endpoint", :rsc, type: :request do
 
     chunks = response.body.lines.map(&:chomp).reject(&:empty?).map { |line| JSON.parse(line) }
     # "html" is emitted by the default React on Rails RSC renderer; verify custom renderer output explicitly.
-    expect(chunks.any? { |chunk| chunk.key?("html") }).to be(true)
+    expect(chunks).to include(include("html" => anything))
   end
 end
 ```

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -125,7 +125,7 @@ module RscNodeRenderer
     loop do
       Socket.tcp(host, port, connect_timeout: 1).close
       break
-    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, SocketError
       if pid
         begin
           Process.kill(0, pid)
@@ -157,7 +157,7 @@ RSpec.configure do |config|
 
     cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH") do
       raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is not set. " \
-            "Set it before requiring config/environment so every parallel worker " \
+            "Follow Step 1 of this guide to set it before Rails boots so every parallel worker " \
             "gets a unique renderer bundle cache directory."
     end
     expanded_cache_path = File.expand_path(cache_path)
@@ -174,7 +174,7 @@ RSpec.configure do |config|
       "RAILS_ENV" => "test",
       "RENDERER_PORT" => ENV.fetch("RENDERER_PORT") do
         raise "RENDERER_PORT is not set. " \
-              "Set it before requiring config/environment so every parallel worker " \
+              "Follow Step 1 of this guide to set it before Rails boots so every parallel worker " \
               "gets a unique renderer port."
       end,
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => expanded_cache_path
@@ -211,6 +211,7 @@ RSpec.configure do |config|
 
     # Signal the process group so pnpm and the Node child both stop.
     Process.kill("-TERM", pid)
+    # Thread#join(timeout) returns nil on timeout; skip KILL if TERM already reaped the process.
     next if rsc_node_renderer_waiter&.join(5)
 
     Process.kill("-KILL", pid)
@@ -260,6 +261,7 @@ RSpec.describe "RSC payload endpoint", :rsc, type: :request do
     expect(response.media_type).to eq("application/x-ndjson")
 
     chunks = response.body.lines.map(&:chomp).reject(&:empty?).map { |line| JSON.parse(line) }
+    # "html" is emitted by the default React on Rails RSC renderer; verify custom renderer output explicitly.
     expect(chunks.any? { |chunk| chunk.key?("html") }).to be(true)
   end
 end

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -136,7 +136,7 @@ module RscNodeRenderer
       begin
         Socket.tcp(host, port, connect_timeout: 1).close
         break
-      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, Errno::ECONNABORTED
         # The renderer is still booting or has not bound the port yet; keep retrying until the deadline.
       rescue Errno::EADDRNOTAVAIL, Errno::EHOSTUNREACH, SocketError => e
         raise "Cannot reach node renderer at #{host}:#{port}. " \
@@ -180,6 +180,8 @@ RSpec.configure do |config|
             "Follow Step 1 of this guide to set it before Rails boots so every parallel worker " \
             "gets a unique renderer bundle cache directory."
     end
+    raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is empty." if cache_path.strip.empty?
+
     expanded_cache_path = File.expand_path(cache_path)
     FileUtils.mkdir_p(Rails.root.join("tmp"))
     tmp_root = Rails.root.join("tmp").to_s
@@ -214,7 +216,7 @@ RSpec.configure do |config|
     )
     rsc_node_renderer_waiter = Process.detach(rsc_node_renderer_pid)
 
-    renderer_timeout = ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30").to_i
+    renderer_timeout = Integer(ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30"))
     RscNodeRenderer.wait_until_ready!(
       host: "127.0.0.1",
       port: renderer_env["RENDERER_PORT"].to_i,

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -37,7 +37,7 @@ class ActiveSupport::TestCase
 end
 ```
 
-## RSC And Node Renderer System Tests
+## RSC and Node Renderer System Tests
 
 React Server Components add one more moving part to the standard test setup: system tests need compiled client, server, and RSC bundles, and the Rails test process must be able to reach a node-renderer process that uses the test bundle cache.
 
@@ -66,7 +66,7 @@ ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on, so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on, so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -119,13 +119,22 @@ require "socket"
 module RscNodeRenderer
   module_function
 
-  def wait_until_ready!(host:, port:, timeout_seconds: 30, log_path: nil)
+  def wait_until_ready!(host:, port:, timeout_seconds: 30, log_path: nil, pid: nil)
     deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
     loop do
       TCPSocket.new(host, port).close
       break
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT
+      if pid
+        begin
+          Process.kill(0, pid)
+        rescue Errno::ESRCH
+          hint = log_path ? " Check #{log_path} for startup errors." : ""
+          raise "Node renderer process (pid #{pid}) exited before binding to #{host}:#{port}.#{hint}"
+        end
+      end
+
       if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         hint = log_path ? " Check #{log_path} for startup errors." : ""
         raise "Node renderer did not boot on #{host}:#{port} within #{timeout_seconds}s.#{hint}"
@@ -190,7 +199,8 @@ RSpec.configure do |config|
       host: "127.0.0.1",
       port: ENV.fetch("RENDERER_PORT").to_i,
       timeout_seconds: renderer_timeout,
-      log_path: renderer_log_path
+      log_path: renderer_log_path,
+      pid: rsc_node_renderer_pid
     )
   end
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -55,18 +55,20 @@ ENV["RAILS_ENV"] ||= "test"
 
 test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
 test_worker = "0" if test_worker.empty?
+test_worker_id = test_worker.gsub(/[^0-9]/, "")
+test_worker_id = "0" if test_worker_id.empty?
 
-ENV["RENDERER_PORT"] ||= (3900 + test_worker.to_i).to_s
-renderer_url = "http://127.0.0.1:#{ENV.fetch('RENDERER_PORT')}"
+ENV["RENDERER_PORT"] ||= (3900 + test_worker_id.to_i).to_s
+renderer_url = "http://127.0.0.1:#{ENV["RENDERER_PORT"]}"
 ENV["REACT_RENDERER_URL"] ||= renderer_url # used by config.renderer_url = ENV["REACT_RENDERER_URL"]
 ENV["RENDERER_URL"] ||= renderer_url       # used by some older/custom initializers
 ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
-  File.expand_path("../tmp/node-renderer-bundles-test-#{test_worker}", __dir__)
+  File.expand_path("../tmp/node-renderer-bundles-test-#{test_worker_id}", __dir__)
 
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID so every worker gets a unique port and cache path.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, replace `test_worker` with that tool's worker ID and normalize it to a stable, path-safe `test_worker_id` so every worker gets a unique port and cache path.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -105,11 +107,13 @@ end
 
 Passing any metatags replaces the TestHelper defaults, so include the default `:js`, `:server_rendering`, and `:controller` tags alongside `:rsc` if your suite mixes RSC and non-RSC specs.
 
+The derived metadata block intentionally tags every system and feature spec so the first browser request cannot race ahead of RSC bundle compilation. If only some directories exercise RSC, narrow the regex (for example, `spec/(system/rsc|features/rsc)`) or tag those examples manually to avoid compiling for unrelated system tests.
+
 Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. If your suite uses a different tag scheme, pass the complete list of tags that should trigger compilation. The important part is that the build runs before the first request that can upload bundles to the node renderer.
 
 ### 3. Start One Test Renderer Per Worker
 
-Start the renderer in `before(:suite)` after assets are compiled and stop it in `after(:suite)`. The example below assumes your app has a `node-renderer` package script; replace the package-manager command with the one your project uses.
+Start the renderer in `before(:suite)` after assets are compiled and stop it in `after(:suite)`. The example below assumes your app has a `node-renderer` package script that launches the node-renderer server, reads `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH` from ENV, and serves the RSC test bundle cache. See [Node Renderer JavaScript Configuration](node-renderer/js-configuration.md#example-launch-files) for launch-file and `package.json` script examples. Replace the package-manager command with the one your project uses.
 
 ```ruby
 # spec/support/rsc_node_renderer.rb
@@ -182,7 +186,9 @@ RSpec.configure do |config|
 
     test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
     test_worker = "0" if test_worker.empty?
-    renderer_log_path = Rails.root.join("log/node-renderer-test-#{test_worker}.log").to_s
+    test_worker_id = test_worker.gsub(/[^0-9]/, "")
+    test_worker_id = "0" if test_worker_id.empty?
+    renderer_log_path = Rails.root.join("log/node-renderer-test-#{test_worker_id}.log").to_s
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
       "pnpm", # replace with "npm", "yarn", or "bun" if that is your package manager
@@ -255,6 +261,8 @@ Request specs are still useful for the payload endpoint:
 ```ruby
 RSpec.describe "RSC payload endpoint", :rsc, type: :request do
   it "returns an RSC payload stream" do
+    # Replace this path if your app customizes config.rsc_payload_generation_url_path
+    # or rsc_payload_route.
     get "/rsc_payload/StoryPage", params: { props: { slug: "ruby-rails-react" }.to_json }
 
     expect(response).to have_http_status(:ok)

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -43,9 +43,11 @@ React Server Components add one more moving part to the standard test setup: sys
 
 Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
 
+This recipe builds on the TestHelper and `build_test_command` approach described in [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation). The full lifecycle example is RSpec-focused because it uses `before(:suite)` and `after(:suite)` hooks; Minitest suites can reuse the ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled` call, but must start and stop the renderer from their own suite-level harness.
+
 ### 1. Set Renderer ENV Before Rails Boots
 
-The Pro initializer reads renderer settings while Rails boots. Set test renderer ENV values before requiring `config/environment` in `spec/rails_helper.rb`.
+The Pro initializer reads renderer settings while Rails boots. Set test renderer ENV values before requiring `config/environment` in `spec/rails_helper.rb`. Generated Pro apps read `REACT_RENDERER_URL`; some older or custom initializers read `RENDERER_URL`, so the example sets both names.
 
 ```ruby
 # spec/rails_helper.rb
@@ -79,9 +81,12 @@ ReactOnRails.configure do |config|
 end
 ```
 
+The Quick Start command only sets `RAILS_ENV` for the minimal browser-bundle case. The RSC recipe also sets `NODE_ENV=test` so JavaScript build scripts, webpack/shakapacker config, and the node-renderer all see the test environment consistently. If your app's build does not branch on `NODE_ENV`, the simpler Quick Start command is still enough for non-RSC tests.
+
 ```ruby
 # spec/rails_helper.rb
 require "react_on_rails/test_helper"
+require_relative "support/rsc_node_renderer"
 
 RSpec.configure do |config|
   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config, :rsc)
@@ -92,11 +97,13 @@ RSpec.configure do |config|
 end
 ```
 
+The optional `:rsc` argument is a TestHelper metatag filter. It tells `configure_rspec_to_compile_assets` to compile before `:rsc` examples instead of every example.
+
 Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. You can keep the default `:js`, `:server_rendering`, and `:controller` tags instead if that already matches your suite. The important part is that the build runs before the first request that can upload bundles to the node renderer.
 
 ### 3. Start One Test Renderer Per Worker
 
-Start the renderer in `before(:suite)` after assets are compiled and stop it in `after(:suite)`. The example below assumes your app has a `node-renderer` package script.
+Start the renderer in `before(:suite)` after assets are compiled and stop it in `after(:suite)`. The example below assumes your app has a `node-renderer` package script; replace the package-manager command with the one your project uses.
 
 ```ruby
 # spec/support/rsc_node_renderer.rb
@@ -121,16 +128,19 @@ module RscNodeRenderer
   end
 end
 
-rsc_node_renderer_pid = nil
+rsc_node_renderer_pid = nil # Closure shared by before(:suite) and after(:suite).
 
 RSpec.configure do |config|
   config.before(:suite) do
     next unless ENV["RSC_NODE_RENDERER_TESTS"] == "1"
 
+    # Compile before spawning the renderer; tagged examples would compile too late.
     ReactOnRails::TestHelper.ensure_assets_compiled
 
     cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH") do
-      raise "Set RENDERER_SERVER_BUNDLE_CACHE_PATH before requiring config/environment."
+      raise "RENDERER_SERVER_BUNDLE_CACHE_PATH is not set. " \
+            "Set it before requiring config/environment so every parallel worker " \
+            "gets a unique renderer bundle cache directory."
     end
     FileUtils.rm_rf(cache_path)
     FileUtils.mkdir_p(cache_path)
@@ -139,7 +149,9 @@ RSpec.configure do |config|
       "NODE_ENV" => "test",
       "RAILS_ENV" => "test",
       "RENDERER_PORT" => ENV.fetch("RENDERER_PORT") do
-        raise "Set RENDERER_PORT before requiring config/environment."
+        raise "RENDERER_PORT is not set. " \
+              "Set it before requiring config/environment so every parallel worker " \
+              "gets a unique renderer port."
       end,
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => cache_path
     }
@@ -154,20 +166,26 @@ RSpec.configure do |config|
       err: [:child, :out]
     )
 
-    RscNodeRenderer.wait_until_ready!(host: "127.0.0.1", port: ENV.fetch("RENDERER_PORT").to_i)
+    renderer_timeout = ENV.fetch("RSC_NODE_RENDERER_BOOT_TIMEOUT", "30").to_i
+    RscNodeRenderer.wait_until_ready!(
+      host: "127.0.0.1",
+      port: ENV.fetch("RENDERER_PORT").to_i,
+      timeout_seconds: renderer_timeout
+    )
   end
 
   config.after(:suite) do
-    next unless rsc_node_renderer_pid
+    pid = rsc_node_renderer_pid
+    next unless pid
 
-    Process.kill("TERM", rsc_node_renderer_pid)
-    Timeout.timeout(5) { Process.wait(rsc_node_renderer_pid) }
+    Process.kill("TERM", pid)
+    Timeout.timeout(5) { Process.wait(pid) }
   rescue Errno::ESRCH, Errno::ECHILD
     # Already stopped.
   rescue Timeout::Error
     begin
-      Process.kill("KILL", rsc_node_renderer_pid)
-      Process.wait(rsc_node_renderer_pid)
+      Process.kill("KILL", pid)
+      Process.wait(pid)
     rescue Errno::ESRCH, Errno::ECHILD
       # Already stopped.
     end
@@ -177,7 +195,7 @@ RSpec.configure do |config|
 end
 ```
 
-Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`.
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps. If CI hard-kills the Ruby process before `after(:suite)` runs, clear any orphaned renderer processes or occupied renderer ports before retrying the job.
 
 The explicit `ensure_assets_compiled` call above is intentional: the renderer needs bundles before it boots. Step 2 still wires compilation to `:rsc` examples for suites that do not start the renderer.
 
@@ -212,7 +230,7 @@ RSpec.describe "RSC payload endpoint", :rsc, type: :request do
     expect(response).to have_http_status(:ok)
     expect(response.media_type).to eq("application/x-ndjson")
 
-    chunks = response.body.lines.map { |line| JSON.parse(line) }
+    chunks = response.body.lines.map(&:chomp).reject(&:empty?).map { |line| JSON.parse(line) }
     expect(chunks.any? { |chunk| chunk.key?("html") }).to be(true)
   end
 end

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -113,8 +113,7 @@ module RscNodeRenderer
     loop do
       TCPSocket.open(host, port).close
       break
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
-           Errno::ECONNRESET, Errno::ENETUNREACH
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
       raise "Node renderer did not boot on #{host}:#{port}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
       sleep 0.1
@@ -131,7 +130,7 @@ RSpec.configure do |config|
     ReactOnRails::TestHelper.ensure_assets_compiled
 
     cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH") do
-      raise "Set RENDERER_SERVER_BUNDLE_CACHE_PATH before starting the test renderer (see Step 1)."
+      raise "Set RENDERER_SERVER_BUNDLE_CACHE_PATH before requiring config/environment."
     end
     FileUtils.rm_rf(cache_path)
     FileUtils.mkdir_p(cache_path)
@@ -140,14 +139,14 @@ RSpec.configure do |config|
       "NODE_ENV" => "test",
       "RAILS_ENV" => "test",
       "RENDERER_PORT" => ENV.fetch("RENDERER_PORT") do
-        raise "Set RENDERER_PORT before starting the test renderer (see Step 1)."
+        raise "Set RENDERER_PORT before requiring config/environment."
       end,
       "RENDERER_SERVER_BUNDLE_CACHE_PATH" => cache_path
     }
 
     rsc_node_renderer_pid = Process.spawn(
       renderer_env,
-      "pnpm",
+      "pnpm", # replace with "npm" or "yarn" if that is your package manager
       "run",
       "node-renderer",
       chdir: Rails.root.to_s,
@@ -177,6 +176,10 @@ RSpec.configure do |config|
   end
 end
 ```
+
+Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`.
+
+The explicit `ensure_assets_compiled` call above is intentional: the renderer needs bundles before it boots. Step 2 still wires compilation to `:rsc` examples for suites that do not start the renderer.
 
 In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
 

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -37,6 +37,183 @@ class ActiveSupport::TestCase
 end
 ```
 
+## RSC And Node Renderer System Tests
+
+React Server Components add one more moving part to the standard test setup: system tests need compiled client, server, and RSC bundles, and the Rails test process must be able to reach a node-renderer process that uses the test bundle cache.
+
+Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
+
+### 1. Set Renderer ENV Before Rails Boots
+
+The Pro initializer reads renderer settings while Rails boots. Set test renderer ENV values before requiring `config/environment` in `spec/rails_helper.rb`.
+
+```ruby
+# spec/rails_helper.rb
+ENV["RAILS_ENV"] ||= "test"
+
+test_worker = ENV.fetch("TEST_ENV_NUMBER", "0")
+test_worker = "0" if test_worker.empty?
+
+ENV["RENDERER_PORT"] ||= (3900 + test_worker.to_i).to_s
+ENV["RENDERER_URL"] ||= "http://127.0.0.1:#{ENV.fetch('RENDERER_PORT')}"
+ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
+  File.expand_path("../tmp/node-renderer-bundles-test-#{test_worker}", __dir__)
+
+require_relative "../config/environment"
+```
+
+If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
+
+### 2. Compile Test Bundles Up Front
+
+Configure the React on Rails test helper to compile assets before the first RSC example. Your `build_test_command` must build all bundles needed by the test environment, not only the browser bundle.
+
+```ruby
+# config/initializers/react_on_rails.rb
+ReactOnRails.configure do |config|
+  config.build_test_command = "NODE_ENV=test RAILS_ENV=test bin/shakapacker"
+end
+```
+
+```ruby
+# spec/rails_helper.rb
+require "react_on_rails/test_helper"
+
+RSpec.configure do |config|
+  ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config, :rsc)
+
+  config.define_derived_metadata(file_path: %r{spec/(system|features|requests)}) do |metadata|
+    metadata[:rsc] = true
+  end
+end
+```
+
+You can keep the default `:js`, `:server_rendering`, and `:controller` tags instead if that already matches your suite. The important part is that the build runs before the first request that can upload bundles to the node renderer.
+
+### 3. Start One Test Renderer Per Worker
+
+Start the renderer in `before(:suite)` after assets are compiled and stop it in `after(:suite)`. The example below assumes your app has a `node-renderer` package script.
+
+```ruby
+# spec/support/rsc_node_renderer.rb
+require "fileutils"
+require "socket"
+require "timeout"
+
+module RscNodeRenderer
+  module_function
+
+  def wait_until_ready!(host:, port:, timeout_seconds: 15)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+
+    loop do
+      TCPSocket.open(host, port) { return }
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      raise "Node renderer did not boot on #{host}:#{port}" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+      sleep 0.1
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    next unless ENV["RSC_NODE_RENDERER_TESTS"] == "1"
+
+    ReactOnRails::TestHelper.ensure_assets_compiled
+
+    cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH")
+    FileUtils.rm_rf(cache_path)
+    FileUtils.mkdir_p(cache_path)
+
+    renderer_env = {
+      "NODE_ENV" => "test",
+      "RAILS_ENV" => "test",
+      "RENDERER_PORT" => ENV.fetch("RENDERER_PORT"),
+      "RENDERER_SERVER_BUNDLE_CACHE_PATH" => cache_path
+    }
+
+    @rsc_node_renderer_pid = Process.spawn(
+      renderer_env,
+      "pnpm",
+      "run",
+      "node-renderer",
+      chdir: Rails.root.to_s,
+      out: Rails.root.join("log/node-renderer-test.log").to_s,
+      err: [:child, :out]
+    )
+
+    RscNodeRenderer.wait_until_ready!(host: "127.0.0.1", port: ENV.fetch("RENDERER_PORT").to_i)
+  end
+
+  config.after(:suite) do
+    next unless @rsc_node_renderer_pid
+
+    Process.kill("TERM", @rsc_node_renderer_pid)
+    Timeout.timeout(5) { Process.wait(@rsc_node_renderer_pid) }
+  rescue Errno::ESRCH, Errno::ECHILD
+    # Already stopped.
+  rescue Timeout::Error
+    Process.kill("KILL", @rsc_node_renderer_pid)
+  end
+end
+```
+
+In CI, set `RSC_NODE_RENDERER_TESTS=1` for jobs that need the renderer. For local development, leaving it unset lets you run non-RSC specs without starting another process.
+
+### 4. Write A Capybara RSC Smoke Test
+
+Keep the first system test boring: visit a route that streams one Server Component and assert on visible HTML plus one hydrated Client Component interaction.
+
+```ruby
+RSpec.describe "Story page", :rsc, :js, type: :system do
+  it "renders the streamed RSC page and hydrates client controls" do
+    visit story_path("ruby-rails-react")
+
+    expect(page).to have_css("h1", text: "Ruby, Rails, and React")
+    expect(page).to have_button("Save")
+
+    click_button "Save"
+    expect(page).to have_text("Saved")
+  end
+end
+```
+
+Request specs are still useful for the payload endpoint:
+
+```ruby
+RSpec.describe "RSC payload endpoint", :rsc, type: :request do
+  it "returns an RSC payload stream" do
+    get "/rsc_payload/StoryPage", params: { props: { slug: "ruby-rails-react" }.to_json }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("application/x-ndjson")
+    expect(response.body).to include("html")
+  end
+end
+```
+
+### 5. Stub External APIs At The Right Boundary
+
+Ruby stubbing tools such as WebMock and VCR only intercept requests from the Rails process. They do not intercept HTTP requests made by JavaScript running inside the separate node-renderer process.
+
+Prefer one of these patterns:
+
+- Fetch external data in Rails, stub it with WebMock/VCR, and pass deterministic props into the RSC tree.
+- Point Node-rendered code at a local fake API server started by the test harness.
+- Inject an API base URL through props or environment variables so tests never call the real service.
+
+Avoid letting system tests depend on live third-party APIs. RSC failures from external API drift usually look like renderer timeouts or missing payload chunks, which sends debugging in the wrong direction.
+
+### 6. Parallelization Checklist
+
+- Use one renderer port per worker.
+- Use one renderer bundle cache directory per worker.
+- Clear the renderer cache before starting the renderer.
+- Compile assets before the renderer accepts requests.
+- Do not share a mutable fake API server across workers unless it isolates state per worker.
+- If flakes remain, serialize the RSC system-test group first, then re-enable parallelism once port/cache isolation is proven.
+
 ## Two Approaches to Test Asset Compilation
 
 React on Rails supports two mutually exclusive approaches for compiling webpack assets during tests:

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -623,6 +623,8 @@ E2E Tests (Playwright)
 └── Full page flows -- navigation, forms, etc.
 ```
 
+For Rails system tests that exercise the node renderer, see [RSC and Node Renderer System Tests](../building-features/testing-configuration.md#rsc-and-node-renderer-system-tests). That guide covers test bundle compilation, renderer process startup/shutdown, bundle-cache isolation, parallel-worker caveats, and stubbing external APIs without bypassing the RSC path.
+
 ### Testing Mutations
 
 In React on Rails, mutations go through Rails controller endpoints rather than Server Actions. Test mutation logic in your Rails controller specs (RSpec request specs) and test the Client Component's form submission behavior with component tests:


### PR DESCRIPTION
## Summary
- add an RSC + node renderer system-test recipe to the testing configuration guide
- cover renderer env setup before Rails boot, upfront asset compilation, renderer lifecycle, cache isolation, and parallel workers
- link RSC troubleshooting readers to the testing setup guidance

Fixes #3181

## Test plan
- `pnpm exec prettier --check docs/oss/building-features/testing-configuration.md docs/oss/migrating/rsc-troubleshooting.md`
- `pnpm start format.listDifferent`
- pre-commit hook: trailing newlines, offline Markdown links, Prettier
- pre-push hook: branch-lint, online Markdown links

## Notes
- Full `bundle exec rubocop` is not a meaningful docs-only gate on current `origin/main`; it reports pre-existing Pro dummy/script offenses unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes; the main risk is readers adopting the new suggested test harness patterns incorrectly (ports/cache paths/renderer lifecycle).
> 
> **Overview**
> Adds a new **"RSC and Node Renderer System Tests"** section to `testing-configuration.md` describing how to run Capybara/system tests that hit RSC streaming and payload routes, including *pre-boot ENV setup*, *test bundle compilation via `build_test_command`*, *per-worker renderer startup/shutdown*, and *port/cache isolation for parallel runs*.
> 
> Updates `rsc-troubleshooting.md` to link readers to this new test setup guidance when they need Rails system tests that exercise the node renderer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c47723a886601ca3dca31c73489413cfe3cc42f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for testing React Server Components with an external node-renderer: setup and environment/config recommendations, test harness compilation, renderer startup/shutdown, per-worker port/cache isolation, external-API stubbing guidance, and a parallelization/flakiness checklist.
  * Updated troubleshooting docs to reference the new RSC testing guide and its end-to-end/system-test best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->