### PR TITLE
test(ci): harden git-diff-base coverage and add deepen progress log

### DIFF
--- a/script/check-docs-sidebar
+++ b/script/check-docs-sidebar
@@ -6,6 +6,10 @@
 # Exit codes:
 #   0 — all new docs have sidebar entries (or no new docs were added)
 #   1 — one or more new docs are missing from sidebars.ts
+#
+# Diff-base logic lives in script/lib/git-diff-base. Run its self-contained
+# tests with: bash script/lib/git-diff-base-test.bash
+# CI invokes the same harness via .github/workflows/git-diff-base-tests.yml.
 
 set -euo pipefail
 

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -2,6 +2,10 @@
 # CI Changes Detector
 # Analyzes git changes to determine which CI jobs need to run
 # Usage: script/ci-changes-detector [base-ref]
+#
+# Diff-base logic lives in script/lib/git-diff-base. Run its self-contained
+# tests with: bash script/lib/git-diff-base-test.bash
+# CI invokes the same harness via .github/workflows/git-diff-base-tests.yml.
 
 set -euo pipefail
 

--- a/script/lib/git-diff-base
+++ b/script/lib/git-diff-base
@@ -463,7 +463,7 @@ git_diff_base_resolve() {
       # the initial fetch and the eventual --unshallow fallback. Keeps the
       # noise low (one line per round) while preserving the full git fetch
       # diagnostics that follow.
-      echo "Deepening shallow history (attempt $deepen_attempts/$max_attempts, depth $deepen_depth)" >&2
+      echo "Deepening shallow history (attempt $deepen_attempts/$max_attempts, fetching $deepen_depth more commits)" >&2
 
       # A successful deepen on either side can reveal the common ancestor, even
       # when the other branch fetch fails. Stop early only when every attempted

--- a/script/lib/git-diff-base
+++ b/script/lib/git-diff-base
@@ -3,6 +3,10 @@
 # Shared helpers for scripts that need a reliable merge-base in shallow clones.
 # Source this file from bash scripts; do not execute it directly.
 #
+# Tests: bash script/lib/git-diff-base-test.bash (self-contained; no extra
+# dependencies beyond bash + git). CI runs the same harness via
+# .github/workflows/git-diff-base-tests.yml.
+#
 # Tuning knobs:
 # - GIT_DIFF_BASE_FETCH_DEPTH: initial fetch size, and first deepen size before doubling (default 50).
 # - GIT_DIFF_BASE_MAX_ATTEMPTS: exponential deepen attempts before falling back to --unshallow
@@ -11,6 +15,17 @@
 # - GIT_DIFF_BASE_UNSHALLOW_TIMEOUT_SECONDS: maximum seconds for the --unshallow fallback when the
 #   system timeout command is available (default 300; set 0 to disable the guard).
 # - GIT_DIFF_BASE_DEBUG: set to any non-empty value to show git merge-base stderr output.
+#
+# Deepen-vs-unshallow rationale:
+# - Typical PRs diverge by tens to a few hundred commits, so the first few doubling rounds
+#   (50 → 100 → 200 → 400) usually resolve the merge base in under a second of network work.
+# - Falling back to --unshallow earlier (e.g., after 1–2 attempts) would pay the full-history
+#   cost on every long-lived branch, even when one more cheap deepen would have sufficed.
+# - Capping the deepen loop at 8 attempts (12,750 commits per branch) gives the bounded loop
+#   a real chance to resolve very stale branches while still bounding the per-CI-run cost; the
+#   --unshallow fallback only fires when both branches are genuinely far apart.
+# - Each deepen attempt emits a single-line progress message to stderr so a slow CI run is not
+#   opaque between the initial fetch and the eventual unshallow.
 #
 # git_diff_base_resolve accepts a third argument selecting the initial-fetch policy:
 # - strict (default): abort immediately if the first base-branch fetch fails in a shallow clone.
@@ -443,6 +458,12 @@ git_diff_base_resolve() {
     while [ "$deepen_attempts" -lt "$max_attempts" ] && [ "$is_shallow" = true ]; do
       deepen_attempts=$((deepen_attempts + 1))
       fetched=false
+
+      # Single-line per-attempt breadcrumb so operators see progress between
+      # the initial fetch and the eventual --unshallow fallback. Keeps the
+      # noise low (one line per round) while preserving the full git fetch
+      # diagnostics that follow.
+      echo "Deepening shallow history (attempt $deepen_attempts/$max_attempts, depth $deepen_depth)" >&2
 
       # A successful deepen on either side can reveal the common ancestor, even
       # when the other branch fetch fails. Stop early only when every attempted

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -344,11 +344,11 @@ test_sha_ref_classifies_full_length_sha() {
   local sha
   sha="$(git rev-parse HEAD)"
   # Sanity check: default git installs produce 40-char SHA-1 hashes. If a future
-  # default flips to SHA-256, this still tests the full-length-classifier path,
-  # but test_sha_ref_classifies_64_char_hex below exercises 64-char inputs
-  # explicitly regardless of the local repository's object format.
+  # default flips to SHA-256, this test will fail with an explicit diagnostic —
+  # the 64-char classifier path is covered independently by
+  # test_sha_ref_classifies_64_char_hex.
   if [ "${#sha}" -ne 40 ]; then
-    fail "expected 40-char SHA from git rev-parse HEAD, got ${#sha}-char '$sha'"
+    fail "expected 40-char SHA from git rev-parse HEAD, got ${#sha}-char '$sha' -- if git now defaults to SHA-256, update this test; the 64-char classifier path is covered by test_sha_ref_classifies_64_char_hex"
     return 1
   fi
   if ! git_diff_base_sha_ref "$sha"; then
@@ -359,9 +359,11 @@ test_sha_ref_classifies_full_length_sha() {
 
 test_sha_ref_classifies_64_char_hex() {
   # The classifier accepts 64-char SHA-256 hashes without local verification
-  # (same policy as 40-char SHA-1). No repo state is required because the
-  # full-length branch of git_diff_base_sha_ref short-circuits before any
-  # rev-parse call. Cwd is still the per-test tmpdir, which has no .git.
+  # (same policy as 40-char SHA-1). No repo state is required: the
+  # verify_ref call is short-circuited for 40/64-char inputs, and the two
+  # branch-name rev-parse checks that follow fail gracefully when there is no
+  # .git in the current directory, so neither match fires and the function
+  # returns 0. Cwd is still the per-test tmpdir, which has no .git.
   local hex="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   if [ "${#hex}" -ne 64 ]; then
     fail "test fixture broken: expected 64-char hex, got ${#hex}"
@@ -394,7 +396,7 @@ test_sha_ref_rejects_short_unknown_hex() {
   # A short hex string that does not resolve to any local object must NOT
   # classify as a SHA. Using all zeros guarantees no real commit collision.
   setup_repo_fixture full
-  if git_diff_base_sha_ref "0000000" 2>/dev/null; then
+  if git_diff_base_sha_ref "0000000"; then
     fail "unknown short hex string should not classify as a SHA"
     return 1
   fi
@@ -539,7 +541,7 @@ test_resolve_logs_deepen_progress() {
   fi
   local stderr_text
   stderr_text="$(cat "$err_file")"
-  assert_contains "$stderr_text" "Deepening" "deepen progress log line"
+  assert_contains "$stderr_text" "Deepening shallow history" "deepen progress log line"
 }
 
 test_resolve_cross_repo_sha_hint_appears() {

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -282,7 +282,6 @@ setup_repo_fixture() {
     git commit --allow-empty -m "feat-2" >/dev/null
     git checkout main >/dev/null 2>&1
     if [ "$main_extra" -gt 0 ]; then
-      local i
       for ((i = 1; i <= main_extra; i++)); do
         git commit --allow-empty -m "main-extra-$i" >/dev/null
       done
@@ -376,6 +375,11 @@ test_sha_ref_classifies_64_char_hex() {
   # branch-name rev-parse checks that follow fail gracefully when there is no
   # .git in the current directory, so neither match fires and the function
   # returns 0. Cwd is still the per-test tmpdir, which has no .git.
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    fail "test must run outside a git repo (no setup_repo_fixture)"
+    return 1
+  fi
+
   local hex="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   if [ "${#hex}" -ne 64 ]; then
     fail "test fixture broken: expected 64-char hex, got ${#hex}"
@@ -517,10 +521,13 @@ test_resolve_lenient_continues_after_initial_fetch_failure() {
 test_resolve_unshallow_fallback_finds_merge_base() {
   # Force the deepen budget to exhaust without finding the merge base, so the
   # --unshallow fallback runs. The fixture adds 10 extra commits on main after
-  # feature branches off (merge base = c5, main tip = main-extra-10). With
-  # initial depth=2 and one deepen attempt of depth=2, main only fetches 4
-  # commits (main-extra-7 through main-extra-10), which never reaches c5; the
-  # unshallow pull then brings in all of main and exposes the merge base.
+  # feature branches off (merge base = c5, main tip = main-extra-10).
+  # git_diff_base_resolve uses GIT_DIFF_BASE_FETCH_DEPTH=2:
+  #   - initial fetch (--depth=2): main-extra-9, main-extra-10
+  #   - one deepen round (--deepen=2): adds main-extra-7, main-extra-8
+  #   - total visible from main: main-extra-7..main-extra-10 (4 commits)
+  # c5 is at depth 20 from the main tip, so it is still not reachable; the
+  # --unshallow fallback then fetches all of main and exposes the merge base.
   # setup_repo_fixture intentionally leaves origin/main unfetched for this
   # main_extra shallow clone so the test does not depend on git fetch --depth
   # re-shallowing an already complete remote-tracking ref.
@@ -544,7 +551,8 @@ test_resolve_unshallow_fallback_finds_merge_base() {
 test_resolve_logs_deepen_progress() {
   # Operators need a visible breadcrumb per deepen iteration so a slow CI run
   # is not opaque between the initial fetch and the eventual unshallow. This
-  # checks each deepen depth in the 2 -> 4 -> 8 sequence.
+  # checks each deepen depth in the 2 -> 4 -> 8 sequence and verifies the
+  # fallback still fires after the deepen budget is exhausted.
   setup_repo_fixture shallow 1 20
   local err_file
   err_file="$(mktemp resolve-err.XXXXXX)"
@@ -558,6 +566,7 @@ test_resolve_logs_deepen_progress() {
   assert_contains "$stderr_text" "Deepening shallow history (attempt 1/3, depth 2)" "first deepen progress line"
   assert_contains "$stderr_text" "Deepening shallow history (attempt 2/3, depth 4)" "second deepen progress line"
   assert_contains "$stderr_text" "Deepening shallow history (attempt 3/3, depth 8)" "third deepen progress line"
+  assert_contains "$stderr_text" "falling back to --unshallow" "unshallow fallback fires after budget exhausted"
 }
 
 test_resolve_cross_repo_sha_hint_appears() {

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -250,7 +250,8 @@ test_run_test_counts_non_final_assertion_failure() {
 # ---------------------------------------------------------------------------
 
 # Build a minimal local "remote" + clone pair inside the current tempdir.
-# After this returns, cwd is the clone repo with the named branches and refs.
+# After this returns, cwd is the clone repo with branch refs needed by the
+# requested fixture mode.
 #
 # Arguments:
 #   $1 clone_kind     "full" (default) or "shallow"
@@ -258,6 +259,8 @@ test_run_test_counts_non_final_assertion_failure() {
 #   $3 main_extra     extra commits to add to main AFTER feature branches off
 #                     (default 0). Use a large value to force the deepen loop
 #                     to exhaust its budget and exercise the --unshallow path.
+#                     In shallow clones with main_extra, origin/main is left for
+#                     git_diff_base_resolve to fetch depth-limited.
 setup_repo_fixture() {
   local clone_kind="${1:-full}"
   local depth="${2:-2}"
@@ -299,6 +302,15 @@ setup_repo_fixture() {
   cd clone || return 1
   git config user.email "t@example.com"
   git config user.name "test"
+
+  if [ "$clone_kind" = "shallow" ] && [ "$main_extra" -gt 0 ]; then
+    # Leave origin/main for git_diff_base_resolve's own initial depth-limited
+    # fetch. Fully prefetching it here would make fallback tests depend on
+    # whether this Git version re-shallows an already complete remote-tracking
+    # ref when a later `git fetch --depth=N` runs.
+    return 0
+  fi
+
   # Clones default to fetching only the checked-out branch, so make sure the
   # base branch is also tracked locally for the deepen path tests. Warn on
   # failure so downstream test failures trace back to the setup step rather
@@ -509,6 +521,9 @@ test_resolve_unshallow_fallback_finds_merge_base() {
   # initial depth=2 and one deepen attempt of depth=2, main only fetches 4
   # commits (main-extra-7 through main-extra-10), which never reaches c5; the
   # unshallow pull then brings in all of main and exposes the merge base.
+  # setup_repo_fixture intentionally leaves origin/main unfetched for this
+  # main_extra shallow clone so the test does not depend on git fetch --depth
+  # re-shallowing an already complete remote-tracking ref.
   setup_repo_fixture shallow 1 10
   local out err_file
   err_file="$(mktemp resolve-err.XXXXXX)"
@@ -529,19 +544,20 @@ test_resolve_unshallow_fallback_finds_merge_base() {
 test_resolve_logs_deepen_progress() {
   # Operators need a visible breadcrumb per deepen iteration so a slow CI run
   # is not opaque between the initial fetch and the eventual unshallow. This
-  # checks that at least one deepen-progress line is emitted when the deepen
-  # loop runs.
-  setup_repo_fixture shallow 1
+  # checks each deepen depth in the 2 -> 4 -> 8 sequence.
+  setup_repo_fixture shallow 1 20
   local err_file
   err_file="$(mktemp resolve-err.XXXXXX)"
-  if ! GIT_DIFF_BASE_FETCH_DEPTH=2 GIT_DIFF_BASE_MAX_ATTEMPTS=8 \
+  if ! GIT_DIFF_BASE_FETCH_DEPTH=2 GIT_DIFF_BASE_MAX_ATTEMPTS=3 \
       git_diff_base_resolve "origin/main" "HEAD" strict >/dev/null 2>"$err_file"; then
     fail "resolve failed; stderr was: $(cat "$err_file")"
     return 1
   fi
   local stderr_text
   stderr_text="$(cat "$err_file")"
-  assert_contains "$stderr_text" "Deepening shallow history" "deepen progress log line"
+  assert_contains "$stderr_text" "Deepening shallow history (attempt 1/3, depth 2)" "first deepen progress line"
+  assert_contains "$stderr_text" "Deepening shallow history (attempt 2/3, depth 4)" "second deepen progress line"
+  assert_contains "$stderr_text" "Deepening shallow history (attempt 3/3, depth 8)" "third deepen progress line"
 }
 
 test_resolve_cross_repo_sha_hint_appears() {

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -526,7 +526,7 @@ test_resolve_unshallow_fallback_finds_merge_base() {
   #   - initial fetch (--depth=2): main-extra-9, main-extra-10
   #   - one deepen round (--deepen=2): adds main-extra-7, main-extra-8
   #   - total visible from main: main-extra-7..main-extra-10 (4 commits)
-  # c5 is at depth 11 from the main tip (10 hops: main-extra-10..main-extra-1, c5),
+  # c5 is at depth 11 from the main tip (main-extra-10 → main-extra-9 → … → main-extra-1 → c5),
   # so it is still not reachable; the --unshallow fallback then fetches all of
   # main and exposes the merge base.
   # setup_repo_fixture intentionally leaves origin/main unfetched for this

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -251,9 +251,17 @@ test_run_test_counts_non_final_assertion_failure() {
 
 # Build a minimal local "remote" + clone pair inside the current tempdir.
 # After this returns, cwd is the clone repo with the named branches and refs.
+#
+# Arguments:
+#   $1 clone_kind     "full" (default) or "shallow"
+#   $2 depth          shallow-clone depth (default 2; ignored for full clones)
+#   $3 main_extra     extra commits to add to main AFTER feature branches off
+#                     (default 0). Use a large value to force the deepen loop
+#                     to exhaust its budget and exercise the --unshallow path.
 setup_repo_fixture() {
   local clone_kind="${1:-full}"
   local depth="${2:-2}"
+  local main_extra="${3:-0}"
 
   git -c init.defaultBranch=main init --bare remote.git >/dev/null
   git -c init.defaultBranch=main init seed >/dev/null
@@ -270,6 +278,12 @@ setup_repo_fixture() {
     git commit --allow-empty -m "feat-1" >/dev/null
     git commit --allow-empty -m "feat-2" >/dev/null
     git checkout main >/dev/null 2>&1
+    if [ "$main_extra" -gt 0 ]; then
+      local i
+      for ((i = 1; i <= main_extra; i++)); do
+        git commit --allow-empty -m "main-extra-$i" >/dev/null
+      done
+    fi
     git remote add origin "$PWD/../remote.git"
     git push origin main feature >/dev/null 2>&1
   )
@@ -329,8 +343,59 @@ test_sha_ref_classifies_full_length_sha() {
   setup_repo_fixture full
   local sha
   sha="$(git rev-parse HEAD)"
+  # Sanity check: default git installs produce 40-char SHA-1 hashes. If a future
+  # default flips to SHA-256, this still tests the full-length-classifier path,
+  # but test_sha_ref_classifies_64_char_hex below exercises 64-char inputs
+  # explicitly regardless of the local repository's object format.
+  if [ "${#sha}" -ne 40 ]; then
+    fail "expected 40-char SHA from git rev-parse HEAD, got ${#sha}-char '$sha'"
+    return 1
+  fi
   if ! git_diff_base_sha_ref "$sha"; then
     fail "$sha should classify as a SHA"
+    return 1
+  fi
+}
+
+test_sha_ref_classifies_64_char_hex() {
+  # The classifier accepts 64-char SHA-256 hashes without local verification
+  # (same policy as 40-char SHA-1). No repo state is required because the
+  # full-length branch of git_diff_base_sha_ref short-circuits before any
+  # rev-parse call. Cwd is still the per-test tmpdir, which has no .git.
+  local hex="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  if [ "${#hex}" -ne 64 ]; then
+    fail "test fixture broken: expected 64-char hex, got ${#hex}"
+    return 1
+  fi
+  if ! git_diff_base_sha_ref "$hex"; then
+    fail "$hex should classify as a 64-char SHA"
+    return 1
+  fi
+}
+
+test_sha_ref_classifies_short_local_sha() {
+  # Short hex strings classify as SHAs only when they resolve locally. This
+  # exercises the verify_ref branch of the classifier, which protects against
+  # treating arbitrary short hex strings as commit refs.
+  setup_repo_fixture full
+  local short_sha
+  short_sha="$(git rev-parse --short=7 HEAD)"
+  if [ "${#short_sha}" -ne 7 ]; then
+    fail "expected 7-char short SHA, got ${#short_sha}-char '$short_sha'"
+    return 1
+  fi
+  if ! git_diff_base_sha_ref "$short_sha"; then
+    fail "$short_sha should classify as a short local SHA"
+    return 1
+  fi
+}
+
+test_sha_ref_rejects_short_unknown_hex() {
+  # A short hex string that does not resolve to any local object must NOT
+  # classify as a SHA. Using all zeros guarantees no real commit collision.
+  setup_repo_fixture full
+  if git_diff_base_sha_ref "0000000" 2>/dev/null; then
+    fail "unknown short hex string should not classify as a SHA"
     return 1
   fi
 }
@@ -435,6 +500,48 @@ test_resolve_lenient_continues_after_initial_fetch_failure() {
   fi
 }
 
+test_resolve_unshallow_fallback_finds_merge_base() {
+  # Force the deepen budget to exhaust without finding the merge base, so the
+  # --unshallow fallback runs. The fixture adds 10 extra commits on main after
+  # feature branches off (merge base = c5, main tip = main-extra-10). With
+  # initial depth=2 and one deepen attempt of depth=2, main only fetches 4
+  # commits (main-extra-7 through main-extra-10), which never reaches c5; the
+  # unshallow pull then brings in all of main and exposes the merge base.
+  setup_repo_fixture shallow 1 10
+  local out err_file
+  err_file="$(mktemp resolve-err.XXXXXX)"
+  if ! out="$(GIT_DIFF_BASE_FETCH_DEPTH=2 GIT_DIFF_BASE_MAX_ATTEMPTS=1 \
+      git_diff_base_resolve "origin/main" "HEAD" strict 2>"$err_file")"; then
+    fail "resolve should succeed after unshallow; stderr was: $(cat "$err_file")"
+    return 1
+  fi
+  if ! git cat-file -e "$out^{commit}" 2>/dev/null; then
+    fail "unshallow path returned non-commit '$out'"
+    return 1
+  fi
+  local stderr_text
+  stderr_text="$(cat "$err_file")"
+  assert_contains "$stderr_text" "falling back to --unshallow" "unshallow warning"
+}
+
+test_resolve_logs_deepen_progress() {
+  # Operators need a visible breadcrumb per deepen iteration so a slow CI run
+  # is not opaque between the initial fetch and the eventual unshallow. This
+  # checks that at least one deepen-progress line is emitted when the deepen
+  # loop runs.
+  setup_repo_fixture shallow 1
+  local err_file
+  err_file="$(mktemp resolve-err.XXXXXX)"
+  if ! GIT_DIFF_BASE_FETCH_DEPTH=2 GIT_DIFF_BASE_MAX_ATTEMPTS=8 \
+      git_diff_base_resolve "origin/main" "HEAD" strict >/dev/null 2>"$err_file"; then
+    fail "resolve failed; stderr was: $(cat "$err_file")"
+    return 1
+  fi
+  local stderr_text
+  stderr_text="$(cat "$err_file")"
+  assert_contains "$stderr_text" "Deepening" "deepen progress log line"
+}
+
 test_resolve_cross_repo_sha_hint_appears() {
   # The hint only fires from the bottom of git_diff_base_resolve after the
   # deepen+unshallow loop has run. To exercise that path, the clone must be
@@ -483,6 +590,9 @@ ALL_TESTS=(
   test_is_shallow_repository_detects_full_clone
   test_is_shallow_repository_detects_shallow_clone
   test_sha_ref_classifies_full_length_sha
+  test_sha_ref_classifies_64_char_hex
+  test_sha_ref_classifies_short_local_sha
+  test_sha_ref_rejects_short_unknown_hex
   test_sha_ref_rejects_existing_branch_name
   test_sha_ref_rejects_non_hex_strings
   test_resolve_full_clone_happy_path
@@ -490,6 +600,8 @@ ALL_TESTS=(
   test_resolve_shallow_deepens_to_find_merge_base
   test_resolve_full_clone_missing_base_ref_errors
   test_resolve_lenient_continues_after_initial_fetch_failure
+  test_resolve_unshallow_fallback_finds_merge_base
+  test_resolve_logs_deepen_progress
   test_resolve_cross_repo_sha_hint_appears
 )
 

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -526,8 +526,9 @@ test_resolve_unshallow_fallback_finds_merge_base() {
   #   - initial fetch (--depth=2): main-extra-9, main-extra-10
   #   - one deepen round (--deepen=2): adds main-extra-7, main-extra-8
   #   - total visible from main: main-extra-7..main-extra-10 (4 commits)
-  # c5 is at depth 20 from the main tip, so it is still not reachable; the
-  # --unshallow fallback then fetches all of main and exposes the merge base.
+  # c5 is at depth 11 from the main tip (10 hops: main-extra-10..main-extra-1, c5),
+  # so it is still not reachable; the --unshallow fallback then fetches all of
+  # main and exposes the merge base.
   # setup_repo_fixture intentionally leaves origin/main unfetched for this
   # main_extra shallow clone so the test does not depend on git fetch --depth
   # re-shallowing an already complete remote-tracking ref.


### PR DESCRIPTION
## Summary

Follow-up to #3224 / Closes #3249.

- Expands `script/lib/git-diff-base-test.bash` to close the gaps called out in the issue:
  - `git_diff_base_sha_ref`: adds 64-char SHA, short local SHA, and short unknown-hex cases (40-char and hex-branch-name cases were already covered).
  - `git_diff_base_resolve`: adds a dedicated `--unshallow` fallback test (the fixture now optionally adds extra commits on `main` after `feature` branches off, so the deepen budget is intentionally exhausted) and a progress-log assertion.
- Adds a single-line breadcrumb per deepen attempt (`Deepening shallow history (attempt N/M, depth D)`) so a slow CI run is no longer opaque between the initial fetch and the eventual unshallow.
- Documents the deepen-vs-unshallow budget rationale inline.
- Points operators at the test runner (`bash script/lib/git-diff-base-test.bash`) from `script/ci-changes-detector`, `script/check-docs-sidebar`, and the library header. The existing `.github/workflows/git-diff-base-tests.yml` already wires this into CI.

No production code paths change beyond the new stderr log line; only test coverage and operator-visible diagnostics are added.

## Test plan

- [x] `bash -n script/ci-changes-detector script/check-docs-sidebar script/lib/git-diff-base script/lib/git-diff-base-test.bash`
- [x] `shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/check-docs-sidebar`
- [x] `bash script/lib/git-diff-base-test.bash` — 33/33 tests pass (was 28/28 before this PR)
- [ ] CI: `Git Diff Base Library Tests` workflow (`.github/workflows/git-diff-base-tests.yml`)

Fixes #3249.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only bash helpers and stderr diagnostics; merge-base resolution behavior is unchanged aside from progress logging.
> 
> **Overview**
> Hardens **CI merge-base** tooling (`script/lib/git-diff-base`) with broader **bash test coverage** and clearer operator docs—no change to how merge bases are computed beyond a new **stderr breadcrumb** each deepen round.
> 
> The test harness gains **SHA ref** cases (64-char hex, short local SHA, unknown short hex), fixtures that add **extra commits on `main`** after `feature` branches (to force deepen budget exhaustion), and tests for the **`--unshallow` fallback** and **deepen progress** logging. `script/ci-changes-detector` and `script/check-docs-sidebar` now point maintainers at `bash script/lib/git-diff-base-test.bash` and the existing **Git Diff Base Library Tests** workflow.
> 
> `git_diff_base_resolve` logs one line per deepen attempt (`Deepening shallow history (attempt N/M, …)`), and the library header documents **why** bounded deepen runs before `--unshallow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e89e6c3de58f75736ff5854959214cf67f9126f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated tests for version-control scenarios: additional SHA-format validations, shallow-clone/fixture variations, deepen-budget exhaustion fallback, and deepen-progress logging; updated test harness to support new scenarios.

* **Documentation**
  * Clarified developer and CI-facing docs with cross-references to the test harness and CI test workflow.

* **Improvements**
  * Added per-attempt progress logging during shallow-history deepening to improve operational visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->