### PR TITLE
fix: add reactDomClientWarning helper for React 16/17 (#3137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Added
+
+- **`react-on-rails/webpackHelpers` subpath export with `reactDomClientWarning`**: New webpack helper export so React 16/17 consumers can suppress the harmless `Module not found: Can't resolve 'react-dom/client'` warning with a one-liner instead of remembering a regex. The require inside `reactApis` is guarded by a runtime React-version check, so this warning never reflects a real failure, but webpack still emits it at build time because the static `require('react-dom/client')` cannot be tree-shaken without breaking React 18+. Pass `reactDomClientWarning` to `ignoreWarnings` (Webpack 5 / Shakapacker) or `stats.warningsFilter` (Webpack 4 / Webpacker 5). Fixes [Issue 3137](https://github.com/shakacode/react_on_rails/issues/3137).
+
 #### Fixed
 
 - **[Pro]** **Preserve ruby-jwt 2.x compatibility in 16.7**: Relaxes the `16.7.0.rc.0` `jwt >= 3.2.0` floor to `jwt >= 2.7`, keeping compatibility with apps that still resolve jwt 2.x while continuing to allow patched jwt 3.2.0+ releases. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).

--- a/docs/oss/building-features/rails-webpacker-react-integration-options.md
+++ b/docs/oss/building-features/rails-webpacker-react-integration-options.md
@@ -87,7 +87,19 @@ const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptio
 module.exports = commonWebpackConfig;
 ```
 
-Webpack 4 / Webpacker 5 users should pass the same regex to [`stats.warningsFilter`](https://v4.webpack.js.org/configuration/stats/#statswarningsfilter) instead, since `ignoreWarnings` is a Webpack 5 option.
+Webpack 4 / Webpacker 5 users should pass the same regex to [`stats.warningsFilter`](https://v4.webpack.js.org/configuration/stats/#statswarningsfilter) instead, since `ignoreWarnings` is a Webpack 5 option:
+
+```js
+// Webpack 4 / Webpacker 5
+const { reactDomClientWarning } = require('react-on-rails/webpackHelpers');
+
+module.exports = {
+  // ...
+  stats: {
+    warningsFilter: [reactDomClientWarning],
+  },
+};
+```
 
 ---
 

--- a/docs/oss/building-features/rails-webpacker-react-integration-options.md
+++ b/docs/oss/building-features/rails-webpacker-react-integration-options.md
@@ -66,10 +66,11 @@ You may see a warning like this when building a Webpack bundle using any version
 Module not found: Error: Can't resolve 'react-dom/client' in ....
 ```
 
-It can be safely [suppressed](https://webpack.js.org/configuration/other-options/#ignorewarnings) in your Webpack configuration. The following is an example of this suppression in `config/webpack/commonWebpackConfig.js`:
+It can be safely [suppressed](https://webpack.js.org/configuration/other-options/#ignorewarnings) in your Webpack configuration. React on Rails exports a ready-made regex from `react-on-rails/webpackHelpers` so you don't have to remember the message text. The following is an example of this suppression in `config/webpack/commonWebpackConfig.js`:
 
 ```js
 const { webpackConfig: baseClientWebpackConfig, merge } = require('shakapacker');
+const { reactDomClientWarning } = require('react-on-rails/webpackHelpers');
 
 const commonOptions = {
   resolve: {
@@ -78,13 +79,15 @@ const commonOptions = {
 };
 
 const ignoreWarningsConfig = {
-  ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
+  ignoreWarnings: [reactDomClientWarning],
 };
 
 const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptions, ignoreWarningsConfig);
 
 module.exports = commonWebpackConfig;
 ```
+
+Webpack 4 / Webpacker 5 users should pass the same regex to [`stats.warningsFilter`](https://v4.webpack.js.org/configuration/stats/#statswarningsfilter) instead, since `ignoreWarnings` is a Webpack 5 option.
 
 ---
 

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -73,7 +73,8 @@
     "lib/**/*.js",
     "lib/**/*.cjs",
     "lib/**/*.mjs",
-    "lib/**/*.d.ts"
+    "lib/**/*.d.ts",
+    "lib/**/*.d.cts"
   ],
   "bugs": {
     "url": "https://github.com/shakacode/react_on_rails/issues"

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -39,6 +39,7 @@
     "./createReactOutput": "./lib/createReactOutput.js",
     "./isServerRenderResult": "./lib/isServerRenderResult.js",
     "./reactApis": "./lib/reactApis.cjs",
+    "./webpackHelpers": "./lib/webpackHelpers.cjs",
     "./reactHydrateOrRender": "./lib/reactHydrateOrRender.js",
     "./turbolinksUtils": "./lib/turbolinksUtils.js",
     "./isRenderFunction": "./lib/isRenderFunction.js",

--- a/packages/react-on-rails/src/reactApis.cts
+++ b/packages/react-on-rails/src/reactApis.cts
@@ -25,7 +25,9 @@ let reactDomClient: typeof import('react-dom/client');
 if (supportsRootApi) {
   // This will never throw an exception, but it's the way to tell Webpack the dependency is optional
   // https://github.com/webpack/webpack/issues/339#issuecomment-47739112
-  // Unfortunately, it only converts the error to a warning.
+  // Unfortunately, it only converts the error to a warning. React 16/17 consumers can suppress
+  // the warning by passing `reactDomClientWarning` from 'react-on-rails/webpackHelpers' to their
+  // webpack `ignoreWarnings` config. See #3137.
   try {
     reactDomClient = require('react-dom/client') as typeof import('react-dom/client');
   } catch (_e) {

--- a/packages/react-on-rails/src/webpackHelpers.cts
+++ b/packages/react-on-rails/src/webpackHelpers.cts
@@ -1,0 +1,25 @@
+/**
+ * Suppression pattern for the "Module not found: Can't resolve 'react-dom/client'"
+ * warning that webpack emits when building React 16/17 apps with react-on-rails.
+ *
+ * The warning is harmless: react-on-rails detects the React version at runtime and
+ * only calls into react-dom/client when React 18+ is available. But webpack's static
+ * analysis still tries to resolve the conditional require at build time, so the
+ * warning shows up on React 16/17 builds even though the build is healthy.
+ *
+ * Usage in your webpack config (Webpack 5 / Shakapacker):
+ *
+ *   const { reactDomClientWarning } = require('react-on-rails/webpackHelpers');
+ *
+ *   module.exports = {
+ *     // ...
+ *     ignoreWarnings: [reactDomClientWarning],
+ *   };
+ *
+ * Webpack 4 / Webpacker 5 users can pass the same regex to
+ * `stats.warningsFilter` instead, since `ignoreWarnings` is a Webpack 5 option.
+ *
+ * Tracking issue: https://github.com/shakacode/react_on_rails/issues/3137
+ */
+// eslint-disable-next-line import/prefer-default-export -- intentionally named so additional helpers can be added later without a breaking change
+export const reactDomClientWarning: RegExp = /Module not found: Error: Can't resolve 'react-dom\/client'/;

--- a/packages/react-on-rails/src/webpackHelpers.cts
+++ b/packages/react-on-rails/src/webpackHelpers.cts
@@ -22,4 +22,4 @@
  * Tracking issue: https://github.com/shakacode/react_on_rails/issues/3137
  */
 // eslint-disable-next-line import/prefer-default-export -- intentionally named so additional helpers can be added later without a breaking change
-export const reactDomClientWarning: RegExp = /Module not found: Error: Can't resolve 'react-dom\/client'/;
+export const reactDomClientWarning = /Module not found: Error: Can't resolve 'react-dom\/client'/;

--- a/packages/react-on-rails/tests/webpackHelpers.test.ts
+++ b/packages/react-on-rails/tests/webpackHelpers.test.ts
@@ -8,6 +8,12 @@ describe('webpackHelpers', () => {
       expect(reactDomClientWarning.test(message)).toBe(true);
     });
 
+    it('matches the webpack 4 "Module not found" warning for react-dom/client', () => {
+      const message =
+        "Module not found: Error: Can't resolve 'react-dom/client' in '/app/node_modules/react-on-rails/src'";
+      expect(reactDomClientWarning.test(message)).toBe(true);
+    });
+
     it('does not match unrelated module-not-found warnings', () => {
       expect(reactDomClientWarning.test("Module not found: Error: Can't resolve 'react-dom'")).toBe(false);
       expect(reactDomClientWarning.test("Module not found: Error: Can't resolve 'react-router/client'")).toBe(

--- a/packages/react-on-rails/tests/webpackHelpers.test.ts
+++ b/packages/react-on-rails/tests/webpackHelpers.test.ts
@@ -1,0 +1,18 @@
+import { reactDomClientWarning } from '../src/webpackHelpers.cts';
+
+describe('webpackHelpers', () => {
+  describe('reactDomClientWarning', () => {
+    it('matches the webpack 5 "Module not found" warning for react-dom/client', () => {
+      const message =
+        "Module not found: Error: Can't resolve 'react-dom/client' in '/app/node_modules/react-on-rails/lib'";
+      expect(reactDomClientWarning.test(message)).toBe(true);
+    });
+
+    it('does not match unrelated module-not-found warnings', () => {
+      expect(reactDomClientWarning.test("Module not found: Error: Can't resolve 'react-dom'")).toBe(false);
+      expect(reactDomClientWarning.test("Module not found: Error: Can't resolve 'react-router/client'")).toBe(
+        false,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Exports a new `reactDomClientWarning` regex at `react-on-rails/webpackHelpers` so React 16/17 consumers can silence the misleading `Module not found: Can't resolve 'react-dom/client'` build warning with a one-line config addition.
- The warning has always been harmless — `reactApis.cts` only calls into `react-dom/client` when `supportsRootApi` is true at runtime — but webpack's static analysis still tries to resolve the literal `require('react-dom/client')` and complains on React 16/17 builds, making a healthy build look broken.

## Why opt-in (and not an automatic fix in `reactApis.cts`)

I exhaustively tested every webpack-evasion technique before settling on this approach:

| Approach | Suppresses warning? | Works for React 18+? |
| --- | --- | --- |
| Static `require('react-dom/client')` (current) | ❌ "Module not found" | ✅ |
| Variable `require(name)` | ❌ "Critical dependency" + bundles entire context | ✅ |
| `__non_webpack_require__('react-dom/client')` | ✅ | ❌ becomes literal `require()`, fails in browsers |
| `import(/* webpackIgnore: true */ ...)` | ✅ | ❌ async API + browser native import fails |
| `package.json` `browser` field → `false` | ✅ | ❌ always aliased to nothing, even on React 18 |
| `if (false) require(...)` | ✅ | ❌ always dead-stripped |

Any technique that hides the require from webpack also stops webpack from bundling the module for React 18+ users. The pragmatic fix is to keep the require where it is and make the suppression dead-simple for the small minority of consumers still on React 16/17.

## Changes

- **New file** `packages/react-on-rails/src/webpackHelpers.cts` — exports the `reactDomClientWarning` regex with full usage comments.
- **New subpath export** `./webpackHelpers` in `packages/react-on-rails/package.json`.
- **Comment update** in `packages/react-on-rails/src/reactApis.cts` pointing maintainers and source-readers at the new helper.
- **Test** at `packages/react-on-rails/tests/webpackHelpers.test.ts` confirming the regex matches the webpack 5 warning string and doesn't catch unrelated `react-dom` / `react-router/client` warnings.
- **Docs** at `docs/oss/building-features/rails-webpacker-react-integration-options.md` updated to use the helper; adds a one-liner for Webpack 4 / Webpacker 5 users.
- **CHANGELOG.md** Unreleased entry under `#### Added`.

## Test plan

- [x] `pnpm run build` builds without errors; `lib/webpackHelpers.cjs` and `lib/webpackHelpers.d.cts` emitted.
- [x] `pnpm exec jest tests/webpackHelpers.test.ts` — new test passes.
- [x] `pnpm exec jest` (whole react-on-rails package) — 151/151 tests still pass.
- [x] `pnpm run type-check` clean.
- [x] `pnpm run lint` clean.
- [x] `pnpm exec prettier --check` on touched files — clean.
- [x] **End-to-end webpack reproduction:** wired the built package into a throwaway dir, ran two webpack 5 builds against the same entry: one without `ignoreWarnings`, one passing `[reactDomClientWarning]`. Confirmed the first emits the `Module not found` warning and the second is fully clean.

Fixes #3137

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: introduces a new helper export, docs, and tests without altering runtime behavior beyond comments and packaging metadata.
> 
> **Overview**
> Adds a new `react-on-rails/webpackHelpers` subpath export exposing `reactDomClientWarning`, a ready-made regex for suppressing webpack’s benign React 16/17 `react-dom/client` “Module not found” warning.
> 
> Updates docs and changelog to recommend using this helper (Webpack 5 `ignoreWarnings` or Webpack 4 `stats.warningsFilter`), adds a small Jest test for the regex, and updates `package.json` exports/files to publish the new helper and `.d.cts` typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b83b18e2bef63a8558052761b940630c315f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility export to help React 16/17 apps suppress Webpack build-time warnings about missing react-dom/client.

* **Documentation**
  * Updated Webpack guidance to show using the new utility with ignoreWarnings (Webpack 5) or stats.warningsFilter (Webpack 4).
  * Added a changelog entry describing the addition.

* **Tests**
  * Added tests verifying the utility matches relevant Webpack warning messages.

* **Chores**
  * Updated package publishing to expose the new utility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->