### PR TITLE
ci: consolidate Ruby setup and Bundler caching

### DIFF
--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -1,5 +1,5 @@
 name: Setup Bundler dependencies
-description: Cache and install Ruby gems for a Bundler project.
+description: Setup Ruby, cache, and install gems for a Bundler project.
 
 inputs:
   working-directory:
@@ -8,22 +8,18 @@ inputs:
   ruby-version:
     description: Ruby version used by the job.
     required: true
-  bundle-path:
-    description: Bundler install path, relative to the working directory.
-    required: false
-    default: vendor/bundle
   frozen:
-    description: Whether to run Bundler in frozen mode. Cache saving is disabled when false; restore still runs.
+    description: Whether to run Bundler in frozen mode.
     required: false
     default: 'true'
   bundler-version:
-    description: Bundler version selector. Use lockfile, system, or x.y.z.
+    description: Bundler version selector. Use Gemfile.lock, default, latest, none, or x.y.z.
     required: false
-    default: lockfile
-  install-args:
-    description: Arguments for bundle install.
+    default: Gemfile.lock
+  cache-version:
+    description: Arbitrary cache-version value passed through to ruby/setup-ruby.
     required: false
-    default: --jobs=4 --retry=3
+    default: '0'
 
 runs:
   using: composite
@@ -37,36 +33,14 @@ runs:
           exit 1
         fi
 
-    - name: Restore Ruby gems cache
-      id: restore-ruby-gems-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: ${{ inputs.working-directory }}/${{ inputs.bundle-path }}
-        # Update to bundle-...-v1 in the future to break the cache if necessary
-        # or v1-bundle-... if you want restore-keys not to trigger either (update the key there in that case)
-        key: bundle-${{ runner.os }}-${{ inputs.working-directory }}-${{ inputs.bundle-path }}-ruby${{ inputs.ruby-version }}-${{ hashFiles(format('{0}/Gemfile.lock', inputs.working-directory)) }}
-        restore-keys: |
-          bundle-${{ runner.os }}-${{ inputs.working-directory }}-${{ inputs.bundle-path }}-ruby${{ inputs.ruby-version }}-
-
-    - name: Install Ruby gems
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
+    - name: Setup Ruby and install cached gems
+      uses: ruby/setup-ruby@v1
       env:
         BUNDLE_FROZEN: ${{ inputs.frozen }}
-        BUNDLE_INSTALL_ARGS: ${{ inputs.install-args }}
-        BUNDLE_PATH_CONFIG: ${{ inputs.bundle-path }}
-        BUNDLER_VERSION_CONFIG: ${{ inputs.bundler-version }}
-      run: |
-        bundle config set --local path "$BUNDLE_PATH_CONFIG"
-        bundle config set --local version "$BUNDLER_VERSION_CONFIG"
-        # shellcheck disable=SC2086
-        # Intentionally allow install args to split into separate bundle arguments
-        bundle check || bundle install $BUNDLE_INSTALL_ARGS
-
-    - name: Save Ruby gems cache
-      # We don't want to overwrite the cache for non-frozen Bundler runs
-      if: inputs.frozen == 'true' && steps.restore-ruby-gems-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
+        BUNDLE_RETRY: '3'
       with:
-        path: ${{ inputs.working-directory }}/${{ inputs.bundle-path }}
-        key: ${{ steps.restore-ruby-gems-cache.outputs.cache-primary-key }}
+        ruby-version: ${{ inputs.ruby-version }}
+        working-directory: ${{ inputs.working-directory }}
+        bundler: ${{ inputs.bundler-version }}
+        bundler-cache: true
+        cache-version: ${{ inputs.cache-version }}

--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -1,5 +1,7 @@
 name: Setup Bundler dependencies
-description: Setup Ruby, cache, and install gems for a Bundler project.
+description: >
+  Setup Ruby, cache, and install gems for a Bundler project. On Linux,
+  ensure libyaml-dev is already present or install it before calling this action.
 
 inputs:
   working-directory:

--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -38,6 +38,7 @@ runs:
       env:
         BUNDLE_FROZEN: ${{ inputs.frozen }}
         BUNDLE_RETRY: '3'
+        BUNDLE_JOBS: '4'
       with:
         ruby-version: ${{ inputs.ruby-version }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -27,3 +27,4 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
         bundler: ${{ inputs.bundler-version }}
+        bundler-cache: false

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,0 +1,29 @@
+name: Setup Ruby runtime
+description: Install Ruby runtime prerequisites and setup Ruby without installing gems.
+
+inputs:
+  ruby-version:
+    description: Ruby version used by the job.
+    required: true
+  bundler-version:
+    description: Bundler version selector passed through to ruby/setup-ruby.
+    required: false
+    default: Gemfile.lock
+  install-libyaml:
+    description: Whether to install libyaml-dev before Ruby/Bundler steps.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install libyaml-dev
+      if: runner.os == 'Linux' && inputs.install-libyaml == 'true'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler: ${{ inputs.bundler-version }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -202,7 +202,7 @@ jobs:
       # libyaml-dev is needed for psych v5 native extensions; install before any
       # bundler-cache step so bundle install can compile psych if required.
       - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev -y
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -146,6 +146,7 @@ jobs:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
       # Pro gem server does not publish checksums; needed for Pro benchmark gem installs.
       BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
+      BENCHMARK_PORT: '3001'
 
     steps:
       # ============================================
@@ -169,7 +170,7 @@ jobs:
       - name: Add tools directory to PATH
         run: |
           mkdir -p ~/bin
-          echo "$HOME/bin" >> $GITHUB_PATH
+          echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - name: Cache Vegeta binary
         id: cache-vegeta
@@ -185,11 +186,11 @@ jobs:
           echo "📦 Installing Vegeta v${VEGETA_VERSION}"
 
           # Download and extract vegeta binary
-          wget -q https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz
-          tar -xzf vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz
+          wget -q "https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
+          tar -xzf "vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
 
           # Store in cache directory
-          mv vegeta ~/bin/
+          mv vegeta "$HOME/bin/"
 
       - name: Setup k6
         uses: grafana/setup-k6-action@v1
@@ -213,7 +214,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Get gem home directory
-        run: echo "GEM_HOME_PATH=$(gem env home)" >> $GITHUB_ENV
+        run: echo "GEM_HOME_PATH=$(gem env home)" >> "$GITHUB_ENV"
 
       - name: Cache foreman gem
         id: cache-foreman
@@ -261,13 +262,13 @@ jobs:
           SERVER_CMD="nice -n -20 taskset -c 1-$((NPROC-1)) bin/prod"
           BENCH_CMD="nice -n -10 taskset -c 0 ruby"
 
-          echo "SERVER_CMD=$SERVER_CMD" >> $GITHUB_ENV
-          echo "BENCH_CMD=$BENCH_CMD" >> $GITHUB_ENV
+          echo "SERVER_CMD=$SERVER_CMD" >> "$GITHUB_ENV"
+          echo "BENCH_CMD=$BENCH_CMD" >> "$GITHUB_ENV"
 
           # Set Puma workers to match available server CPUs (only if not explicitly set)
           if [ -z "$WEB_CONCURRENCY" ]; then
             WEB_CONCURRENCY=$((NPROC-1))
-            echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> $GITHUB_ENV
+            echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> "$GITHUB_ENV"
             echo "WEB_CONCURRENCY (auto): $WEB_CONCURRENCY"
           else
             echo "WEB_CONCURRENCY (from input): $WEB_CONCURRENCY"
@@ -310,13 +311,13 @@ jobs:
           echo "🚀 Starting production server..."
           cd react_on_rails/spec/dummy
 
-          $SERVER_CMD &
+          PORT="$BENCHMARK_PORT" $SERVER_CMD &
           echo "Server started in background"
 
           # Wait for server to be ready (max 30 seconds)
           echo "⏳ Waiting for server to be ready..."
           for i in {1..30}; do
-            if curl -fsS http://localhost:3001 > /dev/null; then
+            if curl -fsS "http://localhost:${BENCHMARK_PORT}" > /dev/null; then
               echo "✅ Server is ready and responding"
               exit 0
             fi
@@ -381,19 +382,19 @@ jobs:
           # Kill all server-related processes (safe in isolated CI environment)
           pkill -9 -f "ruby|node|foreman|overmind|puma" || true
 
-          # Wait for port 3001 to be free
-          echo "⏳ Waiting for port 3001 to be free..."
+          # Wait for benchmark port to be free
+          echo "⏳ Waiting for port ${BENCHMARK_PORT} to be free..."
           for _ in {1..10}; do
-            if ! lsof -ti:3001 > /dev/null 2>&1; then
-              echo "✅ Port 3001 is now free"
+            if ! lsof -ti:"${BENCHMARK_PORT}" > /dev/null 2>&1; then
+              echo "✅ Port ${BENCHMARK_PORT} is now free"
               exit 0
             fi
             sleep 1
           done
 
-          echo "❌ ERROR: Port 3001 is still in use after 10 seconds"
-          echo "Processes using port 3001:"
-          lsof -i:3001 || true
+          echo "❌ ERROR: Port ${BENCHMARK_PORT} is still in use after 10 seconds"
+          echo "Processes using port ${BENCHMARK_PORT}:"
+          lsof -i:"${BENCHMARK_PORT}" || true
           exit 1
 
       # ============================================
@@ -432,13 +433,15 @@ jobs:
           echo "🚀 Starting Pro production server..."
           cd react_on_rails_pro/spec/dummy
 
-          $SERVER_CMD &
+          # Foreman assigns PORT=5000 by default; pin it to the benchmark port
+          # so readiness checks and benchmarks hit the Rails process we started.
+          PORT="$BENCHMARK_PORT" $SERVER_CMD &
           echo "Server started in background"
 
           # Wait for server to be ready (max 30 seconds)
           echo "⏳ Waiting for server to be ready..."
           for i in {1..30}; do
-            if curl -fsS http://localhost:3001 > /dev/null; then
+            if curl -fsS "http://localhost:${BENCHMARK_PORT}" > /dev/null; then
               echo "✅ Server is ready and responding"
               exit 0
             fi
@@ -552,12 +555,14 @@ jobs:
           # branch — new reports compare against main's own history.
           # Feature branches (PRs, dispatch) use --start-point to inherit
           # historical data and thresholds from main.
+          START_POINT_HASH_ARG=""
           if [ "${{ github.event_name }}" = "push" ]; then
             BRANCH="main"
             START_POINT_ARGS=""
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             BRANCH="$GITHUB_HEAD_REF"
-            START_POINT_ARGS="--start-point $GITHUB_BASE_REF --start-point-hash ${{ github.event.pull_request.base.sha }} --start-point-clone-thresholds --start-point-reset"
+            START_POINT_HASH_ARG="--start-point-hash ${{ github.event.pull_request.base.sha }}"
+            START_POINT_ARGS="--start-point $GITHUB_BASE_REF $START_POINT_HASH_ARG --start-point-clone-thresholds --start-point-reset"
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             BRANCH="${{ github.ref_name }}"
             if [ "$BRANCH" = "main" ]; then
@@ -568,7 +573,8 @@ jobs:
               START_POINT_HASH=$(gh api "repos/${{ github.repository }}/compare/main...$BRANCH" --jq '.merge_base_commit.sha' || true)
               if [ -n "$START_POINT_HASH" ]; then
                 echo "Found merge-base via API: $START_POINT_HASH"
-                START_POINT_ARGS="--start-point main --start-point-hash $START_POINT_HASH --start-point-clone-thresholds --start-point-reset"
+                START_POINT_HASH_ARG="--start-point-hash $START_POINT_HASH"
+                START_POINT_ARGS="--start-point main $START_POINT_HASH_ARG --start-point-clone-thresholds --start-point-reset"
               else
                 echo "⚠️ Could not find merge-base with main via GitHub API, continuing without hash"
                 START_POINT_ARGS="--start-point main --start-point-clone-thresholds --start-point-reset"
@@ -646,7 +652,7 @@ jobs:
           # when the pinned hash isn't in its DB. A single combined pattern
           # avoids false-positive matches across unrelated lines.
           if [ $BENCHER_EXIT_CODE -ne 0 ] && grep -q "Head Version.*not found" "$BENCHER_STDERR" && ! grep -qiE "alert|threshold violation|boundary violation" "$BENCHER_STDERR"; then
-            RETRY_ARGS=$(echo "$START_POINT_ARGS" | sed 's/--start-point-hash [^ ]*//')
+            RETRY_ARGS="${START_POINT_ARGS/$START_POINT_HASH_ARG/}"
             if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
               echo ""
               echo "⚠️ Start-point hash not found in Bencher — retrying without --start-point-hash (will use latest baseline)"
@@ -751,13 +757,13 @@ jobs:
             --state open \
             --limit 1 \
             --json number \
-            --jq '.[0].number // empty')
+            --jq ".[0].number // empty")
 
           # Build the benchmark summary snippet (defensive: don't let column failure block alerting)
           SUMMARY=""
           if [ -f bench_results/summary.txt ]; then
             FORMATTED=$(column -t -s $'\t' "bench_results/summary.txt" 2>/dev/null) || FORMATTED=$(cat "bench_results/summary.txt")
-            SUMMARY=$(printf '\n### Benchmark Summary\n\n```\n%s\n```' "$FORMATTED")
+            SUMMARY=$(printf "\n### Benchmark Summary\n\n\`\`\`\n%s\n\`\`\`" "$FORMATTED")
           fi
 
           if [ -n "$EXISTING_ISSUE" ]; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -204,9 +204,9 @@ jobs:
       # libyaml-dev is needed for psych v5 native extensions; install before
       # setup-bundle so bundle install can compile psych if required.
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
-      # Sets up Ruby for unconditional steps like `gem env home`.
+      # Sets up Ruby for unconditional steps (`gem env home`, Foreman cache/install).
       # Dummy app gems are installed in the conditional setup-bundle steps below.
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -290,8 +290,12 @@ jobs:
           working-directory: react_on_rails/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
 
+      # Pin Core steps that shell out to bundle exec, directly or via
+      # bin/prod-assets, bin/prod, or benchmarks/bench.rb, to the Core dummy Gemfile.
       - name: Prepare Core production assets
         if: env.RUN_CORE
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/spec/dummy/Gemfile
         run: |
           set -e  # Exit on any error
           echo "🔨 Building production assets..."
@@ -306,6 +310,8 @@ jobs:
 
       - name: Start Core production server
         if: env.RUN_CORE
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/spec/dummy/Gemfile
         run: |
           set -e  # Exit on any error
           echo "🚀 Starting production server..."
@@ -332,9 +338,13 @@ jobs:
       # STEP 4: RUN CORE BENCHMARKS
       # ============================================
 
+      # bench.rb shells out to `bundle exec rails routes` from the Core dummy;
+      # see the BUNDLE_GEMFILE note above the Core production steps.
       - name: Execute Core benchmark suite
         if: env.RUN_CORE
         timeout-minutes: 120
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/spec/dummy/Gemfile
         run: |
           set -e  # Exit on any error
           echo "🏃 Running Core benchmark suite..."
@@ -652,6 +662,10 @@ jobs:
           # when the pinned hash isn't in its DB. A single combined pattern
           # avoids false-positive matches across unrelated lines.
           if [ $BENCHER_EXIT_CODE -ne 0 ] && grep -q "Head Version.*not found" "$BENCHER_STDERR" && ! grep -qiE "alert|threshold violation|boundary violation" "$BENCHER_STDERR"; then
+            # When START_POINT_HASH_ARG is empty (e.g. workflow_dispatch on a
+            # non-main branch where the merge-base lookup returned ""), the
+            # substitution is a no-op; the inequality guard below skips the
+            # redundant retry.
             RETRY_ARGS="${START_POINT_ARGS/$START_POINT_HASH_ARG/}"
             if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
               echo ""
@@ -763,7 +777,7 @@ jobs:
           SUMMARY=""
           if [ -f bench_results/summary.txt ]; then
             FORMATTED=$(column -t -s $'\t' "bench_results/summary.txt" 2>/dev/null) || FORMATTED=$(cat "bench_results/summary.txt")
-            SUMMARY=$(printf "\n### Benchmark Summary\n\n\`\`\`\n%s\n\`\`\`" "$FORMATTED")
+            SUMMARY=$(printf '\n### Benchmark Summary\n\n```\n%s\n```' "$FORMATTED")
           fi
 
           if [ -n "$EXISTING_ISSUE" ]; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -770,7 +770,8 @@ jobs:
           SUMMARY=""
           if [ -f bench_results/summary.txt ]; then
             FORMATTED=$(column -t -s $'\t' "bench_results/summary.txt" 2>/dev/null) || FORMATTED=$(cat "bench_results/summary.txt")
-            SUMMARY=$(printf "\n### Benchmark Summary\n\n\`\`\`\n%s\n\`\`\`" "$FORMATTED")
+            # shellcheck disable=SC2016
+            SUMMARY=$(printf '\n### Benchmark Summary\n\n```\n%s\n```' "$FORMATTED")
           fi
 
           if [ -n "$EXISTING_ISSUE" ]; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -459,9 +459,13 @@ jobs:
       # STEP 6: RUN PRO BENCHMARKS
       # ============================================
 
+      # bench.rb shells out to `bundle exec rails routes`; pin the Pro dummy
+      # Gemfile so those calls use the same bundle as the Pro server.
       - name: Execute Pro benchmark suite
         if: env.RUN_PRO_RAILS
         timeout-minutes: 120
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails_pro/spec/dummy/Gemfile
         run: |
           set -e
           echo "🏃 Running Pro benchmark suite..."
@@ -655,14 +659,14 @@ jobs:
           # when the pinned hash isn't in its DB. A single combined pattern
           # avoids false-positive matches across unrelated lines.
           if [ $BENCHER_EXIT_CODE -ne 0 ] && grep -q "Head Version.*not found" "$BENCHER_STDERR" && ! grep -qiE "alert|threshold violation|boundary violation" "$BENCHER_STDERR"; then
-            # When START_POINT_HASH_ARG is empty (e.g. workflow_dispatch on a
-            # non-main branch where the merge-base lookup returned ""), the
-            # substitution is a no-op; the inequality guard below skips the
-            # redundant retry.
+          if [ -n "$START_POINT_HASH_ARG" ]; then
             RETRY_ARGS="${START_POINT_ARGS/$START_POINT_HASH_ARG/}"
-            if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
-              echo ""
-              echo "⚠️ Start-point hash not found in Bencher — retrying without --start-point-hash (will use latest baseline)"
+          else
+            RETRY_ARGS="$START_POINT_ARGS"
+          fi
+          if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
+            echo ""
+            echo "⚠️ Start-point hash not found in Bencher — retrying without --start-point-hash (will use latest baseline)"
               echo "::warning::Start-point hash not found in Bencher — falling back to latest baseline for comparison"
               set +e
               run_bencher "$RETRY_ARGS" > bench_results/bencher_report.html 2>"$BENCHER_STDERR"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -198,6 +198,11 @@ jobs:
       # STEP 3: START APPLICATION SERVER
       # ============================================
 
+      # libyaml-dev is needed for psych v5 native extensions; install before any
+      # bundler-cache step so bundle install can compile psych if required.
+      - name: Fix dependency for libyaml-dev
+        run: sudo apt install libyaml-dev -y
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -216,9 +221,6 @@ jobs:
       - name: Install foreman
         if: steps.cache-foreman.outputs.cache-hit != 'true'
         run: gem install foreman
-
-      - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev -y
 
       # Follow https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time
       - name: Setup pnpm

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -349,7 +349,7 @@ jobs:
           set -e  # Exit on any error
           echo "🏃 Running Core benchmark suite..."
 
-          if ! $BENCH_CMD benchmarks/bench.rb; then
+          if ! BASE_URL="localhost:${BENCHMARK_PORT}" $BENCH_CMD benchmarks/bench.rb; then
             echo "❌ ERROR: Benchmark execution failed"
             exit 1
           fi
@@ -473,7 +473,7 @@ jobs:
           set -e
           echo "🏃 Running Pro benchmark suite..."
 
-          if ! PRO=true $BENCH_CMD benchmarks/bench.rb; then
+          if ! BASE_URL="localhost:${BENCHMARK_PORT}" PRO=true $BENCH_CMD benchmarks/bench.rb; then
             echo "❌ ERROR: Benchmark execution failed"
             exit 1
           fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,6 +144,7 @@ jobs:
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
 
     steps:
       # ============================================

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -201,9 +201,9 @@ jobs:
       # STEP 3: START APPLICATION SERVER
       # ============================================
 
-      # libyaml-dev is needed for psych v5 native extensions; install before any
-      # bundler-cache step so bundle install can compile psych if required.
-      - name: Fix dependency for libyaml-dev
+      # libyaml-dev is needed for psych v5 native extensions; install before
+      # setup-bundle so bundle install can compile psych if required.
+      - name: Install libyaml-dev (required for psych v5 native extensions)
         run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       # Sets up Ruby for unconditional steps like `gem env home`.
@@ -777,7 +777,7 @@ jobs:
           SUMMARY=""
           if [ -f bench_results/summary.txt ]; then
             FORMATTED=$(column -t -s $'\t' "bench_results/summary.txt" 2>/dev/null) || FORMATTED=$(cat "bench_results/summary.txt")
-            SUMMARY=$(printf '\n### Benchmark Summary\n\n```\n%s\n```' "$FORMATTED")
+            SUMMARY=$(printf "\n### Benchmark Summary\n\n\`\`\`\n%s\n\`\`\`" "$FORMATTED")
           fi
 
           if [ -n "$EXISTING_ISSUE" ]; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,6 +144,7 @@ jobs:
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      # Pro gem server does not publish checksums; needed for Pro benchmark gem installs.
       BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
 
     steps:
@@ -204,8 +205,8 @@ jobs:
       - name: Fix dependency for libyaml-dev
         run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
-      # Sets up Ruby/Bundler for unconditional steps like `gem env home`.
-      # Dummy app gems are installed in the conditional bundler-cache steps below.
+      # Sets up Ruby for unconditional steps like `gem env home`.
+      # Dummy app gems are installed in the conditional setup-bundle steps below.
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,8 +144,6 @@ jobs:
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      # Pro gem server does not publish checksums; needed for Pro benchmark gem installs.
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
       BENCHMARK_PORT: '3001'
 
     steps:
@@ -201,15 +199,10 @@ jobs:
       # STEP 3: START APPLICATION SERVER
       # ============================================
 
-      # libyaml-dev is needed for psych v5 native extensions; install before
-      # setup-bundle so bundle install can compile psych if required.
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       # Sets up Ruby for unconditional steps (`gem env home`, Foreman cache/install).
       # Dummy app gems are installed in the conditional setup-bundle steps below.
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -659,14 +659,14 @@ jobs:
           # when the pinned hash isn't in its DB. A single combined pattern
           # avoids false-positive matches across unrelated lines.
           if [ $BENCHER_EXIT_CODE -ne 0 ] && grep -q "Head Version.*not found" "$BENCHER_STDERR" && ! grep -qiE "alert|threshold violation|boundary violation" "$BENCHER_STDERR"; then
-          if [ -n "$START_POINT_HASH_ARG" ]; then
-            RETRY_ARGS="${START_POINT_ARGS/$START_POINT_HASH_ARG/}"
-          else
-            RETRY_ARGS="$START_POINT_ARGS"
-          fi
-          if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
-            echo ""
-            echo "⚠️ Start-point hash not found in Bencher — retrying without --start-point-hash (will use latest baseline)"
+            if [ -n "$START_POINT_HASH_ARG" ]; then
+              RETRY_ARGS="${START_POINT_ARGS/$START_POINT_HASH_ARG/}"
+            else
+              RETRY_ARGS="$START_POINT_ARGS"
+            fi
+            if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
+              echo ""
+              echo "⚠️ Start-point hash not found in Bencher — retrying without --start-point-hash (will use latest baseline)"
               echo "::warning::Start-point hash not found in Bencher — falling back to latest baseline for comparison"
               set +e
               run_bencher "$RETRY_ARGS" > bench_results/bencher_report.html 2>"$BENCHER_STDERR"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -204,6 +204,8 @@ jobs:
       - name: Fix dependency for libyaml-dev
         run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
+      # Sets up Ruby/Bundler for unconditional steps like `gem env home`.
+      # Dummy app gems are installed in the conditional bundler-cache steps below.
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -123,14 +123,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -121,6 +121,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -60,13 +60,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -91,13 +93,13 @@ jobs:
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ inputs.force_run }}" == "true" ]] || \
-             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+            [[ "${{ inputs.force_run }}" == "true" ]] || \
+            [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   examples:
@@ -137,7 +139,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -187,7 +189,7 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Verify rake tasks exist
         run: |
           cd react_on_rails

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
       # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -172,6 +172,8 @@ jobs:
         with:
           working-directory: react_on_rails
           ruby-version: ${{ matrix.ruby-version }}
+          # Minimum-dependency legs intentionally install with frozen=false after script/convert,
+          # matching the historical bundle install behavior for converted dependency files.
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Ensure minimum required Chrome version
         run: |

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -120,14 +120,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -118,6 +118,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
       # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -144,6 +144,8 @@ jobs:
         with:
           working-directory: react_on_rails
           ruby-version: ${{ matrix.ruby-version }}
+          # Minimum-dependency legs intentionally install with frozen=false after script/convert,
+          # matching the historical bundle install behavior for converted dependency files.
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Git Stuff
         if: matrix.dependency-level == 'minimum'

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -60,13 +60,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -84,7 +86,7 @@ jobs:
              [[ "${{ steps.check-label.outputs.result }}" == "true" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions × 2 shards
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback × 2 shards
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"}]}' >> "$GITHUB_OUTPUT"
@@ -151,7 +153,7 @@ jobs:
           git commit -am "stop generators from complaining about uncommitted code"
       - name: Set dependency level environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Run rspec tests
         env:
           SHARD: ${{ matrix.shard }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -121,14 +121,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -207,14 +204,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -119,15 +119,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # libyaml-dev is needed for psych v5
+      # this gem depends on sdoc which depends on rdoc which depends on psych
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler: 2.5.9
-      # libyaml-dev is needed for psych v5
-      # this gem depends on sdoc which depends on rdoc which depends on psych
-      - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -206,6 +206,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -121,8 +121,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # libyaml-dev is needed for psych v5
-      # this gem depends on sdoc which depends on rdoc which depends on psych
+      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
       - name: Install libyaml-dev (required for psych v5 native extensions)
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -296,7 +296,15 @@ jobs:
       - name: Set packer version environment variable
         run: |
           echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
+      # The second setup-ruby step above (Install dummy app gems) writes
+      # BUNDLE_GEMFILE to $GITHUB_ENV, leaking the dummy Gemfile into all
+      # later steps. Both Gemfiles eval the shared dev dependencies, so
+      # rspec is resolvable either way, but pin the package Gemfile here
+      # for parity with pro-lint.yml/benchmark.yml and to stay robust if
+      # the Gemfiles ever diverge.
       - name: Main CI
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,13 +58,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
           else
             BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
             script/ci-changes-detector "$BASE_REF"
@@ -88,13 +90,13 @@ jobs:
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ inputs.force_run }}" == "true" ]] || \
-             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+            [[ "${{ inputs.force_run }}" == "true" ]] || \
+            [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build-dummy-app-webpack-test-bundles:
@@ -136,7 +138,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -222,7 +224,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -293,7 +295,7 @@ jobs:
       - run: cd react_on_rails/spec/dummy && bundle info shakapacker
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Main CI
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -296,12 +296,8 @@ jobs:
       - name: Set packer version environment variable
         run: |
           echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
-      # The second setup-ruby step above (Install dummy app gems) writes
-      # BUNDLE_GEMFILE to $GITHUB_ENV, leaking the dummy Gemfile into all
-      # later steps. Both Gemfiles eval the shared dev dependencies, so
-      # rspec is resolvable either way, but pin the package Gemfile here
-      # for parity with pro-lint.yml/benchmark.yml and to stay robust if
-      # the Gemfiles ever diverge.
+      # Pin the package Gemfile explicitly for parity with pro-lint.yml/benchmark.yml
+      # and to stay robust if the package and dummy Gemfiles ever diverge.
       - name: Main CI
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -124,7 +124,7 @@ jobs:
       # libyaml-dev is needed for psych v5
       # this gem depends on sdoc which depends on rdoc which depends on psych
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -210,7 +210,7 @@ jobs:
           persist-credentials: false
       # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -289,11 +289,7 @@ jobs:
       - name: Set packer version environment variable
         run: |
           echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
-      # Pin the package Gemfile explicitly for parity with pro-lint.yml/benchmark.yml
-      # and to stay robust if the package and dummy Gemfiles ever diverge.
       - name: Main CI
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -140,9 +140,19 @@ jobs:
       - name: Install Node modules with pnpm
         run: pnpm install --frozen-lockfile
 
+      # The second setup-ruby step above (Install dummy app gems) writes
+      # BUNDLE_GEMFILE to $GITHUB_ENV, leaking the dummy Gemfile into all
+      # later steps. Both Gemfiles eval the shared dev dependencies, so
+      # rubocop/rbs are resolvable either way, but pin the package Gemfile
+      # explicitly here for parity with pro-lint.yml and to stay robust if
+      # the Gemfiles ever diverge.
       - name: Lint Ruby
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile
         run: cd react_on_rails && bundle exec rubocop
       - name: Validate RBS type signatures
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile
         run: cd react_on_rails && bundle exec rake rbs:validate
       # TODO: Re-enable Steep once RBS signatures are complete for all checked files
       # Currently disabled because 374 type errors need to be fixed first

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -140,12 +140,8 @@ jobs:
       - name: Install Node modules with pnpm
         run: pnpm install --frozen-lockfile
 
-      # The second setup-ruby step above (Install dummy app gems) writes
-      # BUNDLE_GEMFILE to $GITHUB_ENV, leaking the dummy Gemfile into all
-      # later steps. Both Gemfiles eval the shared dev dependencies, so
-      # rubocop/rbs are resolvable either way, but pin the package Gemfile
-      # explicitly here for parity with pro-lint.yml and to stay robust if
-      # the Gemfiles ever diverge.
+      # Pin the package Gemfile explicitly for parity with pro-lint.yml and to
+      # stay robust if the package and dummy Gemfiles ever diverge.
       - name: Lint Ruby
         env:
           BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -52,13 +52,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -111,7 +113,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Ruby
         uses: ./.github/actions/setup-ruby
         with:
-          ruby-version: 3
+          ruby-version: '3.4'
           bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -95,14 +95,11 @@ jobs:
           # No need for history in lint job
           fetch-depth: 1
           persist-credentials: false
-      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: 3
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -93,6 +93,9 @@ jobs:
           # No need for history in lint job
           fetch-depth: 1
           persist-credentials: false
+      # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -97,7 +97,7 @@ jobs:
           persist-credentials: false
       # libyaml-dev is needed for psych v5 native extensions (sdoc -> rdoc -> psych)
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,10 +52,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -65,7 +61,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -83,14 +83,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'
           bundler: 2.5.9
-      # libyaml-dev is needed for psych v5
-      - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -85,7 +85,7 @@ jobs:
           persist-credentials: false
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -83,14 +83,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: '3.4'
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -196,6 +197,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -372,6 +374,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     # Redis service container
     services:
       redis:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -98,8 +98,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      # Bundler's compact index can occasionally return checksums that disagree with older Pro dummy-app locks.
-      # This mirrors the existing CI workaround for the Pro dummy bundle install in this workflow.
+      # Pro gem server does not publish checksums. Keep this job-level so every
+      # setup-bundle install in the job sees the same Bundler setting.
       BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -63,10 +63,12 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -96,6 +98,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      # Bundler's compact index can occasionally return checksums that disagree with older Pro dummy-app locks.
+      # This mirrors the existing CI workaround for the Pro dummy bundle install in this workflow.
       BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +128,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -229,7 +233,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -421,7 +425,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -102,6 +102,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -202,6 +206,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -390,6 +398,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -98,23 +98,16 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      # Pro gem server does not publish checksums. Keep this job-level so every
-      # setup-bundle install in the job sees the same Bundler setting.
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -205,21 +198,16 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -386,7 +374,6 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     # Redis service container
     services:
       redis:
@@ -403,15 +390,11 @@ jobs:
         with:
           persist-credentials: false
 
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -108,7 +108,7 @@ jobs:
 
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -213,7 +213,7 @@ jobs:
 
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -405,7 +405,7 @@ jobs:
 
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -97,8 +97,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      # Pro gem server does not publish checksums. This must be job-level because
-      # ruby/setup-ruby's bundler-cache runs bundle install before step-level env.
+      # Pro gem server does not publish checksums. Keep this job-level so every
+      # setup-bundle install in the job sees the same Bundler setting.
       BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
@@ -173,8 +173,6 @@ jobs:
         working-directory: .
         run: pnpm --filter react-on-rails-pro build
 
-      # After the second setup-ruby step (Install Pro dummy app gems) ran
-      # above, $GITHUB_ENV's BUNDLE_GEMFILE points at the dummy app Gemfile.
       # These steps need the Pro package Gemfile (which carries rubocop/rbs),
       # so pin it via absolute path — robust to changes in defaults.run.
       - name: Lint Ruby

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -97,23 +97,16 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      # Pro gem server does not publish checksums. Keep this job-level so every
-      # setup-bundle install in the job sees the same Bundler setting.
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -205,21 +198,16 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -413,21 +401,16 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      # libyaml-dev is needed for psych v5
-      - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
-
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Print system information
         run: |

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -63,10 +63,12 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -95,6 +97,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      # Pro gem server does not publish checksums. This must be job-level because
+      # ruby/setup-ruby's bundler-cache runs bundle install before step-level env.
       BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
@@ -123,7 +127,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -170,9 +174,13 @@ jobs:
         run: pnpm --filter react-on-rails-pro build
 
       - name: Lint Ruby
+        env:
+          BUNDLE_GEMFILE: Gemfile
         run: bundle exec rubocop --ignore-parent-exclusion
 
       - name: Validate RBS type signatures
+        env:
+          BUNDLE_GEMFILE: Gemfile
         run: bundle exec rake rbs:validate
 
       - name: Check TypeScript

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -107,7 +107,7 @@ jobs:
 
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -213,7 +213,7 @@ jobs:
 
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -421,7 +421,7 @@ jobs:
 
       # libyaml-dev is needed for psych v5
       - name: Install libyaml-dev (required for psych v5 native extensions)
-        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -336,7 +336,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -95,10 +95,15 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -195,6 +200,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -394,10 +403,15 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      # libyaml-dev is needed for psych v5
+      - name: Install libyaml-dev (required for psych v5 native extensions)
+        run: sudo apt-get update && sudo apt-get install -y libyaml-dev
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -173,14 +173,18 @@ jobs:
         working-directory: .
         run: pnpm --filter react-on-rails-pro build
 
+      # After the second setup-ruby step (Install Pro dummy app gems) ran
+      # above, $GITHUB_ENV's BUNDLE_GEMFILE points at the dummy app Gemfile.
+      # These steps need the Pro package Gemfile (which carries rubocop/rbs),
+      # so pin it via absolute path — robust to changes in defaults.run.
       - name: Lint Ruby
         env:
-          BUNDLE_GEMFILE: Gemfile
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails_pro/Gemfile
         run: bundle exec rubocop --ignore-parent-exclusion
 
       - name: Validate RBS type signatures
         env:
-          BUNDLE_GEMFILE: Gemfile
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails_pro/Gemfile
         run: bundle exec rake rbs:validate
 
       - name: Check TypeScript

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -190,6 +190,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BUNDLE_DISABLE_CHECKSUM_VALIDATION: 'true'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Commit `package-lock.json`, `yarn.lock`, or other non-pnpm lock files
 - Add files to the `docs/` root — OSS docs go in `docs/oss/` subdirectories (`getting-started/`, `core-concepts/`, `building-features/`, `configuration/`, `api-reference/`, `deployment/`, `migrating/`, `upgrading/`, `misc/`); Pro docs go in `docs/pro/`
 - Force push to `main` or `master`
+- Reintroduce conditional gem declarations like `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil?` in `react_on_rails/Gemfile.development_dependencies`. Conditional inclusion produces a different dependency set than the lock file, which breaks `bundle install --frozen` in CI when the env var differs between `bundle lock` and `bundle install`. `DISABLE_TURBOLINKS` controls asset loading at the application layer, not gem inclusion.
 
 ## Main branch health
 

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -12,13 +12,7 @@ gem "uglifier"
 gem "jquery-rails"
 gem "puma", "~> 6.0"
 
-# Keep turbolinks declared so the Gemfile remains lock-compatible under frozen Bundler.
-# DISABLE_TURBOLINKS only controls whether the dummy app loads the asset in
-# react_on_rails/spec/dummy/app/assets/javascripts/application_non_webpack.js.erb.
-# Do NOT reintroduce a conditional like `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil?` —
-# conditional gem inclusion produces a different dependency set than the lock
-# file, which breaks `bundle install --frozen` in CI when the env var differs
-# between `bundle lock` and `bundle install`.
+# Unconditional -- see AGENTS.md for why the ENV conditional broke frozen installs.
 gem "turbolinks"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -15,6 +15,10 @@ gem "puma", "~> 6.0"
 # Keep turbolinks declared so the Gemfile remains lock-compatible under frozen Bundler.
 # DISABLE_TURBOLINKS only controls whether the dummy app loads the asset in
 # react_on_rails/spec/dummy/app/assets/javascripts/application_non_webpack.js.erb.
+# Do NOT reintroduce a conditional like `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil?` —
+# conditional gem inclusion produces a different dependency set than the lock
+# file, which breaks `bundle install --frozen` in CI when the env var differs
+# between `bundle lock` and `bundle install`.
 gem "turbolinks"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -13,7 +13,8 @@ gem "jquery-rails"
 gem "puma", "~> 6.0"
 
 # Keep turbolinks declared so the Gemfile remains lock-compatible under frozen Bundler.
-# DISABLE_TURBOLINKS only controls whether the dummy app loads the asset.
+# DISABLE_TURBOLINKS only controls whether the dummy app loads the asset in
+# react_on_rails/spec/dummy/app/assets/javascripts/application_non_webpack.js.erb.
 gem "turbolinks"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -12,8 +12,9 @@ gem "uglifier"
 gem "jquery-rails"
 gem "puma", "~> 6.0"
 
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil? || ENV["DISABLE_TURBOLINKS"].strip.empty?
+# Keep turbolinks declared so the Gemfile remains lock-compatible under frozen Bundler.
+# DISABLE_TURBOLINKS only controls whether the dummy app loads the asset.
+gem "turbolinks"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder"

--- a/react_on_rails/rakelib/run_rspec.rake
+++ b/react_on_rails/rakelib/run_rspec.rake
@@ -69,8 +69,11 @@ namespace :run_rspec do
     env_vars_array = []
     env_vars_array << rbs_runtime_env_vars unless rbs_runtime_env_vars.empty?
     env_vars_array << "DISABLE_TURBOLINKS=TRUE"
-    # This task intentionally runs with a different Gemfile view where the turbolinks gem is excluded.
+    # DISABLE_TURBOLINKS makes the Gemfile diverge from Gemfile.lock (drops the
+    # turbolinks gem), so bundler refuses to load under frozen/deployment mode
+    # that ruby/setup-ruby's bundler-cache enables in CI.
     env_vars_array << "BUNDLE_FROZEN=false"
+    env_vars_array << "BUNDLE_DEPLOYMENT=false"
     env_vars = env_vars_array.join(" ")
     run_tests_in(spec_dummy_dir,
                  env_vars: env_vars,

--- a/react_on_rails/rakelib/run_rspec.rake
+++ b/react_on_rails/rakelib/run_rspec.rake
@@ -69,11 +69,6 @@ namespace :run_rspec do
     env_vars_array = []
     env_vars_array << rbs_runtime_env_vars unless rbs_runtime_env_vars.empty?
     env_vars_array << "DISABLE_TURBOLINKS=TRUE"
-    # DISABLE_TURBOLINKS makes the Gemfile diverge from Gemfile.lock (drops the
-    # turbolinks gem), so bundler refuses to load under frozen/deployment mode
-    # that ruby/setup-ruby's bundler-cache enables in CI.
-    env_vars_array << "BUNDLE_FROZEN=false"
-    env_vars_array << "BUNDLE_DEPLOYMENT=false"
     env_vars = env_vars_array.join(" ")
     run_tests_in(spec_dummy_dir,
                  env_vars: env_vars,

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -354,7 +354,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  base64
   benchmark
   bootsnap
   capybara

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -354,6 +354,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64
   benchmark
   bootsnap
   capybara


### PR DESCRIPTION
## Summary

- Consolidates Ruby and Bundler setup around `.github/actions/setup-bundle`, which now calls `ruby/setup-ruby@v1` with `bundler-cache: true` instead of maintaining custom `actions/cache` restore/save logic in each workflow.
- Adds `.github/actions/setup-ruby` for jobs that need Ruby runtime setup before a separate Bundler install step, including the shared `libyaml-dev` prerequisite.
- Applies the reusable setup pattern across the OSS, Pro, benchmark, precompile, integration, Playwright, and lint workflows while preserving explicit Gemfile selection where later `bundle exec` calls must run against a package or dummy app.
- Keeps the CI reliability fixes from #2224: frozen installs use committed lockfiles, `turbolinks` stays unconditional so Bundler lock resolution is stable, Pro checksum validation remains enabled, and benchmark runs use the configured `BENCHMARK_PORT` consistently.

## Review and CI updates

- Rebased onto `origin/main` and force-pushed the branch at `bbf71aa3cc429dae277783105a599218f494b126`.
- Addressed the remaining must-fix review item by pinning `BUNDLE_GEMFILE` to `react_on_rails_pro/spec/dummy/Gemfile` for the Pro benchmark step, matching the Core benchmark behavior because `bench.rb` shells out through `bundle exec`.
- Addressed the dummy integration review item by removing the `BUNDLE_GEMFILE` override from `run_rspec:all_dummy`, so nested dummy app `bundle exec` calls can use the dummy Gemfile and lockfile.
- Addressed optional review items: explicit Bencher retry guard for an empty start-point hash, Ruby `3.4` pin in the lint bootstrap step, `BUNDLE_JOBS: '4'` preservation in `setup-bundle`, explicit `bundler-cache: false` in `setup-ruby`, Bencher retry indentation cleanup, and a `setup-bundle` description note for the Linux `libyaml-dev` prerequisite.
- No active discuss-only review items were found in the unresolved thread scan. If a later reviewer wants broader changes, the practical next step is to keep them as follow-up design cleanup unless they identify a concrete CI regression in this PR.
- GitHub checks for the latest push are queued/in progress; `inspect_pr_checks.py` reports no failing checks at the time this description was updated.

## Test plan

- [x] `git rebase origin/main`
- [x] Pre-change assertions for the open review items failed, then passed after the fixes
- [x] `git diff --check origin/main...HEAD && git diff --check`
- [x] `SHELLCHECK_OPTS='-S warning' actionlint -color`
- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/actions/setup-bundle/action.yml .github/actions/setup-ruby/action.yml .github/workflows/benchmark.yml .github/workflows/examples.yml .github/workflows/gem-tests.yml .github/workflows/integration-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml`
- [x] `pnpm start format.listDifferent`
- [x] `(cd react_on_rails && bundle exec rubocop)`
- [x] Pre-commit hook: trailing newline check and Prettier on changed workflow/action files
- [x] Pre-push hook: branch RuboCop on `react_on_rails/rakelib/run_rspec.rake` and Markdown link check on `AGENTS.md`
- [ ] Latest GitHub Actions run passes for `bbf71aa3cc429dae277783105a599218f494b126`

## Local note

- `pnpm run lint` currently fails in existing `packages/react-on-rails-pro-node-renderer/src/**` TypeScript files that are outside this PR diff. I did not modify Pro package source files as part of this workflow-focused PR.

Fixes #2224

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bbf71aa3cc429dae277783105a599218f494b126. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
