### PR TITLE
docs: polish RSC node renderer test recipe (#3273)

### DIFF
--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -47,7 +47,11 @@ React Server Components add one more moving part to the standard test setup: sys
 
 Use this recipe for Capybara, system, and end-to-end tests that exercise `stream_react_component`, `RSCRoute`, or the `rsc_payload_route`.
 
-This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails. The full lifecycle example is RSpec-focused because it uses `before(:suite)` and `after(:suite)` hooks; Minitest suites can reuse the ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled` call, but must start and stop the renderer from their own suite-level harness such as `Minitest.after_run { ... }` plus a suite-level startup helper. See [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation) for the underlying compilation tradeoffs.
+This recipe uses the React on Rails TestHelper with `build_test_command`: Rails checks whether generated bundles are stale, runs your test build command when needed, and fails fast if compilation fails.
+
+The Step 3 renderer-lifecycle helper is **RSpec-only** because it relies on `before(:suite)` and `after(:suite)` hooks. Minitest suites can still reuse the Step 1 ENV setup and `ReactOnRails::TestHelper.ensure_assets_compiled`; a turnkey Minitest renderer-lifecycle recipe is future work. Until then, adapt the Step 3 harness into a `Minitest.after_run { ... }` block plus a suite-level startup hook (for example, a Minitest plugin that boots the renderer before the first test) if you need Minitest coverage.
+
+See [Two Approaches to Test Asset Compilation](#two-approaches-to-test-asset-compilation) for the underlying compilation tradeoffs.
 
 ### 1. Set Renderer ENV Before Rails Boots
 
@@ -77,7 +81,7 @@ ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] ||=
 require_relative "../config/environment"
 ```
 
-`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. That unused 3901 port is expected; keeping the normalized worker ID stable matters more than filling every port number. If another service already uses ports in the 3900 range, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, update `spec/support/rsc_test_worker.rb` to normalize that tool's worker ID to a stable, path-safe `RscTestWorker::ID` so every worker gets a unique port, cache path, and renderer log.
+`TEST_ENV_NUMBER` is set by the `parallel_tests` gem. It uses `""` for the first worker, then `"2"`, `"3"`, and so on (skipping `"1"`), so the example uses ports 3900, 3902, 3903, and leaves a harmless gap at 3901. That unused 3901 port is expected; keeping the normalized worker ID stable matters more than filling every port number. Before adopting the 3900 range, check for existing listeners with `lsof -i :3900-3910`; if another service already uses these ports, set `RENDERER_PORT` before this snippet or change the base port in the example. If you use a different parallelization tool, update `spec/support/rsc_test_worker.rb` to normalize that tool's worker ID to a stable, path-safe `RscTestWorker::ID` so every worker gets a unique port, cache path, and renderer log.
 
 If you run tests in parallel, each worker needs its own `RENDERER_PORT` and `RENDERER_SERVER_BUNDLE_CACHE_PATH`. Sharing a renderer cache across parallel workers can produce stale-bundle and missing-bundle failures that look like flaky RSC timeouts.
 
@@ -93,6 +97,12 @@ end
 ```
 
 The Quick Start command only sets `RAILS_ENV` for the minimal browser-bundle case. The RSC recipe also sets `NODE_ENV=test` so JavaScript build scripts, webpack/shakapacker config, and the node-renderer all see the test environment consistently. If your app's build does not branch on `NODE_ENV`, the simpler Quick Start command is still enough for non-RSC tests.
+
+> **Warning:** Three copy-paste hazards in the snippet below — read these before adapting it.
+>
+> - **The metatag list replaces TestHelper defaults.** Passing any metatags to `configure_rspec_to_compile_assets` replaces the defaults, so include `:js`, `:server_rendering`, and `:controller` alongside `:rsc` if your suite mixes RSC and non-RSC specs, or those tag groups will no longer trigger compilation.
+> - **`define_derived_metadata` tags every `spec/system` and `spec/features` example.** That is intentional so the first browser request cannot race ahead of RSC bundle compilation, but it compiles for unrelated system tests too. If only some directories exercise RSC, narrow the regex to something like `%r{spec/(system/rsc|features/rsc)}` or tag those examples manually.
+> - **Load `support/rsc_node_renderer` _after_ registering `configure_rspec_to_compile_assets`.** The Step 3 helper installs a `before(:suite)` hook that validates bundles when the renderer boots, so the compile hook must register first. On older RSpec, also compile assets in CI before running the spec process — see the Caveats note at the end of Step 3.
 
 ```ruby
 # spec/rails_helper.rb
@@ -114,10 +124,6 @@ end
 
 require_relative "support/rsc_node_renderer"
 ```
-
-> **Warning:** Passing any metatags replaces the TestHelper defaults. Include `:js`, `:server_rendering`, and `:controller` alongside `:rsc` if your suite mixes RSC and non-RSC specs, or those tag groups will no longer trigger compilation.
-
-The derived metadata block intentionally tags every system and feature spec so the first browser request cannot race ahead of RSC bundle compilation. If only some directories exercise RSC, narrow the regex (for example, `spec/(system/rsc|features/rsc)`) or tag those examples manually to avoid compiling for unrelated system tests.
 
 Tag request specs that hit the RSC payload endpoint explicitly with `:rsc`. If your suite uses a different tag scheme, pass the complete list of tags that should trigger compilation. The important part is that the build runs before the first request that can upload bundles to the node renderer.
 
@@ -252,9 +258,11 @@ RSpec.configure do |config|
     rescue Errno::ECONNREFUSED
       # Port refused immediately — nothing is listening; safe to spawn.
     rescue Errno::ETIMEDOUT
-      # SYN was silently dropped (firewall/throttle); assume nothing is listening and proceed.
-      # Less certain than ECONNREFUSED on loopback, but treating it as fatal would block tests
-      # whenever a stray DROP rule is present.
+      # SYN silently dropped (firewall/throttle). Unusual on 127.0.0.1, so surface it in
+      # CI logs but proceed — treating it as fatal would block tests whenever a stray DROP
+      # rule is present on loopback.
+      warn "RENDERER_PORT #{renderer_env['RENDERER_PORT']} pre-spawn probe timed out on 127.0.0.1; " \
+           "this is unusual on loopback. Continuing under the assumption that the port is free."
     rescue Errno::ECONNRESET
       raise "RENDERER_PORT #{renderer_env['RENDERER_PORT']} accepted and reset a connection. " \
             "Another service may already be using it."
@@ -340,9 +348,12 @@ end
 
 Require this file from `spec/rails_helper.rb` after loading `react_on_rails/test_helper`, unless your suite already loads `spec/support/**/*.rb`. On slow CI workers, increase `RSC_NODE_RENDERER_BOOT_TIMEOUT` instead of adding sleeps.
 
+> **Note:** The setup writes per-worker artifacts to `tmp/node-renderer-bundles-test-*` and `log/node-renderer-test-*.log`. The default Rails `.gitignore` rules (`/tmp/*` and `/log/*`) cover both, but if you maintain a custom `.gitignore` confirm both paths are excluded so they do not show up as untracked changes on every test run.
+
 **Caveats:**
 
 - The TCP probe above is a fallback for renderers that do not expose a health endpoint; if your renderer has one, replace the probe with an HTTP health check. A successful TCP connection only proves the port is accepting connections, not that route handlers or bundle manifests are fully initialized.
+- The `start_with?` safety check on `Rails.root/tmp` compares raw paths; it does **not** resolve symlinks. If your project's `tmp/` directory is a symlink (for example, mounted to a tmpfs path), an absolute `RENDERER_SERVER_BUNDLE_CACHE_PATH` pointing inside the resolved target will fail the check. Resolve both paths with `Pathname#realpath` before comparing if you need to support a symlinked `tmp/`.
 - A reset during the pre-spawn probe usually means another service is already using the port and closing connections immediately.
 - The `connect_timeout` call is enough for `127.0.0.1` because an unused localhost port refuses the connection immediately. If you adapt the helper for a remote renderer, the operating system may still apply a longer TCP timeout.
 - The deadline is checked after each socket probe, so very tight timeouts can overshoot by up to `connect_timeout + sleep` per iteration (roughly 1.1 s with the defaults above).


### PR DESCRIPTION
## Summary

Follow-up to #3223 addressing the review punch list in #3273 to make the official RSC node-renderer system-test recipe safer to copy-paste.

- **Clarify the Minitest story.** Step 3 renderer lifecycle is now explicitly **RSpec-only**; Minitest reuse of Step 1 ENV setup and `ensure_assets_compiled` is spelled out, and a turnkey Minitest renderer-lifecycle recipe is flagged as future work.
- **Promote the hook-ordering requirement.** Moved the metatag/regex warning above the Step 2 copy-paste block and folded the `configure_rspec_to_compile_assets` → `require_relative "support/rsc_node_renderer"` ordering rule into the same callout (with an actionable narrowed-regex example, e.g. `%r{spec/(system/rsc|features/rsc)}`).
- **`.gitignore` reminder.** New Note ahead of the Step 3 Caveats covering `tmp/node-renderer-bundles-test-*` and `log/node-renderer-test-*.log`.
- **Port range check.** Mentions `lsof -i :3900-3910` for checking existing listeners before adopting the 3900 port range.
- **Document the `start_with?` symlink limitation.** New Caveats bullet noting that the `Rails.root/tmp` safety check does not resolve symlinks; readers needing a symlinked `tmp/` can switch to `Pathname#realpath`.
- **Warn on loopback `Errno::ETIMEDOUT`.** The pre-spawn port probe now emits a warning before proceeding, since ETIMEDOUT on `127.0.0.1` is unusual and worth surfacing in CI logs.

Closes #3273

## Test plan

- [x] `pnpm exec prettier --check docs/oss/building-features/testing-configuration.md`
- [x] Pre-commit hooks: trailing newlines, lychee offline link check, prettier
- [x] Pre-push hooks: branch-lint, lychee online link check
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that clarify test setup ordering and edge cases; no runtime code changes, but copy/paste guidance affects how users configure their test harness.
> 
> **Overview**
> Polishes the RSC/node-renderer system test recipe to be safer to copy/paste, including **explicitly calling out the Step 3 renderer lifecycle as RSpec-only** and giving guidance for adapting it to Minitest.
> 
> Moves/expands warnings around `configure_rspec_to_compile_assets` to highlight metatag/regex hazards and required hook load order, adds a port-range preflight check suggestion, reminds readers to ignore per-worker `tmp/` and `log/` artifacts, documents the `Rails.root/tmp` symlink limitation, and updates the port probe snippet to *warn* on `Errno::ETIMEDOUT` on loopback before proceeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d554862ced26dbdd328c41480b98e3bc9452fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RSC/system testing configuration guide with improved setup instructions
  * Added clarity on RSpec vs Minitest test harness requirements
  * Enhanced renderer port configuration guidance with port range checking
  * Expanded test bundle compilation section with detailed warnings
  * Added caveats about artifact management and symlink handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->