### PR TITLE
chore: bump workspace pnpm to 10.22.0

### DIFF
--- a/.claude/docs/testing-build-scripts.md
+++ b/.claude/docs/testing-build-scripts.md
@@ -111,9 +111,9 @@ If you rename/move directories that contain build artifacts:
 
 ## Workspace Dependencies: PNPM
 
-**CRITICAL: This project uses PNPM (v9+)**
+**CRITICAL: This project uses PNPM (v10+)**
 
-Check `package.json` for: `"packageManager": "pnpm@9.x.x"`
+Check `package.json` for: `"packageManager": "pnpm@10.x.x"`
 
 ### Correct Workspace Dependency Syntax
 

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -110,7 +110,7 @@ CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 Replace the Yarn lines with:
 
 ```dockerfile
-RUN corepack enable && corepack prepare pnpm@9 --activate  # pin to your project's major version
+RUN corepack enable && corepack prepare pnpm@10 --activate  # pin to your project's major version
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -110,7 +110,7 @@ CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 Replace the Yarn lines with:
 
 ```dockerfile
-RUN corepack enable && corepack prepare pnpm@10 --activate  # pin to your project's major version
+RUN corepack enable && corepack prepare pnpm@10.22.0 --activate  # pin to your project's exact version
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "url": "https://github.com/shakacode/react_on_rails/issues"
   },
   "homepage": "https://github.com/shakacode/react_on_rails#readme",
-  "packageManager": "pnpm@9.14.2",
+  "packageManager": "pnpm@10.22.0",
   "pnpm": {
     "// for overrides": [
       "Generated via pnpm audit --fix, with manual caps added to prevent major version jumps.",
@@ -154,6 +154,15 @@
       "picomatch@<2.3.2": ">=2.3.2 <3",
       "picomatch@>=4.0.0 <4.0.4": ">=4.0.4 <5",
       "yaml@>=1.0.0 <1.10.3": ">=1.10.3 <2"
-    }
+    },
+    "// for onlyBuiltDependencies": [
+      "pnpm 10 blocks lifecycle scripts by default. Allowlist packages we trust.",
+      "@swc/core: postinstall verifies the platform-specific native binary loads.",
+      "unrs-resolver: napi-postinstall check, used by eslint-import-resolver-typescript."
+    ],
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "unrs-resolver"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     },
     "// for onlyBuiltDependencies": [
       "pnpm 10 blocks lifecycle scripts by default. Allowlist packages we trust.",
+      "When adding native or compiled dependencies, run pnpm ignored-builds and add trusted packages here.",
       "@swc/core: postinstall verifies the platform-specific native binary loads.",
       "unrs-resolver: napi-postinstall check, used by eslint-import-resolver-typescript."
     ],

--- a/packages/react-on-rails-pro-node-renderer/package.json
+++ b/packages/react-on-rails-pro-node-renderer/package.json
@@ -131,5 +131,5 @@
       "^.+\\.[jt]sx?$": "babel-jest"
     }
   },
-  "packageManager": "pnpm@9.14.2"
+  "packageManager": "pnpm@10.22.0"
 }

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -138,11 +138,11 @@ module ReactOnRails
       # version because `pnpm/action-setup` requires one unless package.json declares
       # `packageManager`. Match the repo's own packageManager version so generated
       # CI defaults to the pnpm major this codebase tests with. Track the exact release
-      # used for this fallback at https://github.com/pnpm/pnpm/releases/tag/v9.14.2;
+      # used for this fallback at https://github.com/pnpm/pnpm/releases/tag/v10.22.0;
       # update this URL with the constant when bumping. Users who need exact
       # reproducibility should commit `packageManager` to their package.json instead.
       # renovate: datasource=github-releases depName=pnpm/pnpm extractVersion=^v(?<version>.+)$
-      CI_PNPM_FALLBACK_VERSION = "9.14.2"
+      CI_PNPM_FALLBACK_VERSION = "10.22.0"
       private_constant :CI_PNPM_FALLBACK_VERSION
 
       # Main generator entry point

--- a/react_on_rails/spec/dummy/package.json
+++ b/react_on_rails/spec/dummy/package.json
@@ -86,5 +86,5 @@
     "build:rescript:dev": "npx rescript build -w"
   },
   "version": "0.0.0",
-  "packageManager": "pnpm@9.14.2"
+  "packageManager": "pnpm@10.22.0"
 }

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -127,5 +127,5 @@
   "bugs": {
     "url": "https://github.com/shakacode/react_on_rails_pro/issues"
   },
-  "packageManager": "pnpm@9.14.2"
+  "packageManager": "pnpm@10.22.0"
 }

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/package.json
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/package.json
@@ -1,5 +1,5 @@
 {
-  "packageManager": "pnpm@9.14.2",
+  "packageManager": "pnpm@10.22.0",
   "name": "app",
   "private": true,
   "version": "0.1.0",


### PR DESCRIPTION
### Summary

Bumps the workspace from `pnpm@9.14.2` to `pnpm@10.22.0`, matching what `create-react-on-rails-app` already pins for generated apps. Updates `packageManager` in the 5 workspace `package.json` files, the `CI_PNPM_FALLBACK_VERSION` constant in the install generator (used when generating CI configs for apps without a `packageManager` field), and the pnpm version references in the Docker deployment and internal testing docs. Adds a `pnpm.onlyBuiltDependencies` allowlist for `@swc/core` and `unrs-resolver` so their postinstall scripts continue to run under pnpm 10's stricter default (which blocks transitive build scripts unless explicitly approved).

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (config-only bump; existing CI covers install/build/test)
- [x] Update documentation (`.claude/docs/testing-build-scripts.md`, `docs/oss/deployment/docker-deployment.md`)
- ~[ ] Update CHANGELOG file~ (internal tooling bump, no user-visible behavior change)

### Other Information

Verified locally: `pnpm install --frozen-lockfile`, `pnpm run build`, and `pnpm run type-check` all pass under pnpm 10.22.0. The existing `pnpm-lock.yaml` (lockfileVersion 9.0) is forward-compatible with pnpm 10 — no lockfile regeneration needed. Unblocks the catalogs migration tracked in #2180 (catalogs ergonomics are better on pnpm 10).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades the workspace package manager major version and changes pnpm install behavior via `onlyBuiltDependencies`, which could impact installs/builds across the monorepo and generated apps if misconfigured.
> 
> **Overview**
> Bumps the workspace `packageManager` pin from `pnpm@9.14.2` to `pnpm@10.22.0` across the root and included workspace/dummy `package.json` files, and updates the Rails install generator’s `CI_PNPM_FALLBACK_VERSION` to match.
> 
> Adjusts pnpm 10 guidance in docs (including Docker `corepack prepare`) and adds a root `pnpm.onlyBuiltDependencies` allowlist (e.g. `@swc/core`, `unrs-resolver`) so required postinstall/build scripts continue to run under pnpm 10’s stricter defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad3a0ae2e5c536ce99f961230f0a9d4a825876bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the project-wide pnpm requirement from v9 to v10, updated scaffolded CI fallback to v10, and added a pnpm configuration to allow specific packages to run their lifecycle scripts during install.
* **Documentation**
  * Updated project and deployment documentation (including Docker guidance) to reflect the pnpm v10 requirement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->