### PR TITLE
docs: plan React 19 partial pre-rendering work

### DIFF
--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -38,9 +38,8 @@ Use a dedicated branch for the actual version verification work:
 - [ ] Audit `renderToString` and `renderToStaticMarkup` call sites in React on Rails SSR paths; React 19 renders Suspense
       fallbacks synchronously in `renderToString` instead of suspending, which can silently change output without an error.
       For each call site in `packages/react-on-rails/src/serverRenderReactComponent.ts`,
-      `packages/react-on-rails/src/handleError.ts`, `packages/react-on-rails-pro-node-renderer/`, and any generated bundles
-      found by
-      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts" --include="*.tsx" --include="*.cts"`,
+      `packages/react-on-rails/src/handleError.ts`, and any generated bundles found by
+      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
 - [ ] Decide the fate of `packages/react-on-rails/src/ReactDOMServer.cts`: either remove the compatibility re-export when
@@ -92,7 +91,8 @@ Use a dedicated branch for the actual version verification work:
       and cleaning:
 
   > **Warning**: `git clean -fdx` deletes all untracked files and cannot be undone. Stash or commit any in-progress work
-  > first.
+  > first. Note: `git stash` only saves tracked changes; untracked files must be committed or moved manually before running
+  > `git clean`.
 
   ```bash
   git stash
@@ -103,8 +103,8 @@ Use a dedicated branch for the actual version verification work:
   Then run the suite:
 
   ```bash
-  bundle exec rake run_rspec:shakapacker_examples_latest   # React 19 examples only
-  bundle exec rake run_rspec:shakapacker_examples           # full suite across pinned React versions when needed
+  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_latest   # React 19 examples only
+  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples           # full suite across pinned React versions when needed
   ```
 
   Note: `bundle exec rake shakapacker_examples:gen_all` only generates apps; a separate `run_rspec:*` task must run their

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -33,7 +33,7 @@ Use a dedicated branch for the actual version verification work:
 4. Run Ruby checks that exercise SSR and generated apps:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`
-   - `bundle exec rspec react_on_rails/spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
+   - `cd react_on_rails && bundle exec rspec spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
    - `cd react_on_rails/spec/dummy && bundle exec rspec spec/requests spec/system spec/packs_generator_spec.rb` for dummy
      SSR and generator integration paths
    - Pro RSC and renderer paths _(requires Pro access and `react_on_rails_pro/` checked out)_:
@@ -103,11 +103,19 @@ Evaluate these in order:
 Track these in [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) before implementation begins so
 each decision has an owner, acceptance criteria, and a closure path.
 
+The prerequisite decision is whether the first implementation should prove the pattern through traditional SSR with
+Suspense, RSC, or both; answer that before settling caching, benchmarks, or streamed-error semantics.
+
 - Which Rails caching layer should be recommended for the static-shell: fragment cache, HTTP cache, CDN cache, or a
   combination?
+  **Owner**: @justin808 | **Target**: before any implementation PR is opened
 - Should the static-shell be rendered by the Node Renderer, cached as a Rails partial fragment, or selected per example?
+  **Owner**: @justin808 | **Target**: before any implementation PR is opened
 - Should the first example use traditional SSR with Suspense, RSC, or both?
+  **Owner**: @justin808 | **Target**: prerequisite decision before any implementation PR is opened
 - How should failures in the dynamic portion affect status codes and error boundaries after part of the response has
   streamed?
+  **Owner**: @justin808 | **Target**: after the SSR-vs-RSC strategy decision, before public docs or examples
 - What metrics matter most for acceptance: TTFB, LCP, response end, total bytes, or client JavaScript reduction, and how
   do Rails `ActionController::Live` and Node Renderer streaming paths affect those metrics differently?
+  **Owner**: @justin808 | **Target**: after the SSR-vs-RSC strategy decision, before benchmark implementation

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -49,8 +49,10 @@ Use a dedicated branch for the actual version verification work:
    - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
    - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
 6. Run the generated-app suite from a clean checkout:
-   `bundle exec rake run_rspec:shakapacker_examples_basic`. Use `bundle exec rake shakapacker_examples:gen_all` for full
-   regenerated example coverage when needed.
+   `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
+   `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
+   `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run
+   their tests.
 7. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
    examples.
 
@@ -90,7 +92,7 @@ Evaluate these in order:
 
 - React 19.2.x passes the same local verification suite as the currently supported React 19 line.
 - Existing SSR, streaming SSR, RSC payload rendering, and client hydration tests stay green.
-- The generated-app suite (`bundle exec rake run_rspec:shakapacker_examples_basic`) passes with React 19.2.x.
+- The generated-app suite (`bundle exec rake run_rspec:shakapacker_examples_latest`) passes with React 19.2.x.
 - Any public docs that cite an explicit React version are updated or explicitly annotated with a minimum-version note.
 - Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR.
 - The first public artifact is documentation or an example unless a missing library API is clearly demonstrated.

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -24,13 +24,15 @@ confirm whether that workspace stays on React 18 during this work. That means th
 verification, not necessarily a broad package-range change.
 
 Note: `packages/react-on-rails-pro/package.json` already sets the `react-on-rails-rsc` peer dependency ceiling to
-`>= 19.0.2 <= 19.2.3` (space means AND; both comparators must be satisfied). Verification should decide whether this ceiling
-should be widened alongside any React 19.2.x range update. Because a hard upper bound would reject a future `19.2.4` patch or
-`19.3.x` minor release, the decision must either widen the range for stable React 19.x, such as `< 20.0.0`, or document the
-specific API risk that requires a tight pin. If verification finds no specific API risk, the default outcome is to widen the
-ceiling to `< 20.0.0`. The same decision must also audit the Pro package `react` and `react-dom` peer dependency ranges,
-currently `>= 16`, so all three peer ranges stay aligned with the minimum React version decision. **Owner**: @justin808 |
-**Target**: before any package-range change is merged (see Open Questions).
+`>= 19.0.2 <= 19.2.3` (space means AND; both comparators must be satisfied). The `<= 19.2.3` upper bound is a precautionary
+verified-patch ceiling from the current planning pass, not a recorded React API incompatibility. Verification should decide
+whether this ceiling should be widened alongside any React 19.2.x range update. Because a hard upper bound would reject a
+future `19.2.4` patch or `19.3.x` minor release, the decision must either widen the stable React 19 range to
+`>= 19.0.2 < 20.0.0` or document the specific API risk that requires a tight pin. Pre-release React versions should remain
+outside the recommended range unless the verification record explicitly tests them. If verification finds no specific API
+risk, the default outcome is to widen the range to `>= 19.0.2 < 20.0.0`. The same decision must also audit the Pro package
+`react` and `react-dom` peer dependency ranges, currently `>= 16`, so all three peer ranges stay aligned with the minimum
+React version decision. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -46,8 +48,9 @@ Use a dedicated branch for the actual version verification work:
       `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
-- [ ] If React 16/17 support is being dropped in this work cycle, remove `packages/react-on-rails/src/ReactDOMServer.cts`.
-      Otherwise, confirm the file's existing removal comment remains the accepted exit criterion and close this task.
+- [ ] If the Issue 3255 minimum-React-version decision drops React 16/17 support, remove
+      `packages/react-on-rails/src/ReactDOMServer.cts`. Otherwise, confirm the file's existing removal comment remains the
+      accepted exit criterion and close this task.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
       `pnpm list -r --depth=0 react react-dom react-on-rails-rsc` output in the verification record, such as a comment on
@@ -71,6 +74,10 @@ Use a dedicated branch for the actual version verification work:
     setup)_
   - Confirm whether `react_on_rails_pro/spec/execjs-compatible-dummy` needs a dedicated React 18 test run as part of the
     acceptance criteria.
+  - Confirm the resolved `@tanstack/react-router` version used by the Pro package still satisfies its React 19 compatibility
+    matrix, and make the Pro `./tanstack-router` export part of the RSC boundary verification. If local Pro prerequisites
+    are unavailable, record the PR's Pro CI result as the proxy and open a follow-up only if that CI does not cover the
+    export.
   - Public contributors without Pro runtime prerequisites should rely on the PR's Pro CI checks as the proxy for these
     Pro verification steps.
 - [ ] Run Ruby checks that exercise SSR and generated apps:
@@ -96,8 +103,7 @@ Use a dedicated branch for the actual version verification work:
 
   ```bash
   git worktree add /tmp/ror-verify HEAD
-  cd /tmp/ror-verify
-  pnpm install
+  (cd /tmp/ror-verify && pnpm install)
   ```
 
   After the suite runs, remove the worktree from the original checkout:
@@ -190,7 +196,8 @@ Track these in [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3
 each decision has an owner, acceptance criteria, and a closure path.
 
 The prerequisite decision is whether the first implementation should prove the pattern through traditional SSR with
-Suspense, RSC, or both; answer that before settling caching, benchmarks, or streamed-error semantics.
+Suspense, RSC, or both. Record that answer in Issue 3255 before opening the first implementation PR; until then, caching,
+benchmarks, and streamed-error semantics stay provisional rather than settled.
 
 Before implementation starts, assign a secondary reviewer for the prerequisite SSR-vs-RSC decision so the plan does not
 stall if @justin808 is unavailable. Also assign a backup reviewer for benchmark metrics because that decision can be

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -24,7 +24,9 @@ verification, not necessarily a broad package-range change.
 
 Note: `react-on-rails-pro` currently pins `react-on-rails-rsc` as a peer dependency at `>= 19.0.2 <= 19.2.3`.
 Verification should confirm whether this ceiling is intentional or should be widened alongside any React 19.2.x range
-update. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
+update. Because this hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the decision must
+either widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that requires a tight
+pin. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -32,11 +34,13 @@ Use a dedicated branch for the actual version verification work:
 
 - [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
       affect React on Rails SSR, streaming, RSC, or hydration integration.
-- [ ] Confirm the existing `renderToString` usages in `packages/react-on-rails/src/serverRenderReactComponent.ts` and
-      `packages/react-on-rails/src/handleError.ts` are intentionally exempt from migration to `renderToPipeableStream`;
-      React 19 soft-deprecates `renderToString`. Also grep `packages/react-on-rails-pro-node-renderer/` and related SSR
-      integration paths for additional call sites, then document either a migration ticket or why current usage is
-      acceptable.
+- [ ] Confirm that no React on Rails SSR path passes a Suspense-containing tree through `renderToString`; React 19 renders
+      Suspense fallbacks synchronously in that path instead of suspending, which can silently change output without an
+      error. Check the existing `renderToString` usages in
+      `packages/react-on-rails/src/serverRenderReactComponent.ts` and `packages/react-on-rails/src/handleError.ts`, plus
+      `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep
+      `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
+      document either a migration ticket or why current usage is acceptable.
 - [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to
       compatible versions.
 - [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
@@ -162,5 +166,6 @@ validated independently from the rest of the implementation tree.
 - Should the minimum supported React version retain React 18.x compatibility or move to React 19.x only?
   **Owner**: @justin808 | **Target**: before any package-range change is merged
 - Should the `react-on-rails-pro` peer dependency ceiling for `react-on-rails-rsc` stay at `<= 19.2.3` or widen with the
-  React 19.2.x verification work?
+  React 19.2.x verification work? If it stays tight, what specific API risk justifies rejecting future React 19.x patch
+  or minor releases?
   **Owner**: @justin808 | **Target**: before any package-range change is merged

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -20,15 +20,21 @@ and Pro dummy app package manifests. To see what versions are currently resolved
 `pnpm list react react-dom react-on-rails-rsc` from the repo root. That means the first implementation step is
 verification, not necessarily a broad package-range change.
 
+Note: `react-on-rails-pro` currently pins `react-on-rails-rsc` as a peer dependency at `>= 19.0.2 <= 19.2.3`.
+Verification should confirm whether this ceiling is intentional or should be widened alongside any React 19.2.x range
+update.
+
 ## React 19.2.x Verification Checklist
 
 Use a dedicated branch for the actual version verification work:
 
 - [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
       affect React on Rails SSR, streaming, RSC, or hydration integration.
-- [ ] Grep for `renderToString` usage across `packages/react-on-rails/`, `node_renderer/`, and related SSR integration
-      paths; React 19 soft-deprecates it in favor of `renderToPipeableStream`, so confirm whether migration is needed or
-      whether current usage is intentionally exempt.
+- [ ] Confirm the existing `renderToString` usages in `packages/react-on-rails/src/serverRenderReactComponent.ts` and
+      `packages/react-on-rails/src/handleError.ts` are intentionally exempt from migration to `renderToPipeableStream`;
+      React 19 soft-deprecates `renderToString`. Also grep `packages/react-on-rails-pro-node-renderer/` and related SSR
+      integration paths for additional call sites, then document either a migration ticket or why current usage is
+      acceptable.
 - [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to
       compatible versions.
 - [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -98,13 +98,16 @@ Use a dedicated branch for the actual version verification work:
     cd react_on_rails_pro/spec/dummy
     bundle exec rspec spec/requests/rsc_payload_spec.rb spec/requests/server_render_check_spec.rb spec/system/renderer_integration_spec.rb
     ```
-  - See `.claude/docs/replicating-ci-failures.md` when mapping a failed CI job back to a narrower local command.
+  - See `.claude/docs/replicating-ci-failures.md` (Claude Code agent reference) when mapping a failed CI job back to a
+    narrower local command; human contributors can also use the failing CI job name from the GitHub Actions log to scope
+    the local repro.
 - [ ] Ensure Playwright browsers are installed, then run E2E coverage:
   - `cd react_on_rails/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails/spec/dummy && pnpm test:e2e` for OSS dummy SSR and hydration paths
   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
-  - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
+  - See `.claude/docs/playwright-e2e-testing.md` (Claude Code agent reference) for additional notes; the commands above
+    are the canonical OSS dummy setup for human contributors.
 - [ ] Run the generated-app suite. Prefer a fresh clone. If a fresh clone is not practical, use a disposable worktree so
       the current checkout and gitignored files are untouched:
 

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -26,6 +26,9 @@ Use a dedicated branch for the actual version verification work:
 
 - [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
       affect React on Rails SSR, streaming, RSC, or hydration integration.
+- [ ] Grep for `renderToString` usage across `packages/react-on-rails/`, `node_renderer/`, and related SSR integration
+      paths; React 19 soft-deprecates it in favor of `renderToPipeableStream`, so confirm whether migration is needed or
+      whether current usage is intentionally exempt.
 - [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to
       compatible versions.
 - [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
@@ -107,6 +110,8 @@ Evaluate these in order:
 - Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR.
 - The first public artifact is documentation or an example unless a missing library API is clearly demonstrated.
 - The feature name and docs explain Rails ownership clearly so users do not expect Next.js-style file-system routing.
+- The decision on the minimum supported React version, including whether React 18.x remains supported, is documented
+  before any package-range change is merged.
 
 ## Open Questions
 
@@ -119,6 +124,10 @@ Suspense, RSC, or both; answer that before settling caching, benchmarks, or stre
 Before implementation starts, assign a secondary reviewer for the prerequisite SSR-vs-RSC decision so the plan does not
 stall if @justin808 is unavailable. Also assign a backup reviewer for benchmark metrics because that decision can be
 validated independently from the rest of the implementation tree.
+
+**Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR]_
+
+**Backup reviewer (benchmarks)**: _[name to be filled before first implementation PR]_
 
 - Which Rails caching layer should be recommended for the static-shell: fragment cache, HTTP cache, CDN cache, or a
   combination?

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -29,14 +29,14 @@ Use a dedicated branch for the actual version verification work:
    - `pnpm run type-check`
    - `pnpm run lint`
    - `pnpm run test`
-   - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access)_
+   - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access and `react_on_rails_pro/` checked out)_
 4. Run Ruby checks that exercise SSR and generated apps:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`
    - `bundle exec rspec react_on_rails/spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
    - `cd react_on_rails/spec/dummy && bundle exec rspec spec/requests spec/system spec/packs_generator_spec.rb` for dummy
      SSR and generator integration paths
-   - Pro RSC and renderer paths _(requires Pro access)_:
+   - Pro RSC and renderer paths _(requires Pro access and `react_on_rails_pro/` checked out)_:
      ```bash
      cd react_on_rails_pro/spec/dummy
      bundle exec rspec spec/requests/rsc_payload_spec.rb spec/requests/server_render_check_spec.rb spec/system/renderer_integration_spec.rb
@@ -64,8 +64,8 @@ too loosely:
 
 - The Rails route still owns routing, authentication, headers, caching, and status codes.
 - React on Rails owns React registration, SSR, streaming, and hydration boundaries.
-- Streaming SSR means the Node Renderer starts work during the request and flushes chunks as Suspense boundaries,
-  server data, and RSC payloads resolve.
+- Streaming SSR means the Node Renderer starts work during the request and flushes chunks as Suspense boundaries and RSC
+  payloads resolve, delivering content progressively without waiting for a full render.
 - True partial pre-rendering would require a reusable static-shell, rendered ahead of dynamic data at build time or at a
   cache layer such as Rails HTTP caching or a CDN, with dynamic holes filled by a later streaming pass.
 - The feature must not require moving a Rails app into a frontend-framework routing model.

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -25,7 +25,10 @@ confirm whether that workspace stays on React 18 during this work. That means th
 verification, not necessarily a broad package-range change.
 
 Note: `packages/react-on-rails-pro/package.json` already sets the `react-on-rails-rsc` peer dependency ceiling to
-`>= 19.0.2 <= 19.2.3` (space means AND; both comparators must be satisfied). The `<= 19.2.3` upper bound is a precautionary
+`>= 19.0.2 <= 19.2.3` (space means AND; both comparators must be satisfied). These 19.x version numbers apply to the
+`react-on-rails-rsc` package, not to React itself: `react-on-rails-rsc`'s major and minor numbers track the React
+release line it targets, so a constraint such as `<= 19.2.3` here is a constraint on the RSC integration package, not on
+the React peer dependency. The `<= 19.2.3` upper bound is a precautionary
 verified-patch ceiling from the current planning pass, not a recorded React API incompatibility. Verification should decide
 whether this ceiling should be widened alongside any React 19.2.x range update. Because a hard upper bound would reject a
 future `19.2.4` patch or `19.3.x` minor release, the decision must either widen the stable React 19 range to
@@ -46,7 +49,7 @@ Use a dedicated branch for the actual version verification work:
       fallbacks synchronously in `renderToString` instead of suspending, which can silently change output without an error.
       For each call site in `packages/react-on-rails/src/serverRenderReactComponent.ts`,
       `packages/react-on-rails/src/handleError.ts`, and any generated bundles found by
-      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`
+      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts" --include="*.mts"`
       run from the repo root,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
@@ -124,6 +127,7 @@ Use a dedicated branch for the actual version verification work:
 
   ```bash
   git stash -u
+  git clean -ndx   # dry run — review the printed list before running the destructive command below
   git clean -fdx
   pnpm install
   ```
@@ -209,10 +213,9 @@ These placeholders must be filled before the first implementation PR is opened. 
 @justin808 is the fallback owner for both roles.
 
 These will be filled in Issue 3255 before any implementation PR is opened; they are intentionally left blank in this planning
-document. Track the assignments with auditable checklist items before opening that PR:
-
-- [ ] Add an Issue 3255 checklist item for assigning the secondary reviewer for the SSR-vs-RSC decision.
-- [ ] Add an Issue 3255 checklist item for assigning the backup reviewer for benchmark metrics.
+document. Before opening the first implementation PR, add checklist items in Issue 3255 for assigning the secondary
+SSR-vs-RSC reviewer and the backup benchmarks reviewer, so each assignment is auditable in the issue tracker rather than
+duplicated here.
 
 **Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR; fallback: @justin808]_
 

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -26,10 +26,15 @@ Use a dedicated branch for the actual version verification work:
    versions.
 3. Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream` and
    `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the runtime paths:
-   - `pnpm run type-check`
-   - `pnpm run lint`
-   - `pnpm run test`
+   - `pnpm run lint` from the repo root
+   - `pnpm --filter react-on-rails run type-check`
+   - `pnpm --filter react-on-rails run test`
+   - `pnpm --filter create-react-on-rails-app run type-check`
+   - `pnpm --filter create-react-on-rails-app run test`
+   - `pnpm --filter react-on-rails-pro run type-check` _(requires Pro access and `react_on_rails_pro/` checked out)_
    - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access and `react_on_rails_pro/` checked out)_
+   - `pnpm --filter react-on-rails-pro-node-renderer run type-check` _(requires Pro access)_
+   - `pnpm --filter react-on-rails-pro-node-renderer run test` _(requires Pro access)_
 4. Run Ruby checks that exercise SSR and generated apps:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -35,19 +35,16 @@ Use a dedicated branch for the actual version verification work:
 
 - [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
       affect React on Rails SSR, streaming, RSC, or hydration integration.
-- [ ] Audit what React trees currently reach `renderToString` in React on Rails SSR paths; React 19 renders Suspense
-      fallbacks synchronously in that path instead of suspending, which can silently change output without an error. For
-      each call site, document whether a Suspense-containing tree could plausibly be passed by a user render function
-      today, and either open a follow-up migration ticket or record why the current usage is acceptable. Check the existing
-      `renderToString` usages in
-      `packages/react-on-rails/src/serverRenderReactComponent.ts` and `packages/react-on-rails/src/handleError.ts`, plus
-      `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep generated bundles
-      and renderer artifacts, such as
-      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts" --include="*.tsx" --include="*.cts"`, plus
-      `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
-      document either a migration ticket or why current usage is acceptable. Include
-      `packages/react-on-rails/src/ReactDOMServer.cts` in the audit, and either remove that compatibility re-export when
-      dropping React 16/17 support or open a dedicated follow-up ticket.
+- [ ] Audit `renderToString` and `renderToStaticMarkup` call sites in React on Rails SSR paths; React 19 renders Suspense
+      fallbacks synchronously in `renderToString` instead of suspending, which can silently change output without an error.
+      For each call site in `packages/react-on-rails/src/serverRenderReactComponent.ts`,
+      `packages/react-on-rails/src/handleError.ts`, `packages/react-on-rails-pro-node-renderer/`, and any generated bundles
+      found by
+      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts" --include="*.tsx" --include="*.cts"`,
+      document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
+      open a follow-up migration ticket or record why the current usage is acceptable.
+- [ ] Decide the fate of `packages/react-on-rails/src/ReactDOMServer.cts`: either remove the compatibility re-export when
+      dropping React 16/17 support or open a dedicated follow-up ticket recording the reason for keeping it.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
       `pnpm list -r react react-dom react-on-rails-rsc` output in the verification record, such as a comment on Issue 3255,
@@ -91,13 +88,28 @@ Use a dedicated branch for the actual version verification work:
   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-- [ ] Run the generated-app suite from a fresh clone (preferred) or from the repo root after `git stash` and
-      `git clean -fdx` if a fresh clone is not practical; `git clean -fdx` deletes all untracked files and cannot be undone.
-      Then run a fresh `pnpm install`:
-      `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
-      `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
-      `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run
-      their tests.
+- [ ] Run the generated-app suite. Prefer a fresh clone. If a fresh clone is not practical, use the repo root after stashing
+      and cleaning:
+
+  > **Warning**: `git clean -fdx` deletes all untracked files and cannot be undone. Stash or commit any in-progress work
+  > first.
+
+  ```bash
+  git stash
+  git clean -fdx
+  pnpm install
+  ```
+
+  Then run the suite:
+
+  ```bash
+  bundle exec rake run_rspec:shakapacker_examples_latest   # React 19 examples only
+  bundle exec rake run_rspec:shakapacker_examples           # full suite across pinned React versions when needed
+  ```
+
+  Note: `bundle exec rake shakapacker_examples:gen_all` only generates apps; a separate `run_rspec:*` task must run their
+  tests.
+
 - [ ] Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
       examples.
 - [ ] Fill the secondary reviewer placeholders in the Open Questions section before opening the first implementation PR.
@@ -164,9 +176,12 @@ Before implementation starts, assign a secondary reviewer for the prerequisite S
 stall if @justin808 is unavailable. Also assign a backup reviewer for benchmark metrics because that decision can be
 validated independently from the rest of the implementation tree.
 
-**Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR]_
+These placeholders must be filled before the first implementation PR is opened. If no name is assigned by that point,
+@justin808 is the fallback owner for both roles.
 
-**Backup reviewer (benchmarks)**: _[name to be filled before first implementation PR]_
+**Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR; fallback: @justin808]_
+
+**Backup reviewer (benchmarks)**: _[name to be filled before first implementation PR; fallback: @justin808]_
 
 - Which Rails caching layer should be recommended for the static-shell: fragment cache, HTTP cache, CDN cache, or a
   combination?

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -43,7 +43,7 @@ Use a dedicated branch for the actual version verification work:
       `packages/react-on-rails/src/serverRenderReactComponent.ts` and `packages/react-on-rails/src/handleError.ts`, plus
       `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep generated bundles
       and renderer artifacts, such as
-      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts"`, plus
+      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts" --include="*.tsx" --include="*.cts"`, plus
       `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
       document either a migration ticket or why current usage is acceptable.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -24,11 +24,11 @@ confirm whether that workspace stays on React 18 during this work. That means th
 verification, not necessarily a broad package-range change.
 
 Note: `packages/react-on-rails-pro/package.json` already sets the `react-on-rails-rsc` peer dependency ceiling to
-`>= 19.0.2 <= 19.2.3`. Verification should decide whether this ceiling should be widened alongside any React 19.2.x range
-update. Because a hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the decision must either
-widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that requires a tight pin. If
-verification finds no specific API risk, the default outcome is to widen the ceiling to `< 20.0.0`. **Owner**: @justin808 |
-**Target**: before any package-range change is merged (see Open Questions).
+`>= 19.0.2 <= 19.2.3` (space means AND; both comparators must be satisfied). Verification should decide whether this ceiling
+should be widened alongside any React 19.2.x range update. Because a hard upper bound would reject a future `19.2.4` patch or
+`19.3.x` minor release, the decision must either widen the range for stable React 19.x, such as `< 20.0.0`, or document the
+specific API risk that requires a tight pin. If verification finds no specific API risk, the default outcome is to widen the
+ceiling to `< 20.0.0`. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -88,13 +88,13 @@ Use a dedicated branch for the actual version verification work:
   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-- [ ] Run the generated-app suite. Prefer a fresh clone. If a fresh clone is not practical, use the repo root after stashing
-      and cleaning:
+- [ ] Run the generated-app suite. Prefer a fresh clone.
 
   > **Warning**: `git clean -fdx` deletes all untracked files, including gitignored files, and cannot be undone. Move or
-  > back up gitignored files, such as `.env`, local credentials, or generated certs, before continuing. For tracked or
-  > non-ignored in-progress work, stash or commit first. Note: `git stash -u` saves untracked non-ignored files, but does
-  > not save gitignored files.
+  > back up gitignored files, such as `.env`, local credentials, or generated certs, before continuing.
+
+  If a fresh clone is not practical, use the repo root after stashing or committing tracked and non-ignored in-progress work.
+  Note: `git stash -u` saves untracked non-ignored files, but does not save gitignored files.
 
   ```bash
   git stash -u

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -29,8 +29,10 @@ Use a dedicated branch for the actual version verification work:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`
    - targeted RSpec for React rendering, doctor, generators, and dummy SSR paths
-4. Run Playwright E2E coverage for SSR and hydration paths from the dummy app, for example
+4. Run Playwright E2E coverage for SSR, hydration, and RSC payload paths from the dummy app, for example
    `cd react_on_rails/spec/dummy && pnpm test:e2e`.
+   Run the Pro dummy E2E to verify `stream_react_component` and RSC rendering under 19.2.x:
+   `cd react_on_rails_pro/spec/dummy && pnpm test:e2e` or equivalent RSC-specific RSpec coverage.
 5. Run at least one generated-app path that installs dependencies from scratch.
 6. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
    examples.

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -11,42 +11,60 @@ This is a planning document. It does not change package versions, build configur
 ## Current Repository Signal
 
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
-for `react-on-rails-rsc`, in the root, dummy app, and Pro dummy app package manifests. The current `pnpm-lock.yaml`
-resolves React and React DOM entries in the 19.2.x line for the main workspace. That means the first implementation
-step is verification, not necessarily a broad package-range change.
+for `react-on-rails-rsc` (the React on Rails RSC integration package, not a React-team package), in the root, dummy app,
+and Pro dummy app package manifests. The current `pnpm-lock.yaml` resolves React and React DOM entries in the 19.2.x
+line for the main workspace. That means the first implementation step is verification, not necessarily a broad
+package-range change.
 
 ## React 19.2.x Verification Checklist
 
 Use a dedicated branch for the actual version verification work:
 
-1. Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to compatible
+1. Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could affect
+   React on Rails SSR, streaming, RSC, or hydration integration.
+2. Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to compatible
    versions.
-2. Run package checks:
+3. Run package checks. These cover the `react-dom/server` streaming APIs most likely to break across React 19 minors,
+   including `renderToPipeableStream` and `renderToReadableStream`:
    - `pnpm run type-check`
    - `pnpm run lint`
    - `pnpm run test`
-3. Run Ruby checks that exercise SSR and generated apps:
+   - `pnpm --filter react-on-rails-pro run test:rsc`
+4. Run Ruby checks that exercise SSR and generated apps:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`
-   - targeted RSpec for React rendering, doctor, generators, and dummy SSR paths
-4. Run Playwright E2E coverage for SSR, hydration, and RSC payload paths from the dummy app, for example
-   `cd react_on_rails/spec/dummy && pnpm test:e2e`.
-   Run the Pro dummy E2E to verify `stream_react_component` and RSC rendering under 19.2.x:
-   `cd react_on_rails_pro/spec/dummy && pnpm test:e2e` or equivalent RSC-specific RSpec coverage.
-5. Run at least one generated-app path that installs dependencies from scratch.
-6. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
+   - `bundle exec rspec react_on_rails/spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
+   - `cd react_on_rails/spec/dummy && bundle exec rspec spec/requests spec/system spec/packs_generator_spec.rb` for dummy
+     SSR and generator integration paths
+   - Pro RSC and renderer paths:
+     ```bash
+     cd react_on_rails_pro/spec/dummy
+     bundle exec rspec spec/requests/rsc_payload_spec.rb spec/requests/server_render_check_spec.rb spec/system/renderer_integration_spec.rb
+     ```
+   - See `.claude/docs/replicating-ci-failures.md` when mapping a failed CI job back to a narrower local command.
+5. Ensure Playwright browsers are installed, then run E2E coverage:
+   - `cd react_on_rails/spec/dummy && pnpm playwright install --with-deps`
+   - `cd react_on_rails/spec/dummy && pnpm test:e2e` for OSS dummy SSR and hydration paths
+   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
+   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
+   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
+6. Run at least one generated-app path that installs dependencies from scratch.
+7. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
    examples.
+
+If any verification step fails, capture the exact command and failure, then decide whether to pin the resolved React
+version, open an upstream or compatibility issue, or block the package-range work until the regression has an owner.
 
 ## Partial Pre-Rendering Definition
 
-Before implementation, define the feature in React on Rails terms instead of importing another framework's terminology
+Before implementation, define the feature in React on Rails terms instead of adopting another framework's terminology
 too loosely:
 
 - The Rails route still owns routing, authentication, headers, caching, and status codes.
 - React on Rails owns React registration, SSR, streaming, and hydration boundaries.
 - Streaming SSR means the Node Renderer starts work during the request and flushes chunks as Suspense boundaries,
   server data, and RSC payloads resolve.
-- True partial pre-rendering would require a reusable static shell, rendered ahead of dynamic data at build time or at a
+- True partial pre-rendering would require a reusable static-shell, rendered ahead of dynamic data at build time or at a
   cache layer such as Rails HTTP caching or a CDN, with dynamic holes filled by a later streaming pass.
 - The feature must not require moving a Rails app into a frontend-framework routing model.
 
@@ -55,7 +73,7 @@ too loosely:
 Evaluate these in order:
 
 1. **Documented pattern only**: show how to combine Rails fragment caching, `react_component` plus Suspense, and RSC
-   boundaries to get a static-shell or streaming-SSR style result without new OSS public APIs. The Pro version of the
+   boundaries to get a static-shell or streaming-SSR-style result without new OSS public APIs. The Pro version of the
    pattern can use `stream_react_component` for streaming delivery.
 2. **Helper-level ergonomics**: add an option or wrapper around existing streaming helpers only if repeated app code
    emerges across examples.
@@ -73,7 +91,10 @@ Evaluate these in order:
 
 ## Open Questions
 
-- Which Rails caching layer should be recommended for the static shell: fragment cache, HTTP cache, CDN cache, or a
+Track these in [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) before implementation begins so
+each decision has an owner, acceptance criteria, and a closure path.
+
+- Which Rails caching layer should be recommended for the static-shell: fragment cache, HTTP cache, CDN cache, or a
   combination?
 - Should the first example use traditional SSR with Suspense, RSC, or both?
 - How should failures in the dynamic portion affect status codes and error boundaries after part of the response has

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -8,6 +8,10 @@ apps.
 
 This is a planning document. It does not change package versions, build configuration, or Pro package code.
 
+**Status**: Draft | **Created**: 2026-04 | **Last updated**: 2026-05-09 | **Tracks**:
+[Issue 2182](https://github.com/shakacode/react_on_rails/issues/2182) and
+[Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255)
+
 ## Current Repository Signal
 
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
@@ -20,46 +24,47 @@ verification, not necessarily a broad package-range change.
 
 Use a dedicated branch for the actual version verification work:
 
-1. Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could affect
-   React on Rails SSR, streaming, RSC, or hydration integration.
-2. Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to compatible
-   versions.
-3. Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream` and
-   `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the runtime paths:
-   - `pnpm run lint` from the repo root (ESLint only; per-package type-check and tests follow)
-   - `pnpm --filter react-on-rails run type-check`
-   - `pnpm --filter react-on-rails run test`
-   - `pnpm --filter create-react-on-rails-app run type-check`
-   - `pnpm --filter create-react-on-rails-app run test`
-   - `pnpm --filter react-on-rails-pro run type-check` _(requires Pro access and `react_on_rails_pro/` checked out)_
-   - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access and `react_on_rails_pro/` checked out)_
-   - `pnpm --filter react-on-rails-pro-node-renderer run type-check` _(requires Pro access)_
-   - `pnpm --filter react-on-rails-pro-node-renderer run test` _(requires Pro access)_
-4. Run Ruby checks that exercise SSR and generated apps:
-   - `bundle exec rubocop`
-   - `bundle exec rake rbs:validate`
-   - `cd react_on_rails && bundle exec rspec spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
-   - `cd react_on_rails/spec/dummy && bundle exec rspec spec/requests spec/system spec/packs_generator_spec.rb` for dummy
-     SSR and generator integration paths
-   - Pro RSC and renderer paths _(requires Pro access and `react_on_rails_pro/` checked out)_:
-     ```bash
-     cd react_on_rails_pro/spec/dummy
-     bundle exec rspec spec/requests/rsc_payload_spec.rb spec/requests/server_render_check_spec.rb spec/system/renderer_integration_spec.rb
-     ```
-   - See `.claude/docs/replicating-ci-failures.md` when mapping a failed CI job back to a narrower local command.
-5. Ensure Playwright browsers are installed, then run E2E coverage:
-   - `cd react_on_rails/spec/dummy && pnpm playwright install --with-deps`
-   - `cd react_on_rails/spec/dummy && pnpm test:e2e` for OSS dummy SSR and hydration paths
-   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
-   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
-   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-6. Run the generated-app suite from the repo root in a clean checkout:
-   `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
-   `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
-   `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run
-   their tests.
-7. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
-   examples.
+- [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
+      affect React on Rails SSR, streaming, RSC, or hydration integration.
+- [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to
+      compatible versions.
+- [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
+      and `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the
+      runtime paths:
+  - `pnpm run lint` from the repo root (ESLint only; per-package type-check and tests follow)
+  - `pnpm --filter react-on-rails run type-check`
+  - `pnpm --filter react-on-rails run test`
+  - `pnpm --filter create-react-on-rails-app run type-check`
+  - `pnpm --filter create-react-on-rails-app run test`
+  - `pnpm --filter react-on-rails-pro run type-check` _(requires Pro access and `react_on_rails_pro/` checked out)_
+  - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access and `react_on_rails_pro/` checked out)_
+  - `pnpm --filter react-on-rails-pro-node-renderer run type-check` _(requires Pro access)_
+  - `pnpm --filter react-on-rails-pro-node-renderer run test` _(requires Pro access)_
+- [ ] Run Ruby checks that exercise SSR and generated apps:
+  - `bundle exec rubocop`
+  - `bundle exec rake rbs:validate`
+  - `cd react_on_rails && bundle exec rspec spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
+  - `cd react_on_rails/spec/dummy && bundle exec rspec spec/requests spec/system spec/packs_generator_spec.rb` for dummy
+    SSR and generator integration paths
+  - Pro RSC and renderer paths _(requires Pro access and `react_on_rails_pro/` checked out)_:
+    ```bash
+    cd react_on_rails_pro/spec/dummy
+    bundle exec rspec spec/requests/rsc_payload_spec.rb spec/requests/server_render_check_spec.rb spec/system/renderer_integration_spec.rb
+    ```
+  - See `.claude/docs/replicating-ci-failures.md` when mapping a failed CI job back to a narrower local command.
+- [ ] Ensure Playwright browsers are installed, then run E2E coverage:
+  - `cd react_on_rails/spec/dummy && pnpm playwright install --with-deps`
+  - `cd react_on_rails/spec/dummy && pnpm test:e2e` for OSS dummy SSR and hydration paths
+  - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
+  - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
+  - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
+- [ ] Run the generated-app suite from the repo root in a clean checkout:
+      `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
+      `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
+      `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run
+      their tests.
+- [ ] Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
+      examples.
 
 If any verification step fails, capture the exact command and failure, then decide whether to pin the resolved React
 version, open an upstream or compatibility issue, or block the package-range work until the regression has an owner.
@@ -111,16 +116,22 @@ each decision has an owner, acceptance criteria, and a closure path.
 The prerequisite decision is whether the first implementation should prove the pattern through traditional SSR with
 Suspense, RSC, or both; answer that before settling caching, benchmarks, or streamed-error semantics.
 
+Before implementation starts, assign a secondary reviewer for the prerequisite SSR-vs-RSC decision so the plan does not
+stall if @justin808 is unavailable. Also assign a backup reviewer for benchmark metrics because that decision can be
+validated independently from the rest of the implementation tree.
+
 - Which Rails caching layer should be recommended for the static-shell: fragment cache, HTTP cache, CDN cache, or a
   combination?
   **Owner**: @justin808 | **Target**: before any implementation PR is opened
 - Should the static-shell be rendered by the Node Renderer, cached as a Rails partial fragment, or selected per example?
   **Owner**: @justin808 | **Target**: before any implementation PR is opened
 - Should the first example use traditional SSR with Suspense, RSC, or both?
-  **Owner**: @justin808 | **Target**: prerequisite decision before any implementation PR is opened
+  **Owner**: @justin808 | **Secondary reviewer**: React on Rails maintainer with Pro access | **Target**: prerequisite
+  decision before any implementation PR is opened
 - How should failures in the dynamic portion affect status codes and error boundaries after part of the response has
   streamed?
   **Owner**: @justin808 | **Target**: after the SSR-vs-RSC strategy decision, before public docs or examples
 - What metrics matter most for acceptance: TTFB, LCP, response end, total bytes, or client JavaScript reduction, and how
   do Rails `ActionController::Live` and Node Renderer streaming paths affect those metrics differently?
-  **Owner**: @justin808 | **Target**: after the SSR-vs-RSC strategy decision, before benchmark implementation
+  **Owner**: @justin808 | **Secondary reviewer**: React on Rails maintainer with Pro access | **Target**: after the
+  SSR-vs-RSC strategy decision, before benchmark implementation

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -105,8 +105,8 @@ Use a dedicated branch for the actual version verification work:
   Then run the suite:
 
   ```bash
-  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_latest   # runs the latest-pinned React examples (currently React 19)
-  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples           # full suite across pinned React versions when needed
+  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_latest   # runs example apps without a pinned React version (resolves to workspace default, currently React 19)
+  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples           # full suite across all example apps (latest + all pinned React versions)
   ```
 
   Note: `bundle exec rake shakapacker_examples:gen_all` only generates apps; a separate `run_rspec:*` task must run their

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -26,7 +26,7 @@ Use a dedicated branch for the actual version verification work:
    versions.
 3. Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream` and
    `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the runtime paths:
-   - `pnpm run lint` from the repo root
+   - `pnpm run lint` from the repo root (ESLint only; per-package type-check and tests follow)
    - `pnpm --filter react-on-rails run type-check`
    - `pnpm --filter react-on-rails run test`
    - `pnpm --filter create-react-on-rails-app run type-check`
@@ -53,7 +53,7 @@ Use a dedicated branch for the actual version verification work:
    - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
    - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
    - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-6. Run the generated-app suite from a clean checkout:
+6. Run the generated-app suite from the repo root in a clean checkout:
    `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
    `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
    `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -96,7 +96,9 @@ each decision has an owner, acceptance criteria, and a closure path.
 
 - Which Rails caching layer should be recommended for the static-shell: fragment cache, HTTP cache, CDN cache, or a
   combination?
+- Should the static-shell be rendered by the Node Renderer, cached as a Rails partial fragment, or selected per example?
 - Should the first example use traditional SSR with Suspense, RSC, or both?
 - How should failures in the dynamic portion affect status codes and error boundaries after part of the response has
   streamed?
-- What metrics matter most for acceptance: TTFB, LCP, response end, total bytes, or client JavaScript reduction?
+- What metrics matter most for acceptance: TTFB, LCP, response end, total bytes, or client JavaScript reduction, and how
+  do Rails `ActionController::Live` and Node Renderer streaming paths affect those metrics differently?

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -34,8 +34,9 @@ ceiling to `< 20.0.0`. **Owner**: @justin808 | **Target**: before any package-ra
 
 Use a dedicated branch for the actual version verification work:
 
-- [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
-      affect React on Rails SSR, streaming, RSC, or hydration integration.
+- [ ] Review the React 19.2.x [changelog](https://github.com/facebook/react/blob/main/CHANGELOG.md) and
+      [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide) for breaking changes,
+      deprecations, and new APIs that could affect React on Rails SSR, streaming, RSC, or hydration integration.
 - [ ] Audit `renderToString` and `renderToStaticMarkup` call sites in React on Rails SSR paths; React 19 renders Suspense
       fallbacks synchronously in `renderToString` instead of suspending, which can silently change output without an error.
       For each call site in `packages/react-on-rails/src/serverRenderReactComponent.ts`,
@@ -43,8 +44,9 @@ Use a dedicated branch for the actual version verification work:
       `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
-- [ ] Decide the fate of `packages/react-on-rails/src/ReactDOMServer.cts`: either remove the compatibility re-export when
-      dropping React 16/17 support or open a dedicated follow-up ticket recording the reason for keeping it.
+- [ ] Open a tracking issue titled "Drop React 16/17 support" if one does not already exist, then link it here. The
+      `packages/react-on-rails/src/ReactDOMServer.cts` compatibility re-export is already marked for deletion when that
+      support is dropped.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
       `pnpm list -r --depth=0 react react-dom react-on-rails-rsc` output in the verification record, such as a comment on
@@ -88,13 +90,27 @@ Use a dedicated branch for the actual version verification work:
   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-- [ ] Run the generated-app suite. Prefer a fresh clone.
+- [ ] Run the generated-app suite. Prefer a fresh clone. If a fresh clone is not practical, use a disposable worktree so
+      the current checkout and gitignored files are untouched:
+
+  ```bash
+  git worktree add /tmp/ror-verify HEAD
+  cd /tmp/ror-verify
+  pnpm install
+  ```
+
+  After the suite runs, remove the worktree from the original checkout:
+
+  ```bash
+  git worktree remove /tmp/ror-verify
+  ```
 
   > **Warning**: `git clean -fdx` deletes all untracked files, including gitignored files, and cannot be undone. Move or
   > back up gitignored files, such as `.env`, local credentials, or generated certs, before continuing.
 
-  If a fresh clone is not practical, use the repo root after stashing or committing tracked and non-ignored in-progress work.
-  Note: `git stash -u` saves untracked non-ignored files, but does not save gitignored files.
+  If neither a fresh clone nor a disposable worktree is practical, use the repo root only after stashing or committing tracked
+  and non-ignored in-progress work. Note: `git stash -u` saves untracked non-ignored files, but does not save gitignored
+  files.
 
   ```bash
   git stash -u
@@ -183,7 +199,10 @@ These placeholders must be filled before the first implementation PR is opened. 
 @justin808 is the fallback owner for both roles.
 
 These will be filled in Issue 3255 before any implementation PR is opened; they are intentionally left blank in this planning
-document.
+document. Track the assignments with auditable checklist items before opening that PR:
+
+- [ ] Add an Issue 3255 checklist item for assigning the secondary reviewer for the SSR-vs-RSC decision.
+- [ ] Add an Issue 3255 checklist item for assigning the backup reviewer for benchmark metrics.
 
 **Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR; fallback: @justin808]_
 

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -17,7 +17,9 @@ This is a planning document. It does not change package versions, build configur
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
 for `react-on-rails-rsc` (the React on Rails RSC integration package, not a React-team package), in the root, dummy app,
 and Pro dummy app package manifests. To see what versions are currently resolved, run
-`pnpm list react react-dom react-on-rails-rsc` from the repo root. That means the first implementation step is
+`pnpm list react react-dom react-on-rails-rsc` from the repo root. Note: `react_on_rails_pro/spec/execjs-compatible-dummy`
+is intentionally pinned to React 18 through pnpm overrides for `app>react` and `app>react-dom`; verification should
+confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
 verification, not necessarily a broad package-range change.
 
 Note: `react-on-rails-pro` currently pins `react-on-rails-rsc` as a peer dependency at `>= 19.0.2 <= 19.2.3`.
@@ -45,10 +47,14 @@ Use a dedicated branch for the actual version verification work:
   - `pnpm --filter react-on-rails run test`
   - `pnpm --filter create-react-on-rails-app run type-check`
   - `pnpm --filter create-react-on-rails-app run test`
-  - `pnpm --filter react-on-rails-pro run type-check` _(requires Pro access and `react_on_rails_pro/` checked out)_
-  - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access and `react_on_rails_pro/` checked out)_
-  - `pnpm --filter react-on-rails-pro-node-renderer run type-check` _(requires Pro access)_
-  - `pnpm --filter react-on-rails-pro-node-renderer run test` _(requires Pro access)_
+  - `pnpm --filter react-on-rails-pro run type-check` _(requires Pro runtime prerequisites such as license or env setup)_
+  - `pnpm --filter react-on-rails-pro run test` _(requires Pro runtime prerequisites such as license or env setup)_
+  - `pnpm --filter react-on-rails-pro-node-renderer run type-check` _(requires Pro runtime prerequisites such as license
+    or env setup)_
+  - `pnpm --filter react-on-rails-pro-node-renderer run test` _(requires Pro runtime prerequisites such as license or env
+    setup)_
+  - Confirm whether `react_on_rails_pro/spec/execjs-compatible-dummy` needs a dedicated React 18 test run as part of the
+    acceptance criteria.
 - [ ] Run Ruby checks that exercise SSR and generated apps:
   - `bundle exec rubocop`
   - `bundle exec rake rbs:validate`

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -45,7 +45,9 @@ Use a dedicated branch for the actual version verification work:
       and renderer artifacts, such as
       `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts" --include="*.tsx" --include="*.cts"`, plus
       `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
-      document either a migration ticket or why current usage is acceptable.
+      document either a migration ticket or why current usage is acceptable. Include
+      `packages/react-on-rails/src/ReactDOMServer.cts` in the audit, and either remove that compatibility re-export when
+      dropping React 16/17 support or open a dedicated follow-up ticket.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
       `pnpm list -r react react-dom react-on-rails-rsc` output in the verification record, such as a comment on Issue 3255,
@@ -89,8 +91,9 @@ Use a dedicated branch for the actual version verification work:
   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-- [ ] Run the generated-app suite from the repo root after `git clean -fdx` and a fresh `pnpm install`, or from a fresh
-      clone:
+- [ ] Run the generated-app suite from a fresh clone (preferred) or from the repo root after `git stash` and
+      `git clean -fdx` if a fresh clone is not practical; `git clean -fdx` deletes all untracked files and cannot be undone.
+      Then run a fresh `pnpm install`:
       `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
       `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
       `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run
@@ -99,8 +102,13 @@ Use a dedicated branch for the actual version verification work:
       examples.
 - [ ] Fill the secondary reviewer placeholders in the Open Questions section before opening the first implementation PR.
 
-If any verification step fails, capture the exact command and failure, then decide whether to pin the resolved React
-version, open an upstream or compatibility issue, or block the package-range work until the regression has an owner.
+If any verification step fails, capture the exact command and failure, then use this default decision rule:
+
+- Public API regression, such as broken SSR output, hydration mismatch, or a missing export: block the package-range work
+  until resolved.
+- Behavior change without breakage, such as a Suspense and `renderToString` semantic shift: open a migration ticket,
+  document the change, and do not block the range work.
+- Pro-only test failure: block the Pro ceiling change; the OSS range update may proceed independently if OSS tests pass.
 
 ## Partial Pre-Rendering Definition
 
@@ -170,7 +178,7 @@ validated independently from the rest of the implementation tree.
   decision before any implementation PR is opened
 - How should failures in the dynamic portion affect status codes and error boundaries after part of the response has
   streamed?
-  **Owner**: @justin808 | **Target**: after the SSR-vs-RSC strategy decision, before public docs or examples
+  **Owner**: @justin808 | **Target**: concurrently with the SSR-vs-RSC strategy decision, before public docs or examples
 - What metrics matter most for acceptance: TTFB, LCP, response end, total bytes, or client JavaScript reduction, and how
   do Rails `ActionController::Live` and Node Renderer streaming paths affect those metrics differently?
   **Owner**: @justin808 | **Secondary reviewer**: React on Rails maintainer with Pro access | **Target**: after the

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -17,7 +17,7 @@ This is a planning document. It does not change package versions, build configur
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
 for `react-on-rails-rsc` (the React on Rails RSC integration package, not a React-team package), in the root, dummy app,
 and Pro dummy app package manifests. To see what versions are currently resolved, run
-`pnpm list react react-dom react-on-rails-rsc` from the repo root. Note: `react_on_rails_pro/spec/execjs-compatible-dummy`
+`pnpm list -r react react-dom react-on-rails-rsc` from the repo root. Note: `react_on_rails_pro/spec/execjs-compatible-dummy`
 is intentionally pinned to React 18 through pnpm overrides for `app>react` and `app>react-dom`; verification should
 confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
 verification, not necessarily a broad package-range change.
@@ -40,7 +40,8 @@ Use a dedicated branch for the actual version verification work:
       error. Check the existing `renderToString` usages in
       `packages/react-on-rails/src/serverRenderReactComponent.ts` and `packages/react-on-rails/src/handleError.ts`, plus
       `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep generated bundles
-      and renderer artifacts, such as `grep -R "renderToString\\|renderToStaticMarkup" dist/ node_package/`, plus
+      and renderer artifacts, such as
+      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts"`, plus
       `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
       document either a migration ticket or why current usage is acceptable.
 - [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -12,9 +12,9 @@ This is a planning document. It does not change package versions, build configur
 
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
 for `react-on-rails-rsc` (the React on Rails RSC integration package, not a React-team package), in the root, dummy app,
-and Pro dummy app package manifests. The current `pnpm-lock.yaml` resolves React and React DOM entries in the 19.2.x
-line for the main workspace. That means the first implementation step is verification, not necessarily a broad
-package-range change.
+and Pro dummy app package manifests. To see what versions are currently resolved, run
+`pnpm list react react-dom react-on-rails-rsc` from the repo root. That means the first implementation step is
+verification, not necessarily a broad package-range change.
 
 ## React 19.2.x Verification Checklist
 
@@ -29,14 +29,14 @@ Use a dedicated branch for the actual version verification work:
    - `pnpm run type-check`
    - `pnpm run lint`
    - `pnpm run test`
-   - `pnpm --filter react-on-rails-pro run test:rsc`
+   - `pnpm --filter react-on-rails-pro run test:rsc` _(requires Pro access)_
 4. Run Ruby checks that exercise SSR and generated apps:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`
    - `bundle exec rspec react_on_rails/spec/react_on_rails/` for gem-side rendering, doctor, and generator coverage
    - `cd react_on_rails/spec/dummy && bundle exec rspec spec/requests spec/system spec/packs_generator_spec.rb` for dummy
      SSR and generator integration paths
-   - Pro RSC and renderer paths:
+   - Pro RSC and renderer paths _(requires Pro access)_:
      ```bash
      cd react_on_rails_pro/spec/dummy
      bundle exec rspec spec/requests/rsc_payload_spec.rb spec/requests/server_render_check_spec.rb spec/system/renderer_integration_spec.rb
@@ -70,6 +70,9 @@ too loosely:
   cache layer such as Rails HTTP caching or a CDN, with dynamic holes filled by a later streaming pass.
 - The feature must not require moving a Rails app into a frontend-framework routing model.
 
+Note: React's official experimental PPR API in canary releases is not required for the patterns described here. This plan
+targets approaches achievable with stable React 19.x unless a specific implementation step states otherwise.
+
 ## Candidate Implementation Shapes
 
 Evaluate these in order:
@@ -87,8 +90,8 @@ Evaluate these in order:
 
 - React 19.2.x passes the same local verification suite as the currently supported React 19 line.
 - Existing SSR, streaming SSR, RSC payload rendering, and client hydration tests stay green.
-- The generated-app suite passes with React 19.2.x.
-- Public docs that cite an explicit React version are updated or explicitly annotated with a minimum-version note.
+- The generated-app suite (`bundle exec rake run_rspec:shakapacker_examples_basic`) passes with React 19.2.x.
+- Any public docs that cite an explicit React version are updated or explicitly annotated with a minimum-version note.
 - Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR.
 - The first public artifact is documentation or an example unless a missing library API is clearly demonstrated.
 - The feature name and docs explain Rails ownership clearly so users do not expect Next.js-style file-system routing.

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -22,13 +22,12 @@ is intentionally pinned to React 18 through pnpm overrides for `app>react` and `
 confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
 verification, not necessarily a broad package-range change.
 
-Note: private Pro package verification should confirm whether any `react-on-rails-rsc` peer dependency ceiling, such as
-`>= 19.0.2 <= 19.2.3`, exists outside the public package manifests and whether it should be widened alongside any React
-19.2.x range update. Because a hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the
-decision must either widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that
-requires a tight pin. If verification finds no specific API risk, the default outcome is to widen the ceiling to
-`< 20.0.0`. This check requires Pro access and cannot be completed by a public contributor without relying on Pro CI.
-**Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
+Note: `packages/react-on-rails-pro/package.json` already sets the `react-on-rails-rsc` peer dependency ceiling to
+`>= 19.0.2 <= 19.2.3`. Verification should decide whether this ceiling should be widened alongside any React 19.2.x range
+update. Because a hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the decision must either
+widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that requires a tight pin. If
+verification finds no specific API risk, the default outcome is to widen the ceiling to `< 20.0.0`. **Owner**: @justin808 |
+**Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -50,7 +49,10 @@ Use a dedicated branch for the actual version verification work:
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
       `pnpm list -r react react-dom react-on-rails-rsc` output in the verification record, such as a comment on Issue 3255,
-      so the tested React 19.2.x patch version is auditable.
+      so the tested React 19.2.x patch version is auditable. Also verify that the resolved `react-on-rails-rsc` version
+      satisfies both the root `^19.0.4` range and the `packages/react-on-rails-pro/package.json` peer dependency ceiling
+      `>= 19.0.2 <= 19.2.3`; a mismatch means the ceiling must be widened before workspace installs stay consistent across
+      OSS and Pro.
 - [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
       and `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the
       runtime paths:
@@ -87,7 +89,8 @@ Use a dedicated branch for the actual version verification work:
   - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
   - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
   - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-- [ ] Run the generated-app suite from the repo root in a clean checkout:
+- [ ] Run the generated-app suite from the repo root after `git clean -fdx` and a fresh `pnpm install`, or from a fresh
+      clone:
       `bundle exec rake run_rspec:shakapacker_examples_latest` for the React 19 examples. Use
       `bundle exec rake run_rspec:shakapacker_examples` to run the full suite across pinned React versions when needed.
       `bundle exec rake shakapacker_examples:gen_all` only generates example apps; a separate `run_rspec:*` task must run

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -28,7 +28,9 @@ Note: `packages/react-on-rails-pro/package.json` already sets the `react-on-rail
 should be widened alongside any React 19.2.x range update. Because a hard upper bound would reject a future `19.2.4` patch or
 `19.3.x` minor release, the decision must either widen the range for stable React 19.x, such as `< 20.0.0`, or document the
 specific API risk that requires a tight pin. If verification finds no specific API risk, the default outcome is to widen the
-ceiling to `< 20.0.0`. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
+ceiling to `< 20.0.0`. The same decision must also audit the Pro package `react` and `react-dom` peer dependency ranges,
+currently `>= 16`, so all three peer ranges stay aligned with the minimum React version decision. **Owner**: @justin808 |
+**Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -44,9 +46,8 @@ Use a dedicated branch for the actual version verification work:
       `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
-- [ ] Open a tracking issue titled "Drop React 16/17 support" if one does not already exist, then link it here. The
-      `packages/react-on-rails/src/ReactDOMServer.cts` compatibility re-export is already marked for deletion when that
-      support is dropped.
+- [ ] If React 16/17 support is being dropped in this work cycle, remove `packages/react-on-rails/src/ReactDOMServer.cts`.
+      Otherwise, confirm the file's existing removal comment remains the accepted exit criterion and close this task.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
       `pnpm list -r --depth=0 react react-dom react-on-rails-rsc` output in the verification record, such as a comment on

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -24,8 +24,8 @@ Use a dedicated branch for the actual version verification work:
    React on Rails SSR, streaming, RSC, or hydration integration.
 2. Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to compatible
    versions.
-3. Run package checks. These cover the `react-dom/server` streaming APIs most likely to break across React 19 minors,
-   including `renderToPipeableStream` and `renderToReadableStream`:
+3. Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream` and
+   `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the runtime paths:
    - `pnpm run type-check`
    - `pnpm run lint`
    - `pnpm run test`
@@ -48,7 +48,9 @@ Use a dedicated branch for the actual version verification work:
    - `cd react_on_rails_pro/spec/dummy && pnpm playwright install --with-deps`
    - `cd react_on_rails_pro/spec/dummy && pnpm run e2e-test` for Pro `stream_react_component` and RSC payload paths
    - See `.claude/docs/playwright-e2e-testing.md` for the OSS dummy setup.
-6. Run at least one generated-app path that installs dependencies from scratch.
+6. Run the generated-app suite from a clean checkout:
+   `bundle exec rake run_rspec:shakapacker_examples_basic`. Use `bundle exec rake shakapacker_examples:gen_all` for full
+   regenerated example coverage when needed.
 7. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
    examples.
 
@@ -85,6 +87,8 @@ Evaluate these in order:
 
 - React 19.2.x passes the same local verification suite as the currently supported React 19 line.
 - Existing SSR, streaming SSR, RSC payload rendering, and client hydration tests stay green.
+- The generated-app suite passes with React 19.2.x.
+- Public docs that cite an explicit React version are updated or explicitly annotated with a minimum-version note.
 - Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR.
 - The first public artifact is documentation or an example unless a missing library API is clearly demonstrated.
 - The feature name and docs explain Rails ownership clearly so users do not expect Next.js-style file-system routing.

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -183,7 +183,7 @@ Evaluate these in order:
 
 - React 19.2.x passes the same local verification suite as the currently supported React 19 line.
 - Existing SSR, streaming SSR, RSC payload rendering, and client hydration tests stay green.
-- The generated-app suite (`bundle exec rake run_rspec:shakapacker_examples_latest`) passes with React 19.2.x.
+- The full generated-app suite (`bundle exec rake run_rspec:shakapacker_examples`) passes with React 19.2.x.
 - Any public docs that cite an explicit React version are updated or explicitly annotated with a minimum-version note.
 - Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR (see
   `internal/planning/library-benchmarking.md` for tooling guidance).

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -1,0 +1,73 @@
+# React 19.2.x and Partial Pre-Rendering Plan
+
+## Purpose
+
+Track the work needed for [Issue 2182](https://github.com/shakacode/react_on_rails/issues/2182): verify React 19.2.x
+support and decide how React on Rails should expose any partial pre-rendering workflow that becomes practical for Rails
+apps.
+
+This is a planning document. It does not change package versions, build configuration, or Pro package code.
+
+## Current Repository Signal
+
+The workspace package ranges already allow React 19.2.x through `^19.0.3` in the root, dummy app, and Pro dummy app
+package manifests. The current `pnpm-lock.yaml` resolves React and React DOM entries in the 19.2.x line for the main
+workspace. That means the first implementation step is verification, not necessarily a broad package-range change.
+
+## React 19.2.x Verification Checklist
+
+Use a dedicated branch for the actual version verification work:
+
+1. Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to compatible
+   versions.
+2. Run package checks:
+   - `pnpm run type-check`
+   - `pnpm run lint`
+   - `pnpm run test`
+3. Run Ruby checks that exercise SSR and generated apps:
+   - `bundle exec rubocop`
+   - `bundle exec rake rbs:validate`
+   - targeted RSpec for React rendering, doctor, generators, and dummy SSR paths
+4. Run at least one generated-app path that installs dependencies from scratch.
+5. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
+   examples.
+
+## Partial Pre-Rendering Definition
+
+Before implementation, define the feature in React on Rails terms instead of importing another framework's terminology
+too loosely:
+
+- The Rails route still owns routing, authentication, headers, caching, and status codes.
+- React on Rails owns React registration, SSR, streaming, and hydration boundaries.
+- The Node Renderer may render a stable shell while dynamic server data resolves later through streaming, RSC payloads,
+  or Rails cache-backed fragments.
+- The feature must not require moving a Rails app into a frontend-framework routing model.
+
+## Candidate Implementation Shapes
+
+Evaluate these in order:
+
+1. **Documented pattern only**: show how to combine Rails fragment caching, `stream_react_component`, Suspense, and RSC
+   boundaries to get a partial-pre-rendering style result without new public APIs.
+2. **Helper-level ergonomics**: add an option or wrapper around existing streaming helpers only if repeated app code
+   emerges across examples.
+3. **Renderer protocol support**: add Node Renderer request metadata only if the helper-level approach cannot express the
+   needed static/dynamic boundary cleanly.
+4. **Generated example**: add a small route in the dummy app after the behavior is proven manually.
+
+## Acceptance Criteria
+
+- React 19.2.x passes the same local verification suite as the currently supported React 19 line.
+- Existing SSR, streaming SSR, RSC payload rendering, and client hydration tests stay green.
+- Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR.
+- The first public artifact is documentation or an example unless a missing library API is clearly demonstrated.
+- The feature name and docs explain Rails ownership clearly so users do not expect Next.js-style file-system routing.
+
+## Open Questions
+
+- Which Rails caching layer should be recommended for the static shell: fragment cache, HTTP cache, CDN cache, or a
+  combination?
+- Should the first example use traditional SSR with Suspense, RSC, or both?
+- How should failures in the dynamic portion affect status codes and error boundaries after part of the response has
+  streamed?
+- What metrics matter most for acceptance: TTFB, LCP, response end, total bytes, or client JavaScript reduction?

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -26,7 +26,8 @@ Note: `react-on-rails-pro` currently pins `react-on-rails-rsc` as a peer depende
 Verification should confirm whether this ceiling is intentional or should be widened alongside any React 19.2.x range
 update. Because this hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the decision must
 either widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that requires a tight
-pin. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
+pin. If verification finds no specific API risk, the default outcome is to widen the ceiling to `< 20.0.0`. **Owner**:
+@justin808 | **Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -38,7 +39,8 @@ Use a dedicated branch for the actual version verification work:
       Suspense fallbacks synchronously in that path instead of suspending, which can silently change output without an
       error. Check the existing `renderToString` usages in
       `packages/react-on-rails/src/serverRenderReactComponent.ts` and `packages/react-on-rails/src/handleError.ts`, plus
-      `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep
+      `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep generated bundles
+      and renderer artifacts, such as `grep -R "renderToString\\|renderToStaticMarkup" dist/ node_package/`, plus
       `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
       document either a migration ticket or why current usage is acceptable.
 - [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to
@@ -100,8 +102,9 @@ too loosely:
 - React on Rails owns React registration, SSR, streaming, and hydration boundaries.
 - Streaming SSR means the Node Renderer starts work during the request and flushes chunks as Suspense boundaries and RSC
   payloads resolve, delivering content progressively without waiting for a full render.
-- True partial pre-rendering would require a reusable static-shell, rendered ahead of dynamic data at build time or at a
-  cache layer such as Rails HTTP caching or a CDN, with dynamic holes filled by a later streaming pass.
+- True partial pre-rendering would require a reusable static-shell, rendered ahead of dynamic data through an explicit
+  cache warm-up request, an asset-pipeline precompile hook, or a cache layer such as Rails HTTP caching or a CDN, with
+  dynamic holes filled by a later streaming pass.
 - The feature must not require moving a Rails app into a frontend-framework routing model.
 
 Note: React's official experimental PPR API in canary releases is not required for the patterns described here. This plan
@@ -167,5 +170,5 @@ validated independently from the rest of the implementation tree.
   **Owner**: @justin808 | **Target**: before any package-range change is merged
 - Should the `react-on-rails-pro` peer dependency ceiling for `react-on-rails-rsc` stay at `<= 19.2.3` or widen with the
   React 19.2.x verification work? If it stays tight, what specific API risk justifies rejecting future React 19.x patch
-  or minor releases?
+  or minor releases? Default to widening to `< 20.0.0` when verification finds no specific API risk.
   **Owner**: @justin808 | **Target**: before any package-range change is merged

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -182,6 +182,9 @@ validated independently from the rest of the implementation tree.
 These placeholders must be filled before the first implementation PR is opened. If no name is assigned by that point,
 @justin808 is the fallback owner for both roles.
 
+These will be filled in Issue 3255 before any implementation PR is opened; they are intentionally left blank in this planning
+document.
+
 **Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR; fallback: @justin808]_
 
 **Backup reviewer (benchmarks)**: _[name to be filled before first implementation PR; fallback: @justin808]_
@@ -190,6 +193,10 @@ These placeholders must be filled before the first implementation PR is opened. 
   combination?
   **Owner**: @justin808 | **Target**: before any implementation PR is opened
 - Should the static-shell be rendered by the Node Renderer, cached as a Rails partial fragment, or selected per example?
+  **Owner**: @justin808 | **Target**: before any implementation PR is opened
+- How does the static-shell or streaming-SSR pattern interact with Turbo Drive navigation, Turbo Frames, and Turbo Streams?
+  Confirm whether Turbo page visits re-request the full response instead of reusing a cached shell, and whether
+  `stream_react_component` can flush into a Turbo Stream frame.
   **Owner**: @justin808 | **Target**: before any implementation PR is opened
 - Should the first example use traditional SSR with Suspense, RSC, or both?
   **Owner**: @justin808 | **Secondary reviewer**: React on Rails maintainer with Pro access | **Target**: prerequisite

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -22,12 +22,13 @@ is intentionally pinned to React 18 through pnpm overrides for `app>react` and `
 confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
 verification, not necessarily a broad package-range change.
 
-Note: `react-on-rails-pro` currently pins `react-on-rails-rsc` as a peer dependency at `>= 19.0.2 <= 19.2.3`.
-Verification should confirm whether this ceiling is intentional or should be widened alongside any React 19.2.x range
-update. Because this hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the decision must
-either widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that requires a tight
-pin. If verification finds no specific API risk, the default outcome is to widen the ceiling to `< 20.0.0`. **Owner**:
-@justin808 | **Target**: before any package-range change is merged (see Open Questions).
+Note: private Pro package verification should confirm whether any `react-on-rails-rsc` peer dependency ceiling, such as
+`>= 19.0.2 <= 19.2.3`, exists outside the public package manifests and whether it should be widened alongside any React
+19.2.x range update. Because a hard upper bound would reject a future `19.2.4` patch or `19.3.x` minor release, the
+decision must either widen the range for stable React 19.x, such as `< 20.0.0`, or document the specific API risk that
+requires a tight pin. If verification finds no specific API risk, the default outcome is to widen the ceiling to
+`< 20.0.0`. This check requires Pro access and cannot be completed by a public contributor without relying on Pro CI.
+**Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -35,17 +36,21 @@ Use a dedicated branch for the actual version verification work:
 
 - [ ] Review the React 19.2.x changelog and release notes for breaking changes, deprecations, and new APIs that could
       affect React on Rails SSR, streaming, RSC, or hydration integration.
-- [ ] Confirm that no React on Rails SSR path passes a Suspense-containing tree through `renderToString`; React 19 renders
-      Suspense fallbacks synchronously in that path instead of suspending, which can silently change output without an
-      error. Check the existing `renderToString` usages in
+- [ ] Audit what React trees currently reach `renderToString` in React on Rails SSR paths; React 19 renders Suspense
+      fallbacks synchronously in that path instead of suspending, which can silently change output without an error. For
+      each call site, document whether a Suspense-containing tree could plausibly be passed by a user render function
+      today, and either open a follow-up migration ticket or record why the current usage is acceptable. Check the existing
+      `renderToString` usages in
       `packages/react-on-rails/src/serverRenderReactComponent.ts` and `packages/react-on-rails/src/handleError.ts`, plus
       `renderToStaticMarkup` if any source or generated-bundle call site participates in SSR. Also grep generated bundles
       and renderer artifacts, such as
       `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.ts"`, plus
       `packages/react-on-rails-pro-node-renderer/` and related SSR integration paths for additional call sites, then
       document either a migration ticket or why current usage is acceptable.
-- [ ] Run `pnpm install` from a clean checkout and confirm React, React DOM, and `react-on-rails-rsc` resolve to
-      compatible versions.
+- [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
+      React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
+      `pnpm list -r react react-dom react-on-rails-rsc` output in the verification record, such as a comment on Issue 3255,
+      so the tested React 19.2.x patch version is auditable.
 - [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
       and `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the
       runtime paths:

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -53,7 +53,7 @@ Use a dedicated branch for the actual version verification work:
       run from the repo root,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
-- [ ] If the Issue 3255 minimum-React-version decision drops React 16/17 support, remove
+- [ ] If the [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) minimum-React-version decision drops React 16/17 support, remove
       `packages/react-on-rails/src/ReactDOMServer.cts`. Otherwise, confirm the file's existing removal comment remains the
       accepted exit criterion and close this task.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
@@ -64,9 +64,10 @@ Use a dedicated branch for the actual version verification work:
       `react-on-rails-rsc` version satisfies both the root `^19.0.4` range and the
       `packages/react-on-rails-pro/package.json` peer dependency ceiling `>= 19.0.2 <= 19.2.3`; a mismatch means the ceiling
       must be widened before workspace installs stay consistent across OSS and Pro.
-- [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
-      and `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the
-      runtime paths:
+- [ ] Run package checks. Type checking catches breaking API changes — `@types/react` shifts such as removal of the
+      implicit `children` prop from `React.FC` and a stricter `useRef` return type, plus `react-dom/server` changes such
+      as `renderToPipeableStream` and `renderToReadableStream` through `@types/react-dom` — lint enforces package style,
+      and tests exercise the runtime paths:
   - `pnpm run lint` from the repo root (ESLint only; per-package type-check and tests follow)
   - `pnpm --filter react-on-rails run type-check`
   - `pnpm --filter react-on-rails run test`
@@ -111,6 +112,7 @@ Use a dedicated branch for the actual version verification work:
   git worktree list                      # confirm no stale /tmp/ror-verify entry from a prior interrupted run
   git worktree add /tmp/ror-verify HEAD  # detached HEAD is intentional for read-only verification
   (cd /tmp/ror-verify && pnpm install)
+  cd /tmp/ror-verify/react_on_rails && bundle exec rake run_rspec:shakapacker_examples   # full suite across all example apps (latest + all pinned React versions)
   ```
 
   After the suite runs, remove the worktree from the original checkout:
@@ -131,11 +133,6 @@ Use a dedicated branch for the actual version verification work:
   git clean -ndx   # dry run — review the printed list before running the destructive command below
   git clean -fdx
   pnpm install
-  ```
-
-  Then run the suite:
-
-  ```bash
   cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples   # full suite across all example apps (latest + all pinned React versions)
   ```
 
@@ -184,7 +181,8 @@ Evaluate these in order:
    emerges across examples.
 3. **Renderer protocol support**: add Node Renderer request metadata only if the helper-level approach cannot express the
    needed static/dynamic boundary cleanly.
-4. **Generated example**: add a small route in the dummy app after the behavior is proven manually.
+4. **Dummy-app example**: add a small route in the dummy app after the behavior is proven manually. Promote to a
+   generated-app entry only if the pattern needs scaffolding coverage in `run_rspec:shakapacker_examples`.
 
 ## Acceptance Criteria
 
@@ -209,12 +207,11 @@ Suspense, RSC, or both. Record that answer in Issue 3255 before opening the firs
 benchmarks, and streamed-error semantics stay provisional rather than settled.
 
 Before implementation starts, assign a secondary reviewer for the prerequisite SSR-vs-RSC decision so the plan does not
-stall if @justin808 is unavailable. Also assign a backup reviewer for benchmark metrics because that decision can be
-validated independently from the rest of the implementation tree.
-
-These placeholders must be filled in [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) before the
-first implementation PR is opened — add checklist items there so each assignment is auditable in the issue tracker. If
-no name is assigned by that point, @justin808 is the fallback owner for both roles.
+stall if @justin808 is unavailable, and a backup reviewer for benchmark metrics (which can be validated independently
+from the rest of the implementation tree). These placeholders must be filled in
+[Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) before the first implementation PR is opened — add
+checklist items there so each assignment is auditable in the issue tracker. If no name is assigned by that point,
+@justin808 is the fallback owner for both roles.
 
 **Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR; fallback: @justin808]_
 

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -108,7 +108,8 @@ Use a dedicated branch for the actual version verification work:
       the current checkout and gitignored files are untouched:
 
   ```bash
-  git worktree add /tmp/ror-verify HEAD
+  git worktree list                      # confirm no stale /tmp/ror-verify entry from a prior interrupted run
+  git worktree add /tmp/ror-verify HEAD  # detached HEAD is intentional for read-only verification
   (cd /tmp/ror-verify && pnpm install)
   ```
 
@@ -145,7 +146,9 @@ Use a dedicated branch for the actual version verification work:
       examples.
 - [ ] Fill the secondary reviewer placeholders in the Open Questions section before opening the first implementation PR.
 
-If any verification step fails, capture the exact command and failure, then use this default decision rule:
+If any verification step fails, capture the exact command and failure in a comment on
+[Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255), then apply this default decision rule
+(**Owner**: @justin808 for all blocking calls):
 
 - Public API regression, such as broken SSR output, hydration mismatch, or a missing export: block the package-range work
   until resolved.
@@ -209,13 +212,9 @@ Before implementation starts, assign a secondary reviewer for the prerequisite S
 stall if @justin808 is unavailable. Also assign a backup reviewer for benchmark metrics because that decision can be
 validated independently from the rest of the implementation tree.
 
-These placeholders must be filled before the first implementation PR is opened. If no name is assigned by that point,
-@justin808 is the fallback owner for both roles.
-
-These will be filled in Issue 3255 before any implementation PR is opened; they are intentionally left blank in this planning
-document. Before opening the first implementation PR, add checklist items in Issue 3255 for assigning the secondary
-SSR-vs-RSC reviewer and the backup benchmarks reviewer, so each assignment is auditable in the issue tracker rather than
-duplicated here.
+These placeholders must be filled in [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) before the
+first implementation PR is opened — add checklist items there so each assignment is auditable in the issue tracker. If
+no name is assigned by that point, @justin808 is the fallback owner for both roles.
 
 **Secondary reviewer (SSR-vs-RSC)**: _[name to be filled before first implementation PR; fallback: @justin808]_
 

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -10,9 +10,10 @@ This is a planning document. It does not change package versions, build configur
 
 ## Current Repository Signal
 
-The workspace package ranges already allow React 19.2.x through `^19.0.3` in the root, dummy app, and Pro dummy app
-package manifests. The current `pnpm-lock.yaml` resolves React and React DOM entries in the 19.2.x line for the main
-workspace. That means the first implementation step is verification, not necessarily a broad package-range change.
+The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
+for `react-on-rails-rsc`, in the root, dummy app, and Pro dummy app package manifests. The current `pnpm-lock.yaml`
+resolves React and React DOM entries in the 19.2.x line for the main workspace. That means the first implementation
+step is verification, not necessarily a broad package-range change.
 
 ## React 19.2.x Verification Checklist
 
@@ -28,8 +29,10 @@ Use a dedicated branch for the actual version verification work:
    - `bundle exec rubocop`
    - `bundle exec rake rbs:validate`
    - targeted RSpec for React rendering, doctor, generators, and dummy SSR paths
-4. Run at least one generated-app path that installs dependencies from scratch.
-5. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
+4. Run Playwright E2E coverage for SSR and hydration paths from the dummy app, for example
+   `cd react_on_rails/spec/dummy && pnpm test:e2e`.
+5. Run at least one generated-app path that installs dependencies from scratch.
+6. Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
    examples.
 
 ## Partial Pre-Rendering Definition
@@ -39,16 +42,19 @@ too loosely:
 
 - The Rails route still owns routing, authentication, headers, caching, and status codes.
 - React on Rails owns React registration, SSR, streaming, and hydration boundaries.
-- The Node Renderer may render a stable shell while dynamic server data resolves later through streaming, RSC payloads,
-  or Rails cache-backed fragments.
+- Streaming SSR means the Node Renderer starts work during the request and flushes chunks as Suspense boundaries,
+  server data, and RSC payloads resolve.
+- True partial pre-rendering would require a reusable static shell, rendered ahead of dynamic data at build time or at a
+  cache layer such as Rails HTTP caching or a CDN, with dynamic holes filled by a later streaming pass.
 - The feature must not require moving a Rails app into a frontend-framework routing model.
 
 ## Candidate Implementation Shapes
 
 Evaluate these in order:
 
-1. **Documented pattern only**: show how to combine Rails fragment caching, `stream_react_component`, Suspense, and RSC
-   boundaries to get a partial-pre-rendering style result without new public APIs.
+1. **Documented pattern only**: show how to combine Rails fragment caching, `react_component` plus Suspense, and RSC
+   boundaries to get a static-shell or streaming-SSR style result without new OSS public APIs. The Pro version of the
+   pattern can use `stream_react_component` for streaming delivery.
 2. **Helper-level ergonomics**: add an option or wrapper around existing streaming helpers only if repeated app code
    emerges across examples.
 3. **Renderer protocol support**: add Node Renderer request metadata only if the helper-level approach cannot express the

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -17,7 +17,8 @@ This is a planning document. It does not change package versions, build configur
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
 for `react-on-rails-rsc` (the React on Rails RSC integration package, not a React-team package), in the root, dummy app,
 and Pro dummy app package manifests. To see what versions are currently resolved, run
-`pnpm list -r --depth=0 react react-dom react-on-rails-rsc` from the repo root. Note:
+`pnpm list -r --depth=0 react react-dom` and
+`pnpm --filter react-on-rails-pro list --depth=0 react-on-rails-rsc` from the repo root. Note:
 `react_on_rails_pro/spec/execjs-compatible-dummy` is intentionally pinned to React 18 through pnpm overrides for `app>react`
 and `app>react-dom`; verification should
 confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
@@ -41,11 +42,12 @@ Use a dedicated branch for the actual version verification work:
 - [ ] Review the React 19.2.x [changelog](https://github.com/facebook/react/blob/main/CHANGELOG.md) and
       [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide) for breaking changes,
       deprecations, and new APIs that could affect React on Rails SSR, streaming, RSC, or hydration integration.
-- [ ] Audit `renderToString` and `renderToStaticMarkup` call sites in React on Rails SSR paths; React 19 renders Suspense
+- [ ] Audit `renderToString` and `renderToStaticMarkup` call sites in React on Rails SSR paths; React 18+ renders Suspense
       fallbacks synchronously in `renderToString` instead of suspending, which can silently change output without an error.
       For each call site in `packages/react-on-rails/src/serverRenderReactComponent.ts`,
       `packages/react-on-rails/src/handleError.ts`, and any generated bundles found by
-      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`,
+      `grep -rE "renderToString|renderToStaticMarkup" packages/ --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.ts" --include="*.tsx" --include="*.cts"`
+      run from the repo root,
       document whether a Suspense-containing tree could plausibly be passed by a user render function today, then either
       open a follow-up migration ticket or record why the current usage is acceptable.
 - [ ] If the Issue 3255 minimum-React-version decision drops React 16/17 support, remove
@@ -53,8 +55,9 @@ Use a dedicated branch for the actual version verification work:
       accepted exit criterion and close this task.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
-      `pnpm list -r --depth=0 react react-dom react-on-rails-rsc` output in the verification record, such as a comment on
-      Issue 3255, so the tested React 19.2.x patch version is auditable. Also verify that the resolved
+      `pnpm list -r --depth=0 react react-dom` and
+      `pnpm --filter react-on-rails-pro list --depth=0 react-on-rails-rsc` output in the verification record, such as a
+      comment on Issue 3255, so the tested React 19.2.x patch version is auditable. Also verify that the resolved
       `react-on-rails-rsc` version satisfies both the root `^19.0.4` range and the
       `packages/react-on-rails-pro/package.json` peer dependency ceiling `>= 19.0.2 <= 19.2.3`; a mismatch means the ceiling
       must be widened before workspace installs stay consistent across OSS and Pro.
@@ -112,12 +115,12 @@ Use a dedicated branch for the actual version verification work:
   git worktree remove /tmp/ror-verify
   ```
 
-  > **Warning**: `git clean -fdx` deletes all untracked files, including gitignored files, and cannot be undone. Move or
-  > back up gitignored files, such as `.env`, local credentials, or generated certs, before continuing.
-
   If neither a fresh clone nor a disposable worktree is practical, use the repo root only after stashing or committing tracked
   and non-ignored in-progress work. Note: `git stash -u` saves untracked non-ignored files, but does not save gitignored
   files.
+
+  > **Warning**: `git clean -fdx` deletes all untracked files, including gitignored files, and cannot be undone. Move or
+  > back up gitignored files, such as `.env`, local credentials, or generated certs, before using the fallback below.
 
   ```bash
   git stash -u
@@ -128,8 +131,7 @@ Use a dedicated branch for the actual version verification work:
   Then run the suite:
 
   ```bash
-  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_latest   # runs example apps without a pinned React version (resolves to workspace default, currently React 19)
-  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples           # full suite across all example apps (latest + all pinned React versions)
+  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples   # full suite across all example apps (latest + all pinned React versions)
   ```
 
   Note: `bundle exec rake shakapacker_examples:gen_all` only generates apps; a separate `run_rspec:*` task must run their

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -17,8 +17,9 @@ This is a planning document. It does not change package versions, build configur
 The workspace package ranges already allow React 19.2.x through `^19.0.3` for `react` and `react-dom`, plus `^19.0.4`
 for `react-on-rails-rsc` (the React on Rails RSC integration package, not a React-team package), in the root, dummy app,
 and Pro dummy app package manifests. To see what versions are currently resolved, run
-`pnpm list -r react react-dom react-on-rails-rsc` from the repo root. Note: `react_on_rails_pro/spec/execjs-compatible-dummy`
-is intentionally pinned to React 18 through pnpm overrides for `app>react` and `app>react-dom`; verification should
+`pnpm list -r --depth=0 react react-dom react-on-rails-rsc` from the repo root. Note:
+`react_on_rails_pro/spec/execjs-compatible-dummy` is intentionally pinned to React 18 through pnpm overrides for `app>react`
+and `app>react-dom`; verification should
 confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
 verification, not necessarily a broad package-range change.
 
@@ -46,11 +47,11 @@ Use a dedicated branch for the actual version verification work:
       dropping React 16/17 support or open a dedicated follow-up ticket recording the reason for keeping it.
 - [ ] Run `pnpm install` from a freshly cloned or freshly cleaned checkout with no existing `node_modules`, then confirm
       React, React DOM, and `react-on-rails-rsc` resolve to compatible versions. Capture the exact
-      `pnpm list -r react react-dom react-on-rails-rsc` output in the verification record, such as a comment on Issue 3255,
-      so the tested React 19.2.x patch version is auditable. Also verify that the resolved `react-on-rails-rsc` version
-      satisfies both the root `^19.0.4` range and the `packages/react-on-rails-pro/package.json` peer dependency ceiling
-      `>= 19.0.2 <= 19.2.3`; a mismatch means the ceiling must be widened before workspace installs stay consistent across
-      OSS and Pro.
+      `pnpm list -r --depth=0 react react-dom react-on-rails-rsc` output in the verification record, such as a comment on
+      Issue 3255, so the tested React 19.2.x patch version is auditable. Also verify that the resolved
+      `react-on-rails-rsc` version satisfies both the root `^19.0.4` range and the
+      `packages/react-on-rails-pro/package.json` peer dependency ceiling `>= 19.0.2 <= 19.2.3`; a mismatch means the ceiling
+      must be widened before workspace installs stay consistent across OSS and Pro.
 - [ ] Run package checks. Type checking catches breaking `react-dom/server` API changes such as `renderToPipeableStream`
       and `renderToReadableStream` through `@types/react-dom`, lint enforces package style, and tests exercise the
       runtime paths:
@@ -90,12 +91,13 @@ Use a dedicated branch for the actual version verification work:
 - [ ] Run the generated-app suite. Prefer a fresh clone. If a fresh clone is not practical, use the repo root after stashing
       and cleaning:
 
-  > **Warning**: `git clean -fdx` deletes all untracked files and cannot be undone. Stash or commit any in-progress work
-  > first. Note: the default `git stash` omits untracked files; use `git stash -u` to include them before running
-  > `git clean`.
+  > **Warning**: `git clean -fdx` deletes all untracked files, including gitignored files, and cannot be undone. Move or
+  > back up gitignored files, such as `.env`, local credentials, or generated certs, before continuing. For tracked or
+  > non-ignored in-progress work, stash or commit first. Note: `git stash -u` saves untracked non-ignored files, but does
+  > not save gitignored files.
 
   ```bash
-  git stash
+  git stash -u
   git clean -fdx
   pnpm install
   ```
@@ -158,7 +160,8 @@ Evaluate these in order:
 - Existing SSR, streaming SSR, RSC payload rendering, and client hydration tests stay green.
 - The generated-app suite (`bundle exec rake run_rspec:shakapacker_examples_latest`) passes with React 19.2.x.
 - Any public docs that cite an explicit React version are updated or explicitly annotated with a minimum-version note.
-- Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR.
+- Any partial pre-rendering proposal includes a same-route benchmark against traditional SSR or streaming SSR (see
+  `internal/planning/library-benchmarking.md` for tooling guidance).
 - The first public artifact is documentation or an example unless a missing library API is clearly demonstrated.
 - The feature name and docs explain Rails ownership clearly so users do not expect Next.js-style file-system routing.
 - The decision on the minimum supported React version, including whether React 18.x remains supported, is documented

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -8,7 +8,7 @@ apps.
 
 This is a planning document. It does not change package versions, build configuration, or Pro package code.
 
-**Status**: Draft | **Created**: 2026-04 | **Last updated**: 2026-05-09 | **Tracks**:
+**Status**: Draft | **Created**: 2026-04-30 | **Last updated**: 2026-05-09 | **Tracks**:
 [Issue 2182](https://github.com/shakacode/react_on_rails/issues/2182) and
 [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255)
 
@@ -24,7 +24,7 @@ verification, not necessarily a broad package-range change.
 
 Note: `react-on-rails-pro` currently pins `react-on-rails-rsc` as a peer dependency at `>= 19.0.2 <= 19.2.3`.
 Verification should confirm whether this ceiling is intentional or should be widened alongside any React 19.2.x range
-update.
+update. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
 
 ## React 19.2.x Verification Checklist
 
@@ -55,6 +55,8 @@ Use a dedicated branch for the actual version verification work:
     setup)_
   - Confirm whether `react_on_rails_pro/spec/execjs-compatible-dummy` needs a dedicated React 18 test run as part of the
     acceptance criteria.
+  - Public contributors without Pro runtime prerequisites should rely on the PR's Pro CI checks as the proxy for these
+    Pro verification steps.
 - [ ] Run Ruby checks that exercise SSR and generated apps:
   - `bundle exec rubocop`
   - `bundle exec rake rbs:validate`
@@ -80,6 +82,7 @@ Use a dedicated branch for the actual version verification work:
       their tests.
 - [ ] Confirm docs that mention explicit React versions are either updated or intentionally left on older minimum-version
       examples.
+- [ ] Fill the secondary reviewer placeholders in the Open Questions section before opening the first implementation PR.
 
 If any verification step fails, capture the exact command and failure, then decide whether to pin the resolved React
 version, open an upstream or compatibility issue, or block the package-range work until the regression has an owner.
@@ -156,3 +159,8 @@ validated independently from the rest of the implementation tree.
   do Rails `ActionController::Live` and Node Renderer streaming paths affect those metrics differently?
   **Owner**: @justin808 | **Secondary reviewer**: React on Rails maintainer with Pro access | **Target**: after the
   SSR-vs-RSC strategy decision, before benchmark implementation
+- Should the minimum supported React version retain React 18.x compatibility or move to React 19.x only?
+  **Owner**: @justin808 | **Target**: before any package-range change is merged
+- Should the `react-on-rails-pro` peer dependency ceiling for `react-on-rails-rsc` stay at `<= 19.2.3` or widen with the
+  React 19.2.x verification work?
+  **Owner**: @justin808 | **Target**: before any package-range change is merged

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -91,7 +91,7 @@ Use a dedicated branch for the actual version verification work:
       and cleaning:
 
   > **Warning**: `git clean -fdx` deletes all untracked files and cannot be undone. Stash or commit any in-progress work
-  > first. Note: `git stash` only saves tracked changes; untracked files must be committed or moved manually before running
+  > first. Note: the default `git stash` omits untracked files; use `git stash -u` to include them before running
   > `git clean`.
 
   ```bash
@@ -103,7 +103,7 @@ Use a dedicated branch for the actual version verification work:
   Then run the suite:
 
   ```bash
-  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_latest   # React 19 examples only
+  cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_latest   # runs the latest-pinned React examples (currently React 19)
   cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples           # full suite across pinned React versions when needed
   ```
 


### PR DESCRIPTION
## Summary
- add an internal plan for verifying React 19.2.x support before changing package ranges
- define partial pre-rendering in Rails/React on Rails terms
- outline candidate implementation shapes, acceptance criteria, and open questions

Refs #2182

## Test Plan
- `pnpm exec prettier --check internal/planning/react-19-partial-prerendering-plan.md`
- `git diff --check`
- pre-commit/pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds internal documentation only, with no runtime, dependency, or build changes.
> 
> **Overview**
> Adds a new internal planning document (`internal/planning/react-19-partial-prerendering-plan.md`) that outlines a **React 19.2.x compatibility verification checklist** (pnpm/ruby/e2e/generator suite, SSR `renderToString` audit, and peer-dependency ceiling review) before any package-range updates.
> 
> Defines “partial pre-rendering” in Rails/React-on-Rails terms, proposes a phased set of implementation options (docs-only → helper ergonomics → renderer protocol → example), and records acceptance criteria plus open questions/owners to resolve before implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465121b1296b0d9d1a41127a4037787ccf7e217e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a planning document for React 19.2.x compatibility: establishes verification checklist and repo baseline signals, defines “partial pre-rendering” vs streaming SSR, enumerates verification steps across Node/Ruby/SSR/generator paths, specifies testing and benchmark acceptance criteria, proposes prioritized implementation shapes, and records open questions on caching, SSR vs RSC strategy, streamed-error handling, ownership boundaries, and testing/benchmark expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->