### PR TITLE
Fail release on unverifiable or Yarn-incompatible npm packages

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler"
+require "English"
 require "json"
 require "open3"
 require "rubygems/version"
@@ -19,6 +20,8 @@ class RaisingMessageHandler
 end
 
 NPM_REGISTRY_URL = "https://registry.npmjs.org/"
+NPM_PUBLISH_VERIFY_ATTEMPTS = 6
+NPM_PUBLISH_VERIFY_RETRY_DELAY_SECONDS = 5
 NPM_INSTALL_DEPENDENCY_FIELDS = %w[dependencies optionalDependencies peerDependencies].freeze
 
 # Helper methods for release-specific tasks
@@ -669,6 +672,7 @@ end
 
 def with_publishable_package_json(dir, package_version)
   package_json_path = File.join(dir, "package.json")
+  changed = false
   original_content = File.read(package_json_path)
   package_json = JSON.parse(original_content)
 
@@ -677,7 +681,14 @@ def with_publishable_package_json(dir, package_version)
 
   yield
 ensure
-  File.write(package_json_path, original_content) if changed
+  original_error = $ERROR_INFO
+
+  begin
+    File.write(package_json_path, original_content) if changed
+  rescue StandardError => e
+    warn "⚠️  Failed to restore #{package_json_path}: #{e.message}"
+    raise e unless original_error
+  end
 end
 
 def fetch_npm_package_metadata(package_ref, registry_url:)
@@ -696,6 +707,25 @@ def fetch_npm_package_metadata(package_ref, registry_url:)
   [output, status]
 end
 
+def fetch_npm_package_metadata_with_retries(package_ref, registry_url:, attempts:, retry_delay_seconds:)
+  last_output = nil
+  last_status = nil
+
+  attempts.times do |attempt|
+    output, status = fetch_npm_package_metadata(package_ref, registry_url: registry_url)
+    return [output, status] if status.success?
+
+    last_output = output
+    last_status = status
+    next if attempt == attempts - 1
+
+    puts "npm did not return #{package_ref} yet; retrying in #{retry_delay_seconds} seconds..."
+    sleep retry_delay_seconds
+  end
+
+  [last_output, last_status]
+end
+
 def parse_npm_package_metadata(package_ref, output)
   JSON.parse(output)
 rescue JSON::ParserError => e
@@ -708,9 +738,20 @@ rescue JSON::ParserError => e
   ERROR
 end
 
-def verify_npm_package_published!(package_name, expected_version, registry_url: NPM_REGISTRY_URL)
+def verify_npm_package_published!(
+  package_name,
+  expected_version,
+  registry_url: NPM_REGISTRY_URL,
+  attempts: NPM_PUBLISH_VERIFY_ATTEMPTS,
+  retry_delay_seconds: NPM_PUBLISH_VERIFY_RETRY_DELAY_SECONDS
+)
   package_ref = "#{package_name}@#{expected_version}"
-  output, status = fetch_npm_package_metadata(package_ref, registry_url: registry_url)
+  output, status = fetch_npm_package_metadata_with_retries(
+    package_ref,
+    registry_url: registry_url,
+    attempts: attempts,
+    retry_delay_seconds: retry_delay_seconds
+  )
   unless status.success?
     abort <<~ERROR
       ❌ #{package_ref} is not visible on npm after publish.
@@ -764,7 +805,7 @@ def publish_npm_with_retry(dir, package_name, base_args: [], otp: nil, max_retri
       with_publishable_package_json(dir, npm_package_version) do
         sh_args_in_dir_for_release(dir, *command_args)
       end
-      verify_npm_package_published!(npm_package_name, npm_package_version, registry_url: NPM_REGISTRY_URL)
+      verify_npm_package_published!(npm_package_name, npm_package_version)
       success = true
     rescue RuntimeError => e
       retry_count += 1

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -635,6 +635,51 @@ def workspace_protocol_dependencies(metadata)
   end
 end
 
+def publish_dependency_version_for_workspace_protocol(dependency_version, package_version)
+  workspace_range = dependency_version.to_s.delete_prefix("workspace:")
+
+  case workspace_range
+  when "*", ""
+    package_version
+  when "^", "~"
+    "#{workspace_range}#{package_version}"
+  else
+    workspace_range
+  end
+end
+
+def replace_workspace_protocol_dependencies_for_publish!(package_json, package_version)
+  changed = false
+
+  NPM_INSTALL_DEPENDENCY_FIELDS.each do |field|
+    dependencies = package_json[field]
+    next unless dependencies.is_a?(Hash)
+
+    dependencies.each do |dependency_name, dependency_version|
+      next unless dependency_version.to_s.start_with?("workspace:")
+
+      dependencies[dependency_name] =
+        publish_dependency_version_for_workspace_protocol(dependency_version, package_version)
+      changed = true
+    end
+  end
+
+  changed
+end
+
+def with_publishable_package_json(dir, package_version)
+  package_json_path = File.join(dir, "package.json")
+  original_content = File.read(package_json_path)
+  package_json = JSON.parse(original_content)
+
+  changed = replace_workspace_protocol_dependencies_for_publish!(package_json, package_version)
+  File.write(package_json_path, "#{JSON.pretty_generate(package_json)}\n") if changed
+
+  yield
+ensure
+  File.write(package_json_path, original_content) if changed
+end
+
 def fetch_npm_package_metadata(package_ref, registry_url:)
   output, status = Open3.capture2e(
     "npm",
@@ -716,7 +761,9 @@ def publish_npm_with_retry(dir, package_name, base_args: [], otp: nil, max_retri
     begin
       command_args = ["pnpm", "publish", *publish_args]
       command_args += ["--otp", current_otp] if current_otp
-      sh_args_in_dir_for_release(dir, *command_args)
+      with_publishable_package_json(dir, npm_package_version) do
+        sh_args_in_dir_for_release(dir, *command_args)
+      end
       verify_npm_package_published!(npm_package_name, npm_package_version, registry_url: NPM_REGISTRY_URL)
       success = true
     rescue RuntimeError => e

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -18,6 +18,9 @@ class RaisingMessageHandler
   end
 end
 
+NPM_REGISTRY_URL = "https://registry.npmjs.org/"
+NPM_INSTALL_DEPENDENCY_FIELDS = %w[dependencies optionalDependencies peerDependencies].freeze
+
 # Helper methods for release-specific tasks
 # These are defined at the top level so they have access to Rake's sh method
 
@@ -610,10 +613,101 @@ def publish_gem_with_retry(dir, gem_name, otp: nil, max_retries: ENV.fetch("GEM_
   current_otp
 end
 
+def parse_npm_package_ref(package_ref)
+  match = package_ref.to_s.match(%r{\A(?<name>@[^/]+/[^@]+|[^@]+)@(?<version>.+)\z})
+  abort "❌ Invalid npm package ref for release verification: #{package_ref.inspect}" unless match
+
+  [match[:name], match[:version]]
+end
+
+def workspace_protocol_dependencies(metadata)
+  return [] unless metadata.is_a?(Hash)
+
+  NPM_INSTALL_DEPENDENCY_FIELDS.flat_map do |field|
+    dependencies = metadata[field]
+    next [] unless dependencies.is_a?(Hash)
+
+    dependencies.filter_map do |dependency_name, dependency_version|
+      next unless dependency_version.to_s.start_with?("workspace:")
+
+      "#{field}.#{dependency_name}=#{dependency_version}"
+    end
+  end
+end
+
+def fetch_npm_package_metadata(package_ref, registry_url:)
+  output, status = Open3.capture2e(
+    "npm",
+    "view",
+    package_ref,
+    "version",
+    "dependencies",
+    "optionalDependencies",
+    "peerDependencies",
+    "--json",
+    "--registry",
+    registry_url
+  )
+  [output, status]
+end
+
+def parse_npm_package_metadata(package_ref, output)
+  JSON.parse(output)
+rescue JSON::ParserError => e
+  abort <<~ERROR
+    ❌ Unable to parse npm metadata for #{package_ref}.
+
+    Error: #{e.message}
+    Output:
+    #{output}
+  ERROR
+end
+
+def verify_npm_package_published!(package_name, expected_version, registry_url: NPM_REGISTRY_URL)
+  package_ref = "#{package_name}@#{expected_version}"
+  output, status = fetch_npm_package_metadata(package_ref, registry_url: registry_url)
+  unless status.success?
+    abort <<~ERROR
+      ❌ #{package_ref} is not visible on npm after publish.
+
+      The release cannot continue because npm did not confirm the published package.
+
+      Technical details:
+      #{output.strip}
+    ERROR
+  end
+
+  metadata = parse_npm_package_metadata(package_ref, output)
+  actual_version = metadata.is_a?(Hash) ? metadata["version"] : metadata.to_s
+  unless actual_version == expected_version
+    abort <<~ERROR
+      ❌ npm returned #{actual_version.inspect} for #{package_ref}; expected #{expected_version.inspect}.
+
+      The release cannot continue because npm did not confirm the exact published version.
+    ERROR
+  end
+
+  workspace_dependencies = workspace_protocol_dependencies(metadata)
+  unless workspace_dependencies.empty?
+    abort <<~ERROR
+      ❌ #{package_ref} was published with workspace protocol dependencies.
+
+      Published packages must not contain workspace:* install-time dependencies because external package managers
+      cannot resolve them from npm.
+
+      Offending dependencies:
+      #{workspace_dependencies.map { |dependency| "  - #{dependency}" }.join("\n")}
+    ERROR
+  end
+
+  puts "✓ Verified npm package #{package_ref}"
+end
+
 def publish_npm_with_retry(dir, package_name, base_args: [], otp: nil, max_retries: 3)
   puts "\nPublishing #{package_name}..."
   current_otp = normalize_otp_code(otp, service_name: "NPM")
   publish_args = Array(base_args)
+  npm_package_name, npm_package_version = parse_npm_package_ref(package_name)
 
   retry_count = 0
   success = false
@@ -623,6 +717,7 @@ def publish_npm_with_retry(dir, package_name, base_args: [], otp: nil, max_retri
       command_args = ["pnpm", "publish", *publish_args]
       command_args += ["--otp", current_otp] if current_otp
       sh_args_in_dir_for_release(dir, *command_args)
+      verify_npm_package_published!(npm_package_name, npm_package_version, registry_url: NPM_REGISTRY_URL)
       success = true
     rescue RuntimeError => e
       retry_count += 1

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -510,8 +510,10 @@ module ReactOnRails
       # @return [Boolean] true if successful, false otherwise
       def add_packages(packages, dev: false)
         return true if add_npm_dependencies(packages, dev: dev)
+        return true if install_packages_with_fallback(packages, dev: dev)
 
-        install_packages_with_fallback(packages, dev: dev)
+        write_versioned_package_specs_to_package_json(packages, dev: dev)
+        false
       end
 
       def install_js_dependencies
@@ -556,6 +558,27 @@ module ReactOnRails
         system(*install_args)
       rescue StandardError => e
         GeneratorMessages.add_warning("⚠️  Fallback package install failed: #{e.message}")
+        false
+      end
+
+      def write_versioned_package_specs_to_package_json(packages, dev:)
+        return false unless File.exist?("package.json")
+
+        versioned_packages = packages.filter_map { |package_spec| package_name_and_version_from_spec(package_spec) }
+        return false if versioned_packages.empty?
+
+        content = JSON.parse(File.read("package.json"))
+        dependency_field = dev ? "devDependencies" : "dependencies"
+        content[dependency_field] ||= {}
+
+        versioned_packages.each do |package_name, package_version|
+          content[dependency_field][package_name] = package_version
+        end
+
+        File.write("package.json", "#{JSON.pretty_generate(content)}\n")
+        true
+      rescue StandardError => e
+        GeneratorMessages.add_warning("⚠️  Could not write dependency pins to package.json: #{e.message}")
         false
       end
 
@@ -621,6 +644,13 @@ module ReactOnRails
 
       def version_specified?(package_spec, package_name)
         package_spec != package_name
+      end
+
+      def package_name_and_version_from_spec(package_spec)
+        package_name = package_name_from_spec(package_spec)
+        return nil unless package_name && version_specified?(package_spec, package_name)
+
+        [package_name, package_spec.delete_prefix("#{package_name}@")]
       end
     end
   end

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -561,6 +561,8 @@ module ReactOnRails
         false
       end
 
+      # Last-resort fallback for install failures. This rewrites package.json with
+      # JSON.pretty_generate so users can rerun their package manager manually.
       def write_versioned_package_specs_to_package_json(packages, dev:)
         return false unless File.exist?("package.json")
 

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -97,6 +97,12 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
   let(:mock_package_json) { double("PackageJson", manager: mock_manager) }
   # rubocop:enable RSpec/VerifiedDoubles
 
+  around do |example|
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) { example.run }
+    end
+  end
+
   # Helper methods to filter GeneratorMessages output
   def warnings
     GeneratorMessages.output.select { |msg| msg.to_s.include?("WARNING") }
@@ -208,6 +214,22 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
       instance.system_result = false
       result = instance.send(:add_packages, %w[package1])
       expect(result).to be(false)
+    end
+
+    it "keeps version-pinned dependencies in package.json when package-manager install fails" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          File.write("package.json", "#{JSON.pretty_generate({ 'dependencies' => {} })}\n")
+          instance.add_npm_dependencies_result = false
+          instance.system_result = false
+
+          result = instance.send(:add_packages, ["react-on-rails-pro@16.7.0-rc.1"])
+
+          package_json = JSON.parse(File.read("package.json"))
+          expect(result).to be(false)
+          expect(package_json.dig("dependencies", "react-on-rails-pro")).to eq("16.7.0-rc.1")
+        end
+      end
     end
 
     it "skips fallback install for packages already present in package.json" do

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -217,19 +217,27 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
     end
 
     it "keeps version-pinned dependencies in package.json when package-manager install fails" do
-      Dir.mktmpdir do |dir|
-        Dir.chdir(dir) do
-          File.write("package.json", "#{JSON.pretty_generate({ 'dependencies' => {} })}\n")
-          instance.add_npm_dependencies_result = false
-          instance.system_result = false
+      File.write("package.json", "#{JSON.pretty_generate({ 'dependencies' => {} })}\n")
+      instance.add_npm_dependencies_result = false
+      instance.system_result = false
 
-          result = instance.send(:add_packages, ["react-on-rails-pro@16.7.0-rc.1"])
+      result = instance.send(:add_packages, ["react-on-rails-pro@16.7.0-rc.1"])
 
-          package_json = JSON.parse(File.read("package.json"))
-          expect(result).to be(false)
-          expect(package_json.dig("dependencies", "react-on-rails-pro")).to eq("16.7.0-rc.1")
-        end
-      end
+      package_json = JSON.parse(File.read("package.json"))
+      expect(result).to be(false)
+      expect(package_json.dig("dependencies", "react-on-rails-pro")).to eq("16.7.0-rc.1")
+    end
+
+    it "does not write unversioned dependencies to package.json when package-manager install fails" do
+      File.write("package.json", "#{JSON.pretty_generate({ 'dependencies' => {} })}\n")
+      instance.add_npm_dependencies_result = false
+      instance.system_result = false
+
+      result = instance.send(:add_packages, ["react-on-rails-pro"])
+
+      package_json = JSON.parse(File.read("package.json"))
+      expect(result).to be(false)
+      expect(package_json.fetch("dependencies")).to eq({})
     end
 
     it "skips fallback install for packages already present in package.json" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -255,23 +255,96 @@ RSpec.describe "release.rake helper methods" do
 
   describe "#publish_npm_with_retry" do
     it "passes OTP as a dedicated CLI argument" do
-      expect(self).to receive(:sh_args_in_dir_for_release).with(
-        "/tmp/pkg",
-        "pnpm",
-        "publish",
-        "--tag",
-        "rc",
-        "--otp",
-        "123456"
-      )
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "package.json"), JSON.pretty_generate({ "name" => "react-on-rails",
+                                                                          "version" => "16.4.0-rc.1" }))
 
-      publish_npm_with_retry(
-        "/tmp/pkg",
-        "react-on-rails@16.4.0-rc.1",
-        base_args: ["--tag", "rc"],
-        otp: "123456",
-        max_retries: 1
-      )
+        expect(self).to receive(:sh_args_in_dir_for_release).with(
+          dir,
+          "pnpm",
+          "publish",
+          "--tag",
+          "rc",
+          "--otp",
+          "123456"
+        )
+        expect(self).to receive(:verify_npm_package_published!).with(
+          "react-on-rails",
+          "16.4.0-rc.1",
+          registry_url: "https://registry.npmjs.org/"
+        )
+
+        publish_npm_with_retry(
+          dir,
+          "react-on-rails@16.4.0-rc.1",
+          base_args: ["--tag", "rc"],
+          otp: "123456",
+          max_retries: 1
+        )
+      end
+    end
+
+    it "raises when pnpm publish exits but npm cannot see the package version" do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, "package.json"), JSON.pretty_generate({ "name" => "react-on-rails",
+                                                                          "version" => "16.7.0-rc.1" }))
+        expect(self).to receive(:sh_args_in_dir_for_release).with(dir, "pnpm", "publish")
+        allow(Open3).to receive(:capture2e)
+          .with(
+            "npm",
+            "view",
+            "react-on-rails@16.7.0-rc.1",
+            "version",
+            "dependencies",
+            "optionalDependencies",
+            "peerDependencies",
+            "--json",
+            "--registry",
+            "https://registry.npmjs.org/"
+          )
+          .and_return(["npm ERR! 404 Not Found", instance_double(Process::Status, success?: false)])
+
+        expect do
+          publish_npm_with_retry(
+            dir,
+            "react-on-rails@16.7.0-rc.1",
+            max_retries: 1
+          )
+        end.to raise_error(SystemExit, /not visible on npm/)
+      end
+    end
+  end
+
+  describe "#verify_npm_package_published!" do
+    it "raises when the published package metadata contains workspace protocol dependencies" do
+      allow(Open3).to receive(:capture2e)
+        .with(
+          "npm",
+          "view",
+          "react-on-rails-pro@16.7.0-rc.1",
+          "version",
+          "dependencies",
+          "optionalDependencies",
+          "peerDependencies",
+          "--json",
+          "--registry",
+          "https://registry.npmjs.org/"
+        )
+        .and_return([
+                      JSON.generate(
+                        {
+                          "version" => "16.7.0-rc.1",
+                          "dependencies" => {
+                            "react-on-rails" => "workspace:*"
+                          }
+                        }
+                      ),
+                      instance_double(Process::Status, success?: true)
+                    ])
+
+      expect do
+        verify_npm_package_published!("react-on-rails-pro", "16.7.0-rc.1")
+      end.to raise_error(SystemExit, /workspace:\*/)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -313,6 +313,45 @@ RSpec.describe "release.rake helper methods" do
         end.to raise_error(SystemExit, /not visible on npm/)
       end
     end
+
+    it "replaces workspace protocol dependencies while publishing and restores the package manifest" do
+      Dir.mktmpdir do |dir|
+        package_json_path = File.join(dir, "package.json")
+        original_package_json = JSON.pretty_generate(
+          {
+            "name" => "react-on-rails-pro",
+            "version" => "16.7.0-rc.1",
+            "dependencies" => {
+              "react-on-rails" => "workspace:*"
+            },
+            "optionalDependencies" => {
+              "react-on-rails-optional" => "workspace:^"
+            },
+            "peerDependencies" => {
+              "react-on-rails-peer" => "workspace:~"
+            }
+          }
+        )
+        File.write(package_json_path, "#{original_package_json}\n")
+
+        expect(self).to receive(:sh_args_in_dir_for_release).with(dir, "pnpm", "publish") do
+          published_package_json = JSON.parse(File.read(package_json_path))
+          expect(published_package_json.dig("dependencies", "react-on-rails")).to eq("16.7.0-rc.1")
+          expect(published_package_json.dig("optionalDependencies", "react-on-rails-optional"))
+            .to eq("^16.7.0-rc.1")
+          expect(published_package_json.dig("peerDependencies", "react-on-rails-peer")).to eq("~16.7.0-rc.1")
+        end
+        expect(self).to receive(:verify_npm_package_published!).with(
+          "react-on-rails-pro",
+          "16.7.0-rc.1",
+          registry_url: "https://registry.npmjs.org/"
+        )
+
+        publish_npm_with_retry(dir, "react-on-rails-pro@16.7.0-rc.1", max_retries: 1)
+
+        expect(File.read(package_json_path)).to eq("#{original_package_json}\n")
+      end
+    end
   end
 
   describe "#verify_npm_package_published!" do

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -270,8 +270,7 @@ RSpec.describe "release.rake helper methods" do
         )
         expect(self).to receive(:verify_npm_package_published!).with(
           "react-on-rails",
-          "16.4.0-rc.1",
-          registry_url: "https://registry.npmjs.org/"
+          "16.4.0-rc.1"
         )
 
         publish_npm_with_retry(
@@ -303,6 +302,7 @@ RSpec.describe "release.rake helper methods" do
             "https://registry.npmjs.org/"
           )
           .and_return(["npm ERR! 404 Not Found", instance_double(Process::Status, success?: false)])
+        allow(self).to receive(:sleep)
 
         expect do
           publish_npm_with_retry(
@@ -343,8 +343,7 @@ RSpec.describe "release.rake helper methods" do
         end
         expect(self).to receive(:verify_npm_package_published!).with(
           "react-on-rails-pro",
-          "16.7.0-rc.1",
-          registry_url: "https://registry.npmjs.org/"
+          "16.7.0-rc.1"
         )
 
         publish_npm_with_retry(dir, "react-on-rails-pro@16.7.0-rc.1", max_retries: 1)
@@ -354,7 +353,64 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#with_publishable_package_json" do
+    it "preserves the original publish failure when package.json restore also fails" do
+      Dir.mktmpdir do |dir|
+        package_json_path = File.join(dir, "package.json")
+        File.write(
+          package_json_path,
+          "#{JSON.pretty_generate({ 'dependencies' => { 'react-on-rails' => 'workspace:*' } })}\n"
+        )
+
+        write_count = 0
+        allow(File).to receive(:write).and_wrap_original do |method, *args|
+          write_count += 1 if args.first == package_json_path
+          raise "restore failed" if args.first == package_json_path && write_count == 2
+
+          method.call(*args)
+        end
+
+        expect do
+          with_publishable_package_json(dir, "16.7.0-rc.1") do
+            raise "publish failed"
+          end
+        end.to raise_error(RuntimeError, "publish failed")
+      end
+    end
+  end
+
   describe "#verify_npm_package_published!" do
+    it "retries transient npm metadata lookup failures before accepting the published package" do
+      failed_status = instance_double(Process::Status, success?: false)
+      successful_status = instance_double(Process::Status, success?: true)
+
+      allow(Open3).to receive(:capture2e)
+        .with(
+          "npm",
+          "view",
+          "react-on-rails@16.7.0-rc.1",
+          "version",
+          "dependencies",
+          "optionalDependencies",
+          "peerDependencies",
+          "--json",
+          "--registry",
+          "https://registry.npmjs.org/"
+        )
+        .and_return(
+          ["npm ERR! 404 Not Found", failed_status],
+          [JSON.generate({ "version" => "16.7.0-rc.1" }), successful_status]
+        )
+      expect(self).to receive(:sleep).with(0).once
+
+      verify_npm_package_published!(
+        "react-on-rails",
+        "16.7.0-rc.1",
+        attempts: 2,
+        retry_delay_seconds: 0
+      )
+    end
+
     it "raises when the published package metadata contains workspace protocol dependencies" do
       allow(Open3).to receive(:capture2e)
         .with(


### PR DESCRIPTION
## Summary
- Verify each npm package is visible on npm immediately after `pnpm publish`.
- Abort the release if npm returns a different version or the package is not visible.
- Temporarily rewrite `workspace:` install-time dependencies before `pnpm publish`, then restore the local `package.json`.
- Abort if published install-time dependency metadata still contains `workspace:` protocol dependencies.
- Preserve explicit `name@version` generator dependency pins in `package.json` when the package-manager install fails.

## Why
The `16.7.0.rc.1` release output reported all npm packages as published, but the first two packages were not visible until manually retried, and `react-on-rails-pro@16.7.0-rc.1` ended up published with `react-on-rails: "workspace:*"` in its npm dependency metadata.

That leaked `workspace:*` dependency is not just a release-reporting problem. Yarn v1 is still common and cannot install a registry package that depends on `workspace:*`, so generated apps can fail to install `react-on-rails-pro` and then silently miss that dependency in `package.json`.

## Validation
- `bundle exec rspec react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb`
  - 35 examples, 0 failures
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb`
  - 71 examples, 0 failures
- `RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bundle exec rubocop rakelib/release.rake react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb`
  - 4 files inspected, no offenses detected
- `git diff --check`
- Commit hook: trailing-newlines and RuboCop passed
- Push hook: branch RuboCop and markdown-links passed

## Manual Testing
- `bundle exec ruby /private/tmp/manual_release_modes.rb /private/tmp/react_on_rails-release-publish-fail-fast simulated`
  - Covered dry-run auth skip, real preflight auth checks, GitHub-release dry-run, same-base prerelease version-policy skip, stable bump mismatch failure, version-policy override, npm dist-tag mapping, scoped/unscoped npm package parsing, npm metadata success, npm invisibility failure, version mismatch failure, malformed metadata failure, workspace dependency failure across install-time dependency fields, npm publish with/without OTP, npm publish retry after runtime failure, verifier abort fail-fast behavior, and RubyGems publish with/without OTP.
- `bundle exec ruby /private/tmp/manual_release_modes.rb /private/tmp/react_on_rails-release-publish-fail-fast registry`
  - Read-only npm registry probe passed for `react-on-rails@16.7.0-rc.1`, `react-on-rails-pro-node-renderer@16.7.0-rc.1`, and `create-react-on-rails-app@16.7.0-rc.1`.
  - The same probe intentionally failed for `react-on-rails-pro@16.7.0-rc.1` with `dependencies.react-on-rails=workspace:*`, confirming this PR catches the failed-release condition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and published npm dependency shape; mistakes could block releases or affect downstream Yarn/npm installs of Pro packages.
> 
> **Overview**
> Release publishing now **fails fast** when npm cannot confirm a package, and it prevents **registry-incompatible** `workspace:` dependency metadata from shipping.
> 
> After each `pnpm publish`, the release rake tasks **retry** `npm view` until the exact version is visible, then **abort** on version mismatch or any install-time `dependencies` / `optionalDependencies` / `peerDependencies` still using `workspace:*`. Immediately before publish, `package.json` is temporarily rewritten to replace `workspace:` ranges with publishable semver (then restored).
> 
> The JS generator’s `add_packages` path gains a **last-resort fallback**: when package-manager installs fail, explicit `name@version` specs are written into `package.json` so users can install manually (unversioned specs are not written).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aefdc5d74b1c9b952ee5eada9ac4cedfec0bb4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced npm package publishing workflow with verification to ensure packages are properly available on the registry
  * Improved package installation resilience with automatic fallback mechanism that updates dependencies directly when standard installation fails

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->