### PR TITLE
docs: add Claude verify command

### DIFF
--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,20 +5,21 @@ Run a local verification loop for the current branch before creating or updating
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
 reproduce CI job selection locally.
 
-For each failing command, limit the loop to three reruns after edits unless the user explicitly asks to keep debugging. If a
-later fix reintroduces an earlier failure, stop and report the cycle instead of continuing indefinitely.
+For each failing command, stop after three reruns for that same failure unless the user explicitly asks to keep debugging. If
+a later fix reintroduces an earlier failure, stop and report the cycle instead of continuing indefinitely.
 
 ## Instructions
 
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
 2. Inspect the current branch diff with `git status --short`, `git diff --name-only origin/main...HEAD`, and
    `git diff --stat origin/main...HEAD`.
-3. Decide the minimal sufficient verification set that covers the changed surface area.
-4. Always include `bundle exec rubocop` before creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
-5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-6. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-7. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
-8. Finish with the exact commands run and their pass/fail status.
+3. Decide the minimal sufficient verification set that covers the changed surface area. Include `bundle exec rubocop`
+   before creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory
+   before every commit.
+4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
+5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
+6. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
+7. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -8,8 +8,9 @@ reproduce CI job selection locally.
 ## Instructions
 
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
-2. Inspect the current branch diff with `git status --short` and `git diff --stat origin/main...HEAD`.
-3. Decide the smallest verification set that covers the changed surface area.
+2. Inspect the current branch diff with `git status --short`, `git diff --name-only origin/main...HEAD`, and
+   `git diff --stat origin/main...HEAD`.
+3. Decide the minimal sufficient verification set that covers the changed surface area.
 4. Always include `bundle exec rubocop` when you will create or amend a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 6. For formatting failures, run `rake autofix`; do not manually edit formatting-only changes.
@@ -53,7 +54,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
-- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm exec prettier --check .`.
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm exec prettier --check .` (equivalent to the root `pnpm start format.listDifferent` Prettier check, scoped to Pro).
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -77,11 +77,10 @@ Use this concise summary:
 ```text
 Verification:
 - PASS git diff --check origin/main...HEAD
-- PASS pnpm start format.listDifferent
-- FAIL bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb
+- FAIL pnpm start format.listDifferent
 
 Next fix:
-- Remove trailing whitespace in `docs/oss/example.md` line 42, then rerun `pnpm start format.listDifferent`.
+- Run `rake autofix` to fix Prettier formatting, then rerun `pnpm start format.listDifferent`.
 ```
 
 If a command is intentionally skipped, explain why in one line. Prefer local verification over waiting for CI.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -17,8 +17,9 @@ command is designed to prevent.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
 6. After one or more edits for a failure, restart at the failed command and continue forward. Count each rerun of the
-   same command that produces the same first failing test name, RuboCop offense, or Prettier file as one loop cycle.
-   Stop and report after three cycles unless the user asks you to keep going.
+   same command that produces the same first failing test name, RuboCop offense, or Prettier file as one loop cycle. The
+   counter is per command, so reset it when you advance to a different step. Stop and report after three cycles unless
+   the user asks you to keep going.
    - If the first failing item changes, reset the counter and continue.
    - If a later step reintroduces a failure that already passed, stop immediately and report the regression.
    - Do not claim a failure is fixed until the command passes locally.
@@ -41,10 +42,12 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run lint`
    - `pnpm run type-check`
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
-     `pnpm --filter react-on-rails exec jest <relative-test-file-path>` for targeted test file runs
+     `pnpm --filter react-on-rails exec jest <relative-test-file-path>` for targeted test file runs; the path is
+     relative to `packages/react-on-rails/`, for example `tests/ReactOnRailsClient.test.ts`
    - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
-     browser-visible integration behavior
+     browser-visible integration behavior; run `pnpm exec playwright install` in that directory first if browsers are
+     not yet installed
 5. Docs:
    - `script/check-docs-sidebar` when docs under `docs/oss/` or `docs/pro/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless the

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,57 @@
+# Verify Command
+
+Run a local verification loop for the current branch before creating or updating a PR.
+
+## Instructions
+
+1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
+2. Inspect the current branch diff with `git status --short` and `git diff --stat origin/main...HEAD`.
+3. Decide the smallest verification set that covers the changed surface area.
+4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
+5. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
+6. Finish with the exact commands run and their pass/fail status.
+
+## Default Verification Order
+
+Use this order unless the changed files make a narrower or broader set clearly appropriate:
+
+1. Formatting and whitespace:
+   - `git diff --check`
+   - `pnpm start format.listDifferent`
+2. Ruby:
+   - `bundle exec rubocop`
+   - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
+   - targeted `bundle exec rspec ...` for changed Ruby behavior
+3. JavaScript and TypeScript:
+   - `pnpm run lint`
+   - `pnpm run type-check`
+   - targeted `pnpm run test -- ...` for changed package behavior
+4. Docs:
+   - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
+   - markdown link checks if links were added or edited
+5. Broad suite:
+   - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
+
+## Scope Guide
+
+- Ruby gem changes: run targeted RSpec, `bundle exec rubocop`, and RBS validation when signatures or public APIs changed.
+- Dummy app or integration changes: run the relevant dummy RSpec command from `react_on_rails/spec/dummy`.
+- TypeScript package changes: run package tests, `pnpm run lint`, and `pnpm run type-check`.
+- Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
+- Documentation-only changes: run Prettier, sidebar validation for `docs/`, and link checks for new or changed URLs.
+
+## Output Format
+
+Use this concise summary:
+
+```text
+Verification:
+- PASS git diff --check
+- PASS pnpm start format.listDifferent
+- FAIL bundle exec rspec path/to/spec.rb
+
+Next fix:
+- ...
+```
+
+If a command is intentionally skipped, explain why in one line. Prefer local verification over waiting for CI.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -13,16 +13,18 @@ command is designed to prevent.
    `git diff --stat origin/main...HEAD`.
 3. Decide the required verification set that covers the changed surface area using the **Scope Guide** below. Always
    include `bundle exec rubocop` before creating a commit, even when the changed surface is documentation-only, because
-   `AGENTS.md` marks it mandatory before every commit.
+   RuboCop scans all Ruby files, not just changed or staged ones, so docs-only commits can still expose pre-existing
+   Ruby offenses that CI will catch.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-6. After one or more edits for a failure, restart at the failed command and continue forward. Count each rerun of the
-   same command that produces the same first failing test name, RuboCop offense, or Prettier file as one loop cycle. The
-   counter is per command, so reset it when you advance to a different step. Stop and report after three cycles unless
-   the user asks you to keep going.
-   - If the first failing item changes, reset the counter and continue.
-   - If a later step reintroduces a failure that already passed, stop immediately and report the regression.
-   - Do not claim a failure is fixed until the command passes locally.
+6. After one or more edits for a failure, restart at the failed command and continue forward. Track a loop counter per
+   command:
+   1. Increment the counter when the same command fails on the same first item (test name, RuboCop offense, or Prettier
+      file) as the previous run.
+   2. Reset the counter when the first failing item changes or when you advance to a different command.
+   3. Stop and report after three consecutive cycles on the same item, unless the user asks you to keep going.
+   4. Stop immediately and report a regression if a command that previously passed now fails again.
+   5. Do not claim a failure is fixed until the command passes locally.
 7. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -14,10 +14,10 @@ reintroduces an earlier failure, stop and report the cycle instead of continuing
 2. Inspect the current branch diff with `git status --short`, `git diff --name-only origin/main...HEAD`, and
    `git diff --stat origin/main...HEAD`.
 3. Decide the minimal sufficient verification set that covers the changed surface area.
-4. Always include `bundle exec rubocop` when you will create or amend a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
+4. Always include `bundle exec rubocop` before creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 6. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, stop and report the error instead of retrying.
+7. After a fix, restart at the failed command and continue forward. Count each fix-and-restart as one loop cycle and stop after three cycles unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
 8. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
@@ -28,7 +28,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR; detects trailing whitespace and conflict markers, not Prettier formatting
    - `pnpm start format.listDifferent`
 2. Ruby:
-   - `bundle exec rubocop` - **mandatory gate before every commit** (per `AGENTS.md`); it lints Ruby, not Markdown or YAML
+   - `bundle exec rubocop` - **mandatory gate before every commit, including documentation-only commits** (per `AGENTS.md`); it lints Ruby, not Markdown or YAML
    - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
    - targeted `bundle exec rspec ...` for changed Ruby behavior
 3. JavaScript and TypeScript:

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -49,8 +49,8 @@ Use this order unless the changed files make a narrower or broader set clearly a
      relative to `packages/react-on-rails/`, for example `tests/ReactOnRailsClient.test.ts`
    - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
-     browser-visible integration behavior; on fresh Linux environments, run `pnpm exec playwright install --with-deps`
-     in that directory first, or run `pnpm exec playwright install` when only browser binaries are missing
+     browser-visible integration behavior; on fresh Linux environments, run `pnpm playwright install --with-deps` in
+     that directory first, or run `pnpm playwright install` when only browser binaries are missing
 5. Docs:
    - `script/check-docs-sidebar` when docs under `docs/oss/` or `docs/pro/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless the
@@ -72,7 +72,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`. For changes that affect SSR rendering or client-side behavior, also run `cd react_on_rails/spec/dummy && pnpm test:e2e`.
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
-- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/oss/` or `docs/pro/`, and `bin/check-links` for new or changed URLs. If committing, still run `bundle exec rubocop`; see Instructions step 3 for why this applies even to docs-only commits. It does not validate Markdown.
+- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/oss/` or `docs/pro/`, and `bin/check-links` for new or changed URLs. If committing, still run `bundle exec rubocop`; see Instructions step 3 for why this applies even to docs-only commits. RuboCop does not validate Markdown.
 - `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent`; in the Pro package, `pnpm start` delegates to that package's `nps` script, so this uses the package-local Prettier check.
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -3,7 +3,8 @@
 Run a local verification loop for the current branch before creating or updating a PR.
 
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
-reproduce CI job selection locally.
+reproduce CI job selection locally. See also `.claude/docs/avoiding-ci-failure-cycles.md` for the failure patterns this
+command is designed to prevent.
 
 ## Instructions
 
@@ -16,9 +17,9 @@ reproduce CI job selection locally.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
 6. After one or more edits for a failure, restart at the failed command and continue forward. Count each rerun of the
-   same command with the same root cause (same failing spec, RuboCop offense, or Prettier file) as one loop cycle. Stop
-   and report after three cycles unless the user asks you to keep going.
-   - If the failure changes to a different root cause, reset the counter and continue.
+   same command that produces the same first failing test name, RuboCop offense, or Prettier file as one loop cycle.
+   Stop and report after three cycles unless the user asks you to keep going.
+   - If the first failing item changes, reset the counter and continue.
    - If a later step reintroduces a failure that already passed, stop immediately and report the regression.
    - Do not claim a failure is fixed until the command passes locally.
 7. Finish with the exact commands run and their pass/fail status.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -23,7 +23,8 @@ command is designed to prevent.
       file) as the previous run.
    2. Reset the counter when the first failing item changes or when you advance to a different command.
    3. Stop and report after three consecutive cycles on the same item, unless the user asks you to keep going.
-   4. Stop immediately and report a regression if a command that previously passed now fails again.
+   4. Stop immediately and report a regression if a later fix causes a command that previously passed to fail again on
+      the same file, symbol, or test item.
    5. Do not claim a failure is fixed until the command passes locally.
 7. Finish with the exact commands run and their pass/fail status.
 
@@ -35,7 +36,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR; detects trailing whitespace and conflict markers, not Prettier formatting
    - `pnpm start format.listDifferent`
 2. Mandatory pre-commit gate:
-   - `bundle exec rubocop` - **mandatory gate before every commit, including documentation-only commits** (per `AGENTS.md`); it lints Ruby, not Markdown or YAML
+   - `bundle exec rubocop` - **mandatory gate before every commit**; see Instructions step 3 for why this still applies to documentation-only commits; it lints Ruby, not Markdown or YAML
 3. Ruby:
    - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
    - targeted `bundle exec rspec ...` for changed Ruby behavior
@@ -48,8 +49,8 @@ Use this order unless the changed files make a narrower or broader set clearly a
      relative to `packages/react-on-rails/`, for example `tests/ReactOnRailsClient.test.ts`
    - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
-     browser-visible integration behavior; run `pnpm exec playwright install` in that directory first if browsers are
-     not yet installed
+     browser-visible integration behavior; on fresh Linux environments, run `pnpm exec playwright install --with-deps`
+     in that directory first, or run `pnpm exec playwright install` when only browser binaries are missing
 5. Docs:
    - `script/check-docs-sidebar` when docs under `docs/oss/` or `docs/pro/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless the
@@ -71,7 +72,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`. For changes that affect SSR rendering or client-side behavior, also run `cd react_on_rails/spec/dummy && pnpm test:e2e`.
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
-- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/oss/` or `docs/pro/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`; it scans all Ruby files, not just staged files, but does not validate Markdown.
+- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/oss/` or `docs/pro/`, and `bin/check-links` for new or changed URLs. If committing, still run `bundle exec rubocop`; see Instructions step 3 for why this applies even to docs-only commits. It does not validate Markdown.
 - `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent`; in the Pro package, `pnpm start` delegates to that package's `nps` script, so this uses the package-local Prettier check.
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -31,7 +31,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
-   - targeted `pnpm --filter react-on-rails run test` for all package tests, or
+   - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
      `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
@@ -54,6 +54,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
 - `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm exec prettier --check .`.
+- `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 
 ## Output Format

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -42,7 +42,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `actionlint` when any `.github/workflows/` file changed
    - `yamllint .github/` when any `.github/workflows/` file changed
    - Do not run RuboCop on `.yml` files
-6. Broad suite:
+6. Broad suite — pick the narrowest command that covers the change:
    - `rake all_but_examples` for broad coverage without the slow generated-examples suite
    - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
    - `rake lint` when the full lint surface is appropriate and a single lint command is clearer than separate steps

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,8 +5,8 @@ Run a local verification loop for the current branch before creating or updating
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
 reproduce CI job selection locally.
 
-Limit the loop to three fix-and-restart cycles unless the user explicitly asks to keep debugging. If a later fix
-reintroduces an earlier failure, stop and report the cycle instead of continuing indefinitely.
+For each failing command, limit the loop to three reruns after edits unless the user explicitly asks to keep debugging. If a
+later fix reintroduces an earlier failure, stop and report the cycle instead of continuing indefinitely.
 
 ## Instructions
 
@@ -35,6 +35,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
+   - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
      `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
@@ -51,7 +52,8 @@ Use this order unless the changed files make a narrower or broader set clearly a
 6. Broad suite — pick the narrowest command that covers the change:
    - `rake all_but_examples` for broad coverage without the slow generated-examples suite
    - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
-   - `rake lint` when the full lint surface is appropriate and a single lint command is clearer than separate steps
+   - `rake lint` when a branch intentionally needs the complete lint gate across Ruby, JavaScript/TypeScript, and
+     formatting; otherwise keep using the narrower lint commands above
 
 ## Scope Guide
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -17,7 +17,7 @@ reintroduces an earlier failure, stop and report the cycle instead of continuing
 4. Always include `bundle exec rubocop` before creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 6. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-7. After a fix, restart at the failed command and continue forward. Count each fix-and-restart as one loop cycle and stop after three cycles unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
+7. After one or more edits for a failure, restart at the failed command and continue forward. Count each command rerun after edits as one loop cycle, and stop after three cycles unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
 8. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -8,7 +8,7 @@ Run a local verification loop for the current branch before creating or updating
 2. Inspect the current branch diff with `git status --short` and `git diff --stat origin/main...HEAD`.
 3. Decide the smallest verification set that covers the changed surface area.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-5. For formatting failures, run `rake autofix` before hand-editing formatting-only changes.
+5. For formatting failures, run `rake autofix` before manually editing formatting-only changes.
 6. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
 7. Finish with the exact commands run and their pass/fail status.
 
@@ -17,7 +17,6 @@ Run a local verification loop for the current branch before creating or updating
 Use this order unless the changed files make a narrower or broader set clearly appropriate:
 
 1. Formatting and whitespace:
-   - `git diff --check`
    - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR
    - `pnpm start format.listDifferent`
 2. Ruby:
@@ -25,6 +24,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
    - targeted `bundle exec rspec ...` for changed Ruby behavior
 3. JavaScript and TypeScript:
+   - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
    - targeted `pnpm run test -- ...` for changed package behavior

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -31,7 +31,8 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
-   - targeted `pnpm --filter react-on-rails run test` or `pnpm run test -- <path>` for changed package behavior
+   - targeted `pnpm --filter react-on-rails run test` or `pnpm --filter react-on-rails run test -- <path>` for
+     changed package behavior
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,17 +5,17 @@ Run a local verification loop for the current branch before creating or updating
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
 reproduce CI job selection locally.
 
-For each failing command, stop after three reruns for that same failure unless the user explicitly asks to keep debugging. If
-a later fix reintroduces an earlier failure, stop and report the cycle instead of continuing indefinitely.
+Step 6 defines the retry cap. If a later fix reintroduces an earlier failure, stop and report the cycle instead of
+continuing indefinitely.
 
 ## Instructions
 
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
 2. Inspect the current branch diff with `git status --short`, `git diff --name-only origin/main...HEAD`, and
    `git diff --stat origin/main...HEAD`.
-3. Decide the minimal sufficient verification set that covers the changed surface area. Include `bundle exec rubocop`
-   before creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory
-   before every commit.
+3. Decide the required verification set that covers the changed surface area. Always include `bundle exec rubocop` before
+   creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before
+   every commit.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
 6. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -15,7 +15,12 @@ reproduce CI job selection locally.
    every commit.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-6. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
+6. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing
+   command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure signature
+   (for example, the same failing spec, RuboCop offense, or Prettier file) unless the user explicitly asks you to keep
+   debugging. If the command fails with a different underlying issue, reset the counter for that new failure and report
+   the transition. Do not claim a failure is fixed until the failed command passes locally. If a later fix reintroduces
+   an earlier failure, stop and report the cycle instead of retrying.
 7. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
@@ -76,7 +81,7 @@ Verification:
 - FAIL bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb
 
 Next fix:
-- ...
+- Remove trailing whitespace in `docs/oss/example.md` line 42, then rerun `pnpm start format.listDifferent`.
 ```
 
 If a command is intentionally skipped, explain why in one line. Prefer local verification over waiting for CI.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,8 +5,7 @@ Run a local verification loop for the current branch before creating or updating
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
 reproduce CI job selection locally.
 
-Step 6 defines the retry cap. If a later fix reintroduces an earlier failure, stop and report the cycle instead of
-continuing indefinitely.
+Step 6 defines the retry cap and what to do if a later fix reintroduces an earlier failure.
 
 ## Instructions
 
@@ -36,9 +35,9 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
-   - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
      `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
+   - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
      browser-visible integration behavior
 4. Docs:

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -17,7 +17,7 @@ reintroduces an earlier failure, stop and report the cycle instead of continuing
 4. Always include `bundle exec rubocop` before creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 6. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-7. After one or more edits for a failure, restart at the failed command and continue forward. Count each command rerun after edits as one loop cycle, and stop after three cycles unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
+7. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure unless the user explicitly asks you to keep debugging. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, or a later fix reintroduces an earlier failure, stop and report the cycle instead of retrying.
 8. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
@@ -60,7 +60,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
-- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent` (the Pro package's own Prettier check, matching how the root uses `pnpm start format.listDifferent`).
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent`; in the Pro package, `pnpm start` delegates to that package's `nps` script, so this uses the package-local Prettier check.
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,8 +5,6 @@ Run a local verification loop for the current branch before creating or updating
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
 reproduce CI job selection locally.
 
-Step 6 defines the retry cap and what to do if a later fix reintroduces an earlier failure.
-
 ## Instructions
 
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
@@ -27,11 +25,12 @@ Use this order unless the changed files make a narrower or broader set clearly a
 1. Formatting and whitespace:
    - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR; detects trailing whitespace and conflict markers, not Prettier formatting
    - `pnpm start format.listDifferent`
-2. Ruby:
+2. Mandatory pre-commit gate:
    - `bundle exec rubocop` - **mandatory gate before every commit, including documentation-only commits** (per `AGENTS.md`); it lints Ruby, not Markdown or YAML
+3. Ruby:
    - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
    - targeted `bundle exec rspec ...` for changed Ruby behavior
-3. JavaScript and TypeScript:
+4. JavaScript and TypeScript:
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
@@ -40,16 +39,16 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
      browser-visible integration behavior
-4. Docs:
+5. Docs:
    - `script/check-docs-sidebar` when docs under `docs/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless the
      branch changes `bin/check-links`, `.lychee.toml`, or the documented link-check workflow itself
-5. CI workflows and YAML:
+6. CI workflows and YAML:
    - Confirm the workflow edit itself was approved because `AGENTS.md` marks changes to `.github/workflows/` as ask-first
    - `actionlint` when any `.github/workflows/` file changed
    - `yamllint .github/` when any `.github/workflows/` file changed
    - Do not run RuboCop on `.yml` files
-6. Broad suite — pick the narrowest command that covers the change:
+7. Broad suite — pick the narrowest command that covers the change:
    - `rake all_but_examples` for broad coverage without the slow generated-examples suite
    - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
    - `rake lint` when a branch intentionally needs the complete lint gate across Ruby, JavaScript/TypeScript, and

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -13,7 +13,7 @@ reproduce CI job selection locally.
 3. Decide the minimal sufficient verification set that covers the changed surface area.
 4. Always include `bundle exec rubocop` when you will create or amend a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-6. For formatting failures, run `rake autofix`; do not manually edit formatting-only changes.
+6. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
 7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, stop and report the error instead of retrying.
 8. Finish with the exact commands run and their pass/fail status.
 
@@ -22,7 +22,7 @@ reproduce CI job selection locally.
 Use this order unless the changed files make a narrower or broader set clearly appropriate:
 
 1. Formatting and whitespace:
-   - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR
+   - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR; detects trailing whitespace and conflict markers, not Prettier formatting
    - `pnpm start format.listDifferent`
 2. Ruby:
    - `bundle exec rubocop` - **mandatory gate before every commit** (per `AGENTS.md`); it lints Ruby, not Markdown or YAML
@@ -35,7 +35,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
      `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
 4. Docs:
-   - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
+   - `script/check-docs-sidebar` when docs under `docs/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command
 5. CI workflows and YAML:
    - Confirm the workflow edit itself was approved because `AGENTS.md` marks changes to `.github/workflows/` as ask-first
@@ -54,7 +54,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
-- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm exec prettier --check .` (equivalent to the root `pnpm start format.listDifferent` Prettier check, scoped to Pro).
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent` (the Pro package's own Prettier check, matching how the root uses `pnpm start format.listDifferent`).
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -8,8 +8,9 @@ Run a local verification loop for the current branch before creating or updating
 2. Inspect the current branch diff with `git status --short` and `git diff --stat origin/main...HEAD`.
 3. Decide the smallest verification set that covers the changed surface area.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-5. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
-6. Finish with the exact commands run and their pass/fail status.
+5. For formatting failures, run `rake autofix` before hand-editing formatting-only changes.
+6. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
+7. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
 
@@ -17,6 +18,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 
 1. Formatting and whitespace:
    - `git diff --check`
+   - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR
    - `pnpm start format.listDifferent`
 2. Ruby:
    - `bundle exec rubocop`
@@ -28,8 +30,10 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - targeted `pnpm run test -- ...` for changed package behavior
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
-   - markdown link checks if links were added or edited
-5. Broad suite:
+   - `bin/check-links` when Markdown links were added or edited
+5. CI workflows:
+   - `actionlint` and `yamllint .github/` when any `.github/workflows/` file changed (do NOT run RuboCop on `.yml` files)
+6. Broad suite:
    - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
 
 ## Scope Guide
@@ -38,7 +42,8 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - Dummy app or integration changes: run the relevant dummy RSpec command from `react_on_rails/spec/dummy`.
 - TypeScript package changes: run package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
-- Documentation-only changes: run Prettier, sidebar validation for `docs/`, and link checks for new or changed URLs.
+- Documentation-only changes: run `pnpm start format.listDifferent`, mandatory `bundle exec rubocop`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs.
+- GitHub Actions workflow changes: ask the user first, then run `actionlint` and `yamllint .github/`.
 
 ## Output Format
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -7,10 +7,11 @@ Run a local verification loop for the current branch before creating or updating
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
 2. Inspect the current branch diff with `git status --short` and `git diff --stat origin/main...HEAD`.
 3. Decide the smallest verification set that covers the changed surface area.
-4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-5. For formatting failures, run `rake autofix` before manually editing formatting-only changes.
-6. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
-7. Finish with the exact commands run and their pass/fail status.
+4. Keep repo-wide commit gates from `AGENTS.md` in the set when you will create a commit, even if the changed surface is narrow.
+5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
+6. For formatting failures, run `rake autofix` before manually editing formatting-only changes.
+7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
+8. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
 
@@ -20,7 +21,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR
    - `pnpm start format.listDifferent`
 2. Ruby:
-   - `bundle exec rubocop`
+   - `bundle exec rubocop` before every commit as required by `AGENTS.md`; it lints Ruby, not Markdown or YAML
    - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
    - targeted `bundle exec rspec ...` for changed Ruby behavior
 3. JavaScript and TypeScript:
@@ -30,20 +31,23 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - targeted `pnpm run test -- ...` for changed package behavior
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
-   - project link checker: `bin/check-links` when Markdown links were added or edited
-5. CI workflows:
-   - `actionlint` and `yamllint .github/` when any `.github/workflows/` file changed (do NOT run RuboCop on `.yml` files)
+   - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command
+5. CI workflows and YAML:
+   - Confirm the workflow edit itself was approved because `AGENTS.md` marks changes to `.github/workflows/` as ask-first
+   - `actionlint` when any `.github/workflows/` file changed
+   - `yamllint .github/` when any `.github/workflows/` file changed
+   - Do not run RuboCop on `.yml` files
 6. Broad suite:
    - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
 
 ## Scope Guide
 
 - Ruby gem changes: run targeted RSpec, `bundle exec rubocop`, and RBS validation when signatures or public APIs changed.
-- Dummy app or integration changes: run the relevant dummy RSpec command from `react_on_rails/spec/dummy`.
+- Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`.
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
-- Documentation-only changes: run `pnpm start format.listDifferent`, mandatory `bundle exec rubocop`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs.
-- GitHub Actions workflow changes: ask the user first, then run `actionlint` and `yamllint .github/`.
+- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
+- GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 
 ## Output Format
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -15,12 +15,12 @@ reproduce CI job selection locally.
    every commit.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
-6. After one or more edits for a failure, restart at the failed command and continue forward. For a single failing
-   command, count each rerun after edits as one loop cycle and stop after three reruns for that same failure signature
-   (for example, the same failing spec, RuboCop offense, or Prettier file) unless the user explicitly asks you to keep
-   debugging. If the command fails with a different underlying issue, reset the counter for that new failure and report
-   the transition. Do not claim a failure is fixed until the failed command passes locally. If a later fix reintroduces
-   an earlier failure, stop and report the cycle instead of retrying.
+6. After one or more edits for a failure, restart at the failed command and continue forward. Count each rerun of the
+   same command with the same root cause (same failing spec, RuboCop offense, or Prettier file) as one loop cycle. Stop
+   and report after three cycles unless the user asks you to keep going.
+   - If the failure changes to a different root cause, reset the counter and continue.
+   - If a later step reintroduces a failure that already passed, stop immediately and report the regression.
+   - Do not claim a failure is fixed until the command passes locally.
 7. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
@@ -40,7 +40,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run lint`
    - `pnpm run type-check`
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
-     `pnpm --filter react-on-rails exec jest <path>` for targeted test file runs
+     `pnpm --filter react-on-rails exec jest <relative-test-file-path>` for targeted test file runs
    - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
      browser-visible integration behavior
@@ -65,7 +65,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`. For changes that affect SSR rendering or client-side behavior, also run `cd react_on_rails/spec/dummy && pnpm test:e2e`.
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
-- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
+- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`; it scans all Ruby files, not just staged files, but does not validate Markdown.
 - `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent`; in the Pro package, `pnpm start` delegates to that package's `nps` script, so this uses the package-local Prettier check.
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -46,7 +46,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
      browser-visible integration behavior
 5. Docs:
-   - `script/check-docs-sidebar` when docs under `docs/` changed
+   - `script/check-docs-sidebar` when docs under `docs/oss/` or `docs/pro/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless the
      branch changes `bin/check-links`, `.lychee.toml`, or the documented link-check workflow itself
 6. CI workflows and YAML:
@@ -66,7 +66,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`. For changes that affect SSR rendering or client-side behavior, also run `cd react_on_rails/spec/dummy && pnpm test:e2e`.
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
-- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`; it scans all Ruby files, not just staged files, but does not validate Markdown.
+- Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/oss/` or `docs/pro/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`; it scans all Ruby files, not just staged files, but does not validate Markdown.
 - `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent`; in the Pro package, `pnpm start` delegates to that package's `nps` script, so this uses the package-local Prettier check.
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -19,13 +19,13 @@ command is designed to prevent.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
 6. After one or more edits for a failure, restart at the failed command and continue forward. Track a loop counter per
    command:
-   1. Increment the counter when the same command fails on the same first item (test name, RuboCop offense, or Prettier
-      file) as the previous run.
-   2. Reset the counter when the first failing item changes or when you advance to a different command.
-   3. Stop and report after three consecutive cycles on the same item, unless the user asks you to keep going.
-   4. Stop immediately and report a regression if a later fix causes a command that previously passed to fail again on
-      the same file, symbol, or test item.
-   5. Do not claim a failure is fixed until the command passes locally.
+   - Increment the counter when the same command fails on the same first item (test name, RuboCop offense, or Prettier
+     file) as the previous run.
+   - Reset the counter when the first failing item changes or when you advance to a different command.
+   - Stop and report after three consecutive cycles on the same item, unless the user asks you to keep going.
+   - Stop immediately and report a regression if a later fix causes a command that previously passed to fail again on
+     the same file, symbol, or test item. Ask the user how to proceed rather than attempting a blind revert.
+   - Do not claim a failure is fixed until the command passes locally.
 7. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
@@ -73,9 +73,10 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/oss/` or `docs/pro/`, and `bin/check-links` for new or changed URLs. If committing, still run `bundle exec rubocop`; see Instructions step 3 for why this applies even to docs-only commits. RuboCop does not validate Markdown.
-- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent`; in the Pro package, `pnpm start` delegates to that package's `nps` script, so this uses the package-local Prettier check.
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm start format.listDifferent` (the Pro package's local Prettier check via its `nps` script).
 - `react_on_rails_pro/**/*.rb` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `bundle exec rubocop react_on_rails_pro/` and any targeted RSpec.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
+- Anything not listed above (for example, Rakefile edits, generator templates, RBS-only changes, or build scripts): apply the narrowest set of checks that covers the changed surface and explain the choice in the output.
 
 ## Output Format
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -10,9 +10,9 @@ reproduce CI job selection locally.
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
 2. Inspect the current branch diff with `git status --short`, `git diff --name-only origin/main...HEAD`, and
    `git diff --stat origin/main...HEAD`.
-3. Decide the required verification set that covers the changed surface area. Always include `bundle exec rubocop` before
-   creating a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before
-   every commit.
+3. Decide the required verification set that covers the changed surface area using the **Scope Guide** below. Always
+   include `bundle exec rubocop` before creating a commit, even when the changed surface is documentation-only, because
+   `AGENTS.md` marks it mandatory before every commit.
 4. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 5. For formatting failures (Prettier or rubocop auto-fixable offenses), run `rake autofix`; do not manually edit formatting-only changes.
 6. After one or more edits for a failure, restart at the failed command and continue forward. Count each rerun of the

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -30,7 +30,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - targeted `pnpm run test -- ...` for changed package behavior
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
-   - `bin/check-links` when Markdown links were added or edited
+   - project link checker: `bin/check-links` when Markdown links were added or edited
 5. CI workflows:
    - `actionlint` and `yamllint .github/` when any `.github/workflows/` file changed (do NOT run RuboCop on `.yml` files)
 6. Broad suite:
@@ -40,7 +40,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 
 - Ruby gem changes: run targeted RSpec, `bundle exec rubocop`, and RBS validation when signatures or public APIs changed.
 - Dummy app or integration changes: run the relevant dummy RSpec command from `react_on_rails/spec/dummy`.
-- TypeScript package changes: run package tests, `pnpm run lint`, and `pnpm run type-check`.
+- TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, mandatory `bundle exec rubocop`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs.
 - GitHub Actions workflow changes: ask the user first, then run `actionlint` and `yamllint .github/`.
@@ -51,7 +51,7 @@ Use this concise summary:
 
 ```text
 Verification:
-- PASS git diff --check
+- PASS git diff --check origin/main...HEAD
 - PASS pnpm start format.listDifferent
 - FAIL bundle exec rspec path/to/spec.rb
 

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -24,7 +24,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `git diff --check origin/main...HEAD` for committed branch content before creating or updating a PR
    - `pnpm start format.listDifferent`
 2. Ruby:
-   - `bundle exec rubocop` before every commit as required by `AGENTS.md`; it lints Ruby, not Markdown or YAML
+   - `bundle exec rubocop` - **mandatory gate before every commit** (per `AGENTS.md`); it lints Ruby, not Markdown or YAML
    - `bundle exec rake rbs:validate` when Ruby signatures or public Ruby APIs changed
    - targeted `bundle exec rspec ...` for changed Ruby behavior
 3. JavaScript and TypeScript:
@@ -52,7 +52,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
-- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved, then run `cd react_on_rails_pro && pnpm run prettier --check .`.
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved, then run `cd react_on_rails_pro && pnpm exec prettier --check .`.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 
 ## Output Format

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -2,6 +2,9 @@
 
 Run a local verification loop for the current branch before creating or updating a PR.
 
+Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
+reproduce CI job selection locally.
+
 ## Instructions
 
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
@@ -9,8 +12,8 @@ Run a local verification loop for the current branch before creating or updating
 3. Decide the smallest verification set that covers the changed surface area.
 4. Keep repo-wide commit gates from `AGENTS.md` in the set when you will create a commit, even if the changed surface is narrow.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-6. For formatting failures, run `rake autofix` instead of manually editing formatting-only changes.
-7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
+6. For formatting failures, run `rake autofix`; do not manually edit formatting-only changes.
+7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, stop and report the error instead of retrying.
 8. Finish with the exact commands run and their pass/fail status.
 
 ## Default Verification Order
@@ -28,7 +31,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
-   - targeted `pnpm run test -- ...` for changed package behavior
+   - targeted `pnpm --filter <package> run test` or `pnpm run test -- <path>` for changed package behavior
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command
@@ -38,7 +41,9 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `yamllint .github/` when any `.github/workflows/` file changed
    - Do not run RuboCop on `.yml` files
 6. Broad suite:
+   - `rake all_but_examples` for broad coverage without the slow generated-examples suite
    - `rake` when shared runtime behavior, generators, cross-package contracts, or release-critical paths changed
+   - `rake lint` when the full lint surface is appropriate and a single lint command is clearer than separate steps
 
 ## Scope Guide
 
@@ -47,6 +52,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved, then run `cd react_on_rails_pro && pnpm run prettier --check .`.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 
 ## Output Format
@@ -57,7 +63,7 @@ Use this concise summary:
 Verification:
 - PASS git diff --check origin/main...HEAD
 - PASS pnpm start format.listDifferent
-- FAIL bundle exec rspec path/to/spec.rb
+- FAIL bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb
 
 Next fix:
 - ...

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -31,8 +31,8 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
-   - targeted `pnpm --filter react-on-rails run test` or `pnpm --filter react-on-rails run test -- <path>` for
-     changed package behavior
+   - targeted `pnpm --filter react-on-rails run test` for all package tests, or
+     `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command
@@ -53,7 +53,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.
-- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved, then run `cd react_on_rails_pro && pnpm exec prettier --check .`.
+- `react_on_rails_pro/**/*.{js,ts,tsx,jsx,json,css,md}` changes: confirm the Pro package edit was approved per the `AGENTS.md` ask-first rule, then run `cd react_on_rails_pro && pnpm exec prettier --check .`.
 - GitHub Actions workflow changes: confirm the edit was approved per the `AGENTS.md` ask-first rule, then run `actionlint` and `yamllint .github/`. Do not run RuboCop on `.yml` files.
 
 ## Output Format

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -40,7 +40,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run lint`
    - `pnpm run type-check`
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
-     `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
+     `pnpm --filter react-on-rails exec jest <path>` for targeted test file runs
    - `pnpm run test` when broad package behavior changed or the touched files are not covered by a narrower package test
    - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
      browser-visible integration behavior

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,6 +5,9 @@ Run a local verification loop for the current branch before creating or updating
 Use `/verify` for local pre-PR checks. Use `/run-ci` when you need the CI change detector or want to
 reproduce CI job selection locally.
 
+Limit the loop to three fix-and-restart cycles unless the user explicitly asks to keep debugging. If a later fix
+reintroduces an earlier failure, stop and report the cycle instead of continuing indefinitely.
+
 ## Instructions
 
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
@@ -34,9 +37,12 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run type-check`
    - targeted `pnpm --filter react-on-rails run test` for react-on-rails package tests, or
      `pnpm --filter react-on-rails exec jest -- <path>` for targeted test file runs
+   - `cd react_on_rails/spec/dummy && pnpm test:e2e` when the branch changes SSR rendering, client hydration, or
+     browser-visible integration behavior
 4. Docs:
    - `script/check-docs-sidebar` when docs under `docs/` changed
-   - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command
+   - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless the
+     branch changes `bin/check-links`, `.lychee.toml`, or the documented link-check workflow itself
 5. CI workflows and YAML:
    - Confirm the workflow edit itself was approved because `AGENTS.md` marks changes to `.github/workflows/` as ask-first
    - `actionlint` when any `.github/workflows/` file changed

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -10,7 +10,7 @@ reproduce CI job selection locally.
 1. Read `AGENTS.md` first. It is the canonical source for required commands, formatting, boundaries, and ask-first areas.
 2. Inspect the current branch diff with `git status --short` and `git diff --stat origin/main...HEAD`.
 3. Decide the smallest verification set that covers the changed surface area.
-4. Keep repo-wide commit gates from `AGENTS.md` in the set when you will create a commit, even if the changed surface is narrow.
+4. Always include `bundle exec rubocop` when you will create or amend a commit, even when the changed surface is documentation-only, because `AGENTS.md` marks it mandatory before every commit.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
 6. For formatting failures, run `rake autofix`; do not manually edit formatting-only changes.
 7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally. If the same command fails again after a fix attempt, stop and report the error instead of retrying.
@@ -31,7 +31,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
    - `pnpm run build`
    - `pnpm run lint`
    - `pnpm run type-check`
-   - targeted `pnpm --filter <package> run test` or `pnpm run test -- <path>` for changed package behavior
+   - targeted `pnpm --filter react-on-rails run test` or `pnpm run test -- <path>` for changed package behavior
 4. Docs:
    - `script/check-docs-sidebar origin/main HEAD` when docs under `docs/` changed
    - `bin/check-links` when Markdown URLs were added or edited; do not substitute an ad hoc link checker unless this branch changes the canonical command

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -9,7 +9,7 @@ Run a local verification loop for the current branch before creating or updating
 3. Decide the smallest verification set that covers the changed surface area.
 4. Keep repo-wide commit gates from `AGENTS.md` in the set when you will create a commit, even if the changed surface is narrow.
 5. Run each command in order and stop on the first failure. Report the failing command, the relevant error output, and the next fix to attempt.
-6. For formatting failures, run `rake autofix` before manually editing formatting-only changes.
+6. For formatting failures, run `rake autofix` instead of manually editing formatting-only changes.
 7. After a fix, restart at the failed command and continue forward. Do not claim a failure is fixed until the failed command passes locally.
 8. Finish with the exact commands run and their pass/fail status.
 
@@ -43,7 +43,7 @@ Use this order unless the changed files make a narrower or broader set clearly a
 ## Scope Guide
 
 - Ruby gem changes: run targeted RSpec, `bundle exec rubocop`, and RBS validation when signatures or public APIs changed.
-- Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`.
+- Dummy app or integration changes: run `rake run_rspec:dummy` or a targeted dummy spec such as `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`. For changes that affect SSR rendering or client-side behavior, also run `cd react_on_rails/spec/dummy && pnpm test:e2e`.
 - TypeScript package changes: run `pnpm run build`, package tests, `pnpm run lint`, and `pnpm run type-check`.
 - Generated examples or scripts: run the relevant generator/script command plus formatting and linting.
 - Documentation-only changes: run `pnpm start format.listDifferent`, sidebar validation for `docs/`, and `bin/check-links` for new or changed URLs. If committing, still run the repo-wide `bundle exec rubocop` gate from `AGENTS.md`, but do not treat it as a Markdown validator.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ bundle exec rubocop                  # Ruby — must pass with zero offenses
 pnpm run lint                        # JS/TS via ESLint
 pnpm start format.listDifferent      # Check Prettier formatting
 rake lint                            # All linting (Ruby + JS + formatting)
+bin/check-links                      # Markdown link checks
 
 # Auto-fix formatting
 rake autofix                         # Preferred for all formatting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,9 @@ rake run_rspec                       # All Ruby tests
 rake all_but_examples                # All tests except generated examples
 rake run_rspec:shakapacker_examples_basic  # Single example test
 
-# Link checking (requires lychee)
-bin/check-links                      # Markdown link checks
+# Documentation checks
+script/check-docs-sidebar            # Validate docs sidebar coverage
+bin/check-links                      # Markdown link checks (requires lychee)
 
 # Full initial setup
 bundle && pnpm install && rake shakapacker_examples:gen_all && rake node_package && rake
@@ -181,7 +182,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Use `bundle exec` for Ruby commands
 - Ensure all files end with a newline
 - Let Prettier and RuboCop handle formatting — never format manually
-- When adding docs under `docs/oss/` or `docs/pro/`, also add the doc ID to `docs/sidebars.ts` — CI will fail otherwise. To intentionally exclude a doc from the sidebar, add its ID to `docs/.sidebar-exclusions` with a reason comment.
+- When adding docs under `docs/oss/` or `docs/pro/`, also add the doc ID to `docs/sidebars.ts` and run `script/check-docs-sidebar` — CI will fail otherwise. To intentionally exclude a doc from the sidebar, add its ID to `docs/.sidebar-exclusions` with a reason comment.
 
 ### Ask First
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,6 @@ bundle exec rubocop                  # Ruby — must pass with zero offenses
 pnpm run lint                        # JS/TS via ESLint
 pnpm start format.listDifferent      # Check Prettier formatting
 rake lint                            # All linting (Ruby + JS + formatting)
-bin/check-links                      # Markdown link checks
 
 # Auto-fix formatting
 rake autofix                         # Preferred for all formatting
@@ -56,6 +55,9 @@ bundle exec rake rbs:validate        # RBS signatures
 rake run_rspec                       # All Ruby tests
 rake all_but_examples                # All tests except generated examples
 rake run_rspec:shakapacker_examples_basic  # Single example test
+
+# Link checking (requires lychee)
+bin/check-links                      # Markdown link checks
 
 # Full initial setup
 bundle && pnpm install && rake shakapacker_examples:gen_all && rake node_package && rake


### PR DESCRIPTION
## Summary
- add a Claude `/verify` command that reads AGENTS.md first and runs a local stop-on-failure verification loop
- document default ordering for formatting, Ruby, TypeScript, docs, and broad-suite checks
- keep the command scoped to `.claude/commands` so AGENTS.md remains the canonical policy

Part of #2572

## Test Plan
- `pnpm exec prettier --check .claude/commands/verify.md`
- `git diff --check`
- pre-commit/pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add guidance for running local checks; no production code paths are modified.
> 
> **Overview**
> Adds a new Claude slash command doc, `.claude/commands/verify.md`, defining a stop-on-failure local verification loop (default command ordering, scope-based check selection, and a required output format).
> 
> Updates `AGENTS.md` to include doc-check commands (`script/check-docs-sidebar`, `bin/check-links`) and tightens the docs boundary guidance to explicitly require running the sidebar validator when adding docs under `docs/oss/` or `docs/pro/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190f4776cbcbac1cb73139d52faf4e665fa038c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized pre-PR local verification guide describing prerequisites, how to inspect diffs, choosing minimal verification steps, running an ordered command sequence (stop on first failure), re-running from the failing step after fixes, expected "Verification"/"Next fix" output format, reporting skipped steps, a scope guide mapping change types to checks, and a default verification flow for formatting, Ruby, JavaScript/TypeScript, docs, CI, and a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->