### PR TITLE
Plan: flagship 2026 React on Rails starter kit (#3357)

### DIFF
--- a/internal/planning/3357-react-on-rails-starter-2026-implementation.md
+++ b/internal/planning/3357-react-on-rails-starter-2026-implementation.md
@@ -80,7 +80,7 @@ A phase is "done" when every task in it passes its acceptance criteria AND the p
 
 **Outputs:**
 
-- A new local branch `spike/starter-2026-stack-validation` containing a fresh app produced by `create-react-on-rails-app --rsc --rspack`.
+- A new local branch `spike/starter-tanstack-stack-validation` containing a fresh app produced by `create-react-on-rails-app --rsc --rspack`.
 - `SPIKE.md` at the app root with a "what we're testing" section.
 
 **Acceptance criteria:**
@@ -211,7 +211,7 @@ A phase is "done" when every task in it passes its acceptance criteria AND the p
 
 **Outputs:**
 
-- New repo at `shakacode/react-on-rails-starter-2026` (or whatever name the implementer picks — Justin defers).
+- New repo at `shakacode/react-on-rails-starter-tanstack` (name locked by Justin 2026-05-22).
 - Repository setting: "Template repository" = enabled.
 - `README.md` with: "Scaffolding in progress — see #3357" and a link to the strategic plan.
 - `LICENSE` (MIT, matching ShakaCode convention).
@@ -825,7 +825,7 @@ A phase is "done" when every task in it passes its acceptance criteria AND the p
 
 - [ ] Slow-throttle one query: that card shows skeleton, others show data.
 - [ ] Force one query to 500: that card shows error, others render.
-- [ ] Page is RSC-streamed (verify in network tab: chunked response).
+- [ ] `/dashboard` renders via `react_component` (classic SSR through the Pro Node renderer) — NOT `rsc: true`. RSC lives on the public landing where its TTFB / SEO / cold-load wins apply; behind auth it doesn't earn its keep. Verify the page source contains the rendered HTML and that hydration is clean (no console errors).
 
 ### T4.4: Projects list with TanStack Table
 
@@ -924,18 +924,29 @@ A phase is "done" when every task in it passes its acceptance criteria AND the p
 
 **Goal:** Each pattern ships with empty / loading / error / success states. All largely parallel.
 
-### T5.1: Hero block (landing page)
+### T5.1: Hero block (RSC-rendered landing page)
 
-**Depends on:** Phase 1 complete
+**Depends on:** Phase 1 complete, T0.4 GREEN (RSC + shadcn + Tailwind v4 validated)
 **Parallel-safe with:** all T5.\*
-**Est. CC time:** 60 min
+**Est. CC time:** 75 min
 
-**Outputs:** Public landing at `/` with hero ("Best TanStack on Rails"), 4 demo-portfolio link cards, "Use this template" + "see dashboard demo" CTAs, signed-in user sees "go to dashboard" instead.
+**Goal:** The public landing is where RSC earns its keep. This task ships the RSC-rendered landing that demonstrates the kit's "right tool for the right surface" thesis.
+
+**Outputs:**
+
+- Public landing at `/` rendered via `react_on_rails_component` with `rsc: true`.
+- Hero ("Best TanStack on Rails") + 4 demo-portfolio link cards + dark-mode toggle + CTAs ("Use this template" + "see dashboard demo"). Signed-in user sees "go to dashboard" instead.
+- Includes one interactive client-component child (e.g. the dark-mode toggle, or a "copy template URL" button) to demonstrate the RSC + client-component boundary pattern.
+- Marked `// REFERENCE PATTERN: rsc-page — see AGENTS.md §11` (the RSC vs SSR vs client decision tree section).
 
 **Acceptance criteria:**
 
+- [ ] First HTML response includes the rendered hero markup (view source, not blank).
+- [ ] Network tab shows chunked/streaming response on cold load.
+- [ ] The client-component child hydrates and responds to interaction.
+- [ ] No console errors related to `'use client'` boundaries.
 - [ ] Visually polished, responsive (mobile + desktop).
-- [ ] Dark mode renders correctly.
+- [ ] Dark mode renders correctly with no flash of wrong theme on cold load.
 
 ### T5.2–T5.6: Per-pattern 4-state components
 
@@ -1333,12 +1344,13 @@ A team of 4 AI sub-agents working in parallel could realistically land Phase 0 i
 
 ---
 
-## Open Items for Coordinator
+## Coordinator Decisions — Locked 2026-05-22
 
-These need a human (or top-level agent) call BEFORE dispatch begins:
+These were open at the time of the strategic-plan rewrite; all locked in the same session before dispatch.
 
-1. **Repo name decision** — Justin defers; pick something. Recommended: `react-on-rails-starter-2026` (matches the issue) or `react-on-rails-starter` (evergreen). The plan accepts either.
-2. **Dashboard narrative** (Required-Before-Implementation #9) — recommended: SaaS app dashboard first, rendering-tech as a drawer, pattern catalog as a `/playground` route in dev. Pick before T5.1.
-3. **Accessibility target** (Required-Before-Implementation #8) — recommended: WCAG AA, contrast ratio 4.5:1 for text. Pick before T2.8.
-4. **Demo deploy host** (T10.3) — Fly.io or Render. Pick before Phase 10.
-5. **Spike GREEN/AMBER decision authority** — if T0.5 lands AMBER, who approves the named fallbacks? Recommended: Justin reviews; coordinator dispatches once approved.
+1. **Repo name:** `react-on-rails-starter-tanstack`. Locks the identity to TanStack — sharper positioning bet than a year-suffixed name, no calendar-trap maintenance pressure.
+2. **Dashboard narrative:** SaaS app dashboard first. Rendering-tech as a drawer in the dashboard header. Pattern catalog at a dev-only `/playground` route (not the lead).
+3. **Rendering split (added 2026-05-22):** **RSC + streaming lives on the public landing `/`** (where TTFB, mobile perf, and SEO actually matter); **classic SSR + TanStack lives on the authenticated `/dashboard` + nested routes** (where TanStack's interactivity/type-safety wins apply and RSC's wins don't). The dashboard's rendering-mode drawer tells this story honestly.
+4. **Accessibility target:** WCAG AA, contrast 4.5:1 for text. Standard target; shadcn/Radix primitives get most of the way, Playwright specs verify the rest.
+5. **Demo deploy host (T10.3):** Decide at Phase 10 dispatch. Default Fly.io if no preference surfaces.
+6. **Spike approval authority:** **Full auto.** Coordinator interprets the `SPIKE.md` verdict (GREEN/AMBER/RED) and dispatches Phase 1 without waiting for human approval. Justin sees results at Phase 1 PR review. Max velocity; tradeoff is that the coordinator must accurately read the spike outcome.

--- a/internal/planning/3357-react-on-rails-starter-2026-implementation.md
+++ b/internal/planning/3357-react-on-rails-starter-2026-implementation.md
@@ -8,6 +8,23 @@ This document is the executable companion to the strategic plan. Each task is sc
 
 ---
 
+## Kickoff (read this first)
+
+If you're a coordinator or sub-agent picking this up cold on a fresh machine:
+
+1. **Read both planning docs** in order:
+   - `internal/planning/3357-react-on-rails-starter-2026.md` (strategic plan — what we're building and why)
+   - This file (implementation plan — how to build it)
+2. **Confirm coordinator decisions** are locked: see the "Coordinator Decisions — Locked 2026-05-22" section at the bottom of this file. Repo name, a11y target, surface split, dashboard narrative, spike approval mode are all decided.
+3. **Start at T0.1.** Phase 0 is sequential (T0.1 → T0.2 → T0.3 → T0.4 → T0.5) and produces a `SPIKE.md` with a GREEN / AMBER / RED verdict.
+4. **Per coordinator decision #6** (spike approval = full auto): if `SPIKE.md` lands GREEN, dispatch Phase 1 immediately. If AMBER, apply the named fallback decision tree (see the strategic plan's Required-Before-Implementation #3) and dispatch Phase 1 with the fallback in place. If RED, stop and escalate to Justin.
+5. **Phase 1 onwards:** fan out parallel-safe tasks across multiple sub-agents (the "Parallel-safe with:" field on each task card identifies what can co-run).
+6. **No skill names from gstack appear in any task.** All tasks are framework-neutral and can be executed by any capable agent.
+
+Repo location for the spike: a new throwaway local branch (`spike/starter-tanstack-stack-validation`) on the existing `react_on_rails` repo. Do NOT create the public `react-on-rails-starter-tanstack` repo until T1.1 (after the spike passes).
+
+---
+
 ## How to Use This Plan
 
 ### Task IDs

--- a/internal/planning/3357-react-on-rails-starter-2026-implementation.md
+++ b/internal/planning/3357-react-on-rails-starter-2026-implementation.md
@@ -1,0 +1,1344 @@
+# Implementation Plan: React on Rails Starter 2026 (Issue #3357)
+
+**Status:** Draft — 2026-05-22. Ready for AI-sub-agent execution after Phase 0 spike confirms stack compatibility.
+**Parent plan:** [3357-react-on-rails-starter-2026.md](./3357-react-on-rails-starter-2026.md)
+**Tracking issue:** https://github.com/shakacode/react_on_rails/issues/3357
+
+This document is the executable companion to the strategic plan. Each task is scoped for a single AI sub-agent session (~15–45 min CC time), with explicit inputs, outputs, acceptance criteria, and dependencies. Tasks within the same phase are parallel-safe unless their `Depends on:` lines say otherwise.
+
+---
+
+## How to Use This Plan
+
+### Task IDs
+
+Format: `T<phase>.<number>` — e.g. `T2.4` is Phase 2, Task 4. IDs are stable; never renumber. New tasks get the next available number in their phase.
+
+### Task card format
+
+```
+### T<phase>.<num>: <Title>
+
+**Depends on:** <task IDs, or "none">
+**Parallel-safe with:** <task IDs in same phase>
+**Est. CC time:** <minutes>
+
+**Goal:** <1–2 sentences>
+
+**Inputs:**
+- <file paths or spec sections to read>
+
+**Outputs:**
+- <files created or modified>
+
+**Acceptance criteria:**
+- [ ] <testable condition>
+- [ ] <testable condition>
+
+**Notes:**
+<gotchas, references, decisions to make inline>
+```
+
+### Dispatching tasks
+
+A coordinator (human or top-level agent) picks tasks where `Depends on:` is satisfied and dispatches them. Within a phase, multiple `Parallel-safe with:` tasks can run concurrently. Each sub-agent gets only the task card plus the named inputs — no shared conversation history needed.
+
+### Phase gates
+
+A phase is "done" when every task in it passes its acceptance criteria AND the phase's PR has green CI. The next phase doesn't start until the prior one is merged. (Within a phase, all task PRs can stack on a single phase branch and merge as one squash.)
+
+### Conventions in effect everywhere
+
+- Ruby: `bundle exec` prefix on all gem tools. Lint with `(cd <project_root> && bundle exec rubocop)`.
+- JS: `pnpm` for package management. `bun` only for `bunx shadcn add ...`.
+- File endings: every file ends with a newline.
+- Commits: small, focused, conventional-commit style (`feat:`, `fix:`, `docs:`, `test:`, `chore:`).
+- Test framework: RSpec for backend, Playwright for cross-stack, Vitest for non-trivial JS units.
+- Marker comments on canonical reference patterns: `# REFERENCE PATTERN: <name> — see AGENTS.md §<N>` (Ruby) or `// REFERENCE PATTERN: ...` (JS).
+
+---
+
+## Phase 0 — Spike PR (mandatory precondition)
+
+**Goal:** Validate that the three open compatibility risks all work together before public scaffold commits.
+
+**Mode:** SEQUENTIAL. One throwaway branch. No public repo activity yet.
+
+**Gate to Phase 1:** every task below must pass. If any fails, follow the fallback decision tree in the strategic plan, then re-spike.
+
+### T0.1: Throwaway scaffold
+
+**Depends on:** none
+**Parallel-safe with:** none (the throwaway branch starts here)
+**Est. CC time:** 30 min
+
+**Goal:** Bootstrap a throwaway Rails 8 + RoR Pro app with RSC and Rspack enabled, on its own branch.
+
+**Inputs:**
+
+- `packages/create-react-on-rails-app/` (CLI source — to understand flags)
+
+**Outputs:**
+
+- A new local branch `spike/starter-2026-stack-validation` containing a fresh app produced by `create-react-on-rails-app --rsc --rspack`.
+- `SPIKE.md` at the app root with a "what we're testing" section.
+
+**Acceptance criteria:**
+
+- [ ] `bin/setup` runs clean on a fresh macOS clone.
+- [ ] `bin/dev` boots web + Rspack + Node renderer without errors.
+- [ ] `localhost:3000` shows the generated welcome page.
+- [ ] `SPIKE.md` lists the four validation goals (see T0.2–T0.5).
+
+### T0.2: TanStack Router under a Rails shell route
+
+**Depends on:** T0.1
+**Parallel-safe with:** none (sequential spike)
+**Est. CC time:** 45 min
+
+**Goal:** Confirm TanStack Router mounts cleanly under a Rails-served shell route with SSR loaders and clean hydration.
+
+**Inputs:**
+
+- TanStack Router docs (SSR setup): https://tanstack.com/router/latest/docs/framework/react/guide/ssr
+- RoR Pro Node renderer config in the scaffolded app.
+
+**Outputs:**
+
+- A `/spike/tan-router` Rails route serving a TanStack Router shell.
+- One nested TanStack child route (`/spike/tan-router/child`).
+- SSR loader that reads a piece of data and renders it.
+
+**Acceptance criteria:**
+
+- [ ] First paint of `/spike/tan-router` includes the loader's data (no flash of unloaded content).
+- [ ] Browser console shows zero hydration mismatch errors.
+- [ ] Client-side navigation to `/child` works without a full page reload.
+- [ ] CSRF token from Rails meta tag is available to TanStack Router via a shared reader.
+
+**Notes:** This is the single highest-risk integration. If it fails, the whole kit identity is at risk — escalate before continuing.
+
+### T0.3: TanStack Query against Rails JSON
+
+**Depends on:** T0.2
+**Parallel-safe with:** none
+**Est. CC time:** 30 min
+
+**Goal:** Confirm TanStack Query can read from a Rails JSON endpoint with CSRF, with independent loading/error states per query.
+
+**Inputs:**
+
+- T0.2 outputs.
+
+**Outputs:**
+
+- `/api/spike/ping` Rails JSON endpoint.
+- Two independent TanStack Query hooks on `/spike/tan-router` rendering separate cards, each with its own loading + error state.
+
+**Acceptance criteria:**
+
+- [ ] Both queries fire on mount; slow one doesn't block the fast one.
+- [ ] Forced 500 response renders just-that-card's error state, not a global error.
+- [ ] CSRF token sent correctly (verify via Rails request log).
+
+### T0.4: shadcn/ui on Tailwind v4 inside an RSC component
+
+**Depends on:** T0.1
+**Parallel-safe with:** T0.2, T0.3 (after T0.1)
+**Est. CC time:** 30 min
+
+**Goal:** Confirm shadcn/ui blocks render correctly when used inside a Pro RSC bundle on Tailwind v4.
+
+**Inputs:**
+
+- shadcn/ui docs (Tailwind v4 path): https://ui.shadcn.com/docs/tailwind-v4
+- The Pro RSC config in the scaffolded app.
+
+**Outputs:**
+
+- A `/spike/rsc-shadcn` Rails route that renders a Pro RSC component (`rsc: true`).
+- The RSC component uses one shadcn block (e.g. `Card`).
+- A nested client component (e.g. `Button` with `onClick`) inside the RSC tree.
+
+**Acceptance criteria:**
+
+- [ ] First HTML response includes the rendered shadcn Card markup (server-rendered, not blank).
+- [ ] The Button hydrates on the client and responds to clicks.
+- [ ] No console errors related to `'use client'` boundaries.
+- [ ] Tailwind v4 CSS reaches the page (visible styling).
+
+**Notes:** If Tailwind v4 fails, fall back to v3 per the strategic plan's decision tree. Document the fallback choice in `SPIKE.md`.
+
+### T0.5: All three together + outcome report
+
+**Depends on:** T0.2, T0.3, T0.4
+**Parallel-safe with:** none
+**Est. CC time:** 30 min
+
+**Goal:** Render one throwaway route that uses TanStack Router + TanStack Query + Pro RSC + shadcn on Tailwind v4 simultaneously. Document the outcome.
+
+**Outputs:**
+
+- `/spike/all-the-things` route.
+- Updated `SPIKE.md` with: what worked, what didn't, fallback decisions (if any), recommended adjustments to the strategic plan's stack.
+
+**Acceptance criteria:**
+
+- [ ] The combined route works end-to-end (server render → hydrate → query → user interaction → state update).
+- [ ] `SPIKE.md` includes a verdict: GREEN (proceed with planned stack), AMBER (proceed with named fallbacks), or RED (escalate before Phase 1).
+- [ ] If AMBER or RED, the doc names each affected `Required-Before-Implementation` item that needs revision.
+
+**Notes:** This is the gate to Phase 1. Do not start any Phase 1 work until T0.5 lands GREEN or AMBER with named, accepted fallbacks.
+
+---
+
+## Phase 1 — Repo Bootstrap
+
+**Goal:** Public template repo with a working scaffold, CI, dev tooling, and the "first-5-minutes error budget" copy.
+
+**Parallel tracks:**
+
+- Track A (sequential): T1.1 → T1.2 → T1.3
+- Track B (parallel after T1.2): T1.4, T1.5, T1.6, T1.7, T1.8
+
+### T1.1: Create GitHub Template Repository
+
+**Depends on:** Phase 0 GREEN/AMBER
+**Parallel-safe with:** none
+**Est. CC time:** 15 min
+
+**Goal:** Create the public GitHub repository configured as a template, with a placeholder README pointing at the tracking issue.
+
+**Outputs:**
+
+- New repo at `shakacode/react-on-rails-starter-2026` (or whatever name the implementer picks — Justin defers).
+- Repository setting: "Template repository" = enabled.
+- `README.md` with: "Scaffolding in progress — see #3357" and a link to the strategic plan.
+- `LICENSE` (MIT, matching ShakaCode convention).
+
+**Acceptance criteria:**
+
+- [ ] Repo is public.
+- [ ] "Use this template" button visible on the repo page.
+- [ ] README placeholder visible at the URL.
+
+### T1.2: Initial scaffold + push
+
+**Depends on:** T1.1
+**Parallel-safe with:** none
+**Est. CC time:** 30 min
+
+**Goal:** Run `create-react-on-rails-app --rsc --rspack`, apply the spike's findings, push first commit.
+
+**Inputs:**
+
+- Phase 0 `SPIKE.md` (apply any AMBER fallback choices).
+
+**Outputs:**
+
+- First commit to the new repo with a working scaffold.
+- `CHANGELOG.md` initialized.
+- `.github/` directory with placeholder issue + PR templates.
+
+**Acceptance criteria:**
+
+- [ ] `git clone` + `bin/setup` + `bin/dev` on a fresh macOS laptop boots the welcome page (TTHW measurement starts here — target ≤ 3 min from clone).
+- [ ] `git log` shows one initial commit signed by the implementer.
+
+### T1.3: GitHub Actions CI skeleton
+
+**Depends on:** T1.2
+**Parallel-safe with:** T1.4, T1.5, T1.6, T1.7, T1.8
+**Est. CC time:** 30 min
+
+**Goal:** CI runs RSpec + Playwright on every push and PR. Tests can be empty stubs — the goal is green CI infrastructure.
+
+**Outputs:**
+
+- `.github/workflows/ci.yml` with two jobs: `rspec` and `playwright`.
+- One stub RSpec test (passes trivially).
+- One stub Playwright test (passes trivially).
+- Branch protection: `main` requires both jobs green to merge.
+
+**Acceptance criteria:**
+
+- [ ] First PR can't merge without CI green.
+- [ ] CI run takes < 5 min on a no-change PR.
+
+### T1.4: `bin/doctor` preflight
+
+**Depends on:** T1.2
+**Parallel-safe with:** T1.3, T1.5, T1.6, T1.7, T1.8
+**Est. CC time:** 30 min
+
+**Goal:** A script that checks every prerequisite a dev needs to boot the app, with actionable error messages.
+
+**Outputs:**
+
+- `bin/doctor` (Ruby or Bash, implementer's choice).
+- Checks: Ruby version (matches `.ruby-version`), Postgres reachable, Node version (≥ 20), pnpm installed, bun installed.
+- Each failed check prints: problem + cause + concrete fix command.
+
+**Acceptance criteria:**
+
+- [ ] Running `bin/doctor` on a healthy macOS dev box prints "all checks passed" and exits 0.
+- [ ] Failing any one check exits non-zero with a fix message.
+- [ ] `bin/doctor` runs in < 3 seconds.
+
+### T1.5: `bin/setup` wrapping doctor + db prep + seed
+
+**Depends on:** T1.4
+**Parallel-safe with:** T1.3, T1.6, T1.7, T1.8
+**Est. CC time:** 20 min
+
+**Goal:** Single command that primes a fresh clone — runs doctor, installs deps, prepares db, seeds dev data.
+
+**Outputs:**
+
+- `bin/setup` (overrides the default Rails one).
+- Calls: `bin/doctor`, `bundle install`, `pnpm install`, `bin/rails db:prepare`, `bin/rails db:seed`.
+
+**Acceptance criteria:**
+
+- [ ] On a fresh clone, `bin/setup` exits 0 and `bin/dev` then boots the app.
+- [ ] If `bin/doctor` fails, `bin/setup` aborts with the doctor message.
+
+### T1.6: `Procfile.dev` with the four processes
+
+**Depends on:** T1.2
+**Parallel-safe with:** T1.3, T1.4, T1.5, T1.7, T1.8
+**Est. CC time:** 15 min
+
+**Goal:** `bin/dev` boots web + Rspack-watch + SolidQueue + Node renderer via Foreman/Overmind.
+
+**Outputs:**
+
+- `Procfile.dev` defining: `web`, `rspack`, `worker` (SolidQueue), `renderer` (Pro Node renderer).
+- `bin/dev` script (the standard Rails one is fine if it reads Procfile.dev).
+
+**Acceptance criteria:**
+
+- [ ] `bin/dev` boots all four processes; killing one logs the failure without taking down the others.
+- [ ] All four are reachable: web at :3000, renderer at its port, etc.
+
+### T1.7: First-5-minutes error budget copy
+
+**Depends on:** T1.2
+**Parallel-safe with:** T1.3, T1.4, T1.5, T1.6, T1.8
+**Est. CC time:** 45 min
+
+**Goal:** The 6–8 predictable evaluator failures each surface with problem + cause + fix.
+
+**Outputs:**
+
+- Dev-only middleware in `config/initializers/development_error_hints.rb` that:
+  - Detects `User.count == 0` and renders "no demo user — run `bin/rails db:seed`" inline.
+  - Detects SolidQueue not running (check the worker process via the same Procfile mechanism) and shows a banner.
+- `bin/dev` preflight: checks port 3000 is free, Postgres is reachable, Node renderer port is free — prints a fix message before booting.
+- `docs/05-troubleshooting.md` lists every predictable failure mode with copy-pasteable fixes (stub now; flesh out in T9.8).
+
+**Acceptance criteria:**
+
+- [ ] Manually breaking each known failure (kill Postgres, run on port-taken, skip seed) produces a clear actionable message.
+- [ ] None of the messages contain raw stack traces as the primary content — stack traces are a follow-on detail, not the headline.
+
+### T1.8: `.env.example` with required vars
+
+**Depends on:** T1.2
+**Parallel-safe with:** T1.3, T1.4, T1.5, T1.6, T1.7
+**Est. CC time:** 15 min
+
+**Goal:** Document every ENV var the kit reads.
+
+**Outputs:**
+
+- `.env.example` with: `RAILS_MASTER_KEY`, `DATABASE_URL`, `SOLID_QUEUE_IN_PUMA`, `SENTRY_DSN`, mail-provider vars (`SMTP_*` or `MAILGUN_API_KEY` etc.).
+- Each var has an inline comment explaining purpose and dev-vs-prod expectations.
+- `.gitignore` entry for `.env` (just `.env.example` is tracked).
+
+**Acceptance criteria:**
+
+- [ ] `cp .env.example .env` produces a usable dev config (the dev-mode defaults work).
+
+---
+
+## Phase 2 — Auth Surface + Verification Funnel
+
+**Goal:** Rails 8 auth generator + custom signup + email verification (per Required-Before-Implementation #1 spec) + WelcomeMailer, re-skinned with shadcn/ui.
+
+**Parallel tracks** (after T2.1, T2.2):
+
+- Track A: T2.3 → T2.8 (signup controller + view re-skin)
+- Track B: T2.4 → T2.10 → T2.11 (verification controller + throttling + tests)
+- Track C: T2.5 (verification mailer)
+- Track D: T2.6 (welcome mailer)
+- Track E: T2.7 (gate middleware) — after T2.4
+- Track F: T2.9 (verification UX funnel) — after T2.4, T2.5
+
+### T2.1: Run Rails 8 auth generator
+
+**Depends on:** Phase 1 complete
+**Parallel-safe with:** none (must be first in phase)
+**Est. CC time:** 15 min
+
+**Goal:** Commit the baseline `bin/rails generate authentication` output before any custom changes.
+
+**Outputs:**
+
+- One commit containing the generator's raw emit (controllers, views, migration, models).
+
+**Acceptance criteria:**
+
+- [ ] Commit message: `feat(auth): run Rails 8 authentication generator (baseline)`.
+- [ ] No edits to the generated files in this commit — they get edited in T2.2+.
+
+### T2.2: Edit the User migration before first run
+
+**Depends on:** T2.1
+**Parallel-safe with:** none
+**Est. CC time:** 20 min
+
+**Goal:** Add `name`, `email_verification_token_digest`, `email_verified_at`, `verification_sent_at` columns to the generator's `CreateUsers` migration before any `db:migrate`.
+
+**Outputs:**
+
+- Edited migration file in `db/migrate/`.
+- Updated `app/models/user.rb` with the new attributes + validations.
+- `bin/rails db:migrate` runs clean.
+
+**Acceptance criteria:**
+
+- [ ] Migration version unchanged (still the generator's original number; we edit, not re-emit).
+- [ ] `User.new(email_address: "x@y.com", password: "z", name: "X")` is valid.
+- [ ] Index exists on `email_verification_token_digest`.
+
+**Notes:** The strategic plan documents this approach in `AGENTS.md` so adopters who re-run the generator know why their migration diverges.
+
+### T2.3: Signup controller + view
+
+**Depends on:** T2.2
+**Parallel-safe with:** T2.4, T2.5, T2.6
+**Est. CC time:** 30 min
+
+**Goal:** `RegistrationsController` (the generator does NOT provide this) with `new` and `create`, view at `/signup`.
+
+**Outputs:**
+
+- `app/controllers/registrations_controller.rb` (marked `# REFERENCE PATTERN: signup-controller — see AGENTS.md §2`).
+- `app/views/registrations/new.html.erb` (initial scaffold; re-skin in T2.8).
+- Route: `resource :registration, only: [:new, :create]` (or `get/post '/signup'` — pick the more idiomatic).
+- On successful create: triggers `EmailVerificationMailer.welcome(...).deliver_later` (the verification mailer also acts as the post-signup mail; no duplicate).
+- On successful create: triggers `WelcomeMailer.welcome(...).deliver_later`.
+- Renders `/email_verifications/sent` after create.
+
+**Acceptance criteria:**
+
+- [ ] GET `/signup` shows the form.
+- [ ] POST `/signup` with valid params creates a user with `email_verified_at: nil` and a generated verification token.
+- [ ] POST `/signup` with invalid params re-renders with errors.
+- [ ] CSRF protection active (default Rails — verify `protect_from_forgery` is in `ApplicationController`).
+
+### T2.4: EmailVerificationsController per spec
+
+**Depends on:** T2.2
+**Parallel-safe with:** T2.3, T2.5, T2.6
+**Est. CC time:** 60 min
+
+**Goal:** Full implementation of the email verification token lifecycle per Required-Before-Implementation #1.
+
+**Outputs:**
+
+- `app/controllers/email_verifications_controller.rb` with:
+  - `#create` — generates a fresh token, stores digest only, sets `verification_sent_at`, sends mail, returns identical UX whether email exists or not (enumeration defense).
+  - `#show` (the email-click endpoint) — looks up by digest, checks TTL (24h), checks single-use (not already consumed), on success: sets `email_verified_at`, nulls the token digest, rotates the session.
+  - Audit logging via `Rails.logger.tagged("auth")`.
+- Routes: `resources :email_verifications, only: [:create, :show]`.
+- Token generation helper: `SecureRandom.urlsafe_base64(32)`, digest via `Digest::SHA256.hexdigest`, comparison via `ActiveSupport::SecurityUtils.secure_compare`.
+
+**Acceptance criteria:**
+
+- [ ] Visiting a valid token URL marks the user verified and rotates the session (verify via session ID change).
+- [ ] Visiting a stale (>24h) token URL shows "expired — request a new one" (no token consumed).
+- [ ] Visiting a previously-consumed token URL shows the same expired message (replay-safe).
+- [ ] Verification events appear in logs tagged `[auth]`.
+
+### T2.5: EmailVerificationMailer
+
+**Depends on:** T2.2
+**Parallel-safe with:** T2.3, T2.4, T2.6
+**Est. CC time:** 30 min
+
+**Goal:** Mailer + view templates for the verification email.
+
+**Outputs:**
+
+- `app/mailers/email_verification_mailer.rb` with `welcome(user)` method.
+- `app/views/email_verification_mailer/welcome.html.erb` and `.text.erb`.
+- Copy: friendly, branded, with a single CTA button + plain-text fallback URL.
+- Marked `# REFERENCE PATTERN: mailer — see AGENTS.md §6`.
+
+**Acceptance criteria:**
+
+- [ ] `EmailVerificationMailer.welcome(user).deliver_now` works in dev (visible via `letter_opener`).
+- [ ] HTML and text variants both render.
+- [ ] Mailer preview at `/rails/mailers/email_verification_mailer/welcome` renders.
+
+### T2.6: WelcomeMailer
+
+**Depends on:** T2.2
+**Parallel-safe with:** T2.3, T2.4, T2.5
+**Est. CC time:** 20 min
+
+**Goal:** Generic welcome email triggered on signup (separate from verification).
+
+**Outputs:**
+
+- `app/mailers/welcome_mailer.rb`.
+- HTML + text templates.
+
+**Acceptance criteria:**
+
+- [ ] Sends on signup (after verification email).
+- [ ] Mailer preview renders.
+
+### T2.7: `require_verified_email` gate
+
+**Depends on:** T2.4
+**Parallel-safe with:** T2.5, T2.6, T2.8
+**Est. CC time:** 20 min
+
+**Goal:** A `before_action` that redirects unverified users away from protected routes.
+
+**Outputs:**
+
+- Concern at `app/controllers/concerns/verified_authentication.rb` defining `require_verified_email`.
+- Applied to a base controller that the dashboard, projects, and settings controllers will inherit from.
+- Redirects unverified users to `email_verifications#sent` (the "check your email" landing).
+
+**Acceptance criteria:**
+
+- [ ] Authenticated-but-unverified user visiting `/dashboard` redirects to "check your email."
+- [ ] Verified user reaches `/dashboard`.
+- [ ] Anonymous user redirects to `/session/new` (not "check your email") — different failure modes get different redirects.
+
+### T2.8: Re-skin auth views with shadcn/ui
+
+**Depends on:** T2.3, generator's session/passwords views
+**Parallel-safe with:** T2.7
+**Est. CC time:** 60 min
+
+**Goal:** Replace the generator's raw scaffold styling with shadcn/ui blocks across login, signup, password reset, and password reset request views.
+
+**Outputs:**
+
+- All `app/views/sessions/`, `app/views/registrations/`, `app/views/passwords/`, `app/views/email_verifications/` views using shadcn blocks (`Card`, `Input`, `Button`, `Label`).
+- One canonical login view marked `# REFERENCE PATTERN: form — see AGENTS.md §4`.
+- Each view ships with the four states (empty/error/loading/success) where applicable.
+- `aria-live="polite"` on flash messages, `aria-describedby` on input errors.
+
+**Acceptance criteria:**
+
+- [ ] Visual: signup, login, password reset all look polished and consistent.
+- [ ] Keyboard nav: tab order works, Enter submits, focus rings visible.
+- [ ] Screen reader: form errors announced via `aria-live`.
+
+### T2.9: Post-signup verification UX funnel
+
+**Depends on:** T2.4, T2.5
+**Parallel-safe with:** T2.7, T2.8
+**Est. CC time:** 60 min
+
+**Goal:** The "highest-friction touchpoint in the funnel" (Design review) as a designed UX, not a backend gate.
+
+**Outputs:**
+
+- `/email_verifications/sent` page rendered after signup: shows the target email (masked partially: `j***@gmail.com`), resend button (with cooldown), "change email" link, spam-folder hint, "open `letter_opener`" link in dev.
+- Resend cooldown: 60 seconds client-side, enforced server-side via Rack::Attack (T2.10).
+- "Expired or already-used token" landing with a "request a new link" CTA that doesn't require an authenticated session for 24 hours post-signup.
+
+**Acceptance criteria:**
+
+- [ ] Signup → "check your email" page with the user's email visible.
+- [ ] Resend button disables for 60s after click, re-enables, can be clicked again.
+- [ ] Clicking an expired token URL lands on the expired page with a resend CTA.
+- [ ] Spam-folder hint copy reads natural, not legalistic.
+
+### T2.10: Rack::Attack throttling
+
+**Depends on:** T2.4
+**Parallel-safe with:** T2.7, T2.8, T2.9
+**Est. CC time:** 30 min
+
+**Goal:** Rate-limit verification-email sends per Required-Before-Implementation #1.
+
+**Outputs:**
+
+- `config/initializers/rack_attack.rb` with two throttles:
+  - 5 verification-email-sends per IP per hour.
+  - 3 per email per hour.
+- 429 response with a clear "too many requests — try again in N minutes" body.
+
+**Acceptance criteria:**
+
+- [ ] Manual test: hitting `POST /email_verifications` 6 times from the same IP returns 429 on attempt 6.
+- [ ] Throttle clears after the window.
+
+### T2.11: Verification + auth test suite
+
+**Depends on:** T2.4, T2.10
+**Parallel-safe with:** T2.7, T2.8, T2.9
+**Est. CC time:** 75 min
+
+**Goal:** Request and model specs covering token expiry, single-use, replay, throttling, session rotation, enumeration defense.
+
+**Outputs:**
+
+- `spec/requests/email_verifications_spec.rb` — happy path, expired token, consumed token, throttle hit, enumeration probe.
+- `spec/requests/registrations_spec.rb` — happy path, duplicate email, weak password, mail-provider-down scenario (mock).
+- `spec/models/user_spec.rb` — verification token methods, digest comparison, expiry.
+- `spec/system/signup_to_dashboard_spec.rb` — full Capybara flow.
+- Factories with traits: `:unverified`, `:expired_token`, `:verified`.
+
+**Acceptance criteria:**
+
+- [ ] All specs pass.
+- [ ] CI green.
+- [ ] Coverage report shows ≥ 90% line coverage on the auth code paths.
+
+---
+
+## Phase 3 — Projects Model + CRUD + JSON API
+
+**Goal:** The Project resource: model, controllers (HTML and JSON), reference form pattern, factories, specs.
+
+**Parallel tracks** (after T3.1, T3.2):
+
+- Track A: T3.3 (HTML controller) + T3.4 (reference form view)
+- Track B: T3.5 (JSON API controller)
+- Track C: T3.6 (factories)
+- Track D: T3.7, T3.8 (specs) — after Track A
+
+### T3.1: Projects migration
+
+**Depends on:** Phase 2 complete
+**Parallel-safe with:** none
+**Est. CC time:** 15 min
+
+**Outputs:** Migration adding `projects` table: `name`, `description`, `status` (integer enum), `user_id` (FK), `last_activity_at`, timestamps.
+
+**Acceptance criteria:**
+
+- [ ] `bin/rails db:migrate` runs clean.
+- [ ] Index on `user_id`, `last_activity_at`, `status`.
+
+### T3.2: Project model
+
+**Depends on:** T3.1
+**Parallel-safe with:** none
+**Est. CC time:** 20 min
+
+**Outputs:** `app/models/project.rb` with: `belongs_to :user`, status enum (active/paused/completed/archived), name validation (presence, length), scope `active`, scope `recent`.
+
+**Acceptance criteria:**
+
+- [ ] Model spec passes.
+- [ ] `Project.statuses` returns the enum hash.
+
+### T3.3: HTML ProjectsController + reference form view
+
+**Depends on:** T3.2
+**Parallel-safe with:** T3.5, T3.6
+**Est. CC time:** 75 min
+
+**Goal:** The HTML controller is the **canonical reference pattern** for "Rails controller + server-side validation + shadcn form + flash success."
+
+**Outputs:**
+
+- `app/controllers/projects_controller.rb` with `index`, `show`, `new`, `create`, `edit`, `update`, `destroy`. Marked `# REFERENCE PATTERN: controller — see AGENTS.md §2`.
+- `app/views/projects/_form.html.erb` marked `# REFERENCE PATTERN: form — see AGENTS.md §4` — server-side validation errors render inline with `aria-describedby`, success redirects with a flash toast.
+- All views (`index`, `show`, `new`, `edit`) use shadcn blocks.
+- `before_action :authenticate_user`, `before_action :require_verified_email`, `before_action :set_project, only: [:show, :edit, :update, :destroy]`.
+- Authorization: `Project.find` scoped to `current_user.projects`.
+
+**Acceptance criteria:**
+
+- [ ] Manual: signup → verify → `/projects/new` → submit empty → see inline errors → submit valid → redirect to `/projects/:id` with flash toast.
+- [ ] Authorization: User A cannot view User B's project (404, not 403).
+
+### T3.4: Delete confirmation flow
+
+**Depends on:** T3.3
+**Parallel-safe with:** T3.5, T3.6
+**Est. CC time:** 30 min
+
+**Outputs:** Confirm dialog (shadcn AlertDialog) on Project destroy. Soft-delete via `archive!` rather than DELETE for the demo? (Implementer decision — but the destroy reference pattern must be visible.)
+
+**Acceptance criteria:**
+
+- [ ] Cancel button dismisses the dialog without action.
+- [ ] Confirm button archives the project, redirects with flash.
+
+### T3.5: JSON API ProjectsController
+
+**Depends on:** T3.2
+**Parallel-safe with:** T3.3, T3.6
+**Est. CC time:** 45 min
+
+**Outputs:**
+
+- `app/controllers/api/projects_controller.rb` namespaced under `/api`.
+- Routes: `namespace :api { resources :projects, only: [:index, :show] }`.
+- Endpoints: `GET /api/projects` (list, supports `status`, `sort`, `page`, `per_page` query params), `GET /api/projects/:id`, `GET /api/projects/:id/metrics` (4 metric values for the dashboard cards).
+- JSON shape: each project includes id, name, status, last_activity_at, computed fields.
+- Same `authenticate_user` + `require_verified_email` before_actions.
+- CSRF: standard Rails (not skipped) — TanStack Query will pass the meta-tag token.
+
+**Acceptance criteria:**
+
+- [ ] `GET /api/projects?status=active` returns only active projects for the current user.
+- [ ] `GET /api/projects?sort=last_activity_at&dir=desc` orders correctly.
+- [ ] `GET /api/projects/:id/metrics` returns 4 fields: total, active_count, completed_this_week, avg_cycle_time.
+- [ ] Without auth: 401.
+
+### T3.6: Project factory
+
+**Depends on:** T3.2
+**Parallel-safe with:** T3.3, T3.5
+**Est. CC time:** 15 min
+
+**Outputs:** `spec/factories/projects.rb` with traits: `:active`, `:paused`, `:completed`, `:archived`, `:stale` (old `last_activity_at`).
+
+**Acceptance criteria:**
+
+- [ ] `FactoryBot.lint` passes.
+
+### T3.7: Projects request specs
+
+**Depends on:** T3.3, T3.5, T3.6
+**Parallel-safe with:** T3.8
+**Est. CC time:** 60 min
+
+**Outputs:** `spec/requests/projects_spec.rb` covering all HTML and JSON endpoints, happy + error paths, authorization scoping.
+
+**Acceptance criteria:**
+
+- [ ] All specs pass.
+- [ ] Authorization tests confirm user-A-can't-see-user-B for every endpoint.
+
+### T3.8: Projects system spec (signup → create-project flow)
+
+**Depends on:** T3.3, T3.6
+**Parallel-safe with:** T3.7
+**Est. CC time:** 45 min
+
+**Outputs:** `spec/system/full_signup_to_project_flow_spec.rb` — Capybara flow: signup → verify (intercept mailer) → dashboard → new project → fill form → submit → see in list.
+
+**Acceptance criteria:**
+
+- [ ] Passes headless and headed.
+
+### T3.9: Seed data
+
+**Depends on:** T3.2
+**Parallel-safe with:** T3.3, T3.5, T3.6
+**Est. CC time:** 15 min
+
+**Outputs:** `db/seeds.rb` (guarded by `Rails.env.development? || Rails.env.test?`) creating `demo@example.com / password` pre-verified + 12 sample projects across all four statuses with varied `last_activity_at`.
+
+**Acceptance criteria:**
+
+- [ ] `bin/rails db:seed` works in dev.
+- [ ] `RAILS_ENV=production bin/rails db:seed` is a no-op (and logs the skip reason).
+
+---
+
+## Phase 4 — TanStack-Driven Authenticated Surface
+
+**Goal:** The kit's structural moat — TanStack Router + Query + Table operationalized end-to-end on a single dashboard.
+
+**Parallel tracks** (after T4.1, T4.2):
+
+- Track A: T4.3 + T4.4 (dashboard) — depends on T4.1, T4.2
+- Track B: T4.5 (settings routes) — depends on T4.1
+- Track C: T4.6 (projects routes) — depends on T4.1
+- Track D: T4.7 (rendering-mode drawer) — parallel
+- Track E: T4.8 (error/Suspense boundaries) — after T4.3, T4.4
+
+### T4.1: TanStack Router setup + SSR shell
+
+**Depends on:** Phase 3 complete
+**Parallel-safe with:** T4.2
+**Est. CC time:** 90 min
+
+**Goal:** Install and configure TanStack Router with SSR loaders, mounted under a single Rails shell controller.
+
+**Outputs:**
+
+- `pnpm add @tanstack/react-router @tanstack/router-vite-plugin @tanstack/router-devtools` etc.
+- `app/controllers/authenticated_controller.rb` — base controller with auth + verification gates, renders an empty Rails view that mounts the TanStack app.
+- `app/javascript/routes/__root.tsx` — the TanStack root route.
+- `app/javascript/routes/dashboard.tsx` — placeholder route.
+- TanStack Router config wired into the Pro Node renderer for SSR.
+- A shared `getCsrfToken()` helper that reads the Rails meta tag.
+
+**Acceptance criteria:**
+
+- [ ] `/dashboard` first paint includes server-rendered content (view source shows the rendered HTML, not just a `<div id="root">`).
+- [ ] Browser console: zero hydration mismatch errors.
+- [ ] Tab to `/settings` (via TanStack Link) is a client-side navigation (no Rails round-trip).
+- [ ] Marked `// REFERENCE PATTERN: tanstack-route — see AGENTS.md §2`.
+
+### T4.2: TanStack Query setup with CSRF
+
+**Depends on:** Phase 3 complete
+**Parallel-safe with:** T4.1
+**Est. CC time:** 45 min
+
+**Goal:** `QueryClient`, provider, and a shared `apiFetch` wrapper that injects CSRF token from the meta tag.
+
+**Outputs:**
+
+- `pnpm add @tanstack/react-query @tanstack/react-query-devtools`.
+- `app/javascript/lib/queryClient.ts` exporting a configured QueryClient.
+- `app/javascript/lib/apiFetch.ts` — wraps `fetch` with CSRF + JSON + error normalization.
+- `<QueryClientProvider>` wired in the root route.
+
+**Acceptance criteria:**
+
+- [ ] A test query against `/api/projects` succeeds in dev.
+- [ ] Without the CSRF token, the request fails with a clear Rails 422 — confirms CSRF is on.
+- [ ] React Query Devtools loads in dev.
+
+### T4.3: `/dashboard` with metric cards (TanStack Query)
+
+**Depends on:** T4.1, T4.2
+**Parallel-safe with:** T4.4, T4.5, T4.6
+**Est. CC time:** 60 min
+
+**Outputs:**
+
+- `/dashboard` TanStack route renders 4 metric cards.
+- Each card is an independent `useQuery` against `/api/projects/:id/metrics` (or a per-metric endpoint).
+- Per-card loading skeleton, error state, success render.
+
+**Acceptance criteria:**
+
+- [ ] Slow-throttle one query: that card shows skeleton, others show data.
+- [ ] Force one query to 500: that card shows error, others render.
+- [ ] Page is RSC-streamed (verify in network tab: chunked response).
+
+### T4.4: Projects list with TanStack Table
+
+**Depends on:** T4.1, T4.2
+**Parallel-safe with:** T4.3, T4.5, T4.6
+**Est. CC time:** 90 min
+
+**Goal:** The Projects list demonstrates the kit's signature pattern — server-driven sort/filter/paginate with URL state.
+
+**Outputs:**
+
+- `pnpm add @tanstack/react-table`.
+- Projects list rendered with TanStack Table.
+- Columns: name, status, last_activity_at, actions.
+- Server-side sort/filter/paginate via query params on `/api/projects`.
+- URL state reflects table state (TanStack Router search params).
+- Marked `// REFERENCE PATTERN: tanstack-table — see AGENTS.md §7`.
+
+**Acceptance criteria:**
+
+- [ ] Sorting a column updates the URL and re-fetches.
+- [ ] Filtering by status updates the URL.
+- [ ] Pagination updates the URL.
+- [ ] Pasting the URL with `?sort=last_activity_at&dir=desc&status=active` loads the right state.
+
+### T4.5: `/settings/*` nested routes
+
+**Depends on:** T4.1
+**Parallel-safe with:** T4.3, T4.4, T4.6
+**Est. CC time:** 60 min
+
+**Outputs:**
+
+- `/settings` overview route.
+- `/settings/profile` — edit name + email (email change triggers re-verification).
+- `/settings/security` — change password (uses Rails password reset flow under the hood).
+- All TanStack routes with loaders.
+
+**Acceptance criteria:**
+
+- [ ] Tab navigation between profile and security is client-side.
+- [ ] Email change triggers a new verification email and logs the user out / re-gates.
+
+### T4.6: `/projects/new`, `/projects/:id`, `/projects/:id/edit` routes
+
+**Depends on:** T4.1
+**Parallel-safe with:** T4.3, T4.4, T4.5
+**Est. CC time:** 60 min
+
+**Outputs:**
+
+- Three TanStack routes wrapping the Rails-served forms (or fully client-side — implementer's call; recommended: keep the form server-rendered to preserve the reference pattern from T3.3, but navigate to it via TanStack Link).
+
+**Acceptance criteria:**
+
+- [ ] Create flow works end-to-end via TanStack-routed pages.
+
+### T4.7: Rendering-mode drawer
+
+**Depends on:** T4.3
+**Parallel-safe with:** T4.4, T4.5, T4.6
+**Est. CC time:** 30 min
+
+**Goal:** A small "what's rendering this page" drawer that names the rendering path (RSC streaming) and links to the demo portfolio for the other modes.
+
+**Outputs:**
+
+- Drawer component triggered by a small "i" icon in the dashboard header.
+- Content: "This page renders via React Server Components + streaming. Other render paths: [Hacker News demo →] [Gumroad Inertia comparison →]".
+
+**Acceptance criteria:**
+
+- [ ] Drawer opens/closes, links work.
+- [ ] Keyboard accessible (Escape closes, focus trap).
+
+### T4.8: Error + Suspense boundaries
+
+**Depends on:** T4.3, T4.4
+**Parallel-safe with:** T4.5, T4.6, T4.7
+**Est. CC time:** 45 min
+
+**Outputs:**
+
+- Route-level error boundary on `/dashboard` and `/settings/*`.
+- `<Suspense>` boundaries per metric card and per Projects-list segment.
+- Loader-failure UX: "this section is unavailable — retry" with a retry CTA.
+
+**Acceptance criteria:**
+
+- [ ] Force loader exception: boundary catches it, page rest still renders.
+- [ ] Force RSC stream interruption (kill the renderer mid-stream in dev): rest of the dashboard still shows what loaded.
+
+---
+
+## Phase 5 — shadcn/ui Pattern Catalog with State Coverage
+
+**Goal:** Each pattern ships with empty / loading / error / success states. All largely parallel.
+
+### T5.1: Hero block (landing page)
+
+**Depends on:** Phase 1 complete
+**Parallel-safe with:** all T5.\*
+**Est. CC time:** 60 min
+
+**Outputs:** Public landing at `/` with hero ("Best TanStack on Rails"), 4 demo-portfolio link cards, "Use this template" + "see dashboard demo" CTAs, signed-in user sees "go to dashboard" instead.
+
+**Acceptance criteria:**
+
+- [ ] Visually polished, responsive (mobile + desktop).
+- [ ] Dark mode renders correctly.
+
+### T5.2–T5.6: Per-pattern 4-state components
+
+**Depends on:** Phase 1
+**Parallel-safe with:** each other
+**Est. CC time:** 30 min each
+
+Each task ships one composable pattern with paired empty / loading / error / success components. Mark the canonical pattern files.
+
+- T5.2: Metric card pattern (`# REFERENCE PATTERN: metric-card — see AGENTS.md §3`)
+- T5.3: List view pattern
+- T5.4: Form pattern (already touched in T3.3; T5.4 _adds_ the state-set components if missing)
+- T5.5: Dialog pattern
+- T5.6: Toast pattern (`aria-live="polite"`)
+
+**Acceptance criteria each:** All 4 states render; can be triggered manually via a dev-only playground route.
+
+### T5.7: Dark-mode toggle + `prefers-color-scheme`
+
+**Depends on:** Phase 1
+**Parallel-safe with:** all T5.\*
+**Est. CC time:** 45 min
+
+**Outputs:**
+
+- Inline `<script>` in `<head>` that reads `localStorage.theme` AND falls back to `prefers-color-scheme: dark` if unset.
+- Toggle component in the dashboard nav.
+- Persistence via `localStorage`.
+
+**Acceptance criteria:**
+
+- [ ] Cold load with `prefers-color-scheme: dark` and empty localStorage: no light-mode flash.
+- [ ] Toggle clicks switch instantly, persist on reload.
+
+### T5.8: Custom 404 / 500 pages
+
+**Depends on:** Phase 1
+**Parallel-safe with:** all T5.\*
+**Est. CC time:** 30 min
+
+**Outputs:** `public/404.html` and `public/500.html` styled with shadcn defaults (must be static — these load when Rails isn't reachable).
+
+**Acceptance criteria:**
+
+- [ ] Visiting a 404 URL shows the styled page.
+- [ ] Force a 500 in dev: shows the styled page.
+
+---
+
+## Phase 6 — Background Job + Sentry
+
+### T6.1: SolidQueue config
+
+**Depends on:** Phase 1 complete
+**Parallel-safe with:** T6.4
+**Est. CC time:** 30 min
+
+**Outputs:** `config/queue.yml`, `config/recurring.yml` (for `ProjectArchiveJob`), Procfile.dev worker line confirmed.
+
+**Acceptance criteria:** SolidQueue boots via `bin/dev`, worker dashboard accessible at `/jobs` (dev only).
+
+### T6.2: ProjectArchiveJob
+
+**Depends on:** T6.1, Phase 3
+**Parallel-safe with:** T6.4
+**Est. CC time:** 30 min
+
+**Outputs:** `app/jobs/project_archive_job.rb` marked `# REFERENCE PATTERN: background-job — see AGENTS.md §5`. Archives projects with `last_activity_at < N.days.ago` and status not `archived`.
+
+**Acceptance criteria:** Manually triggering the job archives the expected projects.
+
+### T6.3: Retry + DLQ test
+
+**Depends on:** T6.2
+**Parallel-safe with:** T6.4
+**Est. CC time:** 45 min
+
+**Outputs:** Test that forces a job failure 5 times → DLQ entry created. Test that a successful retry recovers.
+
+**Acceptance criteria:** CI passes.
+
+### T6.4: Sentry initializer
+
+**Depends on:** Phase 1
+**Parallel-safe with:** T6.1, T6.2, T6.3
+**Est. CC time:** 15 min
+
+**Outputs:** `Gemfile` entries for `sentry-ruby` and `sentry-rails`. `config/initializers/sentry.rb` with the full config, **all commented out**, single env var to enable (`SENTRY_DSN`). README sentence explaining how to flip it on.
+
+**Acceptance criteria:** Setting `SENTRY_DSN` in `.env` and uncommenting the initializer captures a test exception.
+
+---
+
+## Phase 7 — AGENTS.md + Canonical Reference Comments
+
+### T7.1: Directory tree (Required-Before-Implementation #6)
+
+**Depends on:** Phase 4 complete (so the actual structure exists)
+**Parallel-safe with:** none (anchors the rest)
+**Est. CC time:** 30 min
+
+**Outputs:** `AGENTS.md` section: directory tree diagram (~30 lines) showing where each piece lives. Locked from this commit forward — file moves require updating this.
+
+**Acceptance criteria:** Every directory referenced by other AGENTS.md sections appears in the tree.
+
+### T7.2: Audit canonical-reference markers
+
+**Depends on:** T7.1
+**Parallel-safe with:** T7.3
+**Est. CC time:** 30 min
+
+**Goal:** Confirm every category has exactly one `REFERENCE PATTERN:` marker in the code, and no category is missing one.
+
+**Outputs:** A short audit doc (delete after) listing each category and its canonical file. Add markers to any missing ones.
+
+**Acceptance criteria:** `grep -rn "REFERENCE PATTERN:" app/ spec/` produces exactly one match per pattern category from AGENTS.md.
+
+### T7.3 – T7.13: One AGENTS.md section per category
+
+**Depends on:** T7.1
+**Parallel-safe with:** each other
+**Est. CC time:** 20–30 min each
+
+Each task writes one AGENTS.md section against the actual code. Tasks:
+
+- T7.3: "How to add a new TanStack route with a Rails loader" (§2) — pointer to T4.5 outputs
+- T7.4: "How to add a new shadcn/ui block" (§3) — `bunx shadcn add` workflow
+- T7.5: "How to add a new form" (§4) — pointer to T3.3 outputs
+- T7.6: "How to add a new background job" (§5) — pointer to T6.2
+- T7.7: "How to add a new email" (§6) — pointer to T2.5
+- T7.8: "How to add a new TanStack Table column" (§7) — pointer to T4.4
+- T7.9: "How to add a new TanStack Query" (§8) — pointer to T4.3
+- T7.10: "Naming conventions" (§9)
+- T7.11: "Testing conventions" decision table (§10)
+- T7.12: "Key Concept: when to RSC vs SSR vs client component" (§11) — the load-bearing section, mirrors monorepo `.client.`/`'use client'` content
+- T7.13: "Key Concept: CSRF + TanStack Query" (§12)
+
+**Acceptance criteria each:** Section ends with a literal command (e.g., `bunx shadcn add ...`, `bin/rails g ...`) plus the exact paths it will touch.
+
+### T7.14: CLAUDE.md and `.cursorrules` thin pointers
+
+**Depends on:** T7.1
+**Parallel-safe with:** T7.3–T7.13
+**Est. CC time:** 10 min
+
+**Outputs:** `CLAUDE.md` and `.cursorrules` — one-page docs that each say "See AGENTS.md for project conventions" + the most critical 3-5 highlights (lint command, test command, never force-push).
+
+---
+
+## Phase 8 — Acceptance Tests
+
+All parallel.
+
+### T8.1: Playwright auth flow
+
+**Depends on:** Phase 2 complete
+**Est. CC time:** 45 min
+
+**Outputs:** Playwright spec covering signup → mail intercept → verification click → dashboard. Logout. Password reset request → mail intercept → token URL → new password → login.
+
+### T8.2: Playwright RSC streaming assertion
+
+**Depends on:** Phase 4 complete
+**Est. CC time:** 30 min
+
+**Outputs:** Network-level test: capture the response for `/dashboard` and assert that multiple chunks arrive (not a single buffered response). Fail loudly if streaming silently fell back to buffered SSR.
+
+### T8.3: Playwright CRUD round trip
+
+**Depends on:** Phase 4 complete
+**Est. CC time:** 45 min
+
+**Outputs:** Create → see in list → edit → see updated → delete with confirm → list empty.
+
+### T8.4: Playwright TanStack URL state
+
+**Depends on:** Phase 4 complete
+**Est. CC time:** 30 min
+
+**Outputs:** Sort the Projects table, observe URL change, paste URL in a new tab, observe table loads with the same state. Also: prefetch verification on hover.
+
+### T8.5: Playwright SSR hydration
+
+**Depends on:** Phase 4 complete
+**Est. CC time:** 20 min
+
+**Outputs:** Test that visits `/dashboard` and `/settings/profile`, asserts zero console errors and zero hydration warnings.
+
+### T8.6: Playwright dark-mode no-flicker
+
+**Depends on:** Phase 5 complete
+**Est. CC time:** 30 min
+
+**Outputs:** Cold load with `prefers-color-scheme: dark` set in Playwright context, screenshot at first paint, assert no light-background pixels.
+
+### T8.7: Playwright accessibility specs
+
+**Depends on:** Phase 5 complete
+**Est. CC time:** 60 min
+
+**Outputs:** Keyboard-only navigation through signup → verification → create-project. `aria-live` assertion on flash and form errors. Focus management on Dialog open/close and route changes.
+
+### T8.8: RSpec authorization-bypass tests
+
+**Depends on:** Phase 3 complete
+**Est. CC time:** 30 min
+
+**Outputs:** Anonymous user cannot reach `/dashboard`. Unverified user cannot reach `/dashboard`. User A cannot access User B's `/projects/:id`. Each test asserts the exact response code (302 for redirect, 404 for scoped not-found).
+
+---
+
+## Phase 9 — Deployment Story
+
+### T9.1: Production Procfile
+
+**Depends on:** Phase 6 complete
+**Est. CC time:** 15 min
+
+**Outputs:** `Procfile` (production): `web`, `worker`, `renderer`. SolidQueue dispatcher configured.
+
+### T9.2: `bin/upgrade-check`
+
+**Depends on:** Phase 1 complete
+**Est. CC time:** 60 min
+
+**Outputs:** Script that diffs the adopter's clone against the latest tagged release of the template, prints categorized changelist (config bumps vs structural vs adopter-owned).
+
+### T9.3: `UPGRADING.md`
+
+**Depends on:** none (can be written empty and grow)
+**Est. CC time:** 30 min
+
+**Outputs:** `UPGRADING.md` with the upgrade policy: what adopters own (their `app/` code) vs what they should pull from upstream (`bin/`, `config/`, `package.json` defaults). Stub release notes for the initial release.
+
+### T9.4 – T9.8: docs/ pages
+
+**Depends on:** Phase 8 (so claims are testable)
+**Parallel-safe with:** each other
+**Est. CC time:** 30–60 min each
+
+- T9.4: `docs/01-architecture.md` — single diagram (Rails ↔ Node renderer ↔ RSC bundle ↔ TanStack) + 1-page narrative
+- T9.5: `docs/02-vs-inertia.md` — feature comparison + link to `react-on-rails-demo-gumroad-rsc` for the head-to-head
+- T9.6: `docs/03-customizing.md` — rename the app, swap mailer provider, disable RSC, add a route
+- T9.7: `docs/04-deploying.md` — generic guide + Mailgun/Postmark/Resend swap-in copy + RSC bundle precompile gotcha + production seed safety + secret hints
+- T9.8: `docs/05-troubleshooting.md` — every predictable failure mode with fix copy (overlaps with T1.7's middleware messages)
+
+### T9.9: Production safety
+
+**Depends on:** Phase 2 (T2.1 onward)
+**Est. CC time:** 30 min
+
+**Outputs:** Verify `db/seeds.rb` is guarded by `Rails.env.development? || Rails.env.test?` (added in T3.9). `config.force_ssl = true` in `config/environments/production.rb`. `assets:precompile` includes the RSC bundle (verify via `RAILS_ENV=production bin/rails assets:precompile` succeeding and the RSC bundle being present in the manifest).
+
+**Acceptance criteria:** Production seed in a Rails console is a no-op. Asset precompile in production env includes the RSC bundle.
+
+---
+
+## Phase 10 — README + Launch
+
+### T10.1: README
+
+**Depends on:** Phase 9 complete
+**Est. CC time:** 75 min
+
+**Outputs:**
+
+- README opens with the "Best TanStack on Rails" pitch (one paragraph, no marketing prose).
+- Single copy-paste setup block (`git clone … && bin/setup && bin/dev && open …`) — Required-Before-Implementation #7's TTHW commitment.
+- Demo-portfolio link cards (Hacker News, Marketplace, Gumroad, Octochangelog) with one-line each.
+- Screenshots of: landing, dashboard (light + dark), `/settings/profile`, `/projects/new`.
+- "Why TanStack" narrative section (1-2 paragraphs).
+- "Demo user" instructions (`demo@example.com` / `password`).
+- "What this kit teaches AI agents" section pointing at `AGENTS.md`.
+- Footer: license, contributing, link to tracking issue.
+
+### T10.2: CI integration as RoR Pro RC QA vehicle
+
+**Depends on:** Phase 8 complete
+**Est. CC time:** 45 min
+
+**Goal:** Implements Goal #5 — the starter as the canonical QA vehicle for RoR Pro releases.
+
+**Outputs:**
+
+- `.github/workflows/pro-rc.yml` workflow triggered by a `workflow_dispatch` event (so RoR Pro CI can call it) OR a scheduled nightly run that pulls the latest Pro RC.
+- The workflow installs the latest Pro RC, runs the full test suite (RSpec + Playwright), reports back to the RoR Pro main repo (issue comment or status check).
+
+**Acceptance criteria:** A manual `workflow_dispatch` run completes and posts results.
+
+### T10.3: Demo deploy (optional but recommended)
+
+**Depends on:** Phase 9 complete
+**Est. CC time:** 90 min
+
+**Outputs:** Hosted demo at a stable URL (Fly.io or Render — implementer's choice) with `demo@example.com / password` pre-seeded, links from the landing page.
+
+**Acceptance criteria:** Demo URL responds, login works, dashboard renders.
+
+### T10.4: Public flip + docs-site update
+
+**Depends on:** T10.1, T10.3 (if doing the demo)
+**Est. CC time:** 30 min
+
+**Outputs:**
+
+- Repo `description` set, topics tagged, "About" section filled.
+- The reactonrails.com docs site updated to feature the kit (separate PR in the docs-site repo).
+- Tracking issue (#3357) closed with a link to the public repo + a "what shipped" summary.
+
+---
+
+## Cross-Cutting: Conventions Reference
+
+Quick-reference for any sub-agent picking up a task without conversation history:
+
+### Test commands
+
+```
+bundle exec rspec                  # backend
+pnpm test                          # Vitest frontend
+bin/test --smoke                   # Playwright smoke
+bin/test --a11y                    # accessibility-tagged Playwright
+bin/test                           # everything
+```
+
+### Lint commands
+
+```
+(cd <project_root> && bundle exec rubocop)   # Ruby lint
+pnpm lint                                     # JS/TS lint
+pnpm format                                   # Prettier
+```
+
+### Routing conventions
+
+- Rails owns: `/`, `/session/*`, `/signup`, `/passwords/*`, `/email_verifications/*`, `/api/*`, the authenticated shell.
+- TanStack Router owns: everything under the authenticated shell — `/dashboard`, `/dashboard/projects/*`, `/projects/new`, `/projects/:id/*`, `/settings/*`.
+
+### Naming
+
+- Files: snake_case Ruby, kebab-case JS for component files, camelCase TS for util files.
+- Routes: RESTful Rails routes; TanStack routes match URL path 1:1.
+- React components: PascalCase, one component per file.
+
+### Where things live (locked in T7.1)
+
+```
+app/
+  controllers/        # Rails controllers (HTML + JSON)
+    api/              # JSON API controllers
+  views/              # Rails views (auth, layout shell, mailer templates)
+  javascript/
+    routes/           # TanStack Router route files
+    components/       # React components (PascalCase)
+      ui/             # shadcn primitives
+    lib/              # apiFetch, queryClient, getCsrfToken, etc.
+  models/             # ActiveRecord
+  jobs/               # SolidQueue
+  mailers/            # ActionMailer
+  middleware/         # Rack middleware (rate limit, etc.)
+config/
+  initializers/       # Sentry, Rack::Attack, etc.
+  routes.rb
+spec/
+  models/, requests/, system/, factories/
+test/
+  playwright/         # Playwright specs
+docs/                 # Adopter-facing docs (Diataxis-ish)
+AGENTS.md             # Pattern index
+CLAUDE.md             # Pointer at AGENTS.md
+.cursorrules          # Pointer at AGENTS.md
+```
+
+---
+
+## Estimated Total Effort
+
+| Phase           | Tasks | Est. CC hours | Parallelizable?             |
+| --------------- | ----- | ------------- | --------------------------- |
+| 0 — Spike       | 5     | 2.5           | Mostly sequential           |
+| 1 — Bootstrap   | 8     | 3.5           | Some parallel after T1.2    |
+| 2 — Auth        | 11    | 7.5           | Heavily parallel after T2.2 |
+| 3 — Projects    | 9     | 4.5           | Parallel after T3.2         |
+| 4 — TanStack    | 8     | 8.5           | Parallel after T4.1, T4.2   |
+| 5 — Patterns    | 8     | 4.5           | Fully parallel              |
+| 6 — Jobs/Sentry | 4     | 2.0           | Mostly parallel             |
+| 7 — AGENTS.md   | 14    | 5.0           | Mostly parallel after T7.1  |
+| 8 — Tests       | 8     | 4.5           | Fully parallel              |
+| 9 — Deploy      | 9     | 4.5           | Mostly parallel             |
+| 10 — Launch     | 4     | 4.0           | Some parallel               |
+
+**Total: ~50 CC-hours sequentially; ~25-30 wall-clock hours with parallel dispatch across ~3-4 sub-agents.**
+
+A team of 4 AI sub-agents working in parallel could realistically land Phase 0 in a half-day, then Phases 1-10 in 3-5 working days assuming clean integration points and the Phase 0 spike lands GREEN.
+
+---
+
+## Open Items for Coordinator
+
+These need a human (or top-level agent) call BEFORE dispatch begins:
+
+1. **Repo name decision** — Justin defers; pick something. Recommended: `react-on-rails-starter-2026` (matches the issue) or `react-on-rails-starter` (evergreen). The plan accepts either.
+2. **Dashboard narrative** (Required-Before-Implementation #9) — recommended: SaaS app dashboard first, rendering-tech as a drawer, pattern catalog as a `/playground` route in dev. Pick before T5.1.
+3. **Accessibility target** (Required-Before-Implementation #8) — recommended: WCAG AA, contrast ratio 4.5:1 for text. Pick before T2.8.
+4. **Demo deploy host** (T10.3) — Fly.io or Render. Pick before Phase 10.
+5. **Spike GREEN/AMBER decision authority** — if T0.5 lands AMBER, who approves the named fallbacks? Recommended: Justin reviews; coordinator dispatches once approved.

--- a/internal/planning/3357-react-on-rails-starter-2026.md
+++ b/internal/planning/3357-react-on-rails-starter-2026.md
@@ -1,53 +1,79 @@
+<!-- /autoplan restore point: /Users/justin/.gstack/projects/shakacode-react_on_rails/jg-conductor-3357-autoplan-restore-20260521-155332.md -->
+
 # Plan: React on Rails Starter 2026 (Issue #3357)
 
-**Status:** Draft — design approved 2026-05-21, awaiting implementation plan.
+**Status:** Draft — design approved 2026-05-21; revised 2026-05-22 after `/autoplan` multi-voice review (CEO + Design + Eng + DX, each dual-voice via Claude subagent + Codex).
 **Tracking issue:** https://github.com/shakacode/react_on_rails/issues/3357
 **Public repo (to be created):** `shakacode/react-on-rails-starter-2026`
+
+## Autoplan Review Outcome (2026-05-22)
+
+Two strategic reframes adopted after dual-voice review surfaced cross-phase convergent dissent on the original framing:
+
+1. **Demo portfolio framing.** The 2026 starter is the _greenfield seed_ at the head of an existing demo portfolio (`react-on-rails-demo-marketplace-rsc`, `react-on-rails-demo-hacker-news-rsc`, `react-on-rails-demo-gumroad-rsc`, `react_on_rails-demo-octochangelog-on-rails-pro`). The demos carry the proof points (RSC streaming, performance under traffic, Inertia head-to-head, migration story). The starter doesn't re-prove what the demos prove.
+
+2. **"Best TanStack on Rails" positioning.** Reframed from "Inertia counter-kit" to a category claim. Two structural reasons it's defensible: (a) Inertia _is_ a routing model — adding TanStack Router on top fights what Inertia owns; (b) RSC plus streaming is hard to ship correctly — Inertia is unlikely to bring up its own RSC-streaming plumbing, and if it ever does, it would most naturally do so on top of React on Rails Pro (a separate, intriguing discussion: "Inertia on Pro" as a bridge product, captured in #3144's neighborhood). So the moat is the combination — incremental React, full-page React, RSC streaming via Pro, AND a deep TanStack integration — not any one piece.
+
+The review also surfaced 7+ engineering and DX gaps that survived the reframes — see [Required Before Implementation](#required-before-implementation) below.
+
+Findings traceability: see `~/.gstack/projects/shakacode-react_on_rails/` for the full dual-voice transcripts. Restore point for pre-review plan: see the HTML comment above this file's title.
 
 ## Problem Statement
 
 The Evil Martians [Inertia Rails React Starter Kit](https://evilmartians.com/opensource/inertia-rails-react-starter-kit), the [official Inertia Rails starter kits](https://inertia-rails.dev/guide/starter-kits) (React / Vue / Svelte), and similar polished kits such as [GrowthX Starter](https://github.com/growthxai/starter) (Rails 8 + React 19 + shadcn/ui) are the most visible front door into "Rails + React in 2026" for new teams.
 
-`create-react-on-rails-app` exists and is solid, but does not currently lead with the same modern stack defaults (shadcn/ui, TanStack Router, RSC demo, Rails 8 auth) — so a developer in a 30-minute side-by-side evaluation sees Inertia as the more "batteries-included" choice for greenfield work, even though React on Rails has a deeper feature set under the hood.
+`create-react-on-rails-app` exists and is solid, but does not currently lead with the same modern stack defaults (shadcn/ui, TanStack ecosystem, RSC, Rails 8 auth) — so a developer in a 30-minute side-by-side evaluation sees Inertia as the more "batteries-included" choice for greenfield work, even though React on Rails has a deeper feature set under the hood.
 
-This plan ships a flagship clone-target starter kit that closes the front-door perception gap and demonstrates the React on Rails Pro story end-to-end.
+This plan ships **the best TanStack-on-Rails starter kit** — a public greenfield seed at the head of the React on Rails demo portfolio. The category claim is structural, not derivative: Inertia _is_ a routing model and therefore cannot host TanStack Router as a peer; React on Rails Pro can and does. The starter operationalizes that claim end-to-end (Router + Query + Table as a coherent surface) while the existing demo repos (Hacker News, Marketplace, Gumroad, Octochangelog) carry the orthogonal proof points (perf, RSC streaming, Inertia head-to-head, migration story).
 
-## Audience (Primary)
+Beyond the front-door positioning, the kit serves three additional purposes the dual-voice review surfaced as material:
 
-**Developers using AI agents to bootstrap and iterate on a Rails + React SaaS** — "vibe coders."
+1. **Canonical reference for AI agents extending Rails + React + RSC + TanStack apps.** AI coding tools (Claude Code, Cursor, etc.) clone the kit's patterns when extending downstream user apps. The kit's job is to teach the right defaults, not just demo features.
+2. **Demonstration of superior TanStack integration** — the kit is the canonical answer to "how do I use TanStack Router/Query/Table with Rails + RSC?" No other Rails+React kit owns this.
+3. **QA vehicle for React on Rails releases** — the starter runs CI against every RoR Pro release candidate. Regressions are caught at the dogfood level before public release, and adopters who ship from this template inherit the same safety net. This is ongoing operational value, not one-time marketing.
 
-Manual evaluators (the 30-minute Inertia vs RoR comparison reader) and adopters (clone-and-build-a-real-SaaS users) are secondary audiences that this design also serves, but every contested decision in this document is resolved in favor of vibe-coding friendliness.
+## Audience
 
-The practical implication: ship **complete patterns the agent can clone**, not the minimum surface needed to demonstrate a feature. Email verification, profile edit, a working background job, a working mailer, factories, system specs, and an `AGENTS.md` are all in scope because they give the downstream agent concrete reference implementations to extrapolate from.
+Two audiences with different leverage points:
+
+**Primary: Developers using AI agents to bootstrap and iterate on a Rails + React SaaS** ("vibe coders"). The agent is the proximate reader; it learns this kit's patterns and extrapolates them across the user's future work. Implication: ship **complete patterns the agent can clone** (auth, mailer, background job, form, CRUD, nested route, system spec) — and let the _code structure itself_ be the load-bearing teaching artifact. `AGENTS.md` documents the patterns but isn't the load-bearing primitive; the canonical reference files are.
+
+**Secondary but consequential: The senior Rails/React maintainer doing a 30-minute side-by-side eval against Inertia/GrowthX.** Dual-voice review flagged this audience as more decision-making than the original framing acknowledged. Implication: surface polish, TTHW, error message quality, deployment readiness, and the "why TanStack" narrative all matter — the human evaluator never gets to the AI-agent value if they bounce in the first 5 minutes.
+
+Both audiences are served by the same core decision: an opinionated TanStack-first surface with concrete, copy-pasteable reference patterns.
 
 ## Goals
 
-1. Ship a polished, public clone-target that wins the side-by-side evaluation against Inertia/GrowthX kits.
-2. Demonstrate three structural advantages Inertia cannot match: TanStack Router with SSR, React Server Components, and incremental adoption via `react_component` (implicit — the kit _is_ a React on Rails app).
-3. Pair with `react-on-rails-demo-gumroad-rsc` so the benchmark story and the starter story reinforce each other.
-4. Give AI agents extending the kit a complete pattern catalog: at least one working reference for every common SaaS concern (auth, mailer, background job, form, CRUD, nested route, system spec).
+1. **Establish "best TanStack on Rails" as a category claim** with end-to-end operationalization: TanStack Router as the routing primitive for the authenticated surface, TanStack Query for client-side data fetching, TanStack Table for the Projects list. Structural moat: Inertia owns its routing model (TanStack can't be a peer), RSC + streaming is hard to bring up correctly (Inertia is unlikely to ship its own — and if it does, naturally lands on top of Pro). The combination — incremental React, full-page React, RSC streaming via Pro, AND deep TanStack integration — is the moat, not any single piece.
+2. **Be the polished greenfield seed of the React on Rails demo portfolio.** Link out to `react-on-rails-demo-hacker-news-rsc` for public-traffic perf, `react-on-rails-demo-marketplace-rsc` for e-commerce, `react-on-rails-demo-gumroad-rsc` for direct Inertia head-to-head, `react_on_rails-demo-octochangelog-on-rails-pro` for migration from a real Rails app. The starter doesn't re-prove what the demos prove.
+3. **Win the human evaluator's 30-minute eval** — TTHW ≤ 3 min on a primed macOS laptop, clean error UX on the predictable first-5-minutes failures (forgot to seed, port conflict, Postgres not up, Node renderer not running), README that opens with the "why TanStack on Rails" narrative.
+4. **Give AI agents extending the kit cloneable patterns** via the code structure itself (canonical reference files with marker comments + colocated specs and factories), with `AGENTS.md` as the _index_, not the strategy pillar.
+5. **Serve as the canonical QA / dogfood vehicle for React on Rails Pro release candidates.** CI runs the full kit (RSpec + Playwright + Lighthouse) against every RoR Pro RC. Regressions detected here gate public RoR Pro releases. Adopters inherit this safety net implicitly.
 
 ## Non-Goals
 
-- **Not** a `--flagship` variant flag on `create-react-on-rails-app`.
+- **Not** a `--flagship` variant flag on `create-react-on-rails-app` for Tier 1. (Revisit at Tier 2 — see Required-Before-Implementation #4.)
 - **Not** a sibling generator package.
 - **Not** a benchmark/positioning artifact (those live in #3144, #3128, and `react-on-rails-demo-gumroad-rsc`).
 - **Not** an Inertia-bridge product (captured separately in #3144).
-- **Not** auto-generated — users clone the repo and rename, the same delivery model every Inertia kit uses.
+- **Not** auto-generated — users clone the repo (via GitHub's "Use this template") and rename, the same delivery model every Inertia kit uses.
+- **Not** a place to re-prove what the demo portfolio already proves (RSC streaming, public-traffic perf, direct Inertia head-to-head, migration story). Those stay in the demo repos; the starter links out.
+- **Not** an "Inertia on top of Pro" bridge product. That idea is _intriguing_ (Inertia's hard problem is RSC streaming, which Pro solves; Inertia-on-Pro could be the natural shape if Inertia ever wants RSC) but it is a separate strategic conversation, not in scope here. Tracked separately.
 
 ## Delivery Decision
 
-**Standalone public GitHub repo, `shakacode/react-on-rails-starter-2026`, public from commit 1.**
+**Standalone public GitHub repo, `shakacode/react-on-rails-starter-2026`, public from commit 1, configured as a GitHub Template Repository** (so adopters get a fresh tree via "Use this template," not a stale clone).
 
 Considered alternatives:
 
-- A new flag on `create-react-on-rails-app`: rejected because it bloats the OSS CLI matrix with Pro-heavy choices and makes every flag combination a permanent maintenance burden.
-- A sibling generator package (`create-react-on-rails-flagship`): rejected because no Inertia kit ships as a CLI — all three (official, Evil Martians, GrowthX) are clone-driven, so a CLI fails the apples-to-apples evaluation comparison.
+- A new flag on `create-react-on-rails-app`: deferred to Tier 2 review, not rejected. Original argument ("no Inertia kit ships as a CLI") is competitor-mimicry rather than user reasoning. The real argument is CLI-matrix bloat + Pro-heavy maintenance burden, which is legitimate but not load-bearing. After Tier 1 ships, if the maintained template proves stable, fold its defaults back into `create-react-on-rails-app --template starter-2026` (the flag clones the maintained template repo, doesn't re-generate every permutation).
+- A sibling generator package (`create-react-on-rails-flagship`): rejected — duplicates the maintenance burden of both the CLI and the template repo.
 - Private-first, public when polished: rejected; the credibility cost of a messy public commit log is small enough to accept in exchange for "build in public" signal.
+- Fork the Evil Martians Inertia kit and swap Inertia for RoR Pro: rejected — TanStack-on-Rails is a _different_ product, not a recoloring of their kit.
 
 The kit is bootstrapped via `create-react-on-rails-app --rsc --rspack` and then heavily customized; downstream improvements to that CLI flow benefit both projects.
 
-Naming pattern is a new addition to the `internal/planning/examples-catalog-and-repo-naming-plan.md` taxonomy: `react-on-rails-starter-*` for opinionated greenfield clone-targets. The `-2026` suffix telegraphs "reflects current best practice" without committing the name to evergreen freshness.
+**On the `-2026` naming** (dual-voice review surfaced this as a maintenance trap): the suffix telegraphs freshness in Q1 and decay by Q3 of 2027. Two acceptable resolutions, both deferred to Required-Before-Implementation #5: (a) rename to `react-on-rails-starter` (evergreen, freshening-cadence-as-policy), or (b) commit to a yearly cut-over (`-2026` → archived; `-2027` ships in January) so the suffix is a feature, not a self-defeating prophecy. Pick before public-commit-1.
 
 ## Scope: Tier 1 ("B-prime")
 
@@ -55,25 +81,25 @@ Tier 1 is what ships in the first public release. Tier 2 is deferred (listed bel
 
 ### Surfaces
 
-- **Public landing** — shadcn/ui hero block, three feature blurbs (RSC, TanStack Router SSR, incremental adoption), dark-mode toggle, CTAs for signup and "view the dashboard demo."
+- **Public landing** — shadcn/ui hero, "Best TanStack on Rails" hero narrative (positioning, not feature blurbs), 4 demo-portfolio link cards (Hacker News, Marketplace, Gumroad, Octochangelog) each scoped to its proof point, dark-mode toggle, CTAs for "Use this template" and "see the dashboard demo." Signed-in users see a "go to dashboard" CTA on the landing.
 - **Auth surface** — built on top of `bin/rails generate authentication` plus custom additions:
   - **From the Rails 8 generator (no changes):** login at `POST /session` (singular `resource :session`), logout at `DELETE /session`, password reset at `/passwords/new` and `/passwords/:token/edit`, `PasswordsMailer`, `User` / `Session` / `Current` models, `Authentication` concern auto-included in `ApplicationController`.
   - **Custom on top (vibe-coder pattern catalog):** signup (`RegistrationsController` + view at `/signup` — the generator does NOT provide this), email verification (token column on `User`, `EmailVerificationsController`, `EmailVerificationMailer`, `email_verified_at` gate that blocks the dashboard until verified), profile edit at `/settings/profile`, password change at `/settings/security`.
+  - **Email verification UX as a designed funnel, not a backend gate.** Post-signup confirmation screen with visible target email, resend button with cooldown, "change email" affordance, expired-token recovery flow, spam-folder hint, dev-mode `letter_opener` link surfaced. (Both Design voices flagged this as the highest-friction touchpoint in the funnel; full spec lives in Required-Before-Implementation #1.)
   - `letter_opener` for dev mail.
   - Views are re-skinned with shadcn/ui blocks; the generator's raw scaffold views are replaced.
-- **Authenticated dashboard, two implementations**
-  - `/dashboard/rsc` — RSC-rendered Projects view (Pro RSC mode, server components, streamed).
-  - `/dashboard/ssr` — classic SSR Projects view (Pro Node renderer), identical UI, different render path.
-  - Both render: Projects list with status filter, four metric cards (total / active / completed-this-week / avg cycle time), "New Project" CTA.
-- **TanStack Router-driven `/settings`** (the structural-advantage demo)
-  - `/settings` overview
-  - `/settings/profile` (edit name + email)
-  - `/settings/security` (change password)
-  - Type-safe nested routing with SSR loaders. Rails serves the shell; TanStack handles `/settings/*` nesting on the client + SSR.
-- **Projects CRUD** — `new`, `show`, `edit`, `destroy` with one reference form-with-validation pattern (server-side validation + inline error display).
-- **Background job demo** — SolidQueue + `ProjectArchiveJob` (archives projects whose `last_activity_at` is older than N days).
+- **Authenticated TanStack-routed surface** (the structural moat — operationalized end-to-end)
+  - `/dashboard` — single canonical dashboard, Pro RSC streaming by default. **TanStack Table** drives the Projects list (column sort, status filter, pagination, persisted view). **TanStack Query** fans out the 4 metric cards as independent fetches with per-card loading/error states, no head-of-line blocking. **TanStack Router** owns navigation to `/projects/:id` with route-level loader prefetch. A small "rendering mode" drawer surfaces _which_ Pro path is rendering (RSC) and links to the Hacker News and Gumroad demos for the classic-SSR and Inertia-head-to-head comparisons — replacing the originally-planned `/dashboard/ssr` duplicate.
+  - `/settings` overview, `/settings/profile`, `/settings/security` — TanStack Router nested routes with SSR loaders, same primitive as the dashboard.
+  - `/projects/:id`, `/projects/:id/edit`, `/projects/new` — TanStack-routed, with route-level loaders.
+  - Auth + email-verification gates run server-side on the Rails shell route before any TanStack code mounts.
+- **Projects CRUD** — `new`, `show`, `edit`, `destroy`. Reference form pattern: Rails server-side validation as the source of truth, inline error display per field, optimistic-pending state on submit, marked with a canonical-reference comment header (see Required-Before-Implementation #6). TanStack Form is **not** in Tier 1 scope — deferred to Tier 2 as a second TanStack-ecosystem milestone.
+- **State coverage commitment** (Design review surfaced as catastrophic gap): every surface above ships with explicit empty, loading, error, and success states. The pattern catalog (below) ships paired empty/loading/error/success components per category, not just the happy path.
+- **shadcn/ui pattern catalog** — hero block, list view, metric cards, form, dialog, toast, plus the four-state set (empty / loading / error / success) for each composable surface, plus dark-mode toggle. Each pattern marked with a canonical-reference comment so AI agents grep-find the right one.
+- **Background job demo** — SolidQueue + `ProjectArchiveJob` (archives projects whose `last_activity_at` is older than N days). Retry policy + DLQ behavior + Sentry capture all spec'd; tests cover retry exhaustion.
 - **Mailer demo** — `WelcomeMailer` (sent on signup, custom), the Rails 8 generator's `PasswordsMailer` (reset), and a custom `EmailVerificationMailer` (the generator does not provide one).
 - **Sentry** — wired in `Gemfile`, initializer commented out, single env var (`SENTRY_DSN`) to enable. README documents how to flip it on.
+- **Accessibility floor** (Design review surfaced as 0/10): WCAG AA contrast on all surfaces, keyboard nav verified in Playwright, `aria-live` on flash + form errors, focus management on dialog open/close + route changes, reduced-motion handling on transitions, touch targets ≥ 44px. Not a section in `AGENTS.md` — a property of every shipped surface.
 
 ### Stack
 
@@ -81,13 +107,17 @@ Tier 1 is what ships in the first public release. Tier 2 is deferred (listed bel
 - Shakapacker + Rspack
 - React 19 + TypeScript 5
 - React on Rails Pro (RSC mode)
-- TanStack Router with SSR (Pro-supported)
+- **TanStack Router with SSR** — routing primitive for the entire authenticated surface (Pro-supported)
+- **TanStack Query** — client-side data fetching against Rails JSON endpoints, with per-component loading/error states
+- **TanStack Table** — Projects list (sort, filter, paginate, persisted view state)
+- TanStack Form — **deferred to Tier 2** (less mature than Router/Query/Table, less differentiated, adds learning curve at the wrong time)
 - shadcn/ui + Tailwind v4
 - SolidQueue (background jobs)
+- Rack::Attack (rate limiting — needed for the email verification spec; see Required-Before-Implementation #1)
 - `letter_opener` (dev mail)
 - Sentry-ruby + sentry-rails (commented-out initializer)
 - RSpec + factory_bot + Capybara (backend & system)
-- Playwright (cross-stack smoke)
+- Playwright (cross-stack smoke, with `aria-` + keyboard nav assertions)
 - Vitest (frontend unit, light)
 
 ## Data Model
@@ -129,112 +159,235 @@ The auth generator's password-reset token lives on the `Session` row indirectly 
 
 ## Data Flow
 
-- Rails routes (`config/routes.rb`) handle the landing page, auth surface, dashboard shells, project CRUD, and the `/settings` shell.
-- TanStack Router mounts under the `/settings` Rails shell route and handles nested `/settings/*` paths client-side, with SSR loaders for first-paint correctness.
-- Auth gate (the `Authentication` concern from the Rails 8 generator, included in `ApplicationController`) protects all `/dashboard/*`, `/settings/*`, `/projects/*` controllers via `before_action :require_authentication`.
-- Email-verification gate: a separate `before_action :require_verified_email` on the dashboard / projects / settings controllers redirects unverified users to a "check your email" landing. Verification clicks set `email_verified_at` and clear the gate.
-- `/dashboard/rsc` renders via `react_on_rails_component` with `rsc: true`, streaming from the server.
-- `/dashboard/ssr` renders via `react_component` (classic SSR through the Pro Node renderer).
-- Both dashboard routes pull `Project.where(user: current_user)` server-side, sort by `last_activity_at desc`, group by `status` for the metric cards.
+- Rails routes (`config/routes.rb`) handle the landing page, the auth surface, and the **single** authenticated shell route. Everything under that shell is TanStack-Router-driven.
+- The Rails auth + verification gates run server-side on the shell controller, _before_ any TanStack code mounts. Specifically: `Authentication` concern (`before_action :require_authentication`) + `before_action :require_verified_email` on the shell controller. Unverified users never reach the TanStack mount point.
+- TanStack Router owns `/dashboard`, `/dashboard/projects/:id`, `/projects/new`, `/settings`, `/settings/profile`, `/settings/security`. SSR loaders run server-side via the Pro Node renderer so first paint is correct; client takes over for subsequent navigations with prefetch.
+- `/dashboard` renders via `react_on_rails_component` with `rsc: true` (RSC + streaming, default rendering path). The Hacker News and Gumroad demo repos carry the classic-SSR and Inertia head-to-head comparisons respectively — the starter links to them rather than duplicating them inline.
+- Per-component data fetching uses **TanStack Query** against thin Rails JSON endpoints (`/api/projects`, `/api/projects/:id/metrics`). Each metric card on `/dashboard` is an independent query — one slow query never blocks the rest of the dashboard.
+- The Projects list uses **TanStack Table** with server-side sort/filter/page params reflected in URL state via TanStack Router search params. AI agents extending the kit get a single canonical pattern for "list with server-driven sort/filter/paginate."
+- CSRF: TanStack Query and TanStack Router both honor the Rails CSRF token via a shared `getCsrfToken()` reader (meta tag on the Rails shell). Documented in `AGENTS.md` as the one cross-cutting subtlety.
 
 ## Error Handling
 
 - Custom 404 and 500 pages styled with shadcn (overrides `public/404.html`, `public/500.html`).
-- Server-side validation on `Project` and `User` models. The Project form is the reference pattern: validation errors render inline next to fields, success redirects with a flash toast.
-- SolidQueue retry policy on `ProjectArchiveJob` (max 5, exponential backoff). Failed jobs surface in the dev queue dashboard; when Sentry is enabled, also captured there.
-- Email delivery failure: in dev `letter_opener` shows the message in a browser tab (no failure path). README documents Mailgun / Postmark / Resend swap-in for production with one-line ActionMailer config.
+- Server-side validation on `Project` and `User` models. The Project form is the reference pattern: validation errors render inline next to fields with `aria-live`, success redirects with a flash toast.
+- SolidQueue retry policy on `ProjectArchiveJob` (max 5, exponential backoff). Failed jobs land in DLQ + are captured by Sentry when enabled. Spec'd test: forced failure → 5 retries → DLQ entry.
+- **TanStack Router SSR loader failure** — loader exceptions caught by a route-level error boundary that renders a "this section is unavailable" panel with a retry CTA. Tests cover loader-throws-on-SSR and client-side-retry-recovers.
+- **RSC stream interruption** — `<Suspense>` boundaries scoped per metric card + per Projects-list segment, with error boundaries that allow the rest of the dashboard to render. Spec'd Playwright test: mid-stream connection cut → other cards still appear.
+- **Node renderer crash** — Rails falls back to the empty-shell + client-side TanStack mount (degraded but functional) and emits a `react_on_rails.node_renderer_down` Sentry event. README documents the operational signal.
+- **Email provider down on signup** — user sees "we couldn't send your verification email; try resend" instead of being silently locked out. The resend route accepts a recently-signed-up email without an authenticated session for a 24-hour window.
+- **First-5-minutes error budget** — the predictable evaluator failures (port 3000 conflict, Postgres not running, `bin/rails db:seed` not run, SolidQueue not started, Node renderer not running, missing `RAILS_MASTER_KEY`) each get a problem + cause + fix message. `bin/doctor` checks preflight; dev-only middleware surfaces the "no demo user — run `bin/rails db:seed`" hint inline when `Rails.env.development? && User.count == 0`.
+- Email delivery failure in dev: `letter_opener` shows the message in a browser tab. Production: README documents Mailgun / Postmark / Resend swap-in with both the one-line ActionMailer config AND the relevant ENV vars.
 
 ## Testing
 
+Test types AND specific acceptance targets — "at least one spec per category" is not enough for a kit whose value prop is "agents clone these patterns."
+
 - **RSpec** for backend
   - Model specs for `User`, `Project`.
-  - Request specs for sessions, registrations, projects.
-  - System specs (Capybara + headless Chrome) for the full signup → dashboard → create-project flow.
-  - At least one reference spec per category that agents extrapolate from.
-- **Playwright** for cross-stack smoke
-  - Auth flow (signup, login, logout).
-  - Dashboard render on both `/dashboard/rsc` and `/dashboard/ssr`.
-  - Project CRUD round trip.
-  - TanStack Router nested-route navigation under `/settings`.
-- **Vitest** for any non-trivial frontend unit logic (light — most logic is server-resident).
-- **Factories** via `factory_bot` for `User`, `Project`.
-- **CI** via GitHub Actions: RSpec + Playwright on push and PR.
-- **Local helpers**: `bin/test` runs everything, `bin/test --smoke` runs Playwright only.
+  - Request specs for sessions, registrations, projects, email verifications (token expiry, single-use, replay rejection, resend throttle).
+  - System specs (Capybara + headless Chrome) for the full signup → verification → dashboard → create-project flow.
+  - Authorization-bypass tests: anonymous user can't reach `/dashboard`; unverified user can't reach `/dashboard`; user A can't access user B's `/projects/:id`.
+- **Playwright** for cross-stack acceptance
+  - Auth flow (signup, login, logout, password reset, email verification with mock-mail interception).
+  - **RSC streaming assertion** — network-trace assertion that response chunks arrive progressively (not the bare "page rendered" assertion, which passes even if streaming silently fell back to full SSR).
+  - Project CRUD round trip including optimistic state, validation error display, delete confirmation flow.
+  - TanStack Router navigation: `/dashboard` → `/projects/:id` → back, with prefetch verification and URL-state-reflects-table-state assertions.
+  - **TanStack SSR hydration**: console-errors-fail-the-test, plus explicit "no hydration mismatch" assertion on `/dashboard` and `/settings/profile`.
+  - **Dark mode no-flicker**: cold load with `prefers-color-scheme: dark` shows no light-mode frame before paint.
+  - **Accessibility**: keyboard-only navigation through signup → verification → create-project, `aria-live` on flash messages and form errors, focus-trap on dialog open/close.
+- **Vitest** for non-trivial frontend unit logic (TanStack Table column definitions, TanStack Query key factory, etc.).
+- **Factories** via `factory_bot` for `User`, `Project`. Verification-token factory traits: `:unverified`, `:expired_token`, `:verified`.
+- **CI** via GitHub Actions: RSpec + Playwright on push and PR. **Lighthouse run** on `/dashboard` (logged-in seeded user) with budgets defined in Required-Before-Implementation #2.
+- **Local helpers**: `bin/test` runs everything, `bin/test --smoke` runs Playwright only, `bin/test --a11y` runs only the accessibility-tagged Playwright specs.
 
-## `AGENTS.md` (Load-Bearing)
+## `AGENTS.md` (Index, Not Strategy)
 
-The kit's root `AGENTS.md` is treated as a first-class artifact, not an afterthought. It is the primary mechanism by which the kit is "vibe-coding-friendly."
+The kit's root `AGENTS.md` is the index that points AI agents at the canonical reference files. It is _not_ the load-bearing teaching artifact — the code structure (with marker comments + colocated specs and factories) is. Dual-voice review explicitly challenged the original "AGENTS.md as load-bearing" framing: AI agents extract patterns from code, not docs; the docs index those patterns, the code teaches them.
 
-Contents (sections, each with a working code reference in the kit):
+Density target: match the monorepo's existing `AGENTS.md` (concrete commands, exact file paths, key concept deep-dives where they matter). Every "How to add X" section ends with a literal command the agent can execute (`bunx shadcn add card`, `bin/rails g migration AddXToProjects`) plus the exact paths it will touch.
 
-1. **File layout map** — where models, controllers, views, components, routes, tests, factories, mailers, jobs each live.
-2. **How to add a new route** — Rails controller + view + spec, with a pointer to `app/controllers/projects_controller.rb` as the canonical example.
-3. **How to add a new shadcn/ui block** — `bunx shadcn add ...` workflow, where the block lives in the file tree, how to compose it.
-4. **How to add a new form** — pointer to the Project form (validation + error display + flash success).
-5. **How to add a new background job** — pointer to `ProjectArchiveJob` (SolidQueue, retry policy).
-6. **How to add a new email** — pointer to `WelcomeMailer` (mailer, view, preview, spec).
-7. **How to add a new TanStack Router child route** — pointer to `/settings/profile` and `/settings/security`.
-8. **Naming conventions** — file naming, route naming, component naming, model naming.
-9. **Testing conventions** — when to use RSpec vs Playwright vs Vitest.
-10. **Pointer to the reference implementations** that agents should clone.
+Contents (sections, each with a working code reference + canonical-marker comment in the kit):
 
-## Default Decisions (Q&A defaults committed during brainstorming)
+1. **File layout tree** — concrete directory diagram with what lives where. Defined now in this plan (see Required-Before-Implementation #6), not back-filled at Phase 8.
+2. **How to add a new TanStack route with a Rails data loader** — the kit's signature pattern. Pointer to `/settings/profile` as canonical.
+3. **How to add a new shadcn/ui block** — `bunx shadcn add ...` workflow, where the block lives, RSC-vs-client decision tree (see below).
+4. **How to add a new form** — pointer to the Project form (validation + error display + flash + a11y).
+5. **How to add a new background job** — pointer to `ProjectArchiveJob` (SolidQueue, retry, DLQ, Sentry).
+6. **How to add a new email** — pointer to `WelcomeMailer` (mailer, view, preview, spec, throttle pattern).
+7. **How to add a new TanStack Table column** — pointer to the Projects list.
+8. **How to add a new TanStack Query** — pointer to a metric card on the dashboard.
+9. **Naming conventions** — file naming, route naming, component naming, model naming.
+10. **Testing conventions** — decision table (RSpec vs Playwright vs Vitest), not prose.
+11. **Key Concept: when to RSC vs SSR vs client component in this kit** — mirrors the monorepo's `.client.`/`'use client'` block. THE most valuable single decision tree the kit can ship. Includes the shadcn-on-Tailwind-v4-inside-RSC boundary placement guidance.
+12. **Key Concept: CSRF + TanStack Query** — the one cross-cutting subtlety the data flow introduces.
+13. **Pointer to canonical references** — absolute paths to every canonical example, indexed by category.
 
-These were marked "**Decision (default):** …" — answered with the recommended option unless the user pushes back at file-review time.
+## Default Decisions
 
-1. **TanStack Router mount strategy** — TanStack-under-a-Rails-shell-route (Rails serves the shell at `/settings`, TanStack handles `/settings/*` nesting). If a different pattern is already canonical in `react_on_rails_pro`, the implementation phase will match that.
-2. **Dark mode** — default light. Toggle persisted in `localStorage`. Small inline `<script>` in `<head>` reads `localStorage` and sets the class before paint, to avoid SSR theme flicker.
-3. **Demo user in seeds** — yes, `demo@example.com` / `password`, pre-verified. Documented in the README as the evaluation login.
-4. **Repo creation timing** — create `shakacode/react-on-rails-starter-2026` as the first step of execution (not before the spec lands). Avoids a public-empty-repo window.
+1. **TanStack Router mount strategy** — Rails serves a single authenticated shell route; TanStack Router owns everything under it. SSR loaders run via the Pro Node renderer. If `react_on_rails_pro` has a canonical alternative pattern, match it.
+2. **Dark mode** — default light, toggle persisted in `localStorage`, inline `<script>` in `<head>` to prevent flicker, **also check `prefers-color-scheme` on first visit if no `localStorage` value is set**. Palette = shadcn defaults for Tier 1 (full brand system deferred to Tier 2).
+3. **Demo user in seeds** — yes, `demo@example.com` / `password`, pre-verified. `db/seeds.rb` is guarded by `Rails.env.development? || Rails.env.test?` to prevent the seed running in production (dual-voice Eng review flagged this as a takeover vector). Production seed (if any) lives in `db/seeds/production.rb` and is opt-in.
+4. **Repo creation timing** — create the GitHub repo as the first step of execution, configured as a Template Repository, with a placeholder README that says "scaffolding in progress; see [tracking issue]." Avoids a public-empty-repo window.
+5. **Email verification design** — see Required-Before-Implementation #1 for the full spec. Default: `urlsafe_base64(32)` token, stored as `digest`, 24-hour TTL, single-use, throttled at 5/hour/IP + 3/hour/email via Rack::Attack, session rotated on verification.
 
 ## Tier 2 (Deferred — explicitly NOT in the first public release)
 
 Listed for tracking only. Each may become its own plan doc later.
 
+- **TanStack Form** — second TanStack-ecosystem milestone; replace the Rails-validation reference form with a TanStack-Form-driven equivalent once the library matures and the Tier 1 kit's stability is proven.
+- **Full brand system** — typography scale, palette beyond shadcn defaults, illustration/iconography direction, content voice. Tier 1 ships on shadcn defaults; Tier 2 commits a visual identity.
 - Kamal deploy config (delays choice of ops platform).
-- Production Sentry recipe with provider examples (Mailgun / Postmark / Resend swap-in copy + screenshots).
+- Production Sentry recipe with provider examples.
 - Additional UI patterns: file upload, multi-step wizard, infinite scroll, charts / data viz.
 - API auth (JWT or OAuth) demo for headless consumers.
 - More TanStack Router patterns: route-level data loaders, params validation, code splitting.
 - i18n setup.
 - Multi-tenant example.
 - Vue and Svelte variants (only if usage of the React variant proves the model).
+- **`create-react-on-rails-app --template starter-2026` flag** — reopen the CLI question after Tier 1 ships and the maintained template proves stable; folding the starter's defaults back into the CLI flow is the natural distribution play once the maintenance burden is known.
 
 ## Freshening Cadence
 
-Quarterly review owned by the React on Rails team:
+Quarterly review with a **named DRI** (not "owned by the team" — dual-voice review flagged that as ownership-by-nobody). DRI named at kick-off, rotates yearly.
 
-- Bump Rails, React, TanStack Router, shadcn/ui, Tailwind, React on Rails Pro to current versions.
-- Re-run the full Playwright smoke suite against the bumped stack.
+- Bump Rails, React, TanStack (Router/Query/Table), shadcn/ui, Tailwind, React on Rails Pro to current versions.
+- Re-run the full Playwright smoke suite + Lighthouse budget check against the bumped stack.
 - Update the README's "last refreshed YYYY-MM-DD" line.
 - Tag a release matching the calendar quarter (`2026.Q3`, `2026.Q4`, …).
+- Ship `UPGRADING.md` updates per release (what changed, migration steps for adopters).
 
-Without this cadence the kit will look stale within 12 months and undo the front-door win.
+Calendar reminder + release checklist owned by the DRI. If the DRI changes roles, the role transfers before any quarterly slot is missed. **Two missed quarters = the kit auto-archives** with a banner pointing to the next maintained alternative — better to retire honestly than rot publicly.
 
-## Implementation Phasing (high-level — detailed plan TBD via `writing-plans`)
+## Implementation Phasing (high-level — see [Detailed Implementation Plan](./3357-react-on-rails-starter-2026-implementation.md))
 
 The detailed implementation plan is the deliverable of the next phase. High-level phases:
 
-1. **Repo bootstrap.** Create `shakacode/react-on-rails-starter-2026`, push initial Rails 8 + RoR Pro scaffold via `create-react-on-rails-app --rsc --rspack`. Land first CI green build.
-2. **Auth surface.** Run `bin/rails generate authentication`, add `name` column + signup (`RegistrationsController` + view) + email verification (token column, `EmailVerificationsController`, `EmailVerificationMailer`) on top of it, re-skin views with shadcn/ui, add `letter_opener` for dev, ship `WelcomeMailer`.
-3. **Projects model + CRUD.** Migration, model, controller, views, form-with-validation reference, factory, RSpec specs.
-4. **Dashboard, both implementations.** `/dashboard/rsc` + `/dashboard/ssr` rendering the same Projects view.
-5. **TanStack Router `/settings` nested routes.** Settings shell + `profile` + `security`.
-6. **shadcn/ui pattern catalog.** Hero block, list view, metric cards, form, dialog, toast, empty state, loading state, dark-mode toggle.
-7. **Background job + Sentry wiring.** `ProjectArchiveJob`, SolidQueue config, Sentry initializer (commented).
-8. **`AGENTS.md` content.** Authored against the actual reference implementations in the kit.
-9. **Playwright smoke suite.** Auth, dashboard, CRUD, TanStack nav.
-10. **README + launch.** README, screenshots, demo-user instructions, "compare to Gumroad benchmark" footnote. Flip-visible event matches docs-site update.
+0. **Spike PR (required precondition, not optional).** One-day spike validating TanStack Router + TanStack Query + Pro RSC + shadcn/ui on Tailwind v4 all working together on a single throwaway route. If the spike fails on any of the three open compatibility risks, fall back per the decision tree in Required-Before-Implementation #3 BEFORE any of phases 1-10. No phase 1 work until spike is green.
+1. **Repo bootstrap.** Create the GitHub Template Repository, push initial Rails 8 + RoR Pro scaffold via `create-react-on-rails-app --rsc --rspack`. Land first CI green build. `bin/doctor` and the "first-5-minutes error budget" copy ship in this phase.
+2. **Auth surface + verification funnel.** Run `bin/rails generate authentication`, add `name` column + signup + email verification (full spec from Required-Before-Implementation #1), re-skin views with shadcn/ui, add `letter_opener`, ship `WelcomeMailer`. Post-signup verification UX is part of THIS phase, not back-filled later.
+3. **Projects model + CRUD.** Migration, model, controller, JSON API endpoints, server-side validation reference form (marked with canonical-reference comment), factory, request + system specs.
+4. **TanStack-driven authenticated surface.** Single `/dashboard` with TanStack Router + Query (metric cards) + Table (Projects list). `/settings/*` nested routes. `/projects/:id` and `/projects/new`. Rendering mode drawer + outbound links to demo portfolio.
+5. **shadcn/ui pattern catalog with state coverage.** Hero, list view, metric cards, form, dialog, toast, plus paired empty/loading/error/success states per pattern, dark-mode toggle with `prefers-color-scheme` fallback.
+6. **Background job + Sentry wiring.** `ProjectArchiveJob`, SolidQueue config + `Procfile.dev`, Sentry initializer (commented). Retry exhaustion + DLQ test.
+7. **`AGENTS.md` + canonical-reference comments.** Authored against the actual reference implementations in the kit. Density target: monorepo's existing `AGENTS.md`.
+8. **Playwright + RSpec acceptance suite.** All the test targets above, plus Lighthouse budget check, plus accessibility-tagged specs.
+9. **Deployment story.** `Procfile`, `.env.example`, `bin/setup`, `bin/doctor`, `UPGRADING.md`, deploy docs (Mailgun/Postmark/Resend swap-in + RSC bundle precompile gotcha + production seed safety).
+10. **README + launch.** README opens with the "Best TanStack on Rails" pitch, demo-portfolio link cards, screenshots, demo-user instructions. Flip-visible event matches docs-site update.
 
-Each phase is one PR. Each PR ships green CI before merge.
+Each phase is one PR. Each PR ships green CI before merge. Phase 0 (spike) is non-optional and runs BEFORE the public template repo flips from placeholder to populated.
 
 ## Open Questions
 
-1. **TanStack Router + Pro RSC interaction.** Issue #3357 step 3 calls this out. Skipped explicit de-risking per the brainstorm (Justin confirmed the Pro support is already there); implementation should validate end-to-end in a fresh kit and adjust this plan if needed.
-2. **shadcn/ui Tailwind v4 maturity.** Confirm shadcn/ui's Tailwind v4 path is stable enough for a flagship at the time of implementation; if not, fall back to v3 for tier 1 and bump to v4 in a tier 2 freshening pass.
-3. **`AGENTS.md` vs `CLAUDE.md`.** The repo's primary agent-conventions file is `AGENTS.md` because it's the cross-agent open standard. The implementation phase should also drop a thin `CLAUDE.md` that points at `AGENTS.md` (and the same for any other agent-specific convention files Claude Code or Cursor pick up), so no agent misses the conventions.
-4. **Tailwind v4 + Pro RSC streaming compatibility.** Confirm Tailwind v4's CSS-first config doesn't conflict with how Pro RSC streams CSS for server-component routes. If incompatible at implementation time, fall back to Tailwind v3.
-5. **Signup vs `User` migration in `db/seeds.rb`.** Since Rails 8's generator skips `CreateUsers` if `app/models/user.rb` already exists, the implementation phase must decide whether the `RegistrationsController` and `name` column are added in a separate migration on top of the generator's `CreateUsers`, or by editing the generator's emitted migration before first run. Editing the generator output is cleaner; document the choice in the AGENTS.md.
+All originally-listed open questions are now resolved or absorbed into the Phase 0 spike. Nothing here gates implementation.
+
+1. ~~TanStack Router + Pro RSC interaction~~ — **CLOSED.** Validated as mandatory in the Phase 0 spike. Confirmed by Justin as non-negotiable for the kit's identity.
+2. ~~shadcn/ui Tailwind v4 maturity~~ — **CLOSED.** Phase 0 spike validates; fallback to Tailwind v3 ships if v4 isn't ready.
+3. ~~`AGENTS.md` vs `CLAUDE.md`~~ — **CLOSED.** Both ship. `AGENTS.md` is canonical; `CLAUDE.md` is a thin pointer.
+4. ~~Tailwind v4 + Pro RSC streaming compatibility~~ — **CLOSED.** Phase 0 spike validates.
+5. ~~Signup vs `User` migration~~ — **CLOSED.** Edit the generator's emitted migration before first run; documented in `AGENTS.md`.
+6. ~~TanStack Form in Tier 2 timing~~ — **CLOSED.** Defer until Tier 1 ships and adopters ask for it.
+7. ~~`-2026` naming~~ — **CLOSED.** Implementer's call; Justin will update later if needed.
+
+Active follow-up (separate discussion, NOT in this plan's scope): **"Inertia on Pro" as a bridge product.** Inertia's hard problem is RSC streaming; Pro solves it. The natural shape if Inertia ever wants RSC is on top of Pro. Worth a separate strategy conversation — likely lives in #3144's neighborhood.
+
+## Required Before Implementation
+
+These are pre-Phase-0 deliverables — gaps the autoplan dual-voice review surfaced that cannot ride along with implementation. Block phase 0 (spike) on items 3 and 5; block phase 1 (public scaffold push) on the rest.
+
+### 1. Email verification token specification (Eng critical — both voices 1-3/10)
+
+Full spec, not a column name:
+
+- Token: `SecureRandom.urlsafe_base64(32)`, generated at signup or resend request.
+- Storage: digest only (`Digest::SHA256.hexdigest(token)`). Compare via `ActiveSupport::SecurityUtils.secure_compare`.
+- TTL: 24 hours via `verification_sent_at` column.
+- Single-use: nulled on consume.
+- Throttling: Rack::Attack — 5 verification-email-sends per IP per hour, 3 per email per hour.
+- Replay: previously-consumed tokens return generic "this link has expired, request a new one."
+- Enumeration defense: `EmailVerificationsController#create` returns identical UX whether email exists or not.
+- Session rotation: on successful verification, the session is rotated (`reset_session` + re-issue the auth cookie).
+- Audit: log verification events to `Rails.logger.tagged("auth")` with user_id and IP.
+- Resend route: accepts a recently-signed-up email without an authenticated session for a 24-hour window after signup.
+
+### 2. Performance budgets (deferred — Tier 1 ships without strict budgets)
+
+**Justin's call: defer to post-Tier-1.** Strict perf budgets aren't a ship blocker; the demo portfolio carries the perf story (Hacker News demo specifically), and ship velocity matters more here than measured Lighthouse numbers.
+
+Tier 1 commits to "no obviously broken behavior" — dark-mode flicker test (Playwright assertion: zero pixels of wrong-mode before paint) is the one perf-adjacent check that stays in Tier 1 because it's a correctness bug, not a budget. Everything else (TTFB targets, Lighthouse gates, bundle-size budgets, Node renderer warmup script) moves to **Required After Tier 1 Ships**:
+
+- Tier 2 ships measured budgets after we have real adopter data on what "good" looks like.
+- If evaluator complaints surface a specific perf gap in the first 90 days post-ship, fast-follow that gap; otherwise hold until Tier 2.
+
+### 3. Phase 0 spike PR + fallback decision tree (Eng critical — three unresolved integrations)
+
+One-day spike, one throwaway branch, validates:
+
+- TanStack Router SSR mounting under a Rails shell controller (auth-gated, CSRF-passing, hydration-clean).
+- TanStack Query reading from a Rails JSON endpoint with CSRF.
+- Pro RSC streaming a component that uses a shadcn-from-Tailwind-v4 primitive.
+- All three together on the same throwaway route.
+
+Fallback decision tree (committed BEFORE the spike, so the outcome doesn't require a new decision under pressure):
+
+- **TanStack Router + Pro RSC integration breaks:** drop RSC default for `/dashboard`; ship classic SSR via Pro Node renderer. Demo portfolio still carries the RSC story. The kit's TanStack-on-Rails identity holds.
+- **shadcn/ui on Tailwind v4 breaks inside RSC bundle:** ship Tier 1 on Tailwind v3 with shadcn's v3 path; defer v4 to Tier 2 freshening.
+- **Tailwind v4 CSS-streaming incompatibility:** also forces v3 fallback.
+- **All three fail:** stop. Re-spec before any phase 1 work. This is a strategy-level reset, not a tactical pivot.
+
+### 4. Deployment readiness (Eng high — both voices 2-4/10)
+
+Tier 1 ships with:
+
+- `Procfile.dev` defining web / Rspack-watch / SolidQueue / Node-renderer processes.
+- `Procfile` for production (`web`, `worker`, `node-renderer`).
+- `.env.example` with every required ENV var (`RAILS_MASTER_KEY`, `DATABASE_URL`, `SOLID_QUEUE_IN_PUMA`, `SENTRY_DSN`, mail-provider vars).
+- `bin/setup` runs the full prerequisite check + db prep + seed (dev only).
+- `bin/doctor` smoke-checks Ruby/Postgres/Node/pnpm/bun versions + dependencies.
+- Production safety: `db/seeds.rb` guarded by `Rails.env.development?`; `config.force_ssl = true` in production.yml; production secret hints in `.env.example`.
+- RSC bundle precompilation documented in `config/initializers/assets.rb` (the Pro RSC pipeline emits a separate bundle that `assets:precompile` must include).
+- `docs/` set: `01-architecture.md`, `02-vs-inertia.md`, `03-customizing.md`, `04-deploying.md`, `05-troubleshooting.md`, `UPGRADING.md`.
+
+### 5. `-2026` naming resolution (CEO + Eng both flagged)
+
+Pick before public-commit-1:
+
+- **Option A:** Rename to `react-on-rails-starter` (no year suffix). Freshening cadence is policy. Less calendar pressure, more ambient "is this still current" risk.
+- **Option B:** Keep `-2026`, commit to yearly cut-over (`-2026` → archived banner pointing to `-2027`; new repo each January). Suffix is a feature, not a self-defeating prophecy.
+- **Option C (rejected):** Keep `-2026` with quarterly freshening. Becomes self-defeating in Q1 2027 per dual-voice review.
+
+### 6. Directory tree + canonical-reference convention (DX high)
+
+Lock now, not back-fill at Phase 7:
+
+- 30-line directory tree diagram (Rails + JS sides) showing where TanStack routes, shadcn blocks, RSC components, client components, factories, specs, mailers, jobs each live.
+- Canonical-reference comment header convention: `# REFERENCE PATTERN: <name> — see AGENTS.md §N`. Every canonical example file has one; non-canonical files do not. AI agents grep for `REFERENCE PATTERN:` to find the source-of-truth example per pattern.
+- One canonical example per pattern category. If a category has 3 instances (signup / profile-edit / project-create forms), exactly one wears the `REFERENCE PATTERN:` marker.
+
+### 7. TTHW measurement + dev environment friction (DX medium-high)
+
+- TTHW target: ≤ 3 minutes on a primed macOS laptop from `git clone` to dashboard visible (measured, not asserted).
+- README opens with a single copy-paste block achieving TTHW: `git clone … && cd … && bin/setup && bin/dev && open http://localhost:3000`.
+- Letter_opener mounted at `/letter_opener` in development + surfaced via a "Dev Tools" nav item on the dashboard (development env only) alongside the SolidQueue dashboard.
+- The "first-5-minutes error budget" copy (port conflict, Postgres down, no seed user, etc.) ships in Phase 1 (not back-filled).
+
+### 8. Accessibility floor (Design 0/10)
+
+Pre-implementation:
+
+- Pick a specific WCAG target (AA recommended) and a specific contrast ratio.
+- Add accessibility-tagged Playwright specs to the test plan: keyboard nav, `aria-live` on flash + errors, focus management on dialog + route changes, reduced-motion.
+- Cite Radix primitives (under shadcn/ui) as the keyboard-nav baseline so the implementer knows what comes free.
+
+### 9. Dashboard narrative decision (Design)
+
+Both Design voices: "is this a SaaS app dashboard, a rendering-tech demo, or a pattern catalog?" Pick one. Recommend: **SaaS app dashboard first, rendering-tech and pattern catalog visible as drawers/links — not the lead.** A first-time user lands on something that feels like a real product, not a lab demo. The rendering-mode drawer is for the curious; the demo-portfolio links are for the seriously evaluating.
+
+### 10. Upgrade path for adopters (DX low-medium, but the single weakest dimension in the DX review)
+
+- `UPGRADING.md` ships in Tier 1, not "later."
+- `bin/upgrade-check` script diffs the cloned repo against the latest tag and prints categorized changelist (config bumps vs structural changes vs adopter code).
+- Convention about what the adopter "owns" (their app code in `app/`) vs what they should pull from upstream (`bin/`, `config/`, `package.json` defaults).
 
 ## Related
 
@@ -243,4 +396,25 @@ Each phase is one PR. Each PR ships green CI before merge.
 - #3128 — Gumroad public comparison repo
 - `internal/planning/examples-catalog-and-repo-naming-plan.md` — naming taxonomy this plan extends
 - `docs/oss/getting-started/comparison-with-alternatives.md` — Inertia vs React on Rails comparison this plan operationalizes
-- `react-on-rails-demo-gumroad-rsc` — benchmark repo the starter dashboard surface mirrors structurally
+
+**Demo portfolio (the starter links to these instead of duplicating their proof points):**
+
+- `react-on-rails-demo-hacker-news-rsc` — public-traffic perf demo (Pro + React 19 + RSC)
+- `react-on-rails-demo-marketplace-rsc` — e-commerce / marketplace surface
+- `react-on-rails-demo-gumroad-rsc` — creator dashboard with direct Inertia head-to-head
+- `react_on_rails-demo-octochangelog-on-rails-pro` — migration of an existing Rails app to Pro + RSC
+
+## Autoplan Findings Summary (for reviewers)
+
+Dual-voice review (Claude subagent + Codex) ran CEO, Design, Eng, and DX phases on the pre-rewrite plan. Headline:
+
+| Phase  | Subagent verdict                                       | Codex verdict                      |
+| ------ | ------------------------------------------------------ | ---------------------------------- |
+| CEO    | "Would not fund as scoped"                             | "Fund with changes"                |
+| Design | "Ships the checklist of a starter, not the aesthetic"  | 2/10 overall                       |
+| Eng    | "Not implementation-ready"                             | "Blocked on 6 items"               |
+| DX     | "Cheap concrete fixes turn a 6/10 starter into 8.5/10" | (not run — superseded by reframes) |
+
+Convergent dissent on the original strategic foundation (vibe-coders-as-primary, AGENTS.md-as-load-bearing, standalone-repo-as-the-artifact, two-dashboard demo, RSC-as-moat) drove the two reframes adopted at the top of this file. Convergent engineering findings (security, performance, deployment, a11y, TTHW, naming, freshening ownership) survived the reframes and live in [Required Before Implementation](#required-before-implementation).
+
+Full dual-voice transcripts: `~/.gstack/projects/shakacode-react_on_rails/` and the conversation log from 2026-05-21 → 2026-05-22.

--- a/internal/planning/3357-react-on-rails-starter-2026.md
+++ b/internal/planning/3357-react-on-rails-starter-2026.md
@@ -290,7 +290,7 @@ All originally-listed open questions are now resolved or absorbed into the Phase
 6. ~~TanStack Form in Tier 2 timing~~ — **CLOSED.** Defer until Tier 1 ships and adopters ask for it.
 7. ~~`-2026` naming~~ — **CLOSED.** Repo named `react-on-rails-starter-tanstack` (locks identity to positioning, sidesteps the calendar-suffix maintenance trap).
 
-Active follow-up (separate discussion, NOT in this plan's scope): **"Inertia on Pro" as a bridge product.** Inertia's hard problem is RSC streaming; Pro solves it. The natural shape if Inertia ever wants RSC is on top of Pro. Worth a separate strategy conversation — likely lives in #3144's neighborhood.
+Active follow-up (separate discussion, NOT in this plan's scope): **"Inertia on Pro" as a bridge product** — tracked in #3371. Inertia's hard problem is RSC streaming; Pro solves it. The natural shape if Inertia ever wants RSC is on top of Pro. Discussed separately so the 2026 starter ships on TanStack-on-Rails without entangling Inertia-bridge product strategy.
 
 ## Required Before Implementation
 
@@ -393,6 +393,7 @@ Both Design voices: "is this a SaaS app dashboard, a rendering-tech demo, or a p
 - #3357 — this issue
 - #3144 — Gumroad RSC experiment: benchmark findings and positioning
 - #3128 — Gumroad public comparison repo
+- #3371 — "Inertia on Pro" bridge-product strategic discussion (surfaced during this plan's review; carved out as a separate track)
 - `internal/planning/examples-catalog-and-repo-naming-plan.md` — naming taxonomy this plan extends
 - `docs/oss/getting-started/comparison-with-alternatives.md` — Inertia vs React on Rails comparison this plan operationalizes
 

--- a/internal/planning/3357-react-on-rails-starter-2026.md
+++ b/internal/planning/3357-react-on-rails-starter-2026.md
@@ -4,7 +4,7 @@
 
 **Status:** Draft — design approved 2026-05-21; revised 2026-05-22 after `/autoplan` multi-voice review (CEO + Design + Eng + DX, each dual-voice via Claude subagent + Codex).
 **Tracking issue:** https://github.com/shakacode/react_on_rails/issues/3357
-**Public repo (to be created):** `shakacode/react-on-rails-starter-2026`
+**Public repo (to be created):** `shakacode/react-on-rails-starter-tanstack`
 
 ## Autoplan Review Outcome (2026-05-22)
 
@@ -62,18 +62,18 @@ Both audiences are served by the same core decision: an opinionated TanStack-fir
 
 ## Delivery Decision
 
-**Standalone public GitHub repo, `shakacode/react-on-rails-starter-2026`, public from commit 1, configured as a GitHub Template Repository** (so adopters get a fresh tree via "Use this template," not a stale clone).
+**Standalone public GitHub repo, `shakacode/react-on-rails-starter-tanstack`, public from commit 1, configured as a GitHub Template Repository** (so adopters get a fresh tree via "Use this template," not a stale clone).
 
 Considered alternatives:
 
-- A new flag on `create-react-on-rails-app`: deferred to Tier 2 review, not rejected. Original argument ("no Inertia kit ships as a CLI") is competitor-mimicry rather than user reasoning. The real argument is CLI-matrix bloat + Pro-heavy maintenance burden, which is legitimate but not load-bearing. After Tier 1 ships, if the maintained template proves stable, fold its defaults back into `create-react-on-rails-app --template starter-2026` (the flag clones the maintained template repo, doesn't re-generate every permutation).
+- A new flag on `create-react-on-rails-app`: deferred to Tier 2 review, not rejected. Original argument ("no Inertia kit ships as a CLI") is competitor-mimicry rather than user reasoning. The real argument is CLI-matrix bloat + Pro-heavy maintenance burden, which is legitimate but not load-bearing. After Tier 1 ships, if the maintained template proves stable, fold its defaults back into `create-react-on-rails-app --template tanstack` (the flag clones the maintained template repo, doesn't re-generate every permutation).
 - A sibling generator package (`create-react-on-rails-flagship`): rejected — duplicates the maintenance burden of both the CLI and the template repo.
 - Private-first, public when polished: rejected; the credibility cost of a messy public commit log is small enough to accept in exchange for "build in public" signal.
 - Fork the Evil Martians Inertia kit and swap Inertia for RoR Pro: rejected — TanStack-on-Rails is a _different_ product, not a recoloring of their kit.
 
 The kit is bootstrapped via `create-react-on-rails-app --rsc --rspack` and then heavily customized; downstream improvements to that CLI flow benefit both projects.
 
-**On the `-2026` naming** (dual-voice review surfaced this as a maintenance trap): the suffix telegraphs freshness in Q1 and decay by Q3 of 2027. Two acceptable resolutions, both deferred to Required-Before-Implementation #5: (a) rename to `react-on-rails-starter` (evergreen, freshening-cadence-as-policy), or (b) commit to a yearly cut-over (`-2026` → archived; `-2027` ships in January) so the suffix is a feature, not a self-defeating prophecy. Pick before public-commit-1.
+**Naming decision (2026-05-22):** the repo is `react-on-rails-starter-tanstack`. The `-tanstack` suffix locks the kit's identity to its strongest positioning rather than a calendar year — sharper claim, no maintenance trap. If TanStack momentum stalls in the future the name becomes a softer "the modern Rails+React starter" identity, which is a survivable downside. Either way the name doesn't expire on a fixed date.
 
 ## Scope: Tier 1 ("B-prime")
 
@@ -81,15 +81,15 @@ Tier 1 is what ships in the first public release. Tier 2 is deferred (listed bel
 
 ### Surfaces
 
-- **Public landing** — shadcn/ui hero, "Best TanStack on Rails" hero narrative (positioning, not feature blurbs), 4 demo-portfolio link cards (Hacker News, Marketplace, Gumroad, Octochangelog) each scoped to its proof point, dark-mode toggle, CTAs for "Use this template" and "see the dashboard demo." Signed-in users see a "go to dashboard" CTA on the landing.
+- **Public landing** — **RSC-rendered + streamed** (this is where RSC earns its keep: cold-load TTFB matters, mobile perf matters, SEO matters, the visitor hasn't downloaded the app shell yet). Pro RSC + shadcn/ui hero, "Best TanStack on Rails" hero narrative (positioning, not feature blurbs), 4 demo-portfolio link cards (Hacker News, Marketplace, Gumroad, Octochangelog) each scoped to its proof point, dark-mode toggle, CTAs for "Use this template" and "see the dashboard demo." Signed-in users see a "go to dashboard" CTA on the landing.
 - **Auth surface** — built on top of `bin/rails generate authentication` plus custom additions:
   - **From the Rails 8 generator (no changes):** login at `POST /session` (singular `resource :session`), logout at `DELETE /session`, password reset at `/passwords/new` and `/passwords/:token/edit`, `PasswordsMailer`, `User` / `Session` / `Current` models, `Authentication` concern auto-included in `ApplicationController`.
   - **Custom on top (vibe-coder pattern catalog):** signup (`RegistrationsController` + view at `/signup` — the generator does NOT provide this), email verification (token column on `User`, `EmailVerificationsController`, `EmailVerificationMailer`, `email_verified_at` gate that blocks the dashboard until verified), profile edit at `/settings/profile`, password change at `/settings/security`.
   - **Email verification UX as a designed funnel, not a backend gate.** Post-signup confirmation screen with visible target email, resend button with cooldown, "change email" affordance, expired-token recovery flow, spam-folder hint, dev-mode `letter_opener` link surfaced. (Both Design voices flagged this as the highest-friction touchpoint in the funnel; full spec lives in Required-Before-Implementation #1.)
   - `letter_opener` for dev mail.
   - Views are re-skinned with shadcn/ui blocks; the generator's raw scaffold views are replaced.
-- **Authenticated TanStack-routed surface** (the structural moat — operationalized end-to-end)
-  - `/dashboard` — single canonical dashboard, Pro RSC streaming by default. **TanStack Table** drives the Projects list (column sort, status filter, pagination, persisted view). **TanStack Query** fans out the 4 metric cards as independent fetches with per-card loading/error states, no head-of-line blocking. **TanStack Router** owns navigation to `/projects/:id` with route-level loader prefetch. A small "rendering mode" drawer surfaces _which_ Pro path is rendering (RSC) and links to the Hacker News and Gumroad demos for the classic-SSR and Inertia-head-to-head comparisons — replacing the originally-planned `/dashboard/ssr` duplicate.
+- **Authenticated TanStack-routed surface** (the structural moat — operationalized end-to-end). **Rendered via classic SSR through the Pro Node renderer**, not RSC. Rationale: RSC's headline wins (TTFB on cold load, reduced client JS, streaming SEO content) don't apply behind auth — the visitor has already loaded the app, JS is cached, search engines don't index gated pages. TanStack's wins (type-safe routing, prefetch-on-hover, URL-state interop, Query's fan-out, Table's interactivity) all show up most on the authenticated surface. RSC stays on the public landing where it pays off.
+  - `/dashboard` — single canonical dashboard. **TanStack Table** drives the Projects list (column sort, status filter, pagination, persisted view). **TanStack Query** fans out the 4 metric cards as independent fetches with per-card loading/error states, no head-of-line blocking. **TanStack Router** owns navigation to `/projects/:id` with route-level loader prefetch. A small "rendering mode" drawer in the dashboard header tells the honest surface-split story: _"This authenticated surface is TanStack-driven, classic SSR via the Pro Node renderer — chosen for type safety + interactivity. The public landing uses RSC for cold-load and SEO. The full RSC streaming story lives in the [Hacker News demo →] and [Marketplace demo →]; the Inertia head-to-head lives in the [Gumroad demo →]."_
   - `/settings` overview, `/settings/profile`, `/settings/security` — TanStack Router nested routes with SSR loaders, same primitive as the dashboard.
   - `/projects/:id`, `/projects/:id/edit`, `/projects/new` — TanStack-routed, with route-level loaders.
   - Auth + email-verification gates run server-side on the Rails shell route before any TanStack code mounts.
@@ -159,10 +159,11 @@ The auth generator's password-reset token lives on the `Session` row indirectly 
 
 ## Data Flow
 
-- Rails routes (`config/routes.rb`) handle the landing page, the auth surface, and the **single** authenticated shell route. Everything under that shell is TanStack-Router-driven.
+- Rails routes (`config/routes.rb`) handle the **public landing** (RSC-rendered), the auth surface (classic Rails views), and the **single** authenticated shell route. Everything under that shell is TanStack-Router-driven.
+- **Public landing (`/`)** renders via `react_on_rails_component` with `rsc: true` — RSC + streaming. This is the surface where RSC's headline wins (TTFB, mobile perf, SEO content streaming) actually apply. Cold visitors land on a fast, search-indexable, low-JS first paint.
 - The Rails auth + verification gates run server-side on the shell controller, _before_ any TanStack code mounts. Specifically: `Authentication` concern (`before_action :require_authentication`) + `before_action :require_verified_email` on the shell controller. Unverified users never reach the TanStack mount point.
 - TanStack Router owns `/dashboard`, `/dashboard/projects/:id`, `/projects/new`, `/settings`, `/settings/profile`, `/settings/security`. SSR loaders run server-side via the Pro Node renderer so first paint is correct; client takes over for subsequent navigations with prefetch.
-- `/dashboard` renders via `react_on_rails_component` with `rsc: true` (RSC + streaming, default rendering path). The Hacker News and Gumroad demo repos carry the classic-SSR and Inertia head-to-head comparisons respectively — the starter links to them rather than duplicating them inline.
+- **Authenticated `/dashboard` renders via `react_component` (classic SSR through the Pro Node renderer)**, not RSC. Rationale: behind auth, RSC's TTFB / SEO / cold-load wins don't apply; TanStack's interactivity / type-safety / URL-state wins do. The RSC streaming story is carried by the public landing here and by the demo portfolio (Hacker News, Marketplace) externally.
 - Per-component data fetching uses **TanStack Query** against thin Rails JSON endpoints (`/api/projects`, `/api/projects/:id/metrics`). Each metric card on `/dashboard` is an independent query — one slow query never blocks the rest of the dashboard.
 - The Projects list uses **TanStack Table** with server-side sort/filter/page params reflected in URL state via TanStack Router search params. AI agents extending the kit get a single canonical pattern for "list with server-driven sort/filter/paginate."
 - CSRF: TanStack Query and TanStack Router both honor the Rails CSRF token via a shared `getCsrfToken()` reader (meta tag on the Rails shell). Documented in `AGENTS.md` as the one cross-cutting subtlety.
@@ -245,7 +246,7 @@ Listed for tracking only. Each may become its own plan doc later.
 - i18n setup.
 - Multi-tenant example.
 - Vue and Svelte variants (only if usage of the React variant proves the model).
-- **`create-react-on-rails-app --template starter-2026` flag** — reopen the CLI question after Tier 1 ships and the maintained template proves stable; folding the starter's defaults back into the CLI flow is the natural distribution play once the maintenance burden is known.
+- **`create-react-on-rails-app --template tanstack` flag** — reopen the CLI question after Tier 1 ships and the maintained template proves stable; folding the starter's defaults back into the CLI flow is the natural distribution play once the maintenance burden is known.
 
 ## Freshening Cadence
 
@@ -287,7 +288,7 @@ All originally-listed open questions are now resolved or absorbed into the Phase
 4. ~~Tailwind v4 + Pro RSC streaming compatibility~~ — **CLOSED.** Phase 0 spike validates.
 5. ~~Signup vs `User` migration~~ — **CLOSED.** Edit the generator's emitted migration before first run; documented in `AGENTS.md`.
 6. ~~TanStack Form in Tier 2 timing~~ — **CLOSED.** Defer until Tier 1 ships and adopters ask for it.
-7. ~~`-2026` naming~~ — **CLOSED.** Implementer's call; Justin will update later if needed.
+7. ~~`-2026` naming~~ — **CLOSED.** Repo named `react-on-rails-starter-tanstack` (locks identity to positioning, sidesteps the calendar-suffix maintenance trap).
 
 Active follow-up (separate discussion, NOT in this plan's scope): **"Inertia on Pro" as a bridge product.** Inertia's hard problem is RSC streaming; Pro solves it. The natural shape if Inertia ever wants RSC is on top of Pro. Worth a separate strategy conversation — likely lives in #3144's neighborhood.
 
@@ -348,13 +349,11 @@ Tier 1 ships with:
 - RSC bundle precompilation documented in `config/initializers/assets.rb` (the Pro RSC pipeline emits a separate bundle that `assets:precompile` must include).
 - `docs/` set: `01-architecture.md`, `02-vs-inertia.md`, `03-customizing.md`, `04-deploying.md`, `05-troubleshooting.md`, `UPGRADING.md`.
 
-### 5. `-2026` naming resolution (CEO + Eng both flagged)
+### 5. ~~`-2026` naming resolution~~ — RESOLVED 2026-05-22
 
-Pick before public-commit-1:
+Repo named **`react-on-rails-starter-tanstack`**. Locks identity to the strongest positioning rather than a calendar year. Sidesteps the maintenance trap of a year-suffixed name without giving up the freshness signal entirely (the kit's `latest 2026.Q3` tag carries the calendar information).
 
-- **Option A:** Rename to `react-on-rails-starter` (no year suffix). Freshening cadence is policy. Less calendar pressure, more ambient "is this still current" risk.
-- **Option B:** Keep `-2026`, commit to yearly cut-over (`-2026` → archived banner pointing to `-2027`; new repo each January). Suffix is a feature, not a self-defeating prophecy.
-- **Option C (rejected):** Keep `-2026` with quarterly freshening. Becomes self-defeating in Q1 2027 per dual-voice review.
+If TanStack momentum stalls in some future year, the name degrades gracefully to "the modern Rails+React starter" identity — still a survivable downside.
 
 ### 6. Directory tree + canonical-reference convention (DX high)
 

--- a/internal/planning/3357-react-on-rails-starter-2026.md
+++ b/internal/planning/3357-react-on-rails-starter-2026.md
@@ -1,0 +1,246 @@
+# Plan: React on Rails Starter 2026 (Issue #3357)
+
+**Status:** Draft — design approved 2026-05-21, awaiting implementation plan.
+**Tracking issue:** https://github.com/shakacode/react_on_rails/issues/3357
+**Public repo (to be created):** `shakacode/react-on-rails-starter-2026`
+
+## Problem Statement
+
+The Evil Martians [Inertia Rails React Starter Kit](https://evilmartians.com/opensource/inertia-rails-react-starter-kit), the [official Inertia Rails starter kits](https://inertia-rails.dev/guide/starter-kits) (React / Vue / Svelte), and similar polished kits such as [GrowthX Starter](https://github.com/growthxai/starter) (Rails 8 + React 19 + shadcn/ui) are the most visible front door into "Rails + React in 2026" for new teams.
+
+`create-react-on-rails-app` exists and is solid, but does not currently lead with the same modern stack defaults (shadcn/ui, TanStack Router, RSC demo, Rails 8 auth) — so a developer in a 30-minute side-by-side evaluation sees Inertia as the more "batteries-included" choice for greenfield work, even though React on Rails has a deeper feature set under the hood.
+
+This plan ships a flagship clone-target starter kit that closes the front-door perception gap and demonstrates the React on Rails Pro story end-to-end.
+
+## Audience (Primary)
+
+**Developers using AI agents to bootstrap and iterate on a Rails + React SaaS** — "vibe coders."
+
+Manual evaluators (the 30-minute Inertia vs RoR comparison reader) and adopters (clone-and-build-a-real-SaaS users) are secondary audiences that this design also serves, but every contested decision in this document is resolved in favor of vibe-coding friendliness.
+
+The practical implication: ship **complete patterns the agent can clone**, not the minimum surface needed to demonstrate a feature. Email verification, profile edit, a working background job, a working mailer, factories, system specs, and an `AGENTS.md` are all in scope because they give the downstream agent concrete reference implementations to extrapolate from.
+
+## Goals
+
+1. Ship a polished, public clone-target that wins the side-by-side evaluation against Inertia/GrowthX kits.
+2. Demonstrate three structural advantages Inertia cannot match: TanStack Router with SSR, React Server Components, and incremental adoption via `react_component` (implicit — the kit _is_ a React on Rails app).
+3. Pair with `react-on-rails-demo-gumroad-rsc` so the benchmark story and the starter story reinforce each other.
+4. Give AI agents extending the kit a complete pattern catalog: at least one working reference for every common SaaS concern (auth, mailer, background job, form, CRUD, nested route, system spec).
+
+## Non-Goals
+
+- **Not** a `--flagship` variant flag on `create-react-on-rails-app`.
+- **Not** a sibling generator package.
+- **Not** a benchmark/positioning artifact (those live in #3144, #3128, and `react-on-rails-demo-gumroad-rsc`).
+- **Not** an Inertia-bridge product (captured separately in #3144).
+- **Not** auto-generated — users clone the repo and rename, the same delivery model every Inertia kit uses.
+
+## Delivery Decision
+
+**Standalone public GitHub repo, `shakacode/react-on-rails-starter-2026`, public from commit 1.**
+
+Considered alternatives:
+
+- A new flag on `create-react-on-rails-app`: rejected because it bloats the OSS CLI matrix with Pro-heavy choices and makes every flag combination a permanent maintenance burden.
+- A sibling generator package (`create-react-on-rails-flagship`): rejected because no Inertia kit ships as a CLI — all three (official, Evil Martians, GrowthX) are clone-driven, so a CLI fails the apples-to-apples evaluation comparison.
+- Private-first, public when polished: rejected; the credibility cost of a messy public commit log is small enough to accept in exchange for "build in public" signal.
+
+The kit is bootstrapped via `create-react-on-rails-app --rsc --rspack` and then heavily customized; downstream improvements to that CLI flow benefit both projects.
+
+Naming pattern is a new addition to the `internal/planning/examples-catalog-and-repo-naming-plan.md` taxonomy: `react-on-rails-starter-*` for opinionated greenfield clone-targets. The `-2026` suffix telegraphs "reflects current best practice" without committing the name to evergreen freshness.
+
+## Scope: Tier 1 ("B-prime")
+
+Tier 1 is what ships in the first public release. Tier 2 is deferred (listed below).
+
+### Surfaces
+
+- **Public landing** — shadcn/ui hero block, three feature blurbs (RSC, TanStack Router SSR, incremental adoption), dark-mode toggle, CTAs for signup and "view the dashboard demo."
+- **Auth surface** — built on top of `bin/rails generate authentication` plus custom additions:
+  - **From the Rails 8 generator (no changes):** login at `POST /session` (singular `resource :session`), logout at `DELETE /session`, password reset at `/passwords/new` and `/passwords/:token/edit`, `PasswordsMailer`, `User` / `Session` / `Current` models, `Authentication` concern auto-included in `ApplicationController`.
+  - **Custom on top (vibe-coder pattern catalog):** signup (`RegistrationsController` + view at `/signup` — the generator does NOT provide this), email verification (token column on `User`, `EmailVerificationsController`, `EmailVerificationMailer`, `email_verified_at` gate that blocks the dashboard until verified), profile edit at `/settings/profile`, password change at `/settings/security`.
+  - `letter_opener` for dev mail.
+  - Views are re-skinned with shadcn/ui blocks; the generator's raw scaffold views are replaced.
+- **Authenticated dashboard, two implementations**
+  - `/dashboard/rsc` — RSC-rendered Projects view (Pro RSC mode, server components, streamed).
+  - `/dashboard/ssr` — classic SSR Projects view (Pro Node renderer), identical UI, different render path.
+  - Both render: Projects list with status filter, four metric cards (total / active / completed-this-week / avg cycle time), "New Project" CTA.
+- **TanStack Router-driven `/settings`** (the structural-advantage demo)
+  - `/settings` overview
+  - `/settings/profile` (edit name + email)
+  - `/settings/security` (change password)
+  - Type-safe nested routing with SSR loaders. Rails serves the shell; TanStack handles `/settings/*` nesting on the client + SSR.
+- **Projects CRUD** — `new`, `show`, `edit`, `destroy` with one reference form-with-validation pattern (server-side validation + inline error display).
+- **Background job demo** — SolidQueue + `ProjectArchiveJob` (archives projects whose `last_activity_at` is older than N days).
+- **Mailer demo** — `WelcomeMailer` (sent on signup, custom), the Rails 8 generator's `PasswordsMailer` (reset), and a custom `EmailVerificationMailer` (the generator does not provide one).
+- **Sentry** — wired in `Gemfile`, initializer commented out, single env var (`SENTRY_DSN`) to enable. README documents how to flip it on.
+
+### Stack
+
+- Ruby 3.4+, Rails 8.0+, PostgreSQL
+- Shakapacker + Rspack
+- React 19 + TypeScript 5
+- React on Rails Pro (RSC mode)
+- TanStack Router with SSR (Pro-supported)
+- shadcn/ui + Tailwind v4
+- SolidQueue (background jobs)
+- `letter_opener` (dev mail)
+- Sentry-ruby + sentry-rails (commented-out initializer)
+- RSpec + factory_bot + Capybara (backend & system)
+- Playwright (cross-stack smoke)
+- Vitest (frontend unit, light)
+
+## Data Model
+
+```
+User (Rails 8 generator emits email_address + password_digest; remaining columns are this kit's additions)
+  - email_address (string, NOT NULL, uniquely indexed)   # from generator
+  - password_digest (string, NOT NULL)                   # from generator
+  - name (string)                                        # custom (for signup + profile)
+  - email_verification_token (string, nullable, indexed) # custom
+  - email_verified_at (datetime, nullable)               # custom
+  - timestamps
+
+Session (from Rails 8 generator; database-backed sessions)
+  - user_id (FK)
+  - ip_address (string)
+  - user_agent (string)
+  - timestamps
+
+Project
+  - name (string)
+  - description (text)
+  - status (integer enum: active / paused / completed / archived)
+  - user_id (FK)
+  - last_activity_at (datetime)
+  - timestamps
+```
+
+`Current` is a Rails `ActiveSupport::CurrentAttributes` class also emitted by the generator (not a database table). Holds the request-scoped `Current.user` and `Current.session`.
+
+The auth generator's password-reset token lives on the `Session` row indirectly via the `PasswordsController` flow — no separate `password_reset_token` column is required.
+
+### Seed Data
+
+`db/seeds.rb` creates:
+
+- One demo user: `demo@example.com` / `password`, pre-verified.
+- 12 sample projects distributed across all four statuses, varied `last_activity_at` values.
+
+## Data Flow
+
+- Rails routes (`config/routes.rb`) handle the landing page, auth surface, dashboard shells, project CRUD, and the `/settings` shell.
+- TanStack Router mounts under the `/settings` Rails shell route and handles nested `/settings/*` paths client-side, with SSR loaders for first-paint correctness.
+- Auth gate (the `Authentication` concern from the Rails 8 generator, included in `ApplicationController`) protects all `/dashboard/*`, `/settings/*`, `/projects/*` controllers via `before_action :require_authentication`.
+- Email-verification gate: a separate `before_action :require_verified_email` on the dashboard / projects / settings controllers redirects unverified users to a "check your email" landing. Verification clicks set `email_verified_at` and clear the gate.
+- `/dashboard/rsc` renders via `react_on_rails_component` with `rsc: true`, streaming from the server.
+- `/dashboard/ssr` renders via `react_component` (classic SSR through the Pro Node renderer).
+- Both dashboard routes pull `Project.where(user: current_user)` server-side, sort by `last_activity_at desc`, group by `status` for the metric cards.
+
+## Error Handling
+
+- Custom 404 and 500 pages styled with shadcn (overrides `public/404.html`, `public/500.html`).
+- Server-side validation on `Project` and `User` models. The Project form is the reference pattern: validation errors render inline next to fields, success redirects with a flash toast.
+- SolidQueue retry policy on `ProjectArchiveJob` (max 5, exponential backoff). Failed jobs surface in the dev queue dashboard; when Sentry is enabled, also captured there.
+- Email delivery failure: in dev `letter_opener` shows the message in a browser tab (no failure path). README documents Mailgun / Postmark / Resend swap-in for production with one-line ActionMailer config.
+
+## Testing
+
+- **RSpec** for backend
+  - Model specs for `User`, `Project`.
+  - Request specs for sessions, registrations, projects.
+  - System specs (Capybara + headless Chrome) for the full signup → dashboard → create-project flow.
+  - At least one reference spec per category that agents extrapolate from.
+- **Playwright** for cross-stack smoke
+  - Auth flow (signup, login, logout).
+  - Dashboard render on both `/dashboard/rsc` and `/dashboard/ssr`.
+  - Project CRUD round trip.
+  - TanStack Router nested-route navigation under `/settings`.
+- **Vitest** for any non-trivial frontend unit logic (light — most logic is server-resident).
+- **Factories** via `factory_bot` for `User`, `Project`.
+- **CI** via GitHub Actions: RSpec + Playwright on push and PR.
+- **Local helpers**: `bin/test` runs everything, `bin/test --smoke` runs Playwright only.
+
+## `AGENTS.md` (Load-Bearing)
+
+The kit's root `AGENTS.md` is treated as a first-class artifact, not an afterthought. It is the primary mechanism by which the kit is "vibe-coding-friendly."
+
+Contents (sections, each with a working code reference in the kit):
+
+1. **File layout map** — where models, controllers, views, components, routes, tests, factories, mailers, jobs each live.
+2. **How to add a new route** — Rails controller + view + spec, with a pointer to `app/controllers/projects_controller.rb` as the canonical example.
+3. **How to add a new shadcn/ui block** — `bunx shadcn add ...` workflow, where the block lives in the file tree, how to compose it.
+4. **How to add a new form** — pointer to the Project form (validation + error display + flash success).
+5. **How to add a new background job** — pointer to `ProjectArchiveJob` (SolidQueue, retry policy).
+6. **How to add a new email** — pointer to `WelcomeMailer` (mailer, view, preview, spec).
+7. **How to add a new TanStack Router child route** — pointer to `/settings/profile` and `/settings/security`.
+8. **Naming conventions** — file naming, route naming, component naming, model naming.
+9. **Testing conventions** — when to use RSpec vs Playwright vs Vitest.
+10. **Pointer to the reference implementations** that agents should clone.
+
+## Default Decisions (Q&A defaults committed during brainstorming)
+
+These were marked "**Decision (default):** …" — answered with the recommended option unless the user pushes back at file-review time.
+
+1. **TanStack Router mount strategy** — TanStack-under-a-Rails-shell-route (Rails serves the shell at `/settings`, TanStack handles `/settings/*` nesting). If a different pattern is already canonical in `react_on_rails_pro`, the implementation phase will match that.
+2. **Dark mode** — default light. Toggle persisted in `localStorage`. Small inline `<script>` in `<head>` reads `localStorage` and sets the class before paint, to avoid SSR theme flicker.
+3. **Demo user in seeds** — yes, `demo@example.com` / `password`, pre-verified. Documented in the README as the evaluation login.
+4. **Repo creation timing** — create `shakacode/react-on-rails-starter-2026` as the first step of execution (not before the spec lands). Avoids a public-empty-repo window.
+
+## Tier 2 (Deferred — explicitly NOT in the first public release)
+
+Listed for tracking only. Each may become its own plan doc later.
+
+- Kamal deploy config (delays choice of ops platform).
+- Production Sentry recipe with provider examples (Mailgun / Postmark / Resend swap-in copy + screenshots).
+- Additional UI patterns: file upload, multi-step wizard, infinite scroll, charts / data viz.
+- API auth (JWT or OAuth) demo for headless consumers.
+- More TanStack Router patterns: route-level data loaders, params validation, code splitting.
+- i18n setup.
+- Multi-tenant example.
+- Vue and Svelte variants (only if usage of the React variant proves the model).
+
+## Freshening Cadence
+
+Quarterly review owned by the React on Rails team:
+
+- Bump Rails, React, TanStack Router, shadcn/ui, Tailwind, React on Rails Pro to current versions.
+- Re-run the full Playwright smoke suite against the bumped stack.
+- Update the README's "last refreshed YYYY-MM-DD" line.
+- Tag a release matching the calendar quarter (`2026.Q3`, `2026.Q4`, …).
+
+Without this cadence the kit will look stale within 12 months and undo the front-door win.
+
+## Implementation Phasing (high-level — detailed plan TBD via `writing-plans`)
+
+The detailed implementation plan is the deliverable of the next phase. High-level phases:
+
+1. **Repo bootstrap.** Create `shakacode/react-on-rails-starter-2026`, push initial Rails 8 + RoR Pro scaffold via `create-react-on-rails-app --rsc --rspack`. Land first CI green build.
+2. **Auth surface.** Run `bin/rails generate authentication`, add `name` column + signup (`RegistrationsController` + view) + email verification (token column, `EmailVerificationsController`, `EmailVerificationMailer`) on top of it, re-skin views with shadcn/ui, add `letter_opener` for dev, ship `WelcomeMailer`.
+3. **Projects model + CRUD.** Migration, model, controller, views, form-with-validation reference, factory, RSpec specs.
+4. **Dashboard, both implementations.** `/dashboard/rsc` + `/dashboard/ssr` rendering the same Projects view.
+5. **TanStack Router `/settings` nested routes.** Settings shell + `profile` + `security`.
+6. **shadcn/ui pattern catalog.** Hero block, list view, metric cards, form, dialog, toast, empty state, loading state, dark-mode toggle.
+7. **Background job + Sentry wiring.** `ProjectArchiveJob`, SolidQueue config, Sentry initializer (commented).
+8. **`AGENTS.md` content.** Authored against the actual reference implementations in the kit.
+9. **Playwright smoke suite.** Auth, dashboard, CRUD, TanStack nav.
+10. **README + launch.** README, screenshots, demo-user instructions, "compare to Gumroad benchmark" footnote. Flip-visible event matches docs-site update.
+
+Each phase is one PR. Each PR ships green CI before merge.
+
+## Open Questions
+
+1. **TanStack Router + Pro RSC interaction.** Issue #3357 step 3 calls this out. Skipped explicit de-risking per the brainstorm (Justin confirmed the Pro support is already there); implementation should validate end-to-end in a fresh kit and adjust this plan if needed.
+2. **shadcn/ui Tailwind v4 maturity.** Confirm shadcn/ui's Tailwind v4 path is stable enough for a flagship at the time of implementation; if not, fall back to v3 for tier 1 and bump to v4 in a tier 2 freshening pass.
+3. **`AGENTS.md` vs `CLAUDE.md`.** The repo's primary agent-conventions file is `AGENTS.md` because it's the cross-agent open standard. The implementation phase should also drop a thin `CLAUDE.md` that points at `AGENTS.md` (and the same for any other agent-specific convention files Claude Code or Cursor pick up), so no agent misses the conventions.
+4. **Tailwind v4 + Pro RSC streaming compatibility.** Confirm Tailwind v4's CSS-first config doesn't conflict with how Pro RSC streams CSS for server-component routes. If incompatible at implementation time, fall back to Tailwind v3.
+5. **Signup vs `User` migration in `db/seeds.rb`.** Since Rails 8's generator skips `CreateUsers` if `app/models/user.rb` already exists, the implementation phase must decide whether the `RegistrationsController` and `name` column are added in a separate migration on top of the generator's `CreateUsers`, or by editing the generator's emitted migration before first run. Editing the generator output is cleaner; document the choice in the AGENTS.md.
+
+## Related
+
+- #3357 — this issue
+- #3144 — Gumroad RSC experiment: benchmark findings and positioning
+- #3128 — Gumroad public comparison repo
+- `internal/planning/examples-catalog-and-repo-naming-plan.md` — naming taxonomy this plan extends
+- `docs/oss/getting-started/comparison-with-alternatives.md` — Inertia vs React on Rails comparison this plan operationalizes
+- `react-on-rails-demo-gumroad-rsc` — benchmark repo the starter dashboard surface mirrors structurally


### PR DESCRIPTION
## Summary

Plans the flagship 2026 React on Rails starter kit (#3357). Two documents:

- **`internal/planning/3357-react-on-rails-starter-2026.md`** — strategic plan, revised after a multi-voice review (`/autoplan`: CEO + Design + Eng + DX, each via Claude subagent + Codex).
- **`internal/planning/3357-react-on-rails-starter-2026-implementation.md`** — detailed implementation plan structured for AI sub-agent dispatch: 74 numbered tasks across 11 phases, each with dependencies, parallel-safety, inputs/outputs, acceptance criteria, est. CC time. The "Kickoff (read this first)" section at the top tells a fresh coordinator or sub-agent exactly how to start.

## Strategic decisions captured

- **Positioning:** "Best TanStack on Rails" (category claim with structural moat) instead of "Inertia counter-kit" (reactive). TanStack Router is a routing primitive Inertia cannot host as a peer. RSC + streaming plumbing is hard; Inertia is unlikely to bring up its own — if it ever does, the natural shape is on top of Pro (separate strategic discussion, tracked at #3371).
- **Delivery model:** Public GitHub Template Repository at `shakacode/react-on-rails-starter-tanstack` at the head of the existing demo portfolio (Hacker News, Marketplace, Gumroad, Octochangelog). The starter is the greenfield seed; the demos carry the proof points.
- **Rendering surface split:** **RSC + streaming on the public landing `/`** (where TTFB, mobile perf, and SEO actually pay off); **classic SSR + TanStack on the authenticated `/dashboard` + nested routes** (where TanStack's interactivity / type-safety / URL-state wins apply and RSC's wins don't). The dashboard's rendering-mode drawer tells the honest surface-split story instead of the contrived two-dashboard demo the original plan had.
- **Scope:** TanStack Router + Query + Table in Tier 1. TanStack Form deferred to Tier 2.
- **Value props beyond positioning:** AI-agent extension reference, TanStack-on-Rails showcase, and canonical QA / dogfood vehicle for RoR Pro release candidates (the kit's CI runs the full suite against every Pro RC).

## Coordinator decisions locked

- Repo name: `react-on-rails-starter-tanstack`
- Dashboard narrative: SaaS app first; rendering-tech as drawer; pattern catalog at dev-only `/playground`
- Accessibility target: WCAG AA, 4.5:1 contrast
- Spike approval: full auto (coordinator interprets `SPIKE.md` verdict and dispatches Phase 1 without waiting)
- Performance budgets: deferred to post-Tier-1

## Required Before Implementation

10 items surfaced by the dual-voice review: email verification token spec (CSRF / session rotation / replay defense / Rack::Attack throttle), deployment readiness (Procfile / `bin/doctor` / RSC bundle precompile / production-safe seeds), directory tree + canonical-reference-marker convention, TTHW target (≤3 min), accessibility floor (per locked decision), dashboard narrative (per locked decision), upgrade path for adopters (`UPGRADING.md` + `bin/upgrade-check`).

## Implementation phasing

- **Phase 0 (mandatory, sequential):** Spike PR validating TanStack Router + Query + Pro RSC + shadcn on Tailwind v4 compatibility on a throwaway branch before any public scaffold commit.
- **Phases 1–10:** Bootstrap → Auth + verification funnel → Projects CRUD → TanStack surface → Pattern catalog with state coverage → Jobs/Sentry → AGENTS.md → Acceptance tests → Deployment story → README + launch.

Estimated effort: ~50 CC-hours sequentially; ~25-30 wall-clock hours with parallel sub-agent dispatch across 3-4 agents.

## Out of scope (follow-ups)

- **"Inertia on Pro" bridge product** — tracked separately at #3371.
- **Phase 0 spike execution** — separate session on a different machine.

## Commits in this PR

- `530cbb15` — original strategic plan (pre-review baseline)
- `3ec3ddf8` — strategic-plan revision + 1344-line implementation plan
- `54622b01` — coordinator decisions locked + rendering surface split
- `1a82d7ea` — kickoff section + Inertia-on-Pro issue link

## Test plan

- [x] Documents render correctly on GitHub
- [x] Cross-references between the two planning docs resolve
- [x] Implementation plan has a "Kickoff (read this first)" section so a fresh agent can pick up Phase 0 cold
- [x] Coordinator decisions are explicit and locked in-doc
- [ ] Reviewer reads both documents and confirms the strategic reframe + 74-task implementation breakdown match expectations

Fixes #3357 (planning portion — implementation tracked separately once the spike lands)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded planning for the React on Rails Starter 2026: clarified strategic framing, added a required pre-implementation checklist, risk fallback decision tree, DX/A11y targets, phased acceptance criteria, deployment-readiness requirements, and an Autoplan findings summary.
  * Added an implementation companion detailing phased delivery workflow, task cards and gates, auth/email-verification lifecycle, UI pattern/catalog guidance, testing/acceptance plans, and launch/deployment deliverables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->