### PR TITLE
test: replace call_count stub pattern with and_return sequence (#2157)

### DIFF
--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -493,11 +493,7 @@ describe ReactOnRailsProHelper do
         mock_request_and_response(many_chunks)
 
         # Simulate client disconnect after first chunk
-        call_count = 0
-        allow(mocked_rails_stream).to receive(:closed?) do
-          call_count += 1
-          call_count > 1 # false for first call, true after
-        end
+        allow(mocked_rails_stream).to receive(:closed?).and_return(false, true)
 
         # Start streaming - first chunk returned synchronously
         initial_result = stream_react_component(component_name, props: props, **component_options)
@@ -525,11 +521,7 @@ describe ReactOnRailsProHelper do
         mock_request_and_response(many_chunks)
 
         # Simulate client disconnect after first chunk
-        closed_call_count = 0
-        allow(mocked_rails_stream).to receive(:closed?) do
-          closed_call_count += 1
-          closed_call_count > 1
-        end
+        allow(mocked_rails_stream).to receive(:closed?).and_return(false, true)
 
         on_complete_called = false
         on_complete = lambda { |_chunks|


### PR DESCRIPTION
## Summary

Replaces the manual `call_count`/`closed_call_count` stub pattern in two client-disconnect tests with RSpec's built-in `and_return(false, true)` sequence idiom. Functionally equivalent (RSpec returns the first value once, then the last value forever) but removes shared mutable state from the stub block.

## Scope

Addresses the specific files called out in the issue:

- `react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb`
  - `stops processing chunks when client disconnects`
  - `does not call on_complete when client disconnects mid-stream`

The concurrent execution test (around line 1010) is left as-is per the issue — incrementing/decrementing a counter to track active concurrency is a valid use case, not the anti-pattern.

## Why not `have_received` here?

The issue's primary example targets `expect(call_count).to eq(N)`-style assertions. These two tests don't assert on the counter — they use the counter to drive stub *return values* (`false` first, then `true`). The cleaner RSpec idiom for that is `and_return(false, true)`, not `have_received`.

## Test plan

- [x] `bundle exec rspec spec/helpers/react_on_rails_pro_helper_spec.rb -e "stops processing chunks when client disconnects" -e "does not call on_complete when client disconnects mid-stream"` — both pass
- [x] All 8 examples in the `#stream_react_component` describe block pass
- [x] `bundle exec rubocop` clean on the modified file
- [x] Ruby syntax check passes

Other failures observed locally in the spec file (`#cached_react_component`, `cached_stream_react_component integration with RandomValue`) are pre-existing environment issues (missing webpack assets, no running node-renderer on port 3800) unrelated to this change.

Fixes #2157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that preserves behavior while removing mutable counter state from stubs.
> 
> **Overview**
> Simplifies the `stream_react_component` client-disconnect specs by replacing the manual `call_count`/`closed_call_count` stub blocks with `allow(...).to receive(:closed?).and_return(false, true)`.
> 
> This keeps the same disconnect simulation (first check open, subsequent checks closed) while making the tests less stateful and easier to read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6e2a1531729470d8f9dce7831fbb6dfe500760b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test mocking patterns for streaming-disconnect tests.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->