### PR TITLE
Document OTel lifecycle ownership; centralize integration API test mocks

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/integrations/api.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/integrations/api.ts
@@ -35,6 +35,8 @@ export {
   MessageNotifier,
 } from '../shared/errorReporter.js';
 export {
+  resetTracing,
+  resetSubSpan,
   setupTracing,
   setupSubSpan,
   subSpan,
@@ -45,22 +47,10 @@ export {
   SubSpanFn,
   SubSpanController,
 } from '../shared/tracing.js';
-/**
- * Lifecycle teardown helpers for integrations that own the active tracing state.
- * Do not call these while another integration owns tracing or while SSR requests
- * are in flight.
- */
-export { resetTracing, resetSubSpan } from '../shared/tracing.js';
-export { getOpenTelemetryTracerProvider } from '../shared/opentelemetryState.js';
-/**
- * Updates the OpenTelemetry lifecycle owner. Callers must pair provider
- * ownership with cleanup and must not call this during another init/shutdown
- * cycle.
- *
- * Note: getOpenTelemetryTracerProvider above is read-only and has no such
- * restriction.
- */
-export { setOpenTelemetryTracerProvider } from '../shared/opentelemetryState.js';
+export {
+  getOpenTelemetryTracerProvider,
+  setOpenTelemetryTracerProvider,
+} from '../shared/opentelemetryState.js';
 export {
   configureFastify,
   registerFastifyConfigFunction,

--- a/packages/react-on-rails-pro-node-renderer/src/integrations/api.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/integrations/api.ts
@@ -35,8 +35,6 @@ export {
   MessageNotifier,
 } from '../shared/errorReporter.js';
 export {
-  resetTracing,
-  resetSubSpan,
   setupTracing,
   setupSubSpan,
   subSpan,
@@ -47,10 +45,22 @@ export {
   SubSpanFn,
   SubSpanController,
 } from '../shared/tracing.js';
-export {
-  getOpenTelemetryTracerProvider,
-  setOpenTelemetryTracerProvider,
-} from '../shared/opentelemetryState.js';
+/**
+ * Lifecycle teardown helpers for integrations that own the active tracing state.
+ * Do not call these while another integration owns tracing or while SSR requests
+ * are in flight.
+ */
+export { resetTracing, resetSubSpan } from '../shared/tracing.js';
+export { getOpenTelemetryTracerProvider } from '../shared/opentelemetryState.js';
+/**
+ * Updates the OpenTelemetry lifecycle owner. Callers must pair provider
+ * ownership with cleanup and must not call this during another init/shutdown
+ * cycle.
+ *
+ * Note: getOpenTelemetryTracerProvider above is read-only and has no such
+ * restriction.
+ */
+export { setOpenTelemetryTracerProvider } from '../shared/opentelemetryState.js';
 export {
   configureFastify,
   registerFastifyConfigFunction,

--- a/packages/react-on-rails-pro-node-renderer/src/shared/opentelemetryState.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/opentelemetryState.ts
@@ -6,6 +6,13 @@ export function getOpenTelemetryTracerProvider(): NodeTracerProviderType | null 
   return tracerProvider;
 }
 
+/**
+ * Updates the process-global OpenTelemetry provider reference.
+ *
+ * Caller contract: only integrations that own the OpenTelemetry init/shutdown
+ * lifecycle should call this, and the value must mirror that lifecycle's
+ * current provider ownership.
+ */
 export function setOpenTelemetryTracerProvider(provider: NodeTracerProviderType | null): void {
   tracerProvider = provider;
 }

--- a/packages/react-on-rails-pro-node-renderer/src/shared/tracing.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/tracing.ts
@@ -94,6 +94,9 @@ export function trace<T>(fn: UnitOfWork<T>, unitOfWorkOptions: UnitOfWorkOptions
 /**
  * Resets the installed tracing executor + startSsrRequestOptions back to
  * defaults. Integrations use this during lifecycle teardown or failed initialization cleanup.
+ *
+ * Caller contract: only integrations that own the active tracing lifecycle
+ * should call this, and only while tearing that lifecycle down.
  */
 export function resetTracing(): void {
   executor = (fn) => fn();
@@ -226,6 +229,9 @@ export function subSpan<T>(
 /**
  * Resets the installed sub-span implementation back to the default pass-through.
  * Integrations use this during lifecycle teardown or failed initialization cleanup.
+ *
+ * Caller contract: only integrations that own the active sub-span lifecycle
+ * should call this, and only while tearing that lifecycle down.
  */
 export function resetSubSpan(): void {
   subSpanImpl = defaultSubSpan;

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry-init.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry-init.test.ts
@@ -6,6 +6,8 @@ import {
   propagation as otelPropagation,
   trace as otelTrace,
 } from '@opentelemetry/api';
+// Static import is intentional: WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS is a primitive
+// constant, so it is unaffected by jest.resetModules() in beforeEach.
 import { WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS } from '../../src/integrations/api.js';
 
 const resetOpenTelemetryForTest = async () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry-init.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry-init.test.ts
@@ -6,11 +6,33 @@ import {
   propagation as otelPropagation,
   trace as otelTrace,
 } from '@opentelemetry/api';
+import { WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS } from '../../src/integrations/api.js';
 
 const resetOpenTelemetryForTest = async () => {
   const testUtils = await import('../../src/testUtils/opentelemetry');
   await testUtils.resetOpenTelemetryForTest();
 };
+
+const createLogMock = () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+});
+
+const createIntegrationsApiMock = (log: ReturnType<typeof createLogMock>) => ({
+  log,
+  message: jest.fn(),
+  resetTracing: jest.fn(),
+  resetSubSpan: jest.fn(),
+  setupTracing: jest.fn(),
+  setupSubSpan: jest.fn(),
+  getOpenTelemetryTracerProvider: jest.fn(() => null),
+  setOpenTelemetryTracerProvider: jest.fn(),
+  registerFastifyConfigFunction: jest.fn(() => jest.fn()),
+  WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS,
+  registerWorkerShutdownHook: jest.fn(() => jest.fn()),
+});
 
 describe('opentelemetry integration: init() failure path', () => {
   beforeEach(() => {
@@ -30,8 +52,6 @@ describe('opentelemetry integration: init() failure path', () => {
     jest.dontMock('@opentelemetry/sdk-trace-base');
     jest.dontMock('@opentelemetry/sdk-trace-node');
     jest.dontMock('../../src/integrations/api.js');
-    jest.dontMock('../../src/worker/fastifyConfig.js');
-    jest.dontMock('../../src/worker/shutdownHooks.js');
     jest.dontMock('fastify');
     jest.restoreAllMocks();
     otelTrace.disable();
@@ -135,13 +155,15 @@ describe('opentelemetry integration: init() failure path', () => {
       let configureFastifyCallback: ((app: { addHook: jest.Mock }) => void) | undefined;
       let onClose: (() => Promise<void>) | undefined;
       const shutdown = jest.fn(() => new Promise<void>(() => undefined));
+      const log = createLogMock();
+      const registerFastifyConfigFunction = jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
+        configureFastifyCallback = callback;
+        return jest.fn();
+      });
 
-      jest.doMock('../../src/worker/fastifyConfig.js', () => ({
-        __resetFastifyConfigFunctionsForTest: jest.fn(),
-        registerFastifyConfigFunction: jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
-          configureFastifyCallback = callback;
-          return jest.fn();
-        }),
+      jest.doMock('../../src/integrations/api.js', () => ({
+        ...createIntegrationsApiMock(log),
+        registerFastifyConfigFunction,
       }));
       jest.doMock('@opentelemetry/sdk-trace-node', () => ({
         NodeTracerProvider: jest.fn(function NodeTracerProvider() {
@@ -178,9 +200,10 @@ describe('opentelemetry integration: init() failure path', () => {
 
   test('init() does not register a Fastify shutdown hook when provider.register() fails', async () => {
     const registerFastifyConfigFunction = jest.fn();
+    const log = createLogMock();
 
-    jest.doMock('../../src/worker/fastifyConfig.js', () => ({
-      __resetFastifyConfigFunctionsForTest: jest.fn(),
+    jest.doMock('../../src/integrations/api.js', () => ({
+      ...createIntegrationsApiMock(log),
       registerFastifyConfigFunction,
     }));
     jest.doMock('@opentelemetry/sdk-trace-node', () => ({
@@ -218,13 +241,26 @@ describe('opentelemetry integration: init() failure path', () => {
 
   test('Fastify onClose disables the global tracer provider so init() can run again', async () => {
     const configureFastifyCallbacks: Array<(app: { addHook: jest.Mock }) => void> = [];
+    const log = createLogMock();
+    // Import real implementations before jest.doMock so the mock factory can
+    // capture their references. beforeEach reset the module registry, so these
+    // are the same fresh instances that the code under test will share.
+    const tracing = await import('../../src/shared/tracing');
+    const opentelemetryState = await import('../../src/shared/opentelemetryState');
+    const registerFastifyConfigFunction = jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
+      configureFastifyCallbacks.push(callback);
+      return jest.fn();
+    });
 
-    jest.doMock('../../src/worker/fastifyConfig.js', () => ({
-      __resetFastifyConfigFunctionsForTest: jest.fn(),
-      registerFastifyConfigFunction: jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
-        configureFastifyCallbacks.push(callback);
-        return jest.fn();
-      }),
+    jest.doMock('../../src/integrations/api.js', () => ({
+      ...createIntegrationsApiMock(log),
+      setupTracing: tracing.setupTracing,
+      setupSubSpan: tracing.setupSubSpan,
+      resetTracing: tracing.resetTracing,
+      resetSubSpan: tracing.resetSubSpan,
+      getOpenTelemetryTracerProvider: opentelemetryState.getOpenTelemetryTracerProvider,
+      setOpenTelemetryTracerProvider: opentelemetryState.setOpenTelemetryTracerProvider,
+      registerFastifyConfigFunction,
     }));
 
     const { trace } = await import('@opentelemetry/api');
@@ -232,7 +268,6 @@ describe('opentelemetry integration: init() failure path', () => {
     const firstExporter = new InMemorySpanExporter();
     const secondExporter = new InMemorySpanExporter();
     const otel = await import('../../src/integrations/opentelemetry');
-    const tracing = await import('../../src/shared/tracing');
 
     const installOnCloseHook = async () => {
       let onClose: (() => Promise<void>) | undefined;
@@ -285,13 +320,18 @@ describe('opentelemetry integration: init() failure path', () => {
 
   test('worker shutdown hook disables the global tracer provider so init() can run again', async () => {
     let workerShutdownHook: (() => Promise<void>) | undefined;
+    const log = createLogMock();
+    const opentelemetryState = await import('../../src/shared/opentelemetryState');
+    const registerWorkerShutdownHook = jest.fn((hook: () => Promise<void>) => {
+      workerShutdownHook = hook;
+      return jest.fn();
+    });
 
-    jest.doMock('../../src/worker/shutdownHooks.js', () => ({
-      __resetWorkerShutdownHooksForTest: jest.fn(),
-      registerWorkerShutdownHook: jest.fn((hook: () => Promise<void>) => {
-        workerShutdownHook = hook;
-        return jest.fn();
-      }),
+    jest.doMock('../../src/integrations/api.js', () => ({
+      ...createIntegrationsApiMock(log),
+      getOpenTelemetryTracerProvider: opentelemetryState.getOpenTelemetryTracerProvider,
+      setOpenTelemetryTracerProvider: opentelemetryState.setOpenTelemetryTracerProvider,
+      registerWorkerShutdownHook,
     }));
 
     const { trace } = await import('@opentelemetry/api');
@@ -322,18 +362,9 @@ describe('opentelemetry integration: init() failure path', () => {
   });
 
   test('OpenTelemetry diagnostics preserve warn and error severity in renderer logs', async () => {
-    const log = {
-      debug: jest.fn(),
-      error: jest.fn(),
-      info: jest.fn(),
-      warn: jest.fn(),
-    };
+    const log = createLogMock();
 
-    jest.doMock('../../src/integrations/api.js', () => ({
-      ...jest.requireActual<typeof import('../../src/integrations/api.js')>('../../src/integrations/api.js'),
-      log,
-      message: jest.fn(),
-    }));
+    jest.doMock('../../src/integrations/api.js', () => createIntegrationsApiMock(log));
 
     const { diag } = await import('@opentelemetry/api');
     const { InMemorySpanExporter, SimpleSpanProcessor } = await import('@opentelemetry/sdk-trace-base');
@@ -357,6 +388,10 @@ describe('opentelemetry integration: init() failure path', () => {
   });
 
   test('init() clears global OTel state when Fastify shutdown hook registration fails', async () => {
+    const log = createLogMock();
+    const errorReporter = await import('../../src/shared/errorReporter');
+    const messageSpy = jest.spyOn(errorReporter, 'message');
+    const opentelemetryState = await import('../../src/shared/opentelemetryState');
     const registerFastifyConfigFunction = jest
       .fn((_callback: (app: { addHook: jest.Mock }) => void) => jest.fn())
       .mockImplementationOnce(() => {
@@ -364,15 +399,16 @@ describe('opentelemetry integration: init() failure path', () => {
       })
       .mockImplementationOnce(() => jest.fn());
 
-    jest.doMock('../../src/worker/fastifyConfig.js', () => ({
-      __resetFastifyConfigFunctionsForTest: jest.fn(),
+    jest.doMock('../../src/integrations/api.js', () => ({
+      ...createIntegrationsApiMock(log),
+      message: errorReporter.message,
+      getOpenTelemetryTracerProvider: opentelemetryState.getOpenTelemetryTracerProvider,
+      setOpenTelemetryTracerProvider: opentelemetryState.setOpenTelemetryTracerProvider,
       registerFastifyConfigFunction,
     }));
 
     const { trace } = await import('@opentelemetry/api');
     const { InMemorySpanExporter, SimpleSpanProcessor } = await import('@opentelemetry/sdk-trace-base');
-    const errorReporter = await import('../../src/shared/errorReporter');
-    const messageSpy = jest.spyOn(errorReporter, 'message');
     const firstExporter = new InMemorySpanExporter();
     const secondExporter = new InMemorySpanExporter();
     const otel = await import('../../src/integrations/opentelemetry');
@@ -446,27 +482,16 @@ describe('opentelemetry integration: init() failure path', () => {
     try {
       let configureFastifyCallback: ((app: { addHook: jest.Mock }) => void) | undefined;
       let onClose: (() => Promise<void>) | undefined;
-      const log = {
-        debug: jest.fn(),
-        error: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-      };
+      const log = createLogMock();
       const shutdown = jest.fn(() => new Promise<void>(() => undefined));
+      const registerFastifyConfigFunction = jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
+        configureFastifyCallback = callback;
+        return jest.fn();
+      });
 
-      jest.doMock('../../src/worker/fastifyConfig.js', () => ({
-        __resetFastifyConfigFunctionsForTest: jest.fn(),
-        registerFastifyConfigFunction: jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
-          configureFastifyCallback = callback;
-          return jest.fn();
-        }),
-      }));
       jest.doMock('../../src/integrations/api.js', () => ({
-        ...jest.requireActual<typeof import('../../src/integrations/api.js')>(
-          '../../src/integrations/api.js',
-        ),
-        log,
-        message: jest.fn(),
+        ...createIntegrationsApiMock(log),
+        registerFastifyConfigFunction,
       }));
       jest.doMock('@opentelemetry/sdk-trace-node', () => ({
         NodeTracerProvider: jest.fn(function NodeTracerProvider() {
@@ -566,32 +591,21 @@ describe('opentelemetry integration: init() failure path', () => {
       let configureFastifyCallback: ((app: { addHook: jest.Mock }) => void) | undefined;
       let onClose: (() => Promise<void>) | undefined;
       let rejectShutdown: ((error: Error) => void) | undefined;
-      const log = {
-        debug: jest.fn(),
-        error: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-      };
+      const log = createLogMock();
       const shutdown = jest.fn(
         () =>
           new Promise<void>((_resolve, reject) => {
             rejectShutdown = reject;
           }),
       );
+      const registerFastifyConfigFunction = jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
+        configureFastifyCallback = callback;
+        return jest.fn();
+      });
 
-      jest.doMock('../../src/worker/fastifyConfig.js', () => ({
-        __resetFastifyConfigFunctionsForTest: jest.fn(),
-        registerFastifyConfigFunction: jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
-          configureFastifyCallback = callback;
-          return jest.fn();
-        }),
-      }));
       jest.doMock('../../src/integrations/api.js', () => ({
-        ...jest.requireActual<typeof import('../../src/integrations/api.js')>(
-          '../../src/integrations/api.js',
-        ),
-        log,
-        message: jest.fn(),
+        ...createIntegrationsApiMock(log),
+        registerFastifyConfigFunction,
       }));
       jest.doMock('@opentelemetry/sdk-trace-node', () => ({
         NodeTracerProvider: jest.fn(function NodeTracerProvider() {


### PR DESCRIPTION
### Summary

Incremental polish on top of the now-merged [#3456](https://github.com/shakacode/react_on_rails/pull/3456). PR #3456 already moved the OpenTelemetry integration through `integrations/api.js` and removed the `no-restricted-imports` escape hatch. This PR adds two follow-ups:

1. **Lifecycle ownership docs on the public surface.** Groups `resetTracing` / `resetSubSpan` and `setOpenTelemetryTracerProvider` exports in `integrations/api.ts` under JSDoc that calls out they are owned by a single integration lifecycle and not safe to invoke concurrently. Same caller contract is repeated on the underlying source declarations in `shared/tracing.ts` and `shared/opentelemetryState.ts` so deep importers see it too.
2. **Centralized OTel init test mocks.** Refactors `opentelemetry-init.test.ts` to mock `integrations/api.js` via a single `createIntegrationsApiMock` helper, instead of `jest.doMock`ing `worker/fastifyConfig.js` and `worker/shutdownHooks.js` directly. The test surface now matches the architectural boundary that `opentelemetry.ts` actually uses.

No source behavior change — comments only on the source side; tests are a refactor with no new coverage gaps.

### Verification

- [x] `corepack pnpm --filter react-on-rails-pro-node-renderer exec jest tests/integrations/opentelemetry-init.test.ts tests/integrations/api.test.ts tests/integrations/opentelemetry.test.ts --runInBand` (17 + 7 = 24 tests pass)
- [x] `corepack pnpm --filter react-on-rails-pro-node-renderer run type-check`
- [x] `corepack pnpm exec prettier --check` on the four modified files
- [x] `corepack pnpm --filter react-on-rails-pro-node-renderer exec eslint` on the four modified files

### Pull Request Checklist

- [x] Add/update test to cover these changes (test refactor; no new uncovered behavior)
- [ ] ~Update documentation~ (JSDoc only)
- [ ] ~Update CHANGELOG file~ (no user-visible change)

### Other Information

Refs #3419. Rebased onto current `main` on 2026-05-27 — squashed prior 11 review-iteration commits into a single commit since the core API exposure work in those commits is already on `main` via #3456.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments-only in production code; test refactor aligned with the existing integrations API boundary with no new runtime paths.
> 
> **Overview**
> Follow-up polish after the OpenTelemetry integration boundary work in #3456: **no runtime behavior changes**.
> 
> **Documentation** adds explicit **caller contracts** on `setOpenTelemetryTracerProvider`, `resetTracing`, and `resetSubSpan` in `shared/opentelemetryState.ts` and `shared/tracing.ts`—only the integration that owns init/shutdown should touch these, and only during teardown.
> 
> **Tests** in `opentelemetry-init.test.ts` now mock **`integrations/api.js`** through shared helpers (`createLogMock`, `createIntegrationsApiMock`) instead of reaching into `worker/fastifyConfig.js` and `worker/shutdownHooks.js`. Tests that need real tracing/state wire real implementations through the mock; `WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS` is imported statically so it survives `jest.resetModules()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67ef66ba1c4530f9dba9ea954bc82ac7ee6ab799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for OpenTelemetry integration contracts and lifecycle management.

* **Tests**
  * Refactored test scaffolding with shared helper utilities for improved test maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->