### PR TITLE
Spike: Prism-based Gemfile rewriter for Pro migration (#3313)

### DIFF
--- a/react_on_rails/.rubocop.yml
+++ b/react_on_rails/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
 
   Exclude:
     - 'spec/dummy/bin/*'
+    - 'spike/**/*'  # Exploratory spike code outside lib/ — not part of the production surface
 
 Naming/FileName:
   Exclude:

--- a/react_on_rails/react_on_rails.gemspec
+++ b/react_on_rails/react_on_rails.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
-      f.match(%r{^(spec|tmp)/})
+      f.match(%r{^(spec|tmp|spike)/})
     end
   end
   s.bindir        = "exe"

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/DECISION.md
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/DECISION.md
@@ -63,10 +63,11 @@ as part of this spike" non-goal.
    `react_on_rails_pro`.
 3. Decide based on whether an active Pro gem is present:
    - **No Pro gem:** for each base call, replace the first string literal with
-     `react_on_rails_pro`. If the call has no user version pin (no second positional
-     `StringNode`), splice in the default version literal after the gem name.
+     `react_on_rails_pro`. If the call has no user version requirement and no source
+     option (`git:`, `github:`, or `path:`), splice in the default version literal
+     after the gem name.
    - **Pro gem already present:** for each base call, remove its enclosing
-     statement byte range (line start through trailing newline).
+     statement byte range without deleting unrelated semicolon-separated statements.
 4. After removals, re-parse and find any `if/unless ... end` whose branch became
    empty. If the conditional's surviving branch contains exactly the Pro gem call,
    collapse the conditional to that single declaration. Otherwise remove just the
@@ -98,6 +99,8 @@ prototype as written:
 | No final newline                                           | ✅                                  | ✅                         |
 | Duplicate declarations across groups                       | ✅                                  | ✅                         |
 | Active Pro present, base stale                             | ✅ (removes base)                   | ✅                         |
+| Active Pro present, base on shared line                    | ✅                                  | ⚠️ removes full line       |
+| Non-string version requirement (`SOME_VERSION`)            | ✅                                  | ⚠️ adds default version    |
 | Conditional with `if/else` (both branches base)            | ✅ (rewrites both)                  | ✅                         |
 | Conditional with `if pro / else base`                      | ✅ **collapses to single Pro decl** | ⚠️ **leaves empty `else`** |
 
@@ -115,6 +118,14 @@ The only **observable behavior differences**:
 
    This is the policy choice asked for in the issue's acceptance criteria. See
    "Conditional/empty-branch policy" below for the reasoning.
+
+3. **Non-literal version/source declarations.** The Prism prototype treats any
+   positional argument and `git:`, `github:`, or `path:` source option as an existing
+   user requirement, so it does not inject the default Pro version into those calls.
+   This avoids adding redundant or conflicting constraints to source-backed gems.
+4. **Semicolon-separated statements.** When removing stale base declarations, the
+   Prism prototype removes only the matched statement instead of the whole source
+   line, so neighboring gem declarations survive.
 
 ## Conditional / empty-branch policy
 

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/DECISION.md
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/DECISION.md
@@ -1,0 +1,257 @@
+# Decision record: Prism-based Gemfile rewriting for Pro migration
+
+**Issue:** [#3313](https://github.com/shakacode/react_on_rails/issues/3313)
+**Status:** Spike complete, recommendation: **wait for Ruby floor to rise to 3.3**, keep
+the current text scanner in the meantime, and revisit then.
+**Date:** 2026-05-21
+**Author:** Justin Gordon (Claude Code assistance)
+
+## TL;DR
+
+A working Prism prototype lives at
+[`prism_gemfile_rewriter.rb`](./prism_gemfile_rewriter.rb) with a 32-case behavior
+matrix in [`prism_gemfile_rewriter_spec.rb`](./prism_gemfile_rewriter_spec.rb). All
+cases pass, including the empty-`else` case the current scanner gets wrong.
+
+The prototype demonstrates that a parser-backed rewrite is **viable** and produces
+cleaner output for conditional declarations. It is also dramatically simpler than
+the current scanner (~210 lines including the conditional-collapse pass, vs.
+~175 lines of pure scanner in `pro_migration.rb` plus ~330 lines of rewrite logic
+across `pro_generator.rb`).
+
+But the **cost is a new runtime gem dependency** (`prism`) for the ~30% of users
+still on Ruby 3.0–3.2. Until the gem's Ruby floor rises to 3.3 (when Prism is
+in CRuby's stdlib), the dependency cost outweighs the rewrite cleanup. Migration
+generator code runs once per user, and the current scanner is tested against the
+full matrix already.
+
+Recommendation: keep the current scanner. Revisit when `react_on_rails` drops
+Ruby 3.0–3.2 support.
+
+## Background
+
+PR [#3232](https://github.com/shakacode/react_on_rails/pull/3232) hardened the Pro
+migration generator's Gemfile rewrite path with a regex-free text scanner. The
+review cycle exposed a maintenance pattern: each unusual Gemfile shape (multiline
+parenthesized calls, postfix guards, trailing-comma suffixes, no-final-newline,
+stale-base-with-pro-present) needed more scanner special-casing. CodeQL ReDoS
+detection tripped on the original regex implementation and forced a regex-free
+rewrite.
+
+Issue #3313 asked: would a Prism-backed rewrite reduce this maintenance cost and
+remove the static-analysis exposure?
+
+## What was built
+
+A standalone Prism-based rewriter at
+[`spike/3313_prism_gemfile_rewriter/`](./).
+
+| File                             | Purpose                                                                      |
+| -------------------------------- | ---------------------------------------------------------------------------- |
+| `prism_gemfile_rewriter.rb`      | The prototype: parse → locate `gem` call nodes → location-based source edits |
+| `prism_gemfile_rewriter_spec.rb` | 32-case behavior matrix                                                      |
+| `benchmark.rb`                   | Parse + rewrite timing vs. the current scanner                               |
+
+The prototype is **outside `lib/`** to satisfy the issue's "Do not rewrite #3232
+as part of this spike" non-goal.
+
+### Approach
+
+1. Parse Gemfile source with `Prism.parse`.
+2. Walk the AST and collect every `CallNode` whose receiver is `nil`, name is `:gem`,
+   and whose first argument is a `StringNode` literal of `react_on_rails` or
+   `react_on_rails_pro`.
+3. Decide based on whether an active Pro gem is present:
+   - **No Pro gem:** for each base call, replace the first string literal with
+     `react_on_rails_pro`. If the call has no user version pin (no second positional
+     `StringNode`), splice in the default version literal after the gem name.
+   - **Pro gem already present:** for each base call, remove its enclosing
+     statement byte range (line start through trailing newline).
+4. After removals, re-parse and find any `if/unless ... end` whose branch became
+   empty. If the conditional's surviving branch contains exactly the Pro gem call,
+   collapse the conditional to that single declaration. Otherwise remove just the
+   empty branch.
+
+All edits are **byte-offset splices**, so comments, spacing, heredocs, and unrelated
+Ruby are preserved by construction (no AST formatter).
+
+## Behavior matrix — full coverage
+
+The spec covers every shape enumerated in #3313 and they all pass with the
+prototype as written:
+
+| Shape                                                      | Prism                               | Current scanner            |
+| ---------------------------------------------------------- | ----------------------------------- | -------------------------- |
+| Exact version pin (`gem "react_on_rails", "16.0.0"`)       | ✅                                  | ✅                         |
+| Pessimistic version pin (`"~> 16.0"`)                      | ✅                                  | ✅                         |
+| Multi-constraint pins (`">= 15.0", "< 16.0"`)              | ✅                                  | ✅                         |
+| Single quote style                                         | ✅                                  | ✅                         |
+| `path:`, `git:`, `github:`, `require: false`, `platforms:` | ✅                                  | ✅                         |
+| Postfix guard (`if ENV["X"]`)                              | ✅                                  | ✅                         |
+| Multiline non-parenthesized continuation                   | ✅                                  | ✅                         |
+| Multiline parenthesized                                    | ✅                                  | ✅ (parens stripped)       |
+| Parenthesized with postfix guard                           | ✅ (parens preserved)               | ✅ (parens stripped)       |
+| Trailing comment after closing paren                       | ✅                                  | ✅                         |
+| Inline comments containing `)`                             | ✅                                  | ✅                         |
+| Comment-only continuation lines                            | ✅                                  | ✅                         |
+| Trailing-comma-only suffix (`gem("ror",)`)                 | ✅ (Ruby 3.3+ parses cleanly)       | ✅                         |
+| No final newline                                           | ✅                                  | ✅                         |
+| Duplicate declarations across groups                       | ✅                                  | ✅                         |
+| Active Pro present, base stale                             | ✅ (removes base)                   | ✅                         |
+| Conditional with `if/else` (both branches base)            | ✅ (rewrites both)                  | ✅                         |
+| Conditional with `if pro / else base`                      | ✅ **collapses to single Pro decl** | ⚠️ **leaves empty `else`** |
+
+The only **observable behavior differences**:
+
+1. **Parenthesized declarations.** The current scanner strips parens
+   (`gem("ror", "~> 16.0")` → `gem "ror", "~> 16.0"`). The Prism prototype
+   preserves the user's style. Neither is wrong; preserving the user's source style
+   is arguably more polite.
+2. **The empty-`else` case (called out in #3313).** The current scanner leaves an
+   ugly empty `else` branch. The Prism prototype collapses the entire conditional
+   to a single `gem "react_on_rails_pro", "16.0.0"` declaration, because the
+   conditional's only purpose was to select between gem variants and there is only
+   one variant after migration.
+
+   This is the policy choice asked for in the issue's acceptance criteria. See
+   "Conditional/empty-branch policy" below for the reasoning.
+
+## Conditional / empty-branch policy
+
+**Chosen:** collapse the conditional when a branch becomes empty _and_ the surviving
+branch contains only `gem "react_on_rails_pro"`.
+
+```ruby
+# Before
+if ENV["PRO"]
+  gem "react_on_rails_pro", "16.0.0"
+else
+  gem "react_on_rails", "16.0.0"
+end
+
+# After
+gem "react_on_rails_pro", "16.0.0"
+```
+
+**Why collapse, not "delete empty branch" or "leave it":**
+
+- "Leave it" is what the scanner does today, and the issue explicitly calls this
+  out as the ugliness the spike should evaluate.
+- "Delete the empty `else`" would leave `if ENV["PRO"] then gem_pro end`, which
+  changes the user's runtime behavior: before, _some_ gem was always installed;
+  after, the gem is conditional on `ENV["PRO"]` being set. This is a silent
+  semantic change and the worst option.
+- Collapse preserves the original semantic ("install one specific gem") with the
+  same conditionality the user had (none).
+
+**Edge cases the prototype does _not_ collapse** (and leaves the empty branch in
+place):
+
+- If the surviving branch has multiple statements (the Pro gem plus other gems
+  or Bundler DSL calls), the conditional is left structurally intact.
+- If the empty branch is the `if`-branch (rare, would require an inverse setup
+  like `if ENV["BASE"] then gem_base else gem_pro end`), we leave it; rewriting
+  `if X; (empty); else BODY; end` into `unless X; BODY; end` is mechanically
+  fine but visually surprising. Out of scope for the spike.
+
+## Parse-failure policy
+
+**Chosen:** return the original Gemfile content untouched with `parse_failed: true`
+and the list of Prism errors. The calling generator should fall back to a clear
+manual-edit message ("we could not parse your Gemfile; please update it manually").
+
+Why not fall back to the current scanner: it would silently re-introduce the exact
+class of edge-case bugs Prism was supposed to remove. Either we trust the parser or
+we don't.
+
+Verified against a deliberately malformed Gemfile in the spec
+(`returns the original content untouched when Gemfile cannot be parsed`). Prism's
+error-tolerant parsing means even quite broken Ruby may produce _some_ AST, but
+`Prism::ParseResult#failure?` is the boundary: if any errors are recorded, we
+treat the file as unmodifiable.
+
+## Compatibility notes
+
+| Ruby | Prism status                                          |
+| ---- | ----------------------------------------------------- |
+| 3.0  | gem only, MRI does not bundle                         |
+| 3.1  | gem only, MRI does not bundle                         |
+| 3.2  | gem only, MRI does not bundle                         |
+| 3.3+ | bundled with CRuby (the parser used by the VM itself) |
+
+`react_on_rails`'s gemspec currently sets `required_ruby_version >= 3.0.0`. Shipping
+Prism as a runtime dependency means:
+
+- Ruby 3.3+ users: no new install. Prism is already in their Ruby.
+- Ruby 3.0–3.2 users: adds one gem (`prism` ~250KB, native extension, builds in
+  seconds). No transitive dependencies.
+
+The prism gem itself is maintained by the Ruby core team, sees frequent releases,
+and the 1.x line has been stable since 2024.
+
+The issue notes that the `parser` gem (whitequark) is in soft deprecation and
+redirects users to `Prism::Translation::Parser`. Any new parser dependency
+should target Prism directly — confirmed.
+
+## Performance
+
+Measured on Ruby 3.4.8 / Prism 1.9.0 / Apple Silicon. 200 iterations per case, with
+3 warm-up iterations to avoid first-call overhead.
+
+| Gemfile                            | Scanner         | Prism           | Ratio |
+| ---------------------------------- | --------------- | --------------- | ----- |
+| Small (~10 lines, 1 ror entry)     | 0.012ms/rewrite | 0.015ms/rewrite | 1.25× |
+| Medium (~45 lines, groups)         | 0.040ms/rewrite | 0.048ms/rewrite | 1.20× |
+| Large (~300 lines, scaled fixture) | 0.285ms/rewrite | 0.304ms/rewrite | 1.07× |
+
+Both are sub-millisecond. The Pro generator runs `bundle install` immediately after
+the rewrite, which takes 5–60 seconds. **Parse-time cost is not a decision factor.**
+
+## Recommendation
+
+**Wait for the Ruby floor to rise to 3.3, then revisit.**
+
+Reasoning:
+
+1. **The current scanner works.** PR #3232 closed the open bugs. The test matrix
+   is comprehensive. CodeQL is happy. The empty-`else` case is the only known
+   residual, and it is **valid Ruby that produces a valid Bundler DSL** — only
+   ugly, not broken.
+2. **Migration code runs once per user.** A small ugliness left behind by the
+   rewrite that the user then commits to their repo is, at worst, a cleanup nit
+   the user can resolve in one minute. It does not regress on subsequent runs
+   because the base gem is gone.
+3. **Adding `prism` as a runtime dep for ~30% of users (Ruby 3.0–3.2) buys
+   migration-generator cleanup only.** No other path in `react_on_rails` would
+   benefit from a parser, and a single-purpose runtime dep is a smell.
+4. **When the Ruby floor moves to 3.3** (planned for the next major), Prism
+   becomes free and the recommendation flips: cut over to the Prism implementation,
+   delete the scanner.
+5. **Until then, the scanner is the right tool.** Pragmatic, tested, and gated
+   behind a generator that the user runs once.
+
+## What to do if/when this flips
+
+1. Move `prism_gemfile_rewriter.rb` into `lib/react_on_rails/pro_migration/prism_gemfile_rewriter.rb`.
+2. Add `spec.add_dependency "prism", "~> 1.0"` to `react_on_rails.gemspec`.
+3. Replace the `swap_base_gem_for_pro_in_gemfile` body in
+   `lib/generators/react_on_rails/pro_generator.rb` with a call to the Prism rewriter.
+4. Add a parse-failure UX path: when `result.parse_failed`, surface a clear
+   "please update your Gemfile manually" message with the prism error line numbers.
+5. Migrate the existing spec assertions to expect the Prism output (parens preserved
+   in `gem("…")` cases, empty-`else` collapsed).
+6. Delete `lib/react_on_rails/pro_migration.rb`'s scanner methods (keep the JS-side
+   constants).
+7. Run the spike spec under the production path to confirm parity.
+
+Approximate effort with the prototype as a starting point: 4–8 hours including
+review and spec migration.
+
+## Open questions left for the implementation PR (not this spike)
+
+- Should the generator output a `say` message when it collapses a conditional, so
+  the user understands the structural change to their Gemfile?
+- Should the empty-`if`-branch case (`if X; (empty); else BODY; end`) be rewritten
+  to `unless X; BODY; end`, or left alone? The prototype leaves it alone.
+- Is `Prism::Translation::Parser` a useful escape hatch for projects that already
+  depend on `parser`, or is the direct Prism API sufficient?

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/README.md
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/README.md
@@ -1,0 +1,28 @@
+# Spike: Prism-based Gemfile rewriter for Pro migration (#3313)
+
+Exploratory prototype evaluating whether a Prism AST-based Gemfile rewriter would
+reduce maintenance and static-analysis risk vs. the current text/scanner approach
+shipped in PR #3232.
+
+**This is not production code.** It is intentionally outside `lib/` to satisfy the
+"Do not rewrite #3232 as part of this spike" non-goal in
+[issue #3313](https://github.com/shakacode/react_on_rails/issues/3313).
+
+## Files
+
+- `prism_gemfile_rewriter.rb` — the prototype rewriter.
+- `prism_gemfile_rewriter_spec.rb` — drives the prototype through the behavior
+  matrix from issue #3313 and compares against the current scanner.
+- `benchmark.rb` — parse+rewrite perf comparison.
+
+## How to run
+
+```
+cd react_on_rails
+bundle exec rspec spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+bundle exec ruby spike/3313_prism_gemfile_rewriter/benchmark.rb
+```
+
+## Decision record
+
+See [`DECISION.md`](./DECISION.md).

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/README.md
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/README.md
@@ -23,6 +23,17 @@ bundle exec rspec spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.
 bundle exec ruby spike/3313_prism_gemfile_rewriter/benchmark.rb
 ```
 
+### `prism` dependency
+
+The prototype `require`s `prism`. On Ruby 3.3+ `prism` ships with the standard
+library, so nothing extra is needed. On Ruby 3.0–3.2 the spike currently relies
+on `prism` being present transitively through RuboCop-related dev dependencies
+in this monorepo's bundle — `bundle exec` works today, but a future RuboCop
+upgrade could drop that transitive dep. If a `LoadError` for `prism` appears,
+add `gem "prism"` to `react_on_rails/Gemfile.development_dependencies` (the
+spike is intentionally not promoting `prism` to a production runtime dep until
+the recommendation in [`DECISION.md`](./DECISION.md) is reconsidered).
+
 ## Decision record
 
 See [`DECISION.md`](./DECISION.md).

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/README.md
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/README.md
@@ -17,7 +17,7 @@ shipped in PR #3232.
 
 ## How to run
 
-```
+```bash
 cd react_on_rails
 bundle exec rspec spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
 bundle exec ruby spike/3313_prism_gemfile_rewriter/benchmark.rb

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb
@@ -134,10 +134,11 @@ puts "Ruby: #{RUBY_VERSION}, Prism: #{Prism::VERSION}\n\n"
 prism = ReactOnRails::Spike::PrismGemfileRewriter.new(default_pro_version: ScannerRewriter::PRO_VERSION)
 scanner = ScannerRewriter.new
 
-printf("%-50s %14s %14s %14s\n", "Gemfile", "scanner total", "prism total", "ratio")
-
-GEMFILES.each do |label, src|
-  # Warm up so we don't measure first-call overhead.
+# One measurement pass per fixture; we derive both the totals/ratio table and
+# the per-rewrite cost table from the same timings so the two views stay
+# consistent. Re-warming and re-measuring between tables (as we used to do)
+# introduced cross-table variance from JIT/cache state drift.
+results = GEMFILES.map do |label, src|
   WARMUP_ITERATIONS.times do
     scanner.rewrite(src)
     prism.rewrite(src)
@@ -145,27 +146,27 @@ GEMFILES.each do |label, src|
 
   scanner_seconds = measure(ITERATIONS) { scanner.rewrite(src) }
   prism_seconds = measure(ITERATIONS) { prism.rewrite(src) }
-  ratio = prism_seconds / scanner_seconds
+  {
+    label: "#{label} (#{src.lines.size}l)",
+    scanner_seconds: scanner_seconds,
+    prism_seconds: prism_seconds
+  }
+end
 
+printf("%-50s %14s %14s %14s\n", "Gemfile", "scanner total", "prism total", "ratio")
+results.each do |row|
   printf("%-50s %12.2fms %12.2fms %12.2fx\n",
-         "#{label} (#{src.lines.size}l)",
-         scanner_seconds * 1000,
-         prism_seconds * 1000,
-         ratio)
+         row[:label],
+         row[:scanner_seconds] * 1000,
+         row[:prism_seconds] * 1000,
+         row[:prism_seconds] / row[:scanner_seconds])
 end
 
 puts
 puts "Per-rewrite cost (scanner / prism):"
-GEMFILES.each do |label, src|
-  WARMUP_ITERATIONS.times do
-    scanner.rewrite(src)
-    prism.rewrite(src)
-  end
-
-  scanner_seconds = measure(ITERATIONS) { scanner.rewrite(src) }
-  prism_seconds = measure(ITERATIONS) { prism.rewrite(src) }
+results.each do |row|
   printf("  %-50s %8.3fms / %8.3fms\n",
-         "#{label} (#{src.lines.size}l)",
-         (scanner_seconds / ITERATIONS) * 1000,
-         (prism_seconds / ITERATIONS) * 1000)
+         row[:label],
+         (row[:scanner_seconds] / ITERATIONS) * 1000,
+         (row[:prism_seconds] / ITERATIONS) * 1000)
 end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb
@@ -92,15 +92,25 @@ GEMFILES = {
   RUBY
   "medium (80 lines, 1 ror entry, groups)" => begin
     body = +"source \"https://rubygems.org\"\n"
-    %w[rails puma sprockets-rails importmap-rails turbo-rails stimulus-rails jbuilder bcrypt bootsnap kredis].each do |g|
+    base_gems = %w[
+      rails puma sprockets-rails importmap-rails turbo-rails stimulus-rails
+      jbuilder bcrypt bootsnap kredis
+    ]
+    base_gems.each do |g|
       body << "gem \"#{g}\"\n"
     end
     body << "gem \"react_on_rails\", \"~> 16.0\"\n"
-    %w[pg redis sidekiq devise pundit kaminari rack-cors dotenv-rails].each { |g| body << "gem \"#{g}\"\n" }
+    %w[pg redis sidekiq devise pundit kaminari rack-cors dotenv-rails].each do |g|
+      body << "gem \"#{g}\"\n"
+    end
     body << "\ngroup :development, :test do\n"
-    %w[rspec-rails factory_bot_rails faker pry-rails pry-byebug debug].each { |g| body << "  gem \"#{g}\"\n" }
+    %w[rspec-rails factory_bot_rails faker pry-rails pry-byebug debug].each do |g|
+      body << "  gem \"#{g}\"\n"
+    end
     body << "end\n\ngroup :development do\n"
-    %w[web-console listen spring spring-watcher-listen rubocop rubocop-rails].each { |g| body << "  gem \"#{g}\"\n" }
+    %w[web-console listen spring spring-watcher-listen rubocop rubocop-rails].each do |g|
+      body << "  gem \"#{g}\"\n"
+    end
     body << "end\n\ngroup :test do\n"
     %w[capybara selenium-webdriver webdrivers shoulda-matchers].each { |g| body << "  gem \"#{g}\"\n" }
     body << "end\n"
@@ -116,6 +126,7 @@ GEMFILES = {
 }.freeze
 
 ITERATIONS = 200
+WARMUP_ITERATIONS = 3
 
 puts "Prism vs. scanner Gemfile rewrite benchmark (#{ITERATIONS} iterations per case)\n\n"
 puts "Ruby: #{RUBY_VERSION}, Prism: #{Prism::VERSION}\n\n"
@@ -127,7 +138,7 @@ printf("%-50s %14s %14s %14s\n", "Gemfile", "scanner total", "prism total", "rat
 
 GEMFILES.each do |label, src|
   # Warm up so we don't measure first-call overhead.
-  3.times do
+  WARMUP_ITERATIONS.times do
     scanner.rewrite(src)
     prism.rewrite(src)
   end
@@ -146,6 +157,11 @@ end
 puts
 puts "Per-rewrite cost (scanner / prism):"
 GEMFILES.each do |label, src|
+  WARMUP_ITERATIONS.times do
+    scanner.rewrite(src)
+    prism.rewrite(src)
+  end
+
   scanner_seconds = measure(ITERATIONS) { scanner.rewrite(src) }
   prism_seconds = measure(ITERATIONS) { prism.rewrite(src) }
   printf("  %-50s %8.3fms / %8.3fms\n",

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Spike benchmark for issue #3313.
+#
+# Compares parse + rewrite time of the Prism prototype against the current
+# scanner from lib/react_on_rails/pro_migration.rb on representative Gemfile sizes.
+#
+# Run with:
+#   bundle exec ruby spike/3313_prism_gemfile_rewriter/benchmark.rb
+
+$LOAD_PATH.unshift(File.expand_path(__dir__))
+$LOAD_PATH.unshift(File.expand_path("../../lib", __dir__))
+
+require "prism_gemfile_rewriter"
+require "react_on_rails/pro_migration"
+
+def measure(iterations)
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  iterations.times { yield }
+  finish = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  finish - start
+end
+
+# Approximates what swap_base_gem_for_pro_in_gemfile does, isolated from the generator
+# so we can time the rewrite path without Thor / Bundler overhead.
+class ScannerRewriter
+  PRO_VERSION = "~> 16.7"
+
+  def rewrite(source)
+    has_pro_gem = ReactOnRails::ProMigration.pro_gem_entry?(source)
+    lines = source.lines
+    updated = []
+    base_found = false
+    line_index = 0
+
+    while line_index < lines.length
+      line = lines[line_index]
+      base_decl = ReactOnRails::ProMigration.base_gem_declaration_at(lines, line_index)
+
+      unless base_decl
+        updated << line
+        line_index += 1
+        next
+      end
+
+      base_found = true
+      unless has_pro_gem
+        updated << build_replacement(base_decl)
+      end
+      line_index = base_decl[:next_index]
+    end
+
+    [updated.join, base_found]
+  end
+
+  private
+
+  def build_replacement(base_decl)
+    indentation = base_decl[:indentation]
+    quote = base_decl[:quote]
+    suffix = base_decl[:trailing_suffix] || "\n"
+    suffix += "\n" unless suffix.end_with?("\n")
+    has_pin = suffix.match?(/\A\s*,\s*(?:#[^\n]*\n\s*)*["']/)
+    version_arg = has_pin ? "" : ", #{quote}#{PRO_VERSION}#{quote}"
+
+    if base_decl[:parenthesized_gem_call]
+      suffix = strip_close_paren(suffix)
+    end
+    suffix = "\n" if suffix.match?(/\A,\s*\n\z/)
+    "#{indentation}gem #{quote}react_on_rails_pro#{quote}#{version_arg}#{suffix}"
+  end
+
+  def strip_close_paren(suffix)
+    # Simplified: drop the first `)` we see; not equivalent to the production code,
+    # but adequate for benchmarking on inputs that do not stress this path.
+    suffix.sub(/\)/, "").gsub(/\n\s*\n/, "\n")
+  end
+end
+
+GEMFILES = {
+  "small (10 lines, 1 ror entry)" => <<~RUBY,
+    source "https://rubygems.org"
+    gem "rails", "~> 7.1"
+    gem "puma"
+    gem "react_on_rails", "~> 16.0"
+    gem "sprockets-rails"
+    gem "importmap-rails"
+    gem "turbo-rails"
+    gem "stimulus-rails"
+    gem "jbuilder"
+    gem "bcrypt"
+  RUBY
+  "medium (80 lines, 1 ror entry, groups)" => begin
+    body = +"source \"https://rubygems.org\"\n"
+    %w[rails puma sprockets-rails importmap-rails turbo-rails stimulus-rails jbuilder bcrypt bootsnap kredis].each do |g|
+      body << "gem \"#{g}\"\n"
+    end
+    body << "gem \"react_on_rails\", \"~> 16.0\"\n"
+    %w[pg redis sidekiq devise pundit kaminari rack-cors dotenv-rails].each { |g| body << "gem \"#{g}\"\n" }
+    body << "\ngroup :development, :test do\n"
+    %w[rspec-rails factory_bot_rails faker pry-rails pry-byebug debug].each { |g| body << "  gem \"#{g}\"\n" }
+    body << "end\n\ngroup :development do\n"
+    %w[web-console listen spring spring-watcher-listen rubocop rubocop-rails].each { |g| body << "  gem \"#{g}\"\n" }
+    body << "end\n\ngroup :test do\n"
+    %w[capybara selenium-webdriver webdrivers shoulda-matchers].each { |g| body << "  gem \"#{g}\"\n" }
+    body << "end\n"
+    body
+  end,
+  "large (~300 lines, scaled fixture)" => begin
+    body = +"source \"https://rubygems.org\"\n"
+    250.times { |i| body << "gem \"library_#{i}\"\n" }
+    body << "gem \"react_on_rails\", \"~> 16.0\"\n"
+    50.times { |i| body << "gem \"util_#{i}\"\n" }
+    body
+  end
+}.freeze
+
+ITERATIONS = 200
+
+puts "Prism vs. scanner Gemfile rewrite benchmark (#{ITERATIONS} iterations per case)\n\n"
+puts "Ruby: #{RUBY_VERSION}, Prism: #{Prism::VERSION}\n\n"
+
+prism = ReactOnRails::Spike::PrismGemfileRewriter.new(default_pro_version: ScannerRewriter::PRO_VERSION)
+scanner = ScannerRewriter.new
+
+printf("%-50s %14s %14s %14s\n", "Gemfile", "scanner total", "prism total", "ratio")
+
+GEMFILES.each do |label, src|
+  # Warm up so we don't measure first-call overhead.
+  3.times do
+    scanner.rewrite(src)
+    prism.rewrite(src)
+  end
+
+  scanner_seconds = measure(ITERATIONS) { scanner.rewrite(src) }
+  prism_seconds = measure(ITERATIONS) { prism.rewrite(src) }
+  ratio = prism_seconds / scanner_seconds
+
+  printf("%-50s %12.2fms %12.2fms %12.2fx\n",
+         "#{label} (#{src.lines.size}l)",
+         scanner_seconds * 1000,
+         prism_seconds * 1000,
+         ratio)
+end
+
+puts
+puts "Per-rewrite cost (scanner / prism):"
+GEMFILES.each do |label, src|
+  scanner_seconds = measure(ITERATIONS) { scanner.rewrite(src) }
+  prism_seconds = measure(ITERATIONS) { prism.rewrite(src) }
+  printf("  %-50s %8.3fms / %8.3fms\n",
+         "#{label} (#{src.lines.size}l)",
+         (scanner_seconds / ITERATIONS) * 1000,
+         (prism_seconds / ITERATIONS) * 1000)
+end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -55,7 +55,8 @@ module ReactOnRails
         program = parse_result.value
         base_calls = []
         pro_calls = []
-        collect_gem_calls(program, base_calls, pro_calls)
+        parent_map = {}
+        collect_gem_calls(program, base_calls, pro_calls, parent_map)
 
         if base_calls.empty?
           return Result.new(
@@ -70,7 +71,7 @@ module ReactOnRails
         preexisting_empty_ranges = has_active_pro ? empty_conditional_ranges(program) : []
         edits = base_calls.map do |call|
           if has_active_pro
-            removal_edit(source, call)
+            removal_edit(source, call, parent_map)
           else
             replacement_edit(source, call)
           end
@@ -96,7 +97,7 @@ module ReactOnRails
 
       attr_reader :default_pro_version
 
-      def collect_gem_calls(node, base_calls, pro_calls)
+      def collect_gem_calls(node, base_calls, pro_calls, parent_map)
         return unless node
 
         if gem_call?(node)
@@ -108,7 +109,8 @@ module ReactOnRails
         end
 
         node.compact_child_nodes.each do |child|
-          collect_gem_calls(child, base_calls, pro_calls)
+          parent_map[child] = node
+          collect_gem_calls(child, base_calls, pro_calls, parent_map)
         end
       end
 
@@ -146,17 +148,23 @@ module ReactOnRails
       end
 
       def has_user_version_pin?(call)
-        positional_args = call.arguments.arguments.drop(1).reject { |a| a.is_a?(Prism::KeywordHashNode) }
+        positional_args = call.arguments.arguments.drop(1).reject { |a| option_hash?(a) }
         positional_args.any? || source_option_present?(call)
       end
 
       def source_option_present?(call)
-        keyword_hashes = call.arguments.arguments.select { |a| a.is_a?(Prism::KeywordHashNode) }
-        keyword_hashes.any? do |keyword_hash|
-          keyword_hash.elements.any? do |element|
-            element.key.is_a?(Prism::SymbolNode) && SOURCE_OPTION_KEYS.include?(element.key.unescaped)
+        option_hashes = call.arguments.arguments.select { |a| option_hash?(a) }
+        option_hashes.any? do |option_hash|
+          option_hash.elements.any? do |element|
+            element.respond_to?(:key) &&
+              element.key.is_a?(Prism::SymbolNode) &&
+              SOURCE_OPTION_KEYS.include?(element.key.unescaped)
           end
         end
+      end
+
+      def option_hash?(node)
+        node.is_a?(Prism::KeywordHashNode) || node.is_a?(Prism::HashNode)
       end
 
       def quote_char(source, string_node)
@@ -166,12 +174,36 @@ module ReactOnRails
         '"'
       end
 
-      def removal_edit(source, call)
+      def removal_edit(source, call, parent_map)
         # Remove only this gem statement. If it is the only statement on a line,
         # remove the whole line; if it shares a line via semicolons, preserve the
         # neighboring statements.
-        start_offset, end_offset = statement_byte_range(source, call)
+        node = removable_statement_node(call, parent_map)
+        start_offset, end_offset = statement_byte_range(source, node)
         { start_offset: start_offset, end_offset: end_offset, replacement: "" }
+      end
+
+      def removable_statement_node(call, parent_map)
+        statements = parent_map[call]
+        return call unless statements.is_a?(Prism::StatementsNode)
+        return call unless statements.body.one?
+
+        parent = parent_map[statements]
+        return call unless parent.is_a?(Prism::IfNode) || parent.is_a?(Prism::UnlessNode)
+        return call if parent.end_keyword_loc
+
+        keyword_loc = conditional_keyword_loc(parent)
+        return call unless keyword_loc && keyword_loc.start_offset > call.location.end_offset
+
+        parent
+      end
+
+      def conditional_keyword_loc(node)
+        if node.is_a?(Prism::IfNode)
+          node.if_keyword_loc
+        elsif node.is_a?(Prism::UnlessNode)
+          node.keyword_loc
+        end
       end
 
       def statement_byte_range(source, node)

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -15,6 +15,10 @@ module ReactOnRails
       PRO_GEM_NAME = "react_on_rails_pro"
       NEWLINE_BYTE = "\n".ord
       SEMICOLON_BYTE = ";".ord
+      COMMENT_BYTE = "#".ord
+      BACKSLASH_BYTE = "\\".ord
+      DOUBLE_QUOTE_BYTE = '"'.ord
+      SINGLE_QUOTE_BYTE = "'".ord
       SOURCE_OPTION_KEYS = %w[git github path].freeze
 
       Result = Struct.new(
@@ -55,8 +59,8 @@ module ReactOnRails
         end
 
         has_active_pro = pro_calls.any?
-        preexisting_empty_conditional_fingerprints =
-          has_active_pro ? empty_conditional_fingerprints(source, program) : []
+        preexisting_empty_counts =
+          has_active_pro ? empty_conditional_fingerprints(source, program).tally : {}
         edits = base_calls.map do |call|
           if has_active_pro
             removal_edit(source, call)
@@ -69,7 +73,7 @@ module ReactOnRails
         if has_active_pro
           new_source = collapse_dead_conditionals(
             new_source,
-            preexisting_empty_conditional_fingerprints
+            preexisting_empty_counts
           )
         end
 
@@ -166,20 +170,19 @@ module ReactOnRails
       def statement_byte_range(source, node)
         line_start = line_start_offset(source, node.location.start_offset)
         line_end = line_end_offset(source, node.location.end_offset)
-        statement_end = node.location.end_offset
-
-        while statement_end < line_end
-          byte = source.getbyte(statement_end)
-          break if byte == NEWLINE_BYTE || byte == SEMICOLON_BYTE
-
-          statement_end += 1
-        end
+        next_semicolon = next_semicolon_offset(
+          source,
+          line_start_offset(source, node.location.end_offset),
+          line_end,
+          node.location.end_offset
+        )
+        statement_end = next_semicolon || line_terminator_offset(source, line_end)
 
         previous_semicolon = previous_semicolon_offset(source, line_start, node.location.start_offset)
         if previous_semicolon
           [previous_semicolon, statement_end]
-        elsif statement_end < line_end && source.getbyte(statement_end) == SEMICOLON_BYTE
-          end_offset = statement_end + 1
+        elsif next_semicolon
+          end_offset = next_semicolon + 1
           end_offset += 1 while end_offset < line_end && horizontal_space?(source.getbyte(end_offset))
           [line_start, end_offset]
         else
@@ -188,14 +191,44 @@ module ReactOnRails
       end
 
       def previous_semicolon_offset(source, line_start, statement_start)
-        scan = statement_start - 1
-        while scan >= line_start
-          return scan if source.getbyte(scan) == SEMICOLON_BYTE
+        statement_separator_offsets(source, line_start, statement_start).last
+      end
 
-          scan -= 1
+      def next_semicolon_offset(source, line_start, line_end, statement_end)
+        statement_separator_offsets(source, line_start, line_end).find { |offset| offset >= statement_end }
+      end
+
+      def statement_separator_offsets(source, line_start, line_end)
+        offsets = []
+        quote_byte = nil
+        scan = line_start
+
+        while scan < line_end
+          byte = source.getbyte(scan)
+          break if byte == NEWLINE_BYTE || (!quote_byte && byte == COMMENT_BYTE)
+
+          if quote_byte
+            if byte == BACKSLASH_BYTE
+              scan += 2
+              next
+            end
+
+            quote_byte = nil if byte == quote_byte
+          elsif byte == DOUBLE_QUOTE_BYTE || byte == SINGLE_QUOTE_BYTE
+            quote_byte = byte
+          elsif byte == SEMICOLON_BYTE
+            offsets << scan
+          end
+
+          scan += 1
         end
 
-        nil
+        offsets
+      end
+
+      def line_terminator_offset(source, line_end)
+        newline_offset = line_end - 1
+        newline_offset >= 0 && source.getbyte(newline_offset) == NEWLINE_BYTE ? newline_offset : line_end
       end
 
       def horizontal_space?(byte)
@@ -239,35 +272,61 @@ module ReactOnRails
       #   variants; after migration there is only one variant, so the conditional has
       #   no remaining purpose).
       # - Otherwise, if a branch is empty, only that branch is removed.
-      def collapse_dead_conditionals(source, preexisting_empty_conditional_fingerprints)
+      def collapse_dead_conditionals(source, preexisting_empty_counts)
         loop do
           parse_result = Prism.parse(source)
           break source if parse_result.failure?
 
-          edit = find_collapse_edit(source, parse_result.value, preexisting_empty_conditional_fingerprints)
+          seen_empty_conditional_fingerprints = Hash.new(0)
+          edit = find_collapse_edit(
+            source,
+            parse_result.value,
+            preexisting_empty_counts,
+            seen_empty_conditional_fingerprints
+          )
           break source unless edit
 
           source = splice_source(source, edit[:start_offset], edit[:end_offset], edit[:replacement])
         end
       end
 
-      def find_collapse_edit(source, node, preexisting_empty_conditional_fingerprints)
+      def find_collapse_edit(
+        source,
+        node,
+        preexisting_empty_counts,
+        seen_empty_conditional_fingerprints
+      )
         return nil unless node
 
         if node.is_a?(Prism::IfNode) || node.is_a?(Prism::UnlessNode)
-          edit = collapse_edit_for_conditional(source, node, preexisting_empty_conditional_fingerprints)
+          edit = collapse_edit_for_conditional(
+            source,
+            node,
+            preexisting_empty_counts,
+            seen_empty_conditional_fingerprints
+          )
           return edit if edit
         end
 
         node.compact_child_nodes.each do |child|
-          edit = find_collapse_edit(source, child, preexisting_empty_conditional_fingerprints)
+          edit = find_collapse_edit(
+            source,
+            child,
+            preexisting_empty_counts,
+            seen_empty_conditional_fingerprints
+          )
           return edit if edit
         end
 
         nil
       end
 
-      def collapse_edit_for_conditional(source, node, preexisting_empty_conditional_fingerprints)
+      def collapse_edit_for_conditional(
+        source,
+        node,
+        preexisting_empty_counts,
+        seen_empty_conditional_fingerprints
+      )
         # Postfix modifiers and ternary-style conditionals have node.end_keyword_loc == nil.
         # Only block-form `if/unless ... end` is considered for collapse.
         return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
@@ -281,7 +340,11 @@ module ReactOnRails
         else_empty = has_else_node && branch_empty?(else_statements)
 
         fingerprint = conditional_empty_branch_fingerprint(source, node)
-        return nil if preexisting_empty_conditional_fingerprints.include?(fingerprint)
+        if fingerprint
+          seen_empty_conditional_fingerprints[fingerprint] += 1
+          return nil if seen_empty_conditional_fingerprints[fingerprint] <=
+                        preexisting_empty_counts[fingerprint].to_i
+        end
 
         if then_empty && has_else_node && !else_empty
           collapse_to_branch(source, node, else_statements) || remove_empty_then_branch(source, node)
@@ -360,11 +423,33 @@ module ReactOnRails
         gem_text = byte_slice(source, gem_call.location.start_offset, gem_call.location.end_offset)
         # Preserve indentation of the original conditional.
         indent = leading_indentation(source, conditional.location.start_offset)
-        {
-          start_offset: line_start_offset(source, conditional.location.start_offset),
-          end_offset: line_end_offset(source, conditional.location.end_offset),
-          replacement: "#{indent}#{gem_text}\n"
-        }
+        collapse_replacement_edit(source, conditional, "#{indent}#{gem_text}\n", gem_text)
+      end
+
+      def collapse_replacement_edit(source, conditional, full_line_replacement, inline_replacement)
+        line_start = line_start_offset(source, conditional.location.start_offset)
+        line_end = line_end_offset(source, conditional.location.end_offset)
+        next_semicolon = next_semicolon_offset(
+          source,
+          line_start_offset(source, conditional.location.end_offset),
+          line_end,
+          conditional.location.end_offset
+        )
+        previous_semicolon = previous_semicolon_offset(source, line_start, conditional.location.start_offset)
+
+        if previous_semicolon || next_semicolon
+          {
+            start_offset: conditional.location.start_offset,
+            end_offset: conditional.location.end_offset,
+            replacement: inline_replacement
+          }
+        else
+          {
+            start_offset: line_start,
+            end_offset: line_end,
+            replacement: full_line_replacement
+          }
+        end
       end
 
       def single_pro_gem_call?(statements_node)

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module ReactOnRails
+  module Spike
+    # Prism-based prototype for the Pro migration Gemfile rewrite.
+    # See spike/3313_prism_gemfile_rewriter/README.md and DECISION.md.
+    #
+    # Approach: parse with Prism, locate `gem` call nodes whose first argument is the
+    # string literal `react_on_rails`, then apply location-based source edits.
+    # Untouched bytes are preserved by construction.
+    class PrismGemfileRewriter
+      BASE_GEM_NAME = "react_on_rails"
+      PRO_GEM_NAME = "react_on_rails_pro"
+
+      Result = Struct.new(
+        :content,
+        :base_entries_removed,
+        :parse_failed,
+        :errors,
+        keyword_init: true
+      )
+
+      def initialize(default_pro_version:)
+        @default_pro_version = default_pro_version
+      end
+
+      def rewrite(source)
+        parse_result = Prism.parse(source)
+        if parse_result.failure?
+          return Result.new(
+            content: source,
+            base_entries_removed: false,
+            parse_failed: true,
+            errors: parse_result.errors.map { |e| "#{e.location.start_line}: #{e.message}" }
+          )
+        end
+
+        program = parse_result.value
+        base_calls = []
+        pro_calls = []
+        collect_gem_calls(program, base_calls, pro_calls)
+
+        if base_calls.empty?
+          return Result.new(
+            content: source,
+            base_entries_removed: false,
+            parse_failed: false,
+            errors: []
+          )
+        end
+
+        has_active_pro = pro_calls.any?
+        edits = base_calls.map do |call|
+          if has_active_pro
+            removal_edit(source, call)
+          else
+            replacement_edit(source, call)
+          end
+        end
+
+        new_source = apply_edits(source, edits)
+        new_source = collapse_dead_conditionals(new_source) if has_active_pro
+
+        Result.new(
+          content: new_source,
+          base_entries_removed: has_active_pro,
+          parse_failed: false,
+          errors: []
+        )
+      end
+
+      private
+
+      attr_reader :default_pro_version
+
+      def collect_gem_calls(node, base_calls, pro_calls)
+        return unless node
+
+        if gem_call?(node)
+          name = gem_call_first_argument_name(node)
+          case name
+          when BASE_GEM_NAME then base_calls << node
+          when PRO_GEM_NAME then pro_calls << node
+          end
+        end
+
+        node.compact_child_nodes.each do |child|
+          collect_gem_calls(child, base_calls, pro_calls)
+        end
+      end
+
+      def gem_call?(node)
+        node.is_a?(Prism::CallNode) && node.name == :gem && node.receiver.nil?
+      end
+
+      def gem_call_first_argument_name(node)
+        first_arg = node.arguments&.arguments&.first
+        return nil unless first_arg.is_a?(Prism::StringNode)
+
+        first_arg.unescaped
+      end
+
+      def replacement_edit(source, call)
+        first_arg = call.arguments.arguments.first
+        quote = quote_char(source, first_arg)
+        new_name_literal = "#{quote}#{PRO_GEM_NAME}#{quote}"
+
+        if has_user_version_pin?(call)
+          {
+            start_offset: first_arg.location.start_offset,
+            end_offset: first_arg.location.end_offset,
+            replacement: new_name_literal
+          }
+        else
+          # No user version pin: insert the default version as the second positional argument.
+          # We splice it after the name literal so any kwargs (path:, git:, ...) remain in place.
+          {
+            start_offset: first_arg.location.start_offset,
+            end_offset: first_arg.location.end_offset,
+            replacement: "#{new_name_literal}, #{quote}#{default_pro_version}#{quote}"
+          }
+        end
+      end
+
+      def has_user_version_pin?(call)
+        positional_args = call.arguments.arguments.drop(1).reject { |a| a.is_a?(Prism::KeywordHashNode) }
+        positional_args.any? { |a| a.is_a?(Prism::StringNode) }
+      end
+
+      def quote_char(source, string_node)
+        source[string_node.location.start_offset]
+      end
+
+      def removal_edit(source, call)
+        # Remove the entire statement containing the gem call, including any postfix
+        # modifier (`if`, `unless`, `while`, `until`) and the trailing newline. The
+        # statement may be wrapped in an `IfNode` / `UnlessNode` when there is a
+        # postfix modifier, so we walk outward until we find the enclosing
+        # statement-level node.
+        statement_node = enclosing_statement_node(call)
+        start_offset, end_offset = statement_byte_range(source, statement_node)
+        { start_offset: start_offset, end_offset: end_offset, replacement: "" }
+      end
+
+      # When Prism parses `gem "foo" if cond`, the outermost node is `IfNode`, not the
+      # `CallNode`. We treat the postfix-modifier node as the statement to remove.
+      def enclosing_statement_node(call)
+        # We do not have an explicit parent pointer; the caller passes the CallNode, so
+        # we need to detect a postfix modifier by looking at the source slice. Prism's
+        # location for the CallNode does NOT include the modifier, so we re-locate by
+        # inspecting the source after the call's end_offset.
+        call
+      end
+
+      def statement_byte_range(source, node)
+        start_offset = line_start_offset(source, node.location.start_offset)
+
+        # Walk forward from the node's end_offset to the end of the source line so that
+        # we also delete trailing modifier text (e.g. `if ENV["X"]`) and the newline.
+        scan = node.location.end_offset
+        scan += 1 while scan < source.length && source[scan] != "\n"
+        scan += 1 if scan < source.length && source[scan] == "\n"
+        [start_offset, scan]
+      end
+
+      def apply_edits(source, edits)
+        sorted = edits.sort_by { |e| -e[:start_offset] }
+        sorted.reduce(source) do |acc, edit|
+          acc[0...edit[:start_offset]] + edit[:replacement] + acc[edit[:end_offset]..]
+        end
+      end
+
+      # After removing base gem statements, conditionals like
+      #   if ENV["PRO"]
+      #     gem "react_on_rails_pro", "16.0.0"
+      #   else
+      #     gem "react_on_rails", "16.0.0"
+      #   end
+      # become
+      #   if ENV["PRO"]
+      #     gem "react_on_rails_pro", "16.0.0"
+      #   else
+      #   end
+      # which is valid but ugly. This pass collapses such conditionals.
+      #
+      # Policy:
+      # - If the conditional has exactly one non-empty branch and that branch contains
+      #   only `gem "react_on_rails_pro"`, the conditional is collapsed to that single
+      #   gem declaration (the conditional's original purpose was to pick between gem
+      #   variants; after migration there is only one variant, so the conditional has
+      #   no remaining purpose).
+      # - Otherwise, if a branch is empty, only that branch is removed.
+      def collapse_dead_conditionals(source)
+        loop do
+          parse_result = Prism.parse(source)
+          break source if parse_result.failure?
+
+          edit = find_collapse_edit(source, parse_result.value)
+          break source unless edit
+
+          source = source[0...edit[:start_offset]] + edit[:replacement] + source[edit[:end_offset]..]
+        end
+      end
+
+      def find_collapse_edit(source, node)
+        return nil unless node
+
+        if node.is_a?(Prism::IfNode) || node.is_a?(Prism::UnlessNode)
+          edit = collapse_edit_for_conditional(source, node)
+          return edit if edit
+        end
+
+        node.compact_child_nodes.each do |child|
+          edit = find_collapse_edit(source, child)
+          return edit if edit
+        end
+
+        nil
+      end
+
+      def collapse_edit_for_conditional(source, node)
+        # Postfix modifiers and ternary-style conditionals have node.end_keyword_loc == nil.
+        # Only block-form `if/unless ... end` is considered for collapse.
+        return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
+
+        then_branch = node.statements
+        has_else_node = node.subsequent.is_a?(Prism::ElseNode)
+        else_statements = has_else_node ? node.subsequent.statements : nil
+
+        then_empty = branch_empty?(then_branch)
+        else_empty = has_else_node && branch_empty?(else_statements)
+
+        if then_empty && has_else_node && !else_empty
+          collapse_to_branch(source, node, else_statements) || remove_empty_then_branch(source, node)
+        elsif has_else_node && else_empty && !then_empty
+          collapse_to_branch(source, node, then_branch) || remove_empty_else_branch(source, node)
+        end
+      end
+
+      def branch_empty?(statements_node)
+        return true if statements_node.nil?
+        return true unless statements_node.respond_to?(:body)
+
+        statements_node.body.empty?
+      end
+
+      def collapse_to_branch(source, conditional, branch_statements)
+        return nil unless single_pro_gem_call?(branch_statements)
+
+        gem_call = branch_statements.body.first
+        gem_text = source[gem_call.location.start_offset...gem_call.location.end_offset]
+        # Preserve indentation of the original conditional.
+        indent = leading_indentation(source, conditional.location.start_offset)
+        {
+          start_offset: line_start_offset(source, conditional.location.start_offset),
+          end_offset: line_end_offset(source, conditional.location.end_offset),
+          replacement: "#{indent}#{gem_text}\n"
+        }
+      end
+
+      def single_pro_gem_call?(statements_node)
+        return false if statements_node.nil?
+        return false unless statements_node.body.size == 1
+
+        call = statements_node.body.first
+        gem_call?(call) && gem_call_first_argument_name(call) == PRO_GEM_NAME
+      end
+
+      def remove_empty_else_branch(source, node)
+        # Find the `else` keyword location and remove from there to just before `end`.
+        return nil unless node.subsequent.is_a?(Prism::ElseNode)
+
+        else_loc = node.subsequent.else_keyword_loc
+        end_loc = node.end_keyword_loc
+        return nil unless else_loc && end_loc
+
+        # Remove the entire `else ... ` (including the line) up to the `end` keyword.
+        start_offset = line_start_offset(source, else_loc.start_offset)
+        end_offset = line_start_offset(source, end_loc.start_offset)
+        {
+          start_offset: start_offset,
+          end_offset: end_offset,
+          replacement: ""
+        }
+      end
+
+      def remove_empty_then_branch(_source, _node)
+        # `if X then (empty) else BODY end` → `unless X then BODY end`.
+        # That is fiddly and uncommon; for the spike we leave this case alone.
+        nil
+      end
+
+      def leading_indentation(source, offset)
+        line_start = line_start_offset(source, offset)
+        slice = source[line_start...offset]
+        slice[/\A\s*/].to_s
+      end
+
+      def line_start_offset(source, offset)
+        return 0 if offset.zero?
+
+        idx = source.rindex("\n", offset - 1)
+        idx ? idx + 1 : 0
+      end
+
+      def line_end_offset(source, offset)
+        idx = source.index("\n", offset)
+        idx ? idx + 1 : source.length
+      end
+    end
+  end
+end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -179,8 +179,50 @@ module ReactOnRails
         # remove the whole line; if it shares a line via semicolons, preserve the
         # neighboring statements.
         node = removable_statement_node(call, parent_map)
+
+        # Inline single-line block conditionals (`if X then gem "ror_pro" else gem "ror" end`)
+        # have no statement separators on the line, so the line-based fallback in
+        # `statement_byte_range` would delete the whole conditional — including the
+        # sibling Pro gem in the other branch. Remove only the call's own byte range;
+        # the collapse pass below tidies the resulting empty branch.
+        if node.equal?(call) && inline_conditional_with_sibling_branch?(call, parent_map)
+          return {
+            start_offset: call.location.start_offset,
+            end_offset: call.location.end_offset,
+            replacement: ""
+          }
+        end
+
         start_offset, end_offset = statement_byte_range(source, node)
         { start_offset: start_offset, end_offset: end_offset, replacement: "" }
+      end
+
+      def inline_conditional_with_sibling_branch?(call, parent_map)
+        statements = parent_map[call]
+        return false unless statements.is_a?(Prism::StatementsNode)
+
+        conditional = parent_map[statements]
+        # For the else-branch case the immediate parent is an ElseNode that
+        # itself sits inside the surrounding IfNode/UnlessNode.
+        conditional = parent_map[conditional] if conditional.is_a?(Prism::ElseNode)
+        return false unless conditional.is_a?(Prism::IfNode) || conditional.is_a?(Prism::UnlessNode)
+        return false unless conditional.respond_to?(:end_keyword_loc) && conditional.end_keyword_loc
+        return false unless conditional.location.start_line == conditional.location.end_line
+
+        sibling_branch_present?(conditional, statements)
+      end
+
+      def sibling_branch_present?(conditional, exclude_statements)
+        then_branch = conditional.statements
+        if then_branch && !then_branch.equal?(exclude_statements) && !branch_empty?(then_branch)
+          return true
+        end
+
+        else_node = conditional_else_node(conditional)
+        else_statements = else_node&.statements
+        !else_statements.nil? &&
+          !else_statements.equal?(exclude_statements) &&
+          !branch_empty?(else_statements)
       end
 
       def removable_statement_node(call, parent_map)
@@ -237,6 +279,11 @@ module ReactOnRails
         statement_separator_offsets(source, line_start, line_end).find { |offset| offset >= statement_end }
       end
 
+      # NOTE: tracks string and percent-literal contexts but does not track
+      # parenthesis depth. A semicolon inside an unquoted call argument
+      # (e.g. `gem "ror" if func(a; b)`) would be misidentified as a
+      # statement separator. Bundler's Gemfile DSL does not produce such
+      # patterns in practice; revisit if the rewriter moves outside Gemfiles.
       def statement_separator_offsets(source, line_start, line_end)
         offsets = []
         quote_byte = nil
@@ -361,21 +408,31 @@ module ReactOnRails
       #   variants; after migration there is only one variant, so the conditional has
       #   no remaining purpose).
       # - Otherwise, if a branch is empty, only that branch is removed.
+      # Safety bound: each iteration removes one collapsible conditional, so the
+      # editable-conditional count is monotonically decreasing. The explicit cap is
+      # belt-and-suspenders insurance against any future change that could let
+      # `find_collapse_edit` return a non-`nil` edit producing no net change.
+      MAX_COLLAPSE_PASSES = 100
+
       def collapse_dead_conditionals(source, preexisting_empty_ranges)
-        loop do
+        MAX_COLLAPSE_PASSES.times do
           parse_result = Prism.parse(source)
-          break source if parse_result.failure?
+          break if parse_result.failure?
 
           edit = find_collapse_edit(
             source,
             parse_result.value,
             preexisting_empty_ranges
           )
-          break source unless edit
+          break unless edit
+          # Defensive: a zero-length empty splice would be reapplied forever.
+          # Real collapse edits always remove or replace at least one byte.
+          break if edit[:start_offset] == edit[:end_offset] && edit[:replacement].empty?
 
           source = splice_source(source, edit[:start_offset], edit[:end_offset], edit[:replacement])
           preexisting_empty_ranges = adjust_ranges_after_edits(preexisting_empty_ranges, [edit])
         end
+        source
       end
 
       def find_collapse_edit(
@@ -424,6 +481,11 @@ module ReactOnRails
         then_empty = branch_empty?(then_branch)
         else_empty = has_else_node && branch_empty?(else_statements)
 
+        # NOTE: when `remove_empty_then_branch` is called the conditional cannot
+        # be collapsed to a single Pro gem (otherwise `collapse_to_branch` would
+        # have matched first). The stub returns `nil` for the spike, so the
+        # empty-`then` conditional is left in the output. See the stub itself
+        # for what production should do.
         if then_empty && has_else_node && !else_empty
           collapse_to_branch(source, node, else_statements) || remove_empty_then_branch(source, node)
         elsif has_else_node && else_empty && !then_empty
@@ -438,16 +500,20 @@ module ReactOnRails
         statements_node.body.empty?
       end
 
-      def empty_conditional_ranges(node, ranges = [])
-        return ranges unless node
+      def empty_conditional_ranges(node)
+        ranges = []
+        collect_empty_conditional_ranges(node, ranges)
+        ranges
+      end
+
+      def collect_empty_conditional_ranges(node, ranges)
+        return unless node
 
         ranges << [node.location.start_offset, node.location.end_offset] if empty_conditional?(node)
 
         node.compact_child_nodes.each do |child|
-          empty_conditional_ranges(child, ranges)
+          collect_empty_conditional_ranges(child, ranges)
         end
-
-        ranges
       end
 
       def empty_conditional?(node)
@@ -547,6 +613,12 @@ module ReactOnRails
         # Remove the entire `else ... ` (including the line) up to the `end` keyword.
         start_offset = line_start_offset(source, else_loc.start_offset)
         end_offset = line_start_offset(source, end_loc.start_offset)
+        # Inline conditionals like `if X; pro; else; end` put `else` and `end`
+        # on the same line, so both line-start lookups return the same offset.
+        # A zero-length empty splice is a no-op; refuse it to avoid leaving the
+        # collapse loop with nothing to do (the source is left unchanged).
+        return nil if start_offset == end_offset
+
         {
           start_offset: start_offset,
           end_offset: end_offset,

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -55,6 +55,8 @@ module ReactOnRails
         end
 
         has_active_pro = pro_calls.any?
+        preexisting_empty_conditional_fingerprints =
+          has_active_pro ? empty_conditional_fingerprints(source, program) : []
         edits = base_calls.map do |call|
           if has_active_pro
             removal_edit(source, call)
@@ -64,7 +66,12 @@ module ReactOnRails
         end
 
         new_source = apply_edits(source, edits)
-        new_source = collapse_dead_conditionals(new_source) if has_active_pro
+        if has_active_pro
+          new_source = collapse_dead_conditionals(
+            new_source,
+            preexisting_empty_conditional_fingerprints
+          )
+        end
 
         Result.new(
           content: new_source,
@@ -142,7 +149,10 @@ module ReactOnRails
       end
 
       def quote_char(source, string_node)
-        source.byteslice(string_node.location.start_offset, 1)
+        quote = source.byteslice(string_node.location.start_offset, 1)
+        return quote if quote == '"' || quote == "'"
+
+        '"'
       end
 
       def removal_edit(source, call)
@@ -229,35 +239,35 @@ module ReactOnRails
       #   variants; after migration there is only one variant, so the conditional has
       #   no remaining purpose).
       # - Otherwise, if a branch is empty, only that branch is removed.
-      def collapse_dead_conditionals(source)
+      def collapse_dead_conditionals(source, preexisting_empty_conditional_fingerprints)
         loop do
           parse_result = Prism.parse(source)
           break source if parse_result.failure?
 
-          edit = find_collapse_edit(source, parse_result.value)
+          edit = find_collapse_edit(source, parse_result.value, preexisting_empty_conditional_fingerprints)
           break source unless edit
 
           source = splice_source(source, edit[:start_offset], edit[:end_offset], edit[:replacement])
         end
       end
 
-      def find_collapse_edit(source, node)
+      def find_collapse_edit(source, node, preexisting_empty_conditional_fingerprints)
         return nil unless node
 
         if node.is_a?(Prism::IfNode) || node.is_a?(Prism::UnlessNode)
-          edit = collapse_edit_for_conditional(source, node)
+          edit = collapse_edit_for_conditional(source, node, preexisting_empty_conditional_fingerprints)
           return edit if edit
         end
 
         node.compact_child_nodes.each do |child|
-          edit = find_collapse_edit(source, child)
+          edit = find_collapse_edit(source, child, preexisting_empty_conditional_fingerprints)
           return edit if edit
         end
 
         nil
       end
 
-      def collapse_edit_for_conditional(source, node)
+      def collapse_edit_for_conditional(source, node, preexisting_empty_conditional_fingerprints)
         # Postfix modifiers and ternary-style conditionals have node.end_keyword_loc == nil.
         # Only block-form `if/unless ... end` is considered for collapse.
         return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
@@ -269,6 +279,9 @@ module ReactOnRails
 
         then_empty = branch_empty?(then_branch)
         else_empty = has_else_node && branch_empty?(else_statements)
+
+        fingerprint = conditional_empty_branch_fingerprint(source, node)
+        return nil if preexisting_empty_conditional_fingerprints.include?(fingerprint)
 
         if then_empty && has_else_node && !else_empty
           collapse_to_branch(source, node, else_statements) || remove_empty_then_branch(source, node)
@@ -282,6 +295,62 @@ module ReactOnRails
         return true unless statements_node.respond_to?(:body)
 
         statements_node.body.empty?
+      end
+
+      def empty_conditional_fingerprints(source, node, fingerprints = [])
+        return fingerprints unless node
+
+        if node.is_a?(Prism::IfNode) || node.is_a?(Prism::UnlessNode)
+          fingerprint = conditional_empty_branch_fingerprint(source, node)
+          fingerprints << fingerprint if fingerprint
+        end
+
+        node.compact_child_nodes.each do |child|
+          empty_conditional_fingerprints(source, child, fingerprints)
+        end
+
+        fingerprints
+      end
+
+      def conditional_empty_branch_fingerprint(source, node)
+        return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
+
+        then_branch = node.statements
+        else_node = conditional_else_node(node)
+        return nil unless else_node
+
+        else_statements = else_node.statements
+        then_empty = branch_empty?(then_branch)
+        else_empty = branch_empty?(else_statements)
+        return nil unless then_empty || else_empty
+
+        [
+          node.class.name,
+          predicate_fingerprint(source, node),
+          branch_fingerprint(source, then_branch),
+          branch_fingerprint(source, else_statements),
+          then_empty,
+          else_empty
+        ]
+      end
+
+      def predicate_fingerprint(source, node)
+        predicate = node.respond_to?(:predicate) ? node.predicate : nil
+        return "" unless predicate
+
+        byte_slice(source, predicate.location.start_offset, predicate.location.end_offset)
+      end
+
+      def branch_fingerprint(source, statements_node)
+        return [] if statements_node.nil?
+        return [] unless statements_node.respond_to?(:body)
+
+        statements_node.body.map do |child|
+          [
+            child.class.name,
+            byte_slice(source, child.location.start_offset, child.location.end_offset)
+          ]
+        end
       end
 
       def collapse_to_branch(source, conditional, branch_statements)

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -19,6 +19,14 @@ module ReactOnRails
       BACKSLASH_BYTE = "\\".ord
       DOUBLE_QUOTE_BYTE = '"'.ord
       SINGLE_QUOTE_BYTE = "'".ord
+      PERCENT_BYTE = "%".ord
+      PERCENT_LITERAL_TYPE_BYTES = "qQwWiIxrs".bytes.freeze
+      PERCENT_LITERAL_CLOSING_DELIMITERS = {
+        "(".ord => ")".ord,
+        "[".ord => "]".ord,
+        "{".ord => "}".ord,
+        "<".ord => ">".ord
+      }.freeze
       SOURCE_OPTION_KEYS = %w[git github path].freeze
 
       Result = Struct.new(
@@ -59,8 +67,7 @@ module ReactOnRails
         end
 
         has_active_pro = pro_calls.any?
-        preexisting_empty_counts =
-          has_active_pro ? empty_conditional_fingerprints(source, program).tally : {}
+        preexisting_empty_ranges = has_active_pro ? empty_conditional_ranges(program) : []
         edits = base_calls.map do |call|
           if has_active_pro
             removal_edit(source, call)
@@ -73,7 +80,7 @@ module ReactOnRails
         if has_active_pro
           new_source = collapse_dead_conditionals(
             new_source,
-            preexisting_empty_counts
+            adjust_ranges_after_edits(preexisting_empty_ranges, edits)
           )
         end
 
@@ -216,6 +223,12 @@ module ReactOnRails
             quote_byte = nil if byte == quote_byte
           elsif byte == DOUBLE_QUOTE_BYTE || byte == SINGLE_QUOTE_BYTE
             quote_byte = byte
+          elsif byte == PERCENT_BYTE
+            percent_literal_end = percent_literal_end_offset(source, scan, line_end)
+            if percent_literal_end
+              scan = percent_literal_end
+              next
+            end
           elsif byte == SEMICOLON_BYTE
             offsets << scan
           end
@@ -224,6 +237,50 @@ module ReactOnRails
         end
 
         offsets
+      end
+
+      def percent_literal_end_offset(source, start_offset, line_end)
+        delimiter_offset = start_offset + 1
+        type_or_delimiter = source.getbyte(delimiter_offset)
+        return nil unless type_or_delimiter
+
+        delimiter_offset += 1 if PERCENT_LITERAL_TYPE_BYTES.include?(type_or_delimiter)
+        delimiter = source.getbyte(delimiter_offset)
+        return nil unless percent_literal_delimiter?(delimiter)
+
+        closing_delimiter = PERCENT_LITERAL_CLOSING_DELIMITERS.fetch(delimiter, delimiter)
+        nesting = PERCENT_LITERAL_CLOSING_DELIMITERS.key?(delimiter) ? 1 : nil
+        scan = delimiter_offset + 1
+
+        while scan < line_end
+          byte = source.getbyte(scan)
+          if byte == BACKSLASH_BYTE
+            scan += 2
+            next
+          end
+
+          if nesting
+            nesting += 1 if byte == delimiter
+            nesting -= 1 if byte == closing_delimiter
+            return scan + 1 if nesting.zero?
+          elsif byte == closing_delimiter
+            return scan + 1
+          end
+
+          scan += 1
+        end
+
+        line_end
+      end
+
+      def percent_literal_delimiter?(byte)
+        byte && !horizontal_space?(byte) && byte != NEWLINE_BYTE && !ascii_alphanumeric?(byte)
+      end
+
+      def ascii_alphanumeric?(byte)
+        (byte >= "a".ord && byte <= "z".ord) ||
+          (byte >= "A".ord && byte <= "Z".ord) ||
+          (byte >= "0".ord && byte <= "9".ord)
       end
 
       def line_terminator_offset(source, line_end)
@@ -272,29 +329,27 @@ module ReactOnRails
       #   variants; after migration there is only one variant, so the conditional has
       #   no remaining purpose).
       # - Otherwise, if a branch is empty, only that branch is removed.
-      def collapse_dead_conditionals(source, preexisting_empty_counts)
+      def collapse_dead_conditionals(source, preexisting_empty_ranges)
         loop do
           parse_result = Prism.parse(source)
           break source if parse_result.failure?
 
-          seen_empty_conditional_fingerprints = Hash.new(0)
           edit = find_collapse_edit(
             source,
             parse_result.value,
-            preexisting_empty_counts,
-            seen_empty_conditional_fingerprints
+            preexisting_empty_ranges
           )
           break source unless edit
 
           source = splice_source(source, edit[:start_offset], edit[:end_offset], edit[:replacement])
+          preexisting_empty_ranges = adjust_ranges_after_edits(preexisting_empty_ranges, [edit])
         end
       end
 
       def find_collapse_edit(
         source,
         node,
-        preexisting_empty_counts,
-        seen_empty_conditional_fingerprints
+        preexisting_empty_ranges
       )
         return nil unless node
 
@@ -302,8 +357,7 @@ module ReactOnRails
           edit = collapse_edit_for_conditional(
             source,
             node,
-            preexisting_empty_counts,
-            seen_empty_conditional_fingerprints
+            preexisting_empty_ranges
           )
           return edit if edit
         end
@@ -312,8 +366,7 @@ module ReactOnRails
           edit = find_collapse_edit(
             source,
             child,
-            preexisting_empty_counts,
-            seen_empty_conditional_fingerprints
+            preexisting_empty_ranges
           )
           return edit if edit
         end
@@ -324,12 +377,12 @@ module ReactOnRails
       def collapse_edit_for_conditional(
         source,
         node,
-        preexisting_empty_counts,
-        seen_empty_conditional_fingerprints
+        preexisting_empty_ranges
       )
         # Postfix modifiers and ternary-style conditionals have node.end_keyword_loc == nil.
         # Only block-form `if/unless ... end` is considered for collapse.
         return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
+        return nil if preexisting_empty_ranges.include?([node.location.start_offset, node.location.end_offset])
 
         then_branch = node.statements
         else_node = conditional_else_node(node)
@@ -338,13 +391,6 @@ module ReactOnRails
 
         then_empty = branch_empty?(then_branch)
         else_empty = has_else_node && branch_empty?(else_statements)
-
-        fingerprint = conditional_empty_branch_fingerprint(source, node)
-        if fingerprint
-          seen_empty_conditional_fingerprints[fingerprint] += 1
-          return nil if seen_empty_conditional_fingerprints[fingerprint] <=
-                        preexisting_empty_counts[fingerprint].to_i
-        end
 
         if then_empty && has_else_node && !else_empty
           collapse_to_branch(source, node, else_statements) || remove_empty_then_branch(source, node)
@@ -360,60 +406,57 @@ module ReactOnRails
         statements_node.body.empty?
       end
 
-      def empty_conditional_fingerprints(source, node, fingerprints = [])
-        return fingerprints unless node
+      def empty_conditional_ranges(node, ranges = [])
+        return ranges unless node
 
-        if node.is_a?(Prism::IfNode) || node.is_a?(Prism::UnlessNode)
-          fingerprint = conditional_empty_branch_fingerprint(source, node)
-          fingerprints << fingerprint if fingerprint
-        end
+        ranges << [node.location.start_offset, node.location.end_offset] if empty_conditional?(node)
 
         node.compact_child_nodes.each do |child|
-          empty_conditional_fingerprints(source, child, fingerprints)
+          empty_conditional_ranges(child, ranges)
         end
 
-        fingerprints
+        ranges
       end
 
-      def conditional_empty_branch_fingerprint(source, node)
-        return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
+      def empty_conditional?(node)
+        return false unless node.is_a?(Prism::IfNode) || node.is_a?(Prism::UnlessNode)
+        return false unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
 
         then_branch = node.statements
         else_node = conditional_else_node(node)
-        return nil unless else_node
+        return false unless else_node
 
         else_statements = else_node.statements
-        then_empty = branch_empty?(then_branch)
-        else_empty = branch_empty?(else_statements)
-        return nil unless then_empty || else_empty
-
-        [
-          node.class.name,
-          predicate_fingerprint(source, node),
-          branch_fingerprint(source, then_branch),
-          branch_fingerprint(source, else_statements),
-          then_empty,
-          else_empty
-        ]
+        branch_empty?(then_branch) || branch_empty?(else_statements)
       end
 
-      def predicate_fingerprint(source, node)
-        predicate = node.respond_to?(:predicate) ? node.predicate : nil
-        return "" unless predicate
-
-        byte_slice(source, predicate.location.start_offset, predicate.location.end_offset)
+      def adjust_ranges_after_edits(ranges, edits)
+        sorted_edits = edits.sort_by { |edit| edit[:start_offset] }
+        ranges.filter_map { |range| adjust_range_after_edits(range, sorted_edits) }
       end
 
-      def branch_fingerprint(source, statements_node)
-        return [] if statements_node.nil?
-        return [] unless statements_node.respond_to?(:body)
+      def adjust_range_after_edits(range, edits)
+        original_start, original_end = range
+        prefix_delta = 0
+        inside_delta = 0
 
-        statements_node.body.map do |child|
-          [
-            child.class.name,
-            byte_slice(source, child.location.start_offset, child.location.end_offset)
-          ]
+        edits.each do |edit|
+          edit_start = edit[:start_offset]
+          edit_end = edit[:end_offset]
+          edit_delta = edit[:replacement].bytesize - (edit_end - edit_start)
+
+          if edit_end <= original_start
+            prefix_delta += edit_delta
+          elsif edit_start >= original_end
+            next
+          elsif edit_start >= original_start && edit_end <= original_end
+            inside_delta += edit_delta
+          else
+            return nil
+          end
         end
+
+        [original_start + prefix_delta, original_end + prefix_delta + inside_delta]
       end
 
       def collapse_to_branch(source, conditional, branch_statements)

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter.rb
@@ -13,6 +13,9 @@ module ReactOnRails
     class PrismGemfileRewriter
       BASE_GEM_NAME = "react_on_rails"
       PRO_GEM_NAME = "react_on_rails_pro"
+      NEWLINE_BYTE = "\n".ord
+      SEMICOLON_BYTE = ";".ord
+      SOURCE_OPTION_KEYS = %w[git github path].freeze
 
       Result = Struct.new(
         :content,
@@ -126,50 +129,84 @@ module ReactOnRails
 
       def has_user_version_pin?(call)
         positional_args = call.arguments.arguments.drop(1).reject { |a| a.is_a?(Prism::KeywordHashNode) }
-        positional_args.any? { |a| a.is_a?(Prism::StringNode) }
+        positional_args.any? || source_option_present?(call)
+      end
+
+      def source_option_present?(call)
+        keyword_hashes = call.arguments.arguments.select { |a| a.is_a?(Prism::KeywordHashNode) }
+        keyword_hashes.any? do |keyword_hash|
+          keyword_hash.elements.any? do |element|
+            element.key.is_a?(Prism::SymbolNode) && SOURCE_OPTION_KEYS.include?(element.key.unescaped)
+          end
+        end
       end
 
       def quote_char(source, string_node)
-        source[string_node.location.start_offset]
+        source.byteslice(string_node.location.start_offset, 1)
       end
 
       def removal_edit(source, call)
-        # Remove the entire statement containing the gem call, including any postfix
-        # modifier (`if`, `unless`, `while`, `until`) and the trailing newline. The
-        # statement may be wrapped in an `IfNode` / `UnlessNode` when there is a
-        # postfix modifier, so we walk outward until we find the enclosing
-        # statement-level node.
-        statement_node = enclosing_statement_node(call)
-        start_offset, end_offset = statement_byte_range(source, statement_node)
+        # Remove only this gem statement. If it is the only statement on a line,
+        # remove the whole line; if it shares a line via semicolons, preserve the
+        # neighboring statements.
+        start_offset, end_offset = statement_byte_range(source, call)
         { start_offset: start_offset, end_offset: end_offset, replacement: "" }
       end
 
-      # When Prism parses `gem "foo" if cond`, the outermost node is `IfNode`, not the
-      # `CallNode`. We treat the postfix-modifier node as the statement to remove.
-      def enclosing_statement_node(call)
-        # We do not have an explicit parent pointer; the caller passes the CallNode, so
-        # we need to detect a postfix modifier by looking at the source slice. Prism's
-        # location for the CallNode does NOT include the modifier, so we re-locate by
-        # inspecting the source after the call's end_offset.
-        call
+      def statement_byte_range(source, node)
+        line_start = line_start_offset(source, node.location.start_offset)
+        line_end = line_end_offset(source, node.location.end_offset)
+        statement_end = node.location.end_offset
+
+        while statement_end < line_end
+          byte = source.getbyte(statement_end)
+          break if byte == NEWLINE_BYTE || byte == SEMICOLON_BYTE
+
+          statement_end += 1
+        end
+
+        previous_semicolon = previous_semicolon_offset(source, line_start, node.location.start_offset)
+        if previous_semicolon
+          [previous_semicolon, statement_end]
+        elsif statement_end < line_end && source.getbyte(statement_end) == SEMICOLON_BYTE
+          end_offset = statement_end + 1
+          end_offset += 1 while end_offset < line_end && horizontal_space?(source.getbyte(end_offset))
+          [line_start, end_offset]
+        else
+          [line_start, line_end]
+        end
       end
 
-      def statement_byte_range(source, node)
-        start_offset = line_start_offset(source, node.location.start_offset)
+      def previous_semicolon_offset(source, line_start, statement_start)
+        scan = statement_start - 1
+        while scan >= line_start
+          return scan if source.getbyte(scan) == SEMICOLON_BYTE
 
-        # Walk forward from the node's end_offset to the end of the source line so that
-        # we also delete trailing modifier text (e.g. `if ENV["X"]`) and the newline.
-        scan = node.location.end_offset
-        scan += 1 while scan < source.length && source[scan] != "\n"
-        scan += 1 if scan < source.length && source[scan] == "\n"
-        [start_offset, scan]
+          scan -= 1
+        end
+
+        nil
+      end
+
+      def horizontal_space?(byte)
+        byte == " ".ord || byte == "\t".ord
       end
 
       def apply_edits(source, edits)
         sorted = edits.sort_by { |e| -e[:start_offset] }
         sorted.reduce(source) do |acc, edit|
-          acc[0...edit[:start_offset]] + edit[:replacement] + acc[edit[:end_offset]..]
+          splice_source(acc, edit[:start_offset], edit[:end_offset], edit[:replacement])
         end
+      end
+
+      def byte_slice(source, start_offset, end_offset)
+        source.byteslice(start_offset, end_offset - start_offset) || ""
+      end
+
+      def splice_source(source, start_offset, end_offset, replacement)
+        prefix = source.byteslice(0, start_offset) || ""
+        suffix = source.byteslice(end_offset, source.bytesize - end_offset) || ""
+        prefix + replacement + suffix
       end
 
       # After removing base gem statements, conditionals like
@@ -200,7 +237,7 @@ module ReactOnRails
           edit = find_collapse_edit(source, parse_result.value)
           break source unless edit
 
-          source = source[0...edit[:start_offset]] + edit[:replacement] + source[edit[:end_offset]..]
+          source = splice_source(source, edit[:start_offset], edit[:end_offset], edit[:replacement])
         end
       end
 
@@ -226,8 +263,9 @@ module ReactOnRails
         return nil unless node.respond_to?(:end_keyword_loc) && node.end_keyword_loc
 
         then_branch = node.statements
-        has_else_node = node.subsequent.is_a?(Prism::ElseNode)
-        else_statements = has_else_node ? node.subsequent.statements : nil
+        else_node = conditional_else_node(node)
+        has_else_node = !else_node.nil?
+        else_statements = has_else_node ? else_node.statements : nil
 
         then_empty = branch_empty?(then_branch)
         else_empty = has_else_node && branch_empty?(else_statements)
@@ -250,7 +288,7 @@ module ReactOnRails
         return nil unless single_pro_gem_call?(branch_statements)
 
         gem_call = branch_statements.body.first
-        gem_text = source[gem_call.location.start_offset...gem_call.location.end_offset]
+        gem_text = byte_slice(source, gem_call.location.start_offset, gem_call.location.end_offset)
         # Preserve indentation of the original conditional.
         indent = leading_indentation(source, conditional.location.start_offset)
         {
@@ -270,9 +308,10 @@ module ReactOnRails
 
       def remove_empty_else_branch(source, node)
         # Find the `else` keyword location and remove from there to just before `end`.
-        return nil unless node.subsequent.is_a?(Prism::ElseNode)
+        else_node = conditional_else_node(node)
+        return nil unless else_node
 
-        else_loc = node.subsequent.else_keyword_loc
+        else_loc = else_node.else_keyword_loc
         end_loc = node.end_keyword_loc
         return nil unless else_loc && end_loc
 
@@ -294,20 +333,28 @@ module ReactOnRails
 
       def leading_indentation(source, offset)
         line_start = line_start_offset(source, offset)
-        slice = source[line_start...offset]
+        slice = byte_slice(source, line_start, offset)
         slice[/\A\s*/].to_s
       end
 
       def line_start_offset(source, offset)
         return 0 if offset.zero?
 
-        idx = source.rindex("\n", offset - 1)
+        idx = source.b.rindex("\n".b, offset - 1)
         idx ? idx + 1 : 0
       end
 
       def line_end_offset(source, offset)
-        idx = source.index("\n", offset)
-        idx ? idx + 1 : source.length
+        idx = source.b.index("\n".b, offset)
+        idx ? idx + 1 : source.bytesize
+      end
+
+      def conditional_else_node(node)
+        if node.is_a?(Prism::IfNode)
+          node.subsequent if node.subsequent.is_a?(Prism::ElseNode)
+        elsif node.is_a?(Prism::UnlessNode)
+          node.else_clause
+        end
       end
     end
   end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -316,6 +316,24 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect_parseable_ruby(result.content)
       end
 
+      it "ignores semicolons in trailing comments when removing a stale base declaration" do
+        src = <<~RUBY
+          gem "react_on_rails", "~> 16.0" # old; remove
+          gem "react_on_rails_pro", "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "ignores semicolons in quoted postfix guards when removing a stale base declaration" do
+        src = 'gem "react_on_rails" if ENV["ROR;ENABLED"]; gem "react_on_rails_pro", "~> 16.0"' \
+              "\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
       it "removes stale base when Pro is parenthesized with comments" do
         src = <<~RUBY
           source "https://rubygems.org"
@@ -373,6 +391,19 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect_parseable_ruby(result.content)
       end
 
+      it "preserves same-line sibling statements when collapsing a conditional" do
+        src = <<~RUBY
+          if ENV["PRO"]
+            gem "react_on_rails_pro", "16.0.0"
+          else
+            gem "react_on_rails", "16.0.0"
+          end; gem "rails"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"16.0.0\"; gem \"rails\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
       it "does not collapse pre-existing empty branches when removing stale base elsewhere" do
         src = <<~RUBY
           if ENV["ENABLE_ROR"]
@@ -387,6 +418,29 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
             gem "react_on_rails_pro", "~> 16.0"
           else
           end
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "only skips as many duplicate empty conditionals as were already empty" do
+        src = <<~RUBY
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+          end
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+            gem "react_on_rails", "~> 16.0"
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+          end
+          gem "react_on_rails_pro", "~> 16.0"
         RUBY
         expect_parseable_ruby(result.content)
       end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect(result.content).to include('gem "react_on_rails_pro", path: "../react_on_rails"')
       end
 
+      it "inserts the default version before explicit hash options" do
+        src = "gem \"react_on_rails\", { require: false }\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"#{default_pro_version}\", { require: false }\n")
+      end
+
+      it "preserves source explicit hash options without inserting a default version" do
+        src = "gem \"react_on_rails\", { path: \"../react_on_rails\", require: false }\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", { path: \"../react_on_rails\", require: false }\n")
+      end
+
       it "treats a non-string positional argument as a user version requirement" do
         src = "gem \"react_on_rails\", REACT_ON_RAILS_VERSION\n"
         result = rewriter.rewrite(src)
@@ -336,6 +348,15 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
 
       it "ignores semicolons in percent-string postfix guards when removing a stale base declaration" do
         src = 'gem "react_on_rails" if ENV[%q[ROR;ENABLED]]; gem "react_on_rails_pro", "~> 16.0"' \
+              "\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "ignores semicolons in regex postfix guards when removing a stale base declaration" do
+        src = 'gem "react_on_rails" if /ROR;ENABLED/.match?(ENV["FLAGS"]); ' \
+              'gem "react_on_rails_pro", "~> 16.0"' \
               "\n"
         result = rewriter.rewrite(src)
         expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -334,6 +334,14 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect_parseable_ruby(result.content)
       end
 
+      it "ignores semicolons in percent-string postfix guards when removing a stale base declaration" do
+        src = 'gem "react_on_rails" if ENV[%q[ROR;ENABLED]]; gem "react_on_rails_pro", "~> 16.0"' \
+              "\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
       it "removes stale base when Pro is parenthesized with comments" do
         src = <<~RUBY
           source "https://rubygems.org"
@@ -441,6 +449,29 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
           else
           end
           gem "react_on_rails_pro", "~> 16.0"
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "matches pre-existing empty branches by conditional identity" do
+        src = <<~RUBY
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+            gem "react_on_rails", "~> 16.0"
+          end
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          gem "react_on_rails_pro", "~> 16.0"
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+          end
         RUBY
         expect_parseable_ruby(result.content)
       end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -1,0 +1,386 @@
+# frozen_string_literal: true
+
+# Spike test for issue #3313. Drives the Prism prototype through the behavior matrix
+# enumerated in the issue and asserts the rewriter produces valid, expected output.
+#
+# This is intentionally a self-contained RSpec file outside of the main spec/ tree so
+# the spike does not pollute the production test suite. Run with:
+#   bundle exec rspec spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+
+$LOAD_PATH.unshift(File.expand_path(__dir__))
+
+require "prism_gemfile_rewriter"
+
+RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
+  let(:default_pro_version) { "~> 16.7" }
+  subject(:rewriter) { described_class.new(default_pro_version: default_pro_version) }
+
+  def expect_parseable_ruby(content)
+    parse_result = Prism.parse(content)
+    expect(parse_result.failure?).to be(false),
+                                     "expected parseable Ruby, got errors: #{parse_result.errors.map(&:message).join(', ')}"
+  end
+
+  describe "#rewrite" do
+    context "single-line declarations" do
+      it "rewrites exact version pin" do
+        src = <<~RUBY
+          source "https://rubygems.org"
+          gem "react_on_rails", "16.0.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", "16.0.0"')
+        expect(result.content).not_to match(/gem\s+["']react_on_rails["']/)
+        expect_parseable_ruby(result.content)
+      end
+
+      it "rewrites pessimistic version pin" do
+        src = <<~RUBY
+          gem "react_on_rails", "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "preserves single-quote style" do
+        src = "gem 'react_on_rails', '~> 16.0'\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem 'react_on_rails_pro', '~> 16.0'\n")
+      end
+
+      it "rewrites a bare gem declaration and inserts default version" do
+        src = "gem \"react_on_rails\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"#{default_pro_version}\"\n")
+      end
+    end
+
+    context "kwargs and options" do
+      it "preserves path: with version pin" do
+        src = "gem \"react_on_rails\", \"~> 16.0\", path: \"../react_on_rails\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", "~> 16.0", path: "../react_on_rails"')
+      end
+
+      it "preserves git: alongside the inserted default version when no user pin is present" do
+        src = "gem \"react_on_rails\", git: \"https://example.invalid/repo.git\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include(
+          "gem \"react_on_rails_pro\", \"#{default_pro_version}\", git: \"https://example.invalid/repo.git\""
+        )
+      end
+
+      it "preserves github: alongside the inserted default version when no user pin is present" do
+        src = "gem \"react_on_rails\", github: \"shakacode/react_on_rails\", branch: \"master\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include(
+          "gem \"react_on_rails_pro\", \"#{default_pro_version}\", github: \"shakacode/react_on_rails\", branch: \"master\""
+        )
+      end
+
+      it "preserves require: false and trailing guard" do
+        src = "gem \"react_on_rails\", \"~> 16.0\", require: false, if: ENV[\"ENABLE_ROR\"]\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include(
+          'gem "react_on_rails_pro", "~> 16.0", require: false, if: ENV["ENABLE_ROR"]'
+        )
+      end
+
+      it "preserves multi-constraint version pins" do
+        src = "gem \"react_on_rails\", \">= 15.0\", \"< 16.0\", require: false\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", ">= 15.0", "< 16.0", require: false')
+      end
+
+      it "preserves platforms: option" do
+        src = "gem \"react_on_rails\", \"~> 16.0\", platforms: :jruby\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", "~> 16.0", platforms: :jruby')
+      end
+    end
+
+    context "multiline non-parenthesized declarations" do
+      it "preserves source layout for non-parenthesized continuation across lines" do
+        src = <<~RUBY
+          gem "react_on_rails",
+            "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          gem "react_on_rails_pro",
+            "~> 16.0"
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "preserves the inline-comment continuation" do
+        src = <<~RUBY
+          gem "react_on_rails", # pinned for compatibility
+            "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", # pinned for compatibility')
+        expect(result.content).to include('  "~> 16.0"')
+        expect_parseable_ruby(result.content)
+      end
+
+      it "handles comment-only lines between continuation segments" do
+        src = <<~RUBY
+          gem "react_on_rails",
+            # pinned for compatibility
+            "~> 16.0"
+          gem "rails"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro",')
+        expect(result.content).to include('"~> 16.0"')
+        expect(result.content).to include('gem "rails"')
+        expect_parseable_ruby(result.content)
+      end
+    end
+
+    context "parenthesized declarations" do
+      it "preserves parens on a single-line declaration" do
+        src = "gem(\"react_on_rails\", \"~> 16.0\")\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem(\"react_on_rails_pro\", \"~> 16.0\")\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "preserves parens on a multiline declaration" do
+        src = <<~RUBY
+          gem(
+            "react_on_rails",
+            "~> 16.0"
+          )
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          gem(
+            "react_on_rails_pro",
+            "~> 16.0"
+          )
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "handles parenthesized declarations with postfix guards" do
+        src = "gem(\"react_on_rails\", \"~> 16.0\") if ENV[\"ENABLE_ROR\"]\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem(\"react_on_rails_pro\", \"~> 16.0\") if ENV[\"ENABLE_ROR\"]\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "handles a trailing comment after the closing paren" do
+        src = <<~RUBY
+          gem(
+            "react_on_rails",
+            "~> 16.0"
+          ) # pin
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('"react_on_rails_pro"')
+        expect(result.content).to include("# pin")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "handles inline Ruby comments containing parens" do
+        src = <<~RUBY
+          gem(
+            "react_on_rails",
+            "~> 16.0", # pinned :)
+            require: false
+          )
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('"react_on_rails_pro"')
+        expect(result.content).to include('"~> 16.0"')
+        expect(result.content).to include("require: false")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "handles nested parens in option values" do
+        src = <<~RUBY
+          gem(
+            "react_on_rails",
+            "~> 16.0",
+            if: ENV.fetch("ENABLE_ROR") { true }
+          )
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('"react_on_rails_pro"')
+        expect(result.content).to include('if: ENV.fetch("ENABLE_ROR") { true }')
+        expect_parseable_ruby(result.content)
+      end
+    end
+
+    context "edge-case Gemfile shapes" do
+      it "leaves valid output when there is no final newline" do
+        src = "gem \"react_on_rails\", \"~> 16.0\""
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", "~> 16.0"')
+        expect_parseable_ruby(result.content)
+      end
+
+      it "rewrites duplicate base declarations across groups" do
+        src = <<~RUBY
+          gem "react_on_rails", "~> 16.0"
+          group :test do
+            gem "react_on_rails", "~> 16.0", require: false
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          gem "react_on_rails_pro", "~> 16.0"
+          group :test do
+            gem "react_on_rails_pro", "~> 16.0", require: false
+          end
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "rewrites duplicate base declarations on the same level (platform-specific)" do
+        src = <<~RUBY
+          gem "react_on_rails", "~> 16.0"
+          gem "react_on_rails", "~> 16.0", platforms: :jruby
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", "~> 16.0"')
+        expect(result.content).to include('gem "react_on_rails_pro", "~> 16.0", platforms: :jruby')
+        expect(result.content).not_to match(/gem\s+["']react_on_rails["']/)
+        expect_parseable_ruby(result.content)
+      end
+
+      it "removes stale base when active Pro is present (single-line Pro)" do
+        src = <<~RUBY
+          gem "react_on_rails", "~> 16.0"
+          gem "react_on_rails_pro", "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect(result.base_entries_removed).to be(true)
+        expect_parseable_ruby(result.content)
+      end
+
+      it "removes stale base when Pro is parenthesized with comments" do
+        src = <<~RUBY
+          source "https://rubygems.org"
+          gem "react_on_rails", "~> 16.0"
+          gem(
+            # pinned for compatibility
+            "react_on_rails_pro",
+            "~> 16.0"
+          )
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          source "https://rubygems.org"
+          gem(
+            # pinned for compatibility
+            "react_on_rails_pro",
+            "~> 16.0"
+          )
+        RUBY
+        expect(result.base_entries_removed).to be(true)
+        expect_parseable_ruby(result.content)
+      end
+
+      it "rewrites base declarations in both conditional branches" do
+        src = <<~RUBY
+          if ENV["ROR_EDGE"]
+            gem "react_on_rails", github: "shakacode/react_on_rails", branch: "master"
+          else
+            gem "react_on_rails", "~> 16.0"
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          if ENV["ROR_EDGE"]
+            gem "react_on_rails_pro", "#{default_pro_version}", github: "shakacode/react_on_rails", branch: "master"
+          else
+            gem "react_on_rails_pro", "~> 16.0"
+          end
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "collapses the empty-else case (the documented #3232 ugliness)" do
+        src = <<~RUBY
+          if ENV["PRO"]
+            gem "react_on_rails_pro", "16.0.0"
+          else
+            gem "react_on_rails", "16.0.0"
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"16.0.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "preserves indentation when collapsing an indented conditional" do
+        src = <<~RUBY
+          group :development do
+            if ENV["PRO"]
+              gem "react_on_rails_pro", "16.0.0"
+            else
+              gem "react_on_rails", "16.0.0"
+            end
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          group :development do
+            gem "react_on_rails_pro", "16.0.0"
+          end
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "preserves inline comments after the gem name" do
+        src = "gem \"react_on_rails\" # pinned for compatibility\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include("gem \"react_on_rails_pro\", \"#{default_pro_version}\"")
+        expect(result.content).to include("# pinned for compatibility")
+      end
+
+      it "does not modify a Gemfile with no react_on_rails entry" do
+        src = "source \"https://rubygems.org\"\ngem \"rails\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(src)
+        expect(result.base_entries_removed).to be(false)
+      end
+
+      it "does not rewrite gem calls that mention react_on_rails only in kwargs" do
+        src = "gem(\"other_gem\", require: \"react_on_rails\")\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(src)
+      end
+    end
+
+    context "trailing comma suffix (gem(\"react_on_rails\",))" do
+      # Prism currently treats `gem("react_on_rails",)` as a syntax error in some Ruby
+      # versions but accepts it as valid in 3.3+. We document the behavior either way.
+      it "either rewrites cleanly or reports a parse failure" do
+        src = "gem(\"react_on_rails\",)\n"
+        result = rewriter.rewrite(src)
+        if result.parse_failed
+          expect(result.content).to eq(src)
+        else
+          expect(result.content).to include('"react_on_rails_pro"')
+          expect_parseable_ruby(result.content)
+        end
+      end
+    end
+
+    context "parse-failure policy" do
+      it "returns the original content untouched when Gemfile cannot be parsed" do
+        src = "gem \"react_on_rails\" if ENV[\"X\"\n" # missing closing bracket
+        result = rewriter.rewrite(src)
+        expect(result.parse_failed).to be(true)
+        expect(result.content).to eq(src)
+        expect(result.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -363,6 +363,21 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect_parseable_ruby(result.content)
       end
 
+      it "preserves a preceding sibling statement when a regex-guarded stale base follows it" do
+        # When an active Pro gem is present, the rewriter calls `removal_edit`, which
+        # uses `previous_semicolon_offset` to find the statement boundary. The scanner
+        # skips `%r[...]` percent-literals but not bare `/regex/` literals, so a `;`
+        # inside `/should;load/` could be miscounted as a separator. In practice this
+        # input rewrites cleanly because `removable_statement_node` returns the full
+        # IfNode (covering the regex), so the regex's `;` falls inside the node's
+        # byte range and below the `statement_end` threshold. Lock that behavior.
+        src = "gem \"react_on_rails_pro\", \"~> 16.0\"; " \
+              "gem \"react_on_rails\" if /should;load/.match?(ENV[\"X\"])\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
       it "removes stale base when Pro is parenthesized with comments" do
         src = <<~RUBY
           source "https://rubygems.org"
@@ -430,6 +445,55 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         RUBY
         result = rewriter.rewrite(src)
         expect(result.content).to eq("gem \"react_on_rails_pro\", \"16.0.0\"; gem \"rails\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "collapses an inline single-line if/then/else without dropping the active Pro gem" do
+        # Regression for the line-fallback in `statement_byte_range`. Inline single-line
+        # block conditionals have no statement separators on the line, so the previous
+        # fallback `[line_start, line_end]` deleted the whole conditional — taking the
+        # active Pro gem with it. Now the call's own byte range is used, and the
+        # collapse pass folds the resulting empty-else conditional to the single Pro
+        # gem declaration.
+        src = "if ENV['PRO'] then gem 'react_on_rails_pro' else gem 'react_on_rails' end\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem 'react_on_rails_pro'\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "terminates when an inline conditional's else branch becomes empty post-removal" do
+        # Regression for the infinite-loop in `collapse_dead_conditionals` when
+        # `remove_empty_else_branch` produced a zero-length splice for inline
+        # conditionals (else and end on the same line). The collapse loop now
+        # bails on no-op edits, so a conditional whose then-branch contains more
+        # than one statement is left intact: still parseable Ruby, uglier than
+        # ideal but no data loss and no hang.
+        src = "if ENV['PRO']; gem 'react_on_rails_pro'; gem 'rails'; " \
+              "else; gem 'react_on_rails', '16.0.0'; end\n"
+        # Use Timeout to fail loudly if the loop ever regresses to hanging.
+        require "timeout"
+        result = Timeout.timeout(5) { rewriter.rewrite(src) }
+        # The call's own byte range is removed; the surrounding `;` separators
+        # survive (`else; ; end`). Still valid Ruby, and crucially the Pro gem
+        # and the unrelated `rails` statement both remain.
+        expect(result.content).to include("gem 'react_on_rails_pro'")
+        expect(result.content).to include("gem 'rails'")
+        expect(result.content).not_to include("react_on_rails'")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "collapses an unless/else conditional whose else branch held the stale base" do
+        # `conditional_else_node` routes UnlessNode to `node.else_clause` (a different
+        # accessor than IfNode's `node.subsequent`). Exercise that branch directly.
+        src = <<~RUBY
+          unless ENV["PRO"]
+            gem "react_on_rails", "16.0.0"
+          else
+            gem "react_on_rails_pro", "16.0.0"
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"16.0.0\"\n")
         expect_parseable_ruby(result.content)
       end
 
@@ -573,16 +637,24 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
     end
 
     context "trailing comma suffix (gem(\"react_on_rails\",))" do
-      # Prism currently treats `gem("react_on_rails",)` as a syntax error in some Ruby
-      # versions but accepts it as valid in 3.3+. We document the behavior either way.
-      it "either rewrites cleanly or reports a parse failure" do
-        src = "gem(\"react_on_rails\",)\n"
-        result = rewriter.rewrite(src)
-        if result.parse_failed
-          expect(result.content).to eq(src)
-        else
+      # Ruby 3.3+ accepts trailing commas in parenthesized calls; earlier Rubies treat
+      # it as a syntax error and Prism reports a parse failure. Split into two gated
+      # tests so each Ruby tightens to a single expected outcome instead of a
+      # "does-not-crash" passthrough that hides a real regression.
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
+        it "rewrites cleanly on Ruby 3.3+" do
+          src = "gem(\"react_on_rails\",)\n"
+          result = rewriter.rewrite(src)
+          expect(result.parse_failed).to be(false)
           expect(result.content).to include('"react_on_rails_pro"')
           expect_parseable_ruby(result.content)
+        end
+      else
+        it "reports a parse failure on Ruby < 3.3" do
+          src = "gem(\"react_on_rails\",)\n"
+          result = rewriter.rewrite(src)
+          expect(result.parse_failed).to be(true)
+          expect(result.content).to eq(src)
         end
       end
     end

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
 
   def expect_parseable_ruby(content)
     parse_result = Prism.parse(content)
+    error_messages = parse_result.errors.map(&:message).join(", ")
     expect(parse_result.failure?).to be(false),
-                                     "expected parseable Ruby, got errors: #{parse_result.errors.map(&:message).join(', ')}"
+                                     "expected parseable Ruby, got errors: #{error_messages}"
   end
 
   describe "#rewrite" do
@@ -54,6 +55,18 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         result = rewriter.rewrite(src)
         expect(result.content).to eq("gem \"react_on_rails_pro\", \"#{default_pro_version}\"\n")
       end
+
+      it "rewrites declarations after UTF-8 content using byte offsets" do
+        src = <<~RUBY
+          # D\u00e9pendances
+          gem "react_on_rails", "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          # D\u00e9pendances
+          gem "react_on_rails_pro", "~> 16.0"
+        RUBY
+      end
     end
 
     context "kwargs and options" do
@@ -63,20 +76,32 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect(result.content).to include('gem "react_on_rails_pro", "~> 16.0", path: "../react_on_rails"')
       end
 
-      it "preserves git: alongside the inserted default version when no user pin is present" do
+      it "preserves git: without inserting a default version when no user pin is present" do
         src = "gem \"react_on_rails\", git: \"https://example.invalid/repo.git\"\n"
         result = rewriter.rewrite(src)
         expect(result.content).to include(
-          "gem \"react_on_rails_pro\", \"#{default_pro_version}\", git: \"https://example.invalid/repo.git\""
+          "gem \"react_on_rails_pro\", git: \"https://example.invalid/repo.git\""
         )
       end
 
-      it "preserves github: alongside the inserted default version when no user pin is present" do
+      it "preserves github: without inserting a default version when no user pin is present" do
         src = "gem \"react_on_rails\", github: \"shakacode/react_on_rails\", branch: \"master\"\n"
         result = rewriter.rewrite(src)
         expect(result.content).to include(
-          "gem \"react_on_rails_pro\", \"#{default_pro_version}\", github: \"shakacode/react_on_rails\", branch: \"master\""
+          "gem \"react_on_rails_pro\", github: \"shakacode/react_on_rails\", branch: \"master\""
         )
+      end
+
+      it "preserves path: without inserting a default version when no user pin is present" do
+        src = "gem \"react_on_rails\", path: \"../react_on_rails\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to include('gem "react_on_rails_pro", path: "../react_on_rails"')
+      end
+
+      it "treats a non-string positional argument as a user version requirement" do
+        src = "gem \"react_on_rails\", REACT_ON_RAILS_VERSION\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", REACT_ON_RAILS_VERSION\n")
       end
 
       it "preserves require: false and trailing guard" do
@@ -263,6 +288,27 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect_parseable_ruby(result.content)
       end
 
+      it "removes a stale base declaration after an active Pro declaration on the same line" do
+        src = "gem \"react_on_rails_pro\", \"~> 16.0\"; gem \"react_on_rails\", \"~> 16.0\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "removes a stale base declaration before an active Pro declaration on the same line" do
+        src = "gem \"react_on_rails\", \"~> 16.0\"; gem \"react_on_rails_pro\", \"~> 16.0\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "removes a stale base declaration in the middle of a shared line" do
+        src = "gem \"rails\"; gem \"react_on_rails\", \"~> 16.0\"; gem \"react_on_rails_pro\", \"~> 16.0\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"rails\"; gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
       it "removes stale base when Pro is parenthesized with comments" do
         src = <<~RUBY
           source "https://rubygems.org"
@@ -295,13 +341,15 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
           end
         RUBY
         result = rewriter.rewrite(src)
-        expect(result.content).to eq(<<~RUBY)
-          if ENV["ROR_EDGE"]
-            gem "react_on_rails_pro", "#{default_pro_version}", github: "shakacode/react_on_rails", branch: "master"
-          else
-            gem "react_on_rails_pro", "~> 16.0"
-          end
-        RUBY
+        expected_github_line = '  gem "react_on_rails_pro", github: "shakacode/react_on_rails", ' \
+                               'branch: "master"'
+        expect(result.content.lines).to eq([
+          "if ENV[\"ROR_EDGE\"]\n",
+          "#{expected_github_line}\n",
+          "else\n",
+          "  gem \"react_on_rails_pro\", \"~> 16.0\"\n",
+          "end\n"
+        ])
         expect_parseable_ruby(result.content)
       end
 
@@ -315,6 +363,41 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         RUBY
         result = rewriter.rewrite(src)
         expect(result.content).to eq("gem \"react_on_rails_pro\", \"16.0.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "does not crash on unrelated unless blocks when removing stale base" do
+        src = <<~RUBY
+          unless ENV["CI"]
+            gem "pry"
+          end
+          gem "react_on_rails", "~> 16.0"
+          gem "react_on_rails_pro", "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          unless ENV["CI"]
+            gem "pry"
+          end
+          gem "react_on_rails_pro", "~> 16.0"
+        RUBY
+        expect_parseable_ruby(result.content)
+      end
+
+      it "collapses stale base conditionals after UTF-8 content using byte offsets" do
+        src = <<~RUBY
+          # D\u00e9pendances
+          if ENV["PRO"]
+            gem "react_on_rails_pro", "16.0.0"
+          else
+            gem "react_on_rails", "16.0.0"
+          end
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          # D\u00e9pendances
+          gem "react_on_rails_pro", "16.0.0"
+        RUBY
         expect_parseable_ruby(result.content)
       end
 

--- a/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
+++ b/react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         expect(result.content).to eq("gem 'react_on_rails_pro', '~> 16.0'\n")
       end
 
+      it "rewrites percent string literals without emitting invalid Ruby" do
+        src = "gem %q[react_on_rails], \"~> 16.0\"\n"
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq("gem \"react_on_rails_pro\", \"~> 16.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
       it "rewrites a bare gem declaration and inserts default version" do
         src = "gem \"react_on_rails\"\n"
         result = rewriter.rewrite(src)
@@ -363,6 +370,24 @@ RSpec.describe ReactOnRails::Spike::PrismGemfileRewriter do
         RUBY
         result = rewriter.rewrite(src)
         expect(result.content).to eq("gem \"react_on_rails_pro\", \"16.0.0\"\n")
+        expect_parseable_ruby(result.content)
+      end
+
+      it "does not collapse pre-existing empty branches when removing stale base elsewhere" do
+        src = <<~RUBY
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+          end
+          gem "react_on_rails", "~> 16.0"
+        RUBY
+        result = rewriter.rewrite(src)
+        expect(result.content).to eq(<<~RUBY)
+          if ENV["ENABLE_ROR"]
+            gem "react_on_rails_pro", "~> 16.0"
+          else
+          end
+        RUBY
         expect_parseable_ruby(result.content)
       end
 


### PR DESCRIPTION
## Summary

Spike for #3313: a working Prism-based Gemfile rewriter prototype, a 32-case behavior matrix, a parse+rewrite benchmark vs. the current scanner, and a decision record.

All artifacts live under `react_on_rails/spike/3313_prism_gemfile_rewriter/` and the directory is excluded from RuboCop — this is exploratory code, **not production**, and `lib/` is untouched (per the issue's "Do not rewrite #3232" non-goal).

## What the spike found

- A Prism prototype is **viable** and produces cleaner output for the conditional case the issue calls out: `if ENV["PRO"]; gem_pro; else; gem_base; end` collapses to a single `gem "react_on_rails_pro"` declaration instead of leaving an ugly empty `else`.
- The Prism implementation is also smaller (~210 lines) than the current scanner+rewrite path (~500 lines combined).
- Performance is sub-millisecond either way (0.012ms vs. 0.015ms small Gemfile, 0.285ms vs. 0.304ms on 300 lines). Not a decision factor.
- The one real cost is **adding `prism` as a runtime dependency** for the ~30% of users still on Ruby 3.0–3.2 (Prism is bundled with CRuby 3.3+).

## Recommendation

**Keep the current scanner.** Revisit when `react_on_rails` drops Ruby 3.0–3.2 support — at that point Prism becomes a free runtime dep and the cutover is a 4–8 hour job using the prototype as the starting point.

Full reasoning, behavior matrix, performance numbers, conditional/empty-branch policy, and parse-failure policy in [`DECISION.md`](https://github.com/shakacode/react_on_rails/blob/jg-conductor/3313-fix/react_on_rails/spike/3313_prism_gemfile_rewriter/DECISION.md).

## Not closing #3313

The issue is a discussion/enhancement asking for a decision record. This PR delivers that decision record. The maintainer can close #3313 once the recommendation is accepted (or push back / pick a different path).

## Test plan

- [x] `bundle exec rspec react_on_rails/spike/3313_prism_gemfile_rewriter/prism_gemfile_rewriter_spec.rb` — 32 examples, 0 failures
- [x] `bundle exec ruby react_on_rails/spike/3313_prism_gemfile_rewriter/benchmark.rb` — clean output, ratios within expected range
- [x] `bundle exec rubocop react_on_rails/lib/react_on_rails/pro_migration.rb` — RuboCop config change does not break linting of the production code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production migration or lib changes; only spike artifacts plus gem/RuboCop exclusions for non-shipped code.
> 
> **Overview**
> Adds an **exploratory spike** under `react_on_rails/spike/3313_prism_gemfile_rewriter/` for issue #3313: a Prism-based Gemfile rewriter prototype, a large behavior-matrix spec, a benchmark vs. the existing text scanner, and **`DECISION.md`** recommending **keep the current scanner** until the gem’s Ruby floor is **3.3+** (avoid a runtime `prism` dep on 3.0–3.2).
> 
> **Packaging / tooling:** `spike/` is excluded from the published gem (`react_on_rails.gemspec`) and from RuboCop (`.rubocop.yml`). **`lib/` and the shipped Pro migration rewrite are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adef418894b95aa3b911a49752963c72fbb1b90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental Gemfile-rewriter prototype and benchmark to evaluate a Prism-based rewrite approach.
* **Chores**
  * Excluded spike files from linting and from gem packaging.
* **Documentation**
  * Added a DECISION record and README describing prototype behavior, compatibility notes, benchmarks, and next steps.
* **Tests**
  * Added an extensive spike test suite covering many Gemfile rewrite scenarios, edge cases, and parse-failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->