### PR TITLE
chore(ci): upgrade k6 benchmarks to v2.0.0 (#3319)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -70,7 +70,7 @@ concurrency:
 env:
   RUBY_VERSION: '3.3.7'
   BUNDLER_VERSION: '2.5.4'
-  K6_VERSION: '1.4.2'
+  K6_VERSION: '2.0.0'
   VEGETA_VERSION: '12.13.0'
   # Determine which apps/benchmarks to run (default is 'both' for all triggers)
   RUN_CORE: ${{ contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@testing-library/react": "^16.2.0",
     "@tsconfig/node14": "^14.1.2",
     "@types/jest": "^29.5.14",
-    "@types/k6": "^1.4.0",
+    "@types/k6": "^2.0.0",
     "@types/node": "^20.17.16",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: ^29.5.14
         version: 29.5.14
       '@types/k6':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^20.17.16
         version: 20.19.25
@@ -2655,8 +2655,8 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
-  '@types/k6@1.4.0':
-    resolution: {integrity: sha512-2tgKVnzNXZTZT1TDAGLY/3cuvHPZLyOF751N7M8T2dBgWzInzUVZYjGn9zVW01S1yNLqAr1az9gctyJHTW6GRQ==}
+  '@types/k6@2.0.0':
+    resolution: {integrity: sha512-ztO2fVOAQxtCpF6VWTn8O6FW6Z4DpjhY+XvD2GpCe/+fAfekD45bQ+vrM0B0C0c5ajLpVgWTMlLu9dKZ1nI+wg==}
 
   '@types/lockfile@1.0.4':
     resolution: {integrity: sha512-Q8oFIHJHr+htLrTXN2FuZfg+WXVHQRwU/hC2GpUu+Q8e3FUM9EDkS2pE3R2AO1ZGu56f479ybdMCNF1DAu8cAQ==}
@@ -2807,6 +2807,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3394,6 +3395,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -8269,6 +8271,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -10795,7 +10798,7 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 20.19.25
 
-  '@types/k6@1.4.0': {}
+  '@types/k6@2.0.0': {}
 
   '@types/lockfile@1.0.4': {}
 


### PR DESCRIPTION
## Summary

Upgrades k6 in the benchmark workflow from `v1.4.2` to `v2.0.0`, the new major version released 2026-05-11. Closes #3319.

- `K6_VERSION` env in `.github/workflows/benchmark.yml`: `1.4.2` → `2.0.0`
- `@types/k6` devDependency in `package.json`: `^1.4.0` → `^2.0.0` (and lockfile)

## v2.0 breaking-change audit

I went through the [v2.0.0 release notes](https://github.com/grafana/k6/releases/tag/v2.0.0) and confirmed that nothing we use is affected:

| v2 breaking change | Used by us? |
| --- | --- |
| `externally-controlled` executor removed | No — we use `constant-vus` and `constant-arrival-rate` |
| `options.ext.loadimpact` removed | No |
| `k6/experimental/redis` removed | No |
| `--no-summary`, `--upload-only`, `--summary-mode=legacy` removed | No |
| `k6 login`, `k6 pause`, `k6 resume`, `k6 scale`, `k6 status` removed | No |
| HTTP API server no longer auto-starts | No (we don't call the REST API) |
| Cloud commands now require a stack | No (we don't use `k6 cloud`) |
| Go module path → `go.k6.io/k6/v2` | Extension authors only |

`--summary-export` (used by `benchmarks/bench.rb`) is not in the breaking-change list and is still wired up through `lib.LegacySummary` in [`internal/cmd/run.go` on the v2.0.0 tag](https://github.com/grafana/k6/blob/v2.0.0/internal/cmd/run.go#L209), so the JSON shape consumed by `bench.rb` (`metrics.iterations.rate`, `metrics.http_req_duration.{med,p(90),p(99),max}`, `metrics.http_reqs.count`, `root_group.checks`) is preserved.

## Test plan

- [x] `pnpm install --lockfile-only` updates `@types/k6` to `2.0.0`
- [x] `pnpm run type-check` passes
- [x] `npx tsc --noEmit benchmarks/k6.ts` passes against the new types
- [x] `npx eslint benchmarks/k6.ts` clean
- [ ] Benchmark workflow runs on this PR (will be triggered by the `benchmark` label, if applied) to confirm `k6 v2.0.0` installs via `grafana/setup-k6-action@v1` and the existing `--summary-export` / `--summary-trend-stats` flags still produce the JSON shape `bench.rb` parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a tooling/CI upgrade for benchmark runs plus TypeScript type updates; the main risk is benchmark workflow breakage due to k6 v2 behavioral changes.
> 
> **Overview**
> Updates the benchmark GitHub Actions workflow to install and run `k6` **v2.0.0** (from v1.4.2).
> 
> Bumps the workspace devDependency `@types/k6` to **v2.0.0** and refreshes `pnpm-lock.yaml` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26a263393e35d13e82e1719c7585967efd7a7738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development and testing framework dependencies to current versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->