### PR TITLE
refactor: extract next_active_prerelease_version helper

### DIFF
--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -411,7 +411,7 @@ end
 # channels on a single base version (e.g., we don't ship both 16.4.0.beta.N
 # and 16.4.0.rc.N), so the active base unambiguously belongs to the current
 # channel in practice.
-def next_active_prerelease_version(mode, monorepo_root, changelog)
+def next_active_prerelease_version(changelog, mode, monorepo_root)
   return nil unless %w[rc beta].include?(mode)
 
   active_base = active_prerelease_base_version(monorepo_root, changelog)
@@ -432,7 +432,7 @@ def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil
   # prerelease base). It is ignored once an rc/beta series has begun.
   changelog_for_bump ||= changelog
 
-  active_version = next_active_prerelease_version(mode, monorepo_root, changelog)
+  active_version = next_active_prerelease_version(changelog, mode, monorepo_root)
   return active_version if active_version
 
   bump_type = inferred_bump_type_from_unreleased(changelog_for_bump)

--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -396,35 +396,44 @@ def collapse_prerelease_sections(changelog, base_version, channel)
 end
 # rubocop:enable Metrics/AbcSize
 
+# For rc/beta modes, if an active prerelease base already exists (from a
+# tag or a draft changelog header above the latest stable), reuse it
+# directly. The bump decision was made when the first RC of the series
+# was stamped; once rc.0 ships, rc.1 must stay on the same base version
+# even if Unreleased is empty or its headings suggest a different bump.
+#
+# Returns the next prerelease version string (e.g., "16.4.0.rc.1") when an
+# active base is found, or nil otherwise so the caller can fall through to
+# stable-bump inference.
+#
+# Note: active_prerelease_base_version is channel-agnostic — it returns the
+# highest active base across rc, beta, alpha, etc. This project does not mix
+# channels on a single base version (e.g., we don't ship both 16.4.0.beta.N
+# and 16.4.0.rc.N), so the active base unambiguously belongs to the current
+# channel in practice.
+def next_active_prerelease_version(mode, monorepo_root, changelog)
+  return nil unless %w[rc beta].include?(mode)
+
+  active_base = active_prerelease_base_version(monorepo_root, changelog)
+  return nil unless active_base
+
+  indices = prerelease_indices_from_tags(monorepo_root, active_base, mode)
+  next_index = indices.empty? ? 0 : indices.max + 1
+  if indices.empty? && !prerelease_indices_from_tags(monorepo_root, active_base, nil).empty?
+    warn "WARNING: active prerelease base #{active_base} was found via a different channel. " \
+         "Verify the computed version is correct."
+  end
+  "#{active_base}.#{mode}.#{next_index}"
+end
+
 def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil)
   # changelog_for_bump is only consulted when the bump type must be inferred
   # from [Unreleased]: namely release mode, and rc/beta cold-start (no active
   # prerelease base). It is ignored once an rc/beta series has begun.
   changelog_for_bump ||= changelog
 
-  # For rc/beta modes, if an active prerelease base already exists (from a
-  # tag or a draft changelog header above the latest stable), reuse it
-  # directly. The bump decision was made when the first RC of the series
-  # was stamped; once rc.0 ships, rc.1 must stay on the same base version
-  # even if Unreleased is empty or its headings suggest a different bump.
-  #
-  # Note: active_prerelease_base_version is channel-agnostic — it returns the
-  # highest active base across rc, beta, alpha, etc. This project does not mix
-  # channels on a single base version (e.g., we don't ship both 16.4.0.beta.N
-  # and 16.4.0.rc.N), so the active base unambiguously belongs to the current
-  # channel in practice.
-  if %w[rc beta].include?(mode)
-    active_base = active_prerelease_base_version(monorepo_root, changelog)
-    if active_base
-      indices = prerelease_indices_from_tags(monorepo_root, active_base, mode)
-      next_index = indices.empty? ? 0 : indices.max + 1
-      if indices.empty? && !prerelease_indices_from_tags(monorepo_root, active_base, nil).empty?
-        warn "WARNING: active prerelease base #{active_base} was found via a different channel. " \
-             "Verify the computed version is correct."
-      end
-      return "#{active_base}.#{mode}.#{next_index}"
-    end
-  end
+  active_version = next_active_prerelease_version(mode, monorepo_root, changelog)
+  return active_version if active_version
 
   bump_type = inferred_bump_type_from_unreleased(changelog_for_bump)
   latest_stable = latest_stable_tag_version(monorepo_root)


### PR DESCRIPTION
## Summary

- Fixes `Metrics/CyclomaticComplexity` failure on `main` for `compute_auto_version` in `react_on_rails/rakelib/update_changelog.rake` (9/8). The cop went over budget after #3396 added the rc/beta active-base branch.
- Pulls that branch out into `next_active_prerelease_version`, which returns the resolved version string or `nil` so the caller can fall through to stable-bump inference.
- Pure refactor — no behavior change.

## Test plan

- [x] `(cd react_on_rails && bundle exec rubocop)` — clean (203 files, 0 offenses)
- [x] `(cd react_on_rails && bundle exec rspec spec/react_on_rails/update_changelog_rake_helpers_spec.rb)` — 31 examples, 0 failures (all 7 `#compute_auto_version` cases pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rake-only parameter reorder with specs passing; no release or runtime behavior change.
> 
> **Overview**
> **Refactors** the changelog rake helper `next_active_prerelease_version` so its arguments are **`(changelog, mode, monorepo_root)`** instead of **`(mode, monorepo_root, changelog)`**, and updates the single call in **`compute_auto_version`** to match.
> 
> This is a **pure refactor** to bring **`compute_auto_version`** back under RuboCop’s cyclomatic complexity limit after recent rc/beta logic landed; **versioning behavior is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aeb18805b895c90b6bdda83814739969dda3e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved prerelease version computation for rc and beta channels.
  * Reuses the highest active prerelease base across changelog and tags to pick a single base.
  * Computes the next prerelease index from shipped tags and warns if the base appears tied to a different channel.
  * Returns a prerelease version early when detected, otherwise falls back to stable-bump inference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->