### PR TITLE
docs: capture Gumroad benchmark JS transfer-size artifacts (#3259)

### DIFF
--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -115,9 +115,10 @@ factor. The routes are:
 > renderer or SSR, while the RSC route uses the Pro Node renderer. Treat the deltas as the combined route-level effect;
 > see the [SSR Performance table](#ssr-performance-execjs-vs-node-renderer) for the renderer baseline.
 
-The April 30, 2026 local benchmark used eight strictly alternating measured runs between the Inertia and RSC routes
-(Inertia, RSC, Inertia, RSC, and so on), four per route. Before each of the eight measured runs, the harness sent one
-warmup request to the route being measured.
+The April 30, 2026 local benchmark used eight cycles, each measuring both routes in alternating cycle order
+(cycle 1: Inertia then RSC; cycle 2: RSC then Inertia; cycle 3: Inertia then RSC; and so on), producing sixteen
+measured runs total — eight per route. Before each measured run, the harness sent one warmup request to the route
+being measured.
 
 Conditions:
 
@@ -163,31 +164,52 @@ while the Inertia control must hydrate the React component tree on the client. B
 comes from the source artifact's Playwright harness rather than `PerformanceNavigationTiming.duration`, the two metrics
 are not from the same timing source and a direct `navigation duration - responseEnd` subtraction is not reported here.
 
-The page-specific script request count was 6 for the Inertia demo and 1 for the RSC demo, recorded as Chrome DevTools
-Network panel `Script`-type requests after loading each route. This is a fixed post-load observation, not a per-run
-timing median or statistical sample. Fewer requests do not necessarily imply a smaller browser payload: the RSC route
-carries runtime, Flight payload, and RSC-specific bundle costs that the Inertia control does not, so total transfer size
-is the meaningful network-cost metric and is not reported here. The raw request-count difference is noted for
-completeness only. See
+The same April 30, 2026 benchmark also captured per-navigation resource bytes via the `PerformanceResourceTiming` API
+for resources whose URL contains `/packs/` and ends in `.js`, plus the HTML response via
+`PerformanceNavigationTiming`. Medians across n=8 measured runs per route:
+
+| Metric                                                              | Inertia demo | RSC demo |
+| ------------------------------------------------------------------- | -----------: | -------: |
+| Page-specific JS requests (`/packs/*.js`)                           |            6 |        1 |
+| Page-specific JS transfer (wire bytes)                              |      3,587 B |      0 B |
+| Page-specific JS encoded body                                       |      3,287 B |      0 B |
+| Page-specific JS decoded body                                       |     10,947 B |      0 B |
+| HTML response transfer (`PerformanceNavigationTiming.transferSize`) |     14,523 B | 12,673 B |
+
+These transfer-size values are warmed-cache wire bytes, not cold-cache bundle totals. The harness sends one warmup
+request to the measured route before each measured run, which primes Chrome's HTTP disk cache so the Resource Timing
+API reports `transferSize: 0` for assets already cached by the warmup. For the Inertia demo, 5 of the 6 `/packs/` JS
+files (webpack-runtime, webpack-commons, two vendor chunks, and the inertia bundle) are served from disk cache on the
+measured run; the freshly-fetched bytes (~3.3 KB compressed, ~10.9 KB decompressed) come from a route-specific page
+chunk. For the RSC demo, the single page-specific JS file (the React on Rails Pro client bootstrap) is served from
+cache on the measured run, so its measured `transferSize` is `0`.
+
+The RSC route's Flight payload is not delivered as a separate `/rsc_payload/*` request in this benchmark; it is inlined
+in the HTML response, so the HTML transfer column (12,673 B vs 14,523 B for the Inertia control) captures most of the
+route-specific data delivered per navigation. The combined route-specific new bytes per warmed-cache navigation are
+roughly ~18.1 KB for the Inertia control (~3.6 KB JS + ~14.5 KB HTML) and ~12.7 KB for the RSC demo (~0 KB JS + ~12.7 KB
+HTML) — a ~30% warmed-cache wire-byte reduction, materially smaller than the -83% page-specific JS request-count
+reduction implies. Cold-cache bundle totals (what a first-time visitor downloads before any caching kicks in) are not
+captured by this benchmark methodology and remain a follow-up; see
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
 - _The linked `performance-findings.md` artifact reflects an earlier run; the April 30 timings shown above will be added
   there in a follow-up, and distribution/variance artifacts are still pending. See
   [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
-- _All timing values are medians from the raw benchmark artifact values (n=4 per route); sample size is too small to
+- _All timing values are medians from the raw benchmark artifact values (n=8 per route); sample size is too small to
   establish statistical significance._
-- _The `action_total` -2.3% delta is likely within expected variance at n=4._
+- _The `action_total` -2.3% delta is likely within expected variance at n=8._
 
 #### Worst-case `responseEnd` counter-signal <a id="gumroad-rsc-worst-case-responseend"></a>
 
-| Metric                             | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
-| ---------------------------------- | -----------: | -------: | ------------------------------: |
-| Worst-case `responseEnd` (max n=4) |        731ms |    768ms |                           +5.1% |
+| Metric                  | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
+| ----------------------- | -----------: | -------: | ------------------------------: |
+| `responseEnd` p95 (n=8) |        731ms |    768ms |                           +5.1% |
 
-With only four samples, p95 is the maximum observed value by definition, not an independently estimated tail
-percentile; this metric is therefore reported as "worst-case (max n=4)" here. It shows a +5.1% RSC regression on
-worst-case `responseEnd` (high variance is expected at n=4), indicating the Inertia control had a faster worst-case
-`responseEnd` than the RSC route.
+At n=8 the p95 is interpolated near the second-worst observed value rather than the maximum, but with only eight
+samples it remains a coarse tail estimate rather than a stable population p95. It shows a +5.1% RSC regression on tail
+`responseEnd` (high variance is expected at n=8), indicating the Inertia control had a faster tail
+`responseEnd` than the RSC route on this run.
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
 renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route showed

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -200,7 +200,7 @@ captured by this benchmark methodology and remain a follow-up; see
   establish statistical significance._
 - _The `action_total` -2.3% delta is likely within expected variance at n=8._
 
-#### Worst-case `responseEnd` counter-signal <a id="gumroad-rsc-worst-case-responseend"></a>
+#### `responseEnd` p95 counter-signal <a id="gumroad-rsc-worst-case-responseend"></a>
 
 | Metric                  | Inertia demo | RSC demo | Delta % (negative = RSC faster) |
 | ----------------------- | -----------: | -------: | ------------------------------: |
@@ -213,7 +213,7 @@ samples it remains a coarse tail estimate rather than a stable population p95. I
 
 Use these numbers as a case-study signal, not a universal performance claim. The RSC route combines RSC, the Pro Node
 renderer, and SSR, while the Inertia control has none of those three factors. With that caveat, the RSC route showed
-faster median navigation duration and LCP on the measured routes. The worst-case `responseEnd` counter-signal favored
+faster median navigation duration and LCP on the measured routes. The `responseEnd` p95 counter-signal favored
 the Inertia control. A stable deployed repeat, renderer-internal timing, environment metadata, and distribution artifacts
 are still required before making stronger production-performance claims.
 


### PR DESCRIPTION
## Summary

Captures the page-specific JS transfer-size data requested in #3259 for the Gumroad-style RSC benchmark demo by extracting it from the same April 30, 2026 `production-like-alternating-8-reindexed-comparison.json` artifact that already supplied the published timing medians.

The previous text in `performance-benchmarks.md` deliberately omitted transfer size with the caveat *"total transfer size is the meaningful network-cost metric and is not reported here"*. It is now reported, in the same table format used elsewhere in the section.

## Key numbers added

| Metric | Inertia demo | RSC demo |
| --- | ---: | ---: |
| Page-specific JS requests (`/packs/*.js`) | 6 | 1 |
| Page-specific JS transfer (wire bytes) | 3,587 B | 0 B |
| Page-specific JS encoded body | 3,287 B | 0 B |
| Page-specific JS decoded body | 10,947 B | 0 B |
| HTML response transfer (`PerformanceNavigationTiming.transferSize`) | 14,523 B | 12,673 B |

These are **warmed-cache wire bytes** (the harness sends one warmup request per measured route per cycle, so most `/packs/` assets are already in Chrome's HTTP disk cache and the Resource Timing API reports `transferSize: 0` for them). The doc now explains this clearly so readers do not misread the RSC route's `0 B` as zero shipped JavaScript.

The headline takeaway in the doc is that the **warmed-cache wire-byte reduction is ~30%** (~18.1 KB Inertia vs ~12.7 KB RSC per navigation), materially smaller than the **-83% raw request-count delta** the previous paragraph showed. The RSC route's Flight payload is inlined in the HTML response rather than fetched as a separate `/rsc_payload/*` request, which is why the HTML transfer column carries most of the route-specific data. Cold-cache bundle totals are not in this artifact and the doc now flags that as the remaining 3259 follow-up.

## Out-of-scope corrections (same paragraph)

While auditing the methodology paragraph against the source artifact, I noticed that the existing prose under-reported the sample size by 2×. The artifact has `cycles: 8` with 16 ordered measurements (8 per route), and the published medians (775.40 / 607.15 / 794.00 / 634.00 / 644.80 / 588.80 / 346.87 / 339.20 ms) match the `pathSummaries.distributions.*.median` values from n=8 exactly. The doc said "four per route" / "n=4" in three places, which I corrected to "eight per route" / "n=8":

1. The methodology paragraph (lines 118–121).
2. The "All timing values are medians… (n=4 per route)" footnote.
3. The "`action_total` -2.3% delta is likely within expected variance at n=4" footnote.

The "Worst-case `responseEnd` (max n=4)" row was also mislabeled: the values `731ms` / `768ms` are `pathSummaries.distributions.navigation.responseEndMs.p95` from n=8 (730.62 / 768.25, rounded), not the actual maxima (739.4 / 779.8). The row is now labeled `responseEnd p95 (n=8)` and the surrounding prose was updated to match. The numeric values and the +5.1% delta did not change.

## Test plan

- [x] `pnpm exec prettier --check docs/oss/core-concepts/performance-benchmarks.md`
- [x] `script/check-docs-sidebar origin/main HEAD` (no new published files)
- [x] pre-commit hooks (trailing-newlines, markdown-links, prettier)
- [x] pre-push hooks (branch-lint, markdown-links)
- [x] Verified every new number against the source artifact at `output/playwright/dashboard-perf/production-like-alternating-8-reindexed-*` in `shakacode/react-on-rails-demo-gumroad-rsc` (the same SHA the doc already cites for earlier metrics)

Fixes #3259

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is readers misinterpreting the new benchmark figures if assumptions (warm cache, resource filters) are misunderstood.
> 
> **Overview**
> Adds warmed-cache network transfer metrics to the Gumroad-style RSC benchmark section, including a new table for page-specific `/packs/*.js` request counts and JS/HTML transfer/encoded/decoded sizes, with narrative clarifying cache effects and what the `0 B` values mean.
> 
> Corrects the benchmark methodology and footnotes to reflect `8` cycles/`n=8` per route (instead of `n=4`), and relabels the tail `responseEnd` section from “worst-case” to `responseEnd` `p95 (n=8)` with updated explanatory text (numbers unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a3272c1ddde51227e1d6f42d7ee4cbba752ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified benchmark methodology: eight alternating cycles (16 measured runs total, eight per route) with a warmup request before each measured run.
  * Published April 30 per-navigation metrics (n=8 per route) for page resources and HTML transfer, noting the inlined RSC Flight payload and warmed-cache interpretation.
  * Updated tail latency framing to use an n=8 p95 estimate instead of the prior n=4 worst-case approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->