### PR TITLE
chore: sync address-review command and import prompt variant

### DIFF
--- a/.claude/commands/address-review.md
+++ b/.claude/commands/address-review.md
@@ -6,24 +6,14 @@ Fetch review comments from a GitHub PR in this repository, triage them, and crea
 
 # Instructions
 
-## Step 1: Determine the Repository
-
-If the user input is a full GitHub URL, extract `org/repo` from the URL and use that as `REPO`.
-Otherwise, detect the repository from the current checkout:
-
-```bash
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-```
-
-If this command fails, ensure `gh` CLI is installed and authenticated (`gh auth status`).
-
-## Step 2: Parse User Input
+## Step 1: Parse User Input
 
 The user's input is: $ARGUMENTS
 
-First, detect whether the request includes the exact phrase `check all reviews`.
+First, detect whether the request includes the phrase `check all reviews` (case-insensitive, trailing position only — match it as the final tokens of the input, after the PR reference).
 
 - If it does, set a `CHECK_ALL_REVIEWS` flag and remove only that phrase before parsing the PR reference.
+- If the phrase appears in any other position (leading, embedded), do not treat it as an override; warn the user and ask them to retry with the trailing form.
 - Mention that override in the eventual PR summary comment so future runs have clear history.
 
 Then extract the PR number and optional review/comment ID from the remaining input:
@@ -41,31 +31,69 @@ Then extract the PR number and optional review/comment ID from the remaining inp
 
 - Extract org/repo from URL path: `github.com/{org}/{repo}/pull/{PR_NUMBER}`
 - Extract fragment ID after `#` (e.g., `pullrequestreview-123456789` → `123456789`)
-- If a full GitHub URL is provided, use the org/repo from the URL instead of the current repo
+- If a full GitHub URL is provided, capture the URL's `org/repo` now so Step 2 can use it without calling `gh repo view`.
+
+## Step 2: Set Repository and PR Number
+
+- If Step 1 extracted `org/repo` from a full GitHub URL, use that as `REPO`.
+- Otherwise, detect the repository from the current checkout.
+- Set `PR_NUMBER` to the number parsed in Step 1.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)  # or the org/repo extracted from the PR URL in Step 1
+PR_NUMBER=<the PR number parsed in Step 1>
+```
+
+Every subsequent snippet uses `${REPO}` and `${PR_NUMBER}` as shell variables; setting them once here means no manual substitution is required later. If `gh repo view` fails (and no URL was supplied), ensure `gh` CLI is installed and authenticated (`gh auth status`).
 
 ## Step 3: Determine Scan Window and Summary Cutoff
 
 For full-PR scans (plain PR number or PR URL with no specific review/comment anchor), default to reviewing only feedback posted after the latest PR summary comment created by this workflow.
 
-- The summary marker is a PR issue comment whose body contains `<!-- address-review-summary -->`.
+- The summary marker is a PR issue comment whose body starts with `<!-- address-review-summary -->` on its very first line. Requiring `startswith` (not `contains`) means a human comment that quotes or embeds the marker in prose is not mistaken for a checkpoint and cannot silently advance the cutoff.
 - If the user explicitly said `check all reviews`, ignore the cutoff and scan the full PR history.
 - If the input is a specific review URL or specific issue-comment URL, fetch that exact target even if it predates the latest summary comment.
 
-Fetch the latest summary comment before collecting review data:
+Fetch the latest summary comment before collecting review data. Extract only the timestamp, guarding against the empty-array case (`jq ... | last` emits JSON `null` when nothing matches):
 
 ```bash
-gh api --paginate repos/${REPO}/issues/{PR_NUMBER}/comments | jq -s '[.[].[] | select(((.body // "") | contains("<!-- address-review-summary -->"))) | {id: .id, created_at: .created_at, html_url: .html_url}] | sort_by(.created_at) | last'
+REVIEW_CUTOFF_AT=$(
+  gh api --paginate repos/${REPO}/issues/${PR_NUMBER}/comments \
+    | jq -rs '[.[].[] | select((.body // "") | startswith("<!-- address-review-summary -->")) | {id: .id, created_at: .created_at, html_url: .html_url}] | sort_by(.created_at) | last | if . == null then "" else .created_at end'
+)
+# Empty string → no prior summary comment; scan full PR history.
 ```
 
 Cutoff rules:
 
-- If a summary comment exists and `CHECK_ALL_REVIEWS` is false, set `REVIEW_CUTOFF_AT` to that comment's `created_at` timestamp.
+- `REVIEW_CUTOFF_AT` is empty when no summary comment exists; treat that as "scan full PR history" and do not filter by timestamp.
+- If `REVIEW_CUTOFF_AT` is non-empty and `CHECK_ALL_REVIEWS` is false, use it as the cutoff.
 - Use exact timestamps in user-facing status updates, for example: "Scanning review activity after 2026-04-01T20:14:33Z."
-- If no summary comment exists, scan the full PR history.
 - When a cutoff is active, keep enough older thread context to understand new replies, but only triage items whose own timestamp or latest thread activity is after `REVIEW_CUTOFF_AT`.
 - If no items survive the cutoff, say that no new review feedback was found since the last summary comment and remind the user they can say `check all reviews` to rescan the full PR.
 
 ## Step 4: Fetch Review Comments
+
+Before fetching, wait for any in-progress `claude-review` CI run on this PR so the triage reflects the latest posted feedback. Skip the wait if the user provided a specific review URL or specific issue-comment URL — fetch that exact target immediately. If `gh pr checks` is unavailable or returns an error, log a warning and continue without blocking.
+
+```bash
+# Block while a claude-review check is still queued/running (bucket == "pending").
+# Pass --repo so cross-repo PR URLs target the parsed REPO, not the current checkout.
+# The fallback `|| echo 0` makes the loop exit gracefully if `gh pr checks` errors.
+# `MAX_WAIT` caps the total wait so a stalled runner cannot block triage indefinitely.
+MAX_WAIT=180
+WAITED=0
+while [ "$(gh pr checks "${PR_NUMBER}" --repo "${REPO}" --json name,bucket 2>/dev/null \
+  | jq '[.[] | select((.name | test("claude.?review"; "i")) and (.bucket == "pending"))] | length' 2>/dev/null || echo 0)" -gt 0 ]; do
+  if [ "${WAITED}" -ge "${MAX_WAIT}" ]; then
+    echo "Warning: claude-review CI still pending after ${MAX_WAIT}s — proceeding with triage anyway."
+    break
+  fi
+  echo "Waiting for in-progress claude-review CI to finish before triaging... (${WAITED}s elapsed)"
+  sleep 15
+  WAITED=$((WAITED + 15))
+done
+```
 
 **If a specific issue comment ID is provided (`#issuecomment-...`):**
 
@@ -77,10 +105,10 @@ gh api repos/${REPO}/issues/comments/{COMMENT_ID} | jq '{body: .body, user: .use
 
 ```bash
 # Review body (often contains summary feedback)
-gh api repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, submitted_at: .submitted_at, html_url: .html_url}'
+gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, created_at: .submitted_at, html_url: .html_url}'
 
 # Inline comments for this review
-gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id, created_at: .created_at, html_url: .html_url}]'
+gh api --paginate repos/${REPO}/pulls/${PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id, created_at: .created_at, html_url: .html_url}]'
 ```
 
 Include the review body as a general comment when it contains actionable feedback. When the review body contains actionable feedback, note that it cannot be replied to via the `/replies` endpoint — responses to review summary bodies must be posted as general PR comments (see Step 8).
@@ -89,13 +117,13 @@ Include the review body as a general comment when it contains actionable feedbac
 
 ```bash
 # Review summary bodies (can contain actionable feedback even without inline comments)
-gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/reviews | jq -s '[.[].[] | select((.body // "") != "") | {id: .id, type: "review_summary", body: .body, state: .state, user: .user.login, submitted_at: .submitted_at, html_url: .html_url}]'
+gh api --paginate repos/${REPO}/pulls/${PR_NUMBER}/reviews | jq -s '[.[].[] | select((.body // "") != "") | {id: .id, type: "review_summary", body: .body, state: .state, user: .user.login, created_at: .submitted_at, html_url: .html_url}]'
 
 # Inline code review comments
-gh api --paginate repos/${REPO}/pulls/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id, created_at: .created_at, html_url: .html_url}]'
+gh api --paginate repos/${REPO}/pulls/${PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id, created_at: .created_at, html_url: .html_url}]'
 
 # General PR discussion comments (not tied to specific lines)
-gh api --paginate repos/${REPO}/issues/{PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, created_at: .created_at, html_url: .html_url}]'
+gh api --paginate repos/${REPO}/issues/${PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, created_at: .created_at, html_url: .html_url}]'
 ```
 
 Include actionable review summary bodies from `/pulls/{PR_NUMBER}/reviews` as additional general comments. Like specific review bodies, they cannot be replied to via the `/replies` endpoint and must be answered as general PR comments (see Step 8).
@@ -113,21 +141,20 @@ When `REVIEW_CUTOFF_AT` is set for a full-PR scan:
 ```bash
 OWNER=${REPO%/*}
 NAME=${REPO#*/}
-gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER} -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'
+gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr="${PR_NUMBER}" -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'
 ```
 
 **Filtering comments:**
 
-- Never triage a prior summary checkpoint comment. Skip any issue comment whose body contains `<!-- address-review-summary -->`.
+- Never triage a prior summary checkpoint comment. Skip any issue comment whose body starts with `<!-- address-review-summary -->`.
 - Skip comments belonging to already-resolved threads (match via `thread_id` and `is_resolved` from the GraphQL response)
 - Do not create standalone triage items from comments where `in_reply_to_id` is set, but use reply text as the latest thread context when it updates or narrows the unresolved concern
 - When `REVIEW_CUTOFF_AT` is set, evaluate unresolved review threads by their latest activity timestamp, not only by the top-level comment timestamp
 - Do not skip bot-generated comments by default. Many actionable review comments in this repository come from bots.
 - Deduplicate repeated bot comments and skip bot status posts, summaries, and acknowledgments that do not require a code or documentation change
-- Treat as must-fix by default only: correctness bugs, regressions, security issues, missing tests, and clear inconsistencies with adjacent code
-- Treat as optional improvements (OPTIONAL, not SKIPPED): style nits, speculative suggestions, changelog wording, test-shape preferences, comment/documentation/naming requests, and "could consider" feedback that would improve the PR but isn't a blocker
-- Treat as truly non-actionable (SKIPPED): duplicate comments, bot status posts, acknowledgments, factually incorrect suggestions, and summaries that do not require action
-- Focus on actionable or improvement-worthy feedback, not acknowledgments or thank-you messages
+- Treat as actionable by default only: correctness bugs, regressions, security issues, missing tests, and clear inconsistencies with adjacent code
+- Treat as non-actionable by default: style nits, speculative suggestions, changelog wording, duplicate bot comments, and "could consider" feedback unless the user explicitly asks for polish work
+- Focus on actionable feedback, not acknowledgments or thank-you messages
 
 **Error handling:**
 
@@ -138,12 +165,11 @@ gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr={PR_NUMBER
 
 ## Step 5: Triage Comments
 
-Before creating any todos, classify every review comment into one of four categories:
+Before creating any todos, classify every review comment into one of three categories:
 
 - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a real bug, and clear inconsistencies with adjacent code that would likely block merge
 - `DISCUSS`: reasonable suggestions that expand scope, architectural opinions that are not clearly right or wrong, and comments where the reviewer claim may be correct but needs a user decision
-- `OPTIONAL`: nits, style preferences, documentation/comment/naming suggestions, test-shape preferences, speculative "consider" suggestions, and changelog polish — items that would genuinely improve the PR but are not blockers. Default to this tier when a comment is well-intentioned and applicable but not required for merge.
-- `SKIPPED`: duplicate comments, factually incorrect suggestions, status posts, acknowledgments, and non-actionable summaries. Reserved for feedback that does not warrant a code change or a rationale reply — if a comment has any useful signal, prefer `OPTIONAL`.
+- `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, non-actionable summaries, and factually incorrect suggestions
 
 Triage rules:
 
@@ -153,18 +179,6 @@ Triage rules:
 - Preserve the original review comment ID and thread ID when available so the command can reply to the correct place and resolve the correct thread later.
 - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
 
-**Greptile claim verification:**
-
-When Greptile MCP tools are available (`mcp__plugin_greptile_greptile__*`), cross-reference reviewer claims against Greptile's codebase analysis before finalizing triage classifications:
-
-1. For each reviewer comment that asserts a factual claim about the codebase (e.g., "this function doesn't handle null", "this breaks the existing API contract"), query Greptile to verify the claim:
-   - Use `mcp__plugin_greptile_greptile__search_greptile_comments` to find prior Greptile analysis of the same code area
-   - Use `mcp__plugin_greptile_greptile__search_custom_context` to check project-specific context that may confirm or contradict the claim
-2. If Greptile's analysis clearly contradicts the reviewer's claim and local code inspection confirms the code already handles the concern, classify as `SKIPPED` per the existing triage rule (claim is demonstrably wrong). If the analysis is inconclusive or only partially contradicts the claim, downgrade to `DISCUSS` and note the discrepancy (e.g., "Greptile analysis suggests current handling may be correct — needs verification").
-3. If Greptile's analysis corroborates the reviewer's claim, keep the `MUST-FIX` classification with higher confidence.
-4. If Greptile has no relevant data, fall back to local verification only.
-5. Do not block triage on Greptile availability — if the tools are not configured or the API fails, proceed with local verification alone.
-
 ## Step 6: Create Todo List
 
 Create a task list with TodoWrite containing **only the `MUST-FIX` items**:
@@ -172,8 +186,7 @@ Create a task list with TodoWrite containing **only the `MUST-FIX` items**:
 - One task per must-fix comment or deduplicated issue
 - Subject: `"{file}:{line} - {comment_summary} (@{username})"`
 - For general comments: Parse the comment body and extract the must-fix action as the subject
-- Description: Include the full review comment text, any relevant context, and a **Recommendation** section with a concrete fix sketch — specific file/line, code snippet, or approach — that the user could act on directly.
-- Before finalizing the recommendation, read the current code around the cited location so the suggestion matches what's actually there. If the reviewer's claim needs inspection before a safe fix can be proposed (e.g., unclear call sites, shared helpers), make the Recommendation the verification step ("Confirm X by reading Y, then guard against Z"), not a guessed patch.
+- Description: Include the full review comment text and any relevant context
 - All tasks should start with status: `"pending"`
 
 ## Step 7: Present Triage and Quick-Action Menu
@@ -181,30 +194,27 @@ Create a task list with TodoWrite containing **only the `MUST-FIX` items**:
 Present the triage to the user - **DO NOT automatically start addressing items**:
 
 - Use a single sequential numbering across all categories (1, 2, 3, ...) so every item has a unique number the user can reference. Do not restart numbering at 1 for each category.
-- `MUST-FIX ({count})`: list the todos created, each followed by its `Recommendation:` sketch on an indented line
+- `MUST-FIX ({count})`: list the todos created
 - `DISCUSS ({count})`: list items needing user choice, with a short reason
-- `OPTIONAL ({count})`: list nits and improvement suggestions that would help the PR but aren't required, with a short reason describing the potential improvement
-- `SKIPPED ({count})`: list skipped comments with a short reason — reserved for duplicates, factually incorrect suggestions, and non-actionable noise
+- `SKIPPED ({count})`: list skipped comments with a short reason, including duplicates and factually incorrect suggestions
 
 After the triage list, present a **quick-action menu**:
 
 ```text
 Quick actions:
-  f     — Fix must-fix items, then prompt for optional/discuss handling and skipped rationale replies
-  f+i   — Fix must-fix + create follow-up issue for discuss/optional items (and non-trivial skipped items)
-  f+o   — Fix must-fix + address all optional items inline in the same PR
+  f     — Fix must-fix items, then confirm whether to reply/resolve skipped items before deciding discuss items
+  f+i   — Fix must-fix + create follow-up issue for discuss/non-trivial skipped items
   d     — Discuss specific items before deciding (e.g., "d2,4"). Bare "d" presents all DISCUSS items.
-  o     — Address specific optional items inline (e.g., "o6,7"). Bare "o" presents all OPTIONAL items for selection.
-  r     — Reply with rationale to items (e.g., "r3,5", "r7-9", "r all skipped", "r all optional", "r all discuss"); add `+ resolve` to also resolve those threads
-  m     — Skip code changes + create follow-up issue for must-fix/discuss/optional items (and non-trivial skipped items)
+  r     — Reply with rationale to items (e.g., "r3,5", "r7-9", "r all skipped", "r all discuss"); add `+ resolve` to also resolve those threads
+  m     — Skip code changes + create follow-up issue for must-fix/discuss/non-trivial skipped items
 
-Or pick items by number: "1,2", "all must-fix", "all optional", "1,3-5"
+Or pick items by number: "1,2", "all must-fix", "1,3-5"
 ```
 
-**Range syntax**: Support `N-M` to expand into individual item numbers (e.g., `3-5` becomes `3,4,5`). Ranges work everywhere: item selection, `d`, `o`, and `r`.
+**Range syntax**: Support `N-M` to expand into individual item numbers (e.g., `3-5` becomes `3,4,5`). Ranges work everywhere: item selection, `d`, and `r`.
 If a range is malformed, reversed, or out of bounds, show a validation message and ask the user to retry (do not silently coerce it).
 
-**Dynamic menu**: Generate `f`, `f+i`, and `f+o` descriptions dynamically using actual item numbers and deferred targets from the current triage set (e.g., "Fix #1, #3" or "Fix #1 plus inline #4-6" instead of "Fix must-fix items"). Only show `f+o` and `o` when there is at least one `OPTIONAL` item. When there are no `DISCUSS`, `OPTIONAL`, or `SKIPPED` items, only show `f` and direct item selection.
+**Dynamic menu**: Generate `f` and `f+i` descriptions dynamically using actual item numbers and deferred targets from the current triage set (e.g., "Fix #1, #3" instead of "Fix must-fix items"). When there are no `DISCUSS` or `SKIPPED` items, only show `f` and direct item selection.
 
 Wait for the user to choose an action before proceeding.
 
@@ -214,59 +224,48 @@ Do not post the PR summary checkpoint during this triage-only phase. Post it onl
 
 ### Action `f` — Fix and merge-ready
 
-1. Address all `MUST-FIX` items (make code changes, run checks). If there are no `MUST-FIX` items, skip directly to optional/discuss/skipped handling.
+1. Address all `MUST-FIX` items (make code changes, run checks). If there are no `MUST-FIX` items, skip directly to discuss/skipped handling.
 2. If local changes exist, commit and then ask for push confirmation before pushing. If there are no local changes, skip commit/push and continue decision flow.
 3. Reply to each addressed comment explaining the fix.
 4. Resolve the corresponding review threads.
-5. If `OPTIONAL` items exist, present them and prompt the user to choose: `o <nums>` to address inline, `f+i` to defer to a follow-up issue, or `r all optional + resolve` to decline and close. Do not auto-address or auto-resolve optional items in `f`.
-6. If `SKIPPED` items exist, ask for explicit confirmation before posting rationale replies and resolving those threads (for example: "Reply/resolve 3 skipped items? y/n"). Default is no replies unless the user opts in.
-7. Do **not** auto-resolve `DISCUSS` items in `f`; after must-fix work, re-present discuss items and prompt the user to choose `d` (discuss), `f+i` (create follow-up issue), or `r all discuss + resolve`. If `f` starts with zero `MUST-FIX` items, show the optional/discuss decision menus immediately.
-8. Tell the user the PR is merge-ready after `DISCUSS` items are resolved or explicitly deferred. `OPTIONAL` items do not block merge-readiness; they are surfaced in step 5 for the user to opt into.
-9. If any `DISCUSS` items remain, explicitly prompt with the next action (for example: "DISCUSS items remain - use `d` to review, `f+i` to defer to a follow-up issue, or `r all discuss + resolve` to decline and close."). If any `OPTIONAL` items remain unaddressed, mention them but do not block merge-readiness.
+5. If `SKIPPED` items exist, ask for explicit confirmation before posting rationale replies and resolving those threads (for example: "Reply/resolve 3 skipped items? y/n").
+6. Do **not** auto-resolve `DISCUSS` items in `f`; after must-fix work, re-present discuss items and prompt the user to choose `d` (discuss), `f+i` (create follow-up issue), or `r all discuss + resolve`. If `f` starts with zero `MUST-FIX` items, show this discuss decision menu immediately.
+7. Tell the user the PR is merge-ready only after `DISCUSS` items are resolved or explicitly deferred.
+8. If any `DISCUSS` items remain, explicitly prompt with the next action (for example: "DISCUSS items remain - use `d` to review, `f+i` to defer to a follow-up issue, or `r all discuss + resolve` to decline and close.").
 
 ### Action `f+i` — Fix, follow-up issue, and merge-ready
 
 1. Do everything in `f` for `MUST-FIX` items. If there are no `MUST-FIX` items, skip the fix phase and continue with deferred-item handling.
-2. Create a **follow-up GitHub issue** (see Step 9) bundling all `DISCUSS`, `OPTIONAL`, and non-trivial `SKIPPED` items. Separate these into distinct sections in the issue body so each reviewer's expectation is clear.
+2. Create a **follow-up GitHub issue** (see Step 9) bundling all `DISCUSS` and non-trivial `SKIPPED` items.
 3. For each deferred item in the follow-up issue, post a reply in the original location referencing the issue (use review-comment replies for inline comments and issue comments for review summaries/general comments), and resolve the thread when one exists. For general PR comments and review summary bodies (which have no thread), the reply alone is sufficient.
-4. For trivial `SKIPPED` items that are not included in the follow-up issue (duplicates, factually incorrect suggestions, status noise), ask whether to post rationale replies and resolve those threads. Default is no replies unless the user opts in.
+4. For trivial `SKIPPED` items that are not included in the follow-up issue (duplicates, factually incorrect suggestions, status noise), still post rationale replies and resolve those threads.
 5. If there are zero deferred items, skip issue creation and behave like `f`.
 6. No additional commit is required unless later steps introduce local changes; if they do, commit and ask for push confirmation before pushing.
 7. Tell the user the PR is merge-ready.
 
-### Action `f+o` — Fix must-fix and address optional inline
-
-1. Address all `MUST-FIX` items as in `f` (self-review gate, commit, push confirmation).
-2. Address all `OPTIONAL` items inline in the same PR: make the code change, reply, and resolve the thread for each. Treat each optional item the same as a selected must-fix once `f+o` is chosen.
-3. If optional fixes require a separate commit (e.g., to keep the must-fix commit atomic), commit them and ask for push confirmation before pushing the additional commit.
-4. Handle `DISCUSS` and `SKIPPED` items using `f` steps 6–7 (skip step 5; optional items are already addressed above).
-5. Tell the user the PR is merge-ready once all selected work is pushed and `DISCUSS` items are resolved or explicitly deferred.
-6. If there are zero `OPTIONAL` items, behave like `f` and note that `f+o` had nothing additional to do.
-
 ### Action `d` — Discuss items
 
-Present the requested items with full context and ask the user for a decision on each. If the user enters bare `d` with no item numbers, present all `DISCUSS` items. After the user decides, treat approved items as `MUST-FIX` (fix, reply, resolve) and declined items as `SKIPPED` (optionally reply with rationale if the user asks). For approved items that produce local changes, use the same commit/push-before-reply ordering as action `f`. After handling requested `d` items, re-offer the quick-action menu for remaining unaddressed items. Note: `d` only accepts `DISCUSS` item numbers. If any selected number refers to an `OPTIONAL`, `MUST-FIX`, or `SKIPPED` item, do not proceed — respond with "Item N is {tier} — use `{o|f|r}` instead" for each mismatched number and ask for a corrected selection.
-
-### Action `o` — Address optional items inline
-
-Present the requested items with full context. If the user enters bare `o` with no item numbers, present all `OPTIONAL` items for selection. For each selected optional item, treat it the same as a `MUST-FIX`: make the code change, run relevant checks, reply, and resolve the thread. Use the same commit/push-before-reply ordering as action `f`. For optional items the user declines, offer a rationale reply via `r <nums>`. After handling requested `o` items, re-offer the quick-action menu for remaining unaddressed items. Note: `o` only accepts `OPTIONAL` item numbers. If any selected number refers to a `DISCUSS`, `MUST-FIX`, or `SKIPPED` item, do not proceed — respond with "Item N is {tier} — use `{d|f|r}` instead" for each mismatched number and ask for a corrected selection.
+Present the requested items with full context and ask the user for a decision on each. If the user enters bare `d` with no item numbers, present all `DISCUSS` items. After the user decides, treat approved items as `MUST-FIX` (fix, reply, resolve) and declined items as `SKIPPED` (optionally reply with rationale if the user asks). For approved items that produce local changes, use the same commit/push-before-reply ordering as action `f`. After handling requested `d` items, re-offer the quick-action menu for remaining unaddressed items.
 
 ### Action `r` — Reply with rationale
 
-Post rationale replies to the specified items explaining why they are being deferred, declined, or treated as optional. By default, do not resolve threads in `r` unless the user explicitly asks to resolve them (for example, `r3,5 + resolve`). Accept `SKIPPED`, `OPTIONAL`, or `DISCUSS` item numbers, ranges, `r all skipped`, `r all optional`, or `r all discuss`. If the selection includes any `MUST-FIX` item (including `r all must-fix`), do not post replies; direct the user to `f` or explicit deferral (`f+i` / `m`).
+Post rationale replies to the specified items explaining why they are being deferred or skipped. By default, do not resolve threads in `r` unless the user explicitly asks to resolve them (for example, `r3,5 + resolve`). Accept only `SKIPPED`/`DISCUSS` item numbers, ranges, `r all skipped`, or `r all discuss`. If the selection includes any `MUST-FIX` item (including `r all must-fix`), do not post replies; direct the user to `f` or explicit deferral (`f+i` / `m`).
+
+- Bare `r` (with no items and no `all` qualifier) is ambiguous. Do not reply to anything. Prompt the user to specify item numbers or ranges, or one of `r all skipped` / `r all discuss`.
+- Bare `r all` (without `skipped` or `discuss`) is also ambiguous. Do not reply to anything. Respond with: `"r all" is ambiguous — use "r all skipped", "r all discuss", or run both: "r all skipped" then "r all discuss"`.
 
 ### Action `m` — Merge as-is
 
-1. Create a follow-up GitHub issue (see Step 9) bundling `MUST-FIX`, `DISCUSS`, `OPTIONAL`, and non-trivial `SKIPPED` items, each in their own section.
+1. Create a follow-up GitHub issue (see Step 9) bundling `MUST-FIX`, `DISCUSS`, and non-trivial `SKIPPED` items.
 2. Post replies in the original location for each deferred item: use review-comment replies for inline comments and issue comments for review summaries/general comments.
-3. Resolve `DISCUSS`, `OPTIONAL`, and `SKIPPED` review threads after replying (resolve only when a thread exists).
+3. Resolve `DISCUSS` and `SKIPPED` review threads after replying (resolve only when a thread exists).
 4. If any `MUST-FIX` items were deferred, keep those review threads open by default unless the user explicitly asks to close them.
 5. If any `MUST-FIX` items were deferred, explicitly tell the user the PR is **not merge-ready** without an override decision.
 6. Only signal merge-ready with no code changes when there are zero deferred `MUST-FIX` items.
 
-### Direct item selection (e.g., "1,2", "all must-fix", "all optional", "1,3-5")
+### Direct item selection (e.g., "1,2", "all must-fix", "1,3-5")
 
-Address only the selected items (`MUST-FIX`, `DISCUSS`, or `OPTIONAL`). After completing them:
+Address only the selected items. After completing them:
 
 1. If selected items produced local changes, commit and ask for push confirmation before pushing (skip this step when there are no local changes).
 2. Reply and resolve threads for addressed items.
@@ -274,52 +273,24 @@ Address only the selected items (`MUST-FIX`, `DISCUSS`, or `OPTIONAL`). After co
 
 ### Combination actions
 
-Users can chain actions: e.g., `f+i` then `r7-9`, or `f+o` then `d3`. After the first action completes, check if there are remaining un-replied items and offer the next logical action.
+Users can chain actions: e.g., `f+i` then `r7-9`. After the first action completes, check if there are remaining un-replied items and offer the next logical action.
 
 ### General rules for all actions
 
-When addressing items, after completing each selected item (whether `MUST-FIX`, `DISCUSS`, or `OPTIONAL`), reply to the original review comment explaining how it was addressed.
-If the user selects `DISCUSS` or `OPTIONAL` items to address, treat them the same as `MUST-FIX`: make the code change, reply, and resolve the thread.
+When addressing items, after completing each selected item (whether `MUST-FIX` or `DISCUSS`), reply to the original review comment explaining how it was addressed.
+If the user selects `DISCUSS` items to address, treat them the same as `MUST-FIX`: make the code change, reply, and resolve the thread.
 If the user selects skipped/declined items for rationale replies, post those replies too.
-
-**Parallel sub-agents for independent fixes:**
-
-When there are 2+ items to fix that touch different files with no logical dependencies between them, use the Task tool to spawn parallel sub-agents for faster execution:
-
-1. Group items by file path. Items in different files with no cross-file dependencies (e.g., a type change in file A that affects callers in file B) are independent.
-2. For each independent group, spawn a sub-agent via the Task tool with:
-   - The full review comment text and context
-   - The file path and line number
-   - Instructions to make the specific fix and run any relevant file-level checks
-   - A reminder not to modify files outside the assigned scope
-   - An explicit instruction **not to commit** the changes — leave all modifications unstaged so the orchestrator can run the self-review gate on the combined diff before committing
-3. After all sub-agents complete, verify there are no conflicts between their changes by checking whether any sub-agents touched the same files (e.g., `git diff --name-only` to list changed files, then check for overlaps).
-4. If conflicts exist, resolve them sequentially before proceeding.
-5. If a sub-agent fails (crashes, hits a tool error, or produces an incorrect edit), fall back to fixing that item sequentially in the parent agent before proceeding.
-6. Items that touch the same file or have logical dependencies must be fixed sequentially, not in parallel.
-7. If only 1 item needs fixing or all items are in the same file, skip parallel dispatch and fix sequentially as before.
-
-**Self-review gate before pushing:**
-
-After making all code changes but before committing, run a self-review on the diff to prevent new review cycles caused by the fixes themselves:
-
-1. Use the Task tool to launch a code-review sub-agent (e.g., `pr-review-toolkit:code-reviewer` if available, or a general-purpose review agent) against the uncommitted changes (`git diff`).
-2. The self-review should check for: correctness bugs introduced by the fixes, style violations against project standards (CLAUDE.md, linter rules), missing error handling, and inconsistencies with surrounding code.
-3. If the self-review finds critical issues (bugs, security problems, or clear correctness errors), fix them immediately before committing. These are issues that would likely trigger a new review round.
-4. If the self-review finds only minor issues (style nits, naming suggestions), note them but proceed — do not block the push for optional improvements.
-5. If the self-review catches and fixes additional issues, mention this in the commit message (e.g., "also fixed: null check in adjacent error path caught by self-review").
-6. Skip the self-review gate for non-code actions (rationale replies, follow-up issue creation, thread resolution).
 
 **For issue comments (general PR comments):**
 
 ```bash
-gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"
+gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST -f body="<response>"
 ```
 
 **For PR review comments (file-specific, replying to a thread):**
 
 ```bash
-gh api repos/${REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"
+gh api repos/${REPO}/pulls/${PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"
 ```
 
 Use the `/replies` endpoint for all existing review comments, including standalone top-level comments.
@@ -329,7 +300,7 @@ Use the `/replies` endpoint for all existing review comments, including standalo
 Review summary bodies do not have a `comment_id` and cannot be replied to via the `/replies` endpoint. Instead, post a general PR comment referencing the review:
 
 ```bash
-gh api repos/${REPO}/issues/{PR_NUMBER}/comments -X POST -f body="<response>"
+gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST -f body="<response>"
 ```
 
 The response should briefly explain:
@@ -356,17 +327,17 @@ If the user explicitly asks to close out a `DISCUSS` or `SKIPPED` item, reply wi
 
 ## Step 9: Create Follow-Up Issue (when requested)
 
-When the user chooses `f+i`, `m`, or explicitly asks for a follow-up issue, create a GitHub issue that bundles deferred items:
+When the user chooses `f+i`, `m`, or explicitly asks for a follow-up issue, create a GitHub issue that bundles deferred items.
+
+**Run Steps 9 and 10 in a single shell call.** They share state — `${FOLLOW_UP_URL}` set in Step 9 is consumed by Step 10's summary template, `${issue_body_file}` and `${summary_body_file}` share an EXIT trap, and the `_cleanup_addr_review` function is defined once. Agents that execute each Bash tool call in a fresh subshell (the default in Claude Code and similar harnesses) will lose `${FOLLOW_UP_URL}` between calls and trigger Step 9's cleanup trap before Step 10 runs. Combine both steps into one heredoc/chained invocation, or capture Step 9's `FOLLOW_UP_URL` from stdout and pass it explicitly into Step 10's invocation.
+
+The cleanup trap below is a named `_cleanup_addr_review` function rather than an inline `trap '...' EXIT` so Step 10's standalone path can redefine the same function without divergence. Installing the trap up front (rather than letting Step 10 replace it) closes the race window where an early exit between Step 9 and Step 10 would skip cleanup of the second temp file.
 
 ```bash
 # Template inputs: replace each <...> placeholder before running this snippet.
 # Use single-quoted heredocs so pasted review text is treated as literal content.
 DISCUSS_ITEMS="$(cat <<'EOF'
 <DISCUSS_ITEMS_BULLETS_OR_EMPTY>
-EOF
-)"
-OPTIONAL_ITEMS="$(cat <<'EOF'
-<OPTIONAL_ITEMS_BULLETS_OR_EMPTY>
 EOF
 )"
 SKIPPED_ITEMS="$(cat <<'EOF'
@@ -380,105 +351,114 @@ MUST_FIX_SECTION="$(cat <<'EOF'
 EOF
 )"
 
-MUST_FIX_BLOCK="${MUST_FIX_SECTION}"
-
 DISCUSS_SECTION=""
 if [ -n "${DISCUSS_ITEMS}" ]; then
-  printf -v DISCUSS_SECTION '### Discuss items\n%s\n' "${DISCUSS_ITEMS}"
-fi
-
-OPTIONAL_SECTION=""
-if [ -n "${OPTIONAL_ITEMS}" ]; then
-  printf -v OPTIONAL_SECTION '### Optional items\n%s\n' "${OPTIONAL_ITEMS}"
+  DISCUSS_SECTION="### Discuss items
+${DISCUSS_ITEMS}
+"
 fi
 
 SKIPPED_SECTION=""
 if [ -n "${SKIPPED_ITEMS}" ]; then
-  printf -v SKIPPED_SECTION '### Skipped items (non-trivial)\n%s\n' "${SKIPPED_ITEMS}"
+  SKIPPED_SECTION="### Skipped items (non-trivial)
+${SKIPPED_ITEMS}
+"
 fi
 
-if [ -z "${MUST_FIX_BLOCK}${DISCUSS_SECTION}${OPTIONAL_SECTION}${SKIPPED_SECTION}" ]; then
+if [ -z "${MUST_FIX_SECTION}${DISCUSS_SECTION}${SKIPPED_SECTION}" ]; then
   echo "No deferred items found; skip follow-up issue creation."
 else
-  SECTION_CONTENT=""
-  for section in "${MUST_FIX_BLOCK}" "${DISCUSS_SECTION}" "${OPTIONAL_SECTION}" "${SKIPPED_SECTION}"; do
-    [ -z "${section}" ] && continue
-    if [ -n "${SECTION_CONTENT}" ]; then
-      SECTION_CONTENT="${SECTION_CONTENT}"$'\n\n'
-    fi
-    SECTION_CONTENT="${SECTION_CONTENT}${section}"
-  done
   issue_body_file="$(mktemp)"
+  # Cleanup covers both temp files; Step 10 redefines _cleanup_addr_review for its standalone path.
+  _cleanup_addr_review() {
+    [ -n "${issue_body_file:-}" ]   && rm -f "${issue_body_file}"
+    [ -n "${summary_body_file:-}" ] && rm -f "${summary_body_file}"
+  }
+  trap _cleanup_addr_review EXIT
+  # Build the issue body with printf only — avoids bash-only ANSI-C quoting
+  # (e.g., $'\n\n') which expands to a literal "$\n\n" under POSIX sh (dash).
   {
     printf '## Deferred review feedback from PR #%s\n\n' "${PR_NUMBER}"
     printf 'These items were triaged during review and deferred for follow-up.\n\n'
-    printf '%s\n\n' "${SECTION_CONTENT}"
+    printed_first=0
+    for section in "${MUST_FIX_SECTION}" "${DISCUSS_SECTION}" "${SKIPPED_SECTION}"; do
+      [ -z "${section}" ] && continue
+      if [ "${printed_first}" -eq 1 ]; then
+        printf '\n\n'
+      fi
+      printf '%s' "${section}"
+      printed_first=1
+    done
+    printf '\n\n'
     printf -- '---\n'
     printf 'Original PR: https://github.com/%s/pull/%s\n' "${REPO}" "${PR_NUMBER}"
   } > "${issue_body_file}"
 
-  gh issue create --repo "${REPO}" --title "Follow-up: Review feedback from PR #${PR_NUMBER}" --body-file "${issue_body_file}"
-  rm -f "${issue_body_file}"
+  FOLLOW_UP_URL=$(gh issue create --repo "${REPO}" --title "Follow-up: Review feedback from PR #${PR_NUMBER}" --body-file "${issue_body_file}" --json url -q .url)
 fi
 ```
 
 Rules for follow-up issues:
 
-- Always include every `DISCUSS` and `OPTIONAL` item in their respective sections; these are the primary purpose of the follow-up issue
 - Only include non-trivial `SKIPPED` items (skip pure duplicates and factually incorrect suggestions)
 - For `f+i`, omit the must-fix section because must-fix items were addressed in the current PR
 - For `m`, include a must-fix section with heading `### Must-fix items (deferred)` and deferred blockers
 - Omit any section heading when its corresponding item list is empty
 - Include the original reviewer username and comment link for each item
-- For `OPTIONAL` items, include the improvement rationale so a future reader can decide whether it's still worth doing
 - Include enough context that someone can act on the issue without re-reading the full PR review
 - After creating the issue, reference it in thread replies (e.g., "Tracked in #NNN for follow-up")
+- Capture the `gh issue create` output into `FOLLOW_UP_URL` (as shown above) so Step 10's summary comment can include the link
 - Return the issue URL to the user
 
 ## Step 10: Post PR Summary Comment
 
-After any chosen action or completed action chain (`f`, `f+i`, `f+o`, `d`, `o`, `r`, `m`, or direct item selection), post a consolidated PR comment that becomes the next default review cutoff.
+After any chosen action or completed action chain (`f`, `f+i`, `d`, `r`, `m`, or direct item selection), post a consolidated PR comment that becomes the next default review cutoff.
 
 Rules for the summary comment:
 
 - Always post it as a general PR issue comment, never as a review-thread reply.
 - Include the exact marker `<!-- address-review-summary -->` on its own line near the top.
 - Summarize `MUST-FIX` and `DISCUSS` items under a `Mattered` section, including whether each item was addressed, deferred, or left pending by user choice.
-- Summarize `OPTIONAL` items under an `Optional` section, including whether each was addressed inline, deferred to a follow-up issue, declined, or left pending.
 - Summarize `SKIPPED` items under a `Skipped` section with short reasons.
 - Mention any follow-up issue URL that was created.
 - Mention whether the run used the default cutoff or the explicit `check all reviews` override.
 - End with a note that future full-PR scans should start after this comment unless the user says `check all reviews`.
 
-Suggested structure:
+Suggested structure. As called out in Step 9, run Steps 9 and 10 in the same shell call so `${FOLLOW_UP_URL}` and the EXIT trap persist; otherwise capture `FOLLOW_UP_URL` from Step 9's stdout and pass it in explicitly. `_cleanup_addr_review` is redefined here to cover the standalone-Step-10 path (when Step 9 was skipped and `issue_body_file` is unset). Redefining the same function is harmless if Step 9 already defined it; the `[ -n ... ]` guards keep `rm -f ""` out of the picture on shells that reject empty path arguments.
 
 ```bash
 summary_body_file="$(mktemp)"
+# Cleanup mirrors Step 9's definition for the standalone-Step-10 path.
+_cleanup_addr_review() {
+  [ -n "${issue_body_file:-}" ]   && rm -f "${issue_body_file}"
+  [ -n "${summary_body_file:-}" ] && rm -f "${summary_body_file}"
+}
+trap _cleanup_addr_review EXIT
+# Set SCAN_SCOPE before this block, e.g.:
+#   SCAN_SCOPE="since previous summary at ${REVIEW_CUTOFF_AT}"  # cutoff active
+#   SCAN_SCOPE="full history via check all reviews"              # CHECK_ALL_REVIEWS set
 {
   printf '<!-- address-review-summary -->\n'
   printf '## Address-review summary\n\n'
-  printf 'Scan scope: %s\n\n' "<since previous summary at 2026-04-01T20:14:33Z | full history via check all reviews>"
+  printf 'Scan scope: %s\n\n' "${SCAN_SCOPE}"
   printf '### Mattered\n'
   printf '%s\n\n' "<bullets for must-fix/discuss outcomes, or - None.>"
-  printf '### Optional\n'
-  printf '%s\n\n' "<bullets for optional outcomes (addressed inline, deferred, declined, or pending), or - None.>"
   printf '### Skipped\n'
   printf '%s\n\n' "<bullets for skipped items, or - None.>"
-  if [ -n "${FOLLOW_UP_URL}" ]; then
+  if [ -n "${FOLLOW_UP_URL:-}" ]; then
     printf 'Follow-up issue: %s\n\n' "${FOLLOW_UP_URL}"
   fi
   printf 'Next default scan starts after this comment. Say `check all reviews` to rescan the full PR.\n'
 } > "${summary_body_file}"
 
-gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST --input "${summary_body_file}"
-rm -f "${summary_body_file}"
+gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST -f body=@"${summary_body_file}"
 ```
 
 Use exact dates/timestamps in this comment when referring to the cutoff or scan window.
 
 ## Step 11: Merge-Ready Signal
 
-After completing the chosen action (`f`, `f+i`, `f+o`, `d`, `o`, `r`, `m`, or direct item selection) and posting the PR summary comment, report merge readiness status:
+After completing the chosen action (`f`, `f+i`, `d`, `r`, `m`, or direct item selection) and posting the PR summary comment, report merge readiness status:
 
 ```text
 All review threads resolved. PR is merge-ready.
@@ -493,8 +473,8 @@ Deferred MUST-FIX threads remain open by default.
 PR is NOT merge-ready because must-fix items were deferred.
 ```
 
-If the action was direct item selection and unresolved `MUST-FIX`/`DISCUSS` items remain, do not signal merge-ready. Re-offer the quick-action menu and ask whether to continue with `f`, `f+i`, `f+o`, `d`, `o`, `r`, or `m`. Unresolved `OPTIONAL` items do not block the merge-ready signal.
-If the action was `d`, `o`, or `r` and unresolved `MUST-FIX`/`DISCUSS` items remain, do not signal merge-ready; re-offer the quick-action menu and ask whether to continue with `f`, `f+i`, `f+o`, `d`, `o`, `r`, or `m`. Unresolved `OPTIONAL` items do not block the merge-ready signal.
+If the action was direct item selection and unresolved `MUST-FIX`/`DISCUSS` items remain, do not signal merge-ready. Re-offer the quick-action menu and ask whether to continue with `f`, `f+i`, `d`, `r`, or `m`.
+If the action was `d` or `r` and unresolved `MUST-FIX`/`DISCUSS` items remain, do not signal merge-ready; re-offer the quick-action menu and ask whether to continue with `f`, `f+i`, `d`, `r`, or `m`.
 
 Do not automatically merge. Signal readiness (or non-readiness) and let the user decide.
 
@@ -518,33 +498,30 @@ Found 5 review comments. Triage:
 
 MUST-FIX (1):
 1. ⬜ src/helper.rb:45 - Missing nil guard causes a crash on empty input (@reviewer1)
-   Recommendation: Add `return if input.nil? || input.empty?` at the top of `#process` (line 44) and add a spec with `input: nil` to lock the behavior.
 
 DISCUSS (1):
 2. src/config.rb:12 - Extract this to a shared config constant (@reviewer1)
    Reason: reasonable suggestion, but it expands scope
 
-OPTIONAL (2):
-3. src/helper.rb:50 - "Consider adding a comment" (@claude[bot]) - documentation nit, would clarify why the early return exists
-4. spec/helper_spec.rb:20 - "Consolidate assertions" (@claude[bot]) - test style preference, would reduce duplication across three describes
-
-SKIPPED (1):
-5. src/helper.rb:45 - Same nil guard issue (@greptile-apps[bot]) - duplicate of #1
+SKIPPED (3):
+3. src/helper.rb:50 - "Consider adding a comment" (@claude[bot]) - documentation nit
+4. src/helper.rb:45 - Same nil guard issue (@greptile-apps[bot]) - duplicate of #1
+5. spec/helper_spec.rb:20 - "Consolidate assertions" (@claude[bot]) - test style preference
 
 Quick actions:
-  f     — Fix #1, then prompt about optional #3-4, discuss #2, and skipped #5
-  f+i   — Fix #1, create follow-up issue bundling #2-4, confirm skipped handling for #5
-  f+o   — Fix #1 and address optional #3-4 inline in this PR, then prompt about discuss #2 and skipped #5
-  d     — Discuss specific items (e.g., "d2"). Bare "d" presents all DISCUSS items.
-  o     — Address optional items inline (e.g., "o3,4"). Bare "o" presents all OPTIONAL items.
-  r     — Reply with rationale (e.g., "r3,5", "r3-5", "r all skipped", "r all optional", "r all discuss"); add `+ resolve` to also resolve threads
-  m     — No code changes, create follow-up issue for #1-4, merge-ready only when no must-fix items are deferred
+  f     — Fix #1, then confirm whether to reply/resolve skipped items before deciding discuss items
+  f+i   — Fix #1, create follow-up issue for #2, reply/resolve trivial skipped #3-5
+  d     — Discuss specific items (e.g., "d2,4"). Bare "d" presents all DISCUSS items.
+  r     — Reply with rationale (e.g., "r3,5", "r3-5", "r all skipped", "r all discuss"); add `+ resolve` to also resolve threads
+  m     — No code changes, create follow-up issue, merge-ready only when no must-fix items are deferred
 
-Or pick items by number: "1,2", "all must-fix", "all optional", "1,3-5"
+Or pick items by number: "1,2", "all must-fix", "1,3-5"
 ```
 
 # Important Notes
 
+- `check all reviews` must follow the PR reference (trailing position only). Writing it before or embedded in the PR reference triggers a warning and no rescan
+- Before fetching review data, wait for any in-progress `claude-review` CI run on the PR so triage reflects the latest posted feedback (skip the wait when targeting a specific review/issue-comment URL)
 - Automatically detect the repository using `gh repo view` for the current working directory
 - If a GitHub URL is provided, extract the org/repo from the URL
 - Include file path and line number in each todo for easy navigation (when available)
@@ -554,13 +531,12 @@ Or pick items by number: "1,2", "all must-fix", "all optional", "1,3-5"
 - When given a specific review URL, no need to ask for more information
 - **ALWAYS reply to comments after addressing them** to close the feedback loop
 - Always post a new PR summary comment with the `<!-- address-review-summary -->` marker after completing an action so future runs know where to resume
-- After triage, always offer rationale replies for selected `SKIPPED`/`OPTIONAL`/declined items; `f` requires explicit confirmation before skipped-item replies/resolution and before addressing any `OPTIONAL` items, while `f+i`, `f+o`, and `m` include deferred-item handling in the chosen action flow
+- After triage, always offer rationale replies for selected `SKIPPED`/declined items; `f` requires explicit confirmation before skipped-item replies/resolution, while `f+i` and `m` include skipped-item handling in the chosen action flow
 - Always request push confirmation from the user before running `git push`
 - If this command conflicts with broader agent defaults, this file wins only for `/address-review` workflow behavior; do not override repository safety boundaries
 - Resolve the review thread after replying when the concern is actually addressed and a thread ID is available
-- Surface `OPTIONAL` improvements so the user can opt in; never auto-address them. Reserve `SKIPPED` for comments that have no useful signal (duplicates, incorrect claims, status noise) — if a comment would improve the PR even slightly, classify it `OPTIONAL` instead.
-- Triage comments before creating todos. Only `MUST-FIX` items should become todos by default; `OPTIONAL` items become todos only when the user promotes them via `o`, `f+o`, or explicit item selection
-- Each `MUST-FIX` todo must include a concrete Recommendation with a fix sketch; verify the recommendation against the current code before presenting it
+- Default to real issues only. Do not spend a review cycle on optional polish unless the user explicitly asks for it
+- Triage comments before creating todos. Only `MUST-FIX` items should become todos by default
 - For large review comments (like detailed code reviews), parse and extract the actionable items into separate todos
 - For full-PR scans, default to review activity after the latest summary comment; only rescan the full history when the user says `check all reviews`
 

--- a/.claude/prompts/address-review.md
+++ b/.claude/prompts/address-review.md
@@ -1,0 +1,216 @@
+# Address Review Prompt
+
+Use this prompt in Codex CLI, ChatGPT, or another coding assistant when you want the equivalent of Claude Code's `/address-review` workflow.
+
+## How to Use
+
+Paste the prompt below into your coding assistant and replace `{{PR_REFERENCE}}` with one of:
+
+- A PR number, such as `12345`
+- A PR number plus override, such as `12345 check all reviews`
+- A PR URL, such as `https://github.com/org/repo/pull/12345`
+- A PR URL plus override, such as `https://github.com/org/repo/pull/12345 check all reviews`
+- A specific review URL, such as `https://github.com/org/repo/pull/12345#pullrequestreview-123456789`
+- A specific issue comment URL, such as `https://github.com/org/repo/pull/12345#issuecomment-123456789`
+
+If the assistant has terminal access with `gh`, it should execute the workflow directly. If it does not, it should stop and ask for the missing GitHub data instead of pretending it fetched comments.
+
+Notes:
+
+- `check all reviews` must follow the PR reference (trailing position only). Writing it before or embedded in the PR reference triggers a warning and no rescan.
+- For full-PR scans, the workflow waits for any in-progress `claude-review` CI run on the PR before fetching, so the triage reflects the latest posted feedback. Specific review/issue-comment URLs skip this wait.
+
+## Prompt
+
+````text
+Act as a pull request review triage assistant.
+
+I want the equivalent of Claude Code's `/address-review` command for this input: `{{PR_REFERENCE}}`.
+
+Your job is to fetch GitHub PR review comments, triage them, and wait for my instruction before making code changes.
+
+Behavior rules:
+- Do not claim you fetched comments unless you actually have terminal or API access and used it.
+- If you do not have shell access with `gh`, say so immediately and ask me to provide either:
+  - the PR URL plus exported comment data, or
+  - the output of the required `gh api` commands.
+- Do not auto-fix everything. Stop after triage and wait for my selection.
+- Default to real issues only, not optional polish.
+- For full-PR scans, default to feedback after the latest PR summary comment whose body starts with `<!-- address-review-summary -->` on its first line.
+- If I say `check all reviews`, ignore that cutoff and rescan the full PR history.
+- If I give a specific review URL or specific issue-comment URL, fetch that exact target even if it predates the latest summary comment.
+- After selected items are addressed, reply to the original GitHub comments and resolve threads when appropriate.
+- After each completed action or action chain, post a new PR summary comment with the `<!-- address-review-summary -->` marker that says what mattered and what was skipped.
+
+Execution flow when terminal access is available:
+
+1. Parse the input:
+   - Support:
+     - PR number only
+     - PR number plus `check all reviews`
+     - PR URL
+     - PR URL plus `check all reviews`
+     - Specific review URL with `#pullrequestreview-...`
+     - Specific issue comment URL with `#issuecomment-...`
+   - Detect the phrase `check all reviews` (case-insensitive, trailing position only — must be the final tokens after the PR reference), set a `CHECK_ALL_REVIEWS` flag, and remove only that phrase before parsing the PR reference. If the phrase appears in any other position, do not treat it as an override; warn me and ask me to retry with the trailing form.
+   - If the input is a full GitHub URL, extract the URL's `org/repo` before running `gh repo view`.
+   - Extract the PR number and optional review/comment ID.
+
+2. Set repository and PR number:
+   - If step 1 extracted `org/repo` from a full GitHub URL, use that as `REPO`.
+   - Otherwise run: `REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)`
+   - Set `PR_NUMBER=<PR number parsed in step 1>` so every subsequent snippet can reference `${PR_NUMBER}` as a real shell variable.
+   - If `gh` is unavailable or unauthenticated, stop and tell me to fix that first.
+
+3. Determine scan window and summary cutoff:
+   - For full-PR scans (plain PR number or PR URL with no specific review/comment anchor), default to reviewing only feedback posted after the latest PR summary comment created by this workflow.
+   - The summary marker is a PR issue comment whose body starts with `<!-- address-review-summary -->` on its very first line. Use `startswith` (not `contains`) so a human comment that quotes or embeds the marker in prose is not mistaken for a checkpoint.
+   - If `CHECK_ALL_REVIEWS` is true, ignore the cutoff and scan the full PR history.
+   - If the input is a specific review URL or specific issue-comment URL, fetch that exact target even if it predates the latest summary comment.
+   - Fetch the latest summary comment before collecting review data. Use a null-safe extraction so an empty result becomes an empty string (not JSON `null`):
+     `REVIEW_CUTOFF_AT=$(gh api --paginate repos/${REPO}/issues/${PR_NUMBER}/comments | jq -rs '[.[].[] | select((.body // "") | startswith("<!-- address-review-summary -->")) | {id: .id, created_at: .created_at, html_url: .html_url}] | sort_by(.created_at) | last | if . == null then "" else .created_at end')`
+   - An empty `REVIEW_CUTOFF_AT` means no prior summary comment; scan full history.
+   - If `REVIEW_CUTOFF_AT` is non-empty and `CHECK_ALL_REVIEWS` is false, use it as the cutoff.
+   - Use exact timestamps in user-facing status updates, for example `2026-04-01T20:14:33Z`.
+   - If no items survive the cutoff, tell me no new review feedback was found since that summary comment and remind me I can say `check all reviews`.
+
+4. Fetch review data:
+   - Before fetching for full-PR scans, wait for any in-progress `claude-review` CI check on this PR so triage reflects the latest posted feedback. Skip this wait when the input is a specific review URL or specific issue-comment URL. If `gh pr checks` is unavailable or errors, log a warning and continue without blocking. Example loop:
+     The loop polls `gh pr checks` every 15s, capped at `MAX_WAIT=180` seconds. Pass `--repo "${REPO}"` so cross-repo PR URLs target the parsed `${REPO}`, not the current checkout. When the cap is hit, log a warning and proceed with triage anyway so a stalled runner cannot block indefinitely:
+     `MAX_WAIT=180; WAITED=0; while [ "$(gh pr checks "${PR_NUMBER}" --repo "${REPO}" --json name,bucket 2>/dev/null | jq '[.[] | select((.name | test("claude.?review"; "i")) and (.bucket == "pending"))] | length' 2>/dev/null || echo 0)" -gt 0 ]; do if [ "${WAITED}" -ge "${MAX_WAIT}" ]; then echo "Warning: claude-review CI still pending after ${MAX_WAIT}s — proceeding with triage anyway."; break; fi; echo "Waiting for in-progress claude-review CI to finish before triaging... (${WAITED}s elapsed)"; sleep 15; WAITED=$((WAITED + 15)); done`
+   - Specific issue comment:
+     `gh api repos/${REPO}/issues/comments/{COMMENT_ID} | jq '{body: .body, user: .user.login, created_at: .created_at, html_url: .html_url}'`
+   - Specific review:
+     `gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews/{REVIEW_ID} | jq '{id: .id, body: .body, state: .state, user: .user.login, created_at: .submitted_at, html_url: .html_url}'`
+     `gh api --paginate repos/${REPO}/pulls/${PR_NUMBER}/reviews/{REVIEW_ID}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id, created_at: .created_at, html_url: .html_url}]'`
+   - If the review body contains actionable feedback, include it as an additional general comment. Review summary bodies cannot use the `/replies` endpoint; post those responses as general PR comments (see step 8).
+   - Full PR:
+     `gh api --paginate repos/${REPO}/pulls/${PR_NUMBER}/reviews | jq -s '[.[].[] | select((.body // "") != "") | {id: .id, type: "review_summary", body: .body, state: .state, user: .user.login, created_at: .submitted_at, html_url: .html_url}]'`
+     `gh api --paginate repos/${REPO}/pulls/${PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "review", path: .path, body: .body, line: .line, start_line: .start_line, user: .user.login, in_reply_to_id: .in_reply_to_id, created_at: .created_at, html_url: .html_url}]'`
+     `gh api --paginate repos/${REPO}/issues/${PR_NUMBER}/comments | jq -s '[.[].[] | {id: .id, node_id: .node_id, type: "issue", body: .body, user: .user.login, created_at: .created_at, html_url: .html_url}]'`
+   - Include actionable review summary bodies from `/pulls/{PR_NUMBER}/reviews` as additional general comments. Like specific review bodies, they cannot use the `/replies` endpoint and must be answered as general PR comments (see step 8).
+   - When `REVIEW_CUTOFF_AT` is set for a full-PR scan:
+     - Fetch the full datasets so you keep older context for unresolved threads.
+     - Filter issue comments and review summaries to items created after `REVIEW_CUTOFF_AT`.
+     - For inline review threads, keep an unresolved thread only when at least one comment in that thread has `created_at > REVIEW_CUTOFF_AT`.
+     - Use the thread's top-level comment as the triage item, and use newer replies in that thread as the latest context.
+     - Do not let older comments with no new activity re-enter triage unless I said `check all reviews`.
+   - For all review-comment paths, fetch thread metadata and match `thread_id` by `node_id`:
+     `OWNER=${REPO%/*}`
+     `NAME=${REPO#*/}`
+     `gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr="${PR_NUMBER}" -f query='query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) { repository(owner:$owner, name:$name) { pullRequest(number:$pr) { reviewThreads(first:100, after:$endCursor) { nodes { id isResolved comments(first:100) { nodes { id databaseId } } } pageInfo { hasNextPage endCursor } } } } }' | jq -s '[.[].data.repository.pullRequest.reviewThreads.nodes[] | {thread_id: .id, is_resolved: .isResolved, comments: [.comments.nodes[] | {node_id: .id, id: .databaseId}]}]'`
+
+5. Filter comments:
+   - Never triage a prior summary checkpoint comment. Skip any issue comment whose body starts with `<!-- address-review-summary -->`.
+   - Skip resolved threads.
+   - Do not create standalone triage items from comments where `in_reply_to_id` is set, but use reply text as the latest thread context when it updates or narrows the unresolved concern.
+   - When `REVIEW_CUTOFF_AT` is set, evaluate unresolved review threads by their latest activity timestamp, not only by the top-level comment timestamp.
+   - Keep bot comments by default, but deduplicate duplicates and skip status-only bot posts.
+   - Focus on correctness bugs, regressions, security issues, missing tests that hide bugs, and clear adjacent-code inconsistencies.
+   - Skip style nits, speculative suggestions, documentation nits, changelog wording, duplicate comments, and "could consider" feedback unless I ask for polish work.
+   - If the API returns 404, tell me the PR or comment does not exist.
+   - If the API returns 403, tell me to check `gh auth status`.
+   - If nothing is returned after cutoff filtering, tell me no new review feedback was found since the last summary comment and mention `check all reviews`.
+   - If nothing is returned without a cutoff, tell me no review comments were found.
+
+6. Triage every remaining comment:
+   - `MUST-FIX`: correctness bugs, regressions, security issues, missing tests that could hide a bug, and clear inconsistencies with adjacent code that would likely block merge.
+   - `DISCUSS`: reasonable scope-expanding suggestions, architectural opinions, and comments that need a decision.
+   - `SKIPPED`: style preferences, documentation nits, comment requests, test-shape preferences, speculative suggestions, changelog wording, duplicate comments, status posts, non-actionable summaries, and factually incorrect suggestions.
+   - Deduplicate overlapping comments before classifying them.
+   - Verify reviewer claims locally before calling something `MUST-FIX`.
+   - If a claim is wrong, classify it as `SKIPPED` and say why.
+   - Preserve comment IDs and thread IDs for later replies and thread resolution.
+   - Treat actionable review summary bodies as normal feedback to classify (`MUST-FIX`/`DISCUSS` as appropriate); skip only boilerplate or status-only summaries.
+   - Track only `MUST-FIX` items as your working checklist.
+   - Use one checklist entry per must-fix item or deduplicated issue.
+   - Use the subject format: `"{file}:{line} - {comment_summary} (@{username})"`.
+   - For general comments, extract the must-fix action from the body.
+
+7. Present triage and quick-action menu:
+   - Use a single numbering sequence across all categories.
+   - Show counts for `MUST-FIX`, `DISCUSS`, and `SKIPPED`.
+   - After the triage list, present this quick-action menu:
+     ```
+     Quick actions:
+      f     — Fix must-fix items, then confirm whether to reply/resolve skipped items before deciding discuss items
+      f+i   — Fix must-fix + create follow-up issue for discuss/non-trivial skipped items
+      d     — Discuss specific items before deciding (e.g., "d2,4"). Bare "d" presents all DISCUSS items.
+      r     — Reply with rationale to items (e.g., "r3,5", "r7-9", "r all skipped", "r all discuss"); add `+ resolve` to also resolve threads
+      m     — Skip code changes + create follow-up issue for must-fix/discuss/non-trivial skipped items
+
+     Or pick items by number: "1,2", "all must-fix", "1,3-5"
+     ```
+   - Support range syntax: `N-M` expands to individual items (e.g., `3-5` → `3,4,5`).
+   - If a range is malformed, reversed, or out of bounds, show a validation message and ask the user to retry (do not silently coerce it).
+   - Do not edit code yet.
+   - Do not post the PR summary checkpoint yet. Post it only after a chosen action reaches a stable stopping point so the summary reflects the new baseline.
+
+8. Execute the chosen action:
+   - **`f`**: Fix all must-fix items (if none exist, skip fix phase). If local changes exist, commit, ask for push confirmation, then push; if no local changes, skip commit/push and continue decision flow. Then reply/resolve addressed must-fix threads. If skipped items exist, ask for explicit confirmation before posting rationale replies/resolving skipped threads. Keep discuss items for an explicit follow-up decision (`d`, `f+i`, or `r all discuss + resolve`).
+   - **`f+i`**: Same must-fix handling as `f`, plus create a follow-up GitHub issue bundling discuss and non-trivial skipped items; still reply/resolve trivial skipped items that are excluded from the follow-up issue. For general PR comments and review summary bodies (which have no thread), the reply alone is sufficient. If there are no deferred items, skip issue creation and behave like `f`. No additional commit is needed unless later steps introduce local changes.
+   - **`d`**: Present requested items with full context, ask for a decision on each. Bare `d` presents all DISCUSS items. Approved → fix like must-fix (use the same commit/push-before-reply ordering as `f` when code changes occur). Declined → optionally reply with rationale.
+   - **`r`**: Post rationale replies only for `SKIPPED`/`DISCUSS` items. Do not resolve threads unless the user explicitly asks to resolve them. If selection includes any `MUST-FIX` item (including `r all must-fix`), direct the user to `f` or explicit deferral (`f+i`/`m`) instead of replying.
+   - **`m`**: Create a follow-up issue for deferred items, reply in the original location for each deferred item (review-comment replies for inline comments; issue comments for general/review-summary comments), and resolve `DISCUSS`/`SKIPPED` threads when threads exist. Keep deferred `MUST-FIX` threads open by default unless the user explicitly asks to close them. If any `MUST-FIX` items are deferred, signal that the PR is **not merge-ready** without an override decision.
+   - **Direct selection** (e.g., "1,2", "all must-fix", "1,3-5"): Address only selected items; if code changes were made, commit/push with confirmation before replying/resolving; then ask about remaining items.
+   - Users can chain actions (e.g., `f+i` then `r7-9`).
+   - Reply to each addressed review comment:
+     - Issue comments: `gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST -f body="<response>"`
+     - Review comment replies: `gh api repos/${REPO}/pulls/${PR_NUMBER}/comments/{COMMENT_ID}/replies -X POST -f body="<response>"`
+     - Review summary body replies: `gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST -f body="<response>"`
+   - Resolve threads only when the issue is actually handled or explicitly declined with my approval:
+     `gh api graphql -f query='mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }' -f threadId="<THREAD_ID>"`
+   - Do not resolve anything still in progress or uncertain.
+   - Ask for push confirmation before running `git push`.
+
+9. Create follow-up issue (when `f+i` or `m` is chosen):
+   - **Run steps 9 and 10 in a single shell call.** They share `${FOLLOW_UP_URL}` (set here, consumed in step 10), `${issue_body_file}`/`${summary_body_file}` temp files, and the EXIT cleanup trap. Agents that execute each Bash tool call in a fresh subshell will lose `${FOLLOW_UP_URL}` between calls and fire the cleanup trap prematurely; combine both steps into one heredoc/chained invocation, or capture step 9's `FOLLOW_UP_URL` from stdout and pass it explicitly into step 10's command.
+   - Use `gh issue create --repo "${REPO}"` with title "Follow-up: Review feedback from PR #N"
+   - For `f+i`, include discuss items and non-trivial skipped items (must-fix is already addressed)
+   - For `m`, include deferred must-fix items, discuss items, and non-trivial skipped items
+   - Keep issue body structure consistent: use an optional `### Must-fix items (deferred)` section (for `m` only), then `### Discuss items`, then `### Skipped items (non-trivial)`, plus the original PR link at the bottom
+   - Omit any section heading whose content bucket is empty
+   - Reference the issue in thread replies
+   - Return the issue URL
+
+10. Post a PR summary comment:
+   - After any chosen action or completed action chain (`f`, `f+i`, `d`, `r`, `m`, or direct item selection), post a consolidated general PR comment that becomes the next default review cutoff.
+   - Include the exact marker `<!-- address-review-summary -->` on its own line near the top.
+   - Use a `Mattered` section for `MUST-FIX` and `DISCUSS` items, including whether each item was addressed, deferred, or left pending by user choice.
+   - Use a `Skipped` section for `SKIPPED` items with short reasons.
+   - Mention any follow-up issue URL that was created.
+   - Mention whether the run used the default cutoff or the explicit `check all reviews` override.
+   - End with a note that future full-PR scans should start after this comment unless I say `check all reviews`.
+   - Use exact timestamps in the summary when referring to the scan window.
+   - Post it with: `gh api repos/${REPO}/issues/${PR_NUMBER}/comments -X POST -f body=@"${summary_body_file}"`
+
+11. Merge-ready signal:
+   - After `f`, tell me the PR is merge-ready only when no `DISCUSS` items remain unresolved
+   - After `f+i`, tell me the PR is merge-ready
+   - After `m`, only tell me the PR is merge-ready when no must-fix items were deferred; otherwise explicitly say it is not merge-ready
+   - After direct selection, do not signal merge-ready automatically; first evaluate remaining `MUST-FIX`/`DISCUSS` items and ask whether to continue with `f`, `f+i`, `d`, `r`, or `m`
+   - After `d` or `r`, if unresolved `MUST-FIX`/`DISCUSS` items remain, do not signal merge-ready automatically; re-offer `f`, `f+i`, `d`, `r`, or `m`
+   - Show the follow-up issue URL if one was created
+   - Do not auto-merge
+
+Output format for the triage:
+
+MUST-FIX (count):
+1. item
+
+DISCUSS (count):
+2. item
+   Reason: short explanation
+
+SKIPPED (count):
+3. item - short reason
+
+Quick actions:
+  f     — Fix #N, then confirm whether to reply/resolve skipped items before deciding discuss items
+  f+i   — Fix #N, create follow-up issue for discuss/non-trivial skipped items, reply/resolve trivial skipped rest
+  d     — Discuss specific items (e.g., "d2,4"). Bare "d" presents all DISCUSS items.
+  r     — Reply with rationale (e.g., "r3,5", "r3-5", "r all skipped", "r all discuss"); add `+ resolve` to also resolve threads
+  m     — No code changes, create follow-up issue for must-fix/discuss/non-trivial skipped items
+
+Or pick items by number: "1,2", "all must-fix", "1,3-5"
+````


### PR DESCRIPTION
### Summary

Syncs `.claude/commands/address-review.md` to the current upstream version from [shakacode/claude-code-commands-skills-agents](https://github.com/shakacode/claude-code-commands-skills-agents) and adds `.claude/prompts/address-review.md`, the portable prompt template for use in Codex CLI, ChatGPT, or other coding assistants that don't natively support Claude Code slash commands. Tooling-only changes — no runtime code is touched.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (tooling docs only)
- ~[ ] Update documentation~ (this PR _is_ the documentation update)
- ~[ ] Update CHANGELOG file~ (no user-facing runtime change)

### Other Information

The command file was 571 lines (39,941 bytes) and is now 34,636 bytes — the upstream version is shorter because the local copy contained outdated step structure and stale jq snippets that the upstream has since cleaned up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this PR only updates Claude Code command/prompt documentation (no runtime code), though it does change the documented workflow behavior and shell snippets used by developers.
> 
> **Overview**
> Updates the `/address-review` command doc to match upstream, including stricter parsing of the trailing `check all reviews` override, explicit `REPO`/`PR_NUMBER` setup, a safer summary-cutoff marker check (`startswith`), and a pre-fetch wait for pending `claude-review` CI.
> 
> Simplifies triage/actions by dropping the `OPTIONAL` tier and related commands, tightening what becomes `MUST-FIX` vs `SKIPPED`, and revising follow-up issue + PR summary comment instructions (carry `FOLLOW_UP_URL`, POSIX-safe `printf` construction, temp-file cleanup traps, and corrected `gh api` posting syntax).
> 
> Adds `.claude/prompts/address-review.md`, a portable prompt template mirroring the updated workflow for assistants outside Claude Code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7051748d4c559384f989601bcc7cfb1f47a2823d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced `/address-review` command documentation with improved review parsing, filtering, and classification logic.
  * Updated action workflow menu, tier system simplification, and PR summary checkpoint handling.
  * Added new prompt template for address-review workflow execution guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3271)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->