### PR TITLE
Allow Pro 16.7 to keep jwt 2.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Fixed
+
+- **[Pro]** **Keep jwt 2.x compatibility in 16.7**: React on Rails Pro now requires `jwt >= 2.7`, removing the previous `~> 2.7` cap so applications can resolve patched `jwt 3.2.0+` releases without forcing a hard jwt 3.x floor in the 16.7 release line. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).
+
 ### [16.7.0.rc.0] - 2026-05-20
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
-- **[Pro]** **Keep jwt 2.x compatibility in 16.7**: React on Rails Pro now requires `jwt >= 2.7`, removing the previous `~> 2.7` cap so applications can resolve patched `jwt 3.2.0+` releases without forcing a hard jwt 3.x floor in the 16.7 release line. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).
+- **[Pro]** **Preserve ruby-jwt 2.x compatibility in 16.7**: Relaxes the `16.7.0.rc.0` `jwt >= 3.2.0` floor to `jwt >= 2.7`, keeping compatibility with apps that still resolve jwt 2.x while continuing to allow patched jwt 3.2.0+ releases. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).
 
 ### [16.7.0.rc.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **Preserve ruby-jwt 2.x compatibility in 16.7**: Relaxes the `16.7.0.rc.0` `jwt >= 3.2.0` floor to `jwt >= 2.7`, keeping compatibility with apps that still resolve jwt 2.x while continuing to allow patched jwt 3.2.0+ releases. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).
 
+#### Security
+
+- **[Pro]** **Restore license-token algorithm allowlist on jwt 3.x**: `ReactOnRailsPro::LicenseValidator` now passes the plural `algorithms: ["RS256"]` option to `JWT.decode` instead of the singular `algorithm: "RS256"`. jwt 3.0 removed the singular option (deprecated in 2.x), so on 16.7.0.rc.0 with jwt 3.2.0 resolved the algorithm restriction was silently ignored — tokens signed with HS256 or bearing `alg:none` were not rejected by the algorithm check. The plural form is honored by both jwt 2.x and 3.x. Affects only the unreleased 16.7.0.rc.0; earlier releases pinned jwt `~> 2.7` and never accepted the wrong algorithm. New attack-vector specs cover both the HS256 confusion and `alg:none` cases. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).
+
 ### [16.7.0.rc.0] - 2026-05-20
 
 #### Added

--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -241,7 +241,7 @@ If you only use ExecJS for SSR (the default), you do not need `react-on-rails-pr
 
 ##### JWT gem requirement
 
-`react_on_rails_pro` uses `jwt` for offline license validation. Current versions require `jwt >= 3.2.0`. If your Gemfile pins `jwt` to an older version (e.g., `2.2.x` for compatibility with OAuth gems), you will need to upgrade it. Check for conflicts with:
+`react_on_rails_pro` uses `jwt` for offline license validation. Current versions require `jwt >= 2.7` and no longer cap the dependency at jwt 2.x, so apps can resolve `jwt 3.2.0` or newer when needed. If your Gemfile pins `jwt` to an older version (e.g., `2.2.x` for compatibility with OAuth gems), you will need to upgrade it. Check for conflicts with:
 
 ```bash
 bundle update jwt

--- a/docs/pro/updating.md
+++ b/docs/pro/updating.md
@@ -241,7 +241,7 @@ If you only use ExecJS for SSR (the default), you do not need `react-on-rails-pr
 
 ##### JWT gem requirement
 
-`react_on_rails_pro` uses `jwt` for offline license validation. Current versions require `jwt >= 2.7` and no longer cap the dependency at jwt 2.x, so apps can resolve `jwt 3.2.0` or newer when needed. If your Gemfile pins `jwt` to an older version (e.g., `2.2.x` for compatibility with OAuth gems), you will need to upgrade it. Check for conflicts with:
+`react_on_rails_pro` uses `jwt` for offline license validation. Current versions require `jwt >= 2.7` (relaxed from the `16.7.0.rc.0` floor of `jwt >= 3.2.0`), so apps still pinned to jwt 2.x can bundle without upgrading. Apps that can resolve `jwt 3.2.0` or newer will continue to do so. If your Gemfile pins `jwt` below 2.7 (e.g., `2.2.x` for compatibility with OAuth gems), you will need to upgrade it. Check for conflicts with:
 
 ```bash
 bundle update jwt

--- a/react_on_rails_pro/Gemfile.development_dependencies
+++ b/react_on_rails_pro/Gemfile.development_dependencies
@@ -60,8 +60,11 @@ group :development, :test do
   gem "benchmark", require: false
   gem "logger", require: false
   gem "ostruct", require: false
-  # base64 is a runtime dependency of jwt 3.x but not jwt 2.x; declare it explicitly so
-  # license_validator_spec.rb's `require "base64"` works on Ruby 3.5+ when jwt 2.x resolves.
+  # base64 was promoted from a default gem to a bundled gem in Ruby 3.4, so Bundler-managed
+  # apps must declare it explicitly. jwt 3.x lists base64 as a runtime dep (which transitively
+  # satisfies our spec on jwt 3.x), but jwt 2.x does not — only jwt >= 2.7 added base64 as an
+  # explicit runtime dep. Declare it here so license_validator_spec.rb's `require "base64"`
+  # works on Ruby 3.4+ regardless of whether bundler resolves jwt 2.x or 3.x.
   gem "base64", require: false
 end
 

--- a/react_on_rails_pro/Gemfile.development_dependencies
+++ b/react_on_rails_pro/Gemfile.development_dependencies
@@ -60,6 +60,9 @@ group :development, :test do
   gem "benchmark", require: false
   gem "logger", require: false
   gem "ostruct", require: false
+  # base64 is a runtime dependency of jwt 3.x but not jwt 2.x; declare it explicitly so
+  # license_validator_spec.rb's `require "base64"` works on Ruby 3.5+ when jwt 2.x resolves.
+  gem "base64", require: false
 end
 
 group :test do

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -27,7 +27,7 @@ PATH
       execjs (~> 2.9)
       http-2 (>= 1.1.1)
       httpx (~> 1.5)
-      jwt (>= 3.2.0)
+      jwt (>= 2.7)
       rainbow
       react_on_rails (= 16.7.0.rc.0)
 

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -476,6 +476,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazing_print
+  base64
   benchmark
   bootsnap
   bundler

--- a/react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/license_validator.rb
@@ -246,7 +246,7 @@ module ReactOnRailsPro
           public_key,
           true, # verify signature - NEVER set to false!
           # Enforce RS256 algorithm only to prevent "alg=none" and downgrade attacks
-          algorithm: "RS256",
+          algorithms: ["RS256"],
           verify_expiration: false # we handle expiration manually
         ).first
       rescue StandardError

--- a/react_on_rails_pro/react_on_rails_pro.gemspec
+++ b/react_on_rails_pro/react_on_rails_pro.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   #   https://github.com/HoneyryderChuck/httpx/issues/118
   s.add_runtime_dependency "http-2", ">= 1.1.1"
   s.add_runtime_dependency "httpx", "~> 1.5"
-  s.add_runtime_dependency "jwt", ">= 3.2.0"
+  s.add_runtime_dependency "jwt", ">= 2.7"
   s.add_runtime_dependency "rainbow"
   s.add_runtime_dependency "react_on_rails", ReactOnRails::VERSION
   s.add_development_dependency "bundler"

--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -27,7 +27,7 @@ PATH
       execjs (~> 2.9)
       http-2 (>= 1.1.1)
       httpx (~> 1.5)
-      jwt (>= 3.2.0)
+      jwt (>= 2.7)
       rainbow
       react_on_rails (= 16.7.0.rc.0)
 

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       execjs (~> 2.9)
       http-2 (>= 1.1.1)
       httpx (~> 1.5)
-      jwt (>= 3.2.0)
+      jwt (>= 2.7)
       rainbow
       react_on_rails (= 16.7.0.rc.0)
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe ReactOnRailsPro::LicenseValidator do
     # HS256 token using the server's public key (in PEM form) as the HMAC
     # secret. Without an algorithm allowlist, a verifier might use the public
     # key bytes as the HMAC key and accept the forgery. decode_license passes
-    # `algorithm: "RS256"`, which jwt 2.5+ and jwt 3.x both honour.
+    # `algorithms: ["RS256"]`, the documented allowlist option for jwt 2.x and 3.x.
     context "with HS256 token forged from the public key" do
       before do
         public_key_pem = test_public_key.to_pem

--- a/react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/license_validator_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "base64"
+require "json"
 require "jwt"
 require_relative "spec_helper"
 
@@ -128,6 +130,38 @@ RSpec.describe ReactOnRailsPro::LicenseValidator do
       end
 
       it "returns :invalid" do
+        expect(described_class.license_status).to eq(:invalid)
+      end
+    end
+
+    # Defends against the classic alg-confusion attack: an attacker forges an
+    # HS256 token using the server's public key (in PEM form) as the HMAC
+    # secret. Without an algorithm allowlist, a verifier might use the public
+    # key bytes as the HMAC key and accept the forgery. decode_license passes
+    # `algorithm: "RS256"`, which jwt 2.5+ and jwt 3.x both honour.
+    context "with HS256 token forged from the public key" do
+      before do
+        public_key_pem = test_public_key.to_pem
+        forged_token = JWT.encode(valid_payload, public_key_pem, "HS256")
+        ENV["REACT_ON_RAILS_PRO_LICENSE"] = forged_token
+      end
+
+      it "returns :invalid (RS256 allowlist rejects HS256 tokens)" do
+        expect(described_class.license_status).to eq(:invalid)
+      end
+    end
+
+    # Defends against the classic alg:none attack: tokens with no signature
+    # must be rejected. JWT.encode does not support "none" directly, so the
+    # token is hand-crafted.
+    context "with alg:none token" do
+      before do
+        header = Base64.urlsafe_encode64('{"alg":"none","typ":"JWT"}', padding: false)
+        payload = Base64.urlsafe_encode64(JSON.dump(valid_payload), padding: false)
+        ENV["REACT_ON_RAILS_PRO_LICENSE"] = "#{header}.#{payload}."
+      end
+
+      it "returns :invalid (RS256 allowlist rejects alg:none tokens)" do
         expect(described_class.license_status).to eq(:invalid)
       end
     end


### PR DESCRIPTION
## Summary

- Relax the Pro `jwt` runtime dependency from `>= 3.2.0` to `>= 2.7` for the 16.7 release line.
- Keep the Pro lockfiles resolved to `jwt 3.2.0`, while allowing apps that are still constrained to jwt 2.x to bundle.
- Update the Pro upgrade note to describe removing the jwt 2.x cap instead of requiring jwt 3.2.0.

Follow-up to #3322.

## Test plan

- `(cd react_on_rails_pro && bundle check)`
- `(cd react_on_rails_pro/spec/dummy && bundle check)`
- `(cd react_on_rails_pro/spec/execjs-compatible-dummy && bundle check)`
- `(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)`
- `pnpm start format.listDifferent`
- Pre-commit hook: trailing newlines, markdown links, prettier
- Pre-push hook: branch RuboCop, markdown links

No test suite run locally per React on Rails PR workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compatibility with ruby-jwt 2.x by relaxing the minimum jwt requirement (>= 2.7).
  * Tightened JWT verification to require RS256 via the proper allowlist, improving license token validation and security.

* **Documentation**
  * Updated Pro upgrade guide to clarify jwt version requirements and Gemfile conflict guidance.

* **Tests**
  * Added JWT-focused tests to ensure forged or alg:none tokens are rejected.

* **Chores**
  * Ensured base64 is available in development/test environments to support JWT-related specs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->