### PR TITLE
test: stub stable VERSION in --pro install spec to unblock CI

### DIFF
--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3026,10 +3026,14 @@ describe InstallGenerator, type: :generator do
 
   context "when using --pro flag without Pro gem installed" do
     let(:install_generator) { described_class.new([], { pro: true }) }
-    let(:expected_pro_version) { Gem::Version.new(ReactOnRails::VERSION).release.to_s }
+    # Pin to a stable version so this test exercises the pessimistic (~>) branch
+    # of pro_gem_version_requirement regardless of whether the live VERSION is a
+    # prerelease (the prerelease branch is covered by a separate context below).
+    let(:expected_pro_version) { "16.5.0" }
     let(:fake_pid) { 12_345 }
 
     before do
+      stub_const("ReactOnRails::VERSION", expected_pro_version)
       allow(Gem).to receive(:loaded_specs).and_return({})
       allow(install_generator).to receive(:gem_in_lockfile?).with("react_on_rails_pro").and_return(false)
       allow(Bundler).to receive(:with_unbundled_env).and_yield


### PR DESCRIPTION
## Summary

`Rspec test for gem -> rspec-package-tests (generators)` has been failing on `main` since the bump to `16.7.0.rc.0` (`c7a519332`). The `--pro` install example in `install_generator_spec.rb` expected `~> 16.7.0` in the auto-install error, but `pro_gem_version_requirement` correctly returns the exact prerelease pin (Bundler's `~>` does not match prereleases), so the assertion can never match while VERSION is a prerelease.

This pins `ReactOnRails::VERSION` to a stable value (`16.5.0`) inside that example so it exercises the pessimistic-operator branch regardless of the live VERSION. The prerelease branch is already covered by the existing "when using --rsc flag with a prerelease ReactOnRails version" context that stubs VERSION to `16.4.0.rc.5`.

## Verification

```
bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb \
  -e "missing_pro_gem? returns true and error mentions --pro flag" \
  -e "missing_pro_gem? returns true and error mentions --rsc flag" \
  -e "missing_pro_gem? uses exact version pin and surfaces a prerelease note"
# 3 examples, 0 failures
```

`bundle exec rubocop spec/react_on_rails/generators/install_generator_spec.rb` is clean.

## Test plan

- [ ] CI green on this branch (`rspec-package-tests (3.4, latest, generators)` and the 3.2 minimum matrix entry pass)
- [ ] After merge, rebase open PRs that were blocked by this failure (e.g. #3219)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that stabilizes expectations around prerelease `VERSION` handling without affecting generator runtime behavior.
> 
> **Overview**
> Fixes a flaky `--pro` install generator spec by stubbing `ReactOnRails::VERSION` to a stable value (`16.5.0`) so the assertion consistently exercises the pessimistic `~>` version-requirement path even when the gem’s live version is a prerelease.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 450d1935b91a580fe0db88aa2682f3402e735c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by pinning version values for more deterministic test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->