### PR TITLE
[EXPERIMENT] Send render request body as JSON (closes #3280 hypothesis)

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -24,7 +24,15 @@ module ReactOnRailsPro
       def render_code(path, js_code, send_bundle)
         Rails.logger.info { "[ReactOnRailsPro] Perform rendering request #{path}" }
         form = form_with_code(js_code, send_bundle)
-        perform_request(path, form: form)
+        # Experiment (issue #3280): use JSON for steady-state render to skip
+        # form-urlencode CPU/GC. Keep multipart when send_bundle=true because
+        # form_with_code embeds the bundle file as a Pathname which can't be
+        # JSON-serialized.
+        if send_bundle
+          perform_request(path, form: form)
+        else
+          perform_request(path, json: form)
+        end
       end
 
       def render_code_as_stream(path, js_code, is_rsc_payload:)


### PR DESCRIPTION
Experiment for #3280. **Not for merging as-is** — no tests, no version negotiation, no docs, no migration story. Per the issue's scope: implement in the simplest possible way and measure.

## Change

One-line conditional in `react_on_rails_pro/lib/react_on_rails_pro/request.rb` ([+9, -1]):

```ruby
def render_code(path, js_code, send_bundle)
  Rails.logger.info { "[ReactOnRailsPro] Perform rendering request #{path}" }
  form = form_with_code(js_code, send_bundle)
  if send_bundle
    perform_request(path, form: form)    # keep multipart for bundle upload
  else
    perform_request(path, json: form)    # JSON for steady-state render
  end
end
```

`send_bundle: true` keeps the multipart path because `form_with_code` embeds the bundle as a `Pathname` which JSON.generate can't serialize. Streaming render (`render_code_as_stream`) and incremental render (`render_code_with_incremental_updates`) are intentionally untouched per the issue's scope. **No Node-side change is needed** — Fastify's built-in JSON parser already handles `application/json` for the `/bundles/.../render/...` endpoint.

## Headline results

Workload: `/mega_benchmark_traditional?u=500&p=1000&c=5000` on rsc-benchmar's `apps/ror-rsc` (props ~1.16 MB, HTML ~2.18 MB). Branch base: `upcoming-v16.3.0` (`3d571c32`).

| Metric | Acceptance bar | Baseline | After | Δ | Passes? |
|---|---:|---:|---:|---:|:---:|
| Median total wall | drop ≥ 150 ms | 396 ms | 92 ms | **−304 ms** | ✅ +154 ms |
| Median GC per request | drop ≥ 15 ms | 112.8 ms | 9.8 ms | **−103 ms** | ✅ +88 ms |
| Byte-equivalent HTML | identical | — | — | UUID-only drift | ✅ |
| Streaming SSR no regression | flat or better | — | — | ±noise | ✅ |

## Sequential sweep (n=25 per point, 110-call warmup)

Improvement scales with payload size, exactly as the encoding-cost hypothesis predicts:

| Point (u,p,c) | base total / gc | after total / gc | Δ total |
|---|---:|---:|---:|
| 0, 0, 0 | 7 / 0.1 | 7 / 0.0 | 0 |
| 500, 0, 0 | 45 / 4.3 | 34 / 0.6 | −11 |
| 500, 1000, 0 | 185 / 31.5 | 41 / 1.5 | −144 |
| 500, 1000, 2500 | 238 / 57.4 | 55 / 4.2 | −183 |
| **500, 1000, 5000** | **396 / 112.8** | **92 / 9.8** | **−304** |

## Isolation (n=30 per endpoint, `u=500&p=1000&c=5000`)

`build_only` (controller alloc, no renderer call) is **unchanged** — confirms the savings live in the renderer round-trip path the change touches, not in generic system warmup:

| Endpoint | base total / gc | after total / gc | Δ total |
|---|---:|---:|---:|
| build_only (controller alloc only) | 34 / 2.8 | 32 / 2.9 | −2 |
| **send_only (renderer + view, memoized props)** | **306 / 81.5** | **86 / 6.1** | **−220** |
| full (both) | 339 / 95.9 | 97 / 6.9 | −242 |

## Concurrent load (autocannon `--sweep --duration=20`)

Traditional SSR pages (the change applies):

| Page | c | base p50 | after p50 | Δ p50 | base rps | after rps |
|---|---:|---:|---:|---:|---:|---:|
| hello_world | 1 / 10 / 50 | 10 / 42 / 224 | 10 / 40 / 231 | flat | 193 / 206 / 198 | 224 / 214 / 202 |
| heavy_benchmark_traditional | 10 | 176 | 102 | **−74** | 54 | 94 |
| heavy_benchmark_traditional | 50 | 950 | 588 | **−362** | 51 | 82 |
| **mega_benchmark_traditional** | **1** | 308 | 101 | **−207** | 3 | 10 |
| **mega_benchmark_traditional** | **10** | 2625 | 955 | **−1670** | 3 | 10 |
| **mega_benchmark_traditional** | **50** | 8480 / 69 err | 4668 / 0 err | **−3812** | 2 | 10 |

Streaming SSR (`hello_server`, `mega_benchmark`) is flat ±noise — they go through `render_code_as_stream`, which we left untouched, and the bench confirms no regression.

## Robustness — three independent measurement methodologies agree

To rule out time-varying environmental noise (thermal throttle, OS background activity, CPU governor drift), I also ran two complete Rails+renderer stacks **side-by-side simultaneously** on the same machine: exp on :3000/:3800 (with the change), baseline on :3002/:3810 (without).

| Method | mega p50 Δ |
|---|---:|
| Sequential (consecutive runs, no parallel stack) | **−304 ms** |
| Paired-curl (alternating requests, both stacks live, no load) | **−254 ms** |
| Parallel autocannon c=1 (both stacks under load) | **−272 ms** |

All three within ~50 ms of each other. The slightly smaller delta on the simultaneous methods is symmetric CPU contention from two stacks sharing a 12-core box; the *comparison* stays fair because both sides see the same interference.

## Robustness — does PR #3217 (TCP_NODELAY) eat the win?

Also tested with the [#3217 TCP_NODELAY monkey-patch](https://github.com/shakacode/react_on_rails/pull/3217) applied to baseline only (verified via `HTTPX::TCP.ancestors.include?(ReactOnRailsPro::HttpxTcpNodelayPatch) == true`). Re-ran paired-curl + parallel autocannon:

| Workload | Δ without #3217 on baseline | Δ with #3217 on baseline |
|---|---:|---:|
| mega paired-curl | +254 ms | **+301 ms** |
| mega autocannon c=1 | +272 ms | **+279 ms** |
| mega autocannon c=10 | +2722 ms | **+2747 ms** |
| mega autocannon c=50 | +1696 ms | **+2436 ms** |

**The win is unchanged.** #3217 targets Nagle + delayed-ACK on small writes — but the renderer round-trip is large-burst (1.16 MB props, 2.18 MB HTML), so Nagle never engages, and on localhost loopback (min-RTT ~7 µs) the 40 ms tail doesn't form anyway. The two PRs target orthogonal bottlenecks: **#3217 helps network-RTT-bound scenarios; #3280 helps payload-encoding-bound scenarios**.

## Correctness

Captured HTML before and after for `/hello_world`, `/heavy_benchmark_traditional`, `/mega_benchmark_traditional?u=500&p=1000&c=5000`. **All three byte-equal**: 7,690 / 59,713 / 2,186,638 bytes. `diff` shows only the per-request random UUID drift on `HelloWorld-react-component-<uuid>` DOM ids — same drift you see between two consecutive baseline calls.

## Setup

| | |
|---|---|
| react_on_rails branch | `experiment/3280-json-render-body` off `upcoming-v16.3.0` (`3d571c32`) |
| Single commit | `352743ef1` — 9 added, 1 modified lines in `request.rb` |
| Bench harness | [`AbanoubGhadban/rsc-benchmar`](https://github.com/AbanoubGhadban/rsc-benchmar) branch `fair-comparison-fixes`, `apps/ror-rsc` |
| Ruby / Node / Rails / Puma | 3.3.0 (YJIT) / 22.12.0 / 7.2.3.1 / 8.0.1 |
| OS / CPU | Linux 6.8, Intel i7-9750H (12 logical cores) |
| Renderer | 3 workers, http_pool_size=64, pool_timeout=30s |
| DB | Postgres, 500 users / 1000 posts / 5000 comments |
| jemalloc | not preloaded |

## Recommendation

**Verdict: Go.** Open a production-quality follow-up issue that addresses everything this experiment intentionally skipped:

1. **Backward compatibility with older node renderers.** The gem speaks JSON only against renderers that have Fastify's default JSON parser enabled (all current versions do, but worth confirming the floor). A content-type negotiation or version handshake may be needed if any users are on a custom-configured Fastify that disabled the default JSON parser.

2. **Bundle-warmup path stays multipart** — already handled by the `send_bundle` conditional, but worth adding a test that exercises the warmup path so a future refactor doesn't break it.

3. **Apply the same flip to `render_code_with_incremental_updates`?** It already uses `application/x-ndjson`, but the initial line is JSON-in-multipart-envelope — same opportunity in principle. Out of scope here; needs separate measurement.

4. **Tests** covering the conditional `form:` / `json:` choice, including a regression test that confirms byte-equivalent HTML output across both encodings.

5. **Docs / changelog** entry calling out the wire-protocol change and the perf characteristics.

6. **Defensive audit** of `form_with_code` — confirm there's no future code path that could put a non-JSON-serializable value into the hash when `send_bundle: false`.

#3217 (TCP_NODELAY) and this PR are orthogonal optimizations. **Merging both gives the cumulative benefit** of each on whichever workload it targets — payload-bound (mega-page) gets the JSON win, RTT-bound (smaller frequent writes over real network) gets the TCP_NODELAY win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)