### PR TITLE
fix(doctor): scan Jenkinsfile renderer-cache migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Changed
+
+- **`react_on_rails:doctor` renderer-cache scan covers Jenkinsfile**: The deprecated-task scan that flags `react_on_rails_pro:pre_stage_bundle_for_node_renderer` now also checks `Jenkinsfile`, alongside the existing CI/CD manifests (`.circleci/config.yml`, `.gitlab-ci.yml`, `bitbucket-pipelines.yml`, `.github/workflows/*.yml`/`.yaml`) and deploy scripts. Fixes [Issue 3269](https://github.com/shakacode/react_on_rails/issues/3269). [PR 3345](https://github.com/shakacode/react_on_rails/pull/3345) by [justin808](https://github.com/justin808).
+
 ### [16.7.0.rc.3] - 2026-05-25
 
 #### Breaking Changes
@@ -52,10 +56,6 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   - **No implicit transport retry** for connection drops: drops surface immediately as `ReactOnRailsPro::Error`/connection failures. HTTPX previously performed one implicit transport retry; the new adapter uses `retries: 0` and leaves retry policy to the existing bundle-upload retry loop.
 
   See `docs/pro/updating.md` for the full upgrade guide. [PR 3320](https://github.com/shakacode/react_on_rails/pull/3320) by [AbanoubGhadban](https://github.com/AbanoubGhadban).
-
-#### Changed
-
-- **`react_on_rails:doctor` renderer-cache scan covers Jenkinsfile**: The deprecated-task scan that flags `react_on_rails_pro:pre_stage_bundle_for_node_renderer` now also checks `Jenkinsfile`, alongside the existing CI/CD manifests (`.circleci/config.yml`, `.gitlab-ci.yml`, `bitbucket-pipelines.yml`, `.github/workflows/*.yml`/`.yaml`) and deploy scripts. Fixes [Issue 3269](https://github.com/shakacode/react_on_rails/issues/3269).
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
   See `docs/pro/updating.md` for the full upgrade guide. [PR 3320](https://github.com/shakacode/react_on_rails/pull/3320) by [AbanoubGhadban](https://github.com/AbanoubGhadban).
 
+#### Changed
+
+- **`react_on_rails:doctor` renderer-cache scan covers Jenkinsfile**: The deprecated-task scan that flags `react_on_rails_pro:pre_stage_bundle_for_node_renderer` now also checks `Jenkinsfile`, alongside the existing CI/CD manifests (`.circleci/config.yml`, `.gitlab-ci.yml`, `bitbucket-pipelines.yml`, `.github/workflows/*.yml`/`.yaml`) and deploy scripts. Fixes [Issue 3269](https://github.com/shakacode/react_on_rails/issues/3269).
+
 #### Fixed
 
 - **Client-only Vite setups no longer fail Rails boot on Shakapacker's `packageManager` guard**: React on Rails now installs an engine initializer that runs before `shakapacker.manager_checker` and no-ops Shakapacker's `error_unless_package_manager_is_obvious!` when the host app has no Shakapacker config (`config/shakapacker.yml` or `SHAKAPACKER_CONFIG`). This unblocks apps that use the `react-on-rails/client` npm package from an existing Vite entrypoint and do not use the Ruby render helpers. The Ruby helpers that resolve bundle paths still require Shakapacker configuration. Apps with Shakapacker config keep Shakapacker's guard unchanged. Fixes [Issue 3145](https://github.com/shakacode/react_on_rails/issues/3145). [PR 3365](https://github.com/shakacode/react_on_rails/pull/3365) by [justin808](https://github.com/justin808).

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -94,7 +94,8 @@ module ReactOnRails
       "scripts/deploy.sh",
       ".circleci/config.yml",
       ".gitlab-ci.yml",
-      "bitbucket-pipelines.yml"
+      "bitbucket-pipelines.yml",
+      "Jenkinsfile"
     ].freeze
     # Bounded glob allowlist for deploy manifests that live in a known directory
     # but use per-environment or per-workflow filenames. Each pattern matches
@@ -2899,8 +2900,10 @@ module ReactOnRails
     end
 
     def deploy_script_references_deprecated_task?(full_path)
-      # Only `#` comments matter for the scanned file types: Procfile, Dockerfile*,
-      # and bin/* scripts all use `#`. None use `//`, so we don't filter it.
+      # Filter `#` comments since Procfile, Dockerfile*, YAML, Ruby, and bin/*
+      # scripts all use `#`. Jenkinsfile (Groovy) uses `//`; we accept the rare
+      # false positive of a `//`-commented mention as the cost of keeping the
+      # filter simple — real `sh` invocations are flagged correctly.
       # The trailing-comment strip requires whitespace before `#`, so a fragment
       # like `task#name` stays intact while `cmd # was: <deprecated>` is filtered.
       full_path.binread.each_line.any? do |line|

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -2901,13 +2901,14 @@ module ReactOnRails
 
     def deploy_script_references_deprecated_task?(full_path)
       # Filter whole-line comments used by the scanned deploy and CI files.
-      # The trailing-comment strip requires whitespace before `#`, so a fragment
-      # like `task#name` stays intact while `cmd # was: <deprecated>` is filtered.
+      # The trailing-comment strip requires whitespace before the comment marker,
+      # so fragments like `task#name` or `https://...` stay intact while
+      # `cmd # was: <deprecated>` and `cmd // was: <deprecated>` are filtered.
       full_path.binread.each_line.any? do |line|
         stripped = line.lstrip
         next false if stripped.start_with?("#", "//")
 
-        without_inline_comment = stripped.sub(/ +#.*/, "")
+        without_inline_comment = stripped.sub(%r{ +(?:#|//).*}, "")
         without_inline_comment.include?(DEPRECATED_RENDERER_CACHE_TASK)
       end
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -2900,15 +2900,12 @@ module ReactOnRails
     end
 
     def deploy_script_references_deprecated_task?(full_path)
-      # Filter `#` comments since Procfile, Dockerfile*, YAML, Ruby, and bin/*
-      # scripts all use `#`. Jenkinsfile (Groovy) uses `//`; we accept the rare
-      # false positive of a `//`-commented mention as the cost of keeping the
-      # filter simple — real `sh` invocations are flagged correctly.
+      # Filter whole-line comments used by the scanned deploy and CI files.
       # The trailing-comment strip requires whitespace before `#`, so a fragment
       # like `task#name` stays intact while `cmd # was: <deprecated>` is filtered.
       full_path.binread.each_line.any? do |line|
         stripped = line.lstrip
-        next false if stripped.start_with?("#")
+        next false if stripped.start_with?("#", "//")
 
         without_inline_comment = stripped.sub(/ +#.*/, "")
         without_inline_comment.include?(DEPRECATED_RENDERER_CACHE_TASK)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -3379,6 +3379,7 @@ RSpec.describe ReactOnRails::Doctor do
                           .find { |line| line.include?(".circleci/config.yml →") }
         expect(suggestion_line).not_to be_nil
         expect(suggestion_line).to include("pre_seed_renderer_cache")
+        expect(suggestion_line).to include("MODE=symlink")
       end
     end
 
@@ -3405,6 +3406,21 @@ RSpec.describe ReactOnRails::Doctor do
                           .find { |line| line.include?("Jenkinsfile →") }
         expect(suggestion_line).not_to be_nil
         expect(suggestion_line).to include("pre_seed_renderer_cache")
+        expect(suggestion_line).to include("MODE=symlink")
+      end
+
+      it "still flags a //-commented reference as a known Groovy false positive" do
+        File.write(
+          File.join(tmpdir, "Jenkinsfile"),
+          "// sh 'bundle exec rake react_on_rails_pro:pre_stage_bundle_for_node_renderer'\n"
+        )
+
+        doctor.send(:check_deprecated_renderer_cache_task)
+        warning_msgs = checker.messages.select { |m| m[:type] == :warning }
+        suggestion_line = warning_msgs
+                          .flat_map { |m| m[:content].split("\n") }
+                          .find { |line| line.include?("Jenkinsfile →") }
+        expect(suggestion_line).not_to be_nil
       end
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -3408,13 +3408,46 @@ RSpec.describe ReactOnRails::Doctor do
         expect(suggestion_line).to include("pre_seed_renderer_cache")
         expect(suggestion_line).to include("MODE=symlink")
       end
+    end
 
-      it "does not flag a //-commented Jenkinsfile reference" do
+    context "when a Jenkinsfile has a whole-line //-commented reference" do
+      let(:tmpdir) { Dir.mktmpdir }
+
+      before do
         File.write(
           File.join(tmpdir, "Jenkinsfile"),
           "// sh 'bundle exec rake react_on_rails_pro:pre_stage_bundle_for_node_renderer'\n"
         )
+        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+      end
 
+      after { FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir) }
+
+      it "does not flag the Jenkinsfile" do
+        doctor.send(:check_deprecated_renderer_cache_task)
+        warning_msgs = checker.messages.select { |m| m[:type] == :warning }
+        suggestion_line = warning_msgs
+                          .flat_map { |m| m[:content].split("\n") }
+                          .find { |line| line.include?("Jenkinsfile →") }
+        expect(suggestion_line).to be_nil
+      end
+    end
+
+    context "when a Jenkinsfile has an inline //-commented reference" do
+      let(:tmpdir) { Dir.mktmpdir }
+
+      before do
+        File.write(
+          File.join(tmpdir, "Jenkinsfile"),
+          "sh 'bundle exec rake react_on_rails_pro:pre_seed_renderer_cache' " \
+          "// replaced react_on_rails_pro:pre_stage_bundle_for_node_renderer\n"
+        )
+        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+      end
+
+      after { FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir) }
+
+      it "does not flag the Jenkinsfile" do
         doctor.send(:check_deprecated_renderer_cache_task)
         warning_msgs = checker.messages.select { |m| m[:type] == :warning }
         suggestion_line = warning_msgs

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -3382,6 +3382,32 @@ RSpec.describe ReactOnRails::Doctor do
       end
     end
 
+    context "when a Jenkinsfile references the deprecated task" do
+      let(:tmpdir) { Dir.mktmpdir }
+
+      before do
+        File.write(
+          File.join(tmpdir, "Jenkinsfile"),
+          "pipeline {\n  agent any\n  stages {\n    stage('Deploy') {\n      steps {\n        " \
+          "sh 'bundle exec rake react_on_rails_pro:pre_stage_bundle_for_node_renderer'\n      " \
+          "}\n    }\n  }\n}\n"
+        )
+        allow(Rails).to receive(:root).and_return(Pathname.new(tmpdir))
+      end
+
+      after { FileUtils.remove_entry(tmpdir) if File.directory?(tmpdir) }
+
+      it "flags the Jenkinsfile in the fixed allowlist" do
+        doctor.send(:check_deprecated_renderer_cache_task)
+        warning_msgs = checker.messages.select { |m| m[:type] == :warning }
+        suggestion_line = warning_msgs
+                          .flat_map { |m| m[:content].split("\n") }
+                          .find { |line| line.include?("Jenkinsfile →") }
+        expect(suggestion_line).not_to be_nil
+        expect(suggestion_line).to include("pre_seed_renderer_cache")
+      end
+    end
+
     context "when a GitHub Actions workflow discovered via glob references the deprecated task" do
       let(:tmpdir) { Dir.mktmpdir }
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -3409,7 +3409,7 @@ RSpec.describe ReactOnRails::Doctor do
         expect(suggestion_line).to include("MODE=symlink")
       end
 
-      it "still flags a //-commented reference as a known Groovy false positive" do
+      it "does not flag a //-commented Jenkinsfile reference" do
         File.write(
           File.join(tmpdir, "Jenkinsfile"),
           "// sh 'bundle exec rake react_on_rails_pro:pre_stage_bundle_for_node_renderer'\n"
@@ -3420,7 +3420,7 @@ RSpec.describe ReactOnRails::Doctor do
         suggestion_line = warning_msgs
                           .flat_map { |m| m[:content].split("\n") }
                           .find { |line| line.include?("Jenkinsfile →") }
-        expect(suggestion_line).not_to be_nil
+        expect(suggestion_line).to be_nil
       end
     end
 


### PR DESCRIPTION
## Summary

Adds `Jenkinsfile` to `react_on_rails:doctor`'s deprecated-renderer-cache scan, closing the last CI/CD coverage gap from #3269. The other CI/CD locations called out there (`.circleci/config.yml`, `.gitlab-ci.yml`, and `.github/workflows/*.yml`/`.yaml`) already landed in #3329.

- Adds root `Jenkinsfile` to the existing `RENDERER_CACHE_DEPLOY_SCRIPT_PATHS` fixed allowlist.
- Reuses the existing per-file size gate (`RENDERER_CACHE_DEPLOY_SCRIPT_MAX_BYTES`) and bounded scan path rules.
- Keeps the deploy-script match filter comment-aware for `#` comments and now also skips whole-line `//` comments, so commented Jenkinsfile references are not reported.
- Adds specs for Jenkinsfile detection, `MODE=symlink` migration guidance, and the `//`-comment negative case.
- Adds the required changelog entry with PR attribution under `Unreleased`.

Fixes #3269.

## Review handling

- Must-fix: changelog duplicate heading and missing PR attribution — fixed.
- Optional: stricter `MODE=symlink` assertions and `//` comment handling — fixed.
- Discuss: named root Jenkinsfile variants such as `Jenkinsfile.production` remain out of scope for this PR. The low-risk follow-up is to add a bounded root-level glob like `Jenkinsfile*` to `RENDERER_CACHE_DEPLOY_SCRIPT_GLOBS`; because the pattern has no slash, it stays root-level, and `RENDERER_CACHE_DEPLOY_SCRIPT_GLOB_MAX_MATCHES` bounds matches.

## CI note

The pre-rebase `claude-review` failure reported that the review workflow had to match the default branch. Rebasing onto current `origin/main` cleared that workflow-baseline problem. The fresh `claude-review` run now reaches Claude Code and fails because the account has hit its weekly Claude limit (`resets May 29, 3am UTC`), which is external to this PR's code.

## Test plan

- [x] `bundle exec rspec react_on_rails/spec/lib/react_on_rails/doctor_spec.rb -e "check_deprecated_renderer_cache_task"` — 23 examples, 0 failures.
- [x] `(cd react_on_rails && bundle exec rubocop)` — 204 files, no offenses.
- [x] `pnpm run lint` — clean.
- [x] `pnpm start format.listDifferent` — clean.
- [x] `git diff --check` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only change to doctor scan paths and comment parsing; no runtime deploy or auth behavior.
> 
> **Overview**
> Extends **`react_on_rails:doctor`** so the deprecated renderer-cache rake task scan also inspects a root **`Jenkinsfile`**, matching other CI/deploy manifests already in the allowlist.
> 
> Comment handling for that scan now treats **`//`** like **`#`**: whole-line `//` comments are skipped, and inline `//` fragments are stripped before matching, so commented-out Jenkins references do not produce false positives. Specs cover Jenkins detection, **`MODE=symlink`** migration hints, and the `//` negative cases; **CHANGELOG** documents the change under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f910ac5a8da77421251cb0b46da17a4891b114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->