### PR TITLE
ci(lychee): exclude flyhomes.com from markdown link check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -48,6 +48,7 @@ exclude = [
   # ============================================================================
   # Expired, hostname mismatch, or verification failed
   '^https://(www\.)?blinkinc\.com',     # SSL certificate expired
+  '^https://(www\.)?flyhomes\.com',     # SSL certificate intermittently expired (#3268)
   '^https://(www\.)?localwise\.com',    # SSL verification failed
   '^https://(www\.)?mycfsapp\.com',     # SSL hostname mismatch
   '^https://(www\.)?scoutapp\.com',     # SSL hostname mismatch


### PR DESCRIPTION
## Summary

- The [Flyhomes](https://www.flyhomes.com/) URL in `PROJECTS.md` periodically breaks the markdown link check when their TLS certificate expires (most recently observed on PR #3220 in May 2026).
- Their cert was renewed on May 10, 2026 (valid through Aug 8, 2026), but the same failure mode will recur on the next renewal lapse.
- Add the domain to the existing **SSL certificate issues** exclusion list in `.lychee.toml`, alongside the other PROJECTS.md sites with the same recurring cert problem (`blinkinc.com`, `mycfsapp.com`, etc.).

This keeps the link visible in `PROJECTS.md` for human readers while removing it from CI's link checking.

Fixes #3268

## Test plan

- [x] `lychee --config .lychee.toml --no-progress PROJECTS.md` passes locally with 0 errors
- [x] Verified `https://www.flyhomes.com/` is no longer in the list of URLs to be checked (`lychee --dump` confirms it's excluded)
- [ ] CI `Check Markdown Links / markdown-link-check` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Lychee CI configuration to skip a flaky external domain; no runtime or production code is affected.
> 
> **Overview**
> Adjusts Lychee’s link-check configuration to **exclude `https://(www\.)?flyhomes\.com`** under the *SSL certificate issues* list, preventing intermittent TLS failures on that domain from breaking the markdown link-check CI job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a8936dbb660f7f8123bb202b3298b913efa130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link-checker configuration to exclude an external URL pattern experiencing intermittent SSL certificate issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->