### PR TITLE
fix(ci): sync Pro dummy Gemfile.lock with gemspec to fix benchmark workflow

### DIFF
--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -24,10 +24,9 @@ PATH
       addressable
       async (>= 2.29)
       async-http (~> 0.95)
-      connection_pool
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
-      jwt (>= 3.2.0)
+      jwt (>= 2.5, < 4)
       rainbow
       react_on_rails (= 16.7.0.rc.2)
 


### PR DESCRIPTION
## Summary

- The benchmark workflow's `Install Ruby Gems for Pro dummy app` step has been failing on every push to `main` since PR #3320 (commit `4758078`).
- PR #3320 changed `react_on_rails_pro.gemspec` to drop `connection_pool` and narrow `jwt` to `">= 2.5", "< 4"`, but the path-gem block inside `react_on_rails_pro/spec/dummy/Gemfile.lock` still listed `connection_pool` and `jwt (>= 3.2.0)`.
- Bundler tolerates that mismatch in workflows that install without `--frozen` (`pro-integration-tests.yml` etc.), but the benchmark workflow sets `bundle config set frozen true` and so failed with:
  ```
  The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set
  ```
- This PR regenerates the lockfile so the path-gem dependencies match the gemspec.

Fixes #3406

## Background

The issue body's leading hypotheses (`bench.rb` not writing a summary, port 3001 not freeing) are **not** the current failure mode. In the most recent failing run on `main` ([run #26404417325](https://github.com/shakacode/react_on_rails/actions/runs/26404417325)):

- Core benchmark suite ✅ completes and writes `bench_results/summary.txt` (2.6K).
- `Validate Core benchmark results` ✅ passes.
- `Stop Core production server` ✅ reports `Port 3001 is now free`.
- `Install Ruby Gems for Pro dummy app` ❌ fails immediately (1 second) with the gemspec/lockfile mismatch above.

The older hypotheses were valid for runs **before** #3403 fixed the Foreman `PORT` default, but the dominant failure now is the lockfile mismatch.

## Why this only breaks `benchmark.yml`

| Workflow | Bundle command | Frozen? | Result on `main` |
|---|---|---|---|
| `benchmark.yml` | `bundle _2.5.4_ install --jobs=4 --retry=3` | `bundle config set frozen true` | ❌ |
| `pro-integration-tests.yml` | `bundle _2.5.4_ check \|\| bundle _2.5.4_ install ...` | no | ✅ |
| `pro-test-package-and-gem.yml` | same as above | no | ✅ |
| `pro-lint.yml` | same as above | no | ✅ |

The other workflows silently rewrite the in-memory lockfile to match the gemspec, then move on. Only `benchmark.yml` notices.

## Verification

Reproduced the exact CI error locally on `react_on_rails_pro/spec/dummy` with Bundler `2.5.4`:

```console
$ bundle config set frozen true
$ bundle _2.5.4_ install --jobs=4 --retry=3
The gemspecs for path gems changed, but the lockfile can't be updated because
frozen mode is set
```

After the fix (lockfile regenerated):

```console
$ bundle config set frozen true
$ bundle _2.5.4_ install --jobs=4 --retry=3
Bundle complete! 54 Gemfile dependencies, 184 gems now installed.
```

## Diff scope

A single 3-line change inside the `react_on_rails_pro` PATH block:

```diff
     react_on_rails_pro (16.7.0.rc.2)
       addressable
       async (>= 2.29)
       async-http (~> 0.95)
-      connection_pool
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
-      jwt (>= 3.2.0)
+      jwt (>= 2.5, < 4)
       rainbow
       react_on_rails (= 16.7.0.rc.2)
```

No GEM-section gem versions change.

## Related (out of scope)

`react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock` has the same stale `connection_pool` / `jwt (>= 3.2.0)` lines from #3320, but no workflow runs `bundle install --frozen` there today, so it isn't blocking CI. Worth cleaning up separately to avoid the same trap recurring.

## Test plan

- [ ] Benchmark workflow on this branch reaches the `Install Ruby Gems for Pro dummy app` step and passes it.
- [ ] Subsequent Pro server start + Pro benchmarks proceed (this PR doesn't touch them, so behavior should be unchanged from pre-#3320).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only metadata fix; no application or gemspec changes in this diff.
> 
> **Overview**
> Aligns the **Pro dummy app** `Gemfile.lock` PATH block for `react_on_rails_pro` with the current gemspec after #3320: drops the stale `connection_pool` runtime line and updates the recorded `jwt` constraint from `>= 3.2.0` to `>= 2.5, < 4`.
> 
> No resolved GEM versions change—only the path-gem dependency metadata Bundler compares in **frozen** mode. That unblocks `benchmark.yml`’s Pro dummy `bundle install`, which was failing when the lockfile still described dependencies the gemspec no longer declares.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c5923e771b078ed481d778c93babfa0002820b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->