### PR TITLE
docs: document benchmark gate tuning plan

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -32,7 +32,7 @@ exclude = [
   '^https://invite\.reactrails\.com/?$',  # Slack invite endpoint returns 403 for automated requests
   '^https://docs\.google\.com',  # Private docs require auth
   '^https://claude\.ai',  # Returns 403 for automated requests
-  '^https://bencher\.dev/console/projects/react-on-rails-t8a9ncxo/?$',  # Dashboard requires auth; returns 403
+  '^https://bencher\.dev/console/projects/react-on-rails-t8a9ncxo',  # Dashboard requires auth; returns 403
   '^https://(www\.)?110grill\.com/?$',  # Returns 403 for automated requests
 
   # ============================================================================

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -32,6 +32,7 @@ exclude = [
   '^https://invite\.reactrails\.com/?$',  # Slack invite endpoint returns 403 for automated requests
   '^https://docs\.google\.com',  # Private docs require auth
   '^https://claude\.ai',  # Returns 403 for automated requests
+  '^https://bencher\.dev/console/projects/react-on-rails-t8a9ncxo/?$',  # Dashboard requires auth; returns 403
   '^https://(www\.)?110grill\.com/?$',  # Returns 403 for automated requests
 
   # ============================================================================

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -32,7 +32,7 @@ exclude = [
   '^https://invite\.reactrails\.com/?$',  # Slack invite endpoint returns 403 for automated requests
   '^https://docs\.google\.com',  # Private docs require auth
   '^https://claude\.ai',  # Returns 403 for automated requests
-  '^https://bencher\.dev/console/projects/react-on-rails-t8a9ncxo',  # Dashboard requires auth; returns 403
+  '^https://bencher\.dev/console/projects/react-on-rails-t8a9ncxo(/.*)?$',  # Dashboard requires auth; returns 403
   '^https://(www\.)?110grill\.com/?$',  # Returns 403 for automated requests
 
   # ============================================================================

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -32,7 +32,7 @@ exclude = [
   '^https://invite\.reactrails\.com/?$',  # Slack invite endpoint returns 403 for automated requests
   '^https://docs\.google\.com',  # Private docs require auth
   '^https://claude\.ai',  # Returns 403 for automated requests
-  '^https://bencher\.dev/console/projects/react-on-rails-t8a9ncxo(/.*)?$',  # Dashboard requires auth; returns 403
+  '^https://bencher\.dev/(console/projects|perf)/react-on-rails-t8a9ncxo(/.*)?$',  # Dashboard and perf URLs require auth; return 403
   '^https://(www\.)?110grill\.com/?$',  # Returns 403 for automated requests
 
   # ============================================================================

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -104,15 +104,16 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
-2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the Bencher dashboard or the
-   overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two
-   adjacent alert sets `A` and `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs
-   across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating;
-   begin overlap analysis once at least 5 adjacent-run pairs exist, but proceed to step 3 only after the full 30-run
-   baseline window exists and overlap is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20` and
-   `0.40` avoids flip-flopping between noise and signal states; the thresholds were chosen empirically from the
-   alert-overlap evidence in Issue 3169 and should be revisited if the alert distribution changes significantly. If a
-   comparison has fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
+2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the
+   [Bencher dashboard](https://bencher.dev/console/projects/react-on-rails-t8a9ncxo/) or the overlap-comparison method
+   tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two adjacent alert sets `A` and
+   `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs across 10 total unique alert
+   pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating; begin overlap analysis once
+   at least 5 adjacent-run pairs exist, but proceed to step 3 only after the full 30-run baseline window exists and overlap
+   is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20` and `0.40` avoids flip-flopping between
+   noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in Issue 3169 and
+   should be revisited if the alert distribution changes significantly. If a comparison has fewer than 5 unique alert
+   pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
@@ -139,13 +140,14 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    Bencher regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the
    triggering push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does
    not classify as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
-4. The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
-   failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
-   performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next
-   qualifying run and has no matching performance-sensitive code change. After re-enabling, record each main gate failure
-   in Issue 3169 with a noisy/real classification. Review the running rate after every 5 gate-triggering runs or at least
-   monthly, whichever comes first. If the gate later exceeds this rate on main, revert it to warning mode and re-tune
-   thresholds from the existing baseline window and overlap data before trying to re-enable it again.
+4. Restore the hard gate once criteria 1-3 pass; those checks establish the project false-positive target of no more than
+   1 noisy failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change
+   benchmark performance.
+5. After re-enabling, record each main gate failure in Issue 3169 with a noisy/real classification. Treat an alert as noisy
+   when it does not recur for the same `(benchmark, measure)` pair in the next qualifying run and has no matching
+   performance-sensitive code change. Review the running rate after every 5 gate-triggering runs or at least monthly,
+   whichever comes first. If the gate later exceeds the 1-in-20 noisy-failure rate on main, revert it to warning mode and
+   re-tune thresholds from the existing baseline window and overlap data before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -59,3 +59,39 @@ Options to improve accuracy if needed:
 2. **Adaptive rate** - Quick max-rate probe, then benchmark at 70% capacity
 3. **Per-route fixed rates** - Maintain target RPS config (high maintenance burden)
 4. **Dedicated benchmark runners** - Reduce CI noise with consistent hardware
+
+## Main Gate Re-Enablement Plan
+
+The benchmark workflow currently treats main-regression alerts as warnings because single-run Bencher alerts on
+GitHub-hosted runners have been dominated by environmental noise. The goal is to make a fired alert much more likely
+to represent a real regression before restoring a hard gate.
+
+### Baseline Dependency
+
+Do not re-enable the hard gate until the Bencher reporting baseline fix from
+[PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) has landed and at least 30 post-merge main runs have
+built fresh history. Threshold tuning against missing or sparse baseline history will mostly tune the noise.
+
+### Tuning Sequence
+
+1. Keep the gate in warning mode while gathering the new baseline.
+2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs. A near-disjoint alert set means runner noise
+   is still dominating.
+3. Prefer threshold changes that require stronger evidence before failure:
+   - widen the Bencher boundary from `0.95` toward `0.99`
+   - add a `--threshold-min-sample-size` once each `(branch, benchmark, measure)` pair has enough history
+   - require the same `(benchmark, measure)` pair to alert across consecutive runs before filing or failing
+4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
+   restoring the hard gate.
+
+### Acceptance Criteria
+
+- At least 5 consecutive non-docs main pushes pass the warning-mode check with the current code.
+- The regression tracker accumulates only sustained or overlapping alerts, not a new random alert set on each run.
+- A deliberately introduced local regression, such as an added controller delay on a benchmarked route, still triggers an
+  alert under the tuned settings.
+- The hard gate is restored only after the tuned settings meet the false-positive target chosen for the project, such as
+  no more than 1 noisy failure in 20 unchanged-performance runs.
+
+See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
+alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -106,16 +106,17 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
-2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the
+2. Compare adjacent qualifying main runs by shared `(benchmark, measure)` alert pairs using the
    [Bencher dashboard](https://bencher.dev/console/projects/react-on-rails-t8a9ncxo/) or the overlap-comparison method
    tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two adjacent alert sets `A` and
    `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs across 10 total unique alert
    pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating; begin overlap analysis once
-   at least 5 adjacent-run pairs exist, but proceed to step 3 only after the full 30-run baseline window exists and overlap
-   is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20` and `0.40` avoids flip-flopping between
-   noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in Issue 3169 and
-   should be revisited if the alert distribution changes significantly. If a comparison has fewer than 5 unique alert
-   pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
+   at least 5 adjacent qualifying-run pairs exist, but proceed to step 3 only after the full 30-run baseline window exists
+   and overlap is at least `0.40` for 3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids
+   flip-flopping between noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in
+   Issue 3169 and should be revisited if the alert distribution changes significantly. Use the qualifying-run definition
+   from acceptance criterion 3. If a comparison has fewer than 5 unique alert pairs, record the small-sample caveat in
+   Issue 3169 and keep collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
@@ -133,7 +134,7 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 ### Acceptance Criteria
 
 1. Before restoring the hard gate, verify it can detect real regressions: add a temporary controller delay to a benchmarked
-   SSR route large enough to cause at least 10% degradation versus the current baseline median for that route, confirm an
+   SSR route large enough to cause at least 20% degradation versus the current baseline median for that route, confirm an
    alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before proceeding.
 2. As a pre-condition for starting the 5-run clean-run count below, the tuned settings must require manual tracking in
    Issue 3169 to show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -64,19 +64,21 @@ Options to improve accuracy if needed:
 
 The benchmark workflow currently treats main-regression alerts as warnings because single-run Bencher alerts on
 GitHub-hosted runners have been dominated by environmental noise. The goal is to make a fired alert much more likely
-to represent a real regression before restoring a hard gate.
+to represent a real regression before restoring a hard gate, where CI fails the job instead of posting a warning.
 
 ### Baseline Dependency
 
 Do not re-enable the hard gate until the Bencher reporting baseline fix from
 [PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) has landed and at least 30 post-merge main runs have
-built fresh history. Threshold tuning against missing or sparse baseline history will mostly tune the noise.
+built fresh history. Runs count whether or not they fire alerts because the goal is history volume, not a clean streak.
+Threshold tuning against missing or sparse baseline history will mostly tune the noise.
 
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
-2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs. A near-disjoint alert set means runner noise
-   is still dominating.
+2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the Bencher dashboard or the
+   overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). A
+   near-disjoint alert set means runner noise is still dominating.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - add a `--threshold-min-sample-size` once each `(branch, benchmark, measure)` pair has enough history
@@ -88,8 +90,9 @@ built fresh history. Threshold tuning against missing or sparse baseline history
 
 - At least 5 consecutive non-docs main pushes pass the warning-mode check with the current code.
 - The regression tracker accumulates only sustained or overlapping alerts, not a new random alert set on each run.
-- A deliberately introduced local regression, such as an added controller delay on a benchmarked route, still triggers an
-  alert under the tuned settings.
+- A deliberately introduced local regression still triggers an alert under the tuned settings. The developer re-enabling
+  the gate should add a temporary controller delay to a benchmarked route, verify an alert fires, and then revert the
+  delay.
 - The hard gate is restored only after the tuned settings meet the false-positive target chosen for the project, such as
   no more than 1 noisy failure in 20 unchanged-performance runs.
 

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -88,8 +88,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 - each threshold uses `--threshold-test t_test` and `--threshold-max-sample-size $MAX_SAMPLE`
 - `rps` uses `--threshold-lower-boundary $BOUNDARY` and `--threshold-upper-boundary _` (which disables the upper bound)
   because higher RPS is better; a regression is a drop below the lower bound
-- `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-upper-boundary $BOUNDARY` because lower
-  latency and failure rate are better; a regression is a rise above the upper bound
+- `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-lower-boundary _` (which disables the
+  lower bound) and `--threshold-upper-boundary $BOUNDARY` because lower latency and failure rate are better; a regression
+  is a rise above the upper bound
 - on main, `run_bencher` captures Bencher's non-zero exit as `BENCHER_EXIT_CODE`; the
   `Warn if Bencher detected regression on main` step emits `::warning::` for regression alerts instead of exiting
 - operational Bencher failures already hard-fail via `Fail on non-regression Bencher error on main`, so only regression
@@ -114,8 +115,10 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
      if Bencher supports that flag for the configured threshold type
-   - require external tracking to see the same `(benchmark, measure)` pair alert on at least 2 consecutive runs before
-     filing or failing
+   - require manual tracking in Issue 3169 to see the same `(benchmark, measure)` pair alert on at least 2 consecutive
+     runs before filing or failing
+     If overlap remains below `0.40` after boundary widening, collect 5 more qualifying runs and re-evaluate from step 2
+     before escalating to step 4.
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.
 
@@ -129,8 +132,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
   qualifies when the triggering push modifies at least one file that
   [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify as docs-only. Track the running
   count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
-- External tracking requires the same `(benchmark, measure)` pair to alert on at least 2 consecutive runs before filing or
-  failing; a single noisy run does not trigger the gate.
+- Manual tracking in Issue 3169 must show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs
+  before filing or failing; a single noisy run does not trigger the gate.
 - The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
   failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
   performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -77,8 +77,8 @@ or sparse baseline history will mostly tune the noise.
 
 1. Keep the gate in warning mode while gathering the new baseline.
 2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the Bencher dashboard or the
-   overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). A
-   near-disjoint alert set means runner noise is still dominating.
+   overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). Alert
+   overlap below roughly 20% across two adjacent runs means runner noise is still dominating.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - add a `--threshold-min-sample-size` once each `(branch, benchmark, measure)` pair has enough history
@@ -97,7 +97,8 @@ or sparse baseline history will mostly tune the noise.
   the gate should add a temporary controller delay to a benchmarked route, verify an alert fires, and then revert the
   delay.
 - The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
-  failure in 20 unchanged-performance runs.
+  failure in 20 unchanged-performance runs. If the gate later exceeds this rate on main, revert it to warning mode and
+  re-tune thresholds before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -86,8 +86,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 - `MAX_SAMPLE=64`
 - `--err` causes Bencher regression alerts to return a non-zero exit code
 - each threshold uses `--threshold-test t_test` and `--threshold-max-sample-size $MAX_SAMPLE`
-- `rps` uses `--threshold-lower-boundary $BOUNDARY` because higher RPS is better; a regression is a drop below the
-  lower bound
+- `rps` uses `--threshold-lower-boundary $BOUNDARY` and `--threshold-upper-boundary _` (which disables the upper bound)
+  because higher RPS is better; a regression is a drop below the lower bound
 - `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-upper-boundary $BOUNDARY` because lower
   latency and failure rate are better; a regression is a rise above the upper bound
 - on main, `run_bencher` captures Bencher's non-zero exit as `BENCHER_EXIT_CODE`; the

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -68,10 +68,10 @@ to represent a real regression before restoring a hard gate, where CI fails the 
 
 ### Baseline Dependency
 
-Do not re-enable the hard gate until the Bencher reporting baseline fix from
-[PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) has landed and at least 30 post-merge main runs have
-built fresh history. Runs count whether or not they fire alerts because the goal is history volume, not a clean streak.
-Threshold tuning against missing or sparse baseline history will mostly tune the noise.
+The Bencher reporting baseline fix from [PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) landed on
+2026-04-23. Do not re-enable the hard gate until at least 30 post-merge main runs have built fresh history. Runs count
+whether or not they fire alerts because the goal is history volume, not a clean streak. Threshold tuning against missing
+or sparse baseline history will mostly tune the noise.
 
 ### Tuning Sequence
 
@@ -89,8 +89,10 @@ Threshold tuning against missing or sparse baseline history will mostly tune the
 ### Acceptance Criteria
 
 - At least 5 consecutive non-docs main pushes, meaning pushes that modify files outside `docs/`, `*.md`, and
-  `internal/`, pass the warning-mode check with the current code.
-- The regression tracker accumulates only sustained or overlapping alerts, not a new random alert set on each run.
+  `internal/`, pass the warning-mode check with the current code. Track the running count in
+  [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
+- Bencher is configured to require the same `(benchmark, measure)` pair to alert on consecutive runs before filing or
+  failing; a single noisy run does not trigger the gate.
 - A deliberately introduced local regression still triggers an alert under the tuned settings. The developer re-enabling
   the gate should add a temporary controller delay to a benchmarked route, verify an alert fires, and then revert the
   delay.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -117,8 +117,10 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
      if Bencher supports that flag for the configured threshold type
    - require manual tracking in Issue 3169 to see the same `(benchmark, measure)` pair alert on at least 2 consecutive
      runs before filing or failing
-     If overlap remains below `0.40` after boundary widening, collect 5 more qualifying runs and re-evaluate from step 2
-     before escalating to step 4.
+
+   If overlap remains below `0.40` after boundary widening, collect 5 more qualifying runs and re-evaluate from step 2
+   before escalating to step 4.
+
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.
 

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -67,14 +67,16 @@ GitHub-hosted runners have been dominated by environmental noise. The goal is to
 to represent a real regression before restoring a hard gate, where CI fails the job instead of posting a warning.
 If the hard gate has to return to warning mode, re-tune from the existing baseline window and overlap data first; start a
 fresh 30-run baseline window only after benchmark workflow or runner changes invalidate the old history. Do not tune
-thresholds before the full 30-run window exists because sparse history trains on noise rather than signal.
+thresholds before the full 30-run window exists because sparse history trains on noise rather than signal. Archive this
+section once the hard gate has been restored and held for 30 or more qualifying runs without breaching the false-positive
+target; at that point the plan has executed and the section lives only as historical context.
 
 ### Baseline Dependency
 
 The Bencher reporting baseline fix from [PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) landed on
 2026-04-23. Do not re-enable the hard gate until at least 30 successful `Benchmark Workflow` runs on `main` have built
 fresh history. Count only completed `benchmark` jobs triggered after that merge; exclude pre-merge runs, branch runs,
-reruns, and docs-only pushes skipped by
+reruns of any kind (manual workflow reruns or automatic GitHub retries), and docs-only pushes skipped by
 [`script/ci-changes-detector`](../../script/ci-changes-detector). Record each counted run ID and timestamp in
 [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 
@@ -100,8 +102,10 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 - restoring the hard gate means changing the warning step to exit with `$BENCHER_EXIT_CODE` after the false-positive
   target is met, not removing `--err`
 
-> **Note:** The values above are a snapshot of the workflow at the time of writing. Verify against
-> `.github/workflows/benchmark.yml` (`run_bencher` function) before tuning because the workflow is the source of truth.
+> **Note:** The values above are a snapshot of the workflow at the time of writing and capture only the tuning-relevant
+> flags; operational flags such as `--quiet` and `--format html` are intentionally omitted because they do not affect
+> threshold behavior. Verify against `.github/workflows/benchmark.yml` (`run_bencher` function) before tuning because the
+> workflow is the source of truth.
 
 ### Tuning Sequence
 
@@ -112,8 +116,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two adjacent alert sets `A` and `B`, use
    Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs across 10 total unique alert pairs
    gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating; begin overlap analysis once at
-   least 5 adjacent qualifying-run pairs exist, but proceed to step 3 only after the full 30-run baseline window exists and
-   overlap is at least `0.40` for 3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids
+   least 5 adjacent qualifying-run pairs exist (i.e., at least 6 qualifying runs because each pair shares one run with its
+   neighbor), but proceed to step 3 only after the full 30-run baseline window exists and overlap is at least `0.40` for
+   3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids
    flip-flopping between noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in
    Issue 3169 and should be revisited if the alert distribution changes significantly. A run qualifies when the triggering
    push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify
@@ -137,23 +142,30 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 
 1. Before restoring the hard gate, verify it can detect real regressions: add a temporary controller delay to a benchmarked
    SSR route large enough to cause at least 20% degradation versus the current baseline median for that route, confirm an
-   alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before proceeding.
+   alert fires under the tuned settings, then revert the delay. The 20% magnitude reflects the project's stated detection
+   goal (see "Why We Chose Max Rate" above) and the fact that GitHub-hosted runner noise under `BOUNDARY=0.95` with the
+   t-test masks smaller deltas; recalibrate this floor downward if the gate later moves to dedicated runners or boundary
+   widening reduces the noise floor. If no alert fires, re-tune before proceeding.
 2. As a pre-condition for starting the 5-run clean-run count below, the tuned settings must require manual tracking in
    Issue 3169 to show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or
    failing; a single noisy run does not trigger the gate. This is a manual gate: Bencher still alerts on the first run,
    and the requirement is that a reviewer confirms recurrence in Issue 3169 before acting on it.
 3. Only after steps 1 and 2 pass, at least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no
-   Bencher regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the
+   Bencher regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code (a value of `1` is what
+   triggers the warning step and the regression-issue update). A run qualifies when the
    triggering push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does
    not classify as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 4. Restore the hard gate once criteria 1-3 pass; those checks establish the project false-positive target of no more than
    1 noisy failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change
-   benchmark performance.
+   benchmark performance. Criterion 5 below defines who tracks this rate after re-enabling and the review cadence that
+   triggers reverting to warning mode if the target is breached.
 5. After re-enabling, record each main gate failure in Issue 3169 with a noisy/real classification. Treat an alert as noisy
    when it does not recur for the same `(benchmark, measure)` pair in the next qualifying run and has no matching
-   performance-sensitive code change. Review the running rate after every 5 gate-triggering runs or at least monthly,
-   whichever comes first. If the gate later exceeds the 1-in-20 noisy-failure rate on main, revert it to warning mode and
-   re-tune thresholds from the existing baseline window and overlap data before trying to re-enable it again.
+   performance-sensitive code change. The 1-in-20 window is rolling: count the most recent 20 such qualifying runs (the
+   same cohort defined in criterion 4), and exclude intentional-perf-change commits from both the numerator (noisy
+   failures) and the denominator (the 20-run total) rather than counting them as either real or noisy. Review the running rate after every 5 gate-triggering runs or at least
+   monthly, whichever comes first. If the gate later exceeds the 1-in-20 noisy-failure rate on main, revert it to warning
+   mode and re-tune thresholds from the existing baseline window and overlap data before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -86,8 +86,10 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 - `MAX_SAMPLE=64`
 - `--err` causes Bencher regression alerts to return a non-zero exit code
 - each threshold uses `--threshold-test t_test` and `--threshold-max-sample-size $MAX_SAMPLE`
-- `rps` uses `--threshold-lower-boundary $BOUNDARY`
-- `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-upper-boundary $BOUNDARY`
+- `rps` uses `--threshold-lower-boundary $BOUNDARY` because higher RPS is better; a regression is a drop below the
+  lower bound
+- `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-upper-boundary $BOUNDARY` because lower
+  latency and failure rate are better; a regression is a rise above the upper bound
 - on main, `run_bencher` captures Bencher's non-zero exit as `BENCHER_EXIT_CODE`; the
   `Warn if Bencher detected regression on main` step emits `::warning::` for regression alerts instead of exiting
 - operational Bencher failures already hard-fail via `Fail on non-regression Bencher error on main`, so only regression
@@ -119,16 +121,16 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 
 ### Acceptance Criteria
 
-- At least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no Bencher regression alert; that means
-  `BENCHER_EXIT_CODE` stays `0` or `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the
-  triggering push modifies at least one file that
+- Before restoring the hard gate, verify it can detect real regressions: add a temporary controller delay to a benchmarked
+  route, confirm an alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before
+  proceeding.
+- At least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no Bencher regression alert after the
+  deliberate-regression check above passes; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run
+  qualifies when the triggering push modifies at least one file that
   [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify as docs-only. Track the running
   count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 - External tracking requires the same `(benchmark, measure)` pair to alert on at least 2 consecutive runs before filing or
   failing; a single noisy run does not trigger the gate.
-- A deliberately introduced local regression still triggers an alert under the tuned settings. The developer re-enabling
-  the gate should add a temporary controller delay to a benchmarked route, verify an alert fires, and then revert the
-  delay.
 - The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
   failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
   performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -65,40 +65,61 @@ Options to improve accuracy if needed:
 The benchmark workflow currently treats main-regression alerts as warnings because single-run Bencher alerts on
 GitHub-hosted runners have been dominated by environmental noise. The goal is to make a fired alert much more likely
 to represent a real regression before restoring a hard gate, where CI fails the job instead of posting a warning.
+If the hard gate has to return to warning mode, re-tune from the existing baseline window and overlap data first; start a
+fresh 30-run baseline window only after benchmark workflow or runner changes invalidate the old history.
 
 ### Baseline Dependency
 
 The Bencher reporting baseline fix from [PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) landed on
-2026-04-23. Do not re-enable the hard gate until at least 30 post-merge main runs have built fresh history. Runs count
-whether or not they fire alerts because the goal is history volume, not a clean streak. Threshold tuning against missing
-or sparse baseline history will mostly tune the noise.
+2026-04-23. Do not re-enable the hard gate until at least 30 successful `Benchmark Workflow` runs on `main` have built
+fresh history. Count only completed `benchmark` jobs triggered after that merge; exclude pre-merge runs, branch runs,
+reruns, and docs-only pushes skipped by `script/ci-changes-detector`. Record each counted run ID and timestamp in
+[Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). Threshold tuning against missing or sparse
+baseline history will mostly tune the noise.
+
+### Current Bencher Configuration
+
+The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside the `run_bencher` function:
+
+- `BOUNDARY=0.95`
+- `MAX_SAMPLE=64`
+- `--err` causes Bencher regression alerts to return a non-zero exit code
+- each threshold uses `--threshold-test t_test` and `--threshold-max-sample-size $MAX_SAMPLE`
+- `rps` uses `--threshold-lower-boundary $BOUNDARY`
+- `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-upper-boundary $BOUNDARY`
+- regression alerts currently warn on main in the `Warn if Bencher detected regression on main` step
 
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
 2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the Bencher dashboard or the
-   overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). Alert
-   overlap below roughly 20% across two adjacent runs means runner noise is still dominating.
+   overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two
+   adjacent alert sets `A` and `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs
+   across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
-   - add a `--threshold-min-sample-size` once each `(branch, benchmark, measure)` pair has enough history
-   - require the same `(benchmark, measure)` pair to alert across consecutive runs before filing or failing
+   - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
+     if Bencher supports that flag for the configured threshold type
+   - require external tracking to see the same `(benchmark, measure)` pair alert on at least 2 consecutive runs before
+     filing or failing
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.
 
 ### Acceptance Criteria
 
-- At least 5 consecutive non-docs main pushes, meaning pushes that modify files outside `docs/`, `*.md`, and
-  `internal/`, pass the warning-mode check with the current code. Track the running count in
-  [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
-- Bencher is configured to require the same `(benchmark, measure)` pair to alert on consecutive runs before filing or
+- At least 5 consecutive qualifying main `Benchmark Workflow` runs pass the warning-mode check with the current code.
+  A run qualifies when the triggering push modifies at least one file that `script/ci-changes-detector` does not classify
+  as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
+- External tracking requires the same `(benchmark, measure)` pair to alert on at least 2 consecutive runs before filing or
   failing; a single noisy run does not trigger the gate.
 - A deliberately introduced local regression still triggers an alert under the tuned settings. The developer re-enabling
   the gate should add a temporary controller delay to a benchmarked route, verify an alert fires, and then revert the
   delay.
 - The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
-  failure in 20 unchanged-performance runs. If the gate later exceeds this rate on main, revert it to warning mode and
-  re-tune thresholds before trying to re-enable it again.
+  failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
+  performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next
+  qualifying run and has no matching performance-sensitive code change. If the gate later exceeds this rate on main,
+  revert it to warning mode and re-tune thresholds before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -88,13 +88,14 @@ Threshold tuning against missing or sparse baseline history will mostly tune the
 
 ### Acceptance Criteria
 
-- At least 5 consecutive non-docs main pushes pass the warning-mode check with the current code.
+- At least 5 consecutive non-docs main pushes, meaning pushes that modify files outside `docs/`, `*.md`, and
+  `internal/`, pass the warning-mode check with the current code.
 - The regression tracker accumulates only sustained or overlapping alerts, not a new random alert set on each run.
 - A deliberately introduced local regression still triggers an alert under the tuned settings. The developer re-enabling
   the gate should add a temporary controller delay to a benchmarked route, verify an alert fires, and then revert the
   delay.
-- The hard gate is restored only after the tuned settings meet the false-positive target chosen for the project, such as
-  no more than 1 noisy failure in 20 unchanged-performance runs.
+- The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
+  failure in 20 unchanged-performance runs.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -65,11 +65,19 @@ Options to improve accuracy if needed:
 The benchmark workflow currently treats main-regression alerts as warnings because single-run Bencher alerts on
 GitHub-hosted runners have been dominated by environmental noise. The goal is to make a fired alert much more likely
 to represent a real regression before restoring a hard gate, where CI fails the job instead of posting a warning.
-If the hard gate has to return to warning mode, re-tune from the existing baseline window and overlap data first; start a
-fresh 30-run baseline window only after benchmark workflow or runner changes invalidate the old history. Do not tune
-thresholds before the full 30-run window exists because sparse history trains on noise rather than signal. Archive this
-section once the hard gate has been restored and held for 30 or more qualifying runs without breaching the false-positive
-target; at that point the plan has executed and the section lives only as historical context.
+
+Standing instructions while this plan is in effect:
+
+- **Wait for history before tuning.** Do not tune thresholds before the full 30-run window exists; sparse history trains
+  on noise rather than signal.
+- **Fallback if the gate flips back.** If the hard gate has to return to warning mode, re-tune from the existing baseline
+  window and overlap data first rather than starting over.
+- **Baseline reset exception.** Start a fresh 30-run baseline window only after benchmark workflow or runner changes
+  invalidate the old history.
+- **Archive when done.** Once the hard gate has been restored and held for 30 or more qualifying runs without breaching
+  the false-positive target, delete the entire `## Main Gate Re-Enablement Plan` section (this heading and every
+  subsection through the end of the file, including the trailing Issue 3169 link) in a follow-up commit; the executed
+  plan then lives only in git history.
 
 ### Baseline Dependency
 

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -106,17 +106,19 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
-2. Compare adjacent qualifying main runs by shared `(benchmark, measure)` alert pairs using the
-   [Bencher dashboard](https://bencher.dev/console/projects/react-on-rails-t8a9ncxo/) or the overlap-comparison method
-   tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two adjacent alert sets `A` and
-   `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs across 10 total unique alert
-   pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating; begin overlap analysis once
-   at least 5 adjacent qualifying-run pairs exist, but proceed to step 3 only after the full 30-run baseline window exists
-   and overlap is at least `0.40` for 3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids
+2. Compare adjacent qualifying main runs by shared `(benchmark, measure)` alert pairs using the Bencher HTML report in the
+   workflow run summary. If browser access to Bencher is available, the workflow's history URL is
+   `https://bencher.dev/perf/react-on-rails-t8a9ncxo`; otherwise use the overlap-comparison method tracked in
+   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two adjacent alert sets `A` and `B`, use
+   Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs across 10 total unique alert pairs
+   gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating; begin overlap analysis once at
+   least 5 adjacent qualifying-run pairs exist, but proceed to step 3 only after the full 30-run baseline window exists and
+   overlap is at least `0.40` for 3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids
    flip-flopping between noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in
-   Issue 3169 and should be revisited if the alert distribution changes significantly. Use the qualifying-run definition
-   from acceptance criterion 3. If a comparison has fewer than 5 unique alert pairs, record the small-sample caveat in
-   Issue 3169 and keep collecting runs.
+   Issue 3169 and should be revisited if the alert distribution changes significantly. A run qualifies when the triggering
+   push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify
+   as docs-only. If a comparison has fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep
+   collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -93,6 +93,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
   is a rise above the upper bound
 - on main, `run_bencher` captures Bencher's non-zero exit as `BENCHER_EXIT_CODE`; the
   `Warn if Bencher detected regression on main` step emits `::warning::` for regression alerts instead of exiting
+- a separate main-branch step creates or updates a GitHub issue labeled `performance-regression` and links to the
+  regression run
 - operational Bencher failures already hard-fail via `Fail on non-regression Bencher error on main`, so only regression
   alerts are soft while the gate is in warning mode
 - restoring the hard gate means changing the warning step to exit with `$BENCHER_EXIT_CODE` after the false-positive
@@ -135,7 +137,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before proceeding.
 2. As a pre-condition for starting the 5-run clean-run count below, the tuned settings must require manual tracking in
    Issue 3169 to show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or
-   failing; a single noisy run does not trigger the gate.
+   failing; a single noisy run does not trigger the gate. This is a manual gate: Bencher still alerts on the first run,
+   and the requirement is that a reviewer confirms recurrence in Issue 3169 before acting on it.
 3. Only after steps 1 and 2 pass, at least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no
    Bencher regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the
    triggering push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -74,7 +74,8 @@ thresholds before the full 30-run window exists because sparse history trains on
 The Bencher reporting baseline fix from [PR 3148](https://github.com/shakacode/react_on_rails/pull/3148) landed on
 2026-04-23. Do not re-enable the hard gate until at least 30 successful `Benchmark Workflow` runs on `main` have built
 fresh history. Count only completed `benchmark` jobs triggered after that merge; exclude pre-merge runs, branch runs,
-reruns, and docs-only pushes skipped by `script/ci-changes-detector`. Record each counted run ID and timestamp in
+reruns, and docs-only pushes skipped by
+[`script/ci-changes-detector`](../../script/ci-changes-detector). Record each counted run ID and timestamp in
 [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 
 ### Current Bencher Configuration
@@ -94,6 +95,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 - restoring the hard gate means changing the warning step to exit with `$BENCHER_EXIT_CODE` after the false-positive
   target is met, not removing `--err`
 
+> **Note:** The values above are a snapshot of the workflow at the time of writing. Verify against
+> `.github/workflows/benchmark.yml` (`run_bencher` function) before tuning because the workflow is the source of truth.
+
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
@@ -101,8 +105,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two
    adjacent alert sets `A` and `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs
    across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating;
-   proceed to step 3 only after overlap is at least `0.40` for 3 consecutive adjacent-run pairs. If a comparison has
-   fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
+   proceed to step 3 only after overlap is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20`
+   and `0.40` avoids flip-flopping between noise and signal states. If a comparison has fewer than 5 unique alert pairs,
+   record the small-sample caveat in Issue 3169 and keep collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
@@ -114,9 +119,11 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 
 ### Acceptance Criteria
 
-- At least 5 consecutive qualifying main `Benchmark Workflow` runs pass the warning-mode check with the current code.
-  A run qualifies when the triggering push modifies at least one file that `script/ci-changes-detector` does not classify
-  as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
+- At least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no Bencher regression alert; that means
+  `BENCHER_EXIT_CODE` stays `0` or `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the
+  triggering push modifies at least one file that
+  [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify as docs-only. Track the running
+  count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 - External tracking requires the same `(benchmark, measure)` pair to alert on at least 2 consecutive runs before filing or
   failing; a single noisy run does not trigger the gate.
 - A deliberately introduced local regression still triggers an alert under the tuned settings. The developer re-enabling

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -66,7 +66,8 @@ The benchmark workflow currently treats main-regression alerts as warnings becau
 GitHub-hosted runners have been dominated by environmental noise. The goal is to make a fired alert much more likely
 to represent a real regression before restoring a hard gate, where CI fails the job instead of posting a warning.
 If the hard gate has to return to warning mode, re-tune from the existing baseline window and overlap data first; start a
-fresh 30-run baseline window only after benchmark workflow or runner changes invalidate the old history.
+fresh 30-run baseline window only after benchmark workflow or runner changes invalidate the old history. Do not tune
+thresholds before the full 30-run window exists because sparse history trains on noise rather than signal.
 
 ### Baseline Dependency
 
@@ -74,8 +75,7 @@ The Bencher reporting baseline fix from [PR 3148](https://github.com/shakacode/r
 2026-04-23. Do not re-enable the hard gate until at least 30 successful `Benchmark Workflow` runs on `main` have built
 fresh history. Count only completed `benchmark` jobs triggered after that merge; exclude pre-merge runs, branch runs,
 reruns, and docs-only pushes skipped by `script/ci-changes-detector`. Record each counted run ID and timestamp in
-[Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). Threshold tuning against missing or sparse
-baseline history will mostly tune the noise.
+[Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 
 ### Current Bencher Configuration
 
@@ -87,7 +87,12 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 - each threshold uses `--threshold-test t_test` and `--threshold-max-sample-size $MAX_SAMPLE`
 - `rps` uses `--threshold-lower-boundary $BOUNDARY`
 - `p50_latency`, `p90_latency`, `p99_latency`, and `failed_pct` use `--threshold-upper-boundary $BOUNDARY`
-- regression alerts currently warn on main in the `Warn if Bencher detected regression on main` step
+- on main, `run_bencher` captures Bencher's non-zero exit as `BENCHER_EXIT_CODE`; the
+  `Warn if Bencher detected regression on main` step emits `::warning::` for regression alerts instead of exiting
+- operational Bencher failures already hard-fail via `Fail on non-regression Bencher error on main`, so only regression
+  alerts are soft while the gate is in warning mode
+- restoring the hard gate means changing the warning step to exit with `$BENCHER_EXIT_CODE` after the false-positive
+  target is met, not removing `--err`
 
 ### Tuning Sequence
 
@@ -95,7 +100,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 2. Compare adjacent main runs by shared `(benchmark, measure)` alert pairs using the Bencher dashboard or the
    overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two
    adjacent alert sets `A` and `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs
-   across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating.
+   across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating;
+   proceed to step 3 only after overlap is at least `0.40` for 3 consecutive adjacent-run pairs. If a comparison has
+   fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
@@ -119,7 +126,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
   failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
   performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next
   qualifying run and has no matching performance-sensitive code change. If the gate later exceeds this rate on main,
-  revert it to warning mode and re-tune thresholds before trying to re-enable it again.
+  revert it to warning mode and re-tune thresholds from the existing baseline window and overlap data before trying to
+  re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -110,26 +110,30 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 ### Tuning Sequence
 
 1. Keep the gate in warning mode while gathering the new baseline.
-2. Compare adjacent qualifying main runs by shared `(benchmark, measure)` alert pairs using the Bencher HTML report in the
-   workflow run summary. If browser access to Bencher is available, the workflow's history URL is
-   `https://bencher.dev/perf/react-on-rails-t8a9ncxo`; otherwise use the overlap-comparison method tracked in
-   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two adjacent alert sets `A` and `B`, use
-   Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs across 10 total unique alert pairs
-   gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating; begin overlap analysis once at
-   least 5 adjacent qualifying-run pairs exist (i.e., at least 6 qualifying runs because each pair shares one run with its
-   neighbor), but proceed to step 3 only after the full 30-run baseline window exists and overlap is at least `0.40` for
-   3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids
-   flip-flopping between noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in
-   Issue 3169 and should be revisited if the alert distribution changes significantly. A run qualifies when the triggering
-   push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify
-   as docs-only. If a comparison has fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep
-   collecting runs.
+2. Compare adjacent qualifying main runs by shared `(benchmark, measure)` alert pairs:
+   - **Data source:** Use the Bencher HTML report in the workflow run summary. If browser access to Bencher is available,
+     the history URL is `https://bencher.dev/perf/react-on-rails-t8a9ncxo`; otherwise use the overlap-comparison method
+     tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
+   - **Qualifying run:** A push that modifies at least one file that
+     [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify as docs-only.
+   - **Jaccard overlap formula:** For adjacent alert sets `A` and `B`, compute `|A intersect B| / |A union B|`. For
+     example, two shared pairs across 10 total unique alert pairs gives `2 / 10 = 20%`.
+   - **When to start:** Begin overlap analysis once at least 5 adjacent qualifying-run pairs exist (i.e., at least 6
+     qualifying runs because each pair shares one run with its neighbor).
+   - **Noise floor (`0.20`):** Overlap below this means runner noise is still dominating; keep collecting runs.
+   - **Signal threshold (`0.40`):** Proceed to step 3 only after the full 30-run baseline window exists **and** overlap is
+     at least `0.40` for 3 consecutive adjacent qualifying-run pairs. The gap between `0.20` and `0.40` avoids flip-flopping
+     between noise and signal states; the thresholds were chosen empirically from the alert-overlap evidence in Issue 3169
+     and should be revisited if the alert distribution changes significantly.
+   - **Small-sample caveat:** If a comparison has fewer than 5 unique alert pairs, record it in Issue 3169 and keep
+     collecting runs.
+
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
      if Bencher supports that flag for the configured threshold type
    - require manual tracking in Issue 3169 to see the same `(benchmark, measure)` pair alert on at least 2 consecutive
-     runs before filing or failing
+     runs before filing or failing (restated as Acceptance Criterion 2 below — the same gate, viewed from the tuning side)
 
    If overlap remains below `0.40` after boundary widening, collect 5 more qualifying runs and re-evaluate from step 2
    before escalating to step 4. Escalate to step 4 unconditionally after 2 such re-evaluation cycles, which means at
@@ -149,7 +153,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 2. As a pre-condition for starting the 5-run clean-run count below, the tuned settings must require manual tracking in
    Issue 3169 to show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or
    failing; a single noisy run does not trigger the gate. This is a manual gate: Bencher still alerts on the first run,
-   and the requirement is that a reviewer confirms recurrence in Issue 3169 before acting on it.
+   and the requirement is that a reviewer confirms recurrence in Issue 3169 before acting on it. (This is the same gate
+   stated in Tuning Sequence step 3; restated here because it is also a pre-condition for the 5-run clean-run count.)
 3. Only after steps 1 and 2 pass, at least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no
    Bencher regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code (a value of `1` is what
    triggers the warning step and the regression-issue update). A run qualifies when the
@@ -163,9 +168,10 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    when it does not recur for the same `(benchmark, measure)` pair in the next qualifying run and has no matching
    performance-sensitive code change. The 1-in-20 window is rolling: count the most recent 20 such qualifying runs (the
    same cohort defined in criterion 4), and exclude intentional-perf-change commits from both the numerator (noisy
-   failures) and the denominator (the 20-run total) rather than counting them as either real or noisy. Review the running rate after every 5 gate-triggering runs or at least
-   monthly, whichever comes first. If the gate later exceeds the 1-in-20 noisy-failure rate on main, revert it to warning
-   mode and re-tune thresholds from the existing baseline window and overlap data before trying to re-enable it again.
+   failures) and the denominator (the 20-run total) rather than counting them as either real or noisy.
+   Review the running rate after every 5 gate-triggering runs or at least monthly, whichever comes first. If the gate later
+   exceeds the 1-in-20 noisy-failure rate on main, revert it to warning mode and re-tune thresholds from the existing
+   baseline window and overlap data before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -109,8 +109,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    adjacent alert sets `A` and `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs
    across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating;
    proceed to step 3 only after overlap is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20`
-   and `0.40` avoids flip-flopping between noise and signal states. If a comparison has fewer than 5 unique alert pairs,
-   record the small-sample caveat in Issue 3169 and keep collecting runs.
+   and `0.40` avoids flip-flopping between noise and signal states; the thresholds were chosen empirically from the
+   alert-overlap evidence in Issue 3169 and should be revisited if the alert distribution changes significantly. If a
+   comparison has fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
    - widen the Bencher boundary from `0.95` toward `0.99`
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
@@ -126,22 +127,22 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 
 ### Acceptance Criteria
 
-- Before restoring the hard gate, verify it can detect real regressions: add a temporary controller delay to a benchmarked
-  route, confirm an alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before
-  proceeding.
-- At least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no Bencher regression alert after the
-  deliberate-regression check above passes; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run
-  qualifies when the triggering push modifies at least one file that
-  [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify as docs-only. Track the running
-  count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
-- Manual tracking in Issue 3169 must show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs
-  before filing or failing; a single noisy run does not trigger the gate.
-- The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
-  failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
-  performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next
-  qualifying run and has no matching performance-sensitive code change. If the gate later exceeds this rate on main,
-  revert it to warning mode and re-tune thresholds from the existing baseline window and overlap data before trying to
-  re-enable it again.
+1. Before restoring the hard gate, verify it can detect real regressions: add a temporary controller delay to a benchmarked
+   route, confirm an alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before
+   proceeding.
+2. Only after step 1 passes, at least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no Bencher
+   regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the triggering
+   push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify
+   as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
+3. Manual tracking in Issue 3169 must show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs
+   before filing or failing; a single noisy run does not trigger the gate.
+4. The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
+   failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
+   performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next
+   qualifying run and has no matching performance-sensitive code change. After re-enabling, record each main gate failure
+   in Issue 3169 with a noisy/real classification. Review the running rate after every 5 gate-triggering runs or at least
+   monthly, whichever comes first. If the gate later exceeds this rate on main, revert it to warning mode and re-tune
+   thresholds from the existing baseline window and overlap data before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
 alert-overlap evidence.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -108,8 +108,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    overlap-comparison method tracked in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). For two
    adjacent alert sets `A` and `B`, use Jaccard overlap: `|A intersect B| / |A union B|`. For example, two shared pairs
    across 10 total unique alert pairs gives `2 / 10 = 20%`. Overlap below `0.20` means runner noise is still dominating;
-   proceed to step 3 only after overlap is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20`
-   and `0.40` avoids flip-flopping between noise and signal states; the thresholds were chosen empirically from the
+   begin overlap analysis once at least 5 adjacent-run pairs exist, but proceed to step 3 only after the full 30-run
+   baseline window exists and overlap is at least `0.40` for 3 consecutive adjacent-run pairs. The gap between `0.20` and
+   `0.40` avoids flip-flopping between noise and signal states; the thresholds were chosen empirically from the
    alert-overlap evidence in Issue 3169 and should be revisited if the alert distribution changes significantly. If a
    comparison has fewer than 5 unique alert pairs, record the small-sample caveat in Issue 3169 and keep collecting runs.
 3. Prefer threshold changes that require stronger evidence before failure:
@@ -134,8 +135,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the triggering
    push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify
    as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
-3. Manual tracking in Issue 3169 must show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs
-   before filing or failing; a single noisy run does not trigger the gate.
+3. As a pre-condition for restoration, the tuned settings must require manual tracking in Issue 3169 to show the same
+   `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or failing; a single noisy run does
+   not trigger the gate.
 4. The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
    failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
    performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -121,7 +121,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
      runs before filing or failing
 
    If overlap remains below `0.40` after boundary widening, collect 5 more qualifying runs and re-evaluate from step 2
-   before escalating to step 4.
+   before escalating to step 4. Escalate to step 4 unconditionally after 2 such re-evaluation cycles, which means at
+   least 10 extra qualifying runs beyond the initial 30-run window, if overlap has not reached `0.40`.
 
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.
@@ -129,15 +130,15 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 ### Acceptance Criteria
 
 1. Before restoring the hard gate, verify it can detect real regressions: add a temporary controller delay to a benchmarked
-   route, confirm an alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before
-   proceeding.
-2. Only after step 1 passes, at least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no Bencher
-   regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the triggering
-   push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does not classify
-   as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
-3. As a pre-condition for restoration, the tuned settings must require manual tracking in Issue 3169 to show the same
-   `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or failing; a single noisy run does
-   not trigger the gate.
+   SSR route large enough to cause at least 10% degradation versus the current baseline median for that route, confirm an
+   alert fires under the tuned settings, then revert the delay. If no alert fires, re-tune before proceeding.
+2. As a pre-condition for starting the 5-run clean-run count below, the tuned settings must require manual tracking in
+   Issue 3169 to show the same `(benchmark, measure)` pair alerting on at least 2 consecutive runs before filing or
+   failing; a single noisy run does not trigger the gate.
+3. Only after steps 1 and 2 pass, at least 5 consecutive qualifying main `Benchmark Workflow` runs complete with no
+   Bencher regression alert; that means `BENCHER_HAS_ALERT` stays `0` with the current code. A run qualifies when the
+   triggering push modifies at least one file that [`script/ci-changes-detector`](../../script/ci-changes-detector) does
+   not classify as docs-only. Track the running count in [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169).
 4. The hard gate is restored only after the tuned settings meet the project false-positive target: no more than 1 noisy
    failure in 20 successful main `Benchmark Workflow` runs whose triggering commits do not intentionally change benchmark
    performance. Treat an alert as noisy when it does not recur for the same `(benchmark, measure)` pair in the next


### PR DESCRIPTION
## Summary
- extend the library benchmarking strategy with a main-gate re-enable plan
- capture the baseline dependency on PR #3148 and the need for about 30 clean main runs
- define threshold, sample-size, overlap, and runner-noise acceptance criteria before restoring a hard gate

Refs #3169

## Test Plan
- `pnpm exec prettier --check internal/planning/library-benchmarking.md`
- `git diff --check`
- pre-commit/pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation plus a link-checker exclusion for Bencher URLs; no runtime or CI behavior is modified.
> 
> **Overview**
> Adds a detailed **“Main Gate Re-Enablement Plan”** to `internal/planning/library-benchmarking.md`, defining baseline prerequisites (post-PR-3148 history), an alert-overlap based tuning sequence, and acceptance criteria/false-positive targets before switching Bencher regressions from warnings back to a hard CI gate.
> 
> Updates `.lychee.toml` to exclude authenticated Bencher dashboard/perf URLs from link checking to avoid CI false failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfd4250b6743f4a329095a009b484f6538c60595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Main Gate Re-Enablement Plan" in internal planning: describes baseline run requirements, a stepwise tuning sequence for alert sensitivity, guidance to escalate to dedicated benchmarking runners if noise persists, and acceptance criteria (consecutive-run checks, induced-regression verification, and false-positive targets) for restoring the CI main gate.
* No end-user facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->