### PR TITLE
Canonicalize GitHub file links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,9 @@ It's critical to configure your IDE/editor to ignore certain directories. Otherw
 
 # Example apps
 
-The [`react_on_rails/spec/dummy` app](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy) is an example of the various setup techniques you can use with the gem.
+The [`react_on_rails/spec/dummy` app](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy) is an example of the various setup techniques you can use with the gem.
 
-There are also two such apps for React on Rails Pro: [one using the Node renderer](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/dummy) and [one using ExecJS](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/execjs-compatible-dummy).
+There are also two such apps for React on Rails Pro: [one using the Node renderer](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails_pro/spec/dummy) and [one using ExecJS](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails_pro/spec/execjs-compatible-dummy).
 
 When you add a new feature, consider adding an example demonstrating it to the example apps.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Start with the docs here:
 ## Contributing
 
 Bug reports and pull requests are welcome. Start with
-[CONTRIBUTING.md](https://github.com/shakacode/react_on_rails/tree/main/CONTRIBUTING.md)
+[CONTRIBUTING.md](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md)
 and the
 [help wanted issues](https://github.com/shakacode/react_on_rails/labels/contributions%3A%20up%20for%20grabs%21).
 
@@ -145,7 +145,7 @@ policy. Please do not open a public issue for security reports.
 ## License
 
 React on Rails is available as open source under the terms of the
-[MIT License](https://github.com/shakacode/react_on_rails/tree/main/LICENSE.md).
+[MIT License](https://github.com/shakacode/react_on_rails/blob/main/LICENSE.md).
 
 Some advanced features require a React on Rails Pro subscription. See
 [React on Rails Pro](https://reactonrails.com/docs/pro/) and

--- a/docs/oss/api-reference/redux-store-api.md
+++ b/docs/oss/api-reference/redux-store-api.md
@@ -90,7 +90,7 @@ Include the module `ReactOnRails::Controller` in your controller, probably in Ap
   2. In your component definition, you'll call `ReactOnRails.getStore('storeName')` to get the hydrated Redux store to attach to your components.
 - **props:** Named parameter `props`. ReactOnRails takes care of setting up the hydration of your store with props from the view.
 
-For an example, see [spec/dummy/app/controllers/pages_controller.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/app/controllers/pages_controller.rb). Note: this is preferable to using the equivalent view_helper `redux_store` in that you can be assured that the store is initialized before your components.
+For an example, see [spec/dummy/app/controllers/pages_controller.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/app/controllers/pages_controller.rb). Note: this is preferable to using the equivalent view_helper `redux_store` in that you can be assured that the store is initialized before your components.
 
 ## View Helper
 
@@ -100,9 +100,9 @@ This method has the same API as the controller extension. **HOWEVER**, we recomm
 
 `redux_store_hydration_data`
 
-Place this view helper (no parameters) at the end of your shared layout so ReactOnRails will render the redux store hydration data. Since we're going to be setting up the stores in the controllers, we need to know where on the view to put the client-side rendering of this hydration data, which is a hidden div with a matching class that contains a data props. For an example, see [spec/dummy/app/views/layouts/application.html.erb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/app/views/layouts/application.html.erb).
+Place this view helper (no parameters) at the end of your shared layout so ReactOnRails will render the redux store hydration data. Since we're going to be setting up the stores in the controllers, we need to know where on the view to put the client-side rendering of this hydration data, which is a hidden div with a matching class that contains a data props. For an example, see [spec/dummy/app/views/layouts/application.html.erb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/app/views/layouts/application.html.erb).
 
 ## More Details
 
-- [lib/react_on_rails/controller.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/lib/react_on_rails/controller.rb) source
-- [lib/react_on_rails/helper.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/lib/react_on_rails/helper.rb) source
+- [lib/react_on_rails/controller.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/react_on_rails/controller.rb) source
+- [lib/react_on_rails/helper.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/react_on_rails/helper.rb) source

--- a/docs/oss/api-reference/view-helpers-api.md
+++ b/docs/oss/api-reference/view-helpers-api.md
@@ -113,7 +113,7 @@ Why would you want to take over mounting yourself? One use case is code splittin
 [React Router](https://reactrouter.com/) is supported via manual integration, including server-side rendering. See:
 
 1. [React on Rails docs for React Router](../building-features/react-router.md)
-2. Examples in [spec/dummy/app/views/react_router](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/app/views/react_router) and follow to the JavaScript code in the [spec/dummy/client/app/startup/RouterApp.server.jsx](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/client/app/startup/RouterApp.server.jsx).
+2. Examples in [spec/dummy/app/views/react_router](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/app/views/react_router) and follow to the JavaScript code in the [spec/dummy/client/app/startup/RouterApp.server.jsx](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/client/app/startup/RouterApp.server.jsx).
 3. [React on Rails Pro loadable-components guide](../building-features/code-splitting.md) for modern code splitting with server-side rendering.
 
 ### TanStack Router
@@ -179,4 +179,4 @@ See the [React on Rails Pro Configuration](../configuration/configuration-pro.md
 
 ## More details
 
-See the [lib/react_on_rails/helper.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/lib/react_on_rails/helper.rb) source.
+See the [lib/react_on_rails/helper.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/react_on_rails/helper.rb) source.

--- a/docs/oss/building-features/images.md
+++ b/docs/oss/building-features/images.md
@@ -28,7 +28,7 @@ const assetLoaderRules = [
 ];
 ```
 
-A full example can be found at [react_on_rails/spec/dummy/client/app/startup/ImageExample.jsx](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/client/app/startup/ImageExample.jsx)
+A full example can be found at [react_on_rails/spec/dummy/client/app/startup/ImageExample.jsx](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/client/app/startup/ImageExample.jsx)
 
 You are free to use images either in image tags or as background images in SCSS files. In current
 apps, prefer relative imports from files under `app/javascript`, or define your own webpack alias

--- a/docs/oss/core-concepts/how-react-on-rails-works.md
+++ b/docs/oss/core-concepts/how-react-on-rails-works.md
@@ -30,7 +30,7 @@ You can see all this on the source for [reactrails.com](https://reactrails.com/)
 
 Each time you change your client code, you will need to re-generate the bundles (the Webpack-created JavaScript files included in `application.js`). The included example Foreman `Procfile.dev` files will take care of this for you by starting a Webpack process with the watch flag. This will watch your JavaScript code files for changes. Alternatively, the `shakapacker` library also can ensure that your bundles are built.
 
-For example, you might create a [Procfile.dev](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/Procfile.dev).
+For example, you might create a [Procfile.dev](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/Procfile.dev).
 
 On production deployments that use asset precompilation, such as Heroku deployments, `shakapacker`, by default, will automatically run Webpack to build your JavaScript bundles, running the command `bin/shakapacker` in your app.
 

--- a/docs/oss/core-concepts/render-functions-and-railscontext.md
+++ b/docs/oss/core-concepts/render-functions-and-railscontext.md
@@ -80,7 +80,7 @@ reduxStore = MyReduxStore(props, railsContext);
 > [!NOTE]
 > See [Redux Store](../api-reference/redux-store-api.md#multiple-react-components-on-a-page-with-one-store) on how to set up Redux stores that allow multiple components to talk to the same store.
 
-The `railsContext` has: (see the implementation in [ReactOnRails::Helper](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/lib/react_on_rails/helper.rb), method `rails_context` for the definitive list).
+The `railsContext` has: (see the implementation in [ReactOnRails::Helper](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/react_on_rails/helper.rb), method `rails_context` for the definitive list).
 
 ```ruby
   {
@@ -191,7 +191,7 @@ Set the config value for the `rendering_extension`:
 
 Implement it like this above in the same file. Create a class method on the module called `custom_context` that takes the `view_context` for a param.
 
-See [spec/dummy/config/initializers/react_on_rails.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/config/initializers/react_on_rails.rb) for a detailed example.
+See [spec/dummy/config/initializers/react_on_rails.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/config/initializers/react_on_rails.rb) for a detailed example.
 
 ```ruby
 module RenderingExtension

--- a/internal/contributor-info/linters.md
+++ b/internal/contributor-info/linters.md
@@ -1,6 +1,6 @@
 # Linters
 
-These linters support the [ShakaCode Style Guidelines](../misc/style.md)
+These linters support the [ShakaCode Style Guidelines](../../docs/oss/misc/style.md)
 
 ## Autofix!
 
@@ -70,7 +70,7 @@ Rule severity is configured with `'off'`, `'warn'` or `'error'`. In older config
 
 Rules can also take a few additional options. In this case, the rule can be set to an array, the first item of which is the severity and the rest are options.
 
-See file [.eslintrc](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/lib/generators/react_on_rails/templates/.eslintrc) for examples of configuration
+See file [.eslintrc](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/lib/generators/react_on_rails/templates/.eslintrc) for examples of configuration
 
 ### Specify/Override rules in code
 

--- a/internal/contributor-info/pull-requests.md
+++ b/internal/contributor-info/pull-requests.md
@@ -38,4 +38,4 @@ When making doc changes, we want the change to work on both the gitbook and the 
 ### Links to other docs
 
 - When making references to source code files, use a full GitHub URL, for example:
-  `[spec/dummy/config/initializers/react_on_rails.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy/config/initializers/react_on_rails.rb)`
+  `[spec/dummy/config/initializers/react_on_rails.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails/spec/dummy/config/initializers/react_on_rails.rb)`

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -4,7 +4,7 @@ We're releasing this as a unified release with 6 packages total. We keep the ver
 
 ## Testing the Gem before Release from a Rails App
 
-See [Contributing](https://github.com/shakacode/react_on_rails/tree/main/CONTRIBUTING.md)
+See [Contributing](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md)
 
 ## Release Process
 

--- a/internal/testimonials/README.md
+++ b/internal/testimonials/README.md
@@ -26,4 +26,4 @@ From Kyle Maune of Cooper Aerial, May 4, 2018
 
 ![image](https://user-images.githubusercontent.com/1118459/40891236-9b0b406e-671d-11e8-80ee-c026dbd1d5a2.png)
 
-For more testimonials, see [Live Projects](https://github.com/shakacode/react_on_rails/tree/main/PROJECTS.md) and [Kudos](https://github.com/shakacode/react_on_rails/tree/main/KUDOS.md).
+For more testimonials, see [Live Projects](https://github.com/shakacode/react_on_rails/blob/main/PROJECTS.md) and [Kudos](https://github.com/shakacode/react_on_rails/blob/main/KUDOS.md).

--- a/react_on_rails_pro/CONTRIBUTING.md
+++ b/react_on_rails_pro/CONTRIBUTING.md
@@ -55,7 +55,7 @@ For links from docs pages to non-doc files, use full GitHub URLs so links resolv
   `[Installation Guide](../docs/pro/installation.md)`
 
 - When making references to source code files, use a full url path like:
-  `[spec/dummy/config/initializers/react_on_rails.rb](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails_pro/spec/dummy/config/initializers/react_on_rails.rb)`
+  `[spec/dummy/config/initializers/react_on_rails.rb](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/dummy/config/initializers/react_on_rails.rb)`
 
 ## To run tests:
 


### PR DESCRIPTION
### Summary

Closes #3302.

Canonicalizes same-repo GitHub links so file targets use `/blob/main/...` and directory targets use `/tree/main/...`. Version-root `/tree/` links remain unchanged.

Also fixes a stale relative link in `internal/contributor-info/linters.md` that surfaced during the Markdown link pre-commit check.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Other Information

Verification:

- Full tracked-file sweep confirmed no same-repo GitHub `/tree`/`blob` semantic mismatches remain.
- `git diff --check`
- `bin/lefthook/markdown-link-lint all-changed --offline`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `bin/lefthook/markdown-link-lint branch`
- Pre-commit and pre-push hooks passed.

Note: full `bundle exec rubocop` currently reports unrelated existing offenses in Ruby files that this PR does not touch; branch/pre-push Ruby lint reported no Ruby files to lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected numerous GitHub links across README, API reference, guides, and contributor docs to use the file-view URL format (/blob/) instead of directory-view (/tree/) for more accurate source-file references; also reorganized and standardized a few contributor/CONTRIBUTING example links for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
