### PR TITLE
docs: clarify initial security triage ownership in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,7 @@
 
 - **Last reviewed:** 2026-05-09
 - **Review owner:** React on Rails maintainers
+- **Initial triage owner:** ShakaCode; [@justin808](https://github.com/justin808) is the current primary maintainer and initial triage contact for both the OSS packages and `react_on_rails_pro`.
 - **Next review due:** 2027-05-09
 
 ## Supported Versions


### PR DESCRIPTION
## Summary

Adds an `Initial triage owner` metadata line to `SECURITY.md` naming ShakaCode (with @justin808 as the current primary contact) for the OSS packages and `react_on_rails_pro`. This closes the remaining gap flagged after PR #3236, where the policy already covered supported versions, reporting paths, disclosure timelines, and review ownership, but did not explicitly assign initial triage to a named owner.

## Diff

```diff
 - **Last reviewed:** 2026-05-09
 - **Review owner:** React on Rails maintainers
+- **Initial triage owner:** ShakaCode; [@justin808](https://github.com/justin808) is the current primary maintainer and initial triage contact for both the OSS packages and `react_on_rails_pro`.
 - **Next review due:** 2027-05-09
```

## Why this is small

- Per `.claude/docs/changelog-guidelines.md`, doc-only fixes do not get a CHANGELOG entry.
- No code, build, CI, or runtime changes.
- The reporting path, embargo policy, and disclosure timeline from PR #3236 are unchanged.

## Test plan

- [x] `pnpm exec prettier --check SECURITY.md` (passes; pre-commit prettier hook also passes)
- [x] Pre-push lychee markdown link check (passes)
- [x] Visual review of rendered Markdown bullet list

Closes #3256.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates security policy metadata with no runtime, build, or workflow impact.
> 
> **Overview**
> Clarifies the security policy by adding an **Initial triage owner** line in `SECURITY.md`, naming ShakaCode and pointing to `@justin808` as the current primary initial-contact for security reports (including `react_on_rails_pro`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee1f8259cf49117b51a78c383f13c52aa4a2dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security policy to identify the primary contact for security issue triage and handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->