### PR TITLE
docs: define security-supported versions policy (#3261)

### DIFF
--- a/.claude/docs/changelog-guidelines.md
+++ b/.claude/docs/changelog-guidelines.md
@@ -18,6 +18,7 @@ All entries live in a single chronological flow within each release. Pro entries
 - **Use `/update-changelog` command** for guided changelog updates with automatic formatting
 - **Before a release**: Run `/update-changelog release` (or `rc`/`beta`) to stamp a version header; then `rake release` reads it automatically and creates the GitHub release
 - **Version management**: `bundle exec rake "update_changelog[release]"` (or `rc`/`beta`/explicit version) for header-only updates
+- **Security support window**: For minor and major releases, update `SECURITY.md` "Current support window" rows and cutoff dates to match the new release line
 - **After releasing without changelog**: Run `bundle exec rake "sync_github_release[VERSION]"` to create the GitHub release from CHANGELOG.md
 - **Examples**: Run `grep -A 3 "^#### " CHANGELOG.md | head -30` to see real formatting examples
 - **Prerelease curation**: See `.claude/commands/update-changelog.md` for prerelease-to-stable consolidation process

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,75 @@
 # Security Policy
 
-- **Last reviewed:** 2026-05-09
+- **Last reviewed:** 2026-05-20
 - **Review owner:** React on Rails maintainers
 - **Initial triage owner:** ShakaCode; [@justin808](https://github.com/justin808) is the current primary maintainer and initial triage contact for both the OSS packages and `react_on_rails_pro`.
-- **Next review due:** 2027-05-09
+- **Next review due:** 2027-05-20
 
 ## Supported Versions
 
-React on Rails does not yet publish fixed version numbers for security support. Report suspected vulnerabilities even
-when you find them in an older released React on Rails gem or npm package version; do not self-filter reports by
-version. Maintainers triage all reports, but fixes are normally prepared for the latest released minor line and supported
-upgrade paths first.
+Report suspected vulnerabilities even when you find them in an older released React on Rails gem or npm package
+version; do not self-filter reports by version. Maintainers triage all reports regardless of the affected version. What
+the policy below governs is which versions normally receive a **fix**, not which versions you may **report** against.
 
-| Version line                                                      | Security support                                                      |
-| ----------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Latest released `react_on_rails` gem and `react-on-rails` package | Report and triage                                                     |
-| Older released versions                                           | Report; maintainers evaluate case-by-case and may recommend upgrading |
+The `react_on_rails` Ruby gem and the `react-on-rails` npm package are released as a matched version pair and share a
+single security support window. The same window applies to the `react_on_rails_pro` gem, the `react-on-rails-pro` npm
+package, and the `react-on-rails-pro-node-renderer` npm package — they ship at the same version as the open-source
+release and are patched together. Pro customers on active commercial support agreements may have additional support
+windows negotiated privately; this public policy describes the floor, not the ceiling.
 
-Fixes are generally delivered for the most recent minor line; older releases may receive backports if severity warrants.
+The current released major line is **16.x**. The table below describes the policy in terms of "current major / current
+minor" so it remains accurate as new releases ship; the [Current support window](#current-support-window) section
+restates the same policy with the specific version numbers in effect today.
+
+| Version line                                                              | Security support                                                                                                                                                                                      |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Latest minor of the current major (e.g., `16.6.x` while `16.6` is latest) | Full security support. Fixes are released as a patch on this line.                                                                                                                                    |
+| Previous minor of the current major (e.g., `16.5.x`)                      | Backports for **High / Critical** severity (CVSS ≥ 7.0) for **six months** after the next minor's first release.                                                                                      |
+| Previous major (e.g., `15.x`) — only the latest minor of that major       | Backports for **Critical** severity (CVSS ≥ 9.0) for **six months** after the first stable release of the new major.                                                                                  |
+| All other releases                                                        | Not supported. Reports are still triaged; if the issue also affects a supported line, the fix lands there and the recommended remediation for unsupported releases is to upgrade to a supported line. |
+
+Pre-release builds (`.rc`, `.beta`, `.alpha`) are not separately supported — once superseded by a stable release in the
+same line, the recommended remediation is to upgrade to that stable release.
+
+### What "supported" means
+
+- **Full support:** Maintainers prepare a patch release for confirmed in-scope vulnerabilities of any severity.
+- **Backports (High/Critical):** A patch release is prepared if the vulnerability is rated High or Critical (CVSS ≥
+  7.0) under the GitHub Security Advisory rubric, or, in maintainer judgment, would be rated High or Critical if scored
+  formally.
+- **Backports (Critical only):** A patch release is prepared only for Critical (CVSS ≥ 9.0) vulnerabilities.
+- **Not supported:** No patch will be issued on that line. The fix lands on supported lines; users on unsupported lines
+  upgrade.
+
+When the severity rubric and maintainer judgment disagree, maintainers may choose to backport more aggressively than
+the table promises (for example, backporting a Medium-severity fix that is trivial to apply). The table is a floor on
+maintainer commitment, not a ceiling on maintainer behavior.
+
+### Current support window
+
+As of the **Last reviewed** date at the top of this file:
+
+| Status             | OSS gem & npm                     | Pro gem, Pro npm, Pro node renderer | Until                                                   |
+| ------------------ | --------------------------------- | ----------------------------------- | ------------------------------------------------------- |
+| Full support       | `16.6.x`                          | `16.6.x`                            | Replaced when the next minor (e.g., `16.7.0`) ships.    |
+| High/Critical only | `16.5.x`                          | `16.5.x`                            | Six months after the first release of the next minor.   |
+| Critical only      | _none — no prior major in window_ | _none — no prior major in window_   | Six months after the next major's first stable release. |
+
+When a new minor or major ships, the rows shift accordingly; maintainers update this section at the same time as the
+release.
+
+### Handling reports against unsupported versions
+
+If a reporter discloses a vulnerability that affects only an unsupported version:
+
+1. Maintainers confirm whether any supported line is also affected.
+2. If a supported line is affected, a fix is prepared there and the advisory documents the impact range, including the
+   unsupported lines, with the recommended remediation being "upgrade to a supported line."
+3. If no supported line is affected, the issue is documented privately and the reporter is credited; no patch release
+   is issued for the unsupported line.
+
+This policy is reviewed annually (see **Next review due** above) and may be revised at any time if release cadence,
+dependency landscape, or contributor capacity changes materially.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ restates the same policy with the specific version numbers in effect today.
 | Version line                                                              | Security support                                                                                                                                                                                      |
 | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Latest minor of the current major (e.g., `16.6.x` while `16.6` is latest) | Full security support. Fixes are released as a patch on this line.                                                                                                                                    |
-| Previous minor of the current major (e.g., `16.5.x`)                      | Backports for **High / Critical** severity (CVSS 7.0-10.0) for **six months** after the next minor's first release.                                                                                   |
+| Previous minor of the current major (e.g., `16.5.x`)                      | Backports for **High / Critical** severity (CVSS ≥ 7.0) for **six months** after the next minor's first release.                                                                                      |
 | Previous major (e.g., `15.x`) — only the latest minor of that major       | Backports for **Critical** severity (CVSS ≥ 9.0) for **six months** after the first stable release of the new major.                                                                                  |
 | All other releases                                                        | Not supported. Reports are still triaged; if the issue also affects a supported line, the fix lands there and the recommended remediation for unsupported releases is to upgrade to a supported line. |
 
@@ -57,8 +57,7 @@ As of the **Last reviewed** date at the top of this file:
 | Critical only      | _none — 15.x window closed on 2026-03-16_ | _none — 15.x window closed on 2026-03-16_ | Window closed six months after `16.0.0` shipped.     |
 
 When a new minor or major ships, the rows shift accordingly; maintainers update this section as part of the release
-checklist in [internal/contributor-info/releasing.md](internal/contributor-info/releasing.md) and
-[.claude/docs/changelog-guidelines.md](.claude/docs/changelog-guidelines.md).
+checklist in [internal/contributor-info/releasing.md](internal/contributor-info/releasing.md).
 
 ### Handling reports against unsupported versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,12 +24,13 @@ restates the same policy with the specific version numbers in effect today.
 | Version line                                                              | Security support                                                                                                                                                                                      |
 | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Latest minor of the current major (e.g., `16.6.x` while `16.6` is latest) | Full security support. Fixes are released as a patch on this line.                                                                                                                                    |
-| Previous minor of the current major (e.g., `16.5.x`)                      | Backports for **High / Critical** severity (CVSS ≥ 7.0) for **six months** after the next minor's first release.                                                                                      |
+| Previous minor of the current major (e.g., `16.5.x`)                      | Backports for **High / Critical** severity (CVSS 7.0-10.0) for **six months** after the next minor's first release.                                                                                   |
 | Previous major (e.g., `15.x`) — only the latest minor of that major       | Backports for **Critical** severity (CVSS ≥ 9.0) for **six months** after the first stable release of the new major.                                                                                  |
 | All other releases                                                        | Not supported. Reports are still triaged; if the issue also affects a supported line, the fix lands there and the recommended remediation for unsupported releases is to upgrade to a supported line. |
 
 Pre-release builds (`.rc`, `.beta`, `.alpha`) are not separately supported — once superseded by a stable release in the
-same line, the recommended remediation is to upgrade to that stable release.
+same line, the recommended remediation is to upgrade to that stable release. Security issues found in a pre-release
+build are handled through the same private reporting process and fixed before the stable release when feasible.
 
 ### What "supported" means
 
@@ -49,14 +50,15 @@ maintainer commitment, not a ceiling on maintainer behavior.
 
 As of the **Last reviewed** date at the top of this file:
 
-| Status             | OSS gem & npm                     | Pro gem, Pro npm, Pro node renderer | Until                                                   |
-| ------------------ | --------------------------------- | ----------------------------------- | ------------------------------------------------------- |
-| Full support       | `16.6.x`                          | `16.6.x`                            | Replaced when the next minor (e.g., `16.7.0`) ships.    |
-| High/Critical only | `16.5.x`                          | `16.5.x`                            | Six months after the first release of the next minor.   |
-| Critical only      | _none — no prior major in window_ | _none — no prior major in window_   | Six months after the next major's first stable release. |
+| Status             | OSS gem & npm                             | Pro gem, Pro npm, Pro node renderer       | Until                                                |
+| ------------------ | ----------------------------------------- | ----------------------------------------- | ---------------------------------------------------- |
+| Full support       | `16.6.x`                                  | `16.6.x`                                  | Replaced when the next minor (e.g., `16.7.0`) ships. |
+| High/Critical only | `16.5.x`                                  | `16.5.x`                                  | 2026-10-09 (six months after `16.6.0` shipped).      |
+| Critical only      | _none — 15.x window closed on 2026-03-16_ | _none — 15.x window closed on 2026-03-16_ | Window closed six months after `16.0.0` shipped.     |
 
-When a new minor or major ships, the rows shift accordingly; maintainers update this section at the same time as the
-release.
+When a new minor or major ships, the rows shift accordingly; maintainers update this section as part of the release
+checklist in [internal/contributor-info/releasing.md](internal/contributor-info/releasing.md) and
+[.claude/docs/changelog-guidelines.md](.claude/docs/changelog-guidelines.md).
 
 ### Handling reports against unsupported versions
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -20,7 +20,9 @@ See [Contributing](https://github.com/shakacode/react_on_rails/blob/main/CONTRIB
    - Stamp the version header (e.g., `### [16.5.0] - 2026-03-08`)
    - For `rc`/`beta`: collapse prior prerelease sections and deduplicate entries
    - **Automatically commit, push, and open a PR** with the changelog changes
-3. Review the PR, verify the computed version, and merge
+3. For minor and major releases, update the `SECURITY.md` "Current support window" table so supported version lines and
+   cutoff dates match the release being shipped.
+4. Review the PR, verify the computed version, and merge
 
 If you forget this step, the release task will print a warning and the GitHub release will need to be created manually afterward using `sync_github_release`.
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -20,8 +20,9 @@ See [Contributing](https://github.com/shakacode/react_on_rails/blob/main/CONTRIB
    - Stamp the version header (e.g., `### [16.5.0] - 2026-03-08`)
    - For `rc`/`beta`: collapse prior prerelease sections and deduplicate entries
    - **Automatically commit, push, and open a PR** with the changelog changes
-3. For minor and major releases, update the `SECURITY.md` "Current support window" table so supported version lines and
-   cutoff dates match the release being shipped.
+3. For minor and major releases, add a commit to the changelog PR updating `SECURITY.md`:
+   - "Current support window" table so supported version lines and cutoff dates match the release being shipped
+   - "Last reviewed" date and, when applicable, "Next review due"
 4. Review the PR, verify the computed version, and merge
 
 If you forget this step, the release task will print a warning and the GitHub release will need to be created manually afterward using `sync_github_release`.


### PR DESCRIPTION
## Summary

Replaces the interim "report and triage" guidance in `SECURITY.md` with a concrete supported-versions policy as requested in #3261.

**⚠ Draft for maintainer review.** The specific numbers (six-month backport windows, severity cutoffs at CVSS ≥ 7.0 / ≥ 9.0) are industry-typical defaults, not authoritative maintainer decisions. Please edit before merging.

### Proposed defaults

| Line                                     | Support                                                            |
| ---------------------------------------- | ------------------------------------------------------------------ |
| Latest minor of current major (`16.6.x`) | Full security support                                              |
| Previous minor of current major (`16.5.x`) | High / Critical backports (CVSS ≥ 7.0), 6 months after next minor |
| Previous major's latest minor (`15.x`)   | Critical only (CVSS ≥ 9.0), 6 months after next major's stable    |
| Everything else                          | Triage only; remediation = upgrade to a supported line             |

### Decision points the issue called out

1. **Which OSS lines get security fixes?** → Current minor + previous minor (High/Critical only) + previous major (Critical only). Rails-style envelope, scaled down for a smaller maintainer team.
2. **Same window for gem and npm?** → Yes — they're released as a matched pair.
3. **Pro window documented separately?** → No — Pro packages share the same window in `SECURITY.md`. Note added that commercial Pro contracts may extend support privately ("public policy is the floor, not the ceiling").
4. **Unsupported-version reports when a safe upgrade exists?** → Still triage. If the issue also affects a supported line, fix there; remediation for unsupported lines is upgrade. No standalone backports promised.

### Other small changes in the same commit

- Adds a "Current support window" sub-section that restates the policy with the version numbers in effect today (16.6.x / 16.5.x), so this file stays useful between annual reviews.
- Updates **Last reviewed** to 2026-05-20 and **Next review due** to 2027-05-20.
- Notes that pre-release builds (`.rc`/`.beta`/`.alpha`) are not separately supported.
- Adds a "Handling reports against unsupported versions" sub-section.

## Things to confirm before merge

- [ ] Six-month backport window for the previous minor — too long? too short?
- [ ] CVSS ≥ 7.0 vs. ≥ 9.0 thresholds — match how you actually want to scope work?
- [ ] Treatment of the previous major (currently "none in window" because we're inside 16.x) — is the policy *itself* correct for when there is a prior major?
- [ ] Pro language — okay to say public policy is the floor and commercial agreements may extend?

## Test plan

- [x] `pnpm exec prettier --check SECURITY.md` passes
- [x] Lefthook pre-commit and pre-push hooks pass
- [ ] Manual: render `SECURITY.md` on GitHub and confirm the "Current support window" table reads well

Refs #3261

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes, but they formalize security support windows and backport thresholds, so incorrect dates/tiers could mislead users and maintainers.
> 
> **Overview**
> Defines an explicit supported-versions policy in `SECURITY.md`, including support tiers (full vs High/Critical vs Critical-only), CVSS thresholds, prerelease handling, and a concrete *current support window* table with dates.
> 
> Updates release documentation (`internal/contributor-info/releasing.md` and `.claude/docs/changelog-guidelines.md`) to require updating `SECURITY.md`’s support-window rows and review dates as part of minor/major release changelog PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9165f4e101b7f3f3e6c9720bbd585674728a25bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security policy to define an explicit version support window for the 16.x major line across OSS and Pro, with a table listing current supported minors and expiration dates.
  * Clarified support tiers (full, High/Critical, Critical-only, none), CVSS thresholds, backport norms, and pre-release guidance.
  * Added disclosure handling for unsupported releases and affirmed annual review cadence.
  * Added changelog and release checklist steps to update the support-window before shipping minor/major releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->