### PR TITLE
docs: explain responseEnd/action_total range overlap for Gumroad RSC benchmark

### DIFF
--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -97,12 +97,14 @@ Server components produce HTML that does not need hydration — they have no cli
 
 The [Gumroad-style RSC benchmark demo](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc)
 is a public ShakaCode comparison repo modeled after a creator-dashboard surface with product listings and sales metrics,
-not an official Gumroad integration. The benchmark methodology and earlier-run artifacts are checked in as
-[`docs/performance-findings.md`](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/blob/5a2f0c29dc197184312c55bc4209492accea26e7/docs/performance-findings.md)
-on the active demo PR ([shakacode/react-on-rails-demo-gumroad-rsc#10](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/pull/10));
-the April 30, 2026 absolute timings reported below are from a more recent local run that has not yet landed in that
-artifact ([Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution and
-source artifacts). It measures the same reduced presenter data and outer layout across two routes. The comparison
+not an official Gumroad integration. The benchmark methodology, earlier-run artifacts, and the April 30, 2026
+production-like local run with median and p95 timings are documented in
+[`docs/performance-findings.md`](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/blob/010b3564398dbb9c8f5caafab25daed65b6f425c/docs/performance-findings.md#production-like-compiled-asset-8-cycle-repeat)
+on stacked demo PR
+[shakacode/react-on-rails-demo-gumroad-rsc#12](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/pull/12);
+the per-run JSON files remain gitignored local artifacts
+([Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks publishing per-run distribution data).
+It measures the same reduced presenter data and outer layout across two routes. The comparison
 changes three axes at once (RSC, the Pro Node renderer, and SSR), so the deltas cannot be attributed to any single
 factor. The routes are:
 
@@ -155,8 +157,8 @@ artifact does not yet publish enough logger or extraction-script context to conf
 `process_action` duration including rendering or a narrower controller-action field, so do not use it to infer the
 server-rendering split. Because the Pro Node renderer runs in a separate OS process, Rails wall time may also exclude
 RSC rendering cost that the Inertia control keeps in-process, so the two `action_total` values may not measure identical
-scopes of work. [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks the missing distribution
-and source artifacts.
+scopes of work. The source artifact publishes median and p95 for `responseEnd` but not for `action_total`;
+[Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263) tracks publishing per-run distribution data.
 
 The navigation-duration gain (-21.7%) was larger than the `responseEnd` gain (-8.7%), which is consistent with the RSC
 route delivering fully server-rendered HTML — the browser has minimal client-side hydration work after `responseEnd`,
@@ -193,12 +195,15 @@ reduction implies. Cold-cache bundle totals (what a first-time visitor downloads
 captured by this benchmark methodology and remain a follow-up; see
 [Issue 3259](https://github.com/shakacode/react_on_rails/issues/3259).
 
-- _The linked `performance-findings.md` artifact reflects an earlier run; the April 30 timings shown above will be added
-  there in a follow-up, and distribution/variance artifacts are still pending. See
-  [Issue 3263](https://github.com/shakacode/react_on_rails/issues/3263)._
 - _All timing values are medians from the raw benchmark artifact values (n=8 per route); sample size is too small to
   establish statistical significance._
-- _The `action_total` -2.3% delta is likely within expected variance at n=8._
+- _The published `responseEnd` p95 (731ms Inertia vs 768ms RSC, see the
+  [`responseEnd` p95 counter-signal](#gumroad-rsc-worst-case-responseend) below) is larger than the other route's
+  median in both directions (Inertia p95 731ms > RSC median 589ms; RSC p95 768ms > Inertia median 645ms), so
+  the per-run `responseEnd` ranges overlap and the median -8.7% RSC-favored delta is consistent with measurement noise
+  rather than a stable RSC win on this metric._
+- _The source artifact does not publish a p95 or per-run distribution for `action_total`, so its -2.3% median delta
+  cannot be distinguished from measurement noise at n=8._
 
 #### `responseEnd` p95 counter-signal <a id="gumroad-rsc-worst-case-responseend"></a>
 


### PR DESCRIPTION
## Summary

Addresses the n=8 distribution gap that the PR #3233 review thread (claude[bot]
on `r3213006393`) flagged — with no min/max/stddev published, the `responseEnd`
(-8.7%) and `action_total` (-2.3%) medians could plausibly be within run-to-run
noise. The reviewer suggested either adding a distribution row or noting whether
the per-run ranges overlap.

This PR does the second: it makes the overlap explicit using the median and p95
values that the demo repo's PR #12 publishes for `responseEnd`, and updates the
source-artifact reference to the commit where the April 30, 2026 production-like
run is documented.

### Changes to `docs/oss/core-concepts/performance-benchmarks.md`

- Replace the stale "April 30 timings haven't landed in the artifact" bullet
  with an explicit range-overlap analysis. Inertia `responseEnd` p95 (731ms) is
  worse than RSC's median (589ms), AND RSC's p95 (768ms) is worse than Inertia's
  median (645ms) — so the per-run ranges overlap in both directions and the
  median -8.7% RSC-favored delta is consistent with measurement noise rather
  than a stable RSC win on this metric.
- Strengthen the `action_total` caveat: the source artifact still publishes
  no p95 or per-run distribution for it, so its -2.3% median delta also cannot
  be distinguished from noise at n=8.
- Update the source-artifact reference from demo PR #10's snapshot (which only
  contained the April 15 8-cycle dev-server run) to demo PR #12 at commit
  [`010b3564`](https://github.com/shakacode/react-on-rails-demo-gumroad-rsc/blob/010b3564398dbb9c8f5caafab25daed65b6f425c/docs/performance-findings.md#production-like-compiled-asset-8-cycle-repeat),
  which documents the April 30 production-like run with both median and p95
  timings. The per-run JSON files remain gitignored, so #3263 stays open for
  publishing per-run distribution data.

### Out of scope

- Capturing or recovering the per-run JSON artifacts. They are gitignored under
  `output/playwright/...` in the demo repo and are not currently published.
  #3263 remains open for that follow-up.
- Adding p95 for `action_total` to either docs or the source artifact. Source
  artifact currently publishes p95 only for `responseEnd` (browser) and
  `sql.active_record` (server); adding p95 for `action_total` is a demo-repo
  change tracked by #3263.

## Test plan

- [x] `pnpm exec prettier --check docs/oss/core-concepts/performance-benchmarks.md`
- [x] `script/check-docs-sidebar origin/main HEAD`
- [x] `git diff --check`
- [x] pre-commit hooks (trailing-newlines, lychee markdown-links, prettier)
- [x] Verified the `#production-like-compiled-asset-8-cycle-repeat` anchor
      exists at commit `010b3564` of the demo repo

Refs #3263 (partial — addresses the range-overlap bullet from the issue body;
per-run JSON capture and `action_total` distribution remain demo-repo follow-ups,
so the issue stays open after this PR merges).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that adjusts benchmark sourcing/caveats; no runtime code changes.
> 
> **Overview**
> Updates the Gumroad-style RSC benchmark section to point to the newer demo artifact/PR that includes the April 30, 2026 production-like run and explicitly notes that per-run JSON distributions are still unpublished.
> 
> Adds a stronger interpretation caveat: uses published `responseEnd` p95 vs median to show the Inertia/RSC ranges overlap (so the median delta may be noise) and clarifies that `action_total` lacks p95/distribution data, making its median delta similarly inconclusive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4839a3c58fe5908beceaf052fbaa9c235b7363aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined performance benchmark documentation with clearer explanations of measurement methodology, improved metric interpretation guidance (including responseEnd p95 and action_total analysis), and updated artifact references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
