### PR TITLE
docs: track CI_PNPM_FALLBACK_VERSION bumps in CONTRIBUTING (#3264)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -474,14 +474,14 @@ That fallback comes from `CI_PNPM_FALLBACK_VERSION` in [`react_on_rails/lib/gene
 **When to bump:**
 
 - Whenever Renovate updates the repo's own root `package.json` `packageManager` pin to a newer pnpm version. The spec `keeps the fallback pin tied to a version-specific pnpm release note` (in `react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`) fails when `CI_PNPM_FALLBACK_VERSION` drifts from the `packageManager` version in `package.json`; treat that failure as the signal to update the fallback version and release-note URL in the same PR.
-- Periodically review pnpm release PRs from Renovate, at minimum on every pnpm **major** release and ideally on each minor as well. A new major may change the lockfile format, in which case projects scaffolded without `packageManager` will fail with the older pinned pnpm.
+- Review pnpm release PRs from Renovate, at minimum on every pnpm **major** release and ideally on each minor as well. A new major may change the lockfile format, in which case projects scaffolded without `packageManager` will fail with the older pinned pnpm. Renovate may open separate PRs for `package.json` and `CI_PNPM_FALLBACK_VERSION`; merge the constant-bump PR first or batch both updates into one PR to keep CI green.
 
 **What to update together (single commit):**
 
 1. The `CI_PNPM_FALLBACK_VERSION` constant value in `install_generator.rb`
 2. The `https://github.com/pnpm/pnpm/releases/tag/v<version>` URL in the comment above the constant
-3. The root `package.json` `packageManager` field when bumping manually; for Renovate PRs, verify the existing `packageManager` bump matches the fallback version
-4. Re-run `pnpm install` so `pnpm-lock.yaml` matches
+3. The root `package.json` `packageManager` field when bumping manually; for Renovate PRs, verify the existing `packageManager` bump matches the fallback version. The spec catches drift between these values.
+4. Re-run `pnpm install` in the repo root so the root `pnpm-lock.yaml` matches
 
 **Verification:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,14 +473,14 @@ That fallback comes from `CI_PNPM_FALLBACK_VERSION` in [`react_on_rails/lib/gene
 
 **When to bump:**
 
-- Whenever the repo's own root `package.json` `packageManager` pin is updated to a newer pnpm version. The spec `keeps the fallback pin tied to a version-specific pnpm release note` (in `react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`) fails when `CI_PNPM_FALLBACK_VERSION` drifts from the `packageManager` version in `package.json`.
-- Periodically — at minimum on every pnpm **major** release, and ideally on each minor as well. A new major may change the lockfile format, in which case projects scaffolded without `packageManager` will fail with the older pinned pnpm.
+- Whenever Renovate updates the repo's own root `package.json` `packageManager` pin to a newer pnpm version. The spec `keeps the fallback pin tied to a version-specific pnpm release note` (in `react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`) fails when `CI_PNPM_FALLBACK_VERSION` drifts from the `packageManager` version in `package.json`; treat that failure as the signal to update the fallback version and release-note URL in the same PR.
+- Periodically review pnpm release PRs from Renovate, at minimum on every pnpm **major** release and ideally on each minor as well. A new major may change the lockfile format, in which case projects scaffolded without `packageManager` will fail with the older pinned pnpm.
 
 **What to update together (single commit):**
 
 1. The `CI_PNPM_FALLBACK_VERSION` constant value in `install_generator.rb`
 2. The `https://github.com/pnpm/pnpm/releases/tag/v<version>` URL in the comment above the constant
-3. The root `package.json` `packageManager` field (so the two stay in sync)
+3. The root `package.json` `packageManager` field when bumping manually; for Renovate PRs, verify the existing `packageManager` bump matches the fallback version
 4. Re-run `pnpm install` so `pnpm-lock.yaml` matches
 
 **Verification:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,7 +473,7 @@ That fallback comes from `CI_PNPM_FALLBACK_VERSION` in [`react_on_rails/lib/gene
 
 **When to bump:**
 
-- Whenever the repo's own root `package.json` `packageManager` pin is updated to a newer pnpm version. The spec `keeps the fallback pin tied to a version-specific pnpm release note` (in `react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`) fails when the two drift.
+- Whenever the repo's own root `package.json` `packageManager` pin is updated to a newer pnpm version. The spec `keeps the fallback pin tied to a version-specific pnpm release note` (in `react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`) fails when `CI_PNPM_FALLBACK_VERSION` drifts from the `packageManager` version in `package.json`.
 - Periodically — at minimum on every pnpm **major** release, and ideally on each minor as well. A new major may change the lockfile format, in which case projects scaffolded without `packageManager` will fail with the older pinned pnpm.
 
 **What to update together (single commit):**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,6 +465,33 @@ After updating the source files above, regenerate lock files by running `bundle 
 
 The CI-generated example apps (under `gen-examples/`) automatically resolve the shakapacker version via the gem dependency. The `pin_shakapacker_npm_version` helper in `react_on_rails/rakelib/shakapacker_examples.rake` ensures the npm version matches the gem.
 
+## Updating the pnpm Fallback Version for Scaffolded CI
+
+The `react_on_rails:install` generator scaffolds a GitHub Actions workflow that uses `pnpm/action-setup@v4`. When the target app declares `packageManager: pnpm@…` in its `package.json`, the scaffold reads the pin from there. When it does not (e.g., existing Shakapacker apps that only have `pnpm-lock.yaml`), the scaffold has to supply an explicit `version:` to the action — otherwise the workflow fails before installing dependencies.
+
+That fallback comes from `CI_PNPM_FALLBACK_VERSION` in [`react_on_rails/lib/generators/react_on_rails/install_generator.rb`](./react_on_rails/lib/generators/react_on_rails/install_generator.rb).
+
+**When to bump:**
+
+- Whenever the repo's own root `package.json` `packageManager` pin is updated to a newer pnpm version. The spec `keeps the fallback pin tied to a version-specific pnpm release note` (in `react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`) fails when the two drift.
+- Periodically — at minimum on every pnpm **major** release, and ideally on each minor as well. A new major may change the lockfile format, in which case projects scaffolded without `packageManager` will fail with the older pinned pnpm.
+
+**What to update together (single commit):**
+
+1. The `CI_PNPM_FALLBACK_VERSION` constant value in `install_generator.rb`
+2. The `https://github.com/pnpm/pnpm/releases/tag/v<version>` URL in the comment above the constant
+3. The root `package.json` `packageManager` field (so the two stay in sync)
+4. Re-run `pnpm install` so `pnpm-lock.yaml` matches
+
+**Verification:**
+
+```sh
+bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb \
+  -e "keeps the fallback pin tied to a version-specific pnpm release note"
+```
+
+Users who want exact reproducibility in their generated CI can commit a `packageManager: pnpm@<version>` field to their own `package.json`; the generator then omits the fallback `version:` entirely.
+
 ## CI Testing and Optimization
 
 React on Rails uses an optimized CI pipeline that runs faster on branches while maintaining full coverage on `main`. Contributors have access to local CI tools to validate changes before pushing.

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -141,7 +141,7 @@ module ReactOnRails
       # used for this fallback at https://github.com/pnpm/pnpm/releases/tag/v9.14.2;
       # update this URL with the constant when bumping. Users who need exact
       # reproducibility should commit `packageManager` to their package.json instead.
-      # Bump checklist (exact text is spec-asserted; keep in sync):
+      # Bump checklist: heading text below is spec-asserted.
       # CONTRIBUTING.md > "Updating the pnpm Fallback Version for Scaffolded CI".
       # renovate: datasource=github-releases depName=pnpm/pnpm extractVersion=^v(?<version>.+)$ allowedVersions=<10
       CI_PNPM_FALLBACK_VERSION = "9.14.2"

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -141,7 +141,8 @@ module ReactOnRails
       # used for this fallback at https://github.com/pnpm/pnpm/releases/tag/v9.14.2;
       # update this URL with the constant when bumping. Users who need exact
       # reproducibility should commit `packageManager` to their package.json instead.
-      # Bump checklist: CONTRIBUTING.md > "Updating the pnpm Fallback Version for Scaffolded CI".
+      # Bump checklist (exact text is spec-asserted; keep in sync):
+      # CONTRIBUTING.md > "Updating the pnpm Fallback Version for Scaffolded CI".
       # renovate: datasource=github-releases depName=pnpm/pnpm extractVersion=^v(?<version>.+)$ allowedVersions=<10
       CI_PNPM_FALLBACK_VERSION = "9.14.2"
       private_constant :CI_PNPM_FALLBACK_VERSION

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -141,15 +141,7 @@ module ReactOnRails
       # used for this fallback at https://github.com/pnpm/pnpm/releases/tag/v9.14.2;
       # update this URL with the constant when bumping. Users who need exact
       # reproducibility should commit `packageManager` to their package.json instead.
-      #
-      # Bumping policy (see #3248): this constant is coupled to the repo's own
-      # `package.json#packageManager` via `spec/react_on_rails/generators/install_generator_spec.rb`
-      # (`repo_pinned_pnpm_version`). Bump only as part of a coordinated upgrade of the repo's
-      # pnpm major; do not raise the floor here ahead of the rest of the codebase.
-      #
-      # Last checked: 2026-05-20 — pnpm 10 and pnpm 11 exist upstream, but the repo's own
-      # packageManager is still pnpm@9.14.2, so the fallback stays on 9.x to match what
-      # this codebase actually tests with.
+      # Bump checklist: CONTRIBUTING.md > "Updating the pnpm Fallback Version for Scaffolded CI".
       # renovate: datasource=github-releases depName=pnpm/pnpm extractVersion=^v(?<version>.+)$ allowedVersions=<10
       CI_PNPM_FALLBACK_VERSION = "9.14.2"
       private_constant :CI_PNPM_FALLBACK_VERSION

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -2097,6 +2097,10 @@ describe InstallGenerator, type: :generator do
       "Renovate directive in install_generator.rb must match allowedVersions=<#{next_pnpm_major} " \
       "(derived from repo pnpm major). Update the # renovate: comment line when bumping " \
       "CI_PNPM_FALLBACK_VERSION."
+    fallback_guide_heading = "Updating the pnpm Fallback Version for Scaffolded CI"
+    contributing_guide = File.read(
+      File.expand_path("../../../../CONTRIBUTING.md", __dir__)
+    )
     generator_source = File.read(
       File.expand_path("../../../lib/generators/react_on_rails/install_generator.rb", __dir__)
     )
@@ -2112,8 +2116,9 @@ describe InstallGenerator, type: :generator do
       "renovate: datasource=github-releases depName=pnpm/pnpm"
     )
     expect(generator_source).to include(
-      %(CONTRIBUTING.md > "Updating the pnpm Fallback Version for Scaffolded CI")
+      %(CONTRIBUTING.md > "#{fallback_guide_heading}")
     )
+    expect(contributing_guide).to include("## #{fallback_guide_heading}")
   end
 
   context "when env selects pnpm but packageManager declares yarn" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -2108,6 +2108,12 @@ describe InstallGenerator, type: :generator do
     )
     # Keep the full directive in source order so failures point at the exact Renovate comment to update.
     expect(generator_source).to include(expected_renovate_directive), renovate_directive_mismatch_message
+    expect(generator_source).to include(
+      "renovate: datasource=github-releases depName=pnpm/pnpm"
+    )
+    expect(generator_source).to include(
+      %(CONTRIBUTING.md > "Updating the pnpm Fallback Version for Scaffolded CI")
+    )
   end
 
   context "when env selects pnpm but packageManager declares yarn" do


### PR DESCRIPTION
## Summary

- Adds a "Updating the pnpm Fallback Version for Scaffolded CI" section to `CONTRIBUTING.md` so future pnpm major/minor releases trigger a conscious bump decision rather than relying on review-time vigilance.
- The section lists *when* to bump (repo `packageManager` change, or new pnpm major/minor), *what* to update together (constant, release-tag URL, root `package.json` `packageManager`, lockfile), and the spec command that verifies they stay in sync.
- Adds a breadcrumb comment above `CI_PNPM_FALLBACK_VERSION` in `install_generator.rb` pointing maintainers at the checklist.
- Extends the existing maintenance spec to assert the breadcrumb stays present alongside the version, release-tag URL, and Renovate hint.

Fixes #3264

## Why here

`CONTRIBUTING.md` already documents a parallel maintenance task ("Updating the Shakapacker Version for Testing") right next to where this new section sits. Co-locating the two means contributors performing dependency bumps see both checklists together.

## Test plan

- [x] `bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb -e "keeps the fallback pin tied to a version-specific pnpm release note"` — 1 example, 0 failures
- [x] `(cd react_on_rails && bundle exec rubocop lib/generators/react_on_rails/install_generator.rb spec/react_on_rails/generators/install_generator_spec.rb)` — 2 files, no offenses
- [x] Lefthook pre-commit (lychee link check, Prettier, RuboCop) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generator spec assertions only; the fallback version and scaffolded CI output are unchanged.
> 
> **Overview**
> Documents how maintainers should keep **`CI_PNPM_FALLBACK_VERSION`** (used when the install generator scaffolds GitHub Actions without a `packageManager` pin) aligned with the repo’s own pnpm pin.
> 
> Adds a **CONTRIBUTING** section next to the Shakapacker bump guide: when to bump, which artifacts to change together (constant, release URL, root `packageManager`, lockfile), and the focused RSpec command. Replaces the long inline bump policy on the constant with a short pointer to that heading (the heading text is **spec-asserted**). Extends **`keeps the fallback pin tied to a version-specific pnpm release note`** to require the breadcrumb, the CONTRIBUTING section, and the Renovate datasource comment still present.
> 
> No change to the fallback version value or generated CI behavior—process and enforcement only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5edccbe7e43aabccec12a0914cd5dde8c0a6e7f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance explaining how the install generator scaffolds a pnpm-based CI workflow, how a fallback pnpm version is chosen when apps lack a packageManager pin, when to bump that fallback, which artifacts must be updated together, and how to opt into exact reproducibility by pinning packageManager.

* **Tests**
  * Strengthened generator tests to verify the generated scaffolding includes a link to the new contributing guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->