### PR TITLE
docs: plan performance test expansion

### DIFF
--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -105,7 +105,9 @@ Prerequisites for the first implementation PR:
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
   `node --version` for `node_version`, and run `node -e "console.log(require('react/package.json').version)"` from the
-  active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package.
+  active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package. Capture
+  `bundle_mode` from `ENV["NODE_ENV"]` (falling back to `"production"`) so the recorded mode reflects the actual build
+  rather than silently lying when CI or local runs use a non-production mode.
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
   first slice should start at one run per route. If a later implementation aggregates forward and reverse passes into a
   single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at
@@ -120,10 +122,14 @@ Prerequisites for the first implementation PR:
     "react_version": "<output of: node -e \"console.log(require('react/package.json').version)\" from APP_DIR>",
     "renderer": "<node_renderer when PRO=true, otherwise execjs>",
     "runner_type": "<RUNNER_OS/RUNNER_ARCH when available, otherwise local platform>",
-    "bundle_mode": "production",
+    "bundle_mode": "<ENV[\"NODE_ENV\"] when set, otherwise production>",
     "sample_count": "<number of completed k6 measurement samples included in this summary>"
   }
   ```
+
+  The implementation PR also needs to extend the `actions/upload-artifact` step in `.github/workflows/benchmark.yml` to
+  upload `metadata.json` alongside the existing summary and BMF artifacts; otherwise the schema lands but the artifact
+  never reaches CI consumers.
 
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and extend Bencher
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
@@ -162,7 +168,21 @@ reviewers have one stable compliance checklist.
 - CI behavior is advisory until noise controls are proven.
 - Regression detection favors sustained movement over single-run spikes and uses the current `p50`, `p90`, `p99`, and
   `max` metrics until `p95` is added explicitly.
-- Documentation tells contributors which benchmark to run for each rendering area.
+- Contributor documentation in `benchmarks/README.md` (or the benchmark-specific pull request template referenced under
+  Local Verification Before CI) tells contributors which benchmark to run for each rendering area.
+
+## Rollback / Abort Criteria
+
+If the noise controls in this plan still leave shared-runner variance too high to establish a stable baseline, treat
+the rollout as a rollback signal rather than continuing to lower thresholds:
+
+- If two consecutive benchmark runs on the same commit (no code changes) disagree by more than the largest threshold
+  the plan would set for any tracked metric, pause adding new routes and document the variance in the issue tracker.
+- If, after applying forward-then-reverse passes and the metadata artifact, single-commit variance still exceeds the
+  bands established in `internal/planning/library-benchmarking.md`, defer hard CI gates indefinitely and revisit the
+  approach (dedicated runner, longer sampling windows, or relocating the benchmark out of the shared CI job).
+- Until the abort criteria are clearly satisfied, keep all benchmark CI behavior advisory and do not block merges on
+  benchmark deltas.
 
 ## See Also
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -41,13 +41,15 @@ Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_
 3. Cached SSR route with explicit hit and miss measurements
 
 Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood. The cached SSR slice should
-define separate cache-hit and cache-miss benchmark paths before comparing results. Use a dedicated cache adapter and
-namespace for benchmark routes, such as `ActiveSupport::Cache::FileStore.new(Rails.root.join("tmp/benchmark_cache").to_s)`, instead of the
-app's default store. The miss path should clear only that benchmark cache namespace before measurement, and the hit path
-should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For
-the dedicated `FileStore`, clear the exact store root, for example
-`FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))`; do not clear `tmp/cache/assets` or the app's default cache
-store. Avoid `Rails.cache.clear` on the application cache. Avoid relying on a shared Redis instance, environment-default
+define separate cache-hit and cache-miss benchmark paths before comparing results. Inside the Rails app, use a dedicated
+cache adapter and namespace for benchmark routes, such as
+`ActiveSupport::Cache::FileStore.new(Rails.root.join("tmp/benchmark_cache").to_s)`, instead of the app's default store.
+The miss path should clear only that benchmark cache namespace before measurement, and the hit path should clear that
+namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For the dedicated
+`FileStore`, clear the exact store root: use `FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))` from Rails-loaded
+code, or `FileUtils.rm_rf(File.join(APP_DIR, "tmp/benchmark_cache"))` from `benchmarks/bench.rb` or another plain Ruby
+wrapper where `Rails.root` is unavailable. Do not clear `tmp/cache/assets` or the app's default cache store. Avoid
+`Rails.cache.clear` on the application cache. Avoid relying on a shared Redis instance, environment-default
 `:null_store`/`:memory_store` behavior, or manual cache state. To avoid mixing cold Rails-process noise into cache-miss
 measurements, warm the Rails process with a route that does not populate the benchmark cache, then clear the dedicated
 benchmark cache immediately before the cache-miss k6 measurement. For cache-hit measurements, clear the dedicated
@@ -78,7 +80,9 @@ extended to cover full Rails streaming behavior.
 
 Run Pro routes with `PRO=true`; `benchmarks/bench.rb` switches `APP_DIR` to `react_on_rails_pro/spec/dummy`. The current
 Bencher suffix is `: Core` for OSS routes and `: Pro` for Pro routes, so cache-hit/cache-miss benchmark names should
-preserve that suffix while adding the new cache-state distinction.
+preserve that suffix while adding the exact cache-state suffix ` (cache-hit)` or ` (cache-miss)`, for example
+`/my_route: Core (cache-hit)` and `/my_route: Core (cache-miss)`. Keep the parentheses and hyphenated spelling
+consistent because Bencher treats the benchmark name as the primary key.
 
 ## Noise Controls
 
@@ -111,18 +115,21 @@ Prerequisites for the first implementation PR:
   resolves against `APP_DIR/node_modules` rather than `Dir.pwd`. Preferred form (no global side effects):
 
   ```ruby
-  react_version, _status = Open3.capture2(
+  react_version_output, status = Open3.capture2(
     "node", "-e", "console.log(require('react/package.json').version)",
     chdir: APP_DIR
   )
-  react_version = react_version.strip
+  react_version = status.success? ? react_version_output.strip : "unknown"
+  warn "WARNING: could not capture react_version" unless status.success?
   ```
 
   Equivalent block form using `Dir.chdir(APP_DIR) do ... end` is acceptable when the surrounding code already manages
   working directory state. If the `react_version` capture command fails (for example when `node_modules` is not yet
-  installed in `APP_DIR`), record `react_version: "unknown"` and emit a warning rather than aborting the benchmark run. Capture `bundle_mode` from
-  `ENV["NODE_ENV"]` (falling back to `"production"`) so the recorded mode reflects the actual build rather than silently
-  lying when CI or local runs use a non-production mode.
+  installed in `APP_DIR`), record `react_version: "unknown"` and emit a warning rather than aborting the benchmark run;
+  if `Open3.capture2` raises, use the same fallback path. Capture `bundle_mode` from `ENV["NODE_ENV"]` (falling back to
+  `"production"`) as a best-effort process environment label. Do not treat that value as proof of the Webpack build mode
+  when prebuilt assets or explicit build flags may diverge; if exact asset-build fidelity is needed later, record it from
+  the build output or a build-written metadata file.
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
   first slice should start at one run per route. If a later implementation aggregates forward and reverse passes into a
   single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -54,7 +54,9 @@ Use these controls before treating results as regressions:
 - Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
 - Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and make sure CI
-  summaries, artifacts, and Bencher reporting surface those values consistently.
+  summaries, artifacts, and Bencher reporting surface those values consistently. The current runner intentionally uses
+  `p90` and `p99` instead of `p95`; adding `p95` should update the k6 trend stats, summary table, artifacts, and Bencher
+  reporting together.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -112,7 +112,10 @@ Already in place:
 - Keep the existing per-route warm-up before k6 measurement: 10 sequential requests with 0.5 seconds between requests.
   Each iteration is request round-trip plus 0.5 seconds of sleep, so the warm-up takes a lower bound of 5 seconds per
   route plus the actual request time, which is on the order of 5-6 seconds for SSR routes today. Expand it if routes,
-  especially streaming routes, need more stable startup behavior.
+  especially streaming routes, need more stable startup behavior. Cache-miss benchmark routes are the explicit exception
+  to this per-route warm-up: see Cache Setup above, which warms the Rails process against a different route and then
+  clears the dedicated benchmark cache immediately before the cache-miss k6 measurement, so the 10 pre-requests never
+  populate the fragment cache for the route under measurement.
 - Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
@@ -208,7 +211,15 @@ Prerequisites for the first implementation PR (blocking — must land before or 
   already used by `p50_latency`, `p90_latency`, and `p99_latency`. Updating the matching
   `bmf_collector.add` calls in `benchmarks/bench-node-renderer.rb` (inside the `non_rsc_tests.each` and
   `rsc_tests.each` blocks) is deferred to the Pro follow-on PR so the OSS first slice can land without changing Node
-  Renderer benchmark output.
+  Renderer benchmark output. That follow-on change is intentionally small: `bench-node-renderer.rb` already extracts
+  `vegeta_max` from the Vegeta JSON report and threads `max_latency` through `run_vegeta_benchmark` and
+  `add_to_summary`. The Pro PR only needs to pass `max: max_latency` to those two existing `bmf_collector.add` calls;
+  no Vegeta extraction or summary-row changes are required.
+
+  While editing `BmfCollector` to thread `max_latency`, also fix the stale comment at `benchmarks/lib/bmf_helpers.rb`
+  line 15, which currently lists `p50_latency_ms, p90_latency_ms, p99_latency_ms`. The actual measure keys emitted by
+  `to_bmf` are `p50_latency`, `p90_latency`, and `p99_latency` (no `_ms` suffix); leaving the comment as-is invites a
+  future implementer to add `max_latency_ms` by analogy and diverge from the Bencher measure keys.
 
   `max_latency` lands as an unthresholded advisory metric in the OSS first slice: the BMF payload includes the new key,
   but the `run_bencher` function in `.github/workflows/benchmark.yml` is not modified, so Bencher tracks the value
@@ -221,7 +232,9 @@ Prerequisites for the first implementation PR (blocking — must land before or 
   `benchmarks/lib/benchmark_config.rb`, and reference it from the existing `--summary-trend-stats` invocation in
   `benchmarks/bench.rb`. Landing the constant in the first implementation PR — before any follow-on PR adds `p95` or
   otherwise extends the trend-stats column set — keeps the percentile list in one place rather than scattered across
-  the bench script, summary table, artifacts, and Bencher reporting.
+  the bench script, summary table, artifacts, and Bencher reporting. The constant applies only to k6 in
+  `benchmarks/bench.rb`. `benchmarks/bench-node-renderer.rb` drives Vegeta, which has no equivalent flag and extracts
+  percentiles directly from its JSON report, so do not thread the constant through the Vegeta path.
 
 Recommended prior work (desirable but not blocking for the first benchmark-routes PR):
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -21,8 +21,8 @@ Start with a small, representative matrix before adding more routes:
 | Area                  | Operation                                 | Primary metric          | Notes                                                                                               |
 | --------------------- | ----------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- |
 | Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation              |
-| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | Covers ExecJS and Node Renderer paths; server render duration requires separate instrumentation     |
-| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Covers render-functions returning objects; payload-size capture requires tooling extension          |
+| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | OSS first slice uses ExecJS; Pro Node Renderer follow-up uses `benchmarks/bench-node-renderer.rb`   |
+| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Deferred; see First PR Scope. Payload-size capture requires tooling extension                       |
 | Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB/response-end reporting is a required extension before new thresholds |
 | RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only endpoint throughput and payload-size path; not a streaming TTFB target                     |
 | Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state      |
@@ -41,8 +41,9 @@ Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_
 3. Cached SSR route with explicit hit and miss measurements
 
 Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood. The cached SSR slice should
-define separate cache-hit and cache-miss benchmark paths, or a deterministic priming and busting step, before comparing
-results.
+define separate cache-hit and cache-miss benchmark paths before comparing results. The miss path should clear the
+benchmark cache namespace before measurement, and the hit path should clear that namespace, make one warm-up request to
+prime the fragment, then run k6 against the primed route. Avoid relying on a shared Redis instance or manual cache state.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -77,9 +78,25 @@ Prerequisites for the first implementation PR:
 
 - Define alternating route order in `benchmarks/bench.rb` as two deterministic passes over the same route list: first in
   `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route artifacts before
-  using route ordering as a noise-control signal.
-- Record sample count, runner type, Ruby version, Node version, React version, and bundle mode in a `metadata.json`
-  artifact and mirror the key fields in the `summary.txt` header.
+  using route ordering as a noise-control signal. Budget this intentionally because it roughly doubles route runtime: each
+  route gets two k6 runs plus two warm-up phases, or about `2 * (DURATION + 5 seconds)` per route with the current warm-up.
+- Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
+  `metadata.json` artifact and mirror the key fields in the `summary.txt` header.
+
+  Use these metadata keys as the minimum schema:
+
+  ```json
+  {
+    "ruby_version": "3.3.0",
+    "node_version": "22.0.0",
+    "react_version": "18.3.0",
+    "renderer": "execjs",
+    "runner_type": "ubuntu-22.04-8-core",
+    "bundle_mode": "production",
+    "sample_count": 1
+  }
+  ```
+
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and extend Bencher
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
   `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output.

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -8,22 +8,23 @@ explicitly mitigating CI runtime noise.
 The goal is to compare React on Rails rendering operations against their own historical baselines, not to produce broad
 marketing benchmarks from noisy shared runners.
 
-This plan extends the existing benchmark infrastructure in `benchmarks/bench.rb`, `benchmarks/k6.ts`, and
-`.github/workflows/benchmark.yml`; it should stay aligned with the max-rate strategy in
-`internal/planning/library-benchmarking.md`.
+This plan extends the existing benchmark infrastructure in `benchmarks/bench.rb`, `benchmarks/k6.ts`,
+`benchmarks/bench-node-renderer.rb`, and `.github/workflows/benchmark.yml`; it should stay aligned with the max-rate
+strategy in `internal/planning/library-benchmarking.md`. Pro Node Renderer paths should build on the existing Vegeta
+HTTP/2 Cleartext benchmark rather than duplicating that transport setup in k6.
 
 ## Operations Matrix
 
 Start with a small, representative matrix before adding more routes:
 
-| Area                  | Operation                                 | Primary metric              | Notes                                                                   |
-| --------------------- | ----------------------------------------- | --------------------------- | ----------------------------------------------------------------------- |
-| Client rendering      | `react_component` with `prerender: false` | mount timing                | Measures browser-side startup overhead without server markup to hydrate |
-| Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths                                   |
-| Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects                               |
-| Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Pro-only path; requires Node Renderer and Suspense-friendly examples    |
-| RSC payload rendering | `rsc_payload_react_component`             | payload bytes and duration  | Pro-only path, benchmark separately                                     |
-| Fragment caching      | cached component hit and miss             | hit latency and miss cost   | Separates cache effectiveness from SSR cost                             |
+| Area                  | Operation                                 | Primary metric              | Notes                                                                                    |
+| --------------------- | ----------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
+| Client rendering      | `react_component` with `prerender: false` | route RPS and HTTP latency  | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation   |
+| Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths                                                    |
+| Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects                                                |
+| Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Pro-only path; requires Node Renderer and Suspense-friendly examples                     |
+| RSC payload rendering | `rsc_payload_react_component`             | payload bytes and duration  | Pro-only path; needs static route or explicit target because required params are skipped |
+| Fragment caching      | cached component hit and miss             | hit latency and miss cost   | Separates cache effectiveness from SSR cost                                              |
 
 ## First PR Scope
 
@@ -39,19 +40,21 @@ Recommended OSS first slice:
 Recommended Pro slice, tracked separately from the OSS implementation PR:
 
 1. Streaming route with a small Suspense boundary
-2. RSC payload route with representative payload size measurements
+2. RSC payload route with representative payload size measurements. Use a static benchmark route with no required URL
+   params, teach `benchmarks/bench.rb` how to provide a default component name, or run `benchmarks/k6.ts` with an explicit
+   `TARGET_URL`; automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
 
 ## Noise Controls
 
 Use these controls before treating results as regressions:
 
 - Warm each route before measuring.
-- Run alternating route order instead of grouped route order so cache and process state are less biased.
+- Implement alternating route order in `benchmarks/bench.rb`; routes currently run in `rails routes` order, so this is a
+  prerequisite before using route ordering as a noise-control signal.
 - Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
-- Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md` and surface the existing
-  k6 latency stats (`p50`, `p90`, `p99`, and `max`) beside RPS instead of relying only on averages.
-- Treat new percentile requirements as result-collection work: update `benchmarks/bench.rb`, the exported summary shape,
-  and the workflow reporting before adding metrics that the current runner does not publish.
+- Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
+- Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and make sure CI
+  summaries, artifacts, and Bencher reporting surface those values consistently.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
@@ -81,5 +84,6 @@ same mode.
 
 - `benchmarks/bench.rb`
 - `benchmarks/k6.ts`
+- `benchmarks/bench-node-renderer.rb`
 - `.github/workflows/benchmark.yml`
 - `internal/planning/library-benchmarking.md`

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -34,15 +34,20 @@ Here `p50` maps to k6's `med` stat and the `p50_latency` Bencher Metric Format m
 The first implementation PR should add only one or two routes per category and should reuse existing dummy app examples
 where possible. Avoid building a large benchmark suite until the noise profile is understood.
 
+### OSS First Slice
+
 Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169):
 
 1. Client-only component route
 2. Traditional SSR route with the same component and props
 3. Cached SSR route with explicit hit and miss measurements
 
-Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood. The cached SSR slice should
-define separate cache-hit and cache-miss benchmark paths before comparing results. Inside the Rails app, use a dedicated
-cache adapter and namespace for benchmark routes, such as
+Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood.
+
+### Cache Setup
+
+The cached SSR slice should define separate cache-hit and cache-miss benchmark paths before comparing results. Use a
+dedicated cache adapter and namespace for benchmark routes, such as
 `ActiveSupport::Cache::FileStore.new(Rails.root.join("tmp/benchmark_cache").to_s)`, instead of the app's default store.
 The miss path should clear only that benchmark cache namespace before measurement, and the hit path should clear that
 namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For the dedicated
@@ -55,6 +60,8 @@ measurements, warm the Rails process with a route that does not populate the ben
 benchmark cache immediately before the cache-miss k6 measurement. For cache-hit measurements, clear the dedicated
 benchmark cache, send one explicit cache-prime request to the measured route, then run the existing per-route k6 warm-up
 and measurement against the primed route.
+
+### Pro Follow-Up Slice
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -74,6 +81,8 @@ OSS first slice or in a dedicated follow-up PR:
    before benchmark measurements begin, with an actionable error instead of silently skipping RSC coverage. Do this as a
    preflight check during route-list construction, not as a mid-run abort after partial artifacts have been written.
    Automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
+
+### Script Boundaries And Naming
 
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
@@ -106,8 +115,10 @@ Prerequisites for the first implementation PR:
   because it roughly doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
   `2 * (DURATION + warm-up requests * warm-up sleep)` per route. With today's defaults and the hard-coded warm-up loop in
   `benchmarks/bench.rb`, that is `2 * (30s + 10 * 0.5s)` = 70 seconds. This estimate does not include the per-job
-  `bundle exec rails routes` discovery call, server startup, or server warmdown time. Recalculate the estimate if
-  `DURATION` changes or if the `benchmarks/bench.rb` warm-up loop changes.
+  `bundle exec rails routes` discovery call, server startup, or server warmdown time. At the job level, a benchmark job
+  covering about 10 routes should be budgeted as roughly doubling from 11-12 minutes to 22-24 minutes before additional
+  startup or warmdown overhead. Recalculate the estimate if `DURATION` changes or if the `benchmarks/bench.rb` warm-up
+  loop changes.
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
@@ -123,6 +134,12 @@ Prerequisites for the first implementation PR:
   )
   react_version = status.success? ? react_version_output.strip : "unknown"
   warn "WARNING: could not capture react_version" unless status.success?
+  ```
+
+  Derive `renderer` from the same `PRO` switch that selects `APP_DIR`, rather than copying the example schema value:
+
+  ```ruby
+  renderer = ENV["PRO"] == "true" ? "node_renderer" : "execjs"
   ```
 
   Equivalent block form using `Dir.chdir(APP_DIR) do ... end` is acceptable when the surrounding code already manages
@@ -144,7 +161,8 @@ Prerequisites for the first implementation PR:
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
   first slice should start at one run per route. If a later implementation aggregates forward and reverse passes into a
   single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at
-  `sample_count: 1`.
+  `sample_count: 1`. Do not count a run whose `rps` value is `FAILED`, `MISSING`, or otherwise non-numeric toward
+  `sample_count`; this matches the `BmfCollector#add` guard that skips non-numeric RPS entries.
 
   Use these metadata keys as the minimum schema. The JSON block shows example output values; populate the real artifact
   with the runtime capture rules above instead of copying these literals:
@@ -177,7 +195,9 @@ Prerequisites for the first implementation PR:
 Follow-on enhancements:
 
 - Add `p95` only when the k6 `--summary-trend-stats` flag, currently `med,max,p(90),p(99)` in `benchmarks/bench.rb`, the
-  summary table, artifacts, and Bencher reporting can be updated together.
+  summary table, artifacts, and Bencher reporting can be updated together. Before adding `p95`, extract the current
+  summary-trend-stats string to a named constant, such as
+  `K6_TREND_STATS = "med,max,p(90),p(99)"`, so the percentile set is changed in one place.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 
 ## Local Verification Before CI

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -1,0 +1,66 @@
+# Performance Test Expansion Plan
+
+## Purpose
+
+Plan expanded performance coverage for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169) while
+explicitly mitigating CI runtime noise.
+
+The goal is to compare React on Rails rendering operations against their own historical baselines, not to produce broad
+marketing benchmarks from noisy shared runners.
+
+## Operations Matrix
+
+Start with a small, representative matrix before adding more routes:
+
+| Area                  | Operation                                 | Primary metric              | Notes                                       |
+| --------------------- | ----------------------------------------- | --------------------------- | ------------------------------------------- |
+| Client rendering      | `react_component` with `prerender: false` | mount and hydration timing  | Measures browser-side startup overhead      |
+| Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths       |
+| Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects   |
+| Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Requires Suspense-friendly examples         |
+| RSC payload rendering | `rsc_payload_react_component`             | payload bytes and duration  | Pro-only path, benchmark separately         |
+| Fragment caching      | cached component hit and miss             | hit latency and miss cost   | Separates cache effectiveness from SSR cost |
+
+## First PR Scope
+
+The first implementation PR should add only one or two routes per category and should reuse existing dummy app examples
+where possible. Avoid building a large benchmark suite until the noise profile is understood.
+
+Recommended first slice:
+
+1. Client-only component route
+2. Traditional SSR route with the same component and props
+3. Streaming route with a small Suspense boundary
+4. Cached SSR route with explicit hit and miss measurements
+
+## Noise Controls
+
+Use these controls before treating results as regressions:
+
+- Warm each route before measuring.
+- Run alternating route order instead of grouped route order so cache and process state are less biased.
+- Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
+- Track median and p95, not only averages.
+- Require repeated or overlapping alerts before opening an issue or failing CI.
+- Keep hard CI gates disabled until the benchmark gate tuning in
+  [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
+
+## Local Verification Before CI
+
+Every benchmark PR should include:
+
+- a local command that runs the benchmark subset
+- expected output shape
+- a short note explaining what changed in the measured surface
+- proof that the benchmark can run without unrelated app servers or ports already running
+
+If a benchmark requires generated assets, the command should build those assets explicitly so CI and local runs use the
+same mode.
+
+## Acceptance Criteria
+
+- The expanded suite covers client-only rendering, traditional SSR, streaming SSR, and at least one cache path.
+- Results include enough metadata to compare runs meaningfully.
+- CI behavior is advisory until noise controls are proven.
+- Regression detection favors sustained movement over single-run spikes.
+- Documentation tells contributors which benchmark to run for each rendering area.

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -17,27 +17,30 @@ HTTP/2 Cleartext benchmark rather than duplicating that transport setup in k6.
 
 Start with a small, representative matrix before adding more routes:
 
-| Area                  | Operation                                 | Primary metric              | Notes                                                                                    |
-| --------------------- | ----------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
-| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max     | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation   |
-| Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths                                                    |
-| Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects                                                |
-| Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Pro-only path; requires Node Renderer and Suspense-friendly examples                     |
-| RSC payload rendering | `rsc_payload_react_component`             | payload bytes and duration  | Pro-only path; needs static route or explicit target because required params are skipped |
-| Fragment caching      | cached component hit and miss             | hit latency and miss cost   | Separates cache effectiveness from SSR cost                                              |
+| Area                  | Operation                                 | Primary metric          | Notes                                                                                                  |
+| --------------------- | ----------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation                 |
+| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | Covers ExecJS and Node Renderer paths; server render duration requires separate instrumentation        |
+| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Covers render-functions returning objects; payload-size capture requires tooling extension             |
+| Streaming SSR         | `stream_react_component`                  | TTFB, response end      | Pro-only path; LCP requires separate browser instrumentation such as Playwright or Lighthouse          |
+| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only path; needs static route or explicit target, and payload-size capture needs tooling extension |
+| Fragment caching      | cached component hit and miss             | hit latency, miss cost  | Separates cache effectiveness from SSR cost                                                            |
 
 ## First PR Scope
 
 The first implementation PR should add only one or two routes per category and should reuse existing dummy app examples
 where possible. Avoid building a large benchmark suite until the noise profile is understood.
 
-Recommended OSS first slice:
+Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169):
 
 1. Client-only component route
 2. Traditional SSR route with the same component and props
 3. Cached SSR route with explicit hit and miss measurements
 
-Recommended Pro slice, tracked separately from the OSS implementation PR:
+Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood.
+
+Recommended Pro slice, tracked separately from the OSS implementation PR under
+[Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169):
 
 1. Streaming route with a small Suspense boundary
 2. RSC payload route with representative payload size measurements. Use a static benchmark route with no required URL
@@ -50,20 +53,25 @@ full Rails streaming behavior.
 
 ## Noise Controls
 
-Use these controls before treating results as regressions:
+Use these controls before treating results as regressions.
+
+Already in place:
 
 - Keep the existing per-route warm-up before k6 measurement and expand it if routes need more stable startup behavior.
-- Implement alternating route order in `benchmarks/bench.rb`; routes currently run in `rails routes` order, so this is a
+- Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
+- Keep hard CI gates disabled until the benchmark gate tuning in
+  [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
+
+To implement as part of the benchmark expansion:
+
+- Add alternating route order in `benchmarks/bench.rb`; routes currently run in `rails routes` order, so this is a
   prerequisite before using route ordering as a noise-control signal.
 - Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
-- Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and make sure CI
   summaries, artifacts, and Bencher reporting surface those values consistently. The current runner intentionally uses
   `p90` and `p99` instead of `p95`; adding `p95` should update the k6 trend stats, summary table, artifacts, and Bencher
   reporting together.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
-- Keep hard CI gates disabled until the benchmark gate tuning in
-  [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
 
 ## Local Verification Before CI
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -47,7 +47,8 @@ app's default store. The miss path should clear only that benchmark cache namesp
 should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For
 the dedicated `FileStore`, clear the namespace with `FileUtils.rm_rf("tmp/benchmark_cache")`; avoid `Rails.cache.clear`
 on the application cache. Avoid relying on a shared Redis instance, environment-default `:null_store`/`:memory_store`
-behavior, or manual cache state.
+behavior, or manual cache state. This explicit cache-prime request is an additional step before the existing per-route
+k6 warm-up in [Noise Controls](#noise-controls); it does not replace that 10-request warm-up phase.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -63,6 +64,7 @@ OSS first slice or in a dedicated follow-up PR:
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
 extended to cover full Rails streaming behavior.
+
 Run Pro routes with `PRO=true`; `benchmarks/bench.rb` switches `APP_DIR` to `react_on_rails_pro/spec/dummy` and appends
 `: Pro` to Bencher benchmark names.
 
@@ -80,10 +82,11 @@ Already in place:
 
 Prerequisites for the first implementation PR:
 
-- Define alternating route order in `benchmarks/bench.rb` as two deterministic passes over the same route list: first in
-  `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route artifacts before
-  using route ordering as a noise-control signal. This is large enough to land as its own prerequisite PR, and the first
-  benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally because it roughly
+- Define forward-then-reverse route passes in `benchmarks/bench.rb` as two deterministic passes over the same route list:
+  first in `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route
+  artifacts before using route ordering as a noise-control signal. This is large enough to land as its own prerequisite
+  PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
+  because it roughly
   doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about `2 * (DURATION + 5 seconds)` per
   route with the current warm-up, assuming the default `DURATION=30s`. This estimate does not include the per-job
   `bundle exec rails routes` discovery call, server startup, or server warmdown time. Recalculate the estimate when
@@ -100,11 +103,11 @@ Prerequisites for the first implementation PR:
 
   ```json
   {
-    "ruby_version": "<ruby --version>",
-    "node_version": "<node --version>",
-    "react_version": "<installed react package version>",
-    "renderer": "<execjs|node_renderer>",
-    "runner_type": "<github runner label>",
+    "ruby_version": "ruby 3.3.0 (2023-12-25 revision ...) [x86_64-linux]",
+    "node_version": "v20.11.0",
+    "react_version": "18.3.1",
+    "renderer": "execjs",
+    "runner_type": "ubuntu-latest",
     "bundle_mode": "production",
     "sample_count": 1
   }
@@ -112,7 +115,9 @@ Prerequisites for the first implementation PR:
 
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and extend Bencher
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
-  `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output.
+  `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output. Add a `max:` keyword parameter
+  to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb`, then pass `max_latency:` from the `bmf_collector.add` call
+  in `benchmarks/bench.rb`.
 
 Follow-on enhancements:
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -66,9 +66,11 @@ OSS first slice or in a dedicated follow-up PR:
    introduce an `RSC_BENCHMARK_COMPONENT` environment variable defaulting to a known component name so
    `benchmarks/bench.rb` can construct the URL without relying on route discovery. When `RSC_BENCHMARK_COMPONENT` is set,
    `benchmarks/bench.rb` constructs the target URL as `/rsc_payload/#{RSC_BENCHMARK_COMPONENT}` and bypasses route
-   discovery for that entry. If neither `TARGET_URL` nor `RSC_BENCHMARK_COMPONENT` is provided and no parameter-free RSC
-   route exists, fail setup with an actionable error instead of silently skipping RSC coverage. Automatic route discovery
-   currently skips required-parameter routes such as `/rsc_payload/:component_name`.
+   discovery for that entry. The implementation PR must verify that the `/rsc_payload/` prefix still matches the Pro
+   dummy app's `routes.rb` before relying on this convention. If neither `TARGET_URL` nor `RSC_BENCHMARK_COMPONENT` is
+   provided and no parameter-free RSC route exists, setup must call `abort(msg)` or otherwise exit non-zero with an
+   actionable error instead of silently skipping RSC coverage. Automatic route discovery currently skips
+   required-parameter routes such as `/rsc_payload/:component_name`.
 
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
@@ -126,16 +128,17 @@ Prerequisites for the first implementation PR:
   single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at
   `sample_count: 1`.
 
-  Use these metadata keys as the minimum schema:
+  Use these metadata keys as the minimum schema. The JSON block shows example output values; populate the real artifact
+  with the runtime capture rules above instead of copying these literals:
 
   ```json
   {
-    "ruby_version": "<output of: ruby --version>",
-    "node_version": "<output of: node --version>",
-    "react_version": "<output of: Open3.capture2(\"node\", \"-e\", \"console.log(require('react/package.json').version)\", chdir: APP_DIR)>",
-    "renderer": "<node_renderer when PRO=true, otherwise execjs>",
-    "runner_type": "<RUNNER_OS/RUNNER_ARCH when available, otherwise local platform>",
-    "bundle_mode": "<ENV[\"NODE_ENV\"] when set, otherwise production>",
+    "ruby_version": "ruby 3.3.6",
+    "node_version": "v22.13.1",
+    "react_version": "18.2.0",
+    "renderer": "execjs",
+    "runner_type": "ubuntu-latest/x64",
+    "bundle_mode": "production",
     "sample_count": 1
   }
   ```

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -48,11 +48,11 @@ should clear that namespace, make one warm-up request to prime the fragment, the
 the dedicated `FileStore`, clear the exact store root, for example
 `FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))`; do not clear `tmp/cache/assets` or the app's default cache
 store. Avoid `Rails.cache.clear` on the application cache. Avoid relying on a shared Redis instance, environment-default
-`:null_store`/`:memory_store` behavior, or manual cache state. This explicit cache-prime request is an additional step
-before the existing per-route k6 warm-up in [Noise Controls](#noise-controls); it does not replace that 10-request
-warm-up phase for cache-hit runs. The cache-miss path must either skip the generic per-route warm-up or clear the
-dedicated benchmark cache again after warm-up and immediately before k6 measurement, so measurement starts from a cold
-cache state.
+`:null_store`/`:memory_store` behavior, or manual cache state. To avoid mixing cold Rails-process noise into cache-miss
+measurements, warm the Rails process with a route that does not populate the benchmark cache, then clear the dedicated
+benchmark cache immediately before the cache-miss k6 measurement. For cache-hit measurements, clear the dedicated
+benchmark cache, send one explicit cache-prime request to the measured route, then run the existing per-route k6 warm-up
+and measurement against the primed route.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -64,15 +64,18 @@ OSS first slice or in a dedicated follow-up PR:
    coverage rather than streaming TTFB measurement. Use a static benchmark route with no required URL params. If the
    dummy app has no parameter-free RSC route, run `benchmarks/k6.ts` with an explicit `TARGET_URL`; alternatively,
    introduce an `RSC_BENCHMARK_COMPONENT` environment variable defaulting to a known component name so
-   `benchmarks/bench.rb` can construct the URL without relying on route discovery. Automatic route discovery currently
-   skips required-parameter routes such as `/rsc_payload/:component_name`.
+   `benchmarks/bench.rb` can construct the URL without relying on route discovery. If neither `TARGET_URL` nor
+   `RSC_BENCHMARK_COMPONENT` is provided and no parameter-free RSC route exists, fail setup with an actionable error
+   instead of silently skipping RSC coverage. Automatic route discovery currently skips required-parameter routes such as
+   `/rsc_payload/:component_name`.
 
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
 extended to cover full Rails streaming behavior.
 
-Run Pro routes with `PRO=true`; `benchmarks/bench.rb` switches `APP_DIR` to `react_on_rails_pro/spec/dummy` and appends
-`: Pro` to Bencher benchmark names.
+Run Pro routes with `PRO=true`; `benchmarks/bench.rb` switches `APP_DIR` to `react_on_rails_pro/spec/dummy`. The current
+Bencher suffix is `: Core` for OSS routes and `: Pro` for Pro routes, so cache-hit/cache-miss benchmark names should
+preserve that suffix while adding the new cache-state distinction.
 
 ## Noise Controls
 
@@ -103,9 +106,10 @@ Prerequisites for the first implementation PR:
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
   `node --version` for `node_version`, and run `node -e "console.log(require('react/package.json').version)"` from the
   active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package.
-  Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary; the
-  first slice should start at one run per route, and alternating route order increases it to two when both passes are
-  merged into one route summary.
+  Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
+  first slice should start at one run per route. If a later implementation aggregates forward and reverse passes into a
+  single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at
+  `sample_count: 1`.
 
   Use these metadata keys as the minimum schema:
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -70,9 +70,10 @@ OSS first slice or in a dedicated follow-up PR:
    `benchmarks/bench.rb` constructs the target URL as `/rsc_payload/#{RSC_BENCHMARK_COMPONENT}` and bypasses route
    discovery for that entry. The implementation PR must verify that the `/rsc_payload/` prefix still matches the Pro
    dummy app's `routes.rb` before relying on this convention. If neither `TARGET_URL` nor `RSC_BENCHMARK_COMPONENT` is
-   provided and no parameter-free RSC route exists, setup must call `abort(msg)` or otherwise exit non-zero with an
-   actionable error instead of silently skipping RSC coverage. Automatic route discovery currently skips
-   required-parameter routes such as `/rsc_payload/:component_name`.
+   provided and no parameter-free RSC route exists, route-list setup must call `abort(msg)` or otherwise exit non-zero
+   before benchmark measurements begin, with an actionable error instead of silently skipping RSC coverage. Do this as a
+   preflight check during route-list construction, not as a mid-run abort after partial artifacts have been written.
+   Automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
 
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
@@ -110,9 +111,10 @@ Prerequisites for the first implementation PR:
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
-  `node --version` for `node_version`, and capture `react_version` by invoking Node from `APP_DIR` so OSS and Pro dummy
-  apps report their own installed React package. The implementation PR must use a chdir-aware Ruby call so `require()`
-  resolves against `APP_DIR/node_modules` rather than `Dir.pwd`. Preferred form (no global side effects):
+  `node --version` for `node_version`, populate `runner_type` from `ENV["RUNNER_OS"]` and `ENV["RUNNER_ARCH"]`, and
+  capture `react_version` by invoking Node from `APP_DIR` so OSS and Pro dummy apps report their own installed React
+  package. The implementation PR must use a chdir-aware Ruby call so `require()` resolves against `APP_DIR/node_modules`
+  rather than `Dir.pwd`. Preferred form (no global side effects):
 
   ```ruby
   react_version_output, status = Open3.capture2(
@@ -130,6 +132,15 @@ Prerequisites for the first implementation PR:
   `"production"`) as a best-effort process environment label. Do not treat that value as proof of the Webpack build mode
   when prebuilt assets or explicit build flags may diverge; if exact asset-build fidelity is needed later, record it from
   the build output or a build-written metadata file.
+  Populate `runner_type` with:
+
+  ```ruby
+  runner_type = [ENV["RUNNER_OS"], ENV["RUNNER_ARCH"]]
+                .compact
+                .join("/")
+                .then { |value| value.empty? ? "unknown" : value }
+  ```
+
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
   first slice should start at one run per route. If a later implementation aggregates forward and reverse passes into a
   single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at
@@ -144,7 +155,7 @@ Prerequisites for the first implementation PR:
     "node_version": "v22.13.1",
     "react_version": "18.2.0",
     "renderer": "execjs",
-    "runner_type": "ubuntu-latest/x64",
+    "runner_type": "Linux/X64",
     "bundle_mode": "production",
     "sample_count": 1
   }

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -45,12 +45,14 @@ define separate cache-hit and cache-miss benchmark paths before comparing result
 namespace for benchmark routes, such as `ActiveSupport::Cache::FileStore.new("tmp/benchmark_cache")`, instead of the
 app's default store. The miss path should clear only that benchmark cache namespace before measurement, and the hit path
 should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For
-the dedicated `FileStore`, clear the namespace with `FileUtils.rm_rf("tmp/benchmark_cache")`; avoid `Rails.cache.clear`
-on the application cache. Avoid relying on a shared Redis instance, environment-default `:null_store`/`:memory_store`
-behavior, or manual cache state. This explicit cache-prime request is an additional step before the existing per-route
-k6 warm-up in [Noise Controls](#noise-controls); it does not replace that 10-request warm-up phase for cache-hit runs.
-The cache-miss path must either skip the generic per-route warm-up or clear the dedicated benchmark cache again after
-warm-up and immediately before k6 measurement, so measurement starts from a cold cache state.
+the dedicated `FileStore`, clear the exact store root, for example
+`FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))`; do not clear `tmp/cache/assets` or the app's default cache
+store. Avoid `Rails.cache.clear` on the application cache. Avoid relying on a shared Redis instance, environment-default
+`:null_store`/`:memory_store` behavior, or manual cache state. This explicit cache-prime request is an additional step
+before the existing per-route k6 warm-up in [Noise Controls](#noise-controls); it does not replace that 10-request
+warm-up phase for cache-hit runs. The cache-miss path must either skip the generic per-route warm-up or clear the
+dedicated benchmark cache again after warm-up and immediately before k6 measurement, so measurement starts from a cold
+cache state.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -115,7 +117,7 @@ Prerequisites for the first implementation PR:
     "renderer": "<node_renderer when PRO=true, otherwise execjs>",
     "runner_type": "<RUNNER_OS/RUNNER_ARCH when available, otherwise local platform>",
     "bundle_mode": "production",
-    "sample_count": 1
+    "sample_count": "<number of completed k6 measurement samples included in this summary>"
   }
   ```
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -27,6 +27,8 @@ Start with a small, representative matrix before adding more routes:
 | RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only endpoint throughput and payload-size path; not a streaming TTFB target                     |
 | Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state      |
 
+Here `p50` maps to k6's `med` stat and the `p50_latency` Bencher Metric Format measure.
+
 ## First PR Scope
 
 The first implementation PR should add only one or two routes per category and should reuse existing dummy app examples
@@ -56,6 +58,8 @@ OSS first slice or in a dedicated follow-up PR:
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
 extended to cover full Rails streaming behavior.
+Run Pro routes with `PRO=true`; `benchmarks/bench.rb` switches `APP_DIR` to `react_on_rails_pro/spec/dummy` and appends
+`: Pro` to Bencher benchmark names.
 
 ## Noise Controls
 
@@ -82,7 +86,8 @@ Prerequisites for the first implementation PR:
 
 Follow-on enhancements:
 
-- Add `p95` only when the k6 trend stats, summary table, artifacts, and Bencher reporting can be updated together.
+- Add `p95` only when the k6 `--summary-trend-stats` flag, currently `med,max,p(90),p(99)` in `benchmarks/bench.rb`, the
+  summary table, artifacts, and Bencher reporting can be updated together.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 
 ## Local Verification Before CI

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -41,9 +41,11 @@ Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_
 3. Cached SSR route with explicit hit and miss measurements
 
 Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood. The cached SSR slice should
-define separate cache-hit and cache-miss benchmark paths before comparing results. The miss path should clear the
-benchmark cache namespace before measurement, and the hit path should clear that namespace, make one warm-up request to
-prime the fragment, then run k6 against the primed route. Avoid relying on a shared Redis instance or manual cache state.
+define separate cache-hit and cache-miss benchmark paths before comparing results. Use a dedicated cache adapter and
+namespace for benchmark routes, such as `ActiveSupport::Cache::FileStore.new("tmp/benchmark_cache")`, instead of the
+app's default store. The miss path should clear only that benchmark cache namespace before measurement, and the hit path
+should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. Avoid
+relying on a shared Redis instance, environment-default `:null_store`/`:memory_store` behavior, or manual cache state.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -78,10 +80,15 @@ Prerequisites for the first implementation PR:
 
 - Define alternating route order in `benchmarks/bench.rb` as two deterministic passes over the same route list: first in
   `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route artifacts before
-  using route ordering as a noise-control signal. Budget this intentionally because it roughly doubles route runtime: each
-  route gets two k6 runs plus two warm-up phases, or about `2 * (DURATION + 5 seconds)` per route with the current warm-up.
+  using route ordering as a noise-control signal. This is large enough to land as its own prerequisite PR, and the first
+  benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally because it roughly
+  doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about `2 * (DURATION + 5 seconds)` per
+  route with the current warm-up, assuming the default `DURATION=30s`. Recalculate the estimate when overriding
+  `DURATION`.
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
-  `metadata.json` artifact and mirror the key fields in the `summary.txt` header.
+  `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
+  the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
+  `node --version` for `node_version`, and the installed React package metadata for `react_version`.
 
   Use these metadata keys as the minimum schema:
 
@@ -118,6 +125,10 @@ Every benchmark PR should include:
 
 If a benchmark requires generated assets, the command should build those assets explicitly so CI and local runs use the
 same mode.
+
+Until benchmark-specific contributor docs exist, put this checklist in each benchmark implementation PR description. The
+implementation work should then anchor it in `benchmarks/README.md` or a benchmark-specific pull request template so
+reviewers have one stable compliance checklist.
 
 ## Acceptance Criteria
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -42,7 +42,7 @@ Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_
 
 Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood. The cached SSR slice should
 define separate cache-hit and cache-miss benchmark paths before comparing results. Use a dedicated cache adapter and
-namespace for benchmark routes, such as `ActiveSupport::Cache::FileStore.new("tmp/benchmark_cache")`, instead of the
+namespace for benchmark routes, such as `ActiveSupport::Cache::FileStore.new(Rails.root.join("tmp/benchmark_cache").to_s)`, instead of the
 app's default store. The miss path should clear only that benchmark cache namespace before measurement, and the hit path
 should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For
 the dedicated `FileStore`, clear the exact store root, for example
@@ -104,10 +104,21 @@ Prerequisites for the first implementation PR:
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
-  `node --version` for `node_version`, and run `node -e "console.log(require('react/package.json').version)"` from the
-  active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package. If the
-  `react_version` capture command fails (for example when `node_modules` is not yet installed in `APP_DIR`), record
-  `react_version: "unknown"` and emit a warning rather than aborting the benchmark run. Capture `bundle_mode` from
+  `node --version` for `node_version`, and capture `react_version` by invoking Node from `APP_DIR` so OSS and Pro dummy
+  apps report their own installed React package. The implementation PR must use a chdir-aware Ruby call so `require()`
+  resolves against `APP_DIR/node_modules` rather than `Dir.pwd`. Preferred form (no global side effects):
+
+  ```ruby
+  react_version, _status = Open3.capture2(
+    "node", "-e", "console.log(require('react/package.json').version)",
+    chdir: APP_DIR
+  )
+  react_version = react_version.strip
+  ```
+
+  Equivalent block form using `Dir.chdir(APP_DIR) do ... end` is acceptable when the surrounding code already manages
+  working directory state. If the `react_version` capture command fails (for example when `node_modules` is not yet
+  installed in `APP_DIR`), record `react_version: "unknown"` and emit a warning rather than aborting the benchmark run. Capture `bundle_mode` from
   `ENV["NODE_ENV"]` (falling back to `"production"`) so the recorded mode reflects the actual build rather than silently
   lying when CI or local runs use a non-production mode.
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
@@ -121,11 +132,11 @@ Prerequisites for the first implementation PR:
   {
     "ruby_version": "<output of: ruby --version>",
     "node_version": "<output of: node --version>",
-    "react_version": "<output of: node -e \"console.log(require('react/package.json').version)\" from APP_DIR>",
+    "react_version": "<output of: Open3.capture2(\"node\", \"-e\", \"console.log(require('react/package.json').version)\", chdir: APP_DIR)>",
     "renderer": "<node_renderer when PRO=true, otherwise execjs>",
     "runner_type": "<RUNNER_OS/RUNNER_ARCH when available, otherwise local platform>",
     "bundle_mode": "<ENV[\"NODE_ENV\"] when set, otherwise production>",
-    "sample_count": "<number of completed k6 measurement samples included in this summary>"
+    "sample_count": 1
   }
   ```
 
@@ -138,8 +149,9 @@ Prerequisites for the first implementation PR:
   `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output. Add a `max:` keyword parameter
   to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb` with a default of `nil` so existing callers stay valid, then
   pass `max: max_latency` from the `bmf_collector.add` call in `benchmarks/bench.rb`. Updating the matching
-  `bmf_collector.add` calls in `benchmarks/bench-node-renderer.rb` (currently around lines 315 and 330) is deferred to
-  the Pro follow-on PR so the OSS first slice can land without changing Node Renderer benchmark output.
+  `bmf_collector.add` calls in `benchmarks/bench-node-renderer.rb` (inside the `non_rsc_tests.each` and
+  `rsc_tests.each` blocks) is deferred to the Pro follow-on PR so the OSS first slice can land without changing Node
+  Renderer benchmark output.
 
 Follow-on enhancements:
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -64,10 +64,11 @@ OSS first slice or in a dedicated follow-up PR:
    coverage rather than streaming TTFB measurement. Use a static benchmark route with no required URL params. If the
    dummy app has no parameter-free RSC route, run `benchmarks/k6.ts` with an explicit `TARGET_URL`; alternatively,
    introduce an `RSC_BENCHMARK_COMPONENT` environment variable defaulting to a known component name so
-   `benchmarks/bench.rb` can construct the URL without relying on route discovery. If neither `TARGET_URL` nor
-   `RSC_BENCHMARK_COMPONENT` is provided and no parameter-free RSC route exists, fail setup with an actionable error
-   instead of silently skipping RSC coverage. Automatic route discovery currently skips required-parameter routes such as
-   `/rsc_payload/:component_name`.
+   `benchmarks/bench.rb` can construct the URL without relying on route discovery. When `RSC_BENCHMARK_COMPONENT` is set,
+   `benchmarks/bench.rb` constructs the target URL as `/rsc_payload/#{RSC_BENCHMARK_COMPONENT}` and bypasses route
+   discovery for that entry. If neither `TARGET_URL` nor `RSC_BENCHMARK_COMPONENT` is provided and no parameter-free RSC
+   route exists, fail setup with an actionable error instead of silently skipping RSC coverage. Automatic route discovery
+   currently skips required-parameter routes such as `/rsc_payload/:component_name`.
 
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
@@ -95,8 +96,7 @@ Prerequisites for the first implementation PR:
   first in `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route
   artifacts before using route ordering as a noise-control signal. This is large enough to land as its own prerequisite
   PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
-  because it roughly
-  doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
+  because it roughly doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
   `2 * (DURATION + warm-up requests * warm-up sleep)` per route. With today's defaults and the hard-coded warm-up loop in
   `benchmarks/bench.rb`, that is `2 * (30s + 10 * 0.5s)` = 70 seconds. This estimate does not include the per-job
   `bundle exec rails routes` discovery call, server startup, or server warmdown time. Recalculate the estimate if
@@ -105,9 +105,11 @@ Prerequisites for the first implementation PR:
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
   `node --version` for `node_version`, and run `node -e "console.log(require('react/package.json').version)"` from the
-  active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package. Capture
-  `bundle_mode` from `ENV["NODE_ENV"]` (falling back to `"production"`) so the recorded mode reflects the actual build
-  rather than silently lying when CI or local runs use a non-production mode.
+  active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package. If the
+  `react_version` capture command fails (for example when `node_modules` is not yet installed in `APP_DIR`), record
+  `react_version: "unknown"` and emit a warning rather than aborting the benchmark run. Capture `bundle_mode` from
+  `ENV["NODE_ENV"]` (falling back to `"production"`) so the recorded mode reflects the actual build rather than silently
+  lying when CI or local runs use a non-production mode.
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary. The
   first slice should start at one run per route. If a later implementation aggregates forward and reverse passes into a
   single route summary, record `sample_count: 2`; if it writes one summary per pass, keep each summary at
@@ -134,8 +136,10 @@ Prerequisites for the first implementation PR:
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and extend Bencher
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
   `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output. Add a `max:` keyword parameter
-  to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb`, then pass `max: max_latency` from the `bmf_collector.add`
-  call in `benchmarks/bench.rb`.
+  to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb` with a default of `nil` so existing callers stay valid, then
+  pass `max: max_latency` from the `bmf_collector.add` call in `benchmarks/bench.rb`. Updating the matching
+  `bmf_collector.add` calls in `benchmarks/bench-node-renderer.rb` (currently around lines 315 and 330) is deferred to
+  the Pro follow-on PR so the OSS first slice can land without changing Node Renderer benchmark output.
 
 Follow-on enhancements:
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -22,7 +22,7 @@ Start with a small, representative matrix before adding more routes:
 | Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation                 |
 | Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | Covers ExecJS and Node Renderer paths; server render duration requires separate instrumentation        |
 | Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Covers render-functions returning objects; payload-size capture requires tooling extension             |
-| Streaming SSR         | `stream_react_component`                  | TTFB, response end      | Pro-only path; LCP requires separate browser instrumentation such as Playwright or Lighthouse          |
+| Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB/response-end reporting is a required extension before new thresholds    |
 | RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only path; needs static route or explicit target, and payload-size capture needs tooling extension |
 | Fragment caching      | cached component hit and miss             | hit latency, miss cost  | Separates cache effectiveness from SSR cost                                                            |
 
@@ -42,7 +42,9 @@ Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is un
 Recommended Pro slice, tracked separately from the OSS implementation PR under
 [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169):
 
-1. Streaming route with a small Suspense boundary
+1. Streaming route with a small Suspense boundary. Start with the existing HTTP summary metrics, then add explicit
+   TTFB/response-end capture in the k6 artifacts, CI summary, and Bencher output before defining streaming-specific
+   thresholds. LCP remains separate browser instrumentation such as Playwright or Lighthouse.
 2. RSC payload route with representative payload size measurements. Use a static benchmark route with no required URL
    params, teach `benchmarks/bench.rb` how to provide a default component name, or run `benchmarks/k6.ts` with an explicit
    `TARGET_URL`; automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
@@ -88,7 +90,8 @@ same mode.
 ## Acceptance Criteria
 
 - The OSS suite covers client-only rendering, traditional SSR, and at least one cache path.
-- The Pro suite covers streaming SSR and RSC payload rendering where the Node Renderer is available.
+- The Pro suite covers streaming SSR and RSC payload rendering where the Node Renderer is available. Streaming-specific
+  TTFB/response-end thresholds are only introduced after those metrics are captured in artifacts and reporting.
 - Results include enough metadata to compare runs meaningfully.
 - CI behavior is advisory until noise controls are proven.
 - Regression detection favors sustained movement over single-run spikes and uses the current `p50`, `p90`, `p99`, and

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -115,11 +115,11 @@ Already in place:
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
 
-Prerequisites for the first implementation PR:
+Recommended prior work (desirable but not blocking for the first benchmark-routes PR):
 
 - Define forward-then-reverse route passes in `benchmarks/bench.rb` as two deterministic passes over the same route list:
   first in `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route
-  artifacts before using route ordering as a noise-control signal. This is large enough to land as its own prerequisite
+  artifacts before using route ordering as a noise-control signal. This is large enough to land as its own preparatory
   PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
   because it roughly doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
   `2 * (DURATION + warm-up requests * (request round-trip + warm-up sleep))` per route. With today's defaults and the
@@ -129,6 +129,9 @@ Prerequisites for the first implementation PR:
   discovery call, server startup, or server warmdown time. At the job level, a benchmark job covering about 10 routes
   should be budgeted as roughly doubling from 11-12 minutes to 22-24 minutes before additional startup or warmdown
   overhead. Recalculate the estimate if `DURATION` changes or if the `benchmarks/bench.rb` warm-up loop changes.
+
+Prerequisites for the first implementation PR (blocking — must land before or with the first benchmark-routes PR):
+
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
@@ -138,13 +141,22 @@ Prerequisites for the first implementation PR:
   rather than `Dir.pwd`. Preferred form (no global side effects):
 
   ```ruby
-  react_version_output, status = Open3.capture2(
-    "node", "-e", "console.log(require('react/package.json').version)",
-    chdir: APP_DIR
-  )
-  react_version = status.success? ? react_version_output.strip : "unknown"
-  warn "WARNING: could not capture react_version" unless status.success?
+  begin
+    react_version_output, status = Open3.capture2(
+      "node", "-e", "console.log(require('react/package.json').version)",
+      chdir: APP_DIR
+    )
+    react_version = status.success? ? react_version_output.strip : "unknown"
+    warn "WARNING: could not capture react_version" unless status.success?
+  rescue StandardError => e
+    react_version = "unknown"
+    warn "WARNING: could not capture react_version: #{e.message}"
+  end
   ```
+
+  The `rescue StandardError` wrapper is required so `Errno::ENOENT` (node not on `PATH`), `Errno::EACCES`, and similar
+  spawn failures fall through to the same `"unknown"` fallback as a non-zero exit. Without it, an implementer copying the
+  snippet verbatim will let those exceptions abort the benchmark run.
 
   Derive `renderer` from the same `PRO` switch that selects `APP_DIR`, rather than copying the example schema value.
   Reuse the existing `PRO = ENV.fetch("PRO", "false") == "true"` constant defined at the top of `benchmarks/bench.rb`
@@ -156,9 +168,9 @@ Prerequisites for the first implementation PR:
   ```
 
   Equivalent block form using `Dir.chdir(APP_DIR) do ... end` is acceptable when the surrounding code already manages
-  working directory state. If the `react_version` capture command fails (for example when `node_modules` is not yet
-  installed in `APP_DIR`), record `react_version: "unknown"` and emit a warning rather than aborting the benchmark run;
-  if `Open3.capture2` raises, use the same fallback path. Capture `bundle_mode` from `ENV["NODE_ENV"]` (falling back to
+  working directory state. The snippet above already records `react_version: "unknown"` and emits a warning for both
+  non-zero exit codes (for example when `node_modules` is not yet installed in `APP_DIR`) and `Open3.capture2`
+  exceptions; do not let either path abort the benchmark run. Capture `bundle_mode` from `ENV["NODE_ENV"]` (falling back to
   `"production"`) as a best-effort process environment label. Do not treat that value as proof of the Webpack build mode
   when prebuilt assets or explicit build flags may diverge; if exact asset-build fidelity is needed later, record it from
   the build output or a build-written metadata file.
@@ -200,12 +212,27 @@ Prerequisites for the first implementation PR:
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
   `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output. Add a `max:` keyword parameter
   to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb` with a default of `nil` so existing callers stay valid, then
-  pass `max: max_latency` from the `bmf_collector.add` call in `benchmarks/bench.rb`. Updating the matching
+  pass `max: max_latency` from the `bmf_collector.add` call in `benchmarks/bench.rb`. In `BmfCollector#to_bmf`, emit the
+  new measure as `add_measure(benchmark_entry, "max_latency", r[:max])` so the BMF key matches the `_latency` suffix
+  convention already used by `p50_latency`, `p90_latency`, and `p99_latency`. Updating the matching
   `bmf_collector.add` calls in `benchmarks/bench-node-renderer.rb` (inside the `non_rsc_tests.each` and
   `rsc_tests.each` blocks) is deferred to the Pro follow-on PR so the OSS first slice can land without changing Node
   Renderer benchmark output.
 
+  `max_latency` lands as an unthresholded advisory metric in the OSS first slice: the BMF payload includes the new key,
+  but the `run_bencher` function in `.github/workflows/benchmark.yml` is not modified, so Bencher tracks the value
+  without gating CI. Adding the corresponding threshold block is a deliberate follow-on step (see "Follow-on
+  enhancements" below) so the OSS first slice can land without absorbing a new CI gate before the baseline is
+  characterized.
+
 Follow-on enhancements:
+
+- Add a `--threshold-measure max_latency` block to `run_bencher` in `.github/workflows/benchmark.yml` so `max_latency`
+  becomes a CI gate. Mirror the existing latency-block shape (`--threshold-test t_test`,
+  `--threshold-max-sample-size $MAX_SAMPLE`, `--threshold-lower-boundary _`,
+  `--threshold-upper-boundary $BOUNDARY`) used for `p50_latency`, `p90_latency`, and `p99_latency`. Gate this on
+  observing a stable `max_latency` baseline first, since `max` is more sensitive to single-iteration spikes than the
+  percentile measures.
 
 - Add `p95` only when the k6 `--summary-trend-stats` flag, currently `med,max,p(90),p(99)` in `benchmarks/bench.rb`, the
   summary table, artifacts, and Bencher reporting can be updated together. Before adding `p95`, extract the current

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -8,30 +8,38 @@ explicitly mitigating CI runtime noise.
 The goal is to compare React on Rails rendering operations against their own historical baselines, not to produce broad
 marketing benchmarks from noisy shared runners.
 
+This plan extends the existing benchmark infrastructure in `benchmarks/bench.rb`, `benchmarks/k6.ts`, and
+`.github/workflows/benchmark.yml`; it should stay aligned with the max-rate strategy in
+`internal/planning/library-benchmarking.md`.
+
 ## Operations Matrix
 
 Start with a small, representative matrix before adding more routes:
 
-| Area                  | Operation                                 | Primary metric              | Notes                                       |
-| --------------------- | ----------------------------------------- | --------------------------- | ------------------------------------------- |
-| Client rendering      | `react_component` with `prerender: false` | mount and hydration timing  | Measures browser-side startup overhead      |
-| Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths       |
-| Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects   |
-| Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Requires Suspense-friendly examples         |
-| RSC payload rendering | `rsc_payload_react_component`             | payload bytes and duration  | Pro-only path, benchmark separately         |
-| Fragment caching      | cached component hit and miss             | hit latency and miss cost   | Separates cache effectiveness from SSR cost |
+| Area                  | Operation                                 | Primary metric              | Notes                                                                   |
+| --------------------- | ----------------------------------------- | --------------------------- | ----------------------------------------------------------------------- |
+| Client rendering      | `react_component` with `prerender: false` | mount timing                | Measures browser-side startup overhead without server markup to hydrate |
+| Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths                                   |
+| Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects                               |
+| Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Pro-only path; requires Node Renderer and Suspense-friendly examples    |
+| RSC payload rendering | `rsc_payload_react_component`             | payload bytes and duration  | Pro-only path, benchmark separately                                     |
+| Fragment caching      | cached component hit and miss             | hit latency and miss cost   | Separates cache effectiveness from SSR cost                             |
 
 ## First PR Scope
 
 The first implementation PR should add only one or two routes per category and should reuse existing dummy app examples
 where possible. Avoid building a large benchmark suite until the noise profile is understood.
 
-Recommended first slice:
+Recommended OSS first slice:
 
 1. Client-only component route
 2. Traditional SSR route with the same component and props
-3. Streaming route with a small Suspense boundary
-4. Cached SSR route with explicit hit and miss measurements
+3. Cached SSR route with explicit hit and miss measurements
+
+Recommended Pro slice, tracked separately from the OSS implementation PR:
+
+1. Streaming route with a small Suspense boundary
+2. RSC payload route with representative payload size measurements
 
 ## Noise Controls
 
@@ -40,7 +48,10 @@ Use these controls before treating results as regressions:
 - Warm each route before measuring.
 - Run alternating route order instead of grouped route order so cache and process state are less biased.
 - Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
-- Track median and p95, not only averages.
+- Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md` and surface the existing
+  k6 latency stats (`p50`, `p90`, `p99`, and `max`) beside RPS instead of relying only on averages.
+- Treat new percentile requirements as result-collection work: update `benchmarks/bench.rb`, the exported summary shape,
+  and the workflow reporting before adding metrics that the current runner does not publish.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
@@ -59,8 +70,16 @@ same mode.
 
 ## Acceptance Criteria
 
-- The expanded suite covers client-only rendering, traditional SSR, streaming SSR, and at least one cache path.
+- The OSS suite covers client-only rendering, traditional SSR, and at least one cache path.
+- The Pro suite covers streaming SSR and RSC payload rendering where the Node Renderer is available.
 - Results include enough metadata to compare runs meaningfully.
 - CI behavior is advisory until noise controls are proven.
 - Regression detection favors sustained movement over single-run spikes.
 - Documentation tells contributors which benchmark to run for each rendering area.
+
+## See Also
+
+- `benchmarks/bench.rb`
+- `benchmarks/k6.ts`
+- `.github/workflows/benchmark.yml`
+- `internal/planning/library-benchmarking.md`

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -51,24 +51,47 @@ Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is un
 The cached SSR slice should define separate cache-hit and cache-miss benchmark paths before comparing results. Use a
 dedicated cache adapter and namespace for benchmark routes, such as
 `ActiveSupport::Cache::FileStore.new(Rails.root.join("tmp/benchmark_cache").to_s)`, instead of the app's default store.
-The miss path should clear only that benchmark cache namespace before measurement, and the hit path should clear that
-namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For the dedicated
-`FileStore`, clear the exact store root: use `FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))` from Rails-loaded
-code, or `FileUtils.rm_rf(File.join(APP_DIR, "tmp/benchmark_cache"))` from `benchmarks/bench.rb` or another plain Ruby
-wrapper where `Rails.root` is unavailable. `APP_DIR` in `benchmarks/bench.rb` is the relative path
-`react_on_rails/spec/dummy` (or `react_on_rails_pro/spec/dummy` with `PRO=true`), so this `File.join` call only resolves
-correctly when bench.rb is invoked from the repo root. The benchmark workflow already runs from the repo root, but the
-implementation PR must either document that working-directory assumption near the cache-clear call or anchor the path
-explicitly, for example
-`FileUtils.rm_rf(File.expand_path(File.join(APP_DIR, "tmp/benchmark_cache"), File.join(__dir__, "..")))`, so a future
-runner configuration change cannot silently skip the cache clear. Do not clear `tmp/cache/assets` or the app's default
-cache store. Avoid
-`Rails.cache.clear` on the application cache. Avoid relying on a shared Redis instance, environment-default
-`:null_store`/`:memory_store` behavior, or manual cache state. To avoid mixing cold Rails-process noise into cache-miss
-measurements, warm the Rails process with a route that does not populate the benchmark cache, then clear the dedicated
-benchmark cache immediately before the cache-miss k6 measurement. For cache-hit measurements, clear the dedicated
-benchmark cache, send one explicit cache-prime request to the measured route, then run the existing per-route k6 warm-up
-and measurement against the primed route.
+
+**Clearing the dedicated cache store.** Target the exact store root for the dedicated `FileStore`. From Rails-loaded
+code, use `FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))`. From `benchmarks/bench.rb` or another plain Ruby
+wrapper where `Rails.root` is unavailable, use `FileUtils.rm_rf(File.join(APP_DIR, "tmp/benchmark_cache"))`. `APP_DIR`
+in `benchmarks/bench.rb` is the relative path `react_on_rails/spec/dummy` (or `react_on_rails_pro/spec/dummy` with
+`PRO=true`), so this `File.join` call only resolves correctly when bench.rb is invoked from the repo root. The
+benchmark workflow already runs from the repo root, but the implementation PR must either document that
+working-directory assumption near the cache-clear call or anchor the path explicitly, so a future runner-configuration
+change cannot silently skip the cache clear. The anchored form below must live in `benchmarks/bench.rb` itself, where
+`__dir__` resolves to `benchmarks/` and `File.join(__dir__, "..")` resolves to the repo root:
+
+```ruby
+# In benchmarks/bench.rb (__dir__ is benchmarks/, File.join(__dir__, "..") is the repo root):
+FileUtils.rm_rf(File.expand_path(File.join(APP_DIR, "tmp/benchmark_cache"), File.join(__dir__, "..")))
+```
+
+If this logic is later extracted into a helper file (for example `benchmarks/lib/cache_helpers.rb`), `__dir__` becomes
+the helper's directory and `File.join(__dir__, "..")` resolves to `benchmarks/` — one directory level short of the repo
+root, silently skipping the cache clear. In that case, anchor the path from `__FILE__` in `bench.rb` and pass the
+resolved root into the helper as an argument rather than calling `__dir__` inside the helper.
+
+**Caches to leave alone.** Do not clear `tmp/cache/assets` or the app's default cache store. Avoid `Rails.cache.clear`
+on the application cache. Avoid relying on a shared Redis instance, environment-default `:null_store`/`:memory_store`
+behavior, or manual cache state.
+
+**Cache-miss measurement.** To avoid mixing cold Rails-process noise into the measurement:
+
+1. Warm the Rails process against a route that does not populate the benchmark cache.
+2. Clear the dedicated benchmark cache (using one of the `FileUtils.rm_rf` forms above) immediately before the k6
+   measurement.
+3. Run the k6 measurement against the route under test.
+
+Cache-miss routes are the explicit exception to the per-route k6 warm-up loop described under Noise Controls; otherwise
+the 10 pre-requests would populate the fragment cache for the route before measurement begins.
+
+**Cache-hit measurement.**
+
+1. Clear the dedicated benchmark cache (using one of the `FileUtils.rm_rf` forms above).
+2. Send one explicit cache-prime request to the measured route so the fragment is written to the dedicated cache.
+3. Run the existing per-route k6 warm-up loop. The warm-up does not clear the cache, so the fragment stays primed.
+4. Run the k6 measurement against the primed route.
 
 ### Pro Follow-Up Slice
 
@@ -216,10 +239,11 @@ Prerequisites for the first implementation PR (blocking — must land before or 
   `add_to_summary`. The Pro PR only needs to pass `max: max_latency` to those two existing `bmf_collector.add` calls;
   no Vegeta extraction or summary-row changes are required.
 
-  While editing `BmfCollector` to thread `max_latency`, also fix the stale comment at `benchmarks/lib/bmf_helpers.rb`
-  line 15, which currently lists `p50_latency_ms, p90_latency_ms, p99_latency_ms`. The actual measure keys emitted by
-  `to_bmf` are `p50_latency`, `p90_latency`, and `p99_latency` (no `_ms` suffix); leaving the comment as-is invites a
-  future implementer to add `max_latency_ms` by analogy and diverge from the Bencher measure keys.
+  While editing `BmfCollector` to thread `max_latency`, also fix the stale comment near the top of
+  `benchmarks/lib/bmf_helpers.rb` that currently reads `p50_latency_ms, p90_latency_ms, p99_latency_ms`. The actual
+  measure keys emitted by `to_bmf` are `p50_latency`, `p90_latency`, and `p99_latency` (no `_ms` suffix); leaving the
+  comment as-is invites a future implementer to add `max_latency_ms` by analogy and diverge from the Bencher measure
+  keys.
 
   `max_latency` lands as an unthresholded advisory metric in the OSS first slice: the BMF payload includes the new key,
   but the `run_bencher` function in `.github/workflows/benchmark.yml` is not modified, so Bencher tracks the value

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -24,7 +24,7 @@ Start with a small, representative matrix before adding more routes:
 | Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | OSS first slice uses ExecJS; Pro Node Renderer follow-up uses `benchmarks/bench-node-renderer.rb`   |
 | Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Deferred; see First PR Scope. Payload-size capture requires tooling extension                       |
 | Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB/response-end reporting is a required extension before new thresholds |
-| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only endpoint throughput and payload-size path; not a streaming TTFB target                     |
+| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Use a static/default route because route discovery skips required params                            |
 | Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state      |
 
 Here `p50` maps to k6's `med` stat and the `p50_latency` Bencher Metric Format measure.
@@ -44,8 +44,10 @@ Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is un
 define separate cache-hit and cache-miss benchmark paths before comparing results. Use a dedicated cache adapter and
 namespace for benchmark routes, such as `ActiveSupport::Cache::FileStore.new("tmp/benchmark_cache")`, instead of the
 app's default store. The miss path should clear only that benchmark cache namespace before measurement, and the hit path
-should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. Avoid
-relying on a shared Redis instance, environment-default `:null_store`/`:memory_store` behavior, or manual cache state.
+should clear that namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For
+the dedicated `FileStore`, clear the namespace with `FileUtils.rm_rf("tmp/benchmark_cache")`; avoid `Rails.cache.clear`
+on the application cache. Avoid relying on a shared Redis instance, environment-default `:null_store`/`:memory_store`
+behavior, or manual cache state.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -83,22 +85,26 @@ Prerequisites for the first implementation PR:
   using route ordering as a noise-control signal. This is large enough to land as its own prerequisite PR, and the first
   benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally because it roughly
   doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about `2 * (DURATION + 5 seconds)` per
-  route with the current warm-up, assuming the default `DURATION=30s`. Recalculate the estimate when overriding
-  `DURATION`.
+  route with the current warm-up, assuming the default `DURATION=30s`. This estimate does not include the per-job
+  `bundle exec rails routes` discovery call, server startup, or server warmdown time. Recalculate the estimate when
+  overriding `DURATION`.
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
   `node --version` for `node_version`, and the installed React package metadata for `react_version`.
+  Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary; the
+  first slice should start at one run per route, and alternating route order increases it to two when both passes are
+  merged into one route summary.
 
   Use these metadata keys as the minimum schema:
 
   ```json
   {
-    "ruby_version": "3.3.0",
-    "node_version": "22.0.0",
-    "react_version": "18.3.0",
-    "renderer": "execjs",
-    "runner_type": "ubuntu-22.04-8-core",
+    "ruby_version": "<ruby --version>",
+    "node_version": "<node --version>",
+    "react_version": "<installed react package version>",
+    "renderer": "<execjs|node_renderer>",
+    "runner_type": "<github runner label>",
     "bundle_mode": "production",
     "sample_count": 1
   }
@@ -127,7 +133,7 @@ If a benchmark requires generated assets, the command should build those assets 
 same mode.
 
 Until benchmark-specific contributor docs exist, put this checklist in each benchmark implementation PR description. The
-implementation work should then anchor it in `benchmarks/README.md` or a benchmark-specific pull request template so
+implementation work should then create `benchmarks/README.md` or a benchmark-specific pull request template so
 reviewers have one stable compliance checklist.
 
 ## Acceptance Criteria

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -92,13 +92,15 @@ Prerequisites for the first implementation PR:
   PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
   because it roughly
   doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
-  `2 * (DURATION + WARMUP_REQUESTS * WARMUP_SLEEP_S)` per route (currently `2 * (30s + 10 * 0.5s)` = 70 seconds with
-  defaults). This estimate does not include the per-job `bundle exec rails routes` discovery call, server startup, or
-  server warmdown time. Recalculate the estimate when overriding `DURATION`, `WARMUP_REQUESTS`, or `WARMUP_SLEEP_S`.
+  `2 * (DURATION + warm-up requests * warm-up sleep)` per route. With today's defaults and the hard-coded warm-up loop in
+  `benchmarks/bench.rb`, that is `2 * (30s + 10 * 0.5s)` = 70 seconds. This estimate does not include the per-job
+  `bundle exec rails routes` discovery call, server startup, or server warmdown time. Recalculate the estimate if
+  `DURATION` changes or if the `benchmarks/bench.rb` warm-up loop changes.
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
-  `node --version` for `node_version`, and the installed React package metadata for `react_version`.
+  `node --version` for `node_version`, and run `node -e "console.log(require('react/package.json').version)"` from the
+  active `APP_DIR` for `react_version` so OSS and Pro dummy apps report their own installed React package.
   Define `sample_count` as the number of completed k6 measurement runs contributing to the route's reported summary; the
   first slice should start at one run per route, and alternating route order increases it to two when both passes are
   merged into one route summary.
@@ -109,9 +111,9 @@ Prerequisites for the first implementation PR:
   {
     "ruby_version": "<output of: ruby --version>",
     "node_version": "<output of: node --version>",
-    "react_version": "<installed react package version>",
-    "renderer": "execjs",
-    "runner_type": "ubuntu-latest",
+    "react_version": "<output of: node -e \"console.log(require('react/package.json').version)\" from APP_DIR>",
+    "renderer": "<node_renderer when PRO=true, otherwise execjs>",
+    "runner_type": "<RUNNER_OS/RUNNER_ARCH when available, otherwise local platform>",
     "bundle_mode": "production",
     "sample_count": 1
   }
@@ -120,8 +122,8 @@ Prerequisites for the first implementation PR:
 - Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and extend Bencher
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
   `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output. Add a `max:` keyword parameter
-  to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb`, then pass `max_latency:` from the `bmf_collector.add` call
-  in `benchmarks/bench.rb`.
+  to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb`, then pass `max: max_latency` from the `bmf_collector.add`
+  call in `benchmarks/bench.rb`.
 
 Follow-on enhancements:
 

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -27,7 +27,9 @@ Start with a small, representative matrix before adding more routes:
 | RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Use a static/default route because route discovery skips required params                                                                          |
 | Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state                                                    |
 
-Here `p50` maps to k6's `med` stat and the `p50_latency` Bencher Metric Format measure.
+Here `p50` maps to k6's `med` stat and the `p50_latency` Bencher Metric Format measure. `p90`, `p99`, and `max`
+keep their k6 names (`p(90)`, `p(99)`, `max`) and map to the `p90_latency`, `p99_latency`, and `max_latency` Bencher
+measures — only `med`/`p50` is renamed in the mapping.
 
 ## First PR Scope
 
@@ -115,28 +117,14 @@ Already in place:
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
 
-Recommended prior work (desirable but not blocking for the first benchmark-routes PR):
-
-- Define forward-then-reverse route passes in `benchmarks/bench.rb` as two deterministic passes over the same route list:
-  first in `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route
-  artifacts before using route ordering as a noise-control signal. This is large enough to land as its own preparatory
-  PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
-  because it roughly doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
-  `2 * (DURATION + warm-up requests * (request round-trip + warm-up sleep))` per route. With today's defaults and the
-  hard-coded warm-up loop in `benchmarks/bench.rb`, the sleep-only lower bound is `2 * (30s + 10 * 0.5s)` = 70 seconds;
-  for SSR routes today the warm-up adds another roughly 1-2 seconds per route, putting the real per-route budget closer
-  to 72-80 seconds before any server overhead. This estimate does not include the per-job `bundle exec rails routes`
-  discovery call, server startup, or server warmdown time. At the job level, a benchmark job covering about 10 routes
-  should be budgeted as roughly doubling from 11-12 minutes to 22-24 minutes before additional startup or warmdown
-  overhead. Recalculate the estimate if `DURATION` changes or if the `benchmarks/bench.rb` warm-up loop changes.
-
 Prerequisites for the first implementation PR (blocking — must land before or with the first benchmark-routes PR):
 
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
-  `node --version` for `node_version`, populate `runner_type` from `ENV["RUNNER_OS"]` and `ENV["RUNNER_ARCH"]`, and
-  capture `react_version` by invoking Node from `APP_DIR` so OSS and Pro dummy apps report their own installed React
+  `node --version` for `node_version`, populate `runner_type` from `ENV["RUNNER_OS"]` and `ENV["RUNNER_ARCH"]` (both
+  set by GitHub Actions, so local runs fall back to `"unknown"` via the snippet below), and capture `react_version`
+  by invoking Node from `APP_DIR` so OSS and Pro dummy apps report their own installed React
   package. The implementation PR must use a chdir-aware Ruby call so `require()` resolves against `APP_DIR/node_modules`
   rather than `Dir.pwd`. Preferred form (no global side effects):
 
@@ -212,9 +200,12 @@ Prerequisites for the first implementation PR (blocking — must land before or 
   BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
   `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output. Add a `max:` keyword parameter
   to `BmfCollector#add` in `benchmarks/lib/bmf_helpers.rb` with a default of `nil` so existing callers stay valid, then
-  pass `max: max_latency` from the `bmf_collector.add` call in `benchmarks/bench.rb`. In `BmfCollector#to_bmf`, emit the
-  new measure as `add_measure(benchmark_entry, "max_latency", r[:max])` so the BMF key matches the `_latency` suffix
-  convention already used by `p50_latency`, `p90_latency`, and `p99_latency`. Updating the matching
+  pass `max: max_latency` from the `bmf_collector.add` call in `benchmarks/bench.rb`. Inside `add`, also store the
+  new keyword on the appended `@results` hash by adding `max: max` alongside the existing `name`, `rps`, `p50`,
+  `p90`, `p99`, and `failed_pct` keys; without this step `r[:max]` is always `nil` in `to_bmf` and `add_measure`
+  silently skips the measure. In `BmfCollector#to_bmf`, emit the new measure as
+  `add_measure(benchmark_entry, "max_latency", r[:max])` so the BMF key matches the `_latency` suffix convention
+  already used by `p50_latency`, `p90_latency`, and `p99_latency`. Updating the matching
   `bmf_collector.add` calls in `benchmarks/bench-node-renderer.rb` (inside the `non_rsc_tests.each` and
   `rsc_tests.each` blocks) is deferred to the Pro follow-on PR so the OSS first slice can land without changing Node
   Renderer benchmark output.
@@ -224,6 +215,29 @@ Prerequisites for the first implementation PR (blocking — must land before or 
   without gating CI. Adding the corresponding threshold block is a deliberate follow-on step (see "Follow-on
   enhancements" below) so the OSS first slice can land without absorbing a new CI gate before the baseline is
   characterized.
+
+- Extract the current k6 `--summary-trend-stats` string (`med,max,p(90),p(99)` in `benchmarks/bench.rb`) into a named
+  constant such as `K6_TREND_STATS = "med,max,p(90),p(99)"`, defined alongside `DURATION` in
+  `benchmarks/lib/benchmark_config.rb`, and reference it from the existing `--summary-trend-stats` invocation in
+  `benchmarks/bench.rb`. Landing the constant in the first implementation PR — before any follow-on PR adds `p95` or
+  otherwise extends the trend-stats column set — keeps the percentile list in one place rather than scattered across
+  the bench script, summary table, artifacts, and Bencher reporting.
+
+Recommended prior work (desirable but not blocking for the first benchmark-routes PR):
+
+- Define forward-then-reverse route passes in `benchmarks/bench.rb` as two deterministic passes over the same route list:
+  first in `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route
+  artifacts before using route ordering as a noise-control signal. This is large enough to land as its own preparatory
+  PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
+  because it roughly doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
+  `2 * (DURATION + warm-up requests * (request round-trip + warm-up sleep))` per route. With today's defaults and the
+  hard-coded warm-up loop in `benchmarks/bench.rb`, the sleep-only lower bound is
+  `2 * (DURATION + 10 * 0.5s) = 2 * (30s + 10 * 0.5s) = 70 seconds` at the current `DURATION` default of `30s`;
+  for SSR routes today the warm-up adds another roughly 1-2 seconds per route, putting the real per-route budget closer
+  to 72-80 seconds before any server overhead. This estimate does not include the per-job `bundle exec rails routes`
+  discovery call, server startup, or server warmdown time. At the job level, a benchmark job covering about 10 routes
+  should be budgeted as roughly doubling from 11-12 minutes to 22-24 minutes before additional startup or warmdown
+  overhead. Recalculate the estimate if `DURATION` changes or if the `benchmarks/bench.rb` warm-up loop changes.
 
 Follow-on enhancements:
 
@@ -235,9 +249,8 @@ Follow-on enhancements:
   percentile measures.
 
 - Add `p95` only when the k6 `--summary-trend-stats` flag, currently `med,max,p(90),p(99)` in `benchmarks/bench.rb`, the
-  summary table, artifacts, and Bencher reporting can be updated together. Before adding `p95`, extract the current
-  summary-trend-stats string to a named constant, such as
-  `K6_TREND_STATS = "med,max,p(90),p(99)"`, so the percentile set is changed in one place.
+  summary table, artifacts, and Bencher reporting can be updated together. Update the `K6_TREND_STATS` constant
+  (introduced as a prerequisite of the first implementation PR) so the percentile set is changed in one place.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 
 ## Local Verification Before CI

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -19,7 +19,7 @@ Start with a small, representative matrix before adding more routes:
 
 | Area                  | Operation                                 | Primary metric              | Notes                                                                                    |
 | --------------------- | ----------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
-| Client rendering      | `react_component` with `prerender: false` | route RPS and HTTP latency  | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation   |
+| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max     | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation   |
 | Traditional SSR       | `react_component` with `prerender: true`  | server render duration      | Covers ExecJS and Node Renderer paths                                                    |
 | Hash SSR              | `react_component_hash`                    | render duration and payload | Covers render-functions returning objects                                                |
 | Streaming SSR         | `stream_react_component`                  | TTFB, response end, LCP     | Pro-only path; requires Node Renderer and Suspense-friendly examples                     |
@@ -44,11 +44,15 @@ Recommended Pro slice, tracked separately from the OSS implementation PR:
    params, teach `benchmarks/bench.rb` how to provide a default component name, or run `benchmarks/k6.ts` with an explicit
    `TARGET_URL`; automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
 
+Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR. Use
+`benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is extended to cover
+full Rails streaming behavior.
+
 ## Noise Controls
 
 Use these controls before treating results as regressions:
 
-- Warm each route before measuring.
+- Keep the existing per-route warm-up before k6 measurement and expand it if routes need more stable startup behavior.
 - Implement alternating route order in `benchmarks/bench.rb`; routes currently run in `rails routes` order, so this is a
   prerequisite before using route ordering as a noise-control signal.
 - Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
@@ -79,7 +83,8 @@ same mode.
 - The Pro suite covers streaming SSR and RSC payload rendering where the Node Renderer is available.
 - Results include enough metadata to compare runs meaningfully.
 - CI behavior is advisory until noise controls are proven.
-- Regression detection favors sustained movement over single-run spikes.
+- Regression detection favors sustained movement over single-run spikes and uses the current `p50`, `p90`, `p99`, and
+  `max` metrics until `p95` is added explicitly.
 - Documentation tells contributors which benchmark to run for each rendering area.
 
 ## See Also

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -18,14 +18,14 @@ existing Vegeta HTTP/2 Cleartext benchmark rather than duplicating that transpor
 
 Start with a small, representative matrix before adding more routes:
 
-| Area                  | Operation                                 | Primary metric          | Notes                                                                                               |
-| --------------------- | ----------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- |
-| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation              |
-| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | OSS first slice uses ExecJS; Pro Node Renderer follow-up uses `benchmarks/bench-node-renderer.rb`   |
-| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Deferred; see First PR Scope. Payload-size capture requires tooling extension                       |
-| Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB/response-end reporting is a required extension before new thresholds |
-| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Use a static/default route because route discovery skips required params                            |
-| Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state      |
+| Area                  | Operation                                 | Primary metric          | Notes                                                                                                                                             |
+| --------------------- | ----------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation                                                            |
+| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | OSS first slice uses ExecJS; Pro Node Renderer follow-up uses `benchmarks/bench-node-renderer.rb`                                                 |
+| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Deferred; see First PR Scope. Payload-size capture requires tooling extension                                                                     |
+| Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB (`http_req_waiting`) and response-end (`http_req_duration`) capture in k6 artifacts required before new thresholds |
+| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Use a static/default route because route discovery skips required params                                                                          |
+| Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state                                                    |
 
 Here `p50` maps to k6's `med` stat and the `p50_latency` Bencher Metric Format measure.
 
@@ -48,7 +48,9 @@ should clear that namespace, make one warm-up request to prime the fragment, the
 the dedicated `FileStore`, clear the namespace with `FileUtils.rm_rf("tmp/benchmark_cache")`; avoid `Rails.cache.clear`
 on the application cache. Avoid relying on a shared Redis instance, environment-default `:null_store`/`:memory_store`
 behavior, or manual cache state. This explicit cache-prime request is an additional step before the existing per-route
-k6 warm-up in [Noise Controls](#noise-controls); it does not replace that 10-request warm-up phase.
+k6 warm-up in [Noise Controls](#noise-controls); it does not replace that 10-request warm-up phase for cache-hit runs.
+The cache-miss path must either skip the generic per-route warm-up or clear the dedicated benchmark cache again after
+warm-up and immediately before k6 measurement, so measurement starts from a cold cache state.
 
 Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
 OSS first slice or in a dedicated follow-up PR:
@@ -57,9 +59,11 @@ OSS first slice or in a dedicated follow-up PR:
    TTFB/response-end capture in the k6 artifacts, CI summary, and Bencher output before defining streaming-specific
    thresholds. LCP remains separate browser instrumentation such as Playwright or Lighthouse.
 2. RSC payload route with representative payload size measurements. Treat this as endpoint throughput and payload-size
-   coverage rather than streaming TTFB measurement. Use a static benchmark route with no required URL params, teach
-   `benchmarks/bench.rb` how to provide a default component name, or run `benchmarks/k6.ts` with an explicit `TARGET_URL`;
-   automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
+   coverage rather than streaming TTFB measurement. Use a static benchmark route with no required URL params. If the
+   dummy app has no parameter-free RSC route, run `benchmarks/k6.ts` with an explicit `TARGET_URL`; alternatively,
+   introduce an `RSC_BENCHMARK_COMPONENT` environment variable defaulting to a known component name so
+   `benchmarks/bench.rb` can construct the URL without relying on route discovery. Automatic route discovery currently
+   skips required-parameter routes such as `/rsc_payload/:component_name`.
 
 Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
 checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
@@ -87,10 +91,10 @@ Prerequisites for the first implementation PR:
   artifacts before using route ordering as a noise-control signal. This is large enough to land as its own prerequisite
   PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
   because it roughly
-  doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about `2 * (DURATION + 5 seconds)` per
-  route with the current warm-up, assuming the default `DURATION=30s`. This estimate does not include the per-job
-  `bundle exec rails routes` discovery call, server startup, or server warmdown time. Recalculate the estimate when
-  overriding `DURATION`.
+  doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
+  `2 * (DURATION + WARMUP_REQUESTS * WARMUP_SLEEP_S)` per route (currently `2 * (30s + 10 * 0.5s)` = 70 seconds with
+  defaults). This estimate does not include the per-job `bundle exec rails routes` discovery call, server startup, or
+  server warmdown time. Recalculate the estimate when overriding `DURATION`, `WARMUP_REQUESTS`, or `WARMUP_SLEEP_S`.
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
@@ -103,9 +107,9 @@ Prerequisites for the first implementation PR:
 
   ```json
   {
-    "ruby_version": "ruby 3.3.0 (2023-12-25 revision ...) [x86_64-linux]",
-    "node_version": "v20.11.0",
-    "react_version": "18.3.1",
+    "ruby_version": "<output of: ruby --version>",
+    "node_version": "<output of: node --version>",
+    "react_version": "<installed react package version>",
     "renderer": "execjs",
     "runner_type": "ubuntu-latest",
     "bundle_mode": "production",

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -10,21 +10,22 @@ marketing benchmarks from noisy shared runners.
 
 This plan extends the existing benchmark infrastructure in `benchmarks/bench.rb`, `benchmarks/k6.ts`,
 `benchmarks/bench-node-renderer.rb`, and `.github/workflows/benchmark.yml`; it should stay aligned with the max-rate
-strategy in `internal/planning/library-benchmarking.md`. Pro Node Renderer paths should build on the existing Vegeta
-HTTP/2 Cleartext benchmark rather than duplicating that transport setup in k6.
+strategy in `internal/planning/library-benchmarking.md`. Rails HTTP routes, including Pro streaming SSR, should continue
+through `benchmarks/bench.rb` and `benchmarks/k6.ts`. Direct Pro Node Renderer transport coverage should build on the
+existing Vegeta HTTP/2 Cleartext benchmark rather than duplicating that transport setup in k6.
 
 ## Operations Matrix
 
 Start with a small, representative matrix before adding more routes:
 
-| Area                  | Operation                                 | Primary metric          | Notes                                                                                                  |
-| --------------------- | ----------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
-| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation                 |
-| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | Covers ExecJS and Node Renderer paths; server render duration requires separate instrumentation        |
-| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Covers render-functions returning objects; payload-size capture requires tooling extension             |
-| Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB/response-end reporting is a required extension before new thresholds    |
-| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only path; needs static route or explicit target, and payload-size capture needs tooling extension |
-| Fragment caching      | cached component hit and miss             | hit latency, miss cost  | Separates cache effectiveness from SSR cost                                                            |
+| Area                  | Operation                                 | Primary metric          | Notes                                                                                               |
+| --------------------- | ----------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- |
+| Client rendering      | `react_component` with `prerender: false` | RPS, p50, p90, p99, max | Uses existing HTTP benchmark output; browser mount timing is follow-up instrumentation              |
+| Traditional SSR       | `react_component` with `prerender: true`  | RPS, p50, p90, p99, max | Covers ExecJS and Node Renderer paths; server render duration requires separate instrumentation     |
+| Hash SSR              | `react_component_hash`                    | RPS, p50, p90, p99, max | Covers render-functions returning objects; payload-size capture requires tooling extension          |
+| Streaming SSR         | `stream_react_component`                  | RPS, p50, p90, p99, max | Pro-only Rails HTTP path; TTFB/response-end reporting is a required extension before new thresholds |
+| RSC payload rendering | `rsc_payload_react_component`             | RPS, p50, p90, p99, max | Pro-only endpoint throughput and payload-size path; not a streaming TTFB target                     |
+| Fragment caching      | `react_component` with `cache: true`      | RPS, p50, p90, p99, max | Requires separate primed-hit and busted-miss paths or setup steps; k6 cannot infer cache state      |
 
 ## First PR Scope
 
@@ -37,21 +38,24 @@ Recommended OSS first slice for [Issue 2169](https://github.com/shakacode/react_
 2. Traditional SSR route with the same component and props
 3. Cached SSR route with explicit hit and miss measurements
 
-Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood.
+Hash SSR is deferred to a follow-on PR after the initial OSS noise profile is understood. The cached SSR slice should
+define separate cache-hit and cache-miss benchmark paths, or a deterministic priming and busting step, before comparing
+results.
 
-Recommended Pro slice, tracked separately from the OSS implementation PR under
-[Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169):
+Recommended Pro slice for [Issue 2169](https://github.com/shakacode/react_on_rails/issues/2169), implemented after the
+OSS first slice or in a dedicated follow-up PR:
 
 1. Streaming route with a small Suspense boundary. Start with the existing HTTP summary metrics, then add explicit
    TTFB/response-end capture in the k6 artifacts, CI summary, and Bencher output before defining streaming-specific
    thresholds. LCP remains separate browser instrumentation such as Playwright or Lighthouse.
-2. RSC payload route with representative payload size measurements. Use a static benchmark route with no required URL
-   params, teach `benchmarks/bench.rb` how to provide a default component name, or run `benchmarks/k6.ts` with an explicit
-   `TARGET_URL`; automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
+2. RSC payload route with representative payload size measurements. Treat this as endpoint throughput and payload-size
+   coverage rather than streaming TTFB measurement. Use a static benchmark route with no required URL params, teach
+   `benchmarks/bench.rb` how to provide a default component name, or run `benchmarks/k6.ts` with an explicit `TARGET_URL`;
+   automatic route discovery currently skips required-parameter routes such as `/rsc_payload/:component_name`.
 
-Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR. Use
-`benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is extended to cover
-full Rails streaming behavior.
+Use `benchmarks/bench.rb`/`benchmarks/k6.ts` for Rails HTTP routes such as streaming SSR and static RSC payload endpoint
+checks. Use `benchmarks/bench-node-renderer.rb` for direct Pro Node Renderer transport coverage unless that script is
+extended to cover full Rails streaming behavior.
 
 ## Noise Controls
 
@@ -59,20 +63,26 @@ Use these controls before treating results as regressions.
 
 Already in place:
 
-- Keep the existing per-route warm-up before k6 measurement and expand it if routes need more stable startup behavior.
+- Keep the existing per-route warm-up before k6 measurement: 10 sequential requests with 0.5 seconds between requests, or
+  about 5 seconds per route. Expand it if routes, especially streaming routes, need more stable startup behavior.
 - Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
 
-To implement as part of the benchmark expansion:
+Prerequisites for the first implementation PR:
 
-- Add alternating route order in `benchmarks/bench.rb`; routes currently run in `rails routes` order, so this is a
-  prerequisite before using route ordering as a noise-control signal.
-- Record sample count, runner type, Ruby version, Node version, React version, and bundle mode with every result.
-- Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and make sure CI
-  summaries, artifacts, and Bencher reporting surface those values consistently. The current runner intentionally uses
-  `p90` and `p99` instead of `p95`; adding `p95` should update the k6 trend stats, summary table, artifacts, and Bencher
-  reporting together.
+- Define alternating route order in `benchmarks/bench.rb` as two deterministic passes over the same route list: first in
+  `rails routes` order, then in reverse order in the same job. Record the pass order with the per-route artifacts before
+  using route ordering as a noise-control signal.
+- Record sample count, runner type, Ruby version, Node version, React version, and bundle mode in a `metadata.json`
+  artifact and mirror the key fields in the `summary.txt` header.
+- Preserve the existing `benchmarks/bench.rb` summary metrics (`RPS`, `p50`, `p90`, `p99`, and `max`) and extend Bencher
+  BMF reporting to include `max_latency` alongside the existing `rps`, `p50_latency`, `p90_latency`, `p99_latency`, and
+  `failed_pct` measures. Today `max` appears in `summary.txt` but not in the BMF output.
+
+Follow-on enhancements:
+
+- Add `p95` only when the k6 trend stats, summary table, artifacts, and Bencher reporting can be updated together.
 - Require repeated or overlapping alerts before opening an issue or failing CI.
 
 ## Local Verification Before CI

--- a/internal/planning/performance-test-expansion-plan.md
+++ b/internal/planning/performance-test-expansion-plan.md
@@ -53,7 +53,14 @@ The miss path should clear only that benchmark cache namespace before measuremen
 namespace, make one warm-up request to prime the fragment, then run k6 against the primed route. For the dedicated
 `FileStore`, clear the exact store root: use `FileUtils.rm_rf(Rails.root.join("tmp/benchmark_cache"))` from Rails-loaded
 code, or `FileUtils.rm_rf(File.join(APP_DIR, "tmp/benchmark_cache"))` from `benchmarks/bench.rb` or another plain Ruby
-wrapper where `Rails.root` is unavailable. Do not clear `tmp/cache/assets` or the app's default cache store. Avoid
+wrapper where `Rails.root` is unavailable. `APP_DIR` in `benchmarks/bench.rb` is the relative path
+`react_on_rails/spec/dummy` (or `react_on_rails_pro/spec/dummy` with `PRO=true`), so this `File.join` call only resolves
+correctly when bench.rb is invoked from the repo root. The benchmark workflow already runs from the repo root, but the
+implementation PR must either document that working-directory assumption near the cache-clear call or anchor the path
+explicitly, for example
+`FileUtils.rm_rf(File.expand_path(File.join(APP_DIR, "tmp/benchmark_cache"), File.join(__dir__, "..")))`, so a future
+runner configuration change cannot silently skip the cache clear. Do not clear `tmp/cache/assets` or the app's default
+cache store. Avoid
 `Rails.cache.clear` on the application cache. Avoid relying on a shared Redis instance, environment-default
 `:null_store`/`:memory_store` behavior, or manual cache state. To avoid mixing cold Rails-process noise into cache-miss
 measurements, warm the Rails process with a route that does not populate the benchmark cache, then clear the dedicated
@@ -100,8 +107,10 @@ Use these controls before treating results as regressions.
 
 Already in place:
 
-- Keep the existing per-route warm-up before k6 measurement: 10 sequential requests with 0.5 seconds between requests, or
-  about 5 seconds per route. Expand it if routes, especially streaming routes, need more stable startup behavior.
+- Keep the existing per-route warm-up before k6 measurement: 10 sequential requests with 0.5 seconds between requests.
+  Each iteration is request round-trip plus 0.5 seconds of sleep, so the warm-up takes a lower bound of 5 seconds per
+  route plus the actual request time, which is on the order of 5-6 seconds for SSR routes today. Expand it if routes,
+  especially streaming routes, need more stable startup behavior.
 - Keep the current max-rate throughput baseline from `internal/planning/library-benchmarking.md`.
 - Keep hard CI gates disabled until the benchmark gate tuning in
   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) has a stable baseline.
@@ -113,12 +122,13 @@ Prerequisites for the first implementation PR:
   artifacts before using route ordering as a noise-control signal. This is large enough to land as its own prerequisite
   PR, and the first benchmark-routes PR can defer it if the route-order work blocks progress. Budget it intentionally
   because it roughly doubles route runtime: each route gets two k6 runs plus two warm-up phases, or about
-  `2 * (DURATION + warm-up requests * warm-up sleep)` per route. With today's defaults and the hard-coded warm-up loop in
-  `benchmarks/bench.rb`, that is `2 * (30s + 10 * 0.5s)` = 70 seconds. This estimate does not include the per-job
-  `bundle exec rails routes` discovery call, server startup, or server warmdown time. At the job level, a benchmark job
-  covering about 10 routes should be budgeted as roughly doubling from 11-12 minutes to 22-24 minutes before additional
-  startup or warmdown overhead. Recalculate the estimate if `DURATION` changes or if the `benchmarks/bench.rb` warm-up
-  loop changes.
+  `2 * (DURATION + warm-up requests * (request round-trip + warm-up sleep))` per route. With today's defaults and the
+  hard-coded warm-up loop in `benchmarks/bench.rb`, the sleep-only lower bound is `2 * (30s + 10 * 0.5s)` = 70 seconds;
+  for SSR routes today the warm-up adds another roughly 1-2 seconds per route, putting the real per-route budget closer
+  to 72-80 seconds before any server overhead. This estimate does not include the per-job `bundle exec rails routes`
+  discovery call, server startup, or server warmdown time. At the job level, a benchmark job covering about 10 routes
+  should be budgeted as roughly doubling from 11-12 minutes to 22-24 minutes before additional startup or warmdown
+  overhead. Recalculate the estimate if `DURATION` changes or if the `benchmarks/bench.rb` warm-up loop changes.
 - Record sample count, runner type, Ruby version, Node version, React version, renderer, and bundle mode in a
   `metadata.json` artifact and mirror the key fields in the `summary.txt` header. Capture runtime-dependent fields when
   the benchmark runs instead of hard-coding the example schema values: use `ruby --version` for `ruby_version`,
@@ -136,10 +146,13 @@ Prerequisites for the first implementation PR:
   warn "WARNING: could not capture react_version" unless status.success?
   ```
 
-  Derive `renderer` from the same `PRO` switch that selects `APP_DIR`, rather than copying the example schema value:
+  Derive `renderer` from the same `PRO` switch that selects `APP_DIR`, rather than copying the example schema value.
+  Reuse the existing `PRO = ENV.fetch("PRO", "false") == "true"` constant defined at the top of `benchmarks/bench.rb`
+  rather than re-deriving the boolean inline, so a future change to the constant cannot diverge from the renderer
+  selection:
 
   ```ruby
-  renderer = ENV["PRO"] == "true" ? "node_renderer" : "execjs"
+  renderer = PRO ? "node_renderer" : "execjs"
   ```
 
   Equivalent block form using `Dir.chdir(APP_DIR) do ... end` is acceptable when the surrounding code already manages


### PR DESCRIPTION
## Summary
- add an internal plan for expanding performance tests across client rendering, SSR, streaming, RSC payloads, and caching
- define first-slice scope and CI noise controls
- tie hard-gate behavior to the benchmark tuning work before treating single-run spikes as regressions

Refs #2169

## Test Plan
- `pnpm exec prettier --check internal/planning/performance-test-expansion-plan.md`
- `git diff --check`
- pre-commit/pre-push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an internal benchmarking plan; no runtime or CI behavior is modified in this PR.
> 
> **Overview**
> Adds `internal/planning/performance-test-expansion-plan.md`, an internal document outlining how to expand performance benchmarks across client rendering, SSR (including streaming/RSC), and caching while controlling CI noise.
> 
> Defines a staged rollout (OSS first slice vs Pro follow-up), recommended metrics/artifacts (including `metadata.json` and `max_latency` in Bencher BMF), and concrete implementation prerequisites for upcoming benchmark/CI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8712caab9195b4dc6d2745954160ba94b24e9934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed, route-by-route performance benchmarking plan: an operations matrix covering client rendering, traditional/hash/streaming SSR, RSC payload rendering, and fragment caching; primary metrics and capture prerequisites; rollout scoping into OSS and Pro slices; CI noise controls and gating guidance; required run metadata; extended reporting to include max latency alongside existing metrics; local verification steps, acceptance criteria, and links to related benchmarking workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->