### PR TITLE
refactor: split pro_gem_installed? from deferred-install tracking (#3303)

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -84,11 +84,15 @@ module GeneratorHelper
     false
   end
 
-  # Check if React on Rails Pro gem is installed
+  # Check if React on Rails Pro gem is installed (real state — never "scheduled to be installed").
   #
   # Detection priority:
   # 1. Gem.loaded_specs - gem is loaded in current Ruby process (most reliable)
   # 2. Gemfile.lock - gem is resolved and installed
+  #
+  # Use {#pro_gem_install_deferred?} for the broader "present, or will be installed by this
+  # generator run" meaning. Use {#invalidate_pro_gem_installed_cache!} after an operation
+  # that changes real state (e.g., bundle add) so the next call re-reads the lockfile.
   #
   # @return [Boolean] true if react_on_rails_pro gem is installed
   def pro_gem_installed?
@@ -97,9 +101,22 @@ module GeneratorHelper
     @pro_gem_installed = Gem.loaded_specs.key?("react_on_rails_pro") || gem_in_lockfile?("react_on_rails_pro")
   end
 
-  # TODO: CQS smell: mark_pro_gem_installed! makes pro_gem_installed? return true before install. See #3303.
-  def mark_pro_gem_installed!
-    @pro_gem_installed = true
+  # Clear the memoized {#pro_gem_installed?} result so the next call re-checks
+  # Gem.loaded_specs / Gemfile.lock. Call after any operation that may change real state.
+  def invalidate_pro_gem_installed_cache!
+    remove_instance_variable(:@pro_gem_installed) if defined?(@pro_gem_installed)
+  end
+
+  # True when a later step in this generator run will install the Pro gem
+  # (e.g., the Gemfile swap performed by ProGenerator). Distinct from
+  # {#pro_gem_installed?}, which only reports real present state.
+  def pro_gem_install_deferred?
+    @pro_gem_install_deferred == true
+  end
+
+  # Record that a later step in this generator run will install the Pro gem.
+  def defer_pro_gem_install!
+    @pro_gem_install_deferred = true
   end
 
   # Check if Pro features should be enabled.

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -101,24 +101,6 @@ module GeneratorHelper
     @pro_gem_installed = Gem.loaded_specs.key?("react_on_rails_pro") || gem_in_lockfile?("react_on_rails_pro")
   end
 
-  # Clear the memoized {#pro_gem_installed?} result so the next call re-checks
-  # Gem.loaded_specs / Gemfile.lock. Call after any operation that may change real state.
-  def invalidate_pro_gem_installed_cache!
-    remove_instance_variable(:@pro_gem_installed) if defined?(@pro_gem_installed)
-  end
-
-  # True when a later step in this generator run will install the Pro gem
-  # (e.g., the Gemfile swap performed by ProGenerator). Distinct from
-  # {#pro_gem_installed?}, which only reports real present state.
-  def pro_gem_install_deferred?
-    @pro_gem_install_deferred == true
-  end
-
-  # Record that a later step in this generator run will install the Pro gem.
-  def defer_pro_gem_install!
-    @pro_gem_install_deferred = true
-  end
-
   # Check if Pro features should be enabled.
   # Returns true if --pro or --rsc is set (RSC implies Pro).
   #
@@ -268,6 +250,24 @@ module GeneratorHelper
   end
 
   private
+
+  # Clear the memoized {#pro_gem_installed?} result so the next call re-checks
+  # Gem.loaded_specs / Gemfile.lock. Call after any operation that may change real state.
+  def invalidate_pro_gem_installed_cache!
+    remove_instance_variable(:@pro_gem_installed) if defined?(@pro_gem_installed)
+  end
+
+  # True when a later step in this generator run will install the Pro gem
+  # (e.g., the Gemfile swap performed by ProGenerator). Distinct from
+  # {#pro_gem_installed?}, which only reports real present state.
+  def pro_gem_install_deferred?
+    @pro_gem_install_deferred == true
+  end
+
+  # Record that a later step in this generator run will install the Pro gem.
+  def defer_pro_gem_install!
+    @pro_gem_install_deferred = true
+  end
 
   # NOTE: only the `default:` section is inspected — same assumption as
   # rspack_configured_in_project?. Projects that set `javascript_transpiler`

--- a/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/pro_setup.rb
@@ -19,7 +19,9 @@ module ReactOnRails
     #
     # Including classes must also include GeneratorHelper which provides:
     # - use_pro?, use_rsc?: Feature flag helpers
-    # - pro_gem_installed?: Pro gem detection
+    # - pro_gem_installed?: Pro gem detection (real lockfile / loaded-specs state)
+    # - pro_gem_install_deferred?, defer_pro_gem_install!: deferred-install tracking
+    # - invalidate_pro_gem_installed_cache!: invalidate memoized pro_gem_installed?
     #
     # rubocop:disable Metrics/ModuleLength
     module ProSetup
@@ -63,7 +65,7 @@ module ReactOnRails
       #   is deferred to the Gemfile swap.
       def missing_pro_gem?(force: false)
         return false unless force || use_pro?
-        return false if pro_gem_installed?
+        return false if pro_gem_installed? || pro_gem_install_deferred?
         return false if defer_pro_gem_install_to_gemfile_swap
         return false if attempt_pro_gem_auto_install
 
@@ -126,7 +128,8 @@ module ReactOnRails
 
         # The gem is now in Gemfile/lockfile but not loaded in the current Ruby process.
         # Generator code that follows must not reference ReactOnRailsPro constants directly.
-        mark_pro_gem_installed!
+        # The lockfile changed, so the memoized pro_gem_installed? must be refreshed.
+        invalidate_pro_gem_installed_cache!
         true
       rescue StandardError => e
         say "⚠️  Failed to run bundle add: #{e.message}", :red
@@ -542,7 +545,7 @@ module ReactOnRails
       def defer_pro_gem_install_to_gemfile_swap
         return false unless base_react_on_rails_gem_in_gemfile?
 
-        mark_pro_gem_installed!
+        defer_pro_gem_install!
         true
       end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3116,11 +3116,14 @@ describe InstallGenerator, type: :generator do
       install_generator.instance_variable_set(:@pro_gem_installed, false)
     end
 
-    specify "missing_pro_gem? marks memoized pro_gem_installed? state as installed" do
+    specify "missing_pro_gem? invalidates memoized pro_gem_installed? cache so it re-reads the lockfile" do
       expect(install_generator.send(:missing_pro_gem?)).to be false
       expect(Bundler).to have_received(:with_unbundled_env)
       expect(Process).to have_received(:spawn)
-      expect(install_generator.instance_variable_get(:@pro_gem_installed)).to be true
+      # bundle add updated the lockfile, so the stale `false` cache must be cleared.
+      expect(install_generator.instance_variable_defined?(:@pro_gem_installed)).to be false
+      # Auto-install is a real install, not a deferred one — the deferred flag must stay false.
+      expect(install_generator.send(:pro_gem_install_deferred?)).to be false
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3122,8 +3122,11 @@ describe InstallGenerator, type: :generator do
       expect(Process).to have_received(:spawn)
       # bundle add updated the lockfile, so the stale `false` cache must be cleared.
       expect(install_generator.instance_variable_defined?(:@pro_gem_installed)).to be false
-      # Auto-install is a real install, not a deferred one — the deferred flag must stay false.
+      # Auto-install is a real install, not a deferred one; the deferred flag must stay false.
       expect(install_generator.send(:pro_gem_install_deferred?)).to be false
+      # Re-stub gem_in_lockfile? to simulate what bundle add wrote, then verify the re-read.
+      allow(install_generator).to receive(:gem_in_lockfile?).with("react_on_rails_pro").and_return(true)
+      expect(install_generator.send(:pro_gem_installed?)).to be true
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/pro_generator_spec.rb
@@ -81,7 +81,8 @@ describe ProGenerator, type: :generator do
     specify "missing_pro_gem? returns false and bypasses bundle add to let swap handle the Gemfile" do
       expect(generator.send(:missing_pro_gem?, force: true)).to be false
       expect(Process).not_to have_received(:spawn)
-      expect(generator.send(:pro_gem_installed?)).to be true
+      expect(generator.send(:pro_gem_install_deferred?)).to be true
+      expect(generator.send(:pro_gem_installed?)).to be false
     end
 
     specify "missing_pro_gem? also defers for parenthesized declarations with leading comments" do
@@ -97,7 +98,8 @@ describe ProGenerator, type: :generator do
 
       expect(generator.send(:missing_pro_gem?, force: true)).to be false
       expect(Process).not_to have_received(:spawn)
-      expect(generator.send(:pro_gem_installed?)).to be true
+      expect(generator.send(:pro_gem_install_deferred?)).to be true
+      expect(generator.send(:pro_gem_installed?)).to be false
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #3303. `mark_pro_gem_installed!` was overloading `pro_gem_installed?` with two meanings — "really in the lockfile" *and* "scheduled to be installed by this generator run" — which masked failure paths when a downstream Gemfile swap or `bundle install` errored after marking.

- `pro_gem_installed?` now always reports real state (`Gem.loaded_specs` / `Gemfile.lock`). No more lying.
- New `pro_gem_install_deferred?` / `defer_pro_gem_install!` track the "will be installed later in this run" state explicitly. Callers that need the broader meaning consult both queries.
- `attempt_pro_gem_auto_install` calls `invalidate_pro_gem_installed_cache!` after a successful `bundle add` so the next read sees the updated lockfile (instead of blindly setting `true`).
- `missing_pro_gem?` short-circuits on either real or deferred state.

The change is internal — private helpers on the generator base — so no CHANGELOG entry per the repo guidelines.

## Test plan

- [x] `bundle exec rspec spec/react_on_rails/generators/pro_generator_spec.rb spec/react_on_rails/generators/install_generator_spec.rb` — 450 examples, 0 failures
- [x] `bundle exec rubocop` on the four changed files — clean
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts generator dependency-detection logic around `react_on_rails_pro`, which can affect whether installs proceed or error in Pro/RSC setups. While scoped to generators, it changes control flow during `bundle add`/Gemfile swap paths and relies on correct cache invalidation.
> 
> **Overview**
> **Fixes Pro gem detection in generators by separating real install state from “will be installed later in this run”.** `pro_gem_installed?` now only reflects actual presence via `Gem.loaded_specs`/`Gemfile.lock`, removing the old `mark_pro_gem_installed!` shortcut.
> 
> Adds explicit deferred-install tracking (`pro_gem_install_deferred?`/`defer_pro_gem_install!`) and updates `missing_pro_gem?` to short-circuit when either the gem is truly installed or its install is deferred (e.g., via Gemfile swap). After successful `bundle add`, the code now clears the memoized `pro_gem_installed?` result via `invalidate_pro_gem_installed_cache!` so subsequent checks re-read the lockfile; specs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85fd2a819272e2ddb2c3093ba76780d64aca62b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Pro gem installation detection and state tracking during setup
  * Enhanced cache management for more reliable dependency resolution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->