### PR TITLE
docs: consolidate node renderer probe settings (#3257)

### DIFF
--- a/docs/oss/building-features/node-renderer/container-deployment.md
+++ b/docs/oss/building-features/node-renderer/container-deployment.md
@@ -510,12 +510,19 @@ During container startup, you may see `ERR_STREAM_PREMATURE_CLOSE` errors from F
 
 **Mitigation:**
 
-> The probe values below mirror the recommended settings documented in
+> Probe semantics, timing values, and curl command flags are documented canonically in
 > [JS Configuration: Configuring Startup, Readiness, and Liveness Probes](./js-configuration.md#configuring-startup-readiness-and-liveness-probes).
-> Treat that section as the canonical source when you tune values; update it first and reflect the change in these examples.
+> The full copy-paste YAML lives in [Kubernetes Sidecar Manifest](#kubernetes-sidecar-manifest) below. Update the JS
+> Configuration section first when tuning thresholds, then reflect the change in the manifest.
 
-1. **Health check endpoint** — The Node Renderer exposes a built-in `/info` endpoint that returns the node version and renderer version. Because the renderer uses cleartext HTTP/2, Kubernetes `httpGet` probes (HTTP/1.1) are incompatible with this listener. Use a TCP probe, an `exec` probe with an h2c-aware client such as `curl --http2-prior-knowledge`, or a dedicated HTTP/1.1 sidecar/port for probes. For a custom `/health` route with more granular checks, use the `configureFastify()` option (see [JS Configuration: Adding a Health Check Endpoint](./js-configuration.md#adding-a-health-check-endpoint)). Configure your container orchestrator to wait for it before routing traffic.
-2. **Startup probe** — Configure a startup probe with a generous `initialDelaySeconds`:
+1. **Health check endpoint** — The Node Renderer exposes a built-in `/info` endpoint that returns the node version and
+   renderer version. The renderer uses cleartext HTTP/2, so Kubernetes `httpGet` probes (HTTP/1.1) are incompatible —
+   use a `tcpSocket` probe, an `exec` probe with an h2c-aware client such as `curl --http2-prior-knowledge`, or a
+   dedicated HTTP/1.1 sidecar/port for probes. For a custom `/health` route with more granular checks, see
+   [JS Configuration: Adding a Health Check Endpoint](./js-configuration.md#adding-a-health-check-endpoint).
+2. **Startup probe** — A startup probe is the primary mitigation for this error. It defers readiness and liveness until
+   the renderer has bound its port, so Rails only sends render requests after workers are ready:
+
    ```yaml
    startupProbe:
      tcpSocket:
@@ -525,98 +532,12 @@ During container startup, you may see `ERR_STREAM_PREMATURE_CLOSE` errors from F
      failureThreshold: 6
      timeoutSeconds: 1
    ```
-3. **Readiness probe** — Ensure traffic is only routed to the renderer when it's ready to accept requests. Prefer an `exec` probe with an h2c-aware client for application-level readiness. Use `tcpSocket` only as a minimal fallback that confirms the port is accepting connections:
 
-   ```yaml
-   readinessProbe:
-     exec:
-       command:
-         - curl
-         - -sf
-         - --max-time
-         - '3'
-         - --http2-prior-knowledge
-         - http://localhost:3800/info
-     timeoutSeconds: 5
-     periodSeconds: 5
-     failureThreshold: 3
-   ```
-
-   > **Notes:**
-   >
-   > - The YAML uses `/info` so it works before custom Fastify routes exist. Replace `/info` with `/health` after
-   >   registering that route via `configureFastify` if readiness should wait for renderer-specific warm-up checks.
-   > - Before upgrading an existing readiness probe, keep curl's `--max-time` lower than `timeoutSeconds`. If switching
-   >   from `tcpSocket` to `exec`, verify curl HTTP/2 support in the image first.
-   > - See the probe command notes below for curl HTTP/2 support, `--max-time`, loaded-node buffers, and
-   >   `initialDelaySeconds` guidance.
-
-   > **Readiness fallback option:** If curl lacks HTTP/2 support in your image, replace that `readinessProbe` with this
-   > `tcpSocket` block. This checks port reachability, not application-level readiness:
-   >
-   > ```yaml
-   > readinessProbe:
-   >   tcpSocket:
-   >     port: 3800
-   >   # TCP handshakes should complete quickly; exec/H2 uses timeoutSeconds: 5.
-   >   timeoutSeconds: 1
-   >   periodSeconds: 5
-   >   failureThreshold: 3
-   > ```
-
-4. **Liveness probe** — Ensure the renderer is restarted after hard listener or container failures. Prefer `tcpSocket`
-   for liveness so transient CPU or GC pauses do not trigger an HTTP round-trip failure and restart an otherwise
-   recoverable renderer:
-
-   ```yaml
-   livenessProbe:
-     # Add initialDelaySeconds here if no startupProbe is configured.
-     # Kubernetes 1.20+ defers readiness/liveness until the startupProbe succeeds.
-     tcpSocket:
-       port: 3800
-     # TCP handshakes should complete quickly; exec/H2 uses timeoutSeconds: 5.
-     timeoutSeconds: 1
-     periodSeconds: 10
-     failureThreshold: 3
-   ```
-
-   > **Stricter liveness option:** If you need liveness to catch a blocked Node.js event loop, and you have verified curl
-   > HTTP/2 support in the image, you can use an h2c-aware `exec` probe with a short `--max-time`. Keep external
-   > dependency checks out of liveness; use readiness for dependency or warm-up gates.
-   >
-   > ```yaml
-   > livenessProbe:
-   >   # Add initialDelaySeconds here if no startupProbe is configured.
-   >   # Kubernetes 1.20+ defers readiness/liveness until the startupProbe succeeds.
-   >   # Requires curl with HTTP/2 support (verify: curl --version | grep -i http2).
-   >   exec:
-   >     command:
-   >       - curl
-   >       - -sf
-   >       - --max-time
-   >       - '3'
-   >       - --http2-prior-knowledge
-   >       - http://localhost:3800/info
-   >   timeoutSeconds: 5
-   >   periodSeconds: 10
-   >   failureThreshold: 3
-   > ```
-
-   > **Notes:**
-   >
-   > - Keep `/info` as the optional `exec` liveness endpoint. Only substitute `/health` if that route avoids external
-   >   dependency checks and readiness gates.
-   > - See the probe command notes below for curl HTTP/2 support, `--max-time`, loaded-node buffers, and
-   >   `initialDelaySeconds` guidance.
-
-> [!NOTE]
-> **Probe command notes:** `exec` probes require curl with HTTP/2 support in your image. Verify with
-> `curl --version | grep -i http2`; if unavailable, use `tcpSocket` as a fallback. Set curl `--max-time` shorter than the
-> orchestrator timeout so curl returns a clean non-zero exit code before Kubernetes terminates the probe process. These
-> examples use `--max-time 3` with `timeoutSeconds: 5` for `exec` probes, leaving a 2-second buffer. Readiness and
-> liveness omit `initialDelaySeconds` because Kubernetes 1.20+ (startup probe GA) defers them until the startup probe
-> succeeds. If you skip the startup probe or run an older cluster without startup probe support, add an appropriate
-> `initialDelaySeconds`.
+3. **Readiness and liveness probes** — Configure these alongside the startup probe so Rails only routes requests to a
+   healthy renderer and stuck containers get restarted. See
+   [Configuring Startup, Readiness, and Liveness Probes](./js-configuration.md#configuring-startup-readiness-and-liveness-probes)
+   for probe-style choices, timing values, and curl command guidance, and
+   [Kubernetes Sidecar Manifest](#kubernetes-sidecar-manifest) for the full copy-paste YAML.
 
 > **Security:** See the canonical [`/info` security note](./js-configuration.md#built-in-endpoints) for the
 > unauthenticated-access caveat when `password` is configured.
@@ -649,12 +570,14 @@ In production, `logLevel: 'warn'` is sufficient unless actively debugging.
 
 ## Kubernetes Sidecar Manifest
 
-A complete pod spec for the sidecar pattern:
+A complete pod spec for the sidecar pattern. This is the canonical copy-paste YAML for renderer probes — other sections
+reference it instead of repeating the full block.
 
 > [!NOTE]
 > The manifest uses an h2c-aware `exec` probe for readiness and a `tcpSocket` probe for liveness. Keep that split unless
 > you intentionally need stricter liveness detection and have verified curl HTTP/2 support in the image. Probe timing
-> values mirror [JS Configuration: Configuring Startup, Readiness, and Liveness Probes](./js-configuration.md#configuring-startup-readiness-and-liveness-probes);
+> values and curl command guidance are canonical in
+> [JS Configuration: Configuring Startup, Readiness, and Liveness Probes](./js-configuration.md#configuring-startup-readiness-and-liveness-probes);
 > update that section first when tuning thresholds and reflect the change here.
 
 ```yaml

--- a/docs/oss/building-features/node-renderer/js-configuration.md
+++ b/docs/oss/building-features/node-renderer/js-configuration.md
@@ -244,6 +244,11 @@ The `./master` and `./worker` exports provide direct access to the node-renderer
 
 ## Configuring Startup, Readiness, and Liveness Probes
 
+This section is the canonical source for probe semantics, recommended timing values, and curl command guidance. The
+copy-paste YAML lives in
+[Kubernetes Sidecar Manifest](./container-deployment.md#kubernetes-sidecar-manifest); update the values here first when
+tuning, then reflect the change in the manifest.
+
 Keep the three probe types distinct:
 
 - **Startup** answers whether the renderer has finished booting. Separate it from readiness and liveness so slow startup
@@ -339,7 +344,7 @@ appropriate `initialDelaySeconds` to each.
 See [Kubernetes Sidecar Manifest](./container-deployment.md#kubernetes-sidecar-manifest) for a complete pod spec with
 all three probes wired in, and
 [Startup Errors: `ERR_STREAM_PREMATURE_CLOSE`](./container-deployment.md#startup-errors-err_stream_premature_close) for
-the shared probe command notes on curl HTTP/2 support, `--max-time` buffers, and `initialDelaySeconds` guidance.
+the troubleshooting flow that points back here for tuning.
 
 For Control Plane topology-specific `renderer_url`, host binding, and probe target guidance, see
 [Control Plane Deployment Shapes](./container-deployment.md#control-plane-deployment-shapes).

--- a/docs/oss/building-features/node-renderer/js-configuration.md
+++ b/docs/oss/building-features/node-renderer/js-configuration.md
@@ -344,7 +344,7 @@ appropriate `initialDelaySeconds` to each.
 See [Kubernetes Sidecar Manifest](./container-deployment.md#kubernetes-sidecar-manifest) for a complete pod spec with
 all three probes wired in, and
 [Startup Errors: `ERR_STREAM_PREMATURE_CLOSE`](./container-deployment.md#startup-errors-err_stream_premature_close) for
-the troubleshooting flow that points back here for tuning.
+the startup-error troubleshooting context.
 
 For Control Plane topology-specific `renderer_url`, host binding, and probe target guidance, see
 [Control Plane Deployment Shapes](./container-deployment.md#control-plane-deployment-shapes).


### PR DESCRIPTION
## Summary

- Designate `js-configuration.md` ➜ **Configuring Startup, Readiness, and Liveness Probes** as the canonical source for probe semantics, timing values, and curl command guidance.
- Designate `container-deployment.md` ➜ **Kubernetes Sidecar Manifest** as the canonical copy-paste YAML for renderer probes.
- Trim the `ERR_STREAM_PREMATURE_CLOSE` mitigation section to remove duplicate readiness/liveness/fallback YAML and the repeated curl/`--max-time`/`initialDelaySeconds` prose. Keep the `startupProbe` YAML (the direct mitigation for this specific error) and point to the canonical sections for everything else.
- Net change: -98 / +26 lines, eliminates the three-location drift risk flagged by PR #3241's review while keeping the Sidecar Manifest's copy-paste YAML usable.

Fixes #3257

## Test plan

- [x] `pnpm exec prettier --check` on both modified files — passes.
- [x] `lychee --offline --include-fragments` on both files — 40 links checked, 0 errors.
- [x] Pre-commit hook (trailing newlines, markdown links, prettier) — passes.
- [x] Pre-push hook (branch lint, online markdown links) — passes.
- [ ] CI: `check-markdown-links` workflow runs prettier check + lychee online link check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only refactor that consolidates duplicated probe YAML/guidance into canonical sections, with no runtime code changes.
> 
> **Overview**
> Refactors Node Renderer deployment docs to **eliminate duplicated Kubernetes probe guidance** and reduce drift.
> 
> `js-configuration.md` is now explicitly the canonical source for probe semantics/timing and `curl` (h2c) guidance, while `container-deployment.md`’s **Kubernetes Sidecar Manifest** is positioned as the canonical copy-paste YAML. The `ERR_STREAM_PREMATURE_CLOSE` mitigation section is trimmed to keep only the `startupProbe` example and link out for readiness/liveness details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9fa014d9feb5bf6eff96b88e5141e9a9ce625d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Node Renderer deployment guides with clearer health-check probe guidance, emphasizing the /info endpoint, HTTP/2 (h2c-aware) behavior, and using startup probes to delay traffic until workers are ready.
  * Consolidated probe configuration and timing guidance into a single canonical location and added cross-references to reduce duplication.
  * Clarified the Kubernetes sidecar manifest as the canonical copy-paste source for readiness and liveness probe settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->