### PR TITLE
Clarify RuboCop lint contract

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ AllCops:
     - 'node_modules/**/*'
     - 'spec/fixtures/**/*'
     - 'spec/react_on_rails/dummy-for-generators/**/*'
+    # Root-wide RuboCop uses root-relative paths. Keep generated/package-specific
+    # exclusions here so the root sweep does not become stricter than package CI.
+    - 'react_on_rails_pro/spec/dummy/db/schema.rb'
     - '**/vendor/**/*'
 
 Naming/FileName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ AllCops:
     # Root-wide RuboCop uses root-relative paths. Keep generated/package-specific
     # exclusions here so the root sweep does not fail on files package CI exempts.
     - 'react_on_rails_pro/spec/dummy/db/schema.rb'
+    - 'react_on_rails_pro/spec/dummy/db/seeds.rb'
     - '**/vendor/**/*'
 
 Naming/FileName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'spec/react_on_rails/dummy-for-generators/**/*'
     # Root-wide RuboCop uses root-relative paths. Keep generated/package-specific
-    # exclusions here so the root sweep does not become stricter than package CI.
+    # exclusions here so the root sweep does not fail on files package CI exempts.
     - 'react_on_rails_pro/spec/dummy/db/schema.rb'
     - '**/vendor/**/*'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,15 @@ bundle && pnpm install
 pnpm run build
 
 # Lint (MANDATORY before every commit)
-bundle exec rubocop                  # Ruby — must pass with zero offenses
-pnpm run lint                        # JS/TS via ESLint
-pnpm start format.listDifferent      # Check Prettier formatting
-rake lint                            # All linting (Ruby + JS + formatting)
+cd react_on_rails && bundle exec rubocop                         # OSS Ruby lint — CI-equivalent
+# Pro Ruby lint — CI-equivalent when Pro files or RuboCop config change
+cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion
+pnpm run lint                                                    # JS/TS via ESLint
+pnpm start format.listDifferent                                  # Check Prettier formatting
+rake lint                                                        # All linting (Ruby + JS + formatting)
+
+# Optional Ruby diagnostic from the repo root (not the CI contract)
+bundle exec rubocop
 
 # Auto-fix formatting
 rake autofix                         # Preferred for all formatting
@@ -177,7 +182,10 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 
 ### Always
 
-- Run `bundle exec rubocop` before committing — CI will reject violations
+- Run the CI-equivalent Ruby lint before committing:
+  `cd react_on_rails && bundle exec rubocop`; also run
+  `cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion` when touching Pro Ruby or
+  RuboCop config. Root `bundle exec rubocop` is a broad local sweep, not the CI contract.
 - Use `pnpm` for all JS operations — never `npm` or `yarn`
 - Use `bundle exec` for Ruby commands
 - Ensure all files end with a newline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ bundle && pnpm install
 pnpm run build
 
 # Lint (MANDATORY before every commit)
-cd react_on_rails && bundle exec rubocop                         # OSS Ruby lint — CI-equivalent
+(cd react_on_rails && bundle exec rubocop)                       # OSS Ruby lint — CI-equivalent
 # Pro Ruby lint — CI-equivalent when Pro files or RuboCop config change
-cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion
+(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)
 pnpm run lint                                                    # JS/TS via ESLint
 pnpm start format.listDifferent                                  # Check Prettier formatting
 rake lint                                                        # All linting (Ruby + JS + formatting)
@@ -183,8 +183,8 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 ### Always
 
 - Run the CI-equivalent Ruby lint before committing:
-  `cd react_on_rails && bundle exec rubocop`; also run
-  `cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion` when touching Pro Ruby or
+  `(cd react_on_rails && bundle exec rubocop)`; also run
+  `(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)` when touching Pro Ruby or
   RuboCop config. Root `bundle exec rubocop` is a broad local sweep, not the CI contract.
 - Use `pnpm` for all JS operations — never `npm` or `yarn`
 - Use `bundle exec` for Ruby commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,10 +182,13 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 
 ### Always
 
-- Run the CI-equivalent Ruby lint before committing:
-  `(cd react_on_rails && bundle exec rubocop)`; also run
-  `(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)` when touching Pro Ruby or
-  RuboCop config. Root `bundle exec rubocop` is a broad local sweep, not the CI contract.
+- Run the CI-equivalent Ruby lint before committing, not the root `bundle exec rubocop`:
+  ```bash
+  (cd react_on_rails && bundle exec rubocop)
+  # Also run when touching Pro Ruby or RuboCop config:
+  (cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)
+  ```
+  Root `bundle exec rubocop` is a broad local sweep, not the CI contract.
 - Use `pnpm` for all JS operations — never `npm` or `yarn`
 - Use `bundle exec` for Ruby commands
 - Ensure all files end with a newline

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@
 # Delegates to the react_on_rails gem for development
 
 # Use the open-source gem's Gemfile
-eval_gemfile File.expand_path('react_on_rails/Gemfile', __dir__)
+eval_gemfile File.expand_path("react_on_rails/Gemfile", __dir__)


### PR DESCRIPTION
## Summary

- Document the package-scoped RuboCop commands that match CI for OSS and Pro.
- Clarify that repo-root `bundle exec rubocop` is a broad local sweep, not the CI contract.
- Make the root RuboCop sweep pass by fixing the root `Gemfile` style offense and excluding the Pro dummy schema with its root-relative path.

## Testing

- `bundle exec rubocop --format simple`
- `cd react_on_rails && bundle exec rubocop --format simple`
- `cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion --format simple`
- `pnpm start format.listDifferent`
- `git diff --check`
- Pre-commit and pre-push hooks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code-quality rules to exclude generated/package-specific files from broad root linting.
  * Minor Gemfile formatting adjusted for consistency.

* **Documentation**
  * Clarified contributor guidance to run directory-scoped Ruby linting that matches CI before committing, and noted the root lint command is an optional diagnostic sweep.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->