### PR TITLE
docs: add AI security scanner evaluation plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,12 @@ junit.xml
 .lycheecache
 .playwright-cli/
 .gstack/
+
+# Security scanner output (per internal/planning/ai-security-scanner-evaluation.md):
+# raw findings, SARIF reports, and intermediate artifacts must stay out of this
+# public repo. Commit only sanitized summaries to internal/planning/.
+/security-scans/
+*.sarif
+*.sarif.json
+scanner-output/
+scanner-findings/

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ junit.xml
 # Security scanner output (per internal/planning/ai-security-scanner-evaluation.md):
 # raw findings, SARIF reports, and intermediate artifacts must stay out of this
 # public repo. Commit only sanitized summaries to internal/planning/.
+# *.sarif and *.sarif.json are intentionally non-anchored so they match SARIF
+# files emitted into any subdirectory; the directory entries below stay anchored
+# to the repo root.
 /security-scans/
 *.sarif
 *.sarif.json

--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,5 @@ junit.xml
 /security-scans/
 *.sarif
 *.sarif.json
-scanner-output/
-scanner-findings/
+/scanner-output/
+/scanner-findings/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Bug reports and pull requests are welcome. Start with
 and the
 [help wanted issues](https://github.com/shakacode/react_on_rails/labels/contributions%3A%20up%20for%20grabs%21).
 
+## Security
+
+Suspected security vulnerabilities should be reported privately. See
+[SECURITY.md](SECURITY.md) for the disclosure process and supported version
+policy. Please do not open a public issue for security reports.
+
 ## License
 
 React on Rails is available as open source under the terms of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,8 @@ paths.
 | Latest released `react_on_rails` gem and `react-on-rails` package | Report and triage                                                     |
 | Older released versions                                           | Report; maintainers evaluate case-by-case and may recommend upgrading |
 
+Fixes are generally delivered for the most recent minor line; older releases may receive backports if severity warrants.
+
 ## Scope
 
 This policy covers security vulnerabilities in the `react_on_rails` gem and the `react-on-rails` npm package. It does
@@ -32,8 +34,9 @@ If the repository does not show **Report a vulnerability**, open a confidential
 draft, or contact a repository maintainer with write access directly and coordinate disclosure timing before sharing
 exposure details publicly.
 
-If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) and ask to be
-routed to a React on Rails maintainer for coordinated disclosure. Do not include exploit details in that first contact.
+If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
+line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not
+include exploit details in that first contact.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,13 +23,14 @@ third-party dependencies, or non-technical attacks such as phishing or social en
 
 Please do not open a public issue for suspected vulnerabilities.
 
-Use GitHub's private vulnerability reporting for this repository:
+If GitHub shows private vulnerability reporting for this repository, use that path:
 
 1. Open the repository's **Security** tab on GitHub.
 2. Select **Report a vulnerability**.
 3. Include affected package versions, impact, and the smallest safe reproduction details you can share privately.
 
-If the repository does not show **Report a vulnerability**, open a confidential
+If the repository does not show **Report a vulnerability**, private vulnerability reporting may not be enabled or may not
+be visible to your account. In that case, open a confidential
 [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory)
 draft if your GitHub permissions allow it. If neither GitHub path is available, use the email fallback below and ask to
 be routed to a React on Rails maintainer before sharing exposure details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting A Vulnerability
+
+Please do not open a public issue for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting for this repository when available:
+
+1. Open the repository's **Security** tab on GitHub.
+2. Select **Report a vulnerability**.
+3. Include affected package versions, impact, and the smallest safe reproduction details you can share privately.
+
+If private vulnerability reporting is unavailable, contact a repository maintainer with write access through a private
+channel and coordinate disclosure timing before sharing exposure details publicly.
+
+Maintainers should keep reports private until the issue is patched or disproven, then publish an advisory or release note
+only after sensitive reproduction details are no longer useful for exploiting supported releases.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,8 @@ first email, include the affected package name (`react_on_rails` gem or `react-o
 and a one-line impact description, such as "potential XSS in SSR helper" or "information disclosure in generator output."
 Do not include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a
 private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
+If you prefer to encrypt your first message, ask for a PGP public key at the same address before sending sensitive
+reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline. If you do not
@@ -49,3 +51,6 @@ only after a fix, mitigation, or explicit non-impact determination means the dis
 help exploit supported releases.
 
 Reporters will be credited in the security advisory or release notes unless they request anonymity.
+
+Maintainers will request a CVE for confirmed vulnerabilities affecting released versions of the gem or npm package and
+will include the CVE identifier in the security advisory when one is assigned.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-React on Rails does not yet publish a fixed security-support matrix. Report suspected vulnerabilities for any released
-React on Rails gem or npm package version. Maintainers will triage impact and prioritize fixes for supported upgrade
-paths.
+React on Rails does not yet publish fixed version numbers for security support. Report suspected vulnerabilities for any
+released React on Rails gem or npm package version. Maintainers will triage impact and prioritize fixes for supported
+upgrade paths.
 
 | Version line                                                      | Security support                                                      |
 | ----------------------------------------------------------------- | --------------------------------------------------------------------- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,17 +23,17 @@ third-party dependencies, or non-technical attacks such as phishing or social en
 
 Please do not open a public issue for suspected vulnerabilities.
 
-If GitHub shows private vulnerability reporting for this repository, use that path:
+This repository has GitHub private vulnerability reporting enabled. Use that path when possible:
 
 1. Open the repository's **Security** tab on GitHub.
 2. Select **Report a vulnerability**.
 3. Include affected package versions, impact, and the smallest safe reproduction details you can share privately.
 
-If the repository does not show **Report a vulnerability**, private vulnerability reporting may not be enabled or may not
-be visible to your account. In that case, open a confidential
+If the repository does not show **Report a vulnerability** for your account, use the email fallback below and ask to be
+routed to a React on Rails maintainer before sharing exposure details. Repository maintainers with write access may open
+a confidential
 [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory)
-draft if your GitHub permissions allow it. If neither GitHub path is available, use the email fallback below and ask to
-be routed to a React on Rails maintainer before sharing exposure details.
+draft directly, but external reporters should not rely on that path because it requires repository write access.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,13 +33,16 @@ If the repository does not show **Report a vulnerability** for your account, use
 routed to a React on Rails maintainer before sharing exposure details. Repository maintainers with write access may open
 a confidential
 [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory)
-draft directly, but external reporters should not rely on that path because it requires repository write access.
+draft directly, but external reporters cannot use the GitHub Security Advisory draft path because creating a Security
+Advisory requires repository write access.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not
-include exploit details in that first contact. This fallback remains in place until maintainers publish a dedicated
-security alias. Maintainers will respond with a secure alternative, such as a private GitHub Advisory thread or another
-mutually agreed private channel, before requesting reproduction details.
+include exploit details in that first contact. This fallback remains in place until maintainers publish the dedicated
+security alias tracked in
+[Issue 3266](https://github.com/shakacode/react_on_rails/issues/3266). Maintainers will respond with a secure
+alternative, such as a private GitHub Advisory thread or another mutually agreed private channel, before requesting
+reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,22 +29,14 @@ This repository has GitHub private vulnerability reporting enabled. Use that pat
 2. Select **Report a vulnerability**.
 3. Include affected package versions, impact, and the smallest safe reproduction details you can share privately.
 
-If the repository does not show **Report a vulnerability** for your account, use the email fallback below and ask to be
-routed to a React on Rails maintainer before sharing exposure details. Repository maintainers with write access may open
-a confidential
-[GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory)
-draft directly, but external reporters cannot use the GitHub Security Advisory draft path because creating a Security
-Advisory requires repository write access.
+If the repository does not show **Report a vulnerability** for your account, use the email fallback below.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. In that
 first email, include the affected package name (`react_on_rails` gem or `react-on-rails` npm package), the version range,
 and a one-line impact description, such as "potential XSS in SSR helper" or "information disclosure in generator output."
-Do not include exploit details in that first contact. This fallback remains in place until maintainers publish the
-dedicated security alias tracked in
-[Issue 3266](https://github.com/shakacode/react_on_rails/issues/3266). Maintainers will respond with a secure
-alternative, such as a private GitHub Advisory thread or another mutually agreed private channel, before requesting
-reproduction details.
+Do not include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a
+private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,8 +21,10 @@ Use GitHub's private vulnerability reporting for this repository:
 2. Select **Report a vulnerability**.
 3. Include affected package versions, impact, and the smallest safe reproduction details you can share privately.
 
-If the repository does not show **Report a vulnerability**, contact a repository maintainer with write access through a
-private channel and coordinate disclosure timing before sharing exposure details publicly.
+If the repository does not show **Report a vulnerability**, open a confidential
+[GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory)
+draft, or contact a repository maintainer with write access directly and coordinate disclosure timing before sharing
+exposure details publicly.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,14 +31,13 @@ Use GitHub's private vulnerability reporting for this repository:
 
 If the repository does not show **Report a vulnerability**, open a confidential
 [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/creating-a-repository-security-advisory)
-draft, or contact a repository maintainer with write access directly and coordinate disclosure timing before sharing
-exposure details publicly.
+draft if your GitHub permissions allow it. If neither GitHub path is available, use the email fallback below and ask to
+be routed to a React on Rails maintainer before sharing exposure details.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not
 include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a private
-GitHub Advisory thread, encrypted email, or another mutually agreed private channel, before requesting reproduction
-details.
+GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,8 @@ and a one-line impact description, such as "potential XSS in SSR helper" or "inf
 Do not include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a
 private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
 
-Alternatively, if you prefer PGP-encrypted communication and a PGP key is published for this address, you may request it
-before sending any follow-up message that includes reproduction details.
+Alternatively, if you need an additional secure channel beyond the options above, mention it in your initial email and
+maintainers will arrange one before requesting reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline. If you do not
@@ -54,5 +54,6 @@ help exploit supported releases.
 
 Reporters will be credited in the security advisory or release notes unless they request anonymity.
 
-Maintainers will request a CVE for confirmed vulnerabilities affecting released versions of the gem or npm package and
-will include the CVE identifier in the security advisory when one is assigned.
+Maintainers will request a CVE through GitHub's Security Advisory program for confirmed vulnerabilities affecting
+released versions of the gem or npm package and will include the CVE identifier in the security advisory when one is
+assigned.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,8 @@ Fixes are generally delivered for the most recent minor line; older releases may
 
 This policy covers security vulnerabilities in the `react_on_rails` gem and the `react-on-rails` npm package. It does
 not cover vulnerabilities in end-user Rails applications that happen to use React on Rails, vulnerabilities in
-third-party dependencies, or non-technical attacks such as phishing or social engineering.
+third-party dependencies, or non-technical attacks such as phishing or social engineering. Vulnerabilities in
+`react_on_rails_pro` follow the same reporting process; use the same GitHub advisory path or email fallback below.
 
 ## Reporting a Vulnerability
 
@@ -38,8 +39,8 @@ first email, include the affected package name (`react_on_rails` gem or `react-o
 and a one-line impact description, such as "potential XSS in SSR helper" or "information disclosure in generator output."
 Do not include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a
 private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
-If you prefer to encrypt your first message, ask for a PGP public key at the same address before sending sensitive
-reproduction details.
+If you prefer to encrypt your first message and a PGP key is available for this address, request it before sending
+sensitive reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline. If you do not

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,9 @@
 # Security Policy
 
+- **Last reviewed:** 2026-05-09
+- **Review owner:** React on Rails maintainers
+- **Next review due:** 2027-05-09
+
 ## Supported Versions
 
 React on Rails does not yet publish fixed version numbers for security support. Report suspected vulnerabilities even
@@ -48,9 +52,9 @@ the date of first report unless maintainers and the reporter agree to a shorter 
 receive an initial response within ten business days, send a follow-up to the same email address or private GitHub
 report thread.
 
-Maintainers must keep reports private until the issue is patched or disproven, then publish an advisory or release note
-only after a fix, mitigation, or explicit non-impact determination means the disclosed reproduction details no longer
-help exploit supported releases.
+Maintainers must keep reports private until the issue is patched or disproven. An advisory or release note may be
+published only after a fix, mitigation, or explicit non-impact determination has been made — that is, once the disclosed
+reproduction details no longer help exploit supported releases.
 
 Reporters will be credited in the security advisory or release notes unless they request anonymity.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,12 @@ paths.
 | Latest released `react_on_rails` gem and `react-on-rails` package | Report and triage                                                     |
 | Older released versions                                           | Report; maintainers evaluate case-by-case and may recommend upgrading |
 
+## Scope
+
+This policy covers security vulnerabilities in the `react_on_rails` gem and the `react-on-rails` npm package. It does
+not cover vulnerabilities in end-user Rails applications that happen to use React on Rails, vulnerabilities in
+third-party dependencies, or non-technical attacks such as phishing or social engineering.
+
 ## Reporting a Vulnerability
 
 Please do not open a public issue for suspected vulnerabilities.
@@ -26,8 +32,13 @@ If the repository does not show **Report a vulnerability**, open a confidential
 draft, or contact a repository maintainer with write access directly and coordinate disclosure timing before sharing
 exposure details publicly.
 
+If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) and ask to be
+routed to a React on Rails maintainer for coordinated disclosure. Do not include exploit details in that first contact.
+
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.
 
 Maintainers must keep reports private until the issue is patched or disproven, then publish an advisory or release note
 only after sensitive reproduction details are no longer useful for exploiting supported releases.
+
+Reporters will be credited in the security advisory or release notes unless they request anonymity.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,9 +37,11 @@ draft directly, but external reporters cannot use the GitHub Security Advisory d
 Advisory requires repository write access.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
-line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not
-include exploit details in that first contact. This fallback remains in place until maintainers publish the dedicated
-security alias tracked in
+line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. In that
+first email, include the affected package name (`react_on_rails` gem or `react-on-rails` npm package), the version range,
+and a one-line impact description, such as "potential XSS in SSR helper" or "information disclosure in generator output."
+Do not include exploit details in that first contact. This fallback remains in place until maintainers publish the
+dedicated security alias tracked in
 [Issue 3266](https://github.com/shakacode/react_on_rails/issues/3266). Maintainers will respond with a secure
 alternative, such as a private GitHub Advisory thread or another mutually agreed private channel, before requesting
 reproduction details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,10 @@
 
 ## Supported Versions
 
-React on Rails does not yet publish fixed version numbers for security support. Report suspected vulnerabilities for any
-released React on Rails gem or npm package version. Maintainers will triage impact and prioritize fixes for supported
-upgrade paths.
+React on Rails does not yet publish fixed version numbers for security support. Report suspected vulnerabilities even
+when you find them in an older released React on Rails gem or npm package version; do not self-filter reports by
+version. Maintainers triage all reports, but fixes are normally prepared for the latest released minor line and supported
+upgrade paths first.
 
 | Version line                                                      | Security support                                                      |
 | ----------------------------------------------------------------- | --------------------------------------------------------------------- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,8 +41,10 @@ If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:c
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. In that
 first email, include the affected package name (`react_on_rails` gem or `react-on-rails` npm package), the version range,
 and a one-line impact description, such as "potential XSS in SSR helper" or "information disclosure in generator output."
-Do not include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a
-private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
+These three details are safe to send in plaintext. Do not include reproduction steps, proof-of-concept payloads, code
+snippets, stack traces, or any other technical exploit details in that first contact; maintainers will respond with a
+secure alternative, such as a private GitHub Advisory thread or another mutually agreed private channel, before
+requesting reproduction details.
 
 Alternatively, if you need an additional secure channel beyond the options above, mention it in your initial email and
 maintainers will arrange one before requesting reproduction details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,8 +39,9 @@ first email, include the affected package name (`react_on_rails` gem or `react-o
 and a one-line impact description, such as "potential XSS in SSR helper" or "information disclosure in generator output."
 Do not include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a
 private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
-If you prefer to encrypt your first message and a PGP key is available for this address, request it before sending
-sensitive reproduction details.
+
+Alternatively, if you prefer PGP-encrypted communication and a PGP key is published for this address, you may request it
+before sending any follow-up message that includes reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline. If you do not

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,9 @@
 
 ## Supported Versions
 
-React on Rails does not yet publish a fixed security-support matrix. Until
-[Issue 3261](https://github.com/shakacode/react_on_rails/issues/3261) defines one, report suspected vulnerabilities for
-any released React on Rails gem or npm package version. Maintainers will triage impact and prioritize fixes for supported
-upgrade paths.
+React on Rails does not yet publish a fixed security-support matrix. Report suspected vulnerabilities for any released
+React on Rails gem or npm package version. Maintainers will triage impact and prioritize fixes for supported upgrade
+paths.
 
 | Version line                                                      | Security support                                                      |
 | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
@@ -16,17 +15,17 @@ upgrade paths.
 
 Please do not open a public issue for suspected vulnerabilities.
 
-Use GitHub's private vulnerability reporting for this repository when available:
+Use GitHub's private vulnerability reporting for this repository:
 
 1. Open the repository's **Security** tab on GitHub.
 2. Select **Report a vulnerability**.
 3. Include affected package versions, impact, and the smallest safe reproduction details you can share privately.
 
-If private vulnerability reporting is unavailable, contact a repository maintainer with write access through a private
-channel and coordinate disclosure timing before sharing exposure details publicly.
+If the repository does not show **Report a vulnerability**, contact a repository maintainer with write access through a
+private channel and coordinate disclosure timing before sharing exposure details publicly.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.
 
-Maintainers should keep reports private until the issue is patched or disproven, then publish an advisory or release note
+Maintainers must keep reports private until the issue is patched or disproven, then publish an advisory or release note
 only after sensitive reproduction details are no longer useful for exploiting supported releases.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,9 +39,12 @@ Do not include exploit details in that first contact. Maintainers will respond w
 private GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
-the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.
+the date of first report unless maintainers and the reporter agree to a shorter or longer timeline. If you do not
+receive an initial response within ten business days, send a follow-up to the same email address or private GitHub
+report thread.
 
 Maintainers must keep reports private until the issue is patched or disproven, then publish an advisory or release note
-only after sensitive reproduction details are no longer useful for exploiting supported releases.
+only after a fix, mitigation, or explicit non-impact determination means the disclosed reproduction details no longer
+help exploit supported releases.
 
 Reporters will be credited in the security advisory or release notes unless they request anonymity.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,8 +36,9 @@ be routed to a React on Rails maintainer before sharing exposure details.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not
-include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a private
-GitHub Advisory thread or another mutually agreed private channel, before requesting reproduction details.
+include exploit details in that first contact. This fallback remains in place until maintainers publish a dedicated
+security alias. Maintainers will respond with a secure alternative, such as a private GitHub Advisory thread or another
+mutually agreed private channel, before requesting reproduction details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,18 @@
 # Security Policy
 
-## Reporting A Vulnerability
+## Supported Versions
+
+React on Rails does not yet publish a fixed security-support matrix. Until
+[Issue 3261](https://github.com/shakacode/react_on_rails/issues/3261) defines one, report suspected vulnerabilities for
+any released React on Rails gem or npm package version. Maintainers will triage impact and prioritize fixes for supported
+upgrade paths.
+
+| Version line                                                      | Security support                                                      |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Latest released `react_on_rails` gem and `react-on-rails` package | Report and triage                                                     |
+| Older released versions                                           | Report; maintainers evaluate case-by-case and may recommend upgrading |
+
+## Reporting a Vulnerability
 
 Please do not open a public issue for suspected vulnerabilities.
 
@@ -12,6 +24,9 @@ Use GitHub's private vulnerability reporting for this repository when available:
 
 If private vulnerability reporting is unavailable, contact a repository maintainer with write access through a private
 channel and coordinate disclosure timing before sharing exposure details publicly.
+
+Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
+the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.
 
 Maintainers should keep reports private until the issue is patched or disproven, then publish an advisory or release note
 only after sensitive reproduction details are no longer useful for exploiting supported releases.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,9 @@ exposure details publicly.
 
 If a reporter cannot use GitHub, they may email [contact@shakacode.com](mailto:contact@shakacode.com) with the subject
 line `React on Rails security` and ask to be routed to a React on Rails maintainer for coordinated disclosure. Do not
-include exploit details in that first contact.
+include exploit details in that first contact. Maintainers will respond with a secure alternative, such as a private
+GitHub Advisory thread, encrypted email, or another mutually agreed private channel, before requesting reproduction
+details.
 
 Maintainers aim to provide an initial response within five business days. The default disclosure window is 90 days from
 the date of first report unless maintainers and the reporter agree to a shorter or longer timeline.

--- a/internal/planning/README.md
+++ b/internal/planning/README.md
@@ -1,0 +1,7 @@
+# Planning Notes
+
+This directory holds planning documents, drafts, and historical analysis for React on Rails. It is **not** end-user
+documentation. Despite the `internal/` path, files here live in a public repository and are indexed by GitHub search.
+
+Do not commit raw scanner findings, exploit details, real credentials, private fork URLs, or intentionally vulnerable
+fixtures here. Keep that material outside this repository and link to a private location instead.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -60,7 +60,10 @@ evaluation time.
 | DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
 
 **Deferred:** [Almanax](https://almanax.ai/) was Web3-heavy as of 2026-05-09 with no clear Ruby/TypeScript coverage
-signal. Re-add it to the shortlist only if the next annual review finds evidence of Rails/Node support.
+signal. Re-add it to the shortlist only when both signals are present at the next annual review: (1) vendor
+documentation explicitly names Ruby, Rails, Node, or TypeScript as supported languages or frameworks, and (2) a public
+changelog entry, customer case study, or release note shows non-Web3 coverage on a Rails or Node codebase. Record the
+URL for each signal in this section before promoting the vendor.
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -1,0 +1,81 @@
+# AI Security Scanner Evaluation Plan
+
+## Purpose
+
+Evaluate whether AI-native security scanners can find actionable vulnerabilities or logic bugs in React on Rails beyond
+the issues already covered by existing lint, test, dependency, and code review workflows.
+
+This plan tracks [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018). It is an evaluation plan, not a
+decision to adopt any vendor or CI integration.
+
+## Scope
+
+Evaluate the open-source gem and npm package first:
+
+- Ruby gem code under `react_on_rails/lib`
+- Ruby generators under `react_on_rails/lib/generators`
+- TypeScript package code under `packages/react-on-rails/src`
+- JavaScript and Ruby test fixtures that exercise SSR, ExecJS, RSC registration, and generated app setup
+
+Evaluate React on Rails Pro separately after the OSS scan path is understood, because Pro contains separate package and
+licensing boundaries.
+
+## Candidate Scanner Categories
+
+Use the products named in the issue as candidates if they still offer an appropriate plan at evaluation time:
+
+- AI-native SAST scanners
+- AI-assisted dependency reachability scanners
+- AI review tools that can reason about business logic and security intent
+
+Prefer scanners that can run on a branch without requiring broad organization-level permissions. If a free or trial plan
+is not available, record that and defer paid adoption until at least one OSS scan produces a concrete finding worth
+validating.
+
+## Evaluation Dataset
+
+Use a fixed branch and commit for the first comparison so results are reproducible:
+
+1. Current `main`
+2. A branch with one intentionally vulnerable fixture, kept outside production code, to verify the scanner can catch a
+   known issue
+3. A branch with a known-safe refactor to measure false positives on normal code motion
+
+The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
+Do not commit secrets, real credentials, or exploit-ready application behavior.
+
+## Scoring Criteria
+
+Score each scanner against the same rubric:
+
+| Criterion                 | Question                                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |
+| Correctness               | Can we reproduce or disprove the finding locally?                                  |
+| False-positive rate       | How many findings are noise after local verification?                              |
+| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |
+| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |
+| Permission model          | Can it run with minimal GitHub permissions?                                        |
+| CI fit                    | Can results be advisory first, without failing every PR?                           |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |
+
+## First-Pass Workflow
+
+1. Pick one OSS branch and one scanner.
+2. Run the scan without enabling CI blocking.
+3. Export the raw findings into a private scratch note if needed.
+4. For each high or critical finding, reproduce locally or write down why it is not reachable.
+5. Fix only verified vulnerabilities or correctness bugs.
+6. Summarize scanner signal in the issue before trying the next scanner.
+
+## Adoption Bar
+
+Do not add a scanner to CI until all of these are true:
+
+- It found at least one verified issue or a clearly valuable hardening opportunity.
+- It produced a manageable number of false positives on `main`.
+- It supports advisory mode for pull requests.
+- Its required permissions are acceptable for the repository.
+- The team agrees who owns triage of new alerts.
+
+If no scanner clears this bar, keep the issue as a record of what was tested and revisit later.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -53,12 +53,14 @@ prioritization, explanation, or reachability analysis for a finding that existin
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Initial status | Before scheduling                                                                                                                              |
-| --------------- | -------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                        |
-| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                        |
-| Almanax         | <https://almanax.ai/>      | Lower priority | Confirm OSS or trial access and Ruby/TypeScript coverage; public examples were Web3-heavy as of the document date. Re-evaluate at next review. |
-| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                        |
+| Vendor          | Reference                  | Initial status | Before scheduling                                       |
+| --------------- | -------------------------- | -------------- | ------------------------------------------------------- |
+| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
+| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
+| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
+
+**Deferred:** [Almanax](https://almanax.ai/) was Web3-heavy as of 2026-05-09 with no clear Ruby/TypeScript coverage
+signal. Re-add it to the shortlist only if the next annual review finds evidence of Rails/Node support.
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -181,7 +183,8 @@ Do not add a scanner to CI until all of these are true:
 - Keeps the false-positive rate at or below 15% for that scanner's `main` scan after one triage pass, measured among
   high/critical findings reviewed for that scanner run, not cumulatively across scanners. This initial bar is
   intentionally lenient to support first-pass data collection; tighten it to 10% or lower before moving findings from
-  advisory to blocking. A scan with fewer than five high/critical findings cannot satisfy this false-positive-rate gate
+  advisory to blocking. Revisit this threshold after the second full triage cycle or after 90 days of CI advisory data,
+  whichever comes first. A scan with fewer than five high/critical findings cannot satisfy this false-positive-rate gate
   by itself; manually review every finding, record the raw count and why the sample is too small for a stable rate, and
   gather a larger sample before using this rate to justify CI adoption.
 - Supports advisory mode for pull requests.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -92,8 +92,9 @@ Before running scans, record the exact baselines used:
 
 The follow-up issue,
 [#3265 Track baseline prerequisites for AI security scanner evaluation](https://github.com/shakacode/react_on_rails/issues/3265),
-must be closed, with every dataset table cell filled and committed, before
-[Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) moves from planning to execution.
+tracks this prerequisite, but closing that issue is not sufficient by itself. Before
+[Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) moves from planning to execution, verify that this
+dataset table has no placeholder cells and that the completed table is committed on the evaluation branch.
 
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -90,9 +90,10 @@ Before running scans, record the exact baselines used:
 > **Do not run any scanner evaluation until every cell in this table is filled in and committed.** Undocumented
 > baselines produce results that cannot be reproduced or compared across evaluators.
 
-[Issue 3265](https://github.com/shakacode/react_on_rails/issues/3265) must be closed, with every dataset table cell
-filled and committed, before [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) moves from planning to
-execution.
+The follow-up issue,
+[#3265 Track baseline prerequisites for AI security scanner evaluation](https://github.com/shakacode/react_on_rails/issues/3265),
+must be closed, with every dataset table cell filled and committed, before
+[Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) moves from planning to execution.
 
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
@@ -102,12 +103,13 @@ group unless Issue 2018 assigns a narrower group for the evaluation.
 
 ## Scoring Criteria
 
-Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use weighted totals to make
-security signal and operational cost comparable across evaluators:
-`weighted score = score x weight`; `weighted total = sum(weighted scores) / sum(weights)`.
+Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use a normalized weighted average
+to make security signal and operational cost comparable across evaluators while keeping the final total on the 1-5 scale:
+`weighted score = score x weight`; `normalized weighted average = sum(weighted scores) / sum(weights)`.
 
 Example: Actionability score = 4 with weight = 1.0 produces a weighted score of 4.0. If all eight criteria score 3,
-the weighted total is `(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`.
+the normalized weighted average is
+`(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`.
 
 | Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) | Weighted score |
 | ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
@@ -167,9 +169,9 @@ before adoption, repository maintainers with write access own the next triage de
 Do not add a scanner to CI until all of these are true:
 
 - Finds at least one verified issue or a clearly valuable hardening opportunity.
-- Keeps the false-positive rate at or below 25% among high/critical findings on `main` after one triage pass. If the scan
-  reports fewer than five high/critical findings, manually review every finding and record why the sample is too small
-  for a stable rate.
+- Keeps the false-positive rate at or below 25% for that scanner's `main` scan after one triage pass, measured among
+  high/critical findings reviewed for that scanner run, not cumulatively across scanners. If the scan reports fewer than
+  five high/critical findings, manually review every finding and record why the sample is too small for a stable rate.
 - Supports advisory mode for pull requests.
 - Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,
   merge, or admin permissions.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -23,7 +23,8 @@ licensing boundaries.
 ## Candidate Scanner Categories
 
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
-evaluation time:
+evaluation time. Before scheduling each scan, confirm the current product name, URL, OSS or trial plan, and language
+coverage so the evaluation does not drift from the market.
 
 - ZeroPath
 - Corgea
@@ -56,18 +57,26 @@ inert: no operational code paths, real network calls, or reusable exploit payloa
 
 ## Scoring Criteria
 
-Score each scanner against the same rubric:
+Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use the weight column to make
+security signal and operational cost comparable across evaluators.
 
-| Criterion                 | Question                                                                           |
-| ------------------------- | ---------------------------------------------------------------------------------- |
-| Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |
-| Correctness               | Can we reproduce or disprove the finding locally?                                  |
-| False-positive rate       | How many findings are noise after local verification?                              |
-| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |
-| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |
-| Permission model          | Can it run with minimal GitHub permissions?                                        |
-| CI fit                    | Can results be advisory first, without failing every PR?                           |
-| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |
+| Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) |
+| ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ |
+| Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |             | 1.0          |
+| Correctness               | Can we reproduce or disprove the finding locally?                                  |             | 1.0          |
+| False-positive rate       | How many findings are noise after local verification?                              |             | 0.9          |
+| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |             | 0.8          |
+| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |             | 0.8          |
+| Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |
+| CI fit                    | Can results be advisory first, without failing every PR?                           |             | 0.7          |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |             | 0.5          |
+
+Anchor examples:
+
+- Actionability: 5 means file, reachable path, and reproduction steps; 1 means a vague pattern or generic warning.
+- Correctness: 5 means locally reproduced or disproven with a clear command; 1 means the scanner cannot explain the
+  finding.
+- False-positive rate: 5 means most surfaced findings survive local verification; 1 means the report is mostly noise.
 
 ## First-Pass Workflow
 
@@ -75,14 +84,19 @@ Score each scanner against the same rubric:
 2. Run the scan without enabling CI blocking.
 3. Export raw findings with sensitive details into a private Notion or Google Doc if needed; summarize only sanitized,
    verified results in the public issue after exposure details are fixed or disproven.
-   Limit access to repository maintainers or the security triage group, omit secrets and credentials, redact reproduction
-   snippets, and delete or archive raw notes after the finding is resolved.
+   - Limit access to repository maintainers or the security triage group; omit secrets and credentials; redact
+     reproduction snippets.
+   - Delete or archive raw notes after the finding is resolved.
 4. For each high or critical finding, reproduce locally or write down why it is not reachable.
    Batch-triage medium findings after the high/critical pass. Skip informational findings unless a pattern emerges.
 5. Fix only verified vulnerabilities or correctness bugs.
+   If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched and
+   coordinate with maintainers or the security triage group before public disclosure.
 6. Summarize scanner signal in the issue before trying the next scanner.
 
 ## Adoption Bar
+
+**Owner:** See [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) for tracking and assignment.
 
 Do not add a scanner to CI until all of these are true:
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -1,5 +1,8 @@
 # AI Security Scanner Evaluation Plan
 
+**Vendor snapshot:** 2026-05-09. Re-check product names, URLs, plans, and language coverage before running the
+evaluation.
+
 ## Purpose
 
 Evaluate whether AI-native security scanners can find actionable vulnerabilities or logic bugs in React on Rails beyond
@@ -20,16 +23,17 @@ Evaluate the open-source gem and npm package first:
 Evaluate React on Rails Pro separately after the OSS scan path is understood, because Pro contains separate package and
 licensing boundaries.
 
-## Candidate Scanner Categories
+## Candidate Scanners
 
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
-evaluation time. Before scheduling each scan, confirm the current product name, URL, OSS or trial plan, and language
-coverage so the evaluation does not drift from the market.
+evaluation time.
 
-- ZeroPath
-- Corgea
-- Almanax
-- DryRun
+| Vendor          | Reference                  | Before scheduling                                            |
+| --------------- | -------------------------- | ------------------------------------------------------------ |
+| ZeroPath        | <https://zeropath.com/>    | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
+| Corgea          | <https://corgea.com/>      | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
+| Almanax         | <https://almanax.ai/>      | Confirm current product scope beyond Web3-oriented examples. |
+| DryRun Security | <https://dryrun.security/> | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -50,6 +54,14 @@ Use a fixed branch and commit for the first comparison so results are reproducib
    can catch a known issue without publishing intentionally vulnerable code in the public React on Rails repository
 3. A branch with a known-safe refactor to measure false positives on normal code motion
 
+Before running scans, record the exact baselines used:
+
+| Dataset entry       | Source                           | Branch or URL          | Commit SHA or version | Date recorded |
+| ------------------- | -------------------------------- | ---------------------- | --------------------- | ------------- |
+| `main`              | `react_on_rails`                 | `main`                 | `<fill full SHA>`     | `<fill date>` |
+| Known-issue fixture | Private fork or training project | `<fill branch or URL>` | `<fill SHA/version>`  | `<fill date>` |
+| Safe refactor       | `react_on_rails`                 | `<fill branch>`        | `<fill full SHA>`     | `<fill date>` |
+
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
 public branch of this repository. Keep any private positive-control fixture non-indexable, clearly labeled test-only, and
@@ -57,19 +69,20 @@ inert: no operational code paths, real network calls, or reusable exploit payloa
 
 ## Scoring Criteria
 
-Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use the weight column to make
-security signal and operational cost comparable across evaluators.
+Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use weighted totals to make
+security signal and operational cost comparable across evaluators:
+`weighted total = sum(score x weight) / sum(weights)`.
 
-| Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) |
-| ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ |
-| Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |             | 1.0          |
-| Correctness               | Can we reproduce or disprove the finding locally?                                  |             | 1.0          |
-| False-positive rate       | How many findings are noise after local verification?                              |             | 0.9          |
-| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |             | 0.8          |
-| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |             | 0.8          |
-| Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |
-| CI fit                    | Can results be advisory first, without failing every PR?                           |             | 0.7          |
-| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |             | 0.5          |
+| Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) | Weighted score |
+| ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
+| Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |             | 1.0          |                |
+| Correctness               | Can we reproduce or disprove the finding locally?                                  |             | 1.0          |                |
+| False-positive rate       | How many findings are noise after local verification?                              |             | 0.9          |                |
+| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |             | 0.8          |                |
+| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |             | 0.8          |                |
+| Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |                |
+| CI fit                    | Can results be advisory first, without failing every PR?                           |             | 0.7          |                |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |             | 0.5          |                |
 
 Anchor examples:
 
@@ -82,28 +95,31 @@ Anchor examples:
 
 1. Pick one OSS branch and one scanner.
 2. Run the scan without enabling CI blocking.
-3. Export raw findings with sensitive details into a private Notion or Google Doc if needed; summarize only sanitized,
-   verified results in the public issue after exposure details are fixed or disproven.
-   - Limit access to repository maintainers or the security triage group; omit secrets and credentials; redact
-     reproduction snippets.
+3. Export raw findings with sensitive details into a private, access-controlled location if needed; summarize only
+   sanitized, verified results in the public issue after exposure details are fixed or disproven.
+   - Limit access to repository maintainers with write access, unless Issue 2018 names a narrower security triage group.
+   - Omit secrets and credentials; redact reproduction snippets.
    - Delete or archive raw notes after the finding is resolved.
 4. For each high or critical finding, reproduce locally or write down why it is not reachable.
    Batch-triage medium findings after the high/critical pass. Skip informational findings unless a pattern emerges.
 5. Fix only verified vulnerabilities or correctness bugs.
    If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched and
-   coordinate with maintainers or the security triage group before public disclosure.
+   follow `SECURITY.md` if present; otherwise coordinate a maintainer-approved disclosure path before public disclosure.
 6. Summarize scanner signal in the issue before trying the next scanner.
 
 ## Adoption Bar
 
 **Owner:** See [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) for tracking and assignment.
+**Default triage group:** repository maintainers with write access, unless the issue assigns a narrower group.
 
 Do not add a scanner to CI until all of these are true:
 
-- It found at least one verified issue or a clearly valuable hardening opportunity.
-- It produced a manageable number of false positives on `main`.
-- It supports advisory mode for pull requests.
-- Its required permissions are acceptable for the repository.
-- The team agrees who owns triage of new alerts.
+- Finds at least one verified issue or a clearly valuable hardening opportunity.
+- Produces five or fewer false-positive high/critical findings on `main` after one triage pass.
+- Supports advisory mode for pull requests.
+- Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,
+  merge, or admin permissions.
+- Documents triage ownership in Issue 2018, including the owner or rotation and a target first response within five
+  business days.
 
 If no scanner clears this bar, keep the issue as a record of what was tested and revisit later.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -1,6 +1,6 @@
 # AI Security Scanner Evaluation Plan
 
-**Vendor snapshot:** 2026-05-09. Re-check product names, URLs, plans, and language coverage before running the
+**Vendor snapshot:** See git history for last revision date. Re-check product names, URLs, plans, and language coverage before running the
 evaluation, then refresh this snapshot annually or when a listed vendor is acquired, deprecated, or materially changes
 scope.
 
@@ -43,12 +43,12 @@ prioritization, explanation, or reachability analysis for a finding that existin
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Initial status    | Before scheduling                                            |
-| --------------- | -------------------------- | ----------------- | ------------------------------------------------------------ |
-| ZeroPath        | <https://zeropath.com/>    | Candidate         | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
-| Corgea          | <https://corgea.com/>      | Candidate         | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
-| Almanax         | <https://almanax.ai/>      | Needs scope check | Confirm current product scope beyond Web3-oriented examples. |
-| DryRun Security | <https://dryrun.security/> | Candidate         | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
+| Vendor          | Reference                  | Initial status | Before scheduling                                       |
+| --------------- | -------------------------- | -------------- | ------------------------------------------------------- |
+| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
+| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
+| Almanax         | <https://almanax.ai/>      | Candidate      | Confirm Ruby/TypeScript coverage; examples skew Web3.   |
+| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -125,7 +125,8 @@ Anchor examples:
 
 ## Adoption Bar
 
-**Owner:** See [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) for tracking and assignment.
+**Owner:** Tracked in [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018). If that issue is closed
+before adoption, repository maintainers with write access own the next triage decision.
 **Default triage group:** repository maintainers with write access, unless the issue assigns a narrower group.
 **Default triage SLA:** first response within five business days for high or critical alerts.
 
@@ -138,6 +139,6 @@ Do not add a scanner to CI until all of these are true:
 - Supports advisory mode for pull requests.
 - Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,
   merge, or admin permissions.
-- Records the triage owner or rotation for the default SLA in Issue 2018.
+- Records the triage owner or rotation for the default SLA in this file or Issue 2018.
 
 If no scanner clears this bar, keep the issue as a record of what was tested and revisit later.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -22,8 +22,12 @@ licensing boundaries.
 
 ## Candidate Scanner Categories
 
-Use the products named in the issue as candidates if they still offer an appropriate plan at evaluation time:
+Use this point-in-time candidate list from the issue if the products still offer an appropriate plan at evaluation time:
 
+- ZeroPath
+- Corgea
+- Almanax
+- DryRun
 - AI-native SAST scanners
 - AI-assisted dependency reachability scanners
 - AI review tools that can reason about business logic and security intent
@@ -37,12 +41,13 @@ validating.
 Use a fixed branch and commit for the first comparison so results are reproducible:
 
 1. Current `main`
-2. A branch with one intentionally vulnerable fixture, kept outside production code, to verify the scanner can catch a
-   known issue
+2. A private fork, private Gist, or existing vulnerable-by-design project that verifies the scanner can catch a known
+   issue without publishing intentionally vulnerable code in the public React on Rails repository
 3. A branch with a known-safe refactor to measure false positives on normal code motion
 
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
-Do not commit secrets, real credentials, or exploit-ready application behavior.
+Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
+public branch of this repository.
 
 ## Scoring Criteria
 
@@ -63,7 +68,8 @@ Score each scanner against the same rubric:
 
 1. Pick one OSS branch and one scanner.
 2. Run the scan without enabling CI blocking.
-3. Export the raw findings into a private scratch note if needed.
+3. Export raw findings with sensitive details into a private Notion or Google Doc if needed; summarize only sanitized,
+   verified results in the public issue after exposure details are fixed or disproven.
 4. For each high or critical finding, reproduce locally or write down why it is not reachable.
 5. Fix only verified vulnerabilities or correctness bugs.
 6. Summarize scanner signal in the issue before trying the next scanner.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -43,12 +43,12 @@ prioritization, explanation, or reachability analysis for a finding that existin
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Initial status | Before scheduling                                       |
-| --------------- | -------------------------- | -------------- | ------------------------------------------------------- |
-| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
-| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
-| Almanax         | <https://almanax.ai/>      | Candidate      | Confirm Ruby/TypeScript coverage; examples skew Web3.   |
-| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage. |
+| Vendor          | Reference                  | Initial status | Before scheduling                                                                                          |
+| --------------- | -------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
+| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                    |
+| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                    |
+| Almanax         | <https://almanax.ai/>      | Lower priority | Evaluate only if ZeroPath, Corgea, and DryRun are unsuitable; confirm coverage beyond Web3-heavy examples. |
+| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                    |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -106,10 +106,20 @@ Anchor examples:
 - Correctness: 5 means locally reproduced or disproven with a clear command; 1 means the scanner cannot explain the
   finding.
 - False-positive rate: 5 means most surfaced findings survive local verification; 1 means the report is mostly noise.
+- Ruby/Rails coverage: 5 means it traces Rails generators, helpers, SSR, and ExecJS paths; 1 means generic Ruby syntax
+  only.
+- TypeScript/React coverage: 5 means it understands package exports, SSR utilities, and browser/server boundaries; 1 means
+  generic JavaScript syntax only.
+- Permission model: 5 means read-only repository access plus advisory comments or issues; 1 means organization-wide write,
+  merge, or admin permissions.
+- CI fit: 5 means advisory, opt-in, non-blocking pull request results; 1 means all pull requests are blocked by default
+  with no clear override.
+- Maintenance cost: 5 means near-zero configuration and triage overhead; 1 means weekly manual triage or frequent config
+  churn.
 
 ## First-Pass Workflow
 
-1. Pick one OSS branch and one scanner.
+1. Pick the current `main` branch of `react_on_rails` and one candidate scanner from the shortlist.
 2. Run the scan without enabling CI blocking.
 3. Export raw findings with sensitive details into a private, access-controlled location if needed; summarize only
    sanitized, verified results in the public issue after exposure details are fixed or disproven.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -123,7 +123,7 @@ where 6.4 is the sum of all weights.
 | Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |                |
 | CI fit                    | Can results be advisory first, without failing every PR?                           |             | 0.7          |                |
 | Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |             | 0.5          |                |
-| **Final score**           | Normalized weighted average: `sum(weighted scores) / 6.4`                          |             | **6.4**      | `<fill>`       |
+| **Final score**           | Normalized weighted average: `sum(weighted scores) / 6.4`; total weight = `6.4`    |             | N/A          | `<fill>`       |
 
 Anchor examples:
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -1,8 +1,8 @@
 # AI Security Scanner Evaluation Plan
 
-**Vendor snapshot:** See git history for last revision date. Re-check product names, URLs, plans, and language coverage before running the
-evaluation, then refresh this snapshot annually or when a listed vendor is acquired, deprecated, or materially changes
-scope.
+**Last updated:** 2026-05-09. **Vendor snapshot:** Re-check product names, URLs, plans, and language coverage before
+running the evaluation, then refresh this snapshot annually or when a listed vendor is acquired, deprecated, or materially
+changes scope.
 
 ## Purpose
 
@@ -32,8 +32,9 @@ Compare scanner output against the current baseline before counting a finding as
 - Dependabot security updates for npm, Bundler, and GitHub Actions under `.github/dependabot.yml`
 - Existing lint, test, and code review workflows
 
-No dedicated `bundler-audit`, `bundle-audit`, `npm audit`, or `pnpm audit` CI workflow is configured at this snapshot.
-If one is added before an evaluation run, include it in this baseline before counting dependency CVEs as net-new signal.
+No dedicated `bundler-audit` (CLI: `bundle-audit`), `npm audit`, or `pnpm audit` CI workflow is configured at this
+snapshot. If one is added before an evaluation run, include it in this baseline before counting dependency CVEs as
+net-new signal.
 
 Record whether each verified finding is missed by the existing baseline or whether the scanner mainly improves
 prioritization, explanation, or reachability analysis for a finding that existing tools already surface.
@@ -76,6 +77,9 @@ Before running scans, record the exact baselines used:
 | `main`              | `react_on_rails`                 | `main`                 | `<fill full SHA>`     | `<fill date>` |
 | Known-issue fixture | Private fork or training project | `<fill branch or URL>` | `<fill SHA/version>`  | `<fill date>` |
 | Safe refactor       | `react_on_rails`                 | `<fill branch>`        | `<fill full SHA>`     | `<fill date>` |
+
+> **Do not run any scanner evaluation until every cell in this table is filled in and committed.** Undocumented
+> baselines produce results that cannot be reproduced or compared across evaluators.
 
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -53,12 +53,12 @@ prioritization, explanation, or reachability analysis for a finding that existin
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Initial status | Before scheduling                                                                                                                       |
-| --------------- | -------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                 |
-| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                 |
-| Almanax         | <https://almanax.ai/>      | Lower priority | Confirm OSS or trial access and Ruby/TypeScript coverage; public examples were Web3-heavy as of 2026-05-09. Re-evaluate at next review. |
-| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                 |
+| Vendor          | Reference                  | Initial status | Before scheduling                                                                                                                              |
+| --------------- | -------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                        |
+| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                        |
+| Almanax         | <https://almanax.ai/>      | Lower priority | Confirm OSS or trial access and Ruby/TypeScript coverage; public examples were Web3-heavy as of the document date. Re-evaluate at next review. |
+| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                        |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -89,6 +89,9 @@ Before running scans, record the exact baselines used:
 
 > **Do not run any scanner evaluation until every cell in this table is filled in and committed.** Undocumented
 > baselines produce results that cannot be reproduced or compared across evaluators.
+> For the known-issue fixture, fill the table with a concrete private repository/branch or public training-project URL,
+> commit or version, fixture owner, and access request path before scheduling any scanner. Until Issue 2018 names a
+> narrower owner, repository maintainers with write access own fixture selection and access approval.
 
 The follow-up issue,
 [#3265 Track baseline prerequisites for AI security scanner evaluation](https://github.com/shakacode/react_on_rails/issues/3265),
@@ -111,19 +114,20 @@ to make security signal and operational cost comparable across evaluators while 
 Example: Actionability score = 4 with weight = 1.0 produces a weighted score of 4.0. If all eight criteria score 3,
 the normalized weighted average is
 `(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`,
-where 6.4 is the sum of all weights.
+where 6.4 is the sum of all weights. If any criterion or weight changes, recompute this denominator in the example and
+in the final-score row before merging the change.
 
-| Criterion                 | Question                                                                                         | Score (1-5) | Weight (0-1) | Weighted score |
-| ------------------------- | ------------------------------------------------------------------------------------------------ | ----------- | ------------ | -------------- |
-| Actionability             | Does the finding name the concrete file, behavior, and reachable path?                           |             | 1.0          |                |
-| Correctness               | Can we reproduce or disprove the finding locally?                                                |             | 1.0          |                |
-| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?                 |             | 0.9          |                |
-| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?                        |             | 0.8          |                |
-| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries?               |             | 0.8          |                |
-| Permission model          | Can it run with minimal GitHub permissions?                                                      |             | 0.7          |                |
-| CI fit                    | Can results be advisory first, without failing every PR?                                         |             | 0.7          |                |
-| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                    |             | 0.5          |                |
-| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; current total weight = `6.4` |             | N/A          | `<fill>`       |
+| Criterion                 | Question                                                                                                                      | Score (1-5) | Weight (0-1) | Weighted score |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
+| Actionability             | Does the finding name the concrete file, behavior, and reachable path?                                                        |             | 1.0          |                |
+| Correctness               | Can we reproduce or disprove the finding locally?                                                                             |             | 1.0          |                |
+| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?                                              |             | 0.9          |                |
+| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?                                                     |             | 0.8          |                |
+| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries?                                            |             | 0.8          |                |
+| Permission model          | Can it run with minimal GitHub permissions?                                                                                   |             | 0.7          |                |
+| CI fit                    | Can results be advisory first, without failing every PR?                                                                      |             | 0.7          |                |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                                                 |             | 0.5          |                |
+| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; current total weight = `6.4`; recompute if weights change |             | N/A          | `<fill>`       |
 
 Anchor examples:
 
@@ -172,7 +176,7 @@ before adoption, repository maintainers with write access own the next triage de
 Do not add a scanner to CI until all of these are true:
 
 - Finds at least one verified issue or a clearly valuable hardening opportunity.
-- Keeps the false-positive rate at or below 25% for that scanner's `main` scan after one triage pass, measured among
+- Keeps the false-positive rate at or below 15% for that scanner's `main` scan after one triage pass, measured among
   high/critical findings reviewed for that scanner run, not cumulatively across scanners. If the scan reports fewer than
   five high/critical findings, manually review every finding and record why the sample is too small for a stable rate.
 - Supports advisory mode for pull requests.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -179,10 +179,11 @@ Do not add a scanner to CI until all of these are true:
 
 - Finds at least one verified issue or a clearly valuable hardening opportunity.
 - Keeps the false-positive rate at or below 15% for that scanner's `main` scan after one triage pass, measured among
-  high/critical findings reviewed for that scanner run, not cumulatively across scanners. A scan with fewer than five
-  high/critical findings cannot satisfy this false-positive-rate gate by itself; manually review every finding, record
-  the raw count and why the sample is too small for a stable rate, and gather a larger sample before using this rate to
-  justify CI adoption.
+  high/critical findings reviewed for that scanner run, not cumulatively across scanners. This initial bar is
+  intentionally lenient to support first-pass data collection; tighten it to 10% or lower before moving findings from
+  advisory to blocking. A scan with fewer than five high/critical findings cannot satisfy this false-positive-rate gate
+  by itself; manually review every finding, record the raw count and why the sample is too small for a stable rate, and
+  gather a larger sample before using this rate to justify CI adoption.
 - Supports advisory mode for pull requests.
 - Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,
   merge, or admin permissions.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -53,12 +53,12 @@ prioritization, explanation, or reachability analysis for a finding that existin
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Initial status | Before scheduling                                                                                   |
-| --------------- | -------------------------- | -------------- | --------------------------------------------------------------------------------------------------- |
-| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                             |
-| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                             |
-| Almanax         | <https://almanax.ai/>      | Lower priority | Confirm OSS or trial access and Ruby/TypeScript coverage; public examples are currently Web3-heavy. |
-| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                             |
+| Vendor          | Reference                  | Initial status | Before scheduling                                                                                                                       |
+| --------------- | -------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                 |
+| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                 |
+| Almanax         | <https://almanax.ai/>      | Lower priority | Confirm OSS or trial access and Ruby/TypeScript coverage; public examples were Web3-heavy as of 2026-05-09. Re-evaluate at next review. |
+| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                                                 |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -17,7 +17,8 @@ This plan tracks [Issue 2018](https://github.com/shakacode/react_on_rails/issues
 decision to adopt any vendor or CI integration.
 
 > **Public planning note:** This file lives in a public repository even though the path starts with `internal/planning/`.
-> Keep raw scanner findings, exploit details, private fork URLs, and intentionally vulnerable fixtures outside this repo;
+> Here, `internal` means "not end-user documentation," not restricted access; GitHub search indexes this directory. Keep
+> raw scanner findings, exploit details, private fork URLs, and intentionally vulnerable fixtures outside this repo;
 > commit only sanitized summaries here.
 
 ## Scope
@@ -125,8 +126,8 @@ Anchor examples:
 - Correctness: 5 means locally reproduced or disproven with a clear command; 1 means the scanner cannot explain the
   finding.
 - False-positive rate: 5 means most surfaced findings survive local verification; 1 means the report is mostly noise.
-  If fewer than three high/critical findings are reported, record the raw count and defer scoring until a larger sample is
-  available; do not extrapolate a rate from a single finding.
+  If fewer than five high/critical findings are reported, record the raw count and defer scoring until a larger sample is
+  available; do not extrapolate a rate from a tiny sample.
 - Ruby/Rails coverage: 5 means it traces Rails generators, helpers, SSR, and ExecJS paths; 1 means generic Ruby syntax
   only.
 - TypeScript/React coverage: 5 means it understands package exports, SSR utilities, and browser/server boundaries; 1 means
@@ -167,7 +168,7 @@ Do not add a scanner to CI until all of these are true:
 
 - Finds at least one verified issue or a clearly valuable hardening opportunity.
 - Keeps the false-positive rate at or below 25% among high/critical findings on `main` after one triage pass. If the scan
-  reports fewer than three high/critical findings, manually review every finding and record why the sample is too small
+  reports fewer than five high/critical findings, manually review every finding and record why the sample is too small
   for a stable rate.
 - Supports advisory mode for pull requests.
 - Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -113,17 +113,17 @@ the normalized weighted average is
 `(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`,
 where 6.4 is the sum of all weights.
 
-| Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) | Weighted score |
-| ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
-| Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |             | 1.0          |                |
-| Correctness               | Can we reproduce or disprove the finding locally?                                  |             | 1.0          |                |
-| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?   |             | 0.9          |                |
-| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |             | 0.8          |                |
-| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |             | 0.8          |                |
-| Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |                |
-| CI fit                    | Can results be advisory first, without failing every PR?                           |             | 0.7          |                |
-| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |             | 0.5          |                |
-| **Final score**           | Normalized weighted average: `sum(weighted scores) / 6.4`; total weight = `6.4`    |             | N/A          | `<fill>`       |
+| Criterion                 | Question                                                                                         | Score (1-5) | Weight (0-1) | Weighted score |
+| ------------------------- | ------------------------------------------------------------------------------------------------ | ----------- | ------------ | -------------- |
+| Actionability             | Does the finding name the concrete file, behavior, and reachable path?                           |             | 1.0          |                |
+| Correctness               | Can we reproduce or disprove the finding locally?                                                |             | 1.0          |                |
+| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?                 |             | 0.9          |                |
+| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?                        |             | 0.8          |                |
+| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries?               |             | 0.8          |                |
+| Permission model          | Can it run with minimal GitHub permissions?                                                      |             | 0.7          |                |
+| CI fit                    | Can results be advisory first, without failing every PR?                                         |             | 0.7          |                |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                    |             | 0.5          |                |
+| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; current total weight = `6.4` |             | N/A          | `<fill>`       |
 
 Anchor examples:
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -29,7 +29,11 @@ licensing boundaries.
 Compare scanner output against the current baseline before counting a finding as net-new signal:
 
 - CodeQL configuration under `.github/codeql/codeql-config.yml`
-- Existing lint, test, dependency, and code review workflows
+- Dependabot security updates for npm, Bundler, and GitHub Actions under `.github/dependabot.yml`
+- Existing lint, test, and code review workflows
+
+No dedicated `bundler-audit`, `bundle-audit`, `npm audit`, or `pnpm audit` CI workflow is configured at this snapshot.
+If one is added before an evaluation run, include it in this baseline before counting dependency CVEs as net-new signal.
 
 Record whether each verified finding is missed by the existing baseline or whether the scanner mainly improves
 prioritization, explanation, or reachability analysis for a finding that existing tools already surface.
@@ -115,9 +119,8 @@ Anchor examples:
 4. For each high or critical finding, reproduce locally or write down why it is not reachable.
    Batch-triage medium findings after the high/critical pass. Skip informational findings unless a pattern emerges.
 5. Fix only verified vulnerabilities or correctness bugs.
-   If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched. If
-   `SECURITY.md` exists, follow it; otherwise ask repository maintainers with write access to choose a private
-   coordination path and approve timing before public disclosure.
+   If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched.
+   Follow `SECURITY.md` for the disclosure process and approve timing with maintainers before public disclosure.
 6. Summarize scanner signal in the issue before trying the next scanner.
 
 ## Adoption Bar

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -116,18 +116,20 @@ the normalized weighted average is
 `(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 1.0) / 6.9 = 3.0`,
 where 6.9 is the sum of all weights. If any criterion or weight changes, recompute this denominator in the example and
 in the final-score row before merging the change.
+Current weight sum: 1.0 + 1.0 + 0.9 + 0.8 + 0.8 + 0.7 + 0.7 + 1.0 = **6.9**. Update this line whenever a criterion or
+weight changes.
 
-| Criterion                 | Question                                                                                                                      | Score (1-5) | Weight (0-1) | Weighted score |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
-| Actionability             | Does the finding name the concrete file, behavior, and reachable path?                                                        |             | 1.0          |                |
-| Correctness               | Can we reproduce or disprove the finding locally?                                                                             |             | 1.0          |                |
-| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?                                              |             | 0.9          |                |
-| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?                                                     |             | 0.8          |                |
-| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries?                                            |             | 0.8          |                |
-| Permission model          | Can it run with minimal GitHub permissions?                                                                                   |             | 0.7          |                |
-| CI fit                    | Can results be advisory first, without failing every PR?                                                                      |             | 0.7          |                |
-| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                                                 |             | 1.0          |                |
-| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; current total weight = `6.9`; recompute if weights change |             | N/A          | `<fill>`       |
+| Criterion                 | Question                                                                                                                          | Score (1-5) | Weight (0-1) | Weighted score |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
+| Actionability             | Does the finding name the concrete file, behavior, and reachable path?                                                            |             | 1.0          |                |
+| Correctness               | Can we reproduce or disprove the finding locally?                                                                                 |             | 1.0          |                |
+| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?                                                  |             | 0.9          |                |
+| Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?                                                         |             | 0.8          |                |
+| TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries?                                                |             | 0.8          |                |
+| Permission model          | Can it run with minimal GitHub permissions?                                                                                       |             | 0.7          |                |
+| CI fit                    | Can results be advisory first, without failing every PR?                                                                          |             | 0.7          |                |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                                                     |             | 1.0          |                |
+| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; use the current weight sum above; recompute if weights change |             | N/A          | `<fill>`       |
 
 Anchor examples:
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -123,6 +123,7 @@ where 6.4 is the sum of all weights.
 | Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |                |
 | CI fit                    | Can results be advisory first, without failing every PR?                           |             | 0.7          |                |
 | Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                      |             | 0.5          |                |
+| **Final score**           | Normalized weighted average: `sum(weighted scores) / 6.4`                          |             | **6.4**      | `<fill>`       |
 
 Anchor examples:
 
@@ -145,21 +146,21 @@ Anchor examples:
 
 ## First-Pass Workflow
 
-0. Verify the chosen scanner's current plan availability and Ruby/TypeScript coverage against the shortlist table.
+1. Verify the chosen scanner's current plan availability and Ruby/TypeScript coverage against the shortlist table.
    Update the table's "Initial status" and "Before scheduling" columns if anything has changed.
-1. Pick the current `main` branch of `react_on_rails` and one candidate scanner from the shortlist.
-2. Run the scan without enabling CI blocking.
-3. Export raw findings with sensitive details into a private, access-controlled location if needed; summarize only
+2. Pick the current `main` branch of `react_on_rails` and one candidate scanner from the shortlist.
+3. Run the scan without enabling CI blocking.
+4. Export raw findings with sensitive details into a private, access-controlled location if needed; summarize only
    sanitized, verified results in the public issue after exposure details are fixed or disproven.
    - Limit access to repository maintainers with write access, unless Issue 2018 names a narrower security triage group.
    - Omit secrets and credentials; redact reproduction snippets.
    - Delete or archive raw notes after the finding is resolved.
-4. For each high or critical finding, reproduce locally or write down why it is not reachable.
+5. For each high or critical finding, reproduce locally or write down why it is not reachable.
    Batch-triage medium findings after the high/critical pass. Skip informational findings unless a pattern emerges.
-5. Fix only verified vulnerabilities or correctness bugs.
+6. Fix only verified vulnerabilities or correctness bugs.
    If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched.
    Follow `SECURITY.md` for the disclosure process and approve timing with maintainers before public disclosure.
-6. Summarize scanner signal in the issue before trying the next scanner.
+7. Summarize scanner signal in the issue before trying the next scanner.
 
 ## Adoption Bar
 

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -53,12 +53,12 @@ prioritization, explanation, or reachability analysis for a finding that existin
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Initial status | Before scheduling                                                                                          |
-| --------------- | -------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------- |
-| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                    |
-| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                    |
-| Almanax         | <https://almanax.ai/>      | Lower priority | Evaluate only if ZeroPath, Corgea, and DryRun are unsuitable; confirm coverage beyond Web3-heavy examples. |
-| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                                    |
+| Vendor          | Reference                  | Initial status | Before scheduling                                                                                   |
+| --------------- | -------------------------- | -------------- | --------------------------------------------------------------------------------------------------- |
+| ZeroPath        | <https://zeropath.com/>    | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                             |
+| Corgea          | <https://corgea.com/>      | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                             |
+| Almanax         | <https://almanax.ai/>      | Lower priority | Confirm OSS or trial access and Ruby/TypeScript coverage; public examples are currently Web3-heavy. |
+| DryRun Security | <https://dryrun.security/> | Candidate      | Confirm OSS or trial plan and Ruby/TypeScript coverage.                                             |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -109,13 +109,14 @@ to make security signal and operational cost comparable across evaluators while 
 
 Example: Actionability score = 4 with weight = 1.0 produces a weighted score of 4.0. If all eight criteria score 3,
 the normalized weighted average is
-`(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`.
+`(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`,
+where 6.4 is the sum of all weights.
 
 | Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) | Weighted score |
 | ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
 | Actionability             | Does the finding name the concrete file, behavior, and reachable path?             |             | 1.0          |                |
 | Correctness               | Can we reproduce or disprove the finding locally?                                  |             | 1.0          |                |
-| False-positive rate       | How many findings are noise after local verification?                              |             | 0.9          |                |
+| False-positive rate       | What fraction of surfaced findings survive local verification as true positives?   |             | 0.9          |                |
 | Ruby/Rails coverage       | Does it understand Rails generators, helpers, and server rendering paths?          |             | 0.8          |                |
 | TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries? |             | 0.8          |                |
 | Permission model          | Can it run with minimal GitHub permissions?                                        |             | 0.7          |                |

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -113,8 +113,8 @@ to make security signal and operational cost comparable across evaluators while 
 
 Example: Actionability score = 4 with weight = 1.0 produces a weighted score of 4.0. If all eight criteria score 3,
 the normalized weighted average is
-`(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`,
-where 6.4 is the sum of all weights. If any criterion or weight changes, recompute this denominator in the example and
+`(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 1.0) / 6.9 = 3.0`,
+where 6.9 is the sum of all weights. If any criterion or weight changes, recompute this denominator in the example and
 in the final-score row before merging the change.
 
 | Criterion                 | Question                                                                                                                      | Score (1-5) | Weight (0-1) | Weighted score |
@@ -126,8 +126,8 @@ in the final-score row before merging the change.
 | TypeScript/React coverage | Does it understand package exports, SSR utilities, and browser/runtime boundaries?                                            |             | 0.8          |                |
 | Permission model          | Can it run with minimal GitHub permissions?                                                                                   |             | 0.7          |                |
 | CI fit                    | Can results be advisory first, without failing every PR?                                                                      |             | 0.7          |                |
-| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                                                 |             | 0.5          |                |
-| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; current total weight = `6.4`; recompute if weights change |             | N/A          | `<fill>`       |
+| Maintenance cost          | How much config, triage time, and vendor lock-in does it add?                                                                 |             | 1.0          |                |
+| **Final score**           | Normalized weighted average: `sum(weighted scores) / sum(weights)`; current total weight = `6.9`; recompute if weights change |             | N/A          | `<fill>`       |
 
 Anchor examples:
 
@@ -177,8 +177,10 @@ Do not add a scanner to CI until all of these are true:
 
 - Finds at least one verified issue or a clearly valuable hardening opportunity.
 - Keeps the false-positive rate at or below 15% for that scanner's `main` scan after one triage pass, measured among
-  high/critical findings reviewed for that scanner run, not cumulatively across scanners. If the scan reports fewer than
-  five high/critical findings, manually review every finding and record why the sample is too small for a stable rate.
+  high/critical findings reviewed for that scanner run, not cumulatively across scanners. A scan with fewer than five
+  high/critical findings cannot satisfy this false-positive-rate gate by itself; manually review every finding, record
+  the raw count and why the sample is too small for a stable rate, and gather a larger sample before using this rate to
+  justify CI adoption.
 - Supports advisory mode for pull requests.
 - Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,
   merge, or admin permissions.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -1,7 +1,8 @@
 # AI Security Scanner Evaluation Plan
 
 **Vendor snapshot:** 2026-05-09. Re-check product names, URLs, plans, and language coverage before running the
-evaluation.
+evaluation, then refresh this snapshot annually or when a listed vendor is acquired, deprecated, or materially changes
+scope.
 
 ## Purpose
 
@@ -23,17 +24,27 @@ Evaluate the open-source gem and npm package first:
 Evaluate React on Rails Pro separately after the OSS scan path is understood, because Pro contains separate package and
 licensing boundaries.
 
+## Existing Tooling Baseline
+
+Compare scanner output against the current baseline before counting a finding as net-new signal:
+
+- CodeQL configuration under `.github/codeql/codeql-config.yml`
+- Existing lint, test, dependency, and code review workflows
+
+Record whether each verified finding is missed by the existing baseline or whether the scanner mainly improves
+prioritization, explanation, or reachability analysis for a finding that existing tools already surface.
+
 ## Candidate Scanners
 
 Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
 evaluation time.
 
-| Vendor          | Reference                  | Before scheduling                                            |
-| --------------- | -------------------------- | ------------------------------------------------------------ |
-| ZeroPath        | <https://zeropath.com/>    | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
-| Corgea          | <https://corgea.com/>      | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
-| Almanax         | <https://almanax.ai/>      | Confirm current product scope beyond Web3-oriented examples. |
-| DryRun Security | <https://dryrun.security/> | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
+| Vendor          | Reference                  | Initial status    | Before scheduling                                            |
+| --------------- | -------------------------- | ----------------- | ------------------------------------------------------------ |
+| ZeroPath        | <https://zeropath.com/>    | Candidate         | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
+| Corgea          | <https://corgea.com/>      | Candidate         | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
+| Almanax         | <https://almanax.ai/>      | Needs scope check | Confirm current product scope beyond Web3-oriented examples. |
+| DryRun Security | <https://dryrun.security/> | Candidate         | Confirm OSS or trial plan and Ruby/TypeScript coverage.      |
 
 If the named vendors are unavailable or unsuitable, look for tools in these categories:
 
@@ -65,13 +76,14 @@ Before running scans, record the exact baselines used:
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
 public branch of this repository. Keep any private positive-control fixture non-indexable, clearly labeled test-only, and
-inert: no operational code paths, real network calls, or reusable exploit payloads.
+inert: no operational code paths, real network calls, or reusable exploit payloads. Limit access to the default triage
+group unless Issue 2018 assigns a narrower group for the evaluation.
 
 ## Scoring Criteria
 
 Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use weighted totals to make
 security signal and operational cost comparable across evaluators:
-`weighted total = sum(score x weight) / sum(weights)`.
+`weighted score = score x weight`; `weighted total = sum(weighted scores) / sum(weights)`.
 
 | Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) | Weighted score |
 | ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
@@ -103,23 +115,26 @@ Anchor examples:
 4. For each high or critical finding, reproduce locally or write down why it is not reachable.
    Batch-triage medium findings after the high/critical pass. Skip informational findings unless a pattern emerges.
 5. Fix only verified vulnerabilities or correctness bugs.
-   If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched and
-   follow `SECURITY.md` if present; otherwise coordinate a maintainer-approved disclosure path before public disclosure.
+   If a verified vulnerability affects released gem or npm package code, keep exposure details private until patched. If
+   `SECURITY.md` exists, follow it; otherwise ask repository maintainers with write access to choose a private
+   coordination path and approve timing before public disclosure.
 6. Summarize scanner signal in the issue before trying the next scanner.
 
 ## Adoption Bar
 
 **Owner:** See [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) for tracking and assignment.
 **Default triage group:** repository maintainers with write access, unless the issue assigns a narrower group.
+**Default triage SLA:** first response within five business days for high or critical alerts.
 
 Do not add a scanner to CI until all of these are true:
 
 - Finds at least one verified issue or a clearly valuable hardening opportunity.
-- Produces five or fewer false-positive high/critical findings on `main` after one triage pass.
+- Keeps the false-positive rate at or below 25% among high/critical findings on `main` after one triage pass. If the scan
+  reports fewer than three high/critical findings, manually review every finding and record why the sample is too small
+  for a stable rate.
 - Supports advisory mode for pull requests.
 - Requires only read-only repository access plus permission to post advisory PR comments or create issues; no write,
   merge, or admin permissions.
-- Documents triage ownership in Issue 2018, including the owner or rotation and a target first response within five
-  business days.
+- Records the triage owner or rotation for the default SLA in Issue 2018.
 
 If no scanner clears this bar, keep the issue as a record of what was tested and revisit later.

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -124,6 +124,9 @@ in the final-score row before merging the change.
 Current weight sum: 1.0 + 1.0 + 0.9 + 0.8 + 0.8 + 0.7 + 0.7 + 1.0 = **6.9**. Update this line whenever a criterion or
 weight changes.
 
+The table below has eight scored criteria followed by a `Final score` row; that last row is a computed aggregate (its
+weight is intentionally `N/A`) and must not be counted toward `sum(weights)`.
+
 | Criterion                 | Question                                                                                                                          | Score (1-5) | Weight (0-1) | Weighted score |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |
 | Actionability             | Does the finding name the concrete file, behavior, and reachable path?                                                            |             | 1.0          |                |

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -4,6 +4,10 @@
 Re-check product names, URLs, plans, and language coverage before running the evaluation, then refresh this snapshot
 annually or when a listed vendor is acquired, deprecated, or materially changes scope.
 
+- **Last reviewed:** 2026-05-09
+- **Review owner:** React on Rails maintainers
+- **Next review due:** 2027-05-09
+
 ## Purpose
 
 Evaluate whether AI-native security scanners can find actionable vulnerabilities or logic bugs in React on Rails beyond
@@ -11,6 +15,10 @@ the issues already covered by existing lint, test, dependency, and code review w
 
 This plan tracks [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018). It is an evaluation plan, not a
 decision to adopt any vendor or CI integration.
+
+> **Public planning note:** This file lives in a public repository even though the path starts with `internal/planning/`.
+> Keep raw scanner findings, exploit details, private fork URLs, and intentionally vulnerable fixtures outside this repo;
+> commit only sanitized summaries here.
 
 ## Scope
 
@@ -81,8 +89,9 @@ Before running scans, record the exact baselines used:
 > **Do not run any scanner evaluation until every cell in this table is filled in and committed.** Undocumented
 > baselines produce results that cannot be reproduced or compared across evaluators.
 
-Track this prerequisite in [Issue 3265](https://github.com/shakacode/react_on_rails/issues/3265) before scheduling any
-evaluation run, so the placeholders cannot be missed when Issue 2018 moves from planning to execution.
+[Issue 3265](https://github.com/shakacode/react_on_rails/issues/3265) must be closed, with every dataset table cell
+filled and committed, before [Issue 2018](https://github.com/shakacode/react_on_rails/issues/2018) moves from planning to
+execution.
 
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
@@ -95,6 +104,9 @@ group unless Issue 2018 assigns a narrower group for the evaluation.
 Score each scanner against the same rubric (1 = poor, 3 = acceptable, 5 = excellent). Use weighted totals to make
 security signal and operational cost comparable across evaluators:
 `weighted score = score x weight`; `weighted total = sum(weighted scores) / sum(weights)`.
+
+Example: Actionability score = 4 with weight = 1.0 produces a weighted score of 4.0. If all eight criteria score 3,
+the weighted total is `(3 x 1.0 + 3 x 1.0 + 3 x 0.9 + 3 x 0.8 + 3 x 0.8 + 3 x 0.7 + 3 x 0.7 + 3 x 0.5) / 6.4 = 3.0`.
 
 | Criterion                 | Question                                                                           | Score (1-5) | Weight (0-1) | Weighted score |
 | ------------------------- | ---------------------------------------------------------------------------------- | ----------- | ------------ | -------------- |

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -1,8 +1,8 @@
 # AI Security Scanner Evaluation Plan
 
-**Last updated:** 2026-05-09. **Vendor snapshot:** Re-check product names, URLs, plans, and language coverage before
-running the evaluation, then refresh this snapshot annually or when a listed vendor is acquired, deprecated, or materially
-changes scope.
+**Revision history:** Use `git log -- internal/planning/ai-security-scanner-evaluation.md`. **Vendor snapshot:**
+Re-check product names, URLs, plans, and language coverage before running the evaluation, then refresh this snapshot
+annually or when a listed vendor is acquired, deprecated, or materially changes scope.
 
 ## Purpose
 
@@ -81,6 +81,9 @@ Before running scans, record the exact baselines used:
 > **Do not run any scanner evaluation until every cell in this table is filled in and committed.** Undocumented
 > baselines produce results that cannot be reproduced or compared across evaluators.
 
+Track this prerequisite in [Issue 3265](https://github.com/shakacode/react_on_rails/issues/3265) before scheduling any
+evaluation run, so the placeholders cannot be missed when Issue 2018 moves from planning to execution.
+
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
 public branch of this repository. Keep any private positive-control fixture non-indexable, clearly labeled test-only, and
@@ -110,6 +113,8 @@ Anchor examples:
 - Correctness: 5 means locally reproduced or disproven with a clear command; 1 means the scanner cannot explain the
   finding.
 - False-positive rate: 5 means most surfaced findings survive local verification; 1 means the report is mostly noise.
+  If fewer than three high/critical findings are reported, record the raw count and defer scoring until a larger sample is
+  available; do not extrapolate a rate from a single finding.
 - Ruby/Rails coverage: 5 means it traces Rails generators, helpers, SSR, and ExecJS paths; 1 means generic Ruby syntax
   only.
 - TypeScript/React coverage: 5 means it understands package exports, SSR utilities, and browser/server boundaries; 1 means
@@ -123,6 +128,8 @@ Anchor examples:
 
 ## First-Pass Workflow
 
+0. Verify the chosen scanner's current plan availability and Ruby/TypeScript coverage against the shortlist table.
+   Update the table's "Initial status" and "Before scheduling" columns if anything has changed.
 1. Pick the current `main` branch of `react_on_rails` and one candidate scanner from the shortlist.
 2. Run the scan without enabling CI blocking.
 3. Export raw findings with sensitive details into a private, access-controlled location if needed; summarize only

--- a/internal/planning/ai-security-scanner-evaluation.md
+++ b/internal/planning/ai-security-scanner-evaluation.md
@@ -22,12 +22,16 @@ licensing boundaries.
 
 ## Candidate Scanner Categories
 
-Use this point-in-time candidate list from the issue if the products still offer an appropriate plan at evaluation time:
+Start with this point-in-time vendor shortlist from the issue if the products still offer an appropriate plan at
+evaluation time:
 
 - ZeroPath
 - Corgea
 - Almanax
 - DryRun
+
+If the named vendors are unavailable or unsuitable, look for tools in these categories:
+
 - AI-native SAST scanners
 - AI-assisted dependency reachability scanners
 - AI review tools that can reason about business logic and security intent
@@ -41,13 +45,14 @@ validating.
 Use a fixed branch and commit for the first comparison so results are reproducible:
 
 1. Current `main`
-2. A private fork, private Gist, or existing vulnerable-by-design project that verifies the scanner can catch a known
-   issue without publishing intentionally vulnerable code in the public React on Rails repository
+2. A private, access-controlled fork or an established vulnerable-by-design training project that verifies the scanner
+   can catch a known issue without publishing intentionally vulnerable code in the public React on Rails repository
 3. A branch with a known-safe refactor to measure false positives on normal code motion
 
 The intentionally vulnerable fixture should be small and obvious, such as unsafe template evaluation in a test-only file.
 Do not commit intentionally vulnerable fixtures, secrets, real credentials, or exploit-ready application behavior to a
-public branch of this repository.
+public branch of this repository. Keep any private positive-control fixture non-indexable, clearly labeled test-only, and
+inert: no operational code paths, real network calls, or reusable exploit payloads.
 
 ## Scoring Criteria
 
@@ -70,7 +75,10 @@ Score each scanner against the same rubric:
 2. Run the scan without enabling CI blocking.
 3. Export raw findings with sensitive details into a private Notion or Google Doc if needed; summarize only sanitized,
    verified results in the public issue after exposure details are fixed or disproven.
+   Limit access to repository maintainers or the security triage group, omit secrets and credentials, redact reproduction
+   snippets, and delete or archive raw notes after the finding is resolved.
 4. For each high or critical finding, reproduce locally or write down why it is not reachable.
+   Batch-triage medium findings after the high/critical pass. Skip informational findings unless a pattern emerges.
 5. Fix only verified vulnerabilities or correctness bugs.
 6. Summarize scanner signal in the issue before trying the next scanner.
 


### PR DESCRIPTION
## Summary
- add an internal plan for evaluating AI-native security scanners against the OSS gem and npm package first
- define scanner categories, evaluation datasets, scoring criteria, and an adoption bar
- keep CI adoption out of scope until a scanner proves useful and low-noise

Refs #2018

## Test Plan
- `pnpm exec prettier --check internal/planning/ai-security-scanner-evaluation.md`
- `git diff --check`
- pre-commit/pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation and `.gitignore` updates only, with no runtime or build logic changes.
> 
> **Overview**
> Adds a public `SECURITY.md` describing supported-version policy and private vulnerability reporting, and links it from `README.md`.
> 
> Introduces `internal/planning/` docs (including an AI security scanner evaluation plan with scope, scoring rubric, and adoption bar) and updates `.gitignore` to prevent committing SARIF/scanner output artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23dd07632c071f2216ddfd5ac84fec6f691a242e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an internal evaluation plan for AI-native security scanners targeting React on Rails.
  * Defined scope, vendor shortlist, fallback scanner categories, and a fixed dataset approach with safe and test-only vulnerable fixtures.
  * Introduced a weighted scoring rubric and a first-pass scan, verification, and triage workflow.
  * Documented CI adoption criteria: verified findings thresholds, false-positive limits, permission expectations, and triage ownership/SLA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->