### PR TITLE
docs: allow force-push after a clean rebase without confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 
 ### Ask First
 
-- Destructive git operations: `reset --hard` on a branch with work, branch deletion, or force-push that drops/squashes commits or republishes a conflicted rebase. (Force-push after a clean rebase — no conflicts, all commits preserved — is OK without asking.)
+- Destructive git operations: `reset --hard` on a branch with work, branch deletion, or force-push that drops/squashes commits, republishes a conflicted rebase, or runs when the remote has commits you don't have locally. (Force-push after a clean rebase — no conflicts, all commits preserved — is OK without asking.)
 - Changes to CI workflows (`.github/workflows/`)
 - Changes to build configuration (`package.json` scripts, webpack config)
 - Modifying the Pro package (`react_on_rails_pro/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 
 ### Ask First
 
-- Destructive git operations (force push, reset --hard, branch deletion)
+- Destructive git operations: `reset --hard` on a branch with work, branch deletion, or force-push that drops/squashes commits or republishes a conflicted rebase. (Force-push after a clean rebase — no conflicts, all commits preserved — is OK without asking.)
 - Changes to CI workflows (`.github/workflows/`)
 - Changes to build configuration (`package.json` scripts, webpack config)
 - Modifying the Pro package (`react_on_rails_pro/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,11 @@ If this file conflicts with `AGENTS.md`, follow `AGENTS.md`.
 
 ## Git Safety
 
-- **NEVER force-push** (`--force`, `--force-with-lease`) unless the user explicitly requests it. Force-pushing destroys commit history that may represent significant prior work.
-- **NEVER `git reset --hard`** on a branch that has existing commits (yours or others'). This destroys work.
-- When you need to start fresh or test something without affecting an existing branch, **use a git worktree** (`git worktree add`) or **create a new branch** instead of resetting the current one.
-- If a rebase has conflicts, abort and ask the user how to proceed rather than force-pushing a rewritten history.
+- **Clean rebase → `git push --force-with-lease` without asking.** When `git rebase origin/main` (or `git pull --rebase`) reports no conflicts, every commit is preserved — republishing is the expected workflow. Just push and report the result.
+- **Ask first when force-pushing in these cases:** you resolved rebase conflicts, you dropped/squashed/reordered commits, or the remote branch has commits you don't have locally.
+- **NEVER `git reset --hard`** on a branch with existing commits (yours or others'). This destroys work. Use a worktree or a new branch instead.
+- **NEVER force-push to `main` or `master`.**
+- If a rebase has conflicts you can't resolve cleanly, abort and ask the user how to proceed.
 
 ## Claude-Specific Workflow
 


### PR DESCRIPTION
## Summary

After a clean `git rebase origin/main` (no conflicts, all commits replayed), agents previously paused to ask before `git push --force-with-lease`. That confirmation step is friction — a clean rebase preserves every commit, so republishing is the standard, expected workflow.

This PR updates `CLAUDE.md` and `AGENTS.md` to:

- Allow force-push **without asking** after a clean rebase.
- Keep "Ask first" for cases that can actually lose work: resolved-conflict rebases, dropped/squashed/reordered commits, or a remote branch that has commits you don't have locally.
- Keep the hard prohibitions: never `reset --hard` on a branch with work, never force-push to `main`/`master`.

## Test plan

- [ ] Verify the rendered Markdown reads cleanly on GitHub.
- [ ] Confirm no other docs (e.g. `react_on_rails_pro/CLAUDE.md`) reassert the stricter rule. (Spot-checked — only the two files above carry the policy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to AI agent guidelines; no runtime, auth, or application code is affected.
> 
> **Overview**
> Updates agent git-safety docs so a **clean rebase** (no conflicts, commits preserved) may be followed by **`git push --force-with-lease` without asking**.
> 
> **`CLAUDE.md`** replaces a blanket “never force-push” stance with explicit rules: push after a clean rebase; still ask before force-push when conflicts were resolved, history was rewritten, or the remote has unknown commits; keep bans on `reset --hard` with existing work and force-push to **`main`/`master`**.
> 
> **`AGENTS.md`** folds the same nuance into **Ask First**: destructive git ops still need confirmation, except force-push after a clean rebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23915c59ff2c07433296eea1bf9c7c3fcaa9a29d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified git safety guidance: expanded the “ask first” rule to explicitly cover destructive operations (e.g., hard resets, branch deletion, force-pushes that drop/squash/reorder commits or republish conflicted rebases, or when remote has commits missing locally).
  * Added explicit exception allowing force-push after a clean rebase/pull with no conflicts; reinforced prohibitions for main/master and other high-risk cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->