### PR TITLE
docs: document RSC async helper names

### DIFF
--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -76,6 +76,8 @@ Requires `enable_rsc_support = true` in configuration.
 <%= rsc_payload_react_component("RSCPage", props: { id: @post.id }) %>
 ```
 
+> **Async props note:** The public RSC payload helper is `rsc_payload_react_component`; there is no separate `_with_async_props` helper name. For RSC routes, resolve data in Rails and pass it through `props`, or let `stream_react_component` stream Suspense boundaries as the component tree renders.
+
 ### `async_react_component(component_name, options = {})`
 
 Renders a component asynchronously, returning an `AsyncValue`. Multiple calls execute concurrently.
@@ -89,6 +91,8 @@ Requires the controller to include `ReactOnRailsPro::AsyncRendering` and call `e
 <%= header.value %>
 <%= sidebar.value %>
 ```
+
+Use `async_react_component` for independent legacy React roots that are still rendered through `react_component`. For RSC migration work, the streaming helper remains `stream_react_component`; the "async props" pattern refers to Rails providing props while streaming SSR progressively flushes HTML.
 
 ### `cached_async_react_component(component_name, options = {}, &block)`
 

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -92,7 +92,7 @@ Requires the controller to include `ReactOnRailsPro::AsyncRendering` and call `e
 <%= sidebar.value %>
 ```
 
-Use `async_react_component` for independent legacy React roots that are still rendered through `react_component`. For RSC migration work, the streaming helper remains `stream_react_component`; the "async props" pattern refers to Rails providing props while streaming SSR progressively flushes HTML.
+> **Note:** Use `async_react_component` for independent legacy React roots that are still rendered through `react_component`. For RSC migration work, the streaming helper is `stream_react_component`; the "async props" pattern refers to Rails providing props while streaming SSR progressively flushes HTML.
 
 ### `cached_async_react_component(component_name, options = {}, &block)`
 

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -76,7 +76,7 @@ Requires `enable_rsc_support = true` in configuration.
 <%= rsc_payload_react_component("RSCPage", props: { id: @post.id }) %>
 ```
 
-> **Async props note:** The public RSC payload helper is `rsc_payload_react_component`; there is no separate `_with_async_props` helper name. For RSC routes, resolve data in Rails and pass it through `props`, or let `stream_react_component` stream Suspense boundaries as the component tree renders.
+> **Note:** The public RSC payload helper is `rsc_payload_react_component`; there is no separate `_with_async_props` helper name. Resolve data in Rails and pass it through `props`.
 
 ### `async_react_component(component_name, options = {})`
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -67,7 +67,7 @@ For pages with multiple data sources, use [`stream_react_component`](#data-fetch
 
 In React on Rails applications, Ruby on Rails is the backend. Rather than bypassing Rails to access the database directly from Server Components, React on Rails Pro provides **`stream_react_component`** -- a streaming view helper that uses React's `renderToPipeableStream` to stream rendered HTML to the browser as React processes the component tree. This approach is sometimes called **async props** because Rails owns the data and React streams Suspense boundaries to the browser as the tree resolves.
 
-The helper name is still `stream_react_component`. Existing Pro helpers named `async_react_component` and `cached_async_react_component` are for concurrently rendering separate legacy React roots; RSC payload generation uses `rsc_payload_react_component` without a separate `_with_async_props` suffix.
+The RSC streaming helper is `stream_react_component`. Existing Pro helpers named `async_react_component` and `cached_async_react_component` are for concurrently rendering separate legacy React roots; RSC payload generation uses `rsc_payload_react_component` without a separate `_with_async_props` suffix.
 
 This is the recommended data fetching pattern for React on Rails because:
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -309,7 +309,7 @@ export default function DashboardStats({ fallbackData }) {
 
 ## Avoiding Server-Side Waterfalls
 
-> **React on Rails note:** In React on Rails, the primary way to handle parallel data loading is [async props](#data-fetching-in-react-on-rails-pro) -- Rails emits each prop independently, and Suspense boundaries stream them to the browser as they resolve. The patterns below apply when you have async Server Components that fetch data directly (outside the async props flow).
+> **React on Rails note:** In React on Rails, the primary way to handle parallel data loading is [async props](#data-fetching-in-react-on-rails-pro) -- Rails owns the data and React streams Suspense boundaries to the browser as the component tree resolves. The patterns below apply when you have async Server Components that fetch data directly (outside the async props flow).
 
 The most critical performance pitfall with Server Components is sequential data fetching. When one `await` blocks the next, you create a waterfall on the server:
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -65,7 +65,9 @@ For pages with multiple data sources, use [`stream_react_component`](#data-fetch
 
 ## Data Fetching in React on Rails Pro
 
-In React on Rails applications, Ruby on Rails is the backend. Rather than bypassing Rails to access the database directly from Server Components, React on Rails Pro provides **`stream_react_component`** -- a streaming view helper that uses React's `renderToPipeableStream` to stream rendered HTML to the browser as React processes the component tree. This approach is sometimes called **async props** because Rails can emit each prop independently, with Suspense boundaries streaming them to the browser as they resolve.
+In React on Rails applications, Ruby on Rails is the backend. Rather than bypassing Rails to access the database directly from Server Components, React on Rails Pro provides **`stream_react_component`** -- a streaming view helper that uses React's `renderToPipeableStream` to stream rendered HTML to the browser as React processes the component tree. This approach is sometimes called **async props** because Rails owns the data and React streams Suspense boundaries to the browser as the tree resolves.
+
+The helper name is still `stream_react_component`. Existing Pro helpers named `async_react_component` and `cached_async_react_component` are for concurrently rendering separate legacy React roots; RSC payload generation uses `rsc_payload_react_component` without a separate `_with_async_props` suffix.
 
 This is the recommended data fetching pattern for React on Rails because:
 

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -551,7 +551,7 @@ If the existing page already uses React on Rails Pro async helpers, keep the nam
 
 - `async_react_component` and `cached_async_react_component` render independent legacy React roots concurrently and return values that you later resolve with `.value`.
 - `stream_react_component` is the helper to use when migrating a Rails view root into streaming SSR/RSC.
-- `rsc_payload_react_component` is the lower-level RSC payload helper; it does not have a separate `_with_async_props` variant.
+- `rsc_payload_react_component` generates the raw NDJSON RSC payload rather than streaming rendered HTML; it does not have a separate `_with_async_props` variant.
 
 In the RSC migration docs, "async props" describes the Rails-owned data pattern: fetch or assemble data in Rails, pass it as `props`, and let streaming SSR flush the component tree progressively.
 

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -547,6 +547,14 @@ In each view, replace `react_component` with `stream_react_component`:
 
 `stream_react_component` automatically sets `prerender: true`. The component renders identically — the difference is that the response is now streamed, which will matter when you start adding Suspense boundaries and async Server Components. React on Rails Pro automatically hydrates components early (before `DOMContentLoaded`), so selective hydration works out of the box.
 
+If the existing page already uses React on Rails Pro async helpers, keep the names straight:
+
+- `async_react_component` and `cached_async_react_component` render independent legacy React roots concurrently and return values that you later resolve with `.value`.
+- `stream_react_component` is the helper to use when migrating a Rails view root into streaming SSR/RSC.
+- `rsc_payload_react_component` is the lower-level RSC payload helper; it does not have a separate `_with_async_props` variant.
+
+In the RSC migration docs, "async props" describes the Rails-owned data pattern: fetch or assemble data in Rails, pass it as `props`, and let streaming SSR flush the component tree progressively.
+
 ### 6c. Update script loading in layouts (recommended)
 
 For streaming to deliver its full performance benefit, script tags should use `async` loading so the browser can hydrate components as they arrive:


### PR DESCRIPTION
## Summary
- clarify that RSC streaming uses `stream_react_component` and RSC payloads use `rsc_payload_react_component`
- distinguish legacy async root helpers (`async_react_component`, `cached_async_react_component`) from the RSC async-props pattern
- note that current public helpers do not use a `_with_async_props` suffix

## Test plan
- `pnpm exec prettier --check docs/oss/api-reference/ruby-api-pro.md docs/oss/migrating/rsc-preparing-app.md docs/oss/migrating/rsc-data-fetching.md`
- `pnpm start format.listDifferent`
- `script/check-docs-sidebar origin/main HEAD`
- `git diff --check`
- pre-commit hook: trailing-newlines, offline Markdown links, Prettier
- pre-push hook: branch-lint, online Markdown links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that clarify which Pro helpers apply to RSC streaming vs legacy concurrent root rendering. Main risk is minor confusion if terminology updates don’t match reader expectations, but no code behavior changes.
> 
> **Overview**
> Documentation now explicitly distinguishes RSC streaming/payload helpers from legacy concurrent-root helpers: use `stream_react_component` for streaming SSR/RSC, `rsc_payload_react_component` for NDJSON payloads, and reserve `async_react_component`/`cached_async_react_component` for separate legacy React roots.
> 
> It also clarifies that there is **no** public `_with_async_props` helper name, and refines the “async props” terminology to mean *Rails-owned data passed via `props` while React streams Suspense boundaries as the tree resolves*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7c9072d0a0b1cfaaad6cfc55d9a570d0cd5b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified "async props" terminology and helper naming conventions across API and migration guides.
  * Strengthened guidance distinguishing legacy concurrent-root helpers from streaming/RSC helpers to aid migration decisions.
  * Refined explanations of streaming patterns, payload generation, and how Rails-owned data should be resolved and passed to React.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
