### PR TITLE
docs: document async props helper usage (merge after implementation)

### DIFF
--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -102,6 +102,8 @@ Common options include `props`, `trace`, and `id`. The helper forces `prerender:
 
 Async-props variant of `rsc_payload_react_component`. Use this only when custom RSC payload rendering needs Rails-emitted async props, such as an overridden payload route or template. For standard streamed ERB views, use `stream_react_component_with_async_props`.
 
+Requires `enable_rsc_support = true` in configuration, same as `rsc_payload_react_component`.
+
 This helper accepts the same options as `rsc_payload_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop.
 
 ```ruby

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -95,7 +95,7 @@ Common options include `props`, `trace`, and `id`. The helper forces `prerender:
 
 ### `rsc_payload_react_component_with_async_props(component_name, options = {}, &block)`
 
-Async-props variant of `rsc_payload_react_component`. Use this when custom RSC payload rendering needs the same emitted-prop behavior as `stream_react_component_with_async_props`.
+Async-props variant of `rsc_payload_react_component`. Use this only when custom RSC payload rendering needs Rails-emitted async props, such as an overridden payload route or template. For standard streamed ERB views, use `stream_react_component_with_async_props`.
 
 This helper accepts the same options as `rsc_payload_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop.
 

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -59,9 +59,11 @@ Requires the controller to use `stream_view_containing_react_components`.
 
 Async-props variant of `stream_react_component`. Use this when the view has synchronous props plus slower values that should stream to React behind Suspense boundaries.
 
+Use this helper for RSC Server Components with RSC support enabled. For non-RSC streaming SSR, use `stream_react_component`.
+
 Requires the controller to use `stream_view_containing_react_components`, same as `stream_react_component`.
 
-This helper accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop as it becomes available. Components read emitted values through the injected `getReactOnRailsAsyncProp` prop.
+This helper accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop as it becomes available. RSC Server Components read emitted values through the injected `getReactOnRailsAsyncProp` prop.
 
 ```ruby
 <%= stream_react_component_with_async_props("ProductPage",

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -65,6 +65,8 @@ Requires the controller to use `stream_view_containing_react_components`, same a
 
 This helper accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop as it becomes available. RSC Server Components read emitted values through the injected `getReactOnRailsAsyncProp` prop.
 
+For the complete React component pattern using `WithAsyncProps` and `getReactOnRailsAsyncProp`, see [Data Fetching in React on Rails Pro](../migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
+
 ```ruby
 <%= stream_react_component_with_async_props("ProductPage",
       props: { name: @product.name, price: @product.price }) do |emit|

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -47,12 +47,25 @@ Streams a server-rendered React component using React 18's `renderToPipeableStre
 
 Requires the controller to use `stream_view_containing_react_components`.
 
-Options: same as `react_component`.
+`stream_react_component` forces `prerender: true`; passing `prerender: false` has no effect. Common options mirror `react_component`, including `props`, `id`, `html_options`, `trace`, and `raise_on_prerender_error`.
 
 > **Note (Pro):** React on Rails Pro hydrates streamed components early (before `DOMContentLoaded`) automatically — no per-component toggle is exposed.
 
 ```ruby
 <%= stream_react_component("App", props: { data: @data }) %>
+```
+
+### `stream_react_component_with_async_props(component_name, options = {}, &block)`
+
+Async-props variant of `stream_react_component`. Use this when the view has immediately available props plus slower values that should stream to React behind Suspense boundaries.
+
+This helper accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop as it becomes available. Components read emitted values through the injected `getReactOnRailsAsyncProp` prop.
+
+```ruby
+<%= stream_react_component_with_async_props("ProductPage",
+      props: { name: @product.name, price: @product.price }) do |emit|
+  emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
+end %>
 ```
 
 ### `cached_stream_react_component(component_name, options = {}, &block)`
@@ -70,10 +83,25 @@ Renders the React Server Component payload as NDJSON. Each line contains:
 - `hasErrors` — boolean
 - `isShellReady` — boolean
 
-Requires `enable_rsc_support = true` in configuration.
+Requires `enable_rsc_support = true` in configuration. This helper is normally used by `rsc_payload_route`; call it directly only when you need custom RSC payload rendering.
+
+Common options include `props`, `trace`, and `id`. The helper forces `prerender: true`; passing `prerender: false` has no effect.
 
 ```ruby
 <%= rsc_payload_react_component("RSCPage", props: { id: @post.id }) %>
+```
+
+### `rsc_payload_react_component_with_async_props(component_name, options = {}, &block)`
+
+Async-props variant of `rsc_payload_react_component`. Use this when custom RSC payload rendering needs the same emitted-prop behavior as `stream_react_component_with_async_props`.
+
+This helper accepts the same options as `rsc_payload_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop.
+
+```ruby
+<%= rsc_payload_react_component_with_async_props("ProductPage",
+      props: { name: @product.name, price: @product.price }) do |emit|
+  emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
+end %>
 ```
 
 ### `async_react_component(component_name, options = {})`

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -59,6 +59,8 @@ Requires the controller to use `stream_view_containing_react_components`.
 
 Async-props variant of `stream_react_component`. Use this when the view has immediately available props plus slower values that should stream to React behind Suspense boundaries.
 
+Requires the controller to use `stream_view_containing_react_components`, same as `stream_react_component`.
+
 This helper accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop as it becomes available. Components read emitted values through the injected `getReactOnRailsAsyncProp` prop.
 
 ```ruby

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -57,7 +57,7 @@ Requires the controller to use `stream_view_containing_react_components`.
 
 ### `stream_react_component_with_async_props(component_name, options = {}, &block)`
 
-Async-props variant of `stream_react_component`. Use this when the view has immediately available props plus slower values that should stream to React behind Suspense boundaries.
+Async-props variant of `stream_react_component`. Use this when the view has synchronous props plus slower values that should stream to React behind Suspense boundaries.
 
 Requires the controller to use `stream_view_containing_react_components`, same as `stream_react_component`.
 
@@ -69,6 +69,9 @@ This helper accepts the same options as `stream_react_component`, plus a block t
   emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
 end %>
 ```
+
+> [!IMPORTANT]
+> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ### `cached_stream_react_component(component_name, options = {}, &block)`
 

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -106,6 +106,9 @@ This helper accepts the same options as `rsc_payload_react_component`, plus a bl
 end %>
 ```
 
+> [!IMPORTANT]
+> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
+
 ### `async_react_component(component_name, options = {})`
 
 Renders a component asynchronously, returning an `AsyncValue`. Multiple calls execute concurrently.

--- a/docs/oss/api-reference/ruby-api-pro.md
+++ b/docs/oss/api-reference/ruby-api-pro.md
@@ -75,7 +75,7 @@ end %>
 ```
 
 > [!IMPORTANT]
-> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
+> `stream_react_component_with_async_props` always forces `prerender: true`; passing `prerender: false` has no effect. The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ### `cached_stream_react_component(component_name, options = {}, &block)`
 
@@ -116,7 +116,7 @@ end %>
 ```
 
 > [!IMPORTANT]
-> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
+> `rsc_payload_react_component_with_async_props` always forces `prerender: true`; passing `prerender: false` has no effect. The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ### `async_react_component(component_name, options = {})`
 

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -197,7 +197,7 @@ See the [React on Rails Pro Configuration](../configuration/configuration-pro.md
 
 ### rsc_payload_react_component_with_async_props
 
-Async-props variant of `rsc_payload_react_component`. Use it when custom RSC payload rendering needs async props emitted from Rails.
+Async-props variant of `rsc_payload_react_component`. Use it only when custom RSC payload rendering needs Rails-emitted async props, such as an overridden payload route or template. For standard streamed ERB views, use [`stream_react_component_with_async_props`](#stream_react_component_with_async_props).
 
 It accepts the same options as `rsc_payload_react_component`, plus a block that receives an emitter:
 
@@ -207,6 +207,9 @@ It accepts the same options as `rsc_payload_react_component`, plus a block that 
   emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
 end %>
 ```
+
+> [!IMPORTANT]
+> `rsc_payload_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. Use this helper only for custom RSC payload rendering; standard streamed ERB views should use `stream_react_component_with_async_props`.
 
 ---
 

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -180,6 +180,9 @@ end %>
 
 Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a Promise for each emitted prop.
 
+> [!IMPORTANT]
+> `stream_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. It requires the same controller setup as `stream_react_component`: the controller must call `stream_view_containing_react_components`.
+
 ### rsc_payload_react_component
 
 Renders React Server Component (RSC) payloads in NDJSON format for client-side consumption. Used in conjunction with RSC support to enable:

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -165,6 +165,21 @@ See the [Streaming Server Rendering guide](../building-features/streaming-server
 > [!IMPORTANT]
 > `stream_react_component` always forces `prerender: true` — passing `prerender: false` has no effect. It only supports React components and render functions that return React components; render functions returning a `{ renderedHtml }` hash are incompatible (see [compatibility matrix](../core-concepts/render-functions.md#compatibility-matrix-component-types-and-ruby-helpers)).
 
+### stream_react_component_with_async_props
+
+Async-props variant of `stream_react_component`. Use it when Rails has some props immediately available and other props should stream later through Suspense boundaries.
+
+It accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop:
+
+```erb
+<%= stream_react_component_with_async_props("ProductPage",
+      props: { name: @product.name, price: @product.price }) do |emit|
+  emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
+end %>
+```
+
+Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a Promise for each emitted prop.
+
 ### rsc_payload_react_component
 
 Renders React Server Component (RSC) payloads in NDJSON format for client-side consumption. Used in conjunction with RSC support to enable:
@@ -173,7 +188,22 @@ Renders React Server Component (RSC) payloads in NDJSON format for client-side c
 - Server-side data fetching
 - Selective client-side hydration
 
+The mounted `rsc_payload_route` normally calls this helper for you. Call it directly only for custom RSC payload rendering.
+
 See the [React on Rails Pro Configuration](../configuration/configuration-pro.md) for RSC setup.
+
+### rsc_payload_react_component_with_async_props
+
+Async-props variant of `rsc_payload_react_component`. Use it when custom RSC payload rendering needs async props emitted from Rails.
+
+It accepts the same options as `rsc_payload_react_component`, plus a block that receives an emitter:
+
+```erb
+<%= rsc_payload_react_component_with_async_props("ProductPage",
+      props: { name: @product.name, price: @product.price }) do |emit|
+  emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
+end %>
+```
 
 ---
 

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -182,6 +182,8 @@ end %>
 
 RSC Server Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a Promise for each emitted prop.
 
+For the complete React component pattern using `WithAsyncProps` and `getReactOnRailsAsyncProp`, see [Data Fetching in React on Rails Pro](../migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
+
 > [!IMPORTANT]
 > `stream_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. It requires the same controller setup as `stream_react_component`: the controller must call `stream_view_containing_react_components`. Like `stream_react_component`, it only supports React components and render functions that return React components; render functions returning a `{ renderedHtml }` hash are incompatible (see [compatibility matrix](../core-concepts/render-functions.md#compatibility-matrix-component-types-and-ruby-helpers)).
 >

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -169,6 +169,8 @@ See the [Streaming Server Rendering guide](../building-features/streaming-server
 
 Async-props variant of `stream_react_component`. Use it when Rails has synchronous props plus other props that should stream later through Suspense boundaries.
 
+Use this helper for RSC Server Components with RSC support enabled. For non-RSC streaming SSR, use `stream_react_component`.
+
 It accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop:
 
 ```erb
@@ -178,7 +180,7 @@ It accepts the same options as `stream_react_component`, plus a block that recei
 end %>
 ```
 
-Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a Promise for each emitted prop.
+RSC Server Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a Promise for each emitted prop.
 
 > [!IMPORTANT]
 > `stream_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. It requires the same controller setup as `stream_react_component`: the controller must call `stream_view_containing_react_components`. Like `stream_react_component`, it only supports React components and render functions that return React components; render functions returning a `{ renderedHtml }` hash are incompatible (see [compatibility matrix](../core-concepts/render-functions.md#compatibility-matrix-component-types-and-ruby-helpers)).

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -181,7 +181,7 @@ end %>
 Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a Promise for each emitted prop.
 
 > [!IMPORTANT]
-> `stream_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. It requires the same controller setup as `stream_react_component`: the controller must call `stream_view_containing_react_components`.
+> `stream_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. It requires the same controller setup as `stream_react_component`: the controller must call `stream_view_containing_react_components`. Like `stream_react_component`, it only supports React components and render functions that return React components; render functions returning a `{ renderedHtml }` hash are incompatible (see [compatibility matrix](../core-concepts/render-functions.md#compatibility-matrix-component-types-and-ruby-helpers)).
 
 ### rsc_payload_react_component
 
@@ -209,7 +209,7 @@ end %>
 ```
 
 > [!IMPORTANT]
-> `rsc_payload_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. Use this helper only for custom RSC payload rendering; standard streamed ERB views should use `stream_react_component_with_async_props`.
+> `rsc_payload_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. Use this helper only for custom RSC payload rendering; standard streamed ERB views should use `stream_react_component_with_async_props`. Requires `enable_rsc_support = true` in configuration — see [React on Rails Pro Configuration](../configuration/configuration-pro.md).
 
 ---
 

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -167,7 +167,7 @@ See the [Streaming Server Rendering guide](../building-features/streaming-server
 
 ### stream_react_component_with_async_props
 
-Async-props variant of `stream_react_component`. Use it when Rails has some props immediately available and other props should stream later through Suspense boundaries.
+Async-props variant of `stream_react_component`. Use it when Rails has synchronous props plus other props that should stream later through Suspense boundaries.
 
 It accepts the same options as `stream_react_component`, plus a block that receives an emitter. Call `emit.call(prop_name, value)` for each async prop:
 
@@ -182,6 +182,8 @@ Components rendered this way receive `getReactOnRailsAsyncProp`, which returns a
 
 > [!IMPORTANT]
 > `stream_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. It requires the same controller setup as `stream_react_component`: the controller must call `stream_view_containing_react_components`. Like `stream_react_component`, it only supports React components and render functions that return React components; render functions returning a `{ renderedHtml }` hash are incompatible (see [compatibility matrix](../core-concepts/render-functions.md#compatibility-matrix-component-types-and-ruby-helpers)).
+>
+> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ### rsc_payload_react_component
 
@@ -210,6 +212,8 @@ end %>
 
 > [!IMPORTANT]
 > `rsc_payload_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. Use this helper only for custom RSC payload rendering; standard streamed ERB views should use `stream_react_component_with_async_props`. Requires `enable_rsc_support = true` in configuration — see [React on Rails Pro Configuration](../configuration/configuration-pro.md).
+>
+> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ---
 

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -203,6 +203,8 @@ See the [React on Rails Pro Configuration](../configuration/configuration-pro.md
 
 Async-props variant of `rsc_payload_react_component`. Use it only when custom RSC payload rendering needs Rails-emitted async props, such as an overridden payload route or template. For standard streamed ERB views, use [`stream_react_component_with_async_props`](#stream_react_component_with_async_props).
 
+Requires `enable_rsc_support = true` in configuration, same as `rsc_payload_react_component` — see [React on Rails Pro Configuration](../configuration/configuration-pro.md).
+
 It accepts the same options as `rsc_payload_react_component`, plus a block that receives an emitter:
 
 ```erb
@@ -213,7 +215,7 @@ end %>
 ```
 
 > [!IMPORTANT]
-> `rsc_payload_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. Use this helper only for custom RSC payload rendering; standard streamed ERB views should use `stream_react_component_with_async_props`. Requires `enable_rsc_support = true` in configuration — see [React on Rails Pro Configuration](../configuration/configuration-pro.md).
+> `rsc_payload_react_component_with_async_props` always forces `prerender: true` — passing `prerender: false` has no effect. Use this helper only for custom RSC payload rendering; standard streamed ERB views should use `stream_react_component_with_async_props`.
 >
 > The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](../migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 

--- a/docs/oss/migrating/migrating-to-rsc.md
+++ b/docs/oss/migrating/migrating-to-rsc.md
@@ -5,7 +5,7 @@ This guide covers the React-side challenges of migrating an existing React on Ra
 > [!NOTE]
 > **Summary for AI agents:** Use this page when the user has an existing React on Rails app and wants to adopt RSC. This covers the React-side migration (component restructuring, state, data fetching). For the initial RSC setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). RSC requires Pro with the Node renderer.
 
-> **React on Rails Pro required:** RSC support requires [React on Rails Pro](../../pro/react-on-rails-pro.md) 4+ with the node renderer. The Pro gem provides the streaming view helpers (`stream_react_component`, `rsc_payload_react_component`), the RSC webpack plugin and loader, and the `registerServerComponent` API. For setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). For upgrade steps, see the [performance breakthroughs guide](../../pro/major-performance-breakthroughs-upgrade-guide.md).
+> **React on Rails Pro required:** RSC support requires [React on Rails Pro](../../pro/react-on-rails-pro.md) 4+ with the node renderer. The Pro gem provides the streaming view helpers (`stream_react_component`, `stream_react_component_with_async_props`, `rsc_payload_react_component`, and `rsc_payload_react_component_with_async_props`), the RSC webpack plugin and loader, and the `registerServerComponent` API. For setup, see the [RSC tutorial](../../pro/react-server-components/tutorial.md). For upgrade steps, see the [performance breakthroughs guide](../../pro/major-performance-breakthroughs-upgrade-guide.md).
 
 ## Why Migrate?
 
@@ -121,13 +121,13 @@ How to optimize RSC Flight payload size for better performance. Covers:
 
 Before diving into the React patterns, understand how RSC maps to React on Rails' architecture.
 
-**Multiple component roots.** Unlike single-page apps with one `App.jsx` root, React on Rails renders independent component trees from ERB views. Each `react_component` or `stream_react_component` call is a separate root. You migrate **per-component**, not per-app.
+**Multiple component roots.** Unlike single-page apps with one `App.jsx` root, React on Rails renders independent component trees from ERB views. Each `react_component`, `stream_react_component`, or `stream_react_component_with_async_props` call is a separate root. You migrate **per-component**, not per-app.
 
 **Three API changes per component.** Each component you migrate touches three layers:
 
 | Layer           | Before                               | After                                                                                                                                                                                               |
 | --------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ERB view helper | `react_component("Product", ...)`    | `stream_react_component("Product", ...)`                                                                                                                                                            |
+| ERB view helper | `react_component("Product", ...)`    | `stream_react_component("Product", ...)` or `stream_react_component_with_async_props("Product", ...)` when Rails emits async props                                                                  |
 | JS registration | `ReactOnRails.register({ Product })` | `registerServerComponent` (signature varies per bundle — see [details](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#the-two-registerservercomponent-signatures)) |
 | Controller      | Standard Rails controller            | Add `include ReactOnRailsPro::Stream`                                                                                                                                                               |
 
@@ -145,7 +145,7 @@ Tailored for React on Rails' multi-root architecture:
 
 1. **[Prepare your app](rsc-preparing-app.md)** -- set up the RSC infrastructure, add `'use client'` to all component entry points, and switch to streaming rendering. The app works identically -- nothing changes yet.
 2. **Pick a component and push the boundary down** -- move `'use client'` from the root component to its interactive children, letting parent components become Server Components.
-3. **Adopt advanced patterns** -- add Suspense boundaries, [`stream_react_component`](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for streaming SSR, and server-side data fetching.
+3. **Adopt advanced patterns** -- add Suspense boundaries, [`stream_react_component`](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for streaming SSR, `stream_react_component_with_async_props` for progressively emitted Rails data, and server-side data fetching.
 4. **[Keep route policy in Rails](rsc-http-response-patterns.md)** -- for each route, decide redirects, status codes, and cache headers before streaming commits the response.
 5. **Repeat for each registered component** -- migrate components one at a time, in any order.
 

--- a/docs/oss/migrating/rsc-component-patterns.md
+++ b/docs/oss/migrating/rsc-component-patterns.md
@@ -368,7 +368,7 @@ export default function Stats({ stats }) {
 }
 ```
 
-Rails loads all data as props before rendering begins. `stream_react_component` then streams the rendered HTML to the browser as React processes the component tree — no client-side fetching or loading states needed.
+Rails loads all data as props before rendering begins. `stream_react_component` then streams the rendered HTML to the browser as React processes the component tree — no client-side fetching or loading states needed. For slow Rails data that should not block the initial shell, use `stream_react_component_with_async_props`; see [Data Fetching in React on Rails Pro](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
 
 ## Pattern 5: Server Data to Interactive Client Components
 

--- a/docs/oss/migrating/rsc-context-and-state.md
+++ b/docs/oss/migrating/rsc-context-and-state.md
@@ -164,7 +164,7 @@ function ReviewList({ reviews }) {
 }
 ```
 
-All data is loaded in Rails before rendering begins. `stream_react_component` then streams the rendered HTML to the browser via React's `renderToPipeableStream`.
+All data is loaded in Rails before rendering begins. `stream_react_component` then streams the rendered HTML to the browser via React's `renderToPipeableStream`. For slow Rails data that should not block the initial shell, use `stream_react_component_with_async_props` instead; see [Data Fetching in React on Rails Pro](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
 
 > **Note:** `React.cache()` is only available in React Server Component environments. It is not available in client components or non-RSC server rendering (e.g., `renderToString`).
 
@@ -272,13 +272,13 @@ Zustand and Jotai follow the same pattern as Redux: keep all store access in Cli
 
 RSC reduces the need for global state libraries because data fetching moves to the server:
 
-| Use Case                                                        | Recommended Approach                                                                                |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Server data (read-only display)                                 | Rails controller props → Server Component renders directly                                          |
-| Server data (slow, shouldn't block the shell)                   | [Streaming](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) with `stream_react_component` |
-| Server data (with client cache/revalidation)                    | TanStack Query with prefetch + hydrate                                                              |
-| Client UI state (modals, forms, selections)                     | `useState` / Context in Client Components                                                           |
-| Complex client state (undo/redo, shared across many components) | Redux Toolkit in Client Components                                                                  |
+| Use Case                                                        | Recommended Approach                                                                                                   |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Server data (read-only display)                                 | Rails controller props → Server Component renders directly                                                             |
+| Server data (slow, shouldn't block the shell)                   | [Async props](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) with `stream_react_component_with_async_props` |
+| Server data (with client cache/revalidation)                    | TanStack Query with prefetch + hydrate                                                                                 |
+| Client UI state (modals, forms, selections)                     | `useState` / Context in Client Components                                                                              |
+| Complex client state (undo/redo, shared across many components) | Redux Toolkit in Client Components                                                                                     |
 
 ## Specific Provider Patterns
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -143,7 +143,7 @@ function ReviewList({ reviews }: { reviews: Review[] }) {
 
 **React component for async props (Server Component):**
 
-Use this version with the `stream_react_component_with_async_props` ERB helper above. Keep the registered component name as `ProductPage`; the props shape changes so `reviews` comes from `getReactOnRailsAsyncProp`.
+Use this version with the `stream_react_component_with_async_props` ERB helper above. Keep the registered component name as `ProductPage`; the props shape changes so `reviews` comes from `getReactOnRailsAsyncProp`. `WithAsyncProps<AsyncProps, SyncProps>` combines the props passed directly through `props:` with a typed accessor for the keys emitted from Rails.
 
 ```tsx
 import { Suspense } from 'react';
@@ -199,8 +199,8 @@ export default function ProductPage({ name, price, getReactOnRailsAsyncProp }: P
 
 **How it works:**
 
-1. Rails loads synchronous data and passes it as props to `stream_react_component`
-2. `stream_react_component` uses React's `renderToPipeableStream` for streaming SSR
+1. Rails loads synchronous data and passes it as props to `stream_react_component`, or as immediate `props:` to `stream_react_component_with_async_props` when slower props are emitted from the block
+2. The streaming helper uses React's `renderToPipeableStream` for streaming SSR
 3. HTML streams to the browser as React renders the component tree
 4. No client-side fetching or client-side effect-based loading state needed
 5. The component renders with zero JavaScript cost as a Server Component

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -208,9 +208,10 @@ export default function ProductPage({ name, price, getReactOnRailsAsyncProp }: P
 
 1. Rails evaluates synchronous `props:` for `stream_react_component`, or passes those synchronous `props:` to `stream_react_component_with_async_props` while the block emits slower values with `emit.call`
 2. The streaming helper uses React's `renderToPipeableStream` for streaming SSR
-3. HTML streams to the browser as React renders the component tree
-4. No client-side fetching or `useEffect`-based loading state needed
-5. The component renders with zero JavaScript cost as a Server Component
+3. `getReactOnRailsAsyncProp('reviews')` returns a Promise that resolves when Rails calls `emit.call("reviews", ...)`
+4. HTML streams to the browser as React renders the component tree
+5. No client-side fetching or `useEffect`-based loading state needed
+6. The component renders with zero JavaScript cost as a Server Component
 
 With async props, `stream_react_component_with_async_props` starts rendering with the synchronous `props:` values, then the block emits slow values with `emit.call`. The Server Component uses `getReactOnRailsAsyncProp` to obtain those values as Promises and places them behind Suspense boundaries.
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -198,12 +198,15 @@ export default function ProductPage({ name, price, getReactOnRailsAsyncProp }: P
 }
 ```
 
+> [!IMPORTANT]
+> `<Suspense>` is the loading boundary, not the error UI. If the async-props stream closes before a requested prop is emitted, `getReactOnRailsAsyncProp` rejects and follows the same RSC/streaming error path as other Server Component render errors. Use the page-level handling described in [Error Boundary Limitations](./rsc-troubleshooting.md#error-boundary-limitations) rather than treating the Suspense fallback as failure UI.
+
 **How it works:**
 
 1. Rails loads synchronous data and passes it as props to `stream_react_component`, or as immediate `props:` to `stream_react_component_with_async_props` when slower props are emitted from the block
 2. The streaming helper uses React's `renderToPipeableStream` for streaming SSR
 3. HTML streams to the browser as React renders the component tree
-4. No client-side fetching or client-side effect-based loading state needed
+4. No client-side fetching or `useEffect`-based loading state needed
 5. The component renders with zero JavaScript cost as a Server Component
 
 With async props, `stream_react_component_with_async_props` starts rendering with the synchronous `props:` values, then the block emits slow values with `emit.call`. The Server Component uses `getReactOnRailsAsyncProp` to obtain those values as Promises and places them behind Suspense boundaries.

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -101,29 +101,22 @@ end %>
 
 > **See also:** [React on Rails Pro streaming SSR](../../pro/streaming-ssr.md) for setup instructions and configuration options.
 
-**React component (Server Component):**
+**React component for synchronous props (Server Component):**
+
+Use this version with the `stream_react_component` ERB helper above. Rails resolves every prop before rendering begins, including `reviews`.
 
 ```tsx
-import { Suspense } from 'react';
-import type { WithAsyncProps } from 'react-on-rails-pro';
-
 type Review = {
   id: number;
   text: string;
   rating: number;
 };
 
-type SyncProps = {
+type ProductPageProps = {
   name: string;
   price: number;
-};
-
-type AsyncProps = {
   reviews: Review[];
 };
-
-type ProductPageProps = SyncProps & AsyncProps;
-type ProductPageWithAsyncProps = WithAsyncProps<AsyncProps, SyncProps>;
 
 export default function ProductPage({ name, price, reviews }: ProductPageProps) {
   return (
@@ -146,13 +139,50 @@ function ReviewList({ reviews }: { reviews: Review[] }) {
     </ul>
   );
 }
+```
+
+**React component for async props (Server Component):**
+
+Use this version with the `stream_react_component_with_async_props` ERB helper above. Keep the registered component name as `ProductPage`; the props shape changes so `reviews` comes from `getReactOnRailsAsyncProp`.
+
+```tsx
+import { Suspense } from 'react';
+import type { WithAsyncProps } from 'react-on-rails-pro';
+
+type Review = {
+  id: number;
+  text: string;
+  rating: number;
+};
+
+type SyncProps = {
+  name: string;
+  price: number;
+};
+
+type AsyncProps = {
+  reviews: Review[];
+};
+
+type ProductPageProps = WithAsyncProps<AsyncProps, SyncProps>;
+
+function ReviewList({ reviews }: { reviews: Review[] }) {
+  return (
+    <ul>
+      {reviews.map((review) => (
+        <li key={review.id}>
+          {review.text} ({review.rating}/5)
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 async function AsyncReviewList({ reviewsPromise }: { reviewsPromise: Promise<Review[]> }) {
   return <ReviewList reviews={await reviewsPromise} />;
 }
 
-// With async props, the helper injects getReactOnRailsAsyncProp.
-export function ProductPageAsync({ name, price, getReactOnRailsAsyncProp }: ProductPageWithAsyncProps) {
+export default function ProductPage({ name, price, getReactOnRailsAsyncProp }: ProductPageProps) {
   const reviewsPromise = getReactOnRailsAsyncProp('reviews');
 
   return (

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -61,31 +61,42 @@ Rails prepares the data in the controller and passes it as props. The component 
 - No loading spinner needed in the component itself
 - No JavaScript ships to the client for this component
 
-For pages with multiple data sources, use [`stream_react_component`](#data-fetching-in-react-on-rails-pro) to stream the rendered HTML to the browser as React renders the component tree.
+For pages with multiple data sources, use [`stream_react_component`](#data-fetching-in-react-on-rails-pro) to
+stream the rendered HTML to the browser as React renders the component tree. When slower data sources should resolve
+independently behind Suspense boundaries, use `stream_react_component_with_async_props`.
 
 ## Data Fetching in React on Rails Pro
 
-In React on Rails applications, Ruby on Rails is the backend. Rather than bypassing Rails to access the database directly from Server Components, React on Rails Pro provides **`stream_react_component`** -- a streaming view helper that uses React's `renderToPipeableStream` to stream rendered HTML to the browser as React processes the component tree. This approach is sometimes called **async props** because Rails can emit each prop independently, with Suspense boundaries streaming them to the browser as they resolve.
+In React on Rails applications, Ruby on Rails is the backend. Rather than bypassing Rails to access the database directly from Server Components, React on Rails Pro provides **`stream_react_component`** -- a streaming view helper that uses React's `renderToPipeableStream` to stream rendered HTML to the browser as React processes the component tree.
+
+For ordinary Rails-provided props, pass the data through the helper's `props:` option. For slow or independent props that should resolve behind Suspense boundaries, use the async-props helper variant, **`stream_react_component_with_async_props`**. The helper block receives an emitter; call `emit.call(prop_name, value)` as each async prop becomes available. The Server Component reads emitted values with the injected `getReactOnRailsAsyncProp` prop.
 
 This is the recommended data fetching pattern for React on Rails because:
 
 - It preserves Rails' controller/model/view architecture
 - It leverages Rails' existing data access layers (ActiveRecord, authorization, caching)
 - It supports streaming SSR — HTML streams to the browser as React renders
-- All data passes as props -- no client-side fetching or loading states needed
+- Data passes through Rails-provided props or async props -- no client-side fetching needed
 
 ### How Streaming Works
 
-**Rails view (ERB):**
+**Rails view (ERB), synchronous props:**
 
 ```erb
 <%= stream_react_component("ProductPage",
       props: { name: product.name,
                price: product.price,
                reviews: product.reviews
-                          .as_json(only: [:id, :text, :rating]),
-               recommendations: product.recommended_products
-                          .as_json(only: [:id, :name, :price]) }) %>
+                          .as_json(only: [:id, :text, :rating]) }) %>
+```
+
+**Rails view (ERB), async props:**
+
+```erb
+<%= stream_react_component_with_async_props("ProductPage",
+      props: { name: product.name, price: product.price }) do |emit|
+  emit.call("reviews", product.reviews.as_json(only: [:id, :text, :rating]))
+end %>
 ```
 
 > **See also:** [React on Rails Pro streaming SSR](../../pro/streaming-ssr.md) for setup instructions and configuration options.
@@ -93,21 +104,33 @@ This is the recommended data fetching pattern for React on Rails because:
 **React component (Server Component):**
 
 ```tsx
-type Props = {
-  name: string;
-  price: number;
-  reviews: Review[];
-  recommendations: Product[];
+import { Suspense } from 'react';
+import type { WithAsyncProps } from 'react-on-rails-pro';
+
+type Review = {
+  id: number;
+  text: string;
+  rating: number;
 };
 
-export default function ProductPage({ name, price, reviews, recommendations }: Props) {
+type SyncProps = {
+  name: string;
+  price: number;
+};
+
+type AsyncProps = {
+  reviews: Review[];
+};
+
+type ProductPageProps = SyncProps & AsyncProps;
+type ProductPageWithAsyncProps = WithAsyncProps<AsyncProps, SyncProps>;
+
+export default function ProductPage({ name, price, reviews }: ProductPageProps) {
   return (
     <div>
       <h1>{name}</h1>
       <p>${price}</p>
-
       <ReviewList reviews={reviews} />
-      <RecommendationList items={recommendations} />
     </div>
   );
 }
@@ -115,23 +138,46 @@ export default function ProductPage({ name, price, reviews, recommendations }: P
 function ReviewList({ reviews }: { reviews: Review[] }) {
   return (
     <ul>
-      {reviews.map((r) => (
-        <li key={r.id}>{r.text}</li>
+      {reviews.map((review) => (
+        <li key={review.id}>
+          {review.text} ({review.rating}/5)
+        </li>
       ))}
     </ul>
+  );
+}
+
+async function AsyncReviewList({ reviewsPromise }: { reviewsPromise: Promise<Review[]> }) {
+  return <ReviewList reviews={await reviewsPromise} />;
+}
+
+// With async props, the helper injects getReactOnRailsAsyncProp.
+export function ProductPageAsync({ name, price, getReactOnRailsAsyncProp }: ProductPageWithAsyncProps) {
+  const reviewsPromise = getReactOnRailsAsyncProp('reviews');
+
+  return (
+    <div>
+      <h1>{name}</h1>
+      <p>${price}</p>
+      <Suspense fallback={<p>Loading reviews...</p>}>
+        <AsyncReviewList reviewsPromise={reviewsPromise} />
+      </Suspense>
+    </div>
   );
 }
 ```
 
 **How it works:**
 
-1. Rails loads all data synchronously and passes it as props to `stream_react_component`
+1. Rails loads synchronous data and passes it as props to `stream_react_component`
 2. `stream_react_component` uses React's `renderToPipeableStream` for streaming SSR
 3. HTML streams to the browser as React renders the component tree
-4. No client-side fetching, loading states, or error handling needed
+4. No client-side fetching or client-side effect-based loading state needed
 5. The component renders with zero JavaScript cost as a Server Component
 
-> **HTML streaming vs. progressive data streaming:** With synchronous props, all data is loaded in Rails before rendering begins. The streaming here is _HTML streaming_ — React sends rendered HTML to the browser as it processes the component tree, rather than waiting for the entire page to finish rendering. For progressive data streaming where slow data sources resolve independently via Suspense boundaries, see [Streaming SSR](../../pro/streaming-ssr.md) (React on Rails Pro).
+With async props, `stream_react_component_with_async_props` starts rendering with the synchronous `props:` values, then the block emits slow values with `emit.call`. The Server Component uses `getReactOnRailsAsyncProp` to obtain those values as Promises and places them behind Suspense boundaries.
+
+> **HTML streaming vs. progressive data streaming:** With synchronous props, all data is loaded in Rails before rendering begins. The streaming here is _HTML streaming_ — React sends rendered HTML to the browser as it processes the component tree, rather than waiting for the entire page to finish rendering. For progressive data streaming, use `stream_react_component_with_async_props` so slow data sources resolve independently via Suspense boundaries.
 >
 > **More details:** For setup instructions and configuration options, see the [React on Rails Pro RSC documentation](../../pro/react-server-components/tutorial.md).
 
@@ -187,7 +233,7 @@ function ProductList({ products }) {
 }
 ```
 
-> **React on Rails note:** In React on Rails, the controller prepares the data and passes it as props -- no `async/await` in the component, no direct data layer calls. For data that's slow to compute, use [async props](#data-fetching-in-react-on-rails-pro) to stream it in progressively with Suspense. The generic `async function` + `await` pattern shown in other RSC frameworks bypasses Rails' authorization and caching layers and is not recommended.
+> **React on Rails note:** In React on Rails, the controller prepares the data and passes it as props -- no `async/await` in the component, no direct data layer calls. For data that's slow to compute, use [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) to stream it in progressively with Suspense. The generic `async function` + `await` pattern shown in other RSC frameworks bypasses Rails' authorization and caching layers and is not recommended.
 
 ### Pattern 2: Rails Props as Initial Data (Keep React Query for Client Features)
 
@@ -307,7 +353,7 @@ export default function DashboardStats({ fallbackData }) {
 
 ## Avoiding Server-Side Waterfalls
 
-> **React on Rails note:** In React on Rails, the primary way to handle parallel data loading is [async props](#data-fetching-in-react-on-rails-pro) -- Rails emits each prop independently, and Suspense boundaries stream them to the browser as they resolve. The patterns below apply when you have async Server Components that fetch data directly (outside the async props flow).
+> **React on Rails note:** In React on Rails, the primary way to handle parallel data loading is [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) -- Rails emits each prop independently, and Suspense boundaries stream them to the browser as they resolve. The patterns below apply when you have async Server Components that fetch data directly (outside the async props flow).
 
 The most critical performance pitfall with Server Components is sequential data fetching. When one `await` blocks the next, you create a waterfall on the server:
 
@@ -542,7 +588,7 @@ function Comments({ postId }) {
 
 ## Request Deduplication with `React.cache()`
 
-> **React on Rails note:** In most React on Rails applications, data flows through controller props or async props, so `React.cache()` is unnecessary. This section applies when Server Components call data-fetching functions directly (for example, from the Node renderer). If you are using async props (React on Rails Pro), repeated calls within the same request already share the same deduped Promise.
+> **React on Rails note:** In most React on Rails applications, data flows through controller props or `stream_react_component_with_async_props`, so `React.cache()` is unnecessary. This section applies when Server Components call data-fetching functions directly (for example, from the Node renderer). If you are using `stream_react_component_with_async_props`, repeated calls within the same request already share the same deduped Promise.
 
 When multiple Server Components need the same data, `React.cache()` ensures the fetch happens only once per request:
 
@@ -626,7 +672,7 @@ This preserves Rails' full controller/model layer -- authentication, authorizati
 
 ## When to Keep Client-Side Fetching
 
-Not everything should move to the server. In React on Rails, most read-only data is already server-side -- Rails controller props deliver it to your components without any client-side fetching. The table below covers the cases where you should keep client-side fetching instead of relying on Rails controller props or [async props](#data-fetching-in-react-on-rails-pro):
+Not everything should move to the server. In React on Rails, most read-only data is already server-side -- Rails controller props deliver it to your components without any client-side fetching. The table below covers the cases where you should keep client-side fetching instead of relying on Rails controller props or [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro):
 
 | Use Case                        | Why Client-Side                            | Recommended Tool                    |
 | ------------------------------- | ------------------------------------------ | ----------------------------------- |
@@ -768,7 +814,7 @@ def show
 end
 ```
 
-**Fix:** Use Ruby threads for independent queries (see [Avoiding Server-Side Waterfalls](#avoiding-server-side-waterfalls)), or split into multiple `stream_react_component` calls in the ERB view so each component renders as its data becomes available.
+**Fix:** Use Ruby threads for independent queries (see [Avoiding Server-Side Waterfalls](#avoiding-server-side-waterfalls)), use `stream_react_component_with_async_props` for slow props within one component, or split truly independent sections into multiple `stream_react_component` calls in the ERB view.
 
 ### Mistake 2: Using Server Actions (`'use server'`)
 
@@ -841,9 +887,9 @@ await fetch('/api/items', {
 
 ### Mistake 4: Removing loading states before adding streaming
 
-If you remove `useEffect` + loading state but haven't set up `stream_react_component` with Suspense boundaries, the page appears blank until all server data is ready:
+If you remove `useEffect` + loading state but haven't set up streaming with Suspense boundaries, the page appears blank until all server data is ready:
 
-**Fix:** Complete the streaming setup ([Preparing Your App](rsc-preparing-app.md#step-6-switch-to-streaming-rendering)) before converting data-fetching components. Add Suspense boundaries around sections that should stream independently.
+**Fix:** Complete the streaming setup ([Preparing Your App](rsc-preparing-app.md#step-6-switch-to-streaming-rendering)) before converting data-fetching components. Use `stream_react_component_with_async_props` for Rails data that should resolve behind Suspense, and add Suspense boundaries around sections that should stream independently.
 
 ### Mistake 5: Over-serializing ActiveRecord objects
 
@@ -872,7 +918,7 @@ For each component that fetches data:
 1. Remove the `'use client'` directive
 2. Remove `useState` for data, loading, and error
 3. Remove the `useEffect` data fetch
-4. Accept data as props from Rails (or use [async props](#data-fetching-in-react-on-rails-pro) for slow data)
+4. Accept data as props from Rails (or use [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) for slow data)
 5. Use `stream_react_component` in the ERB view to enable streaming SSR
 6. Remove the API route if it was only used by this component
 
@@ -885,7 +931,7 @@ For each component that fetches data:
 ### Step 4: Optimize
 
 10. Use `stream_react_component` for streaming HTML delivery via React's `renderToPipeableStream`
-11. Parallelize independent Ruby queries with threads to avoid server-side waterfalls
+11. Use `stream_react_component_with_async_props` for slow Rails props, or parallelize independent Ruby queries with threads to avoid server-side waterfalls
 12. For client-side updates after initial render, use React Query or SWR with `initialData`/`fallbackData`
 
 ## Next Steps

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -964,7 +964,7 @@ For each component that fetches data:
 
 ### Step 4: Optimize
 
-10. Use `stream_react_component` for streaming HTML delivery via React's `renderToPipeableStream`
+10. Use `stream_react_component` for synchronous props and streaming HTML delivery via React's `renderToPipeableStream`
 11. Use `stream_react_component_with_async_props` for slow Rails props, or parallelize independent Ruby queries with threads to avoid server-side waterfalls
 12. For client-side updates after initial render, use React Query or SWR with `initialData`/`fallbackData`
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -968,7 +968,7 @@ For each component that fetches data:
 ### Step 4: Optimize
 
 10. Use `stream_react_component` for synchronous props and streaming HTML delivery via React's `renderToPipeableStream`
-11. Use `stream_react_component_with_async_props` for slow Rails props, or parallelize independent Ruby queries with threads to avoid server-side waterfalls
+11. Use `stream_react_component_with_async_props` for slow Rails props behind Suspense boundaries; parallelize independent Ruby queries inside the block when needed to avoid server-side waterfalls
 12. For client-side updates after initial render, use React Query or SWR with `initialData`/`fallbackData`
 
 ## Next Steps

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -949,7 +949,7 @@ For each component that fetches data:
 2. Remove `useState` for data, loading, and error
 3. Remove the `useEffect` data fetch
 4. Accept data as props from Rails (or use [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) for slow data)
-5. Use `stream_react_component` in the ERB view to enable streaming SSR
+5. Use `stream_react_component` in the ERB view, or `stream_react_component_with_async_props` when step 4 moved slow data to async props, to enable streaming SSR
 6. Remove the API route if it was only used by this component
 
 ### Step 3: Add Suspense Boundaries

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -99,6 +99,9 @@ This is the recommended data fetching pattern for React on Rails because:
 end %>
 ```
 
+> [!IMPORTANT]
+> The emitter block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](#avoiding-server-side-waterfalls).
+
 > **See also:** [React on Rails Pro streaming SSR](../../pro/streaming-ssr.md) for setup instructions and configuration options.
 
 **React component for synchronous props (Server Component):**
@@ -203,7 +206,7 @@ export default function ProductPage({ name, price, getReactOnRailsAsyncProp }: P
 
 **How it works:**
 
-1. Rails loads synchronous data and passes it as props to `stream_react_component`, or as immediate `props:` to `stream_react_component_with_async_props` when slower props are emitted from the block
+1. Rails evaluates synchronous `props:` for `stream_react_component`, or passes those synchronous `props:` to `stream_react_component_with_async_props` while the block emits slower values with `emit.call`
 2. The streaming helper uses React's `renderToPipeableStream` for streaming SSR
 3. HTML streams to the browser as React renders the component tree
 4. No client-side fetching or `useEffect`-based loading state needed
@@ -387,7 +390,7 @@ export default function DashboardStats({ fallbackData }) {
 
 ## Avoiding Server-Side Waterfalls
 
-> **React on Rails note:** In React on Rails, the primary way to handle parallel data loading is [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) -- Rails emits each prop independently, and Suspense boundaries stream them to the browser as they resolve. The patterns below apply when you have async Server Components that fetch data directly (outside the async props flow).
+> **React on Rails note:** In React on Rails, use [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) when slow Rails data should stream into Suspense boundaries independently. If independent values require slow Ruby work, start that work concurrently before emitting; the patterns below apply when you have async Server Components that fetch data directly (outside the async props flow).
 
 The most critical performance pitfall with Server Components is sequential data fetching. When one `await` blocks the next, you create a waterfall on the server:
 
@@ -952,7 +955,7 @@ For each component that fetches data:
 1. Remove the `'use client'` directive
 2. Remove `useState` for data, loading, and error
 3. Remove the `useEffect` data fetch
-4. Accept data as props from Rails. For slow data, keep immediate values in `props:` and emit the slow values with [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro).
+4. Accept data as props from Rails. For slow data, keep synchronous values in `props:` and emit the slow values with [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro).
 5. Use the matching ERB helper to enable streaming SSR: `stream_react_component` for synchronous props, or `stream_react_component_with_async_props` for async props.
 6. Remove the API route if it was only used by this component
 

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -179,6 +179,7 @@ function ReviewList({ reviews }: { reviews: Review[] }) {
 }
 
 async function AsyncReviewList({ reviewsPromise }: { reviewsPromise: Promise<Review[]> }) {
+  // This awaits a Promise injected by getReactOnRailsAsyncProp, not a direct data fetch.
   return <ReviewList reviews={await reviewsPromise} />;
 }
 
@@ -948,8 +949,8 @@ For each component that fetches data:
 1. Remove the `'use client'` directive
 2. Remove `useState` for data, loading, and error
 3. Remove the `useEffect` data fetch
-4. Accept data as props from Rails (or use [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro) for slow data)
-5. Use `stream_react_component` in the ERB view, or `stream_react_component_with_async_props` when step 4 moved slow data to async props, to enable streaming SSR
+4. Accept data as props from Rails. For slow data, keep immediate values in `props:` and emit the slow values with [`stream_react_component_with_async_props`](#data-fetching-in-react-on-rails-pro).
+5. Use the matching ERB helper to enable streaming SSR: `stream_react_component` for synchronous props, or `stream_react_component_with_async_props` for async props.
 6. Remove the API route if it was only used by this component
 
 ### Step 3: Add Suspense Boundaries

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -547,6 +547,19 @@ In each view, replace `react_component` with `stream_react_component`:
 
 `stream_react_component` automatically sets `prerender: true`. The component renders identically — the difference is that the response is now streamed, which will matter when you start adding Suspense boundaries and async Server Components. React on Rails Pro automatically hydrates components early (before `DOMContentLoaded`), so selective hydration works out of the box.
 
+When the view uses React on Rails Pro async props, use the async-props helper variant instead. Keep immediately available values in `props:` and emit slower values from the block:
+
+```erb
+<%= stream_react_component_with_async_props("ProductPage",
+      props: { product_id: @product.id }) do |emit|
+  emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
+  emit.call("recommendations",
+            @product.recommended_products.as_json(only: [:id, :name, :price]))
+end %>
+```
+
+The Server Component receives `getReactOnRailsAsyncProp` and reads those emitted values behind Suspense boundaries. See [Data Fetching in React on Rails Pro](./rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the complete pattern.
+
 ### 6c. Update script loading in layouts (recommended)
 
 For streaming to deliver its full performance benefit, script tags should use `async` loading so the browser can hydrate components as they arrive:

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -558,7 +558,10 @@ When the view uses React on Rails Pro async props, use the async-props helper va
 end %>
 ```
 
-The Server Component receives `getReactOnRailsAsyncProp` and reads those emitted values behind Suspense boundaries. The block still runs normal Ruby code in order, so `emit.call` does not parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](./rsc-data-fetching.md#avoiding-server-side-waterfalls). See [Data Fetching in React on Rails Pro](./rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the complete async-props pattern.
+The Server Component receives `getReactOnRailsAsyncProp` and reads those emitted values behind Suspense boundaries. See [Data Fetching in React on Rails Pro](./rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the complete async-props pattern.
+
+> [!IMPORTANT]
+> The block runs normal Ruby code sequentially, so `emit.call` does **not** parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](./rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ### 6c. Update script loading in layouts (recommended)
 

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -547,7 +547,7 @@ In each view, replace `react_component` with `stream_react_component`:
 
 `stream_react_component` automatically sets `prerender: true`. The component renders identically — the difference is that the response is now streamed, which will matter when you start adding Suspense boundaries and async Server Components. React on Rails Pro automatically hydrates components early (before `DOMContentLoaded`), so selective hydration works out of the box.
 
-When the view uses React on Rails Pro async props, use the async-props helper variant instead. Keep immediately available values in `props:` and emit slower values from the block:
+When the view uses React on Rails Pro async props, use the async-props helper variant instead. Keep synchronous values in `props:` and emit slower values from the block:
 
 ```erb
 <%= stream_react_component_with_async_props("ProductPage",

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -551,7 +551,7 @@ When the view uses React on Rails Pro async props, use the async-props helper va
 
 ```erb
 <%= stream_react_component_with_async_props("ProductPage",
-      props: { product_id: @product.id }) do |emit|
+      props: { name: @product.name, price: @product.price }) do |emit|
   emit.call("reviews", @product.reviews.as_json(only: [:id, :text, :rating]))
   emit.call("recommendations",
             @product.recommended_products.as_json(only: [:id, :name, :price]))

--- a/docs/oss/migrating/rsc-preparing-app.md
+++ b/docs/oss/migrating/rsc-preparing-app.md
@@ -558,7 +558,7 @@ When the view uses React on Rails Pro async props, use the async-props helper va
 end %>
 ```
 
-The Server Component receives `getReactOnRailsAsyncProp` and reads those emitted values behind Suspense boundaries. See [Data Fetching in React on Rails Pro](./rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the complete pattern.
+The Server Component receives `getReactOnRailsAsyncProp` and reads those emitted values behind Suspense boundaries. The block still runs normal Ruby code in order, so `emit.call` does not parallelize slow queries by itself. For independent slow data sources, start the work concurrently before emitting values; see [Avoiding Server-Side Waterfalls](./rsc-data-fetching.md#avoiding-server-side-waterfalls). See [Data Fetching in React on Rails Pro](./rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the complete async-props pattern.
 
 ### 6c. Update script loading in layouts (recommended)
 

--- a/docs/oss/migrating/rsc-third-party-libs.md
+++ b/docs/oss/migrating/rsc-third-party-libs.md
@@ -242,12 +242,12 @@ All major date libraries work in Server Components since they are pure utility f
 
 ## Data Fetching Libraries
 
-| Library                          | RSC Pattern                                                                                        | Notes                                                                                                |
-| -------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| **React on Rails Pro streaming** | Recommended for React on Rails. Rails streams components via `stream_react_component`.             | See [Data Fetching Migration](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for details. |
-| **TanStack Query**               | Prefetch on server with `queryClient.prefetchQuery()`, hydrate on client with `HydrationBoundary`. | See [Data Fetching Migration](rsc-data-fetching.md) for details.                                     |
-| **Apollo Client**                | Server-side queries in Server Components, `ApolloProvider` for client queries.                     | Requires `'use client'` wrapper for provider.                                                        |
-| **SWR**                          | Client-only hooks. Use `fallbackData` pattern: fetch in Server Component, pass as props.           | See [Data Fetching Migration](rsc-data-fetching.md) for details.                                     |
+| Library                          | RSC Pattern                                                                                                                                                 | Notes                                                                                                |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **React on Rails Pro streaming** | Recommended for React on Rails. Rails streams components via `stream_react_component`, or slow emitted props via `stream_react_component_with_async_props`. | See [Data Fetching Migration](rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for details. |
+| **TanStack Query**               | Prefetch on server with `queryClient.prefetchQuery()`, hydrate on client with `HydrationBoundary`.                                                          | See [Data Fetching Migration](rsc-data-fetching.md) for details.                                     |
+| **Apollo Client**                | Server-side queries in Server Components, `ApolloProvider` for client queries.                                                                              | Requires `'use client'` wrapper for provider.                                                        |
+| **SWR**                          | Client-only hooks. Use `fallbackData` pattern: fetch in Server Component, pass as props.                                                                    | See [Data Fetching Migration](rsc-data-fetching.md) for details.                                     |
 
 ## Internationalization
 

--- a/docs/oss/migrating/rsc-troubleshooting.md
+++ b/docs/oss/migrating/rsc-troubleshooting.md
@@ -584,7 +584,7 @@ end
                posts: Post.where(user_id: current_user.id).limit(10).as_json }) %>
 ```
 
-See [Data Fetching Migration](rsc-data-fetching.md#avoiding-server-side-waterfalls) for detailed patterns.
+See [Data Fetching Migration](rsc-data-fetching.md#avoiding-server-side-waterfalls) for detailed patterns, including `stream_react_component_with_async_props` when slow Rails props should resolve behind Suspense boundaries.
 
 ### Missing Suspense Boundaries
 


### PR DESCRIPTION
> [!IMPORTANT]
> Merge after the async-props implementation lands on `main`. This PR is review-ready, but the documented helpers/types are currently verified against `origin/upcoming-v16.3.0`, not `main`.

Closes #2524.

## Summary

- Document the async-props helper variants in the Ruby/view helper API docs:
  - `stream_react_component_with_async_props`
  - `rsc_payload_react_component_with_async_props`
- Update the RSC data-fetching guide to distinguish synchronous `props:` HTML streaming from emitted async props behind Suspense.
- Add focused cross-references in the RSC migration/troubleshooting docs for slow Rails data that should use async props.

## Checks

- `pnpm exec prettier --check docs/oss/api-reference/ruby-api-pro.md docs/oss/api-reference/view-helpers-api.md docs/oss/migrating/migrating-to-rsc.md docs/oss/migrating/rsc-data-fetching.md docs/oss/migrating/rsc-preparing-app.md docs/oss/migrating/rsc-context-and-state.md docs/oss/migrating/rsc-component-patterns.md docs/oss/migrating/rsc-third-party-libs.md docs/oss/migrating/rsc-troubleshooting.md`
- `git diff --check`
- pre-commit hooks passed
- pre-push hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Pro API and view-helper docs with examples for emitter-based async-props streaming; clarified that prerender is forced and that streamed components hydrate early.
  * Propagated async-props streaming guidance across migration guides, patterns, data-fetching, troubleshooting, and checklists to recommend progressive async-props streaming for slow server data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3267)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
