### PR TITLE
Keep RC/beta changelog sections separate until stable release

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -163,7 +163,7 @@ The rake task handles:
 - Auto-computing the next version from git tags (prerelease index is determined solely from tags, not changelog headers)
 - Inserting the version header right after `### [Unreleased]`
 - Updating version diff links at the bottom of the file
-- For `rc`/`beta` modes: collapsing prior prerelease sections of the same base version into a single section
+- For `release` mode: collapsing prior `rc`/`beta` sections of the same base version into the new stable section (rc/beta modes leave prior prerelease sections intact so users can see what changed between RCs)
 
 Do NOT manually insert version headers or update diff links -- the rake task does this correctly.
 
@@ -290,7 +290,8 @@ If the user passed `release`, `rc`, `beta`, or an explicit version string as an 
    - Auto-compute the next version
    - Insert the header after `### [Unreleased]`
    - Update diff links at the bottom
-   - For `rc`/`beta`: collapse prior prerelease sections
+   - For `release`: collapse prior `rc`/`beta` sections of the same base version into the new stable section
+   - For `rc`/`beta`: leave prior prerelease sections intact (each prerelease keeps its own section so users on an earlier RC can see what changed)
 
 3. **Verify** the computed version looks correct. If not, the user can manually adjust.
 
@@ -343,16 +344,44 @@ When the user passes `rc` or `beta` as an argument:
 
 2. **Auto-compute the next prerelease version** using the process in "Auto-Computing the Next Version" above.
 
-3. **Always collapse prior prereleases into the current prerelease** (this is the default behavior):
-   - Combine all prior prerelease changelog entries into the new prerelease version section
-   - Remove previous prerelease version sections (e.g., remove `### [16.5.0.rc.0]` when creating `### [16.5.0.rc.1]`)
-   - When collapsing, **consolidate duplicate category headings** — if both the Unreleased section and a prior prerelease section have `#### Fixed`, merge all entries under a single `#### Fixed` heading
-   - **Remove orphaned version diff links** at the bottom of the file for collapsed prerelease sections
-   - Add any new user-visible changes from commits since the last prerelease
-   - Update version diff links to point from the last stable version to the new prerelease
-   - This keeps the changelog clean with a single prerelease section that accumulates all changes since the last stable release
+3. **Do NOT collapse prior prereleases.** Each RC/beta is a separately-tagged release that users install — they need to see what changed between, for example, `rc.0` and `rc.1` (especially when diagnosing a regression in a specific RC). Each `bundle exec rake release` reads only the top-most `### [VERSION]` section, so as long as each RC has its own section, the corresponding GitHub release gets its own focused notes. Instead:
+   - Insert the new prerelease version section immediately after `### [Unreleased]`, **above** any prior prerelease sections (preserves newest-first ordering)
+   - Any entries already under `### [Unreleased]` belong to this prerelease — the rake task moves them under the new header automatically when it inserts the version line right after `### [Unreleased]`
+   - Leave prior prerelease sections (e.g., `### [16.5.0.rc.0]`) untouched — keep their entries and their compare links at the bottom of the file
+   - Add any new user-visible changes from commits since the last prerelease tag to the new section only
+   - Add a new compare link at the bottom comparing the previous prerelease tag (or the last stable tag if this is the first RC) to the new prerelease tag
+   - Update the `[unreleased]:` compare link to point from the new prerelease tag to `main`
 
-**Note**: The new version header must be inserted **immediately after `### [Unreleased]`** (see Step 4). This ensures correct ordering of version headers.
+**Resulting structure** after stamping `16.5.0.rc.1` (with `16.5.0.rc.0` already shipped on top of stable `16.4.0`):
+
+```markdown
+### [Unreleased]
+
+### [16.5.0.rc.1] - 2026-03-15
+
+#### Fixed
+
+- **Fix regression introduced in rc.0**. [PR 2500](https://github.com/shakacode/react_on_rails/pull/2500) by [justin808](https://github.com/justin808).
+
+### [16.5.0.rc.0] - 2026-03-01
+
+#### Added
+
+- **New feature**. [PR 2490](https://github.com/shakacode/react_on_rails/pull/2490) by [justin808](https://github.com/justin808).
+
+### [16.4.0] - 2026-02-15
+
+...
+
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v16.5.0.rc.1...main
+[16.5.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/v16.5.0.rc.0...v16.5.0.rc.1
+[16.5.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v16.4.0...v16.5.0.rc.0
+[16.4.0]: https://github.com/shakacode/react_on_rails/compare/v16.3.0...v16.4.0
+```
+
+Both RC sections remain intact with their own compare links until the stable release coalesces them. **Coalescing happens only at the stable release** — see "For Prerelease to Stable Version Release" below.
+
+**Note**: The new version header must be inserted **immediately after `### [Unreleased]`** (see Step 4). This ensures correct newest-first ordering of version headers.
 
 ### For Prerelease to Stable Version Release
 

--- a/internal/contributor-info/releasing.md
+++ b/internal/contributor-info/releasing.md
@@ -18,7 +18,7 @@ See [Contributing](https://github.com/shakacode/react_on_rails/blob/main/CONTRIB
    - Add changelog entries under the appropriate category headings
    - Auto-compute the next version based on changes (breaking -> major, features -> minor, fixes -> patch) — skipped when an explicit version is provided
    - Stamp the version header (e.g., `### [16.5.0] - 2026-03-08`)
-   - For `rc`/`beta`: collapse prior prerelease sections and deduplicate entries
+   - For `release`: collapse prior `rc`/`beta` sections of the same base version into the new stable section and deduplicate entries (`rc`/`beta` modes leave prior prerelease sections in place so users on an earlier RC can see what changed between RCs)
    - **Automatically commit, push, and open a PR** with the changelog changes
 3. For minor and major releases, add a commit to the changelog PR updating `SECURITY.md`:
    - "Current support window" table so supported version lines and cutoff dates match the release being shipped

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -397,8 +397,9 @@ end
 # rubocop:enable Metrics/AbcSize
 
 def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil)
-  # Keep backward compatibility with older callers that pass changelog_for_bump
-  # as a keyword while allowing the new 3-argument call shape.
+  # changelog_for_bump is only consulted when the bump type must be inferred
+  # from [Unreleased]: namely release mode, and rc/beta cold-start (no active
+  # prerelease base). It is ignored once an rc/beta series has begun.
   changelog_for_bump ||= changelog
 
   # For rc/beta modes, if an active prerelease base already exists (from a
@@ -406,6 +407,12 @@ def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil
   # directly. The bump decision was made when the first RC of the series
   # was stamped; once rc.0 ships, rc.1 must stay on the same base version
   # even if Unreleased is empty or its headings suggest a different bump.
+  #
+  # Note: active_prerelease_base_version is channel-agnostic — it returns the
+  # highest active base across rc, beta, alpha, etc. This project does not mix
+  # channels on a single base version (e.g., we don't ship both 16.4.0.beta.N
+  # and 16.4.0.rc.N), so the active base unambiguously belongs to the current
+  # channel in practice.
   if %w[rc beta].include?(mode)
     active_base = active_prerelease_base_version(monorepo_root, changelog)
     if active_base

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -418,6 +418,10 @@ def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil
     if active_base
       indices = prerelease_indices_from_tags(monorepo_root, active_base, mode)
       next_index = indices.empty? ? 0 : indices.max + 1
+      if indices.empty? && !prerelease_indices_from_tags(monorepo_root, active_base, nil).empty?
+        warn "WARNING: active prerelease base #{active_base} was found via a different channel. " \
+             "Verify the computed version is correct."
+      end
       return "#{active_base}.#{mode}.#{next_index}"
     end
   end

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -502,6 +502,8 @@ task :update_changelog, %i[mode_or_tag] do |_, args|
     # Collapse prior prerelease sections only when stamping the stable
     # release. For rc/beta modes, each prerelease keeps its own section
     # so users on an earlier RC can see what changed between RCs.
+    # For release mode, collapse prior prerelease sections before computing
+    # the version; for rc/beta, the changelog is used as-is.
     prepared_changelog = if auto_mode == "release"
                            prepare_changelog_for_auto_version(changelog, monorepo_root)
                          else

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -400,6 +400,21 @@ def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil
   # Keep backward compatibility with older callers that pass changelog_for_bump
   # as a keyword while allowing the new 3-argument call shape.
   changelog_for_bump ||= changelog
+
+  # For rc/beta modes, if an active prerelease base already exists (from a
+  # tag or a draft changelog header above the latest stable), reuse it
+  # directly. The bump decision was made when the first RC of the series
+  # was stamped; once rc.0 ships, rc.1 must stay on the same base version
+  # even if Unreleased is empty or its headings suggest a different bump.
+  if %w[rc beta].include?(mode)
+    active_base = active_prerelease_base_version(monorepo_root, changelog)
+    if active_base
+      indices = prerelease_indices_from_tags(monorepo_root, active_base, mode)
+      next_index = indices.empty? ? 0 : indices.max + 1
+      return "#{active_base}.#{mode}.#{next_index}"
+    end
+  end
+
   bump_type = inferred_bump_type_from_unreleased(changelog_for_bump)
   latest_stable = latest_stable_tag_version(monorepo_root)
   base_version = bump_stable_version(latest_stable, bump_type)
@@ -450,9 +465,13 @@ desc "Updates CHANGELOG.md by inserting a version header and compare links.
 Argument: Mode (`release`, `rc`, `beta`) or explicit git tag/version.
 
 Modes:
-  - release: auto-compute next stable version from Unreleased section headings
-  - rc: auto-compute next RC version and collapse prior RC sections of same base version
-  - beta: auto-compute next beta version and collapse prior beta sections of same base version
+  - release: auto-compute next stable version and collapse prior RC/beta
+             sections of the same base version into the new stable section
+  - rc: auto-compute next RC version; prior RC/beta sections of the same
+        base version are left in place so users can see what changed
+        between RCs
+  - beta: auto-compute next beta version; prior beta/RC sections of the
+          same base version are left in place
 
 Explicit argument examples:
   - v16.4.0.rc.6
@@ -473,7 +492,14 @@ task :update_changelog, %i[mode_or_tag] do |_, args|
 
   if auto_mode
     fetch_git_tags!(monorepo_root)
-    prepared_changelog = prepare_changelog_for_auto_version(changelog, monorepo_root)
+    # Collapse prior prerelease sections only when stamping the stable
+    # release. For rc/beta modes, each prerelease keeps its own section
+    # so users on an earlier RC can see what changed between RCs.
+    prepared_changelog = if auto_mode == "release"
+                           prepare_changelog_for_auto_version(changelog, monorepo_root)
+                         else
+                           changelog
+                         end
     changelog_version = compute_auto_version(prepared_changelog, auto_mode, monorepo_root)
     changelog = prepared_changelog
     tag_date = Date.today.strftime("%Y-%m-%d")

--- a/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
@@ -501,6 +501,10 @@ RSpec.describe "update_changelog.rake helper methods" do
           - Feature from RC
         CHANGELOG
 
+        # No v16.4.0.rc.0 git tag exists, so prerelease_indices_from_tags
+        # returns [] → next_index 0. The task would skip re-insertion because
+        # the header already exists in the changelog, which is the correct
+        # behaviour for an untagged draft.
         version = compute_auto_version(changelog, "rc", repo_dir)
 
         expect(version).to eq("16.4.0.rc.0")

--- a/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
@@ -501,8 +501,7 @@ RSpec.describe "update_changelog.rake helper methods" do
           - Feature from RC
         CHANGELOG
 
-        prepared_changelog = prepare_changelog_for_auto_version(changelog, repo_dir)
-        version = compute_auto_version(changelog, "rc", repo_dir, changelog_for_bump: prepared_changelog)
+        version = compute_auto_version(changelog, "rc", repo_dir)
 
         expect(version).to eq("16.4.0.rc.0")
       end
@@ -525,6 +524,28 @@ RSpec.describe "update_changelog.rake helper methods" do
         version = compute_auto_version(changelog, "rc", repo_dir)
 
         expect(version).to eq("16.4.0.rc.1")
+      end
+    end
+
+    it "increments beta index from existing beta tag of the same base version" do
+      # Mirrors the rc.1 increment test for the beta channel, since both modes
+      # share the early-return code path in compute_auto_version.
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v16.3.0", chdir: repo_dir)
+        run_git!("tag", "v16.4.0.beta.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ### [Unreleased]
+
+          ### [16.4.0.beta.0] - 2026-03-01
+          #### Added
+          - Feature from beta.0
+        CHANGELOG
+
+        version = compute_auto_version(changelog, "beta", repo_dir)
+
+        expect(version).to eq("16.4.0.beta.1")
       end
     end
 

--- a/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
@@ -507,5 +507,69 @@ RSpec.describe "update_changelog.rake helper methods" do
         expect(version).to eq("16.4.0.rc.0")
       end
     end
+
+    it "increments rc index from existing rc tag of the same base version" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v16.3.0", chdir: repo_dir)
+        run_git!("tag", "v16.4.0.rc.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ### [Unreleased]
+
+          ### [16.4.0.rc.0] - 2026-03-01
+          #### Added
+          - Feature from rc.0
+        CHANGELOG
+
+        version = compute_auto_version(changelog, "rc", repo_dir)
+
+        expect(version).to eq("16.4.0.rc.1")
+      end
+    end
+
+    it "reuses the active prerelease base even when Unreleased entries would suggest a different bump" do
+      # When rc.0 is tagged based on a minor bump (16.3.0 -> 16.4.0), a subsequent
+      # rc.1 must stay on the same 16.4.0 base even if Unreleased only contains a
+      # bug fix (which would naively suggest a patch bump to 16.3.1.rc.0).
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v16.3.0", chdir: repo_dir)
+        run_git!("tag", "v16.4.0.rc.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ### [Unreleased]
+
+          #### Fixed
+          - A patch-level fix added since rc.0
+
+          ### [16.4.0.rc.0] - 2026-03-01
+          #### Added
+          - Feature from rc.0
+        CHANGELOG
+
+        version = compute_auto_version(changelog, "rc", repo_dir)
+
+        expect(version).to eq("16.4.0.rc.1")
+      end
+    end
+
+    it "falls through to stable-bump inference for rc mode when no active prerelease base exists" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v16.3.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ### [Unreleased]
+
+          #### Added
+          - A new feature for the next minor release
+        CHANGELOG
+
+        version = compute_auto_version(changelog, "rc", repo_dir)
+
+        expect(version).to eq("16.4.0.rc.0")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Flips the RC/beta changelog policy from **always-collapse** to **never-collapse-until-stable**, so users on a prior RC can still see what changed between, say, `rc.0` and `rc.1` when diagnosing a regression or deciding whether to upgrade.

Ports the policy from the analogous [shakacode/control-plane-flow PR 320](https://github.com/shakacode/control-plane-flow/pull/320). Builds on [#3395](https://github.com/shakacode/react_on_rails/pull/3395) (docs-only restructuring).

## Behavior change

| Mode | Before | After |
| --- | --- | --- |
| `update_changelog[release]` | Collapses prior `rc`/`beta` sections of the same base version into the new stable section | **Same** — no change |
| `update_changelog[rc]` | Collapses prior `rc`/`beta` sections of the same base version into the new RC | **Inserts the new RC above prior RCs**; prior sections + their compare links stay intact |
| `update_changelog[beta]` | Collapses prior `beta`/`rc` sections of the same base version into the new beta | **Inserts the new beta above prior prereleases**; prior sections + their compare links stay intact |

The rake task's existing `[unreleased]` → new-version → previous-version compare-link chain naturally produces a per-RC link (e.g., `compare/v16.5.0.rc.0...v16.5.0.rc.1`) under the new policy — no cleanup step is needed because `cleanup_collapsed_prerelease_links` is only invoked from the (now release-only) collapse path.

## Version-computation fix for rc.1+

Previously, `compute_auto_version` always inferred the bump type from `### [Unreleased]` headings and applied that bump to the latest stable. Under the new policy, prior RC content stays in its own section and `[Unreleased]` may be empty when rc.1 is stamped — which would (incorrectly) default to a patch bump (`16.3.1.rc.0` instead of `16.4.0.rc.1`).

For `rc`/`beta` modes, the function now first checks `active_prerelease_base_version` (tags + draft changelog headers above the latest stable). When an active base exists, it reuses that base and just increments the prerelease index from git tags. The bump decision was made when the first RC of the series was stamped; subsequent RCs must stay on the same base.

For `release` mode (and the no-active-base rc/beta cold-start case), the bump-from-Unreleased logic is unchanged.

## Resulting changelog structure

After stamping `16.5.0.rc.1` (with `16.5.0.rc.0` already shipped on top of stable `16.4.0`):

```markdown
### [Unreleased]

### [16.5.0.rc.1] - 2026-03-15

#### Fixed
- **Fix regression introduced in rc.0**. ...

### [16.5.0.rc.0] - 2026-03-01

#### Added
- **New feature**. ...

### [16.4.0] - 2026-02-15
...

[unreleased]: .../compare/v16.5.0.rc.1...main
[16.5.0.rc.1]: .../compare/v16.5.0.rc.0...v16.5.0.rc.1
[16.5.0.rc.0]: .../compare/v16.4.0...v16.5.0.rc.0
[16.4.0]: .../compare/v16.3.0...v16.4.0
```

Both RC sections remain intact with their own compare links until the stable release coalesces them via Steps 1–5 of "For Prerelease to Stable Version Release" (from #3395).

## Test plan

- [x] `bundle exec rspec react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb` — all 27 existing helper tests pass unchanged + 3 new `#compute_auto_version` tests pass:
  - `increments rc index from existing rc tag of the same base version`
  - `reuses the active prerelease base even when Unreleased entries would suggest a different bump`
  - `falls through to stable-bump inference for rc mode when no active prerelease base exists`
- [x] `bundle exec rubocop` passes for both changed Ruby files
- [x] `lefthook` pre-commit hooks pass (rubocop, prettier, trailing-newlines, markdown-links)
- [ ] Manual sanity check: next time someone runs `bundle exec rake "update_changelog[rc]"` to stamp a new RC (e.g., `16.7.0.rc.3`), verify the prior `### [16.7.0.rc.2]` section stays in place and a new `### [16.7.0.rc.3]` is inserted above it with a `[16.7.0.rc.3]: compare/v16.7.0.rc.2...v16.7.0.rc.3` link.
- [ ] Manual sanity check: next time someone runs `bundle exec rake "update_changelog[release]"` to stamp the stable `16.7.0`, verify all prior RC sections coalesce into one stable section.

## Compatibility note

The current `CHANGELOG.md` has `16.7.0.rc.2` (with rc.0/rc.1 history already collapsed under the old policy). The new policy applies going forward — no retroactive split needed. If a new RC is stamped before `16.7.0` stable, it will sit above the existing `16.7.0.rc.2` section.

## Stacked PR

This PR is stacked on top of #3395. Merge #3395 first, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect release/changelog automation and documentation only, not runtime gem or app behavior; release-mode collapse behavior is preserved.
> 
> **Overview**
> **RC/beta changelog stamping no longer merges prior prerelease sections** — each new `update_changelog[rc]` or `[beta]` run inserts a fresh section above older RCs/betas and keeps their compare links, so release notes and diffs stay per-prerelease until a stable ship.
> 
> **Stable `update_changelog[release]` still collapses** all `rc`/`beta` sections for the same base version into one stable block (unchanged behavior, now documented consistently in contributor docs and the Claude `/update-changelog` command).
> 
> **`compute_auto_version` for rc/beta** reuses the active prerelease base (from tags/draft headers above latest stable) and bumps only the prerelease index from git tags, instead of re-inferring bump type from `[Unreleased]` — fixing wrong versions like `16.3.1.rc.0` when `rc.1` is stamped with only patch-level unreleased entries. The rake task skips `prepare_changelog_for_auto_version` unless mode is `release`.
> 
> Specs add coverage for rc/beta index increments, active-base reuse, and cold-start bump inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1b4b85076615a79387e64be71b958e8bde549c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified changelog/update workflow and prerelease instructions; prerelease header placement and behavior updated.

* **Tests**
  * Added/expanded specs validating prerelease index progression and auto-versioning behaviors.

* **Bug Fixes**
  * Prerelease (rc/beta) modes now preserve prior prerelease sections.
  * Release mode now collapses prior prerelease sections into the stable release.
  * Auto-versioning for prereleases reuses existing prerelease base versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->