### PR TITLE
docs: add resolve.alias alternative for legacy Webpacker shim (#3252)

### DIFF
--- a/docs/oss/building-features/rails-webpacker-react-integration-options.md
+++ b/docs/oss/building-features/rails-webpacker-react-integration-options.md
@@ -185,6 +185,44 @@ Keep each shim explicit and narrow:
    `@internal/base/client`, `@internal/createReactOnRails`) are not public API — never import them directly,
    even via the `lib/` path fallback.
 
+   **Alternative: redirect with `resolve.alias` instead of changing imports**
+
+   If you would rather keep `react-on-rails/client` (and the named subpath imports above) in your application
+   code, alias them to the same `lib/` paths from your Webpack config instead. The alias keeps the `/client`
+   entry's smaller surface — Webpack loads `lib/ReactOnRails.client.js` directly, so the full-build browser
+   warning and the bundled SSR capability module stay out of the client bundle.
+
+   The same `lib/` path caveats apply: the file paths are not public API and may change in any patch or minor
+   release, so pin `react_on_rails` to an exact version (for example, `gem 'react_on_rails', '= 16.0.0'`) when
+   you rely on these aliases. Use the `$` suffix on each alias key for an exact match so the alias only
+   redirects the bare subpath. Match the file extension listed in the `exports` field of
+   `packages/react-on-rails/package.json` — some subpaths resolve to `.cjs` rather than `.js`. Exports prefixed
+   with `@internal/` are not public API; do not alias them.
+
+   ```js
+   // config/webpack/environment.js
+   // Webpacker 5 uses '@rails/webpacker', not 'shakapacker'.
+   const { environment } = require('@rails/webpacker');
+
+   environment.config.merge({
+     resolve: {
+       alias: {
+         'react-on-rails/client$': 'react-on-rails/lib/ReactOnRails.client.js',
+         // Add only the subpaths your app actually imports:
+         'react-on-rails/context$': 'react-on-rails/lib/context.js',
+         'react-on-rails/pageLifecycle$': 'react-on-rails/lib/pageLifecycle.js',
+         'react-on-rails/turbolinksUtils$': 'react-on-rails/lib/turbolinksUtils.js',
+       },
+     },
+   });
+
+   module.exports = environment;
+   ```
+
+   The aliased files still resolve under `node_modules/react-on-rails/`, so the package-scoped `babel-loader`
+   rule from Step 3 still picks them up. Put Steps 2 and 3 in place before relying on the alias — the
+   redirected files use the same modern syntax and ESM packaging as the `/client` entry point.
+
 2. Ensure Babel can parse modern syntax used by current packages:
 
    Add these plugins to your existing Babel config without replacing existing presets or plugins.

--- a/docs/oss/building-features/rails-webpacker-react-integration-options.md
+++ b/docs/oss/building-features/rails-webpacker-react-integration-options.md
@@ -224,8 +224,10 @@ Keep each shim explicit and narrow:
    ```
 
    The aliased files still resolve under `node_modules/react-on-rails/`, so the package-scoped `babel-loader`
-   rule from Step 3 still picks them up. Put Steps 2 and 3 in place before relying on the alias — the
-   redirected files use the same modern syntax and ESM packaging as the `/client` entry point.
+   rule from Step 3 still picks them up. Put Steps 2 and 3 in place before relying on the alias (Step 2 adds
+   the Babel plugins for optional chaining / nullish coalescing; Step 3 adds the `babel-loader` rule scoped to
+   `node_modules/react-on-rails`) — the redirected files use the same modern syntax and ESM packaging as the
+   `/client` entry point.
 
    If your `environment.js` already has other configuration, add the `environment.config.merge` block before the existing `module.exports` line.
 

--- a/docs/oss/building-features/rails-webpacker-react-integration-options.md
+++ b/docs/oss/building-features/rails-webpacker-react-integration-options.md
@@ -212,6 +212,10 @@ Keep each shim explicit and narrow:
          'react-on-rails/context$': 'react-on-rails/lib/context.js',
          'react-on-rails/pageLifecycle$': 'react-on-rails/lib/pageLifecycle.js',
          'react-on-rails/turbolinksUtils$': 'react-on-rails/lib/turbolinksUtils.js',
+         // .cjs example — check the `exports` field in `packages/react-on-rails/package.json`
+         // for the correct extension before adding subpaths like these:
+         // 'react-on-rails/reactApis$': 'react-on-rails/lib/reactApis.cjs',
+         // 'react-on-rails/ReactDOMServer$': 'react-on-rails/lib/ReactDOMServer.cjs',
        },
      },
    });
@@ -222,6 +226,8 @@ Keep each shim explicit and narrow:
    The aliased files still resolve under `node_modules/react-on-rails/`, so the package-scoped `babel-loader`
    rule from Step 3 still picks them up. Put Steps 2 and 3 in place before relying on the alias — the
    redirected files use the same modern syntax and ESM packaging as the `/client` entry point.
+
+   If your `environment.js` already has other configuration, add the `environment.config.merge` block before the existing `module.exports` line.
 
 2. Ensure Babel can parse modern syntax used by current packages:
 


### PR DESCRIPTION
## Summary

- Documents a `resolve.alias` alternative to the package-root import shim added in #3225.
- The alias points `react-on-rails/client` (and other named subpaths) at the matching `lib/*.js` file. Webpack 4 ignores the `exports` field, so the right-hand side resolves through normal `node_modules` lookup.
- Loads `lib/ReactOnRails.client.js` directly, so the full-build browser warning emitted from [`capabilities/ssr.ts:10`](https://github.com/shakacode/react_on_rails/blob/main/packages/react-on-rails/src/capabilities/ssr.ts) and the SSR capability module stay out of the client bundle, without requiring users to edit imports throughout their app.

## Acceptance criteria from #3252

- ✅ Reproduce Webpacker 5 / Webpack 4 resolution behavior — explained in the existing Step 1 intro (Webpack 4 doesn't honor `exports`, so `react-on-rails/client` resolves to a literal file path).
- ✅ Determine whether `resolve.alias` can point the client subpath at the built client bundle while still allowing the package files to be transpiled — confirmed: aliased files still resolve under `node_modules/react-on-rails/`, so the package-scoped `babel-loader` rule from Step 3 still picks them up.
- ✅ Confirm the alias avoids the full-build browser warning without SSR/client registration regressions — `ReactOnRails.client.js` is the same entry that Webpack 5 selects via `exports`; it doesn't include `createSSRCapability`, the module that emits the bundle-size warning when `typeof window !== 'undefined'`.
- ✅ Document the alias as an alternative shim with required ordering relative to Step 2 / Step 3 (Babel plugins and scoped loader still need to be in place because the redirected files use the same modern syntax and ESM packaging).

## Test plan

- [x] `pnpm exec prettier --check docs/oss/building-features/rails-webpacker-react-integration-options.md`
- [x] `script/check-docs-sidebar origin/main HEAD`
- [x] `git diff --check`
- [x] Pre-commit hook: trailing-newlines, offline Markdown links, Prettier
- [x] Pre-push hook: branch-lint, online Markdown links
- [ ] Reviewer: validate in a real Webpacker 5 / Webpack 4 app if possible (the shims remain outside React on Rails CI; the existing caution callout above the section still applies)

Fixes #3252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates documentation, adding an alternative Webpack configuration snippet without changing runtime code.
> 
> **Overview**
> Adds documentation for a **Webpacker 5 / Webpack 4**-specific alternative shim: using `resolve.alias` to redirect `react-on-rails/client` and other subpath imports to the corresponding `react-on-rails/lib/*` files instead of editing application imports.
> 
> Clarifies aliasing best practices and caveats (exact-match `$` aliases, matching `.js` vs `.cjs` per `exports`, avoiding `@internal/*` exports, pinning versions), and notes the alias still requires the existing Babel plugin + `babel-loader` steps to transpile the redirected `lib/` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff4c3853c33bb44b09be5d51c1221a5b89452ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new subsection describing an alternative migration that preserves existing framework subpath imports via configuration-based redirect rules.
  * Clarifies how to match exact subpath imports, choose correct module file extensions, avoid internal-only exports, pin the package to an exact version, and ensure aliased files are transpiled by the build rule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->