### PR TITLE
docs: point users at bin/shakapacker-config --doctor for bundler-config debugging

### DIFF
--- a/docs/oss/building-features/debugging.md
+++ b/docs/oss/building-features/debugging.md
@@ -204,7 +204,8 @@ cat public/packs/manifest.json | grep "application"
 
 When something is wrong with the build itself — a loader not matching, a plugin missing in production, dev/prod divergence — it helps to inspect the **fully-resolved** webpack or rspack config, including all of Shakapacker's defaults. Shakapacker ships a `--doctor` mode that dumps annotated YAML for every relevant build.
 
-> Note: this is separate from `bundle exec rake react_on_rails:doctor`, which diagnoses React on Rails configuration rather than the bundler config itself.
+> [!NOTE]
+> This is separate from `bundle exec rake react_on_rails:doctor`, which diagnoses React on Rails configuration rather than the bundler config itself.
 
 ```bash
 # Shakapacker 9.6+ canonical binstub

--- a/docs/oss/building-features/debugging.md
+++ b/docs/oss/building-features/debugging.md
@@ -202,7 +202,9 @@ cat public/packs/manifest.json | grep "application"
 
 ### Exporting the Fully-Resolved Bundler Configuration
 
-When something is wrong with the build itself — a loader not matching, a plugin missing in production, dev/prod divergence — it helps to inspect the **fully-resolved** webpack or rspack config, including all of Shakapacker's defaults. Shakapacker ships a `--doctor` mode that dumps annotated YAML for every relevant build:
+When something is wrong with the build itself — a loader not matching, a plugin missing in production, dev/prod divergence — it helps to inspect the **fully-resolved** webpack or rspack config, including all of Shakapacker's defaults. Shakapacker ships a `--doctor` mode that dumps annotated YAML for every relevant build.
+
+> Note: this is separate from `bundle exec rake react_on_rails:doctor`, which diagnoses React on Rails configuration rather than the bundler config itself.
 
 ```bash
 # Shakapacker 9.6+ canonical binstub
@@ -212,7 +214,7 @@ bin/shakapacker-config --doctor
 bin/export-bundler-config --doctor
 ```
 
-Both commands are thin shims over the same exporter and produce the same output: annotated YAML files in `shakapacker-config-exports/` covering development (with and without HMR) and production, split into separate client and server bundle files. The YAML is annotated with inline documentation so you can see, for each loader / plugin / resolve rule, where it came from.
+Both commands are thin shims over the same exporter and produce the same output: annotated YAML files in `shakapacker-config-exports/` (created in your project root) covering development (with and without HMR) and production, split into separate client and server bundle files. The YAML is annotated with inline documentation so you can see, for each loader / plugin / resolve rule, where it came from.
 
 Two common uses:
 

--- a/docs/oss/building-features/debugging.md
+++ b/docs/oss/building-features/debugging.md
@@ -223,7 +223,7 @@ Two common uses:
 - **Troubleshooting:** diff two exports (before/after an upgrade, or against a known-working app) to find configuration drift.
 - **AI-assisted analysis:** paste the annotated YAML into an AI tool to ask questions like "why is this plugin in server but not client?" — the output format is designed to be readable by both humans and LLMs.
 
-For the full set of flags (`--build`, `--init`, `--validate`, `--save-dir`, etc.) and the build-config-file workflow, see the [Shakapacker Configuration Diff Tool docs](https://shakapacker.com/docs/config-diff).
+For the full set of flags (`--build`, `--init`, `--validate`, `--save-dir`, etc.) and the build-config-file workflow, see the [Shakapacker Configuration Diff Tool docs](https://shakapacker.com/docs/config-diff/).
 
 ## Pro Node Renderer Debugging
 

--- a/docs/oss/building-features/debugging.md
+++ b/docs/oss/building-features/debugging.md
@@ -200,6 +200,27 @@ ls ssr-generated/
 cat public/packs/manifest.json | grep "application"
 ```
 
+### Exporting the Fully-Resolved Bundler Configuration
+
+When something is wrong with the build itself — a loader not matching, a plugin missing in production, dev/prod divergence — it helps to inspect the **fully-resolved** webpack or rspack config, including all of Shakapacker's defaults. Shakapacker ships a `--doctor` mode that dumps annotated YAML for every relevant build:
+
+```bash
+# Shakapacker 9.6+ canonical binstub
+bin/shakapacker-config --doctor
+
+# Older Shakapacker versions / projects with the legacy binstub
+bin/export-bundler-config --doctor
+```
+
+Both commands are thin shims over the same exporter and produce the same output: annotated YAML files in `shakapacker-config-exports/` covering development (with and without HMR) and production, split into separate client and server bundle files. The YAML is annotated with inline documentation so you can see, for each loader / plugin / resolve rule, where it came from.
+
+Two common uses:
+
+- **Troubleshooting:** diff two exports (before/after an upgrade, or against a known-working app) to find configuration drift.
+- **AI-assisted analysis:** paste the annotated YAML into an AI tool to ask questions like "why is this plugin in server but not client?" — the output format is designed to be readable by both humans and LLMs.
+
+For the full set of flags (`--build`, `--init`, `--validate`, `--save-dir`, etc.) and the build-config-file workflow, see the [Shakapacker README](https://github.com/shakacode/shakapacker).
+
 ## Pro Node Renderer Debugging
 
 If you're using the React on Rails Pro Node Renderer, the renderer process has its own logs. The log level is controlled by the `RENDERER_LOG_LEVEL` environment variable. See the [Node Renderer Basics](./node-renderer/basics.md) for configuration details.

--- a/docs/oss/building-features/debugging.md
+++ b/docs/oss/building-features/debugging.md
@@ -216,12 +216,14 @@ bin/export-bundler-config --doctor
 
 Both commands are thin shims over the same exporter and produce the same output: annotated YAML files in `shakapacker-config-exports/` (created in your project root) covering development (with and without HMR) and production, split into separate client and server bundle files. The YAML is annotated with inline documentation so you can see, for each loader / plugin / resolve rule, where it came from.
 
+> Tip: add `shakapacker-config-exports/` to your `.gitignore` — these files are intended for local inspection, not version control.
+
 Two common uses:
 
 - **Troubleshooting:** diff two exports (before/after an upgrade, or against a known-working app) to find configuration drift.
 - **AI-assisted analysis:** paste the annotated YAML into an AI tool to ask questions like "why is this plugin in server but not client?" — the output format is designed to be readable by both humans and LLMs.
 
-For the full set of flags (`--build`, `--init`, `--validate`, `--save-dir`, etc.) and the build-config-file workflow, see the [Shakapacker README](https://github.com/shakacode/shakapacker).
+For the full set of flags (`--build`, `--init`, `--validate`, `--save-dir`, etc.) and the build-config-file workflow, see the [Shakapacker Configuration Diff Tool docs](https://shakapacker.com/docs/config-diff).
 
 ## Pro Node Renderer Debugging
 

--- a/docs/oss/building-features/debugging.md
+++ b/docs/oss/building-features/debugging.md
@@ -216,7 +216,8 @@ bin/export-bundler-config --doctor
 
 Both commands are thin shims over the same exporter and produce the same output: annotated YAML files in `shakapacker-config-exports/` (created in your project root) covering development (with and without HMR) and production, split into separate client and server bundle files. The YAML is annotated with inline documentation so you can see, for each loader / plugin / resolve rule, where it came from.
 
-> Tip: add `shakapacker-config-exports/` to your `.gitignore` — these files are intended for local inspection, not version control.
+> [!TIP]
+> Add `shakapacker-config-exports/` to your `.gitignore` — these files are intended for local inspection, not version control.
 
 Two common uses:
 


### PR DESCRIPTION
## Summary

Adds a small subsection to `docs/oss/building-features/debugging.md` documenting Shakapacker's existing `bin/shakapacker-config --doctor` mode for exporting the fully-resolved webpack/rspack configuration. Covers:

- Both binstub names (`bin/shakapacker-config` for Shakapacker 9.6+, legacy `bin/export-bundler-config`)
- What it outputs (annotated YAML, dev with/without HMR, prod; client/server split)
- Two main use cases: diffing for troubleshooting, and AI-assisted analysis
- Link to the Shakapacker README for full flag reference

## Why this instead of the rake task proposed in #1862

The issue proposed a rake task that spins up a fresh Rails + RoR app, runs generators for both bundlers, exports configs via `bin/export-bundler-config --doctor`, and commits 10 reference YAML files to `docs/reference-configs/`. After evaluation:

- **The hard part already exists.** `bin/shakapacker-config --doctor` (shakapacker 9.6+) is the workhorse — it already produces annotated YAML for dev (HMR), dev, and prod with separate client/server files.
- **High maintenance, low signal.** Committed reference YAMLs go stale on every Rails / Shakapacker / RoR / Node bump. Keeping them current via CI would mean running `rails new` + `npm install` on every relevant PR.
- **The cited consumer doesn't need committed files.** The Shakapacker AI prompt (shakapacker#695) is most useful against a user's *real* app, not a vanilla scaffold.
- **Maintainer signal.** #1862 was labeled P3 (parked) and the most recent triage comment asked whether to schedule or park it.

A docs pointer captures ~90% of the educational benefit at ~1% of the implementation/maintenance cost.

Closes #1862.

## Test plan

- [x] `script/check-docs-sidebar` — no new files, existing sidebar entry unchanged
- [x] Prettier formatting check
- [x] Lychee link check on changed file (6/6 OK)
- [x] Pre-commit hooks (trailing newlines, markdown-links, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior. Main risk is minor confusion if projects use different binstubs/versions or paths than described.
> 
> **Overview**
> Adds a new debugging subsection documenting how to export the *fully-resolved* webpack/rspack configuration via Shakapacker’s `--doctor` mode (`bin/shakapacker-config --doctor` and the legacy `bin/export-bundler-config --doctor`).
> 
> Explains the generated annotated YAML outputs (dev with/without HMR and prod; client/server split), recommends ignoring `shakapacker-config-exports/`, and links to the config-diff docs for additional flags/workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceee19e57a5fde7e37a9f9f6385389a401f0ac94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for exporting and inspecting fully-resolved bundler configurations, demonstrating exports for development (with/without HMR) and production client/server outputs.
  * Explains annotated YAML exports that show where loaders/plugins/resolve rules originate, includes .gitignore guidance, diff-based troubleshooting and AI-assisted analysis examples, and links to the configuration diff tool documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->