### PR TITLE
Exclude dead project URLs from markdown link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -41,6 +41,7 @@ exclude = [
   '^https://your-shared-addr\.c9users\.io',
   '^https://hichee\.com',
   '^https?://rubyonrails\.org/doctrine',  # DNS issues
+  '^https://www\.oppenheimerfunds\.com/?$',  # DNS no longer resolves
 
   # ============================================================================
   # SSL CERTIFICATE ISSUES

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -93,6 +93,7 @@ exclude = [
   '^https://(www\.)?guavapass\.com',  # TLS handshake failures from CI
   '^https?://(www\.)?hvmn\.com',  # Returns 503 from CI
   '^https://(www\.)?hawaiichee\.com/?$', # Intermittent 500 from CI
+  '^https://deliveroo\.co\.uk/?$', # Returns 403 for automated requests
 
   # ============================================================================
   # EXTERNAL SITES THAT TIMEOUT DURING CI CHECKS

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -17,7 +17,7 @@ _Please support the project by [emailing Justin Gordon](mailto:justin@shakacode.
 - **[Suntransfers](https://www.suntransfers.com/)**, airport car rides site.
 - **[LocalWise](https://www.localwise.com/)**, local job site.
 - **[Ellevest](https://www.ellevest.com/)**, investments for women.
-- **OppenheimerFunds**, investment site.
+- **[OppenheimerFunds](https://www.oppenheimerfunds.com/)**, investment site.
 - **[KissKissBankBank](https://www.kisskissbankbank.com/)**, large French crowdfunding platform.
 - **HVMN**: Web ecommerce site for "biohacking" products.
 - **[Pivotal Tracker](http://www.pivotaltracker.com/)**: The first (and most-loved) agile project management tool built on Rails. React on Rails has greatly simplified integration and workflow for our React components in Rails!

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -17,7 +17,7 @@ _Please support the project by [emailing Justin Gordon](mailto:justin@shakacode.
 - **[Suntransfers](https://www.suntransfers.com/)**, airport car rides site.
 - **[LocalWise](https://www.localwise.com/)**, local job site.
 - **[Ellevest](https://www.ellevest.com/)**, investments for women.
-- **[OppenheimerFunds](https://www.oppenheimerfunds.com/)**, investment site.
+- **OppenheimerFunds**, investment site.
 - **[KissKissBankBank](https://www.kisskissbankbank.com/)**, large French crowdfunding platform.
 - **HVMN**: Web ecommerce site for "biohacking" products.
 - **[Pivotal Tracker](http://www.pivotaltracker.com/)**: The first (and most-loved) agile project management tool built on Rails. React on Rails has greatly simplified integration and workflow for our React components in Rails!


### PR DESCRIPTION
## Summary
- exclude the dead OppenheimerFunds project URL from lychee checks
- exclude the Deliveroo project URL because it returns 403 to automated checks
- keep `PROJECTS.md` content unchanged

## Test plan
- `printf 'PROJECTS.md\\n' | lychee --config .lychee.toml --files-from -`
- `rm -f .lycheecache && lychee --config .lychee.toml docs/ *.md react_on_rails_pro/*.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link-checker configuration to exclude additional URLs that no longer resolve or return errors on automated requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->