### PR TITLE
docs: document Gumroad RSC benchmark signal

### DIFF
--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -95,11 +95,14 @@ The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rai
 is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
 surface with the same reduced presenter data and outer layout across two routes:
 
-- Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer)
+- Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer or SSR)
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
 > **Note:** Both routes use the same Shakapacker/Rspack page-asset build; this comparison measures the route-level RSC
-> dimension only. It is not a bundler comparison.
+> dimension only. It is not a bundler comparison. It also does not isolate a renderer-only baseline: the Inertia route
+> has no React on Rails Pro renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the
+> combined route-level effect; see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the
+> renderer baseline.
 
 The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
 routes, four per route, with one warmup request before each measured run. Conditions:
@@ -147,7 +150,9 @@ environment metadata, and distribution artifacts are still required before makin
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.
 
-### Popmenu
+### Production Case Studies
+
+#### Popmenu
 
 Popmenu, a restaurant platform serving tens of millions of SSR requests daily, adopted React on Rails Pro and reported:
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -126,12 +126,12 @@ Conditions:
 
 The browser timing medians showed this directional signal:
 
-| Metric                                      | Inertia demo | RSC demo |  Delta |
-| ------------------------------------------- | -----------: | -------: | -----: |
-| Navigation duration                         |     775.40ms | 607.15ms | -21.7% |
-| Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
-| `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |  noise |
+| Metric                                      | Inertia demo | RSC demo | Delta (negative = RSC faster) |
+| ------------------------------------------- | -----------: | -------: | ----------------------------: |
+| Navigation duration                         |     775.40ms | 607.15ms |                        -21.7% |
+| Largest Contentful Paint                    |     794.00ms | 634.00ms |                        -20.2% |
+| `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
+| Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |                             — |
 
 The page-specific script request count, measured as Chrome DevTools Network panel `Script`-type requests after loading
 each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That is a fixed request count,
@@ -140,14 +140,15 @@ not a timing median or statistical sample, and it does not measure combined tran
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
   establish statistical significance._
-- _The `action_total` difference was -2.2%, which is likely within expected variance at n=4._
+- _The `action_total` delta is shown as an em dash because its computed -2.2% difference is likely within expected
+  variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-p95 counter-signal:
+#### p95 counter-signal
 
-| Metric                  | Inertia demo | RSC demo | Delta |
-| ----------------------- | -----------: | -------: | ----: |
-| p95 `responseEnd` (n=4) |     730.62ms | 768.25ms | +5.2% |
+| Metric                  | Inertia demo | RSC demo | Delta (negative = RSC faster) |
+| ----------------------- | -----------: | -------: | ----------------------------: |
+| p95 `responseEnd` (n=4) |     730.62ms | 768.25ms |                         +5.2% |
 
 The p95 row is a percentile comparison over four samples, not a stable tail-latency estimate. It shows a +5.2% RSC
 regression on p95 `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster p95

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -92,9 +92,10 @@ Server components produce HTML that does not need hydration — they have no cli
 ### Non-Production Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
-is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
-surface with the same reduced presenter data and outer layout across two routes. The comparison changes three axes at
-once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed to any single factor. The routes are:
+is a public ShakaCode comparison repo modeled after a creator-dashboard surface with product listings and sales metrics,
+not an official Gumroad integration. It measures the same reduced presenter data and outer layout across two routes. The
+comparison changes three axes at once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed to any
+single factor. The routes are:
 
 - Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer or SSR)
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
@@ -106,7 +107,8 @@ once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed t
 > route-level effect; see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
 
 The April 30, 2026 local benchmark used eight alternating measured runs between the Inertia and RSC routes, four per
-route. Before each of the eight measured runs, the harness sent one warmup request to the route being measured.
+route. Before each of the eight measured runs, the harness sent one warmup request to the route being measured; one
+warmup may not be enough for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state.
 Conditions:
 
 - Compiled page assets from the same Shakapacker/Rspack configuration for both routes
@@ -115,9 +117,12 @@ Conditions:
 - Dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`
 - Chrome 147 with matching ChromeDriver 147
 
-The original artifact does not yet publish `RAILS_ENV`, browser cache behavior between measured runs, hardware/OS, or
-Ruby/Node/Rails versions. [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing
-environment metadata; until that is resolved, treat these numbers as directional signals rather than a stable baseline.
+> [!WARNING]
+> The original artifact does not yet publish `RAILS_ENV`, browser cache behavior between measured runs, hardware/OS, or
+> Ruby/Node/Rails versions. Unknown `RAILS_ENV` can account for large timing differences; unknown browser cache state
+> between measured runs affects repeatability. [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253)
+> tracks the missing environment metadata. Until that is resolved, treat these numbers as directional signals rather than
+> a stable baseline.
 
 The browser timing medians showed this directional signal:
 
@@ -128,8 +133,9 @@ The browser timing medians showed this directional signal:
 | `responseEnd`                               |        645ms |    589ms |  -8.7% |
 | Controller `action_total` (Rails wall time) |        347ms |    339ms |  noise |
 
-The page-specific script request count changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That
-is a fixed request count, not a timing median or statistical sample, and it does not measure combined transfer-size. See
+The page-specific script request count, measured as Chrome DevTools Network panel `Script`-type requests after loading
+each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That is a fixed request count,
+not a timing median or statistical sample, and it does not measure combined transfer-size. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 - _All timing values are medians rounded to the nearest millisecond (n=4 per route); sample size is too small to

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -101,7 +101,7 @@ single factor. The routes are:
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
 > [!NOTE]
-> Both routes use the same Shakapacker/Rspack page-asset build, so this is a route-level comparison rather than a
+> Both routes use the same Shakapacker with Rspack page-asset build, so this is a route-level comparison rather than a
 > bundler comparison. It also does not isolate a renderer-only baseline: the Inertia route has no React on Rails Pro
 > renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined route-level effect;
 > see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
@@ -112,7 +112,7 @@ warmup request to the route being measured.
 
 Conditions:
 
-- Compiled page assets from the same Shakapacker/Rspack configuration for both routes
+- Compiled page assets from the same Shakapacker with Rspack configuration for both routes
 - Compiled RSC demo bundles
 - Rails server without the Shakapacker dev server running
 - Dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`
@@ -130,12 +130,12 @@ Conditions:
 
 The median results showed this directional signal:
 
-| Source  | Metric                                      | Inertia demo | RSC demo | Delta (negative = RSC faster) |
-| ------- | ------------------------------------------- | -----------: | -------: | ----------------------------: |
-| Browser | Navigation duration                         |     775.40ms | 607.15ms |                        -21.7% |
-| Browser | Largest Contentful Paint                    |     794.00ms | 634.00ms |                        -20.2% |
-| Browser | `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
-| Rails   | Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |              -2.2% (variance) |
+| Source  | Metric                                      | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
+| ------- | ------------------------------------------- | -----------: | -------: | ------------------------------: |
+| Browser | Navigation duration                         |     775.40ms | 607.15ms |                          -21.7% |
+| Browser | Largest Contentful Paint                    |     794.00ms | 634.00ms |                          -20.2% |
+| Browser | `responseEnd`                               |     644.80ms | 588.80ms |                           -8.7% |
+| Rails   | Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |                -2.2% (variance) |
 
 `action_total` is the Rails wall-time field from the raw benchmark artifact, not a browser Performance API metric. The
 artifact does not yet publish enough logger or extraction-script context to confirm whether it is the full
@@ -160,11 +160,11 @@ combined transfer size or cache behavior. Fewer requests do not necessarily impl
   variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-#### Worst-case `responseEnd` counter-signal
+#### Worst-case `responseEnd` counter-signal {#gumroad-rsc-worst-case-responsend}
 
-| Metric                             | Inertia demo | RSC demo | Delta (negative = RSC faster) |
-| ---------------------------------- | -----------: | -------: | ----------------------------: |
-| Worst-case `responseEnd` (max n=4) |     730.62ms | 768.25ms |                         +5.2% |
+| Metric                             | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
+| ---------------------------------- | -----------: | -------: | ------------------------------: |
+| Worst-case `responseEnd` (max n=4) |     730.62ms | 768.25ms |                           +5.2% |
 
 The source artifact labels this as p95, but with four samples it is effectively the maximum observed value, not a
 stable tail-latency estimate. It shows a +5.2% RSC regression on worst-case `responseEnd` (high variance is expected at

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -119,11 +119,12 @@ Conditions:
 - Chrome 147 with matching ChromeDriver 147
 
 > [!WARNING]
-> The original artifact does not yet publish `RAILS_ENV`, browser cache behavior between measured runs, hardware/OS, or
-> Ruby/Node/Rails versions. Unknown `RAILS_ENV` can account for large timing differences; unknown browser cache state
-> between measured runs affects repeatability. The single warmup request before each measured run may also be insufficient
-> for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state, which is more likely to
-> make the RSC route look slower than its steady-state performance than to inflate its advantage.
+> The original artifact does not yet publish `RAILS_ENV`, so the absolute timing values may include development-mode or
+> other non-production Rails overhead. It also does not publish browser cache behavior between measured runs, hardware/OS,
+> or Ruby/Node/Rails versions. Unknown browser cache state between measured runs affects repeatability. The single warmup
+> request before each measured run may also be insufficient for the Pro Node renderer worker pool to reach JIT and
+> RSC-payload-compilation steady state, which is more likely to make the RSC route look slower than its steady-state
+> performance than to inflate its advantage.
 > [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata. Until
 > that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
@@ -136,18 +137,20 @@ The median results showed this directional signal:
 | Browser | `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
 | Rails   | Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |              -2.2% (variance) |
 
-`action_total` is the Rails controller wall-time field from the raw benchmark artifact, not a browser Performance API
-metric. The artifact does not yet publish enough logger or extraction-script context to make that field independently
-reproducible; [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution and
-source artifacts.
+`action_total` is the Rails wall-time field from the raw benchmark artifact, not a browser Performance API metric. The
+artifact does not yet publish enough logger or extraction-script context to confirm whether it is the full
+`process_action` duration including rendering or a narrower controller-action field, so do not use it to infer the
+server-rendering split. [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing
+distribution and source artifacts.
 
-The RSC route's post-`responseEnd` client processing time was about 18ms, compared with about 130ms for the Inertia
-control. That gap helps explain why the navigation-duration gain (-21.7%) was larger than the server-response
-`responseEnd` gain (-8.7%).
+Derived from the median table above, the RSC route's post-`responseEnd` client processing time (`navigation duration -
+responseEnd`) was about 18ms, compared with about 130ms for the Inertia control. That gap helps explain why the
+navigation-duration gain (-21.7%) was larger than the `responseEnd` gain (-8.7%).
 
 The page-specific script request count, measured as Chrome DevTools Network panel `Script`-type requests after loading
 each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That is a fixed request count,
-not a timing median or statistical sample, and it does not measure combined transfer-size. See
+not a timing median or statistical sample, and it does not measure combined transfer size or cache behavior. Fewer
+requests do not necessarily imply a smaller browser payload. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,8 +89,9 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
-This section covers a non-production local directional benchmark first, then a production case study. For validated,
-at-scale results, see the [Production Case Study: Popmenu](#popmenu) below.
+> [!NOTE]
+> This section covers a non-production local directional benchmark first, then a production case study. For validated,
+> at-scale results, see the [Production Case Study: Popmenu](#popmenu) below.
 
 ### Non-Production Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
 
@@ -144,7 +145,7 @@ Playwright harness and may differ from `PerformanceNavigationTiming.duration`.
 | Browser | Navigation duration                             |        775ms |    607ms |                          -21.7% |
 | Browser | Largest Contentful Paint                        |        794ms |    634ms |                          -20.2% |
 | Browser | `responseEnd`                                   |        645ms |    589ms |                           -8.7% |
-| Rails   | Controller `action_total` (Rails wall time) [†] |        347ms |    339ms |                -2.3% (variance) |
+| Rails   | Controller `action_total` (Rails wall time) [†] |        347ms |    339ms |                           -2.3% |
 
 [†] `action_total` scope is unconfirmed; do not use it to infer the server-rendering split — see the paragraph below.
 
@@ -170,11 +171,12 @@ is the meaningful network-cost metric and is not reported here. The raw request-
 completeness only. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
+- _The linked `performance-findings.md` artifact reflects an earlier run; the April 30 timings shown above will be added
+  there in a follow-up, and distribution/variance artifacts are still pending. See
+  [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
   establish statistical significance._
-- _The `action_total` delta is shown with a variance qualifier because its -2.3% difference is likely within expected
-  variance at n=4._
-- _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
+- _The `action_total` -2.3% delta is likely within expected variance at n=4._
 
 #### Worst-case `responseEnd` counter-signal {#gumroad-rsc-worst-case-responseend}
 
@@ -182,10 +184,10 @@ completeness only. See
 | ---------------------------------- | -----------: | -------: | ------------------------------: |
 | Worst-case `responseEnd` (max n=4) |        731ms |    768ms |                           +5.1% |
 
-The source artifact mislabels this metric as p95. With only four samples, p95 is the maximum observed value by
-definition, not an independently estimated tail percentile. It shows a +5.1% RSC regression on worst-case `responseEnd`
-(high variance is expected at n=4), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC
-route.
+With only four samples, p95 is the maximum observed value by definition, not an independently estimated tail
+percentile; this metric is therefore reported as "worst-case (max n=4)" here. It shows a +5.1% RSC regression on
+worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster worst-case
+`responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
 renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route showed

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,7 +89,7 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
-### Local Directional Benchmark: Gumroad-Style RSC Demo
+### Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026)
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
@@ -124,7 +124,7 @@ The median results showed this directional signal:
 | Navigation duration                         |     775.40ms | 607.15ms | -21.7% |
 | Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
 | `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total` (Rails wall time) |      346.9ms |  339.2ms |  -2.2% |
+| Controller `action_total` (Rails wall time) |     346.90ms | 339.20ms |  -2.2% |
 | Page-specific script requests (count only)  |            6 |        1 | -83.3% |
 
 _The script-count row does not measure combined transfer-size. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -128,14 +128,15 @@ Conditions:
 > [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata. Until
 > that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
-The median results showed this directional signal:
+The median results showed this directional signal. The source artifact's navigation-duration metric comes from its
+Playwright harness and may differ from `PerformanceNavigationTiming.duration`.
 
 | Source  | Metric                                      | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ------- | ------------------------------------------- | -----------: | -------: | ------------------------------: |
 | Browser | Navigation duration                         |        775ms |    607ms |                          -21.7% |
 | Browser | Largest Contentful Paint                    |        794ms |    634ms |                          -20.2% |
 | Browser | `responseEnd`                               |        645ms |    589ms |                           -8.7% |
-| Rails   | Controller `action_total` (Rails wall time) |        347ms |    339ms |                -2.2% (variance) |
+| Rails   | Controller `action_total` (Rails wall time) |        347ms |    339ms |                -2.3% (variance) |
 
 `action_total` is the Rails wall-time field from the raw benchmark artifact, not a browser Performance API metric. The
 artifact does not yet publish enough logger or extraction-script context to confirm whether it is the full
@@ -158,7 +159,7 @@ combined transfer size or cache behavior. Fewer requests do not necessarily impl
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
   establish statistical significance._
-- _The `action_total` delta is shown with a variance qualifier because its -2.2% difference is likely within expected
+- _The `action_total` delta is shown with a variance qualifier because its -2.3% difference is likely within expected
   variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -132,10 +132,10 @@ The median results showed this directional signal:
 
 | Source  | Metric                                      | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ------- | ------------------------------------------- | -----------: | -------: | ------------------------------: |
-| Browser | Navigation duration                         |     775.40ms | 607.15ms |                          -21.7% |
-| Browser | Largest Contentful Paint                    |     794.00ms | 634.00ms |                          -20.2% |
-| Browser | `responseEnd`                               |     644.80ms | 588.80ms |                           -8.7% |
-| Rails   | Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |                -2.2% (variance) |
+| Browser | Navigation duration                         |        775ms |    607ms |                          -21.7% |
+| Browser | Largest Contentful Paint                    |        794ms |    634ms |                          -20.2% |
+| Browser | `responseEnd`                               |        645ms |    589ms |                           -8.7% |
+| Rails   | Controller `action_total` (Rails wall time) |        347ms |    339ms |                -2.2% (variance) |
 
 `action_total` is the Rails wall-time field from the raw benchmark artifact, not a browser Performance API metric. The
 artifact does not yet publish enough logger or extraction-script context to confirm whether it is the full
@@ -145,8 +145,10 @@ distribution and source artifacts.
 
 Derived from the median table above, the RSC route's post-`responseEnd` browser processing time (`navigation duration -
 responseEnd`, including HTML parsing, sub-resource loading, layout, and paint) was about 18ms, compared with about 130ms
-for the Inertia control. That gap helps explain why the navigation-duration gain (-21.7%) was larger than the
-`responseEnd` gain (-8.7%).
+for the Inertia control. This gap is expected: the RSC route delivers fully server-rendered HTML, so the browser has
+minimal client-side hydration work after `responseEnd`, while the Inertia control must hydrate the React component tree
+on the client. That difference in client-side work helps explain why the navigation-duration gain (-21.7%) was larger
+than the `responseEnd` gain (-8.7%).
 
 The page-specific script request count, recorded as Chrome DevTools Network panel `Script`-type requests after loading
 each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. The artifact reports this as a
@@ -164,7 +166,7 @@ combined transfer size or cache behavior. Fewer requests do not necessarily impl
 
 | Metric                             | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ---------------------------------- | -----------: | -------: | ------------------------------: |
-| Worst-case `responseEnd` (max n=4) |     730.62ms | 768.25ms |                           +5.2% |
+| Worst-case `responseEnd` (max n=4) |        731ms |    768ms |                           +5.2% |
 
 The source artifact labels this as p95, but with four samples it is effectively the maximum observed value, not a
 stable tail-latency estimate. It shows a +5.2% RSC regression on worst-case `responseEnd` (high variance is expected at

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -111,6 +111,7 @@ route. Before each of the eight measured runs, the harness sent one warmup reque
 warmup may not be enough for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state.
 That limitation is more likely to make the RSC route look slower than its steady-state performance than to inflate its
 advantage, so treat the RSC median wins as directional rather than fully warmed production estimates.
+
 Conditions:
 
 - Compiled page assets from the same Shakapacker/Rspack configuration for both routes

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -125,11 +125,11 @@ The median results showed this directional signal:
 | Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
 | `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
 | Controller `action_total` (Rails wall time) |      346.9ms |  339.2ms |  -2.2% |
-| Page-specific script requests               |            6 |        1 | -83.3% |
+| Page-specific script requests (count only)  |            6 |        1 | -83.3% |
 
+_The script-count row does not measure combined transfer-size. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._
 _All values are medians (n=4 per route); sample size is too small to establish statistical significance._
 _The `action_total` delta (-2.2%) is likely within expected variance at n=4._
-_Script count only; combined transfer-size is not yet captured. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._
 _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
 Worst-case counter-signal:

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,13 +89,21 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
+This section covers a non-production local directional benchmark first, then a production case study. For validated,
+at-scale results, see the [Production Case Study: Popmenu](#popmenu) below.
+
 ### Non-Production Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo modeled after a creator-dashboard surface with product listings and sales metrics,
-not an official Gumroad integration. It measures the same reduced presenter data and outer layout across two routes. The
-comparison changes three axes at once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed to any
-single factor. The routes are:
+not an official Gumroad integration. The benchmark methodology and earlier-run artifacts are checked in as
+[`docs/performance-findings.md`](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/blob/5a2f0c29dc197184312c55bc4209492accea26e7/docs/performance-findings.md)
+on the active demo PR ([shakacode/react-on-rails-demo-gumroad-rsc#10](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/pull/10));
+the April 30, 2026 absolute timings reported below are from a more recent local run that has not yet landed in that
+artifact ([Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution and
+source artifacts). It measures the same reduced presenter data and outer layout across two routes. The comparison
+changes three axes at once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed to any single
+factor. The routes are:
 
 - Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer or SSR)
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
@@ -119,24 +127,26 @@ Conditions:
 - Chrome 147 with matching ChromeDriver 147
 
 > [!WARNING]
-> The original artifact does not yet publish `RAILS_ENV`, so the absolute timing values may include development-mode or
-> other non-production Rails overhead. It also does not publish browser cache behavior between measured runs, hardware/OS,
-> or Ruby/Node/Rails versions. Unknown browser cache state between measured runs affects repeatability. The single warmup
-> request before each measured run may also be insufficient for the Pro Node renderer worker pool to reach JIT and
-> RSC-payload-compilation steady state, which is more likely to make the RSC route look slower than its steady-state
-> performance than to inflate its advantage.
+> The original artifact does not yet publish `RAILS_ENV`, so the absolute timing values may include
+> `RAILS_ENV=development` overhead (no eager loading, active code reloader, no asset caching). It also does not publish
+> browser cache behavior between measured runs, hardware/OS, or Ruby/Node/Rails versions. Unknown browser cache state
+> between measured runs affects repeatability. The single warmup request before each measured run may also be
+> insufficient for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state, which is
+> more likely to make the RSC route look slower than its steady-state performance than to inflate its advantage.
 > [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata. Until
 > that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
 The median results showed this directional signal. The source artifact's navigation-duration metric comes from its
 Playwright harness and may differ from `PerformanceNavigationTiming.duration`.
 
-| Source  | Metric                                      | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
-| ------- | ------------------------------------------- | -----------: | -------: | ------------------------------: |
-| Browser | Navigation duration                         |        775ms |    607ms |                          -21.7% |
-| Browser | Largest Contentful Paint                    |        794ms |    634ms |                          -20.2% |
-| Browser | `responseEnd`                               |        645ms |    589ms |                           -8.7% |
-| Rails   | Controller `action_total` (Rails wall time) |        347ms |    339ms |                -2.3% (variance) |
+| Source  | Metric                                          | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
+| ------- | ----------------------------------------------- | -----------: | -------: | ------------------------------: |
+| Browser | Navigation duration                             |        775ms |    607ms |                          -21.7% |
+| Browser | Largest Contentful Paint                        |        794ms |    634ms |                          -20.2% |
+| Browser | `responseEnd`                                   |        645ms |    589ms |                           -8.7% |
+| Rails   | Controller `action_total` (Rails wall time) [†] |        347ms |    339ms |                -2.3% (variance) |
+
+[†] `action_total` scope is unconfirmed; do not use it to infer the server-rendering split — see the paragraph below.
 
 `action_total` is the Rails wall-time field from the raw benchmark artifact, not a browser Performance API metric. The
 artifact does not yet publish enough logger or extraction-script context to confirm whether it is the full
@@ -146,12 +156,11 @@ RSC rendering cost that the Inertia control keeps in-process, so the two `action
 scopes of work. [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution
 and source artifacts.
 
-Derived from the median table above, the RSC route's post-`responseEnd` browser processing time (`navigation duration -
-responseEnd`, including HTML parsing, sub-resource loading, layout, and paint) was about 18ms, compared with about 130ms
-for the Inertia control. This gap is expected: the RSC route delivers fully server-rendered HTML, so the browser has
-minimal client-side hydration work after `responseEnd`, while the Inertia control must hydrate the React component tree
-on the client. That difference in client-side work helps explain why the navigation-duration gain (-21.7%) was larger
-than the `responseEnd` gain (-8.7%).
+The navigation-duration gain (-21.7%) was larger than the `responseEnd` gain (-8.7%), which is consistent with the RSC
+route delivering fully server-rendered HTML — the browser has minimal client-side hydration work after `responseEnd`,
+while the Inertia control must hydrate the React component tree on the client. Because the navigation-duration value
+comes from the source artifact's Playwright harness rather than `PerformanceNavigationTiming.duration`, the two metrics
+are not from the same timing source and a direct `navigation duration - responseEnd` subtraction is not reported here.
 
 The page-specific script request count was 6 for the Inertia demo and 1 for the RSC demo, recorded as Chrome DevTools
 Network panel `Script`-type requests after loading each route. This is a fixed post-load observation, not a per-run

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -98,29 +98,32 @@ surface with the same reduced presenter data and outer layout across two routes:
 - Inertia-style control: `/dashboard/inertia_demo`
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
-The current clean-port, alternating local benchmark recorded on April 30, 2026, showed this directional signal:
+> **Note:** These results reflect two distinct value propositions: **Rspack** addresses build speed and development
+> iteration time, while **React Server Components** target runtime JavaScript reduction and server-side composition.
+> The benchmark below measures only the RSC dimension.
 
-| Metric                    | Inertia demo |   RSC demo |    Delta |
-| ------------------------- | -----------: | ---------: | -------: |
-| Navigation duration       |   `457.16ms` | `402.29ms` | `-12.0%` |
-| Largest Contentful Paint  |   `501.00ms` | `421.00ms` | `-16.0%` |
-| Response end              |   `320.70ms` | `335.96ms` |  `+4.8%` |
-| Controller `action_total` |   `163.10ms` | `169.74ms` |  `+4.1%` |
-| Page-specific JS requests |          `6` |        `1` | `-83.3%` |
+The April 30, 2026 production-like local benchmark used eight alternating cycles between the Inertia and RSC routes,
+with one warmup request before each measured run. It used compiled Shakapacker/Rspack assets, compiled RSC demo bundles,
+Rails without the Shakapacker dev server, a dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`, and
+matching Chrome 147 and ChromeDriver 147. The median results showed this directional signal:
+
+| Metric                    | Inertia demo | RSC demo |  Delta |
+| ------------------------- | -----------: | -------: | -----: |
+| Navigation duration       |     775.40ms | 607.15ms | -21.7% |
+| Largest Contentful Paint  |     794.00ms | 634.00ms | -20.2% |
+| Response end              |     644.80ms | 588.80ms |  -8.7% |
+| Controller `action_total` |     346.87ms | 339.20ms |  -2.2% |
+| Page-specific JS requests |            6 |        1 | -83.3% |
+| p95 `responseEnd`         |     730.62ms | 768.25ms |  +5.2% |
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
-user-visible navigation duration and LCP while sending much less page-specific JavaScript, but the Inertia control was
-still modestly ahead on server response and controller timing. Production-like renderer profiling is still required
-before making stronger production-performance claims.
-
-The important positioning split is:
-
-- **Rspack** is the build-speed and development-loop story.
-- **React Server Components** are the runtime experiment for reducing route-level client JavaScript and moving more
-  composition to the server.
+user-visible median navigation duration and LCP while sending much less page-specific JavaScript, but the p95 response
+timing still favored the Inertia control. A stable deployed repeat, renderer-internal timing, and hardware details for
+the local run are still required before making stronger production-performance claims.
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
-[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the current tracking discussion.
+[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the current tracking discussion, and
+[Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) for the environment-metadata follow-up.
 
 ### Popmenu
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -101,14 +101,16 @@ single factor. The routes are:
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
 > [!NOTE]
-> Both routes use the same Shakapacker/Rspack page-asset build; this comparison measures the route-level RSC dimension
-> only. It is not a bundler comparison. It also does not isolate a renderer-only baseline: the Inertia route has no React
-> on Rails Pro renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined
-> route-level effect; see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
+> Both routes use the same Shakapacker/Rspack page-asset build, so this is a route-level comparison rather than a
+> bundler comparison. It also does not isolate a renderer-only baseline: the Inertia route has no React on Rails Pro
+> renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined route-level effect;
+> see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
 
 The April 30, 2026 local benchmark used eight alternating measured runs between the Inertia and RSC routes, four per
 route. Before each of the eight measured runs, the harness sent one warmup request to the route being measured; one
 warmup may not be enough for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state.
+That limitation is more likely to make the RSC route look slower than its steady-state performance than to inflate its
+advantage, so treat the RSC median wins as directional rather than fully warmed production estimates.
 Conditions:
 
 - Compiled page assets from the same Shakapacker/Rspack configuration for both routes
@@ -132,6 +134,11 @@ The browser timing medians showed this directional signal:
 | Largest Contentful Paint                    |     794.00ms | 634.00ms |                        -20.2% |
 | `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
 | Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |              -2.2% (variance) |
+
+`action_total` is the Rails controller wall-time field from the raw benchmark artifact, not a browser Performance API
+metric. The artifact does not yet publish enough logger or extraction-script context to make that field independently
+reproducible; [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution and
+source artifacts.
 
 The RSC route's post-`responseEnd` client processing time was about 18ms, compared with about 130ms for the Inertia
 control. That gap helps explain why the navigation-duration gain (-21.7%) was larger than the server-response

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -98,11 +98,11 @@ surface with the same reduced presenter data and outer layout across two routes:
 - Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer or SSR)
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
-> **Note:** Both routes use the same Shakapacker/Rspack page-asset build; this comparison measures the route-level RSC
-> dimension only. It is not a bundler comparison. It also does not isolate a renderer-only baseline: the Inertia route
-> has no React on Rails Pro renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the
-> combined route-level effect; see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the
-> renderer baseline.
+> [!NOTE]
+> Both routes use the same Shakapacker/Rspack page-asset build; this comparison measures the route-level RSC dimension
+> only. It is not a bundler comparison. It also does not isolate a renderer-only baseline: the Inertia route has no React
+> on Rails Pro renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined
+> route-level effect; see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
 
 The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
 routes, four per route, with one warmup request before each measured run. Conditions:
@@ -150,9 +150,7 @@ environment metadata, and distribution artifacts are still required before makin
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.
 
-### Production Case Studies
-
-#### Popmenu
+### Production Case Study: Popmenu
 
 Popmenu, a restaurant platform serving tens of millions of SSR requests daily, adopted React on Rails Pro and reported:
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -102,10 +102,11 @@ surface with the same reduced presenter data and outer layout across two routes:
 > iteration time, while **React Server Components** target runtime JavaScript reduction and server-side composition.
 > The benchmark below measures only the RSC dimension.
 
-The April 30, 2026 production-like local benchmark used eight alternating cycles between the Inertia and RSC routes,
-with one warmup request before each measured run. It used compiled Shakapacker/Rspack assets, compiled RSC demo bundles,
-Rails without the Shakapacker dev server, a dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`, and
-matching Chrome 147 and ChromeDriver 147. The median results showed this directional signal:
+The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
+routes, four per route, with one warmup request before each measured run. It used compiled Shakapacker/Rspack assets,
+compiled RSC demo bundles, Rails without the Shakapacker dev server, a dedicated React on Rails Pro Node renderer on
+`RENDERER_PORT=3800`, and matching Chrome 147 and ChromeDriver 147. The median results, plus the observed max
+`responseEnd`, showed this directional signal:
 
 | Metric                        | Inertia demo | RSC demo |  Delta |
 | ----------------------------- | -----------: | -------: | -----: |
@@ -114,12 +115,15 @@ matching Chrome 147 and ChromeDriver 147. The median results showed this directi
 | `responseEnd`                 |     644.80ms | 588.80ms |  -8.7% |
 | Controller `action_total`     |     346.87ms | 339.20ms |  -2.2% |
 | Page-specific script requests |            6 |        1 | -83.3% |
-| Max `responseEnd` (n=4)       |     730.62ms | 768.25ms |  +5.2% |
+| Max `responseEnd`             |     730.62ms | 768.25ms |  +5.2% |
+
+_All rows use n=4 per route: eight alternating measured runs total, with one warmup request before each measured run._
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
 user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case
 timing still favored the Inertia control. A stable deployed repeat, renderer-internal timing, and hardware details for
 the local run are still required before making stronger production-performance claims.
+
 The script-request row counts browser-observed page-specific script resources only; combined transfer-size capture is
 tracked in [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -144,9 +144,10 @@ worst-case `responseEnd` (high variance is expected at n=4), indicating the Iner
 `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
-user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the max
-`responseEnd` counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing,
-environment metadata, and distribution artifacts are still required before making stronger production-performance claims.
+user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the route also
+benefits from both RSC and the Pro Node renderer with SSR, while the Inertia control has neither. The max `responseEnd`
+counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing, environment
+metadata, and distribution artifacts are still required before making stronger production-performance claims.
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,6 +89,39 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
+### Gumroad-Style RSC Benchmark Demo
+
+The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
+is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
+surface with the same reduced presenter data and outer layout across two routes:
+
+- Inertia-style control: `/dashboard/inertia_demo`
+- React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
+
+The current clean-port, alternating local benchmark recorded on April 30, 2026, showed this directional signal:
+
+| Metric                    | Inertia demo |   RSC demo |    Delta |
+| ------------------------- | -----------: | ---------: | -------: |
+| Navigation duration       |   `457.16ms` | `402.29ms` | `-12.0%` |
+| Largest Contentful Paint  |   `501.00ms` | `421.00ms` | `-16.0%` |
+| Response end              |   `320.70ms` | `335.96ms` |  `+4.8%` |
+| Controller `action_total` |   `163.10ms` | `169.74ms` |  `+4.1%` |
+| Page-specific JS requests |          `6` |        `1` | `-83.3%` |
+
+Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
+user-visible navigation duration and LCP while sending much less page-specific JavaScript, but the Inertia control was
+still modestly ahead on server response and controller timing. Production-like renderer profiling is still required
+before making stronger production-performance claims.
+
+The important positioning split is:
+
+- **Rspack** is the build-speed and development-loop story.
+- **React Server Components** are the runtime experiment for reducing route-level client JavaScript and moving more
+  composition to the server.
+
+See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
+[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the current tracking discussion.
+
 ### Popmenu
 
 Popmenu, a restaurant platform serving tens of millions of SSR requests daily, adopted React on Rails Pro and reported:

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -153,12 +153,12 @@ minimal client-side hydration work after `responseEnd`, while the Inertia contro
 on the client. That difference in client-side work helps explain why the navigation-duration gain (-21.7%) was larger
 than the `responseEnd` gain (-8.7%).
 
-The page-specific script request count, recorded as Chrome DevTools Network panel `Script`-type requests after loading
-each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. The artifact reports this as a
-fixed post-load request-count observation, not a per-run timing median or statistical sample, and it does not measure
-combined transfer size or cache behavior. Fewer requests do not necessarily imply a smaller browser payload: the RSC
-route carries runtime, Flight payload, and RSC-specific bundle costs that the Inertia control does not, so total transfer
-size is the meaningful network-cost metric and is not reported here. See
+The page-specific script request count was 6 for the Inertia demo and 1 for the RSC demo, recorded as Chrome DevTools
+Network panel `Script`-type requests after loading each route. This is a fixed post-load observation, not a per-run
+timing median or statistical sample. Fewer requests do not necessarily imply a smaller browser payload: the RSC route
+carries runtime, Flight payload, and RSC-specific bundle costs that the Inertia control does not, so total transfer size
+is the meaningful network-cost metric and is not reported here. The raw request-count difference is noted for
+completeness only. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
@@ -173,15 +173,16 @@ size is the meaningful network-cost metric and is not reported here. See
 | ---------------------------------- | -----------: | -------: | ------------------------------: |
 | Worst-case `responseEnd` (max n=4) |        731ms |    768ms |                           +5.1% |
 
-The source artifact labels this as p95, but with four samples it is effectively the maximum observed value, not a
-stable tail-latency estimate. It shows a +5.1% RSC regression on worst-case `responseEnd` (high variance is expected at
-n=4), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC route.
+The source artifact mislabels this metric as p95. With only four samples, p95 is the maximum observed value by
+definition, not an independently estimated tail percentile. It shows a +5.1% RSC regression on worst-case `responseEnd`
+(high variance is expected at n=4), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC
+route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
-renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route was faster
-on user-visible median navigation duration and LCP while sending fewer page-specific script requests. The p95
-`responseEnd` counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing,
-environment metadata, and distribution artifacts are still required before making stronger production-performance claims.
+renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route showed
+faster median navigation duration and LCP on the measured routes. The worst-case `responseEnd` counter-signal favored
+the Inertia control. A stable deployed repeat, renderer-internal timing, environment metadata, and distribution artifacts
+are still required before making stronger production-performance claims.
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -160,7 +160,7 @@ combined transfer size or cache behavior. Fewer requests do not necessarily impl
   variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-#### Worst-case `responseEnd` counter-signal {#gumroad-rsc-worst-case-responsend}
+#### Worst-case `responseEnd` counter-signal {#gumroad-rsc-worst-case-responseend}
 
 | Metric                             | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ---------------------------------- | -----------: | -------: | ------------------------------: |

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -107,19 +107,21 @@ with one warmup request before each measured run. It used compiled Shakapacker/R
 Rails without the Shakapacker dev server, a dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`, and
 matching Chrome 147 and ChromeDriver 147. The median results showed this directional signal:
 
-| Metric                    | Inertia demo | RSC demo |  Delta |
-| ------------------------- | -----------: | -------: | -----: |
-| Navigation duration       |     775.40ms | 607.15ms | -21.7% |
-| Largest Contentful Paint  |     794.00ms | 634.00ms | -20.2% |
-| Response end              |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total` |     346.87ms | 339.20ms |  -2.2% |
-| Page-specific JS requests |            6 |        1 | -83.3% |
-| p95 `responseEnd`         |     730.62ms | 768.25ms |  +5.2% |
+| Metric                        | Inertia demo | RSC demo |  Delta |
+| ----------------------------- | -----------: | -------: | -----: |
+| Navigation duration           |     775.40ms | 607.15ms | -21.7% |
+| Largest Contentful Paint      |     794.00ms | 634.00ms | -20.2% |
+| `responseEnd`                 |     644.80ms | 588.80ms |  -8.7% |
+| Controller `action_total`     |     346.87ms | 339.20ms |  -2.2% |
+| Page-specific script requests |            6 |        1 | -83.3% |
+| Max `responseEnd` (n=4)       |     730.62ms | 768.25ms |  +5.2% |
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
-user-visible median navigation duration and LCP while sending much less page-specific JavaScript, but the p95 response
+user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case
 timing still favored the Inertia control. A stable deployed repeat, renderer-internal timing, and hardware details for
 the local run are still required before making stronger production-performance claims.
+The script-request row counts browser-observed page-specific script resources only; combined transfer-size capture is
+tracked in [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the current tracking discussion, and

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -100,13 +100,13 @@ surface with the same reduced presenter data and outer layout across two routes:
 
 > **Note:** These results reflect two distinct value propositions: **Rspack** addresses build speed and development
 > iteration time, while **React Server Components** target runtime JavaScript reduction and server-side composition.
-> The benchmark below measures only the RSC dimension.
+> Both routes use the same Shakapacker/Rspack page-asset build; the comparison measures the route-level RSC dimension,
+> not a bundler swap.
 
 The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
-routes, four per route, with one warmup request before each measured run. It used compiled Shakapacker/Rspack assets,
-compiled RSC demo bundles, Rails without the Shakapacker dev server, a dedicated React on Rails Pro Node renderer on
-`RENDERER_PORT=3800`, and matching Chrome 147 and ChromeDriver 147. The median results, plus the observed max
-`responseEnd`, showed this directional signal:
+routes, four per route, with one warmup request before each measured run. It used compiled page assets from the same
+Shakapacker configuration with Rspack for both routes, compiled RSC demo bundles, Rails without the Shakapacker dev
+server, a dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`, and matching Chrome 147 and ChromeDriver 147. The median results, plus the observed max `responseEnd`, showed this directional signal:
 
 | Metric                        | Inertia demo | RSC demo |  Delta |
 | ----------------------------- | -----------: | -------: | -----: |
@@ -117,7 +117,8 @@ compiled RSC demo bundles, Rails without the Shakapacker dev server, a dedicated
 | Page-specific script requests |            6 |        1 | -83.3% |
 | Max `responseEnd`             |     730.62ms | 768.25ms |  +5.2% |
 
-_All rows use n=4 per route: eight alternating measured runs total, with one warmup request before each measured run._
+_Rows 1-5 are medians (n=4 per route); `Max responseEnd` is the observed maximum across those same four runs. The
+benchmark used eight alternating measured runs total, with one warmup request before each measured run._
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
 user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case
@@ -128,7 +129,7 @@ The script-request row counts browser-observed page-specific script resources on
 tracked in [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
-[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the current tracking discussion, and
+[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion, and
 [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) for the environment-metadata follow-up.
 
 ### Popmenu

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,7 +89,7 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
-### Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026)
+### Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
@@ -118,20 +118,22 @@ The original artifact does not yet publish `RAILS_ENV`, hardware/OS, Ruby/Node/R
 [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata; until
 that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
-The browser timing medians and deterministic script request counts showed this directional signal:
+The browser timing medians showed this directional signal:
 
 | Metric                                      | Inertia demo | RSC demo |  Delta |
 | ------------------------------------------- | -----------: | -------: | -----: |
 | Navigation duration                         |     775.40ms | 607.15ms | -21.7% |
 | Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
 | `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total` (Rails wall time) |     346.90ms | 339.20ms |  -2.2% |
-| Page-specific script requests (count only)  |            6 |        1 | -83.3% |
+| Controller `action_total` (Rails wall time) |     346.90ms | 339.20ms |  noise |
 
-_The script-count row is a fixed request count, not a median, and does not measure combined transfer-size. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._
-_All values are medians (n=4 per route); sample size is too small to establish statistical significance._
-_The `action_total` delta (-2.2%) is likely within expected variance at n=4._
-_Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
+The page-specific script request count changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That
+is a fixed request count, not a timing median or statistical sample, and it does not measure combined transfer-size. See
+[Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
+
+- _All timing values are medians (n=4 per route); sample size is too small to establish statistical significance._
+- _The `action_total` difference was -2.2%, which is likely within expected variance at n=4._
+- _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
 Worst-case counter-signal:
 
@@ -143,11 +145,11 @@ The max row is a max-vs-max comparison, not a stable tail-latency estimate. It s
 worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster worst-case
 `responseEnd` than the RSC route.
 
-Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
-user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the route also
-benefits from both RSC and the Pro Node renderer with SSR, while the Inertia control has neither. The max `responseEnd`
-counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing, environment
-metadata, and distribution artifacts are still required before making stronger production-performance claims.
+Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
+renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route was faster
+on user-visible median navigation duration and LCP while sending fewer page-specific script requests. The max
+`responseEnd` counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing,
+environment metadata, and distribution artifacts are still required before making stronger production-performance claims.
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -150,9 +150,7 @@ environment metadata, and distribution artifacts are still required before makin
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.
 
-<a id="popmenu"></a>
-
-### Production Case Study: Popmenu
+### Production Case Study: Popmenu {#popmenu}
 
 Popmenu, a restaurant platform serving tens of millions of SSR requests daily, adopted React on Rails Pro and reported:
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -166,10 +166,10 @@ combined transfer size or cache behavior. Fewer requests do not necessarily impl
 
 | Metric                             | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ---------------------------------- | -----------: | -------: | ------------------------------: |
-| Worst-case `responseEnd` (max n=4) |        731ms |    768ms |                           +5.2% |
+| Worst-case `responseEnd` (max n=4) |        731ms |    768ms |                           +5.1% |
 
 The source artifact labels this as p95, but with four samples it is effectively the maximum observed value, not a
-stable tail-latency estimate. It shows a +5.2% RSC regression on worst-case `responseEnd` (high variance is expected at
+stable tail-latency estimate. It shows a +5.1% RSC regression on worst-case `responseEnd` (high variance is expected at
 n=4), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,11 +89,12 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
-### Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
+### Non-Production Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
-surface with the same reduced presenter data and outer layout across two routes:
+surface with the same reduced presenter data and outer layout across two routes. The comparison changes three axes at
+once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed to any single factor. The routes are:
 
 - Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer or SSR)
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
@@ -114,24 +115,25 @@ Conditions:
 - Dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`
 - Chrome 147 with matching ChromeDriver 147
 
-The original artifact does not yet publish `RAILS_ENV`, hardware/OS, Ruby/Node/Rails versions, or cache-state details.
-[Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata; until
-that is resolved, treat these numbers as directional signals rather than a stable baseline.
+The original artifact does not yet publish `RAILS_ENV`, browser cache behavior between measured runs, hardware/OS, or
+Ruby/Node/Rails versions. [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing
+environment metadata; until that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
 The browser timing medians showed this directional signal:
 
 | Metric                                      | Inertia demo | RSC demo |  Delta |
 | ------------------------------------------- | -----------: | -------: | -----: |
-| Navigation duration                         |     775.40ms | 607.15ms | -21.7% |
-| Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
-| `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total` (Rails wall time) |     346.90ms | 339.20ms |  noise |
+| Navigation duration                         |        775ms |    607ms | -21.7% |
+| Largest Contentful Paint                    |        794ms |    634ms | -20.2% |
+| `responseEnd`                               |        645ms |    589ms |  -8.7% |
+| Controller `action_total` (Rails wall time) |        347ms |    339ms |  noise |
 
 The page-specific script request count changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That
 is a fixed request count, not a timing median or statistical sample, and it does not measure combined transfer-size. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
-- _All timing values are medians (n=4 per route); sample size is too small to establish statistical significance._
+- _All timing values are medians rounded to the nearest millisecond (n=4 per route); sample size is too small to
+  establish statistical significance._
 - _The `action_total` difference was -2.2%, which is likely within expected variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
@@ -139,7 +141,7 @@ Worst-case counter-signal:
 
 | Metric                              | Inertia demo | RSC demo | Delta |
 | ----------------------------------- | -----------: | -------: | ----: |
-| Max `responseEnd` (worst-case, n=4) |     730.62ms | 768.25ms | +5.2% |
+| Max `responseEnd` (worst-case, n=4) |        731ms |    768ms | +5.2% |
 
 The max row is a max-vs-max comparison, not a stable tail-latency estimate. It shows a +5.2% RSC regression on
 worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster worst-case

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -104,21 +104,28 @@ surface with the same reduced presenter data and outer layout across two routes:
 > not a bundler swap.
 
 The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
-routes, four per route, with one warmup request before each measured run. It used compiled page assets from the same
-Shakapacker configuration with Rspack for both routes, compiled RSC demo bundles, Rails without the Shakapacker dev
-server, a dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`, and matching Chrome 147 and ChromeDriver 147. The median results, plus the observed max `responseEnd`, showed this directional signal:
+routes, four per route, with one warmup request before each measured run. Conditions:
+
+- Compiled page assets from the same Shakapacker/Rspack configuration for both routes
+- Compiled RSC demo bundles
+- Rails server without the Shakapacker dev server running
+- Dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`
+- Chrome 147 with matching ChromeDriver 147
+
+The median results showed this directional signal:
 
 | Metric                        | Inertia demo | RSC demo |  Delta |
 | ----------------------------- | -----------: | -------: | -----: |
 | Navigation duration           |     775.40ms | 607.15ms | -21.7% |
 | Largest Contentful Paint      |     794.00ms | 634.00ms | -20.2% |
 | `responseEnd`                 |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total`     |     346.87ms | 339.20ms |  -2.2% |
+| Controller `action_total`     |      346.9ms |  339.2ms |  -2.2% |
 | Page-specific script requests |            6 |        1 | -83.3% |
-| Max `responseEnd`             |     730.62ms | 768.25ms |  +5.2% |
 
-_Rows 1-5 are medians (n=4 per route); `Max responseEnd` is the observed maximum across those same four runs. The
-benchmark used eight alternating measured runs total, with one warmup request before each measured run._
+_Rows 1-5 are medians (n=4 per route)._
+
+The observed **max `responseEnd`** across the same four RSC runs was 768.25ms vs. 730.62ms for the Inertia control
+(+5.2%), indicating worst-case timing still favored the control.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
 user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -104,8 +104,9 @@ surface with the same reduced presenter data and outer layout across two routes:
 > on Rails Pro renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined
 > route-level effect; see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
 
-The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
-routes, four per route, with one warmup request before each measured run. Conditions:
+The April 30, 2026 local benchmark used eight alternating measured runs between the Inertia and RSC routes, four per
+route. Before each of the eight measured runs, the harness sent one warmup request to the route being measured.
+Conditions:
 
 - Compiled page assets from the same Shakapacker/Rspack configuration for both routes
 - Compiled RSC demo bundles
@@ -117,7 +118,7 @@ The original artifact does not yet publish `RAILS_ENV`, hardware/OS, Ruby/Node/R
 [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata; until
 that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
-The median results showed this directional signal:
+The browser timing medians and deterministic script request counts showed this directional signal:
 
 | Metric                                      | Inertia demo | RSC demo |  Delta |
 | ------------------------------------------- | -----------: | -------: | -----: |
@@ -127,7 +128,7 @@ The median results showed this directional signal:
 | Controller `action_total` (Rails wall time) |     346.90ms | 339.20ms |  -2.2% |
 | Page-specific script requests (count only)  |            6 |        1 | -83.3% |
 
-_The script-count row does not measure combined transfer-size. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._
+_The script-count row is a fixed request count, not a median, and does not measure combined transfer-size. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._
 _All values are medians (n=4 per route); sample size is too small to establish statistical significance._
 _The `action_total` delta (-2.2%) is likely within expected variance at n=4._
 _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -150,6 +150,8 @@ environment metadata, and distribution artifacts are still required before makin
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.
 
+<a id="popmenu"></a>
+
 ### Production Case Study: Popmenu
 
 Popmenu, a restaurant platform serving tens of millions of SSR requests daily, adopted React on Rails Pro and reported:

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -98,10 +98,8 @@ surface with the same reduced presenter data and outer layout across two routes:
 - Inertia-style control: `/dashboard/inertia_demo`
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
-> **Note:** These results reflect two distinct value propositions: **Rspack** addresses build speed and development
-> iteration time, while **React Server Components** target runtime JavaScript reduction and server-side composition.
-> Both routes use the same Shakapacker/Rspack page-asset build; the comparison measures the route-level RSC dimension,
-> not a bundler swap.
+> **Note:** Both routes use the same Shakapacker/Rspack page-asset build; this comparison measures the route-level RSC
+> dimension only. It is not a bundler comparison.
 
 The April 30, 2026 production-like local benchmark used eight alternating measured runs between the Inertia and RSC
 routes, four per route, with one warmup request before each measured run. Conditions:
@@ -113,8 +111,8 @@ routes, four per route, with one warmup request before each measured run. Condit
 - Chrome 147 with matching ChromeDriver 147
 
 The original artifact does not yet publish `RAILS_ENV`, hardware/OS, Ruby/Node/Rails versions, or cache-state details.
-[Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks that environment metadata before these
-numbers should be treated as a stable baseline.
+[Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata; until
+that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
 The median results showed this directional signal:
 
@@ -126,11 +124,11 @@ The median results showed this directional signal:
 | Controller `action_total`     |      346.9ms |  339.2ms |  -2.2% |
 | Page-specific script requests |            6 |        1 | -83.3% |
 
-_Rows 1-5 are medians (n=4 per route). Distribution and variance artifacts are tracked in
+_Rows 1-5 are medians (n=4 per route); sample size is too small to establish statistical significance. Distribution and variance artifacts are tracked in
 [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
 The observed **max `responseEnd`** across the four RSC runs was 768.25ms vs. 730.62ms for the Inertia control's max
-(+5.2% for RSC worst-case), indicating worst-case timing still favored the control.
+(+5.2% for RSC worst-case), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
 user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -141,8 +141,10 @@ Playwright harness and may differ from `PerformanceNavigationTiming.duration`.
 `action_total` is the Rails wall-time field from the raw benchmark artifact, not a browser Performance API metric. The
 artifact does not yet publish enough logger or extraction-script context to confirm whether it is the full
 `process_action` duration including rendering or a narrower controller-action field, so do not use it to infer the
-server-rendering split. [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing
-distribution and source artifacts.
+server-rendering split. Because the Pro Node renderer runs in a separate OS process, Rails wall time may also exclude
+RSC rendering cost that the Inertia control keeps in-process, so the two `action_total` values may not measure identical
+scopes of work. [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution
+and source artifacts.
 
 Derived from the median table above, the RSC route's post-`responseEnd` browser processing time (`navigation duration -
 responseEnd`, including HTML parsing, sub-resource loading, layout, and paint) was about 18ms, compared with about 130ms
@@ -154,7 +156,9 @@ than the `responseEnd` gain (-8.7%).
 The page-specific script request count, recorded as Chrome DevTools Network panel `Script`-type requests after loading
 each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. The artifact reports this as a
 fixed post-load request-count observation, not a per-run timing median or statistical sample, and it does not measure
-combined transfer size or cache behavior. Fewer requests do not necessarily imply a smaller browser payload. See
+combined transfer size or cache behavior. Fewer requests do not necessarily imply a smaller browser payload: the RSC
+route carries runtime, Flight payload, and RSC-specific bundle costs that the Inertia control does not, so total transfer
+size is the meaningful network-cost metric and is not reported here. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -143,14 +143,15 @@ artifact does not yet publish enough logger or extraction-script context to conf
 server-rendering split. [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing
 distribution and source artifacts.
 
-Derived from the median table above, the RSC route's post-`responseEnd` client processing time (`navigation duration -
-responseEnd`) was about 18ms, compared with about 130ms for the Inertia control. That gap helps explain why the
-navigation-duration gain (-21.7%) was larger than the `responseEnd` gain (-8.7%).
+Derived from the median table above, the RSC route's post-`responseEnd` browser processing time (`navigation duration -
+responseEnd`, including HTML parsing, sub-resource loading, layout, and paint) was about 18ms, compared with about 130ms
+for the Inertia control. That gap helps explain why the navigation-duration gain (-21.7%) was larger than the
+`responseEnd` gain (-8.7%).
 
-The page-specific script request count, measured as Chrome DevTools Network panel `Script`-type requests after loading
-each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That is a fixed request count,
-not a timing median or statistical sample, and it does not measure combined transfer size or cache behavior. Fewer
-requests do not necessarily imply a smaller browser payload. See
+The page-specific script request count, recorded as Chrome DevTools Network panel `Script`-type requests after loading
+each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. The artifact reports this as a
+fixed post-load request-count observation, not a per-run timing median or statistical sample, and it does not measure
+combined transfer size or cache behavior. Fewer requests do not necessarily imply a smaller browser payload. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -116,19 +116,20 @@ that is resolved, treat these numbers as directional signals rather than a stabl
 
 The median results showed this directional signal:
 
-| Metric                        | Inertia demo | RSC demo |  Delta |
-| ----------------------------- | -----------: | -------: | -----: |
-| Navigation duration           |     775.40ms | 607.15ms | -21.7% |
-| Largest Contentful Paint      |     794.00ms | 634.00ms | -20.2% |
-| `responseEnd`                 |     644.80ms | 588.80ms |  -8.7% |
-| Controller `action_total`     |      346.9ms |  339.2ms |  -2.2% |
-| Page-specific script requests |            6 |        1 | -83.3% |
+| Metric                                      | Inertia demo | RSC demo |  Delta |
+| ------------------------------------------- | -----------: | -------: | -----: |
+| Navigation duration                         |     775.40ms | 607.15ms | -21.7% |
+| Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
+| `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
+| Controller `action_total` (Rails wall time) |      346.9ms |  339.2ms |  -2.2% |
+| Page-specific script requests               |            6 |        1 | -83.3% |
 
-_Rows 1-5 are medians (n=4 per route); sample size is too small to establish statistical significance. Distribution and variance artifacts are tracked in
-[Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
+_Rows 1-5 are medians (n=4 per route); sample size is too small to establish statistical significance._
+_Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
 The observed **max `responseEnd`** across the four RSC runs was 768.25ms vs. 730.62ms for the Inertia control's max
-(+5.2% for RSC worst-case), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC route.
+(+5.2% for RSC worst-case, max of n=4 - high variance expected at this sample size), indicating the Inertia control had
+a faster worst-case `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
 user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -106,11 +106,9 @@ single factor. The routes are:
 > renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined route-level effect;
 > see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
 
-The April 30, 2026 local benchmark used eight alternating measured runs between the Inertia and RSC routes, four per
-route. Before each of the eight measured runs, the harness sent one warmup request to the route being measured; one
-warmup may not be enough for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state.
-That limitation is more likely to make the RSC route look slower than its steady-state performance than to inflate its
-advantage, so treat the RSC median wins as directional rather than fully warmed production estimates.
+The April 30, 2026 local benchmark used eight strictly alternating measured runs between the Inertia and RSC routes
+(Inertia, RSC, Inertia, RSC, and so on), four per route. Before each of the eight measured runs, the harness sent one
+warmup request to the route being measured.
 
 Conditions:
 
@@ -123,18 +121,20 @@ Conditions:
 > [!WARNING]
 > The original artifact does not yet publish `RAILS_ENV`, browser cache behavior between measured runs, hardware/OS, or
 > Ruby/Node/Rails versions. Unknown `RAILS_ENV` can account for large timing differences; unknown browser cache state
-> between measured runs affects repeatability. [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253)
-> tracks the missing environment metadata. Until that is resolved, treat these numbers as directional signals rather than
-> a stable baseline.
+> between measured runs affects repeatability. The single warmup request before each measured run may also be insufficient
+> for the Pro Node renderer worker pool to reach JIT and RSC-payload-compilation steady state, which is more likely to
+> make the RSC route look slower than its steady-state performance than to inflate its advantage.
+> [Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks the missing environment metadata. Until
+> that is resolved, treat these numbers as directional signals rather than a stable baseline.
 
-The browser timing medians showed this directional signal:
+The median results showed this directional signal:
 
-| Metric                                      | Inertia demo | RSC demo | Delta (negative = RSC faster) |
-| ------------------------------------------- | -----------: | -------: | ----------------------------: |
-| Navigation duration                         |     775.40ms | 607.15ms |                        -21.7% |
-| Largest Contentful Paint                    |     794.00ms | 634.00ms |                        -20.2% |
-| `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
-| Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |              -2.2% (variance) |
+| Source  | Metric                                      | Inertia demo | RSC demo | Delta (negative = RSC faster) |
+| ------- | ------------------------------------------- | -----------: | -------: | ----------------------------: |
+| Browser | Navigation duration                         |     775.40ms | 607.15ms |                        -21.7% |
+| Browser | Largest Contentful Paint                    |     794.00ms | 634.00ms |                        -20.2% |
+| Browser | `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
+| Rails   | Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |              -2.2% (variance) |
 
 `action_total` is the Rails controller wall-time field from the raw benchmark artifact, not a browser Performance API
 metric. The artifact does not yet publish enough logger or extraction-script context to make that field independently

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -131,7 +131,11 @@ The browser timing medians showed this directional signal:
 | Navigation duration                         |     775.40ms | 607.15ms |                        -21.7% |
 | Largest Contentful Paint                    |     794.00ms | 634.00ms |                        -20.2% |
 | `responseEnd`                               |     644.80ms | 588.80ms |                         -8.7% |
-| Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |                             — |
+| Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |              -2.2% (variance) |
+
+The RSC route's post-`responseEnd` client processing time was about 18ms, compared with about 130ms for the Inertia
+control. That gap helps explain why the navigation-duration gain (-21.7%) was larger than the server-response
+`responseEnd` gain (-8.7%).
 
 The page-specific script request count, measured as Chrome DevTools Network panel `Script`-type requests after loading
 each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That is a fixed request count,
@@ -140,19 +144,19 @@ not a timing median or statistical sample, and it does not measure combined tran
 
 - _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
   establish statistical significance._
-- _The `action_total` delta is shown as an em dash because its computed -2.2% difference is likely within expected
+- _The `action_total` delta is shown with a variance qualifier because its -2.2% difference is likely within expected
   variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-#### p95 counter-signal
+#### Worst-case `responseEnd` counter-signal
 
-| Metric                  | Inertia demo | RSC demo | Delta (negative = RSC faster) |
-| ----------------------- | -----------: | -------: | ----------------------------: |
-| p95 `responseEnd` (n=4) |     730.62ms | 768.25ms |                         +5.2% |
+| Metric                             | Inertia demo | RSC demo | Delta (negative = RSC faster) |
+| ---------------------------------- | -----------: | -------: | ----------------------------: |
+| Worst-case `responseEnd` (max n=4) |     730.62ms | 768.25ms |                         +5.2% |
 
-The p95 row is a percentile comparison over four samples, not a stable tail-latency estimate. It shows a +5.2% RSC
-regression on p95 `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster p95
-`responseEnd` than the RSC route.
+The source artifact labels this as p95, but with four samples it is effectively the maximum observed value, not a
+stable tail-latency estimate. It shows a +5.2% RSC regression on worst-case `responseEnd` (high variance is expected at
+n=4), indicating the Inertia control had a faster worst-case `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
 renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route was faster

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -95,7 +95,7 @@ The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rai
 is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
 surface with the same reduced presenter data and outer layout across two routes:
 
-- Inertia-style control: `/dashboard/inertia_demo`
+- Inertia-style control: `/dashboard/inertia_demo` (uses the actual `inertia_rails` gem; no Pro renderer)
 - React on Rails Pro + React Server Components: `/dashboard/rsc_demo`
 
 > **Note:** Both routes use the same Shakapacker/Rspack page-asset build; this comparison measures the route-level RSC
@@ -125,23 +125,27 @@ The median results showed this directional signal:
 | Page-specific script requests               |            6 |        1 | -83.3% |
 
 _All values are medians (n=4 per route); sample size is too small to establish statistical significance._
+_The `action_total` delta (-2.2%) is likely within expected variance at n=4._
+_Script count only; combined transfer-size is not yet captured. See [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259)._
 _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-The observed **max `responseEnd`** across the four RSC runs was 768.25ms vs. 730.62ms for the Inertia control's max - a
-+5.2% RSC regression on worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had
-a faster worst-case `responseEnd` than the RSC route.
+Worst-case counter-signal:
+
+| Metric                              | Inertia demo | RSC demo | Delta |
+| ----------------------------------- | -----------: | -------: | ----: |
+| Max `responseEnd` (worst-case, n=4) |     730.62ms | 768.25ms | +5.2% |
+
+The max row is a max-vs-max comparison, not a stable tail-latency estimate. It shows a +5.2% RSC regression on
+worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster worst-case
+`responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
-user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case
-timing still favored the Inertia control. A stable deployed repeat, renderer-internal timing, environment metadata, and
-distribution artifacts are still required before making stronger production-performance claims.
-
-The script-request row counts browser-observed page-specific script resources only; combined transfer-size capture is
-tracked in [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
+user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the max
+`responseEnd` counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing,
+environment metadata, and distribution artifacts are still required before making stronger production-performance claims.
 
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
-[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion, and
-[Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) for the environment-metadata follow-up.
+[Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.
 
 ### Popmenu
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -89,7 +89,7 @@ Server components produce HTML that does not need hydration — they have no cli
 
 ## Real-World Results
 
-### Gumroad-Style RSC Benchmark Demo
+### Local Directional Benchmark: Gumroad-Style RSC Demo
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo, not an official Gumroad integration. It measures a bounded creator-dashboard
@@ -112,6 +112,10 @@ routes, four per route, with one warmup request before each measured run. Condit
 - Dedicated React on Rails Pro Node renderer on `RENDERER_PORT=3800`
 - Chrome 147 with matching ChromeDriver 147
 
+The original artifact does not yet publish `RAILS_ENV`, hardware/OS, Ruby/Node/Rails versions, or cache-state details.
+[Issue 3253](https://github.com/shakacode/react_on_rails/issues/3253) tracks that environment metadata before these
+numbers should be treated as a stable baseline.
+
 The median results showed this directional signal:
 
 | Metric                        | Inertia demo | RSC demo |  Delta |
@@ -122,15 +126,16 @@ The median results showed this directional signal:
 | Controller `action_total`     |      346.9ms |  339.2ms |  -2.2% |
 | Page-specific script requests |            6 |        1 | -83.3% |
 
-_Rows 1-5 are medians (n=4 per route)._
+_Rows 1-5 are medians (n=4 per route). Distribution and variance artifacts are tracked in
+[Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-The observed **max `responseEnd`** across the same four RSC runs was 768.25ms vs. 730.62ms for the Inertia control
-(+5.2%), indicating worst-case timing still favored the control.
+The observed **max `responseEnd`** across the four RSC runs was 768.25ms vs. 730.62ms for the Inertia control's max
+(+5.2% for RSC worst-case), indicating worst-case timing still favored the control.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on
 user-visible median navigation duration and LCP while sending fewer page-specific script requests, but the worst-case
-timing still favored the Inertia control. A stable deployed repeat, renderer-internal timing, and hardware details for
-the local run are still required before making stronger production-performance claims.
+timing still favored the Inertia control. A stable deployed repeat, renderer-internal timing, environment metadata, and
+distribution artifacts are still required before making stronger production-performance claims.
 
 The script-request row counts browser-observed page-specific script resources only; combined transfer-size capture is
 tracked in [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -124,11 +124,11 @@ The median results showed this directional signal:
 | Controller `action_total` (Rails wall time) |      346.9ms |  339.2ms |  -2.2% |
 | Page-specific script requests               |            6 |        1 | -83.3% |
 
-_Rows 1-5 are medians (n=4 per route); sample size is too small to establish statistical significance._
+_All values are medians (n=4 per route); sample size is too small to establish statistical significance._
 _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-The observed **max `responseEnd`** across the four RSC runs was 768.25ms vs. 730.62ms for the Inertia control's max
-(+5.2% for RSC worst-case, max of n=4 - high variance expected at this sample size), indicating the Inertia control had
+The observed **max `responseEnd`** across the four RSC runs was 768.25ms vs. 730.62ms for the Inertia control's max - a
++5.2% RSC regression on worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had
 a faster worst-case `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route was faster on

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -128,34 +128,34 @@ The browser timing medians showed this directional signal:
 
 | Metric                                      | Inertia demo | RSC demo |  Delta |
 | ------------------------------------------- | -----------: | -------: | -----: |
-| Navigation duration                         |        775ms |    607ms | -21.7% |
-| Largest Contentful Paint                    |        794ms |    634ms | -20.2% |
-| `responseEnd`                               |        645ms |    589ms |  -8.7% |
-| Controller `action_total` (Rails wall time) |        347ms |    339ms |  noise |
+| Navigation duration                         |     775.40ms | 607.15ms | -21.7% |
+| Largest Contentful Paint                    |     794.00ms | 634.00ms | -20.2% |
+| `responseEnd`                               |     644.80ms | 588.80ms |  -8.7% |
+| Controller `action_total` (Rails wall time) |     346.87ms | 339.20ms |  noise |
 
 The page-specific script request count, measured as Chrome DevTools Network panel `Script`-type requests after loading
 each route, changed from 6 requests for the Inertia demo to 1 request for the RSC demo. That is a fixed request count,
 not a timing median or statistical sample, and it does not measure combined transfer-size. See
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
-- _All timing values are medians rounded to the nearest millisecond (n=4 per route); sample size is too small to
+- _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
   establish statistical significance._
 - _The `action_total` difference was -2.2%, which is likely within expected variance at n=4._
 - _Distribution and variance artifacts are tracked in [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 
-Worst-case counter-signal:
+p95 counter-signal:
 
-| Metric                              | Inertia demo | RSC demo | Delta |
-| ----------------------------------- | -----------: | -------: | ----: |
-| Max `responseEnd` (worst-case, n=4) |        731ms |    768ms | +5.2% |
+| Metric                  | Inertia demo | RSC demo | Delta |
+| ----------------------- | -----------: | -------: | ----: |
+| p95 `responseEnd` (n=4) |     730.62ms | 768.25ms | +5.2% |
 
-The max row is a max-vs-max comparison, not a stable tail-latency estimate. It shows a +5.2% RSC regression on
-worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster worst-case
+The p95 row is a percentile comparison over four samples, not a stable tail-latency estimate. It shows a +5.2% RSC
+regression on p95 `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster p95
 `responseEnd` than the RSC route.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
 renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route was faster
-on user-visible median navigation duration and LCP while sending fewer page-specific script requests. The max
+on user-visible median navigation duration and LCP while sending fewer page-specific script requests. The p95
 `responseEnd` counter-signal was faster for the Inertia control. A stable deployed repeat, renderer-internal timing,
 environment metadata, and distribution artifacts are still required before making stronger production-performance claims.
 


### PR DESCRIPTION
## Summary
- add the Gumroad-style Inertia vs React on Rails Pro + RSC benchmark signal to the performance benchmarks page
- document matched routes, current local metrics, and caveats around production claims
- link the ongoing tracking issues for deeper benchmark context

Refs #3128
Refs #3144

## Test Plan
- `pnpm exec prettier --check docs/oss/core-concepts/performance-benchmarks.md`
- `script/check-docs-sidebar origin/main HEAD`
- `git diff --check`
- pre-commit/pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this PR only updates documentation, though it introduces new benchmark numbers/interpretation that should be reviewed for accuracy and caveats.
> 
> **Overview**
> Adds a new *non-production* “Gumroad-style” benchmark section to `performance-benchmarks.md`, comparing an Inertia control route vs React on Rails Pro + RSC and reporting median browser/Rails timing deltas.
> 
> Documents the test setup and key caveats (multiple axes changed, limited sample size, missing env/cache metadata), includes a worst-case `responseEnd` counter-signal table, and links to the public demo repo plus tracking issues; the Popmenu production case study remains as the validated reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94898d460b4ae1b82c091ca18bacb72f708dee55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Gumroad-Style RSC Benchmark Demo" case study to the performance benchmarks page, comparing two dashboard implementations across navigation duration, LCP, responseEnd, controller timings, page script request counts, and max responseEnd.
  * Includes a timing/results table, narrative interpretation (median vs worst-case behavior), benchmark methodology for reproducibility, and links to a public comparison repo and related issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3233)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->