### PR TITLE
fix(pro): preserve react-on-rails-rsc/client.browser in client bundle (#3366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **[Pro]** **Preserve ruby-jwt 2.x compatibility in 16.7**: Relaxes the `16.7.0.rc.0` `jwt >= 3.2.0` floor to `jwt >= 2.7`, keeping compatibility with apps that still resolve jwt 2.x while continuing to allow patched jwt 3.2.0+ releases. [PR 3344](https://github.com/shakacode/react_on_rails/pull/3344) by [ihabadham](https://github.com/ihabadham).
+- **[Pro]** **RSC client manifest restored when only `registerServerComponent/client` is in the pack graph**: `wrapServerComponentRenderer/client` now directly imports `react-on-rails-rsc/client.browser` as a side-effect import. Previously the client runtime was only reachable through a three-level transitive chain (`wrapServerComponentRenderer/client` → `getReactServerComponent.client` → `react-on-rails-rsc/client.browser`). Tooling that severed any link in that chain (tree-shaking, transpiler quirks, custom `NormalModuleReplacement`, externals) caused `RSCWebpackPlugin` to emit `Client runtime at react-on-rails-rsc/client was not found. React Server Components module map file react-client-manifest.json was not created.` and silently skip the manifest, breaking RSC hydration on the Pro Node Renderer. The direct import keeps the runtime resource in the module graph so the plugin always emits `react-client-manifest.json`. Fixes [#3366](https://github.com/shakacode/react_on_rails/issues/3366).
 
 #### Security
 

--- a/knip.ts
+++ b/knip.ts
@@ -120,6 +120,8 @@ const config: KnipConfig = {
         // Jest setup and test utilities - not detected by Jest plugin in workspace setup
         'tests/jest.setup.js',
         'tests/utils/removeRSCStackFromAllChunks.ts',
+        // Test fixtures referenced dynamically (e.g. via webpack NormalModuleReplacementPlugin)
+        'tests/fixtures/**',
         // Build output directories that should be ignored
         'lib/**',
         // Pro features exported for external consumption

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -12,6 +12,16 @@
  * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
  */
 
+// Side-effect import: keeps `react-on-rails-rsc/client.browser` in the webpack
+// module graph for the client bundle so RSCWebpackPlugin (which scans every
+// parsed module for this exact resource) can detect the client runtime and
+// emit `react-client-manifest.json`. Without this direct import, the plugin
+// relies on a 3-level transitive chain
+// (`wrapServerComponentRenderer/client` → `getReactServerComponent.client`
+// → `react-on-rails-rsc/client.browser`). Any tooling that severs that chain
+// (tree-shaking, transpilers, NormalModuleReplacement, custom externals)
+// silently drops the manifest and breaks RSC hydration on the renderer.
+import 'react-on-rails-rsc/client.browser';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { ReactComponentOrRenderFunction, RenderFunction } from 'react-on-rails/types';

--- a/packages/react-on-rails-pro/tests/fixtures/rsc-manifest/getReactServerComponent.client.stub.ts
+++ b/packages/react-on-rails-pro/tests/fixtures/rsc-manifest/getReactServerComponent.client.stub.ts
@@ -1,0 +1,3 @@
+export default function getReactServerComponent() {
+  return () => Promise.resolve(null);
+}

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.imports.test.ts
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.imports.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Shakacode LLC
+ *
+ * This file is NOT licensed under the MIT (open source) license.
+ * It is part of the React on Rails Pro offering and is licensed separately.
+ *
+ * For licensing terms, please see:
+ * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Regression test for https://github.com/shakacode/react_on_rails/issues/3366
+//
+// `wrapServerComponentRenderer/client.tsx` MUST contain a top-level side-effect
+// import of `react-on-rails-rsc/client.browser`. RSCWebpackPlugin walks the
+// client bundle's module graph and only emits `react-client-manifest.json`
+// when it parses a module whose resolved path equals the plugin's
+// `require.resolve("../client.browser.js")`. Without a direct side-effect
+// import, the plugin relies on the 3-level chain
+// `wrapServerComponentRenderer/client` → `getReactServerComponent.client`
+// → `react-on-rails-rsc/client.browser`, and any tooling that severs that
+// chain (tree-shaking, transpiler quirks, custom replacers) silently drops
+// the manifest, breaking RSC hydration on the Pro Node Renderer.
+describe('wrapServerComponentRenderer/client.tsx side-effect imports', () => {
+  it('keeps the react-on-rails-rsc/client.browser runtime in the client module graph', () => {
+    const srcPath = path.join(__dirname, '..', 'src', 'wrapServerComponentRenderer', 'client.tsx');
+    const source = fs.readFileSync(srcPath, 'utf8');
+
+    expect(source).toMatch(/^\s*import\s+['"]react-on-rails-rsc\/client\.browser['"]\s*;?\s*$/m);
+  });
+
+  it('keeps the same runtime present in the compiled lib output', () => {
+    const libPath = path.join(__dirname, '..', 'lib', 'wrapServerComponentRenderer', 'client.js');
+    if (!fs.existsSync(libPath)) {
+      // lib is only built before publish or after `pnpm run build`. Skip when
+      // running tests from a fresh checkout without a prior build.
+      return;
+    }
+    const compiled = fs.readFileSync(libPath, 'utf8');
+    expect(compiled).toMatch(/import\s+['"]react-on-rails-rsc\/client\.browser['"]\s*;?/);
+  });
+});

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.imports.test.ts
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.imports.test.ts
@@ -31,13 +31,11 @@ describe('wrapServerComponentRenderer/client.tsx side-effect imports', () => {
     expect(source).toMatch(/^\s*import\s+['"]react-on-rails-rsc\/client\.browser['"]\s*;?\s*$/m);
   });
 
-  it('keeps the same runtime present in the compiled lib output', () => {
-    const libPath = path.join(__dirname, '..', 'lib', 'wrapServerComponentRenderer', 'client.js');
-    if (!fs.existsSync(libPath)) {
-      // lib is only built before publish or after `pnpm run build`. Skip when
-      // running tests from a fresh checkout without a prior build.
-      return;
-    }
+  const libPath = path.join(__dirname, '..', 'lib', 'wrapServerComponentRenderer', 'client.js');
+  const libExists = fs.existsSync(libPath);
+  // lib is only built before publish or after `pnpm run build`. When absent the
+  // test is explicitly skipped (visible in the report) rather than silently green.
+  (libExists ? it : it.skip)('keeps the same runtime present in the compiled lib output', () => {
     const compiled = fs.readFileSync(libPath, 'utf8');
     expect(compiled).toMatch(/import\s+['"]react-on-rails-rsc\/client\.browser['"]\s*;?/);
   });

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.manifest.test.js
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.manifest.test.js
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment node
+ */
+
+import { createRequire } from 'module';
+
+const nodeRequire = createRequire(__filename);
+const path = nodeRequire('path');
+const { Volume, createFsFromVolume } = nodeRequire('memfs');
+const webpack = nodeRequire('webpack');
+const { RSCWebpackPlugin } = nodeRequire('react-on-rails-rsc/WebpackPlugin');
+
+const packageRoot = path.resolve(__dirname, '..');
+const workspaceRoot = path.resolve(packageRoot, '../..');
+const proSrcRoot = path.join(packageRoot, 'src');
+const reactOnRailsSrcRoot = path.join(workspaceRoot, 'packages/react-on-rails/src');
+const outputPath = '/webpack-output';
+
+const swcLoader = nodeRequire.resolve('swc-loader');
+const getReactServerComponentStub = path.join(
+  __dirname,
+  'fixtures/rsc-manifest/getReactServerComponent.client.stub.ts',
+);
+
+const runWebpack = () => {
+  const volume = new Volume();
+  const outputFileSystem = createFsFromVolume(volume);
+  outputFileSystem.join = path.join.bind(path);
+
+  const compiler = webpack({
+    mode: 'development',
+    target: 'web',
+    context: packageRoot,
+    entry: {
+      client: path.join(proSrcRoot, 'wrapServerComponentRenderer/client.tsx'),
+    },
+    output: {
+      filename: '[name].js',
+      path: outputPath,
+    },
+    resolve: {
+      alias: {
+        'react-on-rails/isRenderFunction$': path.join(reactOnRailsSrcRoot, 'isRenderFunction.ts'),
+        'react-on-rails/reactApis$': path.join(reactOnRailsSrcRoot, 'reactApis.cts'),
+        'react-on-rails/types$': path.join(reactOnRailsSrcRoot, 'types/index.ts'),
+      },
+      extensions: ['.tsx', '.ts', '.cts', '.jsx', '.js', '.cjs'],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.[cm]?[jt]sx?$/,
+          exclude: /node_modules/,
+          use: {
+            loader: swcLoader,
+            options: {
+              jsc: {
+                parser: {
+                  syntax: 'typescript',
+                  tsx: true,
+                },
+                transform: {
+                  react: {
+                    runtime: 'automatic',
+                  },
+                },
+                target: 'es2022',
+              },
+            },
+          },
+        },
+      ],
+    },
+    plugins: [
+      new webpack.NormalModuleReplacementPlugin(/getReactServerComponent\.client\.ts$/, (resource) => {
+        resource.request = getReactServerComponentStub;
+      }),
+      new RSCWebpackPlugin({
+        isServer: false,
+        clientReferences: [],
+      }),
+    ],
+    optimization: {
+      minimize: false,
+    },
+  });
+
+  compiler.outputFileSystem = outputFileSystem;
+
+  return new Promise((resolve, reject) => {
+    compiler.run((error, stats) => {
+      compiler.close((closeError) => {
+        if (error || closeError) {
+          reject(error || closeError);
+          return;
+        }
+
+        resolve({
+          volume,
+          stats: stats.toJson({
+            all: false,
+            assets: true,
+            errors: true,
+            warnings: true,
+          }),
+        });
+      });
+    });
+  });
+};
+
+describe('wrapServerComponentRenderer client manifest emission', () => {
+  it('keeps the RSC client runtime visible to RSCWebpackPlugin', async () => {
+    const { stats, volume } = await runWebpack();
+
+    expect(stats.errors).toEqual([]);
+    expect(stats.warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: expect.stringContaining('Client runtime at react-on-rails-rsc/client was not found'),
+        }),
+      ]),
+    );
+    expect(volume.existsSync(path.join(outputPath, 'react-client-manifest.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#3366](https://github.com/shakacode/react_on_rails/issues/3366) — a 16.7.0-rc.0 regression where the RSC client manifest (`react-client-manifest.json`) is silently dropped from the Pro Node Renderer upload, breaking server-component rendering with `ENOENT` on the renderer side.

- Add a side-effect import of `react-on-rails-rsc/client.browser` at the top of `wrapServerComponentRenderer/client.tsx`. RSCWebpackPlugin scans every parsed module's resource path for an exact match against `require.resolve("../client.browser.js")` and only emits `react-client-manifest.json` when it finds one. Previously the client runtime was reachable only through a three-level transitive chain (`wrapServerComponentRenderer/client` → `getReactServerComponent.client` → `react-on-rails-rsc/client.browser`); any tooling that severed a link in that chain silently dropped the manifest and produced the misleading `Client runtime at react-on-rails-rsc/client was not found` warning. The direct import keeps the runtime resource in the client module graph regardless of how downstream tooling handles transitive default imports.
- Add a structural regression test that fails if the side-effect import is removed from either the source or the compiled lib output.
- Add a webpack-level regression test that compiles `wrapServerComponentRenderer/client.tsx` with the old transitive `getReactServerComponent.client` edge replaced by a stub, then asserts `RSCWebpackPlugin` still emits `react-client-manifest.json`. This proves the direct import itself preserves the manifest.

## Why

Issue #3366 reports that the warning + missing manifest first appears when the consuming app upgrades to `react_on_rails_pro` / `react-on-rails-pro` / `react-on-rails-pro-node-renderer` `16.7.0-rc.0` from `16.6.0`, even with `react-on-rails-rsc@19.0.4` and `shakapacker@10.0.0` unchanged. The actual chain in source/lib is intact between both versions, and the issue does not reproduce on the in-tree dummy app or a clean clone of the tutorial PR — but the user's environment clearly does see `clientFileNameFound = false` from the upstream RSC plugin. The defensive direct import removes that fragility: even if a future transpiler/tree-shaker decides `getReactServerComponent.client` is "unused" or rewrites the path, the side-effect import keeps `client.browser` in the graph and the plugin always emits the manifest.

## Evaluation

Confirmed the fix addresses the bug mechanism. The RSC plugin decides whether to write `react-client-manifest.json` by seeing the `react-on-rails-rsc/client.browser` module in the client compilation. The direct side-effect import is an appropriate fix because it changes build graph visibility without changing renderer runtime behavior.

I verified the new behavior test is meaningful by temporarily removing the direct import: with the old transitive helper path stubbed out, webpack emitted the expected `Client runtime at react-on-rails-rsc/client was not found` warning and the test failed. Restoring the import made the same test pass and emit `react-client-manifest.json`. The Pro dummy build also emits both `react-client-manifest.json` and `react-server-client-manifest.json` successfully.

## Test plan

- [x] `pnpm --filter react-on-rails-pro exec jest tests/wrapServerComponentRenderer.client.manifest.test.js --runInBand` passes
- [x] Red check: temporarily removing `import 'react-on-rails-rsc/client.browser';` makes the new manifest test fail with the upstream missing-client-runtime warning
- [x] `pnpm --filter react-on-rails-pro exec jest tests/wrapServerComponentRenderer.client.manifest.test.js tests/wrapServerComponentRenderer.client.imports.test.ts --runInBand` passes
- [x] `pnpm --filter react-on-rails-pro exec jest tests/createReactOnRailsPro.test.ts --runInBand` passes
- [x] `pnpm --filter react-on-rails-pro run test:non-rsc` passes: 7 suites, 58 tests
- [x] `pnpm --filter react-on-rails-pro run type-check` passes
- [x] `pnpm run lint` passes
- [x] `(cd react_on_rails && bundle exec rubocop)` passes
- [x] `(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)` passes; RuboCop prints deprecation warnings from dependencies but reports no offenses
- [x] `pnpm exec prettier --check packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.manifest.test.js packages/react-on-rails-pro/tests/fixtures/rsc-manifest/getReactServerComponent.client.stub.ts` passes
- [x] `RAILS_ENV=test NODE_ENV=development bundle exec bin/shakapacker` from `react_on_rails_pro/spec/dummy` passes and emits `react-client-manifest.json` plus `react-server-client-manifest.json`
- [x] `git diff --check` passes
- [x] Pre-commit and pre-push hooks passed while committing and pushing `3013f9d90`
- [ ] Full-repo `pnpm start format.listDifferent` is blocked by an existing ignored `.context/plans/issue-3366-reproduction-plan.md` formatting issue; the PR files pass direct Prettier checks
- [ ] Verify CI passes on this PR
- [ ] Verify [shakacode/react-webpack-rails-tutorial#740](https://github.com/shakacode/react-webpack-rails-tutorial/pull/740) unblocks once a new RC build with this fix is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pro RSC client entrypoint bundling to force inclusion of the RSC client runtime, which can affect build output and hydration behavior if misconfigured. Added tests reduce regression risk, but changes are in a critical RSC packaging path.
> 
> **Overview**
> Restores reliable React Server Components hydration for Pro by adding a **top-level side-effect import** of `react-on-rails-rsc/client.browser` in `wrapServerComponentRenderer/client.tsx`, ensuring `RSCWebpackPlugin` consistently emits `react-client-manifest.json` even when transitive imports are disrupted.
> 
> Adds regression coverage: a structural test that enforces the presence of the side-effect import (source and built `lib` when available) and a webpack-level test that stubs `getReactServerComponent.client` to prove manifest emission still occurs. Updates `knip.ts` to ignore dynamically referenced test fixtures and records the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb24cc79358ec39062e36d2f2a9064a36ede63e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored inclusion of the client runtime so the client manifest is emitted, preventing React Server Components hydration failures in certain build setups.

* **Tests**
  * Added regression tests to ensure the client runtime import is preserved and the client manifest is emitted during bundling.

* **Documentation**
  * Updated CHANGELOG with the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
