### PR TITLE
chore: add pnpm 10 build allowlist and update Docker example

### DIFF
--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -110,7 +110,7 @@ CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 Replace the Yarn lines with:
 
 ```dockerfile
-RUN corepack enable && corepack prepare pnpm@9 --activate  # pin to your project's major version
+RUN corepack enable && corepack prepare pnpm@10 --activate  # pin to your project's major version
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -154,6 +154,16 @@
       "picomatch@<2.3.2": ">=2.3.2 <3",
       "picomatch@>=4.0.0 <4.0.4": ">=4.0.4 <5",
       "yaml@>=1.0.0 <1.10.3": ">=1.10.3 <2"
-    }
+    },
+    "// for onlyBuiltDependencies": [
+      "pnpm 10 blocks lifecycle scripts by default. Allowlist packages we trust.",
+      "When adding native or compiled dependencies, run pnpm ignored-builds and add trusted packages here.",
+      "@swc/core: postinstall verifies the platform-specific native binary loads.",
+      "unrs-resolver: napi-postinstall check, used by eslint-import-resolver-typescript."
+    ],
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3400 (pnpm v10 upgrade) addressing two small gaps that PR did not cover:

- **Root `package.json`**: add `onlyBuiltDependencies` allowlist. pnpm 10 blocks lifecycle scripts by default, so without an allowlist `pnpm install` warns and skips needed postinstalls.
  - `@swc/core` — postinstall verifies the platform-specific native binary loads
  - `unrs-resolver` — napi-postinstall check, used by `eslint-import-resolver-typescript`
- **`docs/oss/deployment/docker-deployment.md`**: the example still pinned `pnpm@9`; bumped to `pnpm@10` to match the workspace.

The accompanying `"// for onlyBuiltDependencies"` comment array documents intent and includes a maintenance note: when adding native or compiled dependencies, run `pnpm ignored-builds` and add trusted packages here.

## Notes

`pnpm install` still reports one remaining ignored build after this change: `protobufjs@7.6.0`. Its `postinstall` is a version-scheme warning script (returns early in most cases), not a build step, so it is intentionally **not** allowlisted.

## Background

PR #3380 (closed, superseded) attempted both this and the pnpm bump itself. #3400 landed the pnpm bump (to a newer `10.33.4`); this PR salvages the remaining useful pieces against current `main`.

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds; pnpm no longer reports `@swc/core` or `unrs-resolver` as ignored
- [x] `npx prettier --check package.json docs/oss/deployment/docker-deployment.md` passes
- [x] JSON validity confirmed
- [ ] CI green on PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and documentation only; no application runtime or auth/data paths change.
> 
> **Overview**
> Aligns the repo with **pnpm 10** install behavior and Docker docs after the earlier pnpm bump.
> 
> Root **`package.json`** now sets **`pnpm.onlyBuiltDependencies`** so trusted packages can run lifecycle scripts (`@swc/core`, `unrs-resolver`), with inline comments on maintenance via `pnpm ignored-builds`. **`docs/oss/deployment/docker-deployment.md`** updates the pnpm Docker snippet from **`pnpm@9`** to **`pnpm@10`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa7c2207c7f13be1a81fae1f469c8d34f0ebec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Docker deployment instructions to use pnpm version 10.

* **Chores**
  * Added an allowlist to the package manager configuration to restrict which dependencies may run build/lifecycle scripts during installation, improving security and build stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->