### PR TITLE
fix: make cross-channel prerelease warning actually fire

### DIFF
--- a/react_on_rails/rakelib/update_changelog.rake
+++ b/react_on_rails/rakelib/update_changelog.rake
@@ -419,11 +419,18 @@ def next_active_prerelease_version(changelog, mode, monorepo_root)
 
   indices = prerelease_indices_from_tags(monorepo_root, active_base, mode)
   next_index = indices.empty? ? 0 : indices.max + 1
-  if indices.empty? && !prerelease_indices_from_tags(monorepo_root, active_base, nil).empty?
+  if indices.empty? && other_prerelease_channel_present?(monorepo_root, active_base, mode)
     warn "WARNING: active prerelease base #{active_base} was found via a different channel. " \
          "Verify the computed version is correct."
   end
   "#{active_base}.#{mode}.#{next_index}"
+end
+
+def other_prerelease_channel_present?(monorepo_root, base_version, mode)
+  other_channels = %w[test beta alpha rc pre].reject { |channel| channel == mode }
+  other_channels.any? do |channel|
+    !prerelease_indices_from_tags(monorepo_root, base_version, channel).empty?
+  end
 end
 
 def compute_auto_version(changelog, mode, monorepo_root, changelog_for_bump: nil)

--- a/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb
@@ -596,5 +596,47 @@ RSpec.describe "update_changelog.rake helper methods" do
         expect(version).to eq("16.4.0.rc.0")
       end
     end
+
+    it "warns when the active prerelease base only has tags under a different channel" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v16.3.0", chdir: repo_dir)
+        run_git!("tag", "v16.4.0.beta.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ### [Unreleased]
+
+          ### [16.4.0.beta.0] - 2026-03-01
+          #### Added
+          - Feature from beta.0
+        CHANGELOG
+
+        expect do
+          version = compute_auto_version(changelog, "rc", repo_dir)
+          expect(version).to eq("16.4.0.rc.0")
+        end.to output(/WARNING: active prerelease base 16\.4\.0 was found via a different channel/).to_stderr
+      end
+    end
+
+    it "does not warn when the active prerelease base has same-channel tags" do
+      Dir.mktmpdir do |repo_dir|
+        init_git_repo!(repo_dir)
+        run_git!("tag", "v16.3.0", chdir: repo_dir)
+        run_git!("tag", "v16.4.0.rc.0", chdir: repo_dir)
+
+        changelog = <<~CHANGELOG
+          ### [Unreleased]
+
+          ### [16.4.0.rc.0] - 2026-03-01
+          #### Added
+          - Feature from rc.0
+        CHANGELOG
+
+        expect do
+          version = compute_auto_version(changelog, "rc", repo_dir)
+          expect(version).to eq("16.4.0.rc.1")
+        end.not_to output(/different channel/).to_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fix dead cross-channel warning in `next_active_prerelease_version`. The check passed `nil` as the channel into `prerelease_indices_from_tags`, which interpolates as `""` and produces a regex requiring a literal `..` in the tag (e.g., `/\A16\.4\.0\.\.(\d+)\z/i`) — no real tag matches, so the warning never fired.
- Extract `other_prerelease_channel_present?` that iterates the other known prerelease channels (`test`/`beta`/`alpha`/`rc`/`pre` minus the current `mode`) and reports whether any has tags for the active base.
- Add RSpec coverage for both the positive (warning fires when only a different channel is tagged) and negative (no warning when the active channel has tags) paths.

Closes #3415. Follow-up to deferred review feedback from #3414.

## Test plan
- [x] `bundle exec rubocop react_on_rails/rakelib/update_changelog.rake react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb` — passes
- [x] `bundle exec rspec react_on_rails/spec/react_on_rails/update_changelog_rake_helpers_spec.rb` — 33 examples, 0 failures (including the 2 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small rake-helper fix with targeted specs; only affects stderr warnings during version computation, not release artifacts.
> 
> **Overview**
> Repairs the **cross-channel prerelease warning** in `update_changelog` auto-versioning when `rc`/`beta` mode reuses an active base but has **no tags for the current channel**.
> 
> The old guard called `prerelease_indices_from_tags` with a `nil` channel, which built an invalid tag pattern (`..` in the version segment) so the warning **never ran**. It now uses **`other_prerelease_channel_present?`**, which scans the other known prerelease channels (`test`, `beta`, `alpha`, `rc`, `pre`) for tags on that base and emits stderr only when tags exist only on another channel.
> 
> **Specs** cover both paths: warning when only `beta` tags exist but computing `rc`, and silence when same-channel `rc` tags are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96504a591b9bad769ac9642cc59fde81b62d893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined prerelease version warning logic so alerts are shown only when prerelease indices are missing for the current channel and evidence exists of prerelease activity in other channels, reducing spurious warnings.

* **Tests**
  * Added tests that verify warning behavior when prerelease tags exist in different channels versus the same channel, ensuring correct version selection and messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->