### PR TITLE
chore(pro): sync spec/dummy Gemfile.lock with async-http migration

### DIFF
--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -24,10 +24,9 @@ PATH
       addressable
       async (>= 2.29)
       async-http (~> 0.95)
-      connection_pool
       execjs (~> 2.9)
       io-endpoint (~> 0.17.0)
-      jwt (>= 3.2.0)
+      jwt (>= 2.5, < 4)
       rainbow
       react_on_rails (= 16.7.0.rc.2)
 


### PR DESCRIPTION
### Summary

Updates `react_on_rails_pro/spec/dummy/Gemfile.lock` to reflect upstream dependency changes from the recent async-http migration (#3320): drops the `connection_pool` transitive dependency and relaxes the `jwt` constraint to `(>= 2.5, < 4)`.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (lockfile-only update)
- ~[ ] Update documentation~ (no behavior change)
- ~[ ] Update CHANGELOG file~ (lockfile sync, not user-facing)

### Other Information

Mechanical `bundle install` result picking up the gemspec changes already merged to `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only sync for the dummy test app; no runtime or security logic changes in this diff.
> 
> **Overview**
> Syncs **`react_on_rails_pro/spec/dummy/Gemfile.lock`** with the Pro gemspec after the async-http migration: the **`react_on_rails_pro`** path entry no longer lists **`connection_pool`** as a direct dependency, and **`jwt`** is recorded as **`>= 2.5, < 4`** instead of **`>= 3.2.0`**.
> 
> No application or library source changes—only the resolved dependency graph for the dummy app’s test bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe9d023a9fe44a8a0c515014fe158660ccfc375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->