### PR TITLE
docs: fix MDX-incompatible patterns blocking sc-website docs sync

### DIFF
--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -93,7 +93,7 @@ Server components produce HTML that does not need hydration — they have no cli
 > This section covers a non-production local directional benchmark first, then a production case study. For validated,
 > at-scale results, see the [Production Case Study: Popmenu](#popmenu) below.
 
-### Non-Production Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) {#gumroad-style-rsc-demo}
+### Non-Production Local Directional Benchmark: Gumroad-Style RSC Demo (April 2026) <a id="gumroad-style-rsc-demo"></a>
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo modeled after a creator-dashboard surface with product listings and sales metrics,
@@ -178,7 +178,7 @@ completeness only. See
   establish statistical significance._
 - _The `action_total` -2.3% delta is likely within expected variance at n=4._
 
-#### Worst-case `responseEnd` counter-signal {#gumroad-rsc-worst-case-responseend}
+#### Worst-case `responseEnd` counter-signal <a id="gumroad-rsc-worst-case-responseend"></a>
 
 | Metric                             | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ---------------------------------- | -----------: | -------: | ------------------------------: |
@@ -198,7 +198,7 @@ are still required before making stronger production-performance claims.
 See [Issue 3128](https://github.com/shakacode/react_on_rails/issues/3128) and
 [Issue 3144](https://github.com/shakacode/react_on_rails/issues/3144) for the ongoing tracking discussion.
 
-### Production Case Study: Popmenu {#popmenu}
+### Production Case Study: Popmenu <a id="popmenu"></a>
 
 Popmenu, a restaurant platform serving tens of millions of SSR requests daily, adopted React on Rails Pro and reported:
 

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -166,7 +166,7 @@ RUN bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
 
 | Scenario                      | Before                                  | After                           |
 | ----------------------------- | --------------------------------------- | ------------------------------- |
-| First request on fresh deploy | 410→retry: 200ms–1s+                    | Direct render: <50ms            |
+| First request on fresh deploy | 410→retry: 200ms–1s+                    | Direct render: `<50ms`          |
 | Thundering herd on new pod    | N requests queue behind per-bundle lock | All requests served immediately |
 
 ### Rolling deploys: seed current and previous bundle hashes


### PR DESCRIPTION
sc-website pulls these docs via gatsby-source-git and parses them as MDX. Two patterns currently break the build:

1. `<50ms` in `docs/pro/node-renderer.md` is read as an opening JSX tag, and `5` cannot start a component name. Build fails with `Unexpected character \`5\` before name`. Wrapped in backticks (renders identically as inline code).

2. `{#anchor-id}` heading-anchor syntax in `docs/oss/core-concepts/performance-benchmarks.md` (3 lines) is parsed by MDX as a JS expression and `#` is not valid. Build fails with `Could not parse expression with acorn: Unexpected character '#'`. Replaced with inline HTML anchors `<a id="..."></a>` so existing internal references (`#popmenu` etc) keep working.

Surfaced by sc-website#572 CI. Issue 1 introduced in #3124.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Formatted the timing value in the performance comparison table for clearer display.
  * Updated in-page anchor syntax for two performance benchmark headings and aligned other anchors for consistent linking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3275)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->