### PR TITLE
Better specify `PORT` in `prod` scripts to fix the benchmark workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **Upgrade contributor pnpm tooling to 10.33.4**: The monorepo now pins pnpm 10.33.4 with Corepack's hash-qualified `packageManager` format, keeps the install-generator CI fallback on the same pnpm version, and relies on the root workspace pin instead of duplicate workspace `packageManager` declarations. [PR 3400](https://github.com/shakacode/react_on_rails/pull/3400) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
 - **[Pro]** **Updated Pino in the Node Renderer**: Raised the `react-on-rails-pro-node-renderer` `pino` dependency range to `^9.14.0 || ^10.1.0`, aligning with the current Fastify dependency. [PR 3401](https://github.com/shakacode/react_on_rails/pull/3401) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
 
+#### Fixed
+
+- **[Pro]** **Benchmark CI starts the production dummy app on the expected port**: `react_on_rails_pro/spec/dummy/bin/prod` now sets `PORT=3001` by default before launching Foreman, preventing Foreman's default `PORT=5000` from making the Rails server miss the benchmark workflow readiness check on `localhost:3001`. Both `react_on_rails/spec/dummy/bin/prod` and `react_on_rails_pro/spec/dummy/bin/prod` respect `PORT` when it's set. [PR 3403](https://github.com/shakacode/react_on_rails/pull/3403) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
+
 ### [16.7.0.rc.2] - 2026-05-24
 
 #### Added

--- a/react_on_rails/spec/dummy/bin/prod
+++ b/react_on_rails/spec/dummy/bin/prod
@@ -26,4 +26,4 @@ if [ -f "pnpm-lock.yaml" ] && [ "pnpm-lock.yaml" -nt "$MANIFEST" ]; then
   echo "Consider running ./bin/prod-assets to rebuild"
 fi
 
-NODE_ENV=production RAILS_ENV=production bundle exec rails server -p 3001
+NODE_ENV=production RAILS_ENV=production bundle exec rails server -p "${PORT:-3001}"

--- a/react_on_rails_pro/spec/dummy/bin/prod
+++ b/react_on_rails_pro/spec/dummy/bin/prod
@@ -28,6 +28,7 @@ fi
 
 export NODE_ENV=production
 export RAILS_ENV=production
+export PORT="${PORT:-3001}"
 
 if command -v overmind &> /dev/null; then
   overmind start -f Procfile.prod


### PR DESCRIPTION
### Summary

Use `PORT=3001` in `react_on_rails_pro/spec/dummy/bin/prod` by default, or external `PORT` if set.

### Pull Request checklist

~- [ ] Add/update test to cover these changes~
~- [ ] Update documentation~
- [x] Update CHANGELOG file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Process manager launches now default to port 3001 and respect a pre-set PORT environment variable, preventing unexpected port mismatches during local readiness checks.

* **Documentation**
  * Changelog updated to record the change and note that both runtimes respect PORT when provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->