### PR TITLE
[EXPERIMENT] Decouple props from JS source: pass as separate JSON field

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/worker.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker.ts
@@ -345,7 +345,7 @@ export default function run(config: Partial<Config>) {
       await setResponse(badRequestResponseResult('Invalid or missing request body.'), res);
       return;
     }
-    const { renderingRequest } = body;
+    const { renderingRequest, props: propsJson } = body as Record<string, unknown>;
     if (!isValidRenderingRequest(renderingRequest)) {
       await setResponse(badRequestResponseResult(invalidRenderingRequestMessage(body)), res);
       return;
@@ -360,6 +360,7 @@ export default function run(config: Partial<Config>) {
         try {
           const result = await handleRenderRequest({
             renderingRequest,
+            propsJson: typeof propsJson === 'string' ? propsJson : undefined,
             bundleTimestamp,
             dependencyBundleTimestamps,
             providedNewBundles,

--- a/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/handleRenderRequest.ts
@@ -38,9 +38,15 @@ async function prepareResult(
   renderingRequest: string,
   bundleFilePathPerTimestamp: string,
   executionContext: ExecutionContext,
+  propsJson?: string,
 ): Promise<ResponseResult> {
   try {
-    const result = await executionContext.runInVM(renderingRequest, bundleFilePathPerTimestamp, cluster);
+    const result = await executionContext.runInVM(
+      renderingRequest,
+      bundleFilePathPerTimestamp,
+      cluster,
+      propsJson,
+    );
 
     let exceptionMessage = null;
     if (!result) {
@@ -202,6 +208,7 @@ export async function handleNewBundlesProvided(
  */
 export async function handleRenderRequest({
   renderingRequest,
+  propsJson,
   bundleTimestamp,
   dependencyBundleTimestamps,
   providedNewBundles,
@@ -209,6 +216,7 @@ export async function handleRenderRequest({
   tracingContext,
 }: {
   renderingRequest: string;
+  propsJson?: string;
   bundleTimestamp: string | number;
   dependencyBundleTimestamps?: string[] | number[];
   providedNewBundles?: ProvidedNewBundle[] | null;
@@ -237,7 +245,7 @@ export async function handleRenderRequest({
     try {
       const executionContext = await buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ false);
       return {
-        response: await prepareResult(renderingRequest, entryBundleFilePath, executionContext),
+        response: await prepareResult(renderingRequest, entryBundleFilePath, executionContext, propsJson),
         executionContext,
       };
     } catch (e) {
@@ -271,7 +279,7 @@ export async function handleRenderRequest({
     );
     const executionContext = await buildExecutionContext(allBundleFilePaths, /* buildVmsIfNeeded */ true);
     return {
-      response: await prepareResult(renderingRequest, entryBundleFilePath, executionContext),
+      response: await prepareResult(renderingRequest, entryBundleFilePath, executionContext, propsJson),
       executionContext,
     };
   } catch (error) {

--- a/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/worker/vm.ts
@@ -324,6 +324,7 @@ export type ExecutionContext = {
     renderingRequest: string,
     bundleFilePath: string,
     vmCluster?: typeof cluster,
+    propsJson?: string,
   ) => Promise<RenderResult>;
   getVMContext: (bundleFilePath: string) => VMContext | undefined;
 };
@@ -360,7 +361,12 @@ export async function buildExecutionContext(
   // Example: asyncPropsManager is stored here during initial render and accessed by update chunks.
   const sharedExecutionContext = new Map();
 
-  const runInVM = async (renderingRequest: string, bundleFilePath: string, vmCluster?: typeof cluster) => {
+  const runInVM = async (
+    renderingRequest: string,
+    bundleFilePath: string,
+    vmCluster?: typeof cluster,
+    propsJson?: string,
+  ) => {
     try {
       const { serverBundleCachePath } = getConfig();
       const vmContext = mapBundleFilePathToVMContext.get(bundleFilePath);
@@ -397,6 +403,9 @@ export async function buildExecutionContext(
         };
 
         try {
+          if (propsJson) {
+            context.__rorpProps = JSON.parse(propsJson);
+          }
           return vm.runInContext(renderingRequest, context) as RenderCodeResult;
         } finally {
           // Clean up references immediately after execution.
@@ -406,6 +415,7 @@ export async function buildExecutionContext(
           context.renderingRequest = undefined;
           context.sharedExecutionContext = undefined;
           context.runOnOtherBundle = undefined;
+          context.__rorpProps = undefined;
         }
       });
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/js_code_builder.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/js_code_builder.rb
@@ -7,6 +7,11 @@ module ReactOnRailsPro
   # Part of the strategy pattern refactoring (see issue #2905).
   # Currently additive — not yet wired into the main rendering path.
   class JsCodeBuilder < ReactOnRails::JsCodeBuilder
+    def build(render_request)
+      Thread.current[:ror_decoupled_props] = render_request.props_string
+      super
+    end
+
     protected
 
     def build_sections(render_request)
@@ -78,8 +83,8 @@ module ReactOnRailsPro
     #   when `props` IIFE param is undefined, i.e. normal invocation)
     # - render_call_section references both `componentName` and `usedProps`
     # Overriding any one without the others will produce broken JavaScript.
-    def props_section(render_request)
-      "var usedProps = typeof props === 'undefined' ? #{render_request.props_string} : props;"
+    def props_section(_render_request)
+      "var usedProps = typeof props === 'undefined' ? globalThis.__rorpProps : props;"
     end
 
     def render_call_section(render_request)

--- a/react_on_rails_pro/lib/react_on_rails_pro/rendering_strategy/node_strategy.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/rendering_strategy/node_strategy.rb
@@ -14,6 +14,8 @@ module ReactOnRailsPro
         js_code = render_request.to_js
         ReactOnRailsPro::ServerRenderingPool::ProRendering
           .exec_server_render_js(js_code, render_request.render_options)
+      ensure
+        Thread.current[:ror_decoupled_props] = nil
       end
 
       def reset

--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -280,6 +280,10 @@ module ReactOnRailsPro
       def form_with_code(js_code, send_bundle)
         form = common_form_data
         form["renderingRequest"] = js_code
+        if (props = Thread.current[:ror_decoupled_props])
+          form["props"] = props
+          Thread.current[:ror_decoupled_props] = nil
+        end
         populate_form_with_bundle_and_assets(form, check_bundle: false) if send_bundle
         form
       end

--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_js_code.rb
@@ -93,10 +93,10 @@ module ReactOnRailsPro
       # @param render_options [Object] Options that control the rendering behavior
       # @return [String] JavaScript code that will render the React component on the server
       def render(props_string, rails_context, redux_stores, react_component_name, render_options)
+        Thread.current[:ror_decoupled_props] = props_string
+
         render_function_name =
           if ReactOnRailsPro.configuration.enable_rsc_support && render_options.streaming?
-            # Select appropriate function based on whether the rendering request is running on server or rsc bundle
-            # As the same rendering request is used to generate the rsc payload and SSR the component.
             "ReactOnRails.isRSCBundle ? 'serverRenderRSCReactComponent' : 'streamServerRenderedReactComponent'"
           else
             "'serverRenderReactComponent'"
@@ -113,8 +113,6 @@ module ReactOnRailsPro
                        ""
                      end
 
-        # This function is called with specific componentName and props when generateRSCPayload is invoked
-        # In that case, it replaces the empty () with ('componentName', props) in the rendering request
         <<-JS
         (function(componentName = #{react_component_name.to_json}, props = undefined) {
           var railsContext = #{rails_context};
@@ -122,7 +120,7 @@ module ReactOnRailsPro
           #{generate_rsc_payload_js_function(render_options)}
           #{ssr_pre_hook_js}
           #{redux_stores}
-          var usedProps = typeof props === 'undefined' ? #{props_string} : props;
+          var usedProps = typeof props === 'undefined' ? globalThis.__rorpProps : props;
           #{async_props_setup_js(render_options)}
           return ReactOnRails[#{render_function_name}]({
             name: componentName,


### PR DESCRIPTION
## Summary

Experiment to measure the performance impact of decoupling component props from the JavaScript source string sent to the Node renderer.

**Before:** Props (~1.1 MB for mega benchmark) are embedded as a JS object literal inside the IIFE source string. V8 must re-parse the entire string on every request because `domNodeId` (a random UUID) makes each source string unique — V8's compile cache cannot help.

**After:** Props are sent as a separate HTTP form field. The IIFE source shrinks from ~1.1 MB to ~1.3 KB (stable template). On the Node side, `JSON.parse()` parses the props string using V8's optimized JSON parser instead of the JS parser.

## Changes

### Ruby side
- **`ServerRenderingJsCode#render`** — Set `Thread.current[:ror_decoupled_props]` with the props string; replace inline `#{props_string}` with `globalThis.__rorpProps`
- **`Request#form_with_code`** — Pick up the thread-local and add a `props` form field to the HTTP request
- **`JsCodeBuilder`** — Same changes for the new strategy pattern path (not yet wired in)
- **`NodeStrategy#execute`** — Ensure cleanup of thread-local

### Node side
- **`worker.ts`** — Extract `body.props` from the HTTP request
- **`handleRenderRequest.ts`** — Thread `propsJson` parameter through to VM execution
- **`vm.ts`** — Inject `context.__rorpProps = JSON.parse(propsJson)` before `vm.runInContext()`, clean up in `finally`

### RSC compatibility
The `generateRSCPayload` function modifies the IIFE's trailing `()` to pass `(componentName, propsString)`. With the change: `typeof props === 'undefined' ? globalThis.__rorpProps : props` — when called via `generateRSCPayload`, `props !== undefined` so the IIFE parameter is used, not the global. This preserves backward compatibility.

## Benchmark Results

### Microbenchmark: V8 JS parser vs JSON.parse (corrected)

Initial microbenchmark was flawed — it passed the same source string repeatedly, which let V8 reuse compiled code (cache hit). In production, `domNodeId` is a random UUID on every request, making every source string unique. Corrected benchmark uses varying source per iteration:

| Payload Size | JS literal (varying source) | JSON.parse (stable code) | Speedup | Savings/request |
|---|---|---|---|---|
| 0.1 MB | 1.6ms | 0.4ms | 78% | 1.3ms |
| 0.5 MB | 9.8ms | 2.0ms | 79% | 7.8ms |
| 1.0 MB | 19.5ms | 4.3ms | 78% | 15.2ms |
| 1.5 MB | 31.5ms | 6.6ms | 79% | 24.8ms |

Script: `/tmp/bench-json-vs-js-v2.mjs` (500 warmup, 500 measured runs per size)

### End-to-end VM-level measurement (1.1 MB props, n=50)

Instrumented `vm.runInContext()` in the Node renderer to measure actual execution time:

| Metric | Experiment (decoupled) | Baseline (embedded) | Improvement |
|---|---|---|---|
| **Source string size** | 1,277 bytes | 1,164,084 bytes | 99.9% smaller |
| **VM exec avg** | **18.0ms** | **36.4ms** | **18.4ms faster (50.6%)** |
| **Unique source hashes** | 50/50 | 50/50 | No V8 cache reuse on either side |

### Key finding

Every request produces a unique JS source string (due to random `domNodeId`), so V8 cannot cache compiled code across requests. Decoupling props means:
- The IIFE template (~1.3 KB) is the same every request → V8 **can** cache this tiny code
- Props are parsed by `JSON.parse()` which is **~5x faster** than V8's JS parser for large payloads
- Net savings: **~18ms per request** for 1.1 MB props at the VM level

## Recommendations

1. **This optimization is worth pursuing for production.** ~18ms savings per request scales linearly with props size. For apps with large SSR payloads, this is meaningful.

2. **The thread-local pattern should be replaced** with proper method signatures before merging to production. It was used here to minimize changes across 4+ method layers for the experiment.

3. **Consider also decoupling `railsContext`** — it's small (~1-2 KB) so savings would be minimal, but it would further stabilize the IIFE template for V8 caching.

4. **Consider setting `random_dom_id: false`** (or using a fixed `id:`) for SSR-heavy pages. This would allow V8 to cache the compiled IIFE across requests even without this optimization — but only when props don't change between requests.

5. **The `vm.Script` API could provide additional gains** — pre-compiling the stable IIFE template once and reusing it across requests, rather than passing source strings to `vm.runInContext()` each time.

## Test plan

- [x] Verify HTML output is byte-identical between experiment and baseline (2,186,627 bytes for mega benchmark)
- [x] Verify props are actually sent as separate form field (instrumented HTTP handler)
- [x] Verify JS source shrinks from ~1.1 MB to ~1.3 KB
- [x] Verify unique source hashes per request (no V8 cache reuse)
- [x] Run A/B benchmark with instrumented VM execution times

🤖 Generated with [Claude Code](https://claude.com/claude-code)