### PR TITLE
Disable dummy StrictMode in production benchmark builds

### DIFF
--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -6,7 +6,7 @@ gem "shakapacker", "9.6.1"
 gem "bootsnap", require: false
 gem "rails", "~> 7.1.0"
 
-gem "sqlite3", "~> 1.6"
+gem "sqlite3", "~> 2.0"
 gem "sass-rails", "~> 6.0"
 gem "uglifier"
 gem "jquery-rails"

--- a/react_on_rails/Gemfile.lock
+++ b/react_on_rails/Gemfile.lock
@@ -379,10 +379,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3)
+    sqlite3 (2.9.4)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.3-arm64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
     steep (1.9.4)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -479,7 +479,7 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
   spring (~> 4.0)
   sprockets (~> 4.0)
-  sqlite3 (~> 1.6)
+  sqlite3 (~> 2.0)
   steep
   turbo-rails
   turbolinks

--- a/react_on_rails/spec/dummy/Gemfile.lock
+++ b/react_on_rails/spec/dummy/Gemfile.lock
@@ -367,8 +367,10 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.3)
+    sqlite3 (2.9.4)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
     steep (1.9.4)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -465,7 +467,7 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
   spring (~> 4.0)
   sprockets (~> 4.0)
-  sqlite3 (~> 1.6)
+  sqlite3 (~> 2.0)
   steep
   turbo-rails
   turbolinks

--- a/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
@@ -6,6 +6,8 @@ import '@hotwired/turbo-rails';
 
 import ReactOnRails from 'react-on-rails/client';
 
+const useStrictMode = process.env.NODE_ENV !== 'production';
+
 import HelloTurboStream from '../startup/HelloTurboStream';
 import ManualRenderComponent from '../startup/ManualRenderComponent';
 import SharedReduxStore from '../stores/SharedReduxStore';
@@ -27,7 +29,7 @@ const STRICT_MODE_PATCHED = '__reactOnRailsDummyStrictModePatched';
 // webpack compilation (e.g., a standalone bundle config) would get its own unpatched module
 // instance. When adding a pack like that, either fold it into this compilation or duplicate
 // this `STRICT_MODE_PATCHED` block at the top of the new pack before any `register` calls.
-if (!ReactOnRails[STRICT_MODE_PATCHED]) {
+if (useStrictMode && !ReactOnRails[STRICT_MODE_PATCHED]) {
   const originalRegister = ReactOnRails.register.bind(ReactOnRails);
 
   ReactOnRails.register = (components) =>

--- a/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
+++ b/react_on_rails/spec/dummy/client/app/packs/client-bundle.js
@@ -6,12 +6,12 @@ import '@hotwired/turbo-rails';
 
 import ReactOnRails from 'react-on-rails/client';
 
-const useStrictMode = process.env.NODE_ENV !== 'production';
-
 import HelloTurboStream from '../startup/HelloTurboStream';
 import ManualRenderComponent from '../startup/ManualRenderComponent';
 import SharedReduxStore from '../stores/SharedReduxStore';
 import { wrapRegisteredComponentsWithStrictMode } from '../strictModeSupport';
+
+const useStrictMode = process.env.NODE_ENV !== 'production';
 
 const STRICT_MODE_PATCHED = '__reactOnRailsDummyStrictModePatched';
 

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -10,6 +10,7 @@ const wrappedFunctionComponents = new WeakMap();
 const wrappedRenderFunctions = new WeakMap();
 // Object-typed React components (memo, forwardRef, lazy) are GC-safe in a WeakMap.
 const wrappedObjectComponents = new WeakMap();
+const useStrictMode = process.env.NODE_ENV !== 'production';
 
 const isPromiseLike = (value) =>
   typeof value === 'object' && value !== null && typeof value.then === 'function';
@@ -58,6 +59,10 @@ const createStrictModeWrapper = (Component) => {
 };
 
 const wrapComponentInStrictMode = (component) => {
+  if (!useStrictMode) {
+    return component;
+  }
+
   if (typeof component === 'function') {
     const cachedComponent = wrappedFunctionComponents.get(component);
     if (cachedComponent) {
@@ -79,9 +84,14 @@ const wrapComponentInStrictMode = (component) => {
   return wrappedComponent;
 };
 
-export const wrapElementInStrictMode = (reactElement) => <React.StrictMode>{reactElement}</React.StrictMode>;
+export const wrapElementInStrictMode = (reactElement) =>
+  useStrictMode ? <React.StrictMode>{reactElement}</React.StrictMode> : reactElement;
 
 const wrapRenderFunctionResult = (result) => {
+  if (!useStrictMode) {
+    return result;
+  }
+
   if (isPromiseLike(result)) {
     return result.then(wrapRenderFunctionResult);
   }
@@ -103,6 +113,10 @@ const wrapRenderFunctionResult = (result) => {
 // re-entry path unreachable. Note: when called directly (outside the registry path), the wrapper's
 // hardcoded `length === 2` does not reflect the original function's arity.
 const wrapRenderFunctionInStrictMode = (renderFunction) => {
+  if (!useStrictMode) {
+    return renderFunction;
+  }
+
   const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
   if (cachedRenderFunction) {
     return cachedRenderFunction;
@@ -123,8 +137,12 @@ const wrapRenderFunctionInStrictMode = (renderFunction) => {
   return wrappedRenderFunction;
 };
 
-export const wrapRegisteredComponentsWithStrictMode = (components) =>
-  Object.fromEntries(
+export const wrapRegisteredComponentsWithStrictMode = (components) => {
+  if (!useStrictMode) {
+    return components;
+  }
+
+  return Object.fromEntries(
     Object.entries(components).map(([name, component]) => {
       if (isRendererFunction(component)) {
         return [name, component];
@@ -141,3 +159,4 @@ export const wrapRegisteredComponentsWithStrictMode = (components) =>
       return [name, wrapComponentInStrictMode(component)];
     }),
   );
+};

--- a/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
+++ b/react_on_rails/spec/dummy/client/app/strictModeSupport.jsx
@@ -1,16 +1,47 @@
 import React from 'react';
 
-const REACT_OBJECT_COMPONENT_TYPES = new Set([
-  Symbol.for('react.forward_ref'),
-  Symbol.for('react.lazy'),
-  Symbol.for('react.memo'),
-]);
-
-const wrappedFunctionComponents = new WeakMap();
-const wrappedRenderFunctions = new WeakMap();
-// Object-typed React components (memo, forwardRef, lazy) are GC-safe in a WeakMap.
-const wrappedObjectComponents = new WeakMap();
 const useStrictMode = process.env.NODE_ENV !== 'production';
+let reactObjectComponentTypes;
+let wrappedFunctionComponents;
+let wrappedRenderFunctions;
+let wrappedObjectComponents;
+
+const getReactObjectComponentTypes = () => {
+  if (!reactObjectComponentTypes) {
+    reactObjectComponentTypes = new Set([
+      Symbol.for('react.forward_ref'),
+      Symbol.for('react.lazy'),
+      Symbol.for('react.memo'),
+    ]);
+  }
+
+  return reactObjectComponentTypes;
+};
+
+const getWrappedFunctionComponents = () => {
+  if (!wrappedFunctionComponents) {
+    wrappedFunctionComponents = new WeakMap();
+  }
+
+  return wrappedFunctionComponents;
+};
+
+const getWrappedRenderFunctions = () => {
+  if (!wrappedRenderFunctions) {
+    wrappedRenderFunctions = new WeakMap();
+  }
+
+  return wrappedRenderFunctions;
+};
+
+const getWrappedObjectComponents = () => {
+  if (!wrappedObjectComponents) {
+    // Object-typed React components (memo, forwardRef, lazy) are GC-safe in a WeakMap.
+    wrappedObjectComponents = new WeakMap();
+  }
+
+  return wrappedObjectComponents;
+};
 
 const isPromiseLike = (value) =>
   typeof value === 'object' && value !== null && typeof value.then === 'function';
@@ -20,7 +51,7 @@ const isFunctionWithMetadata = (component) => typeof component === 'function';
 const isObjectComponent = (component) =>
   typeof component === 'object' &&
   component !== null &&
-  REACT_OBJECT_COMPONENT_TYPES.has(component.$$typeof ?? 0);
+  getReactObjectComponentTypes().has(component.$$typeof ?? 0);
 
 const isReactComponent = (component) => isFunctionWithMetadata(component) || isObjectComponent(component);
 
@@ -64,23 +95,25 @@ const wrapComponentInStrictMode = (component) => {
   }
 
   if (typeof component === 'function') {
-    const cachedComponent = wrappedFunctionComponents.get(component);
+    const componentCache = getWrappedFunctionComponents();
+    const cachedComponent = componentCache.get(component);
     if (cachedComponent) {
       return cachedComponent;
     }
 
     const wrappedComponent = createStrictModeWrapper(component);
-    wrappedFunctionComponents.set(component, wrappedComponent);
+    componentCache.set(component, wrappedComponent);
     return wrappedComponent;
   }
 
-  const cachedComponent = wrappedObjectComponents.get(component);
+  const objectComponentCache = getWrappedObjectComponents();
+  const cachedComponent = objectComponentCache.get(component);
   if (cachedComponent) {
     return cachedComponent;
   }
 
   const wrappedComponent = createStrictModeWrapper(component);
-  wrappedObjectComponents.set(component, wrappedComponent);
+  objectComponentCache.set(component, wrappedComponent);
   return wrappedComponent;
 };
 
@@ -117,7 +150,8 @@ const wrapRenderFunctionInStrictMode = (renderFunction) => {
     return renderFunction;
   }
 
-  const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
+  const renderFunctionCache = getWrappedRenderFunctions();
+  const cachedRenderFunction = renderFunctionCache.get(renderFunction);
   if (cachedRenderFunction) {
     return cachedRenderFunction;
   }
@@ -133,7 +167,7 @@ const wrapRenderFunctionInStrictMode = (renderFunction) => {
     wrappedRenderFunction.renderFunction = true;
   }
 
-  wrappedRenderFunctions.set(renderFunction, wrappedRenderFunction);
+  renderFunctionCache.set(renderFunction, wrappedRenderFunction);
   return wrappedRenderFunction;
 };
 

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
@@ -1,7 +1,7 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.full';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+const useStrictMode = process.env.NODE_ENV !== 'production';
 
 // Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
-export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;
+export default useStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
@@ -1,4 +1,6 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.full';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-export default enableStrictModeForReactOnRails(ReactOnRails);
+const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+
+export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js
@@ -3,4 +3,5 @@ import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
 const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
 
+// Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
 export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
@@ -1,4 +1,6 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.client';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-export default enableStrictModeForReactOnRails(ReactOnRails);
+const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+
+export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
@@ -3,4 +3,5 @@ import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
 const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
 
+// Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
 export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js
@@ -1,7 +1,7 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.client';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+const useStrictMode = process.env.NODE_ENV !== 'production';
 
 // Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
-export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;
+export default useStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
@@ -8,4 +8,6 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.node';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-export default enableStrictModeForReactOnRails(ReactOnRails);
+const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+
+export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
@@ -8,7 +8,7 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.node';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-// Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
-export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;
+const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
 
+// Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
 export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
@@ -8,7 +8,7 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.node';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+const useStrictMode = process.env.NODE_ENV !== 'production';
 
 // Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
-export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;
+export default useStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js
@@ -8,6 +8,7 @@
 import ReactOnRails from 'react-on-rails-pro/ReactOnRails.node';
 import { enableStrictModeForReactOnRails } from './strictModeSupport';
 
-const shouldEnableStrictMode = process.env.NODE_ENV !== 'production';
+// Outer guard for clarity; enableStrictModeForReactOnRails also no-ops in production.
+export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;
 
 export default shouldEnableStrictMode ? enableStrictModeForReactOnRails(ReactOnRails) : ReactOnRails;

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -27,16 +27,50 @@ type ReactOnRailsWithRegister = {
 };
 
 const STRICT_MODE_PATCHED = '__reactOnRailsProDummyStrictModePatched';
-const REACT_OBJECT_COMPONENT_TYPES = new Set<symbol | number>([
-  Symbol.for('react.forward_ref'),
-  Symbol.for('react.lazy'),
-  Symbol.for('react.memo'),
-]);
 const useStrictMode = process.env.NODE_ENV !== 'production';
+let reactObjectComponentTypes: Set<symbol | number> | undefined;
+let wrappedFunctionComponents: WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata> | undefined;
+let wrappedRenderFunctions: WeakMap<RenderFunction, RenderFunction> | undefined;
+let wrappedObjectComponents: WeakMap<ObjectComponent, ComponentWithMetadata> | undefined;
 
-const wrappedFunctionComponents = new WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata>();
-const wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
-const wrappedObjectComponents = new WeakMap<ObjectComponent, ComponentWithMetadata>();
+const getReactObjectComponentTypes = (): Set<symbol | number> => {
+  if (!reactObjectComponentTypes) {
+    reactObjectComponentTypes = new Set<symbol | number>([
+      Symbol.for('react.forward_ref'),
+      Symbol.for('react.lazy'),
+      Symbol.for('react.memo'),
+    ]);
+  }
+
+  return reactObjectComponentTypes;
+};
+
+const getWrappedFunctionComponents = (): WeakMap<
+  CallableComponent | RenderFunction,
+  ComponentWithMetadata
+> => {
+  if (!wrappedFunctionComponents) {
+    wrappedFunctionComponents = new WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata>();
+  }
+
+  return wrappedFunctionComponents;
+};
+
+const getWrappedRenderFunctions = (): WeakMap<RenderFunction, RenderFunction> => {
+  if (!wrappedRenderFunctions) {
+    wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
+  }
+
+  return wrappedRenderFunctions;
+};
+
+const getWrappedObjectComponents = (): WeakMap<ObjectComponent, ComponentWithMetadata> => {
+  if (!wrappedObjectComponents) {
+    wrappedObjectComponents = new WeakMap<ObjectComponent, ComponentWithMetadata>();
+  }
+
+  return wrappedObjectComponents;
+};
 
 const isPromiseLike = (value: unknown): value is Promise<unknown> =>
   typeof value === 'object' &&
@@ -50,7 +84,7 @@ const isFunctionWithMetadata = (component: unknown): component is CallableCompon
 const isObjectComponent = (component: unknown): component is ObjectComponent =>
   typeof component === 'object' &&
   component !== null &&
-  REACT_OBJECT_COMPONENT_TYPES.has((component as ObjectComponent).$$typeof ?? 0);
+  getReactObjectComponentTypes().has((component as ObjectComponent).$$typeof ?? 0);
 
 const isReactComponent = (component: unknown): component is ComponentWithMetadata =>
   isFunctionWithMetadata(component) || isObjectComponent(component);
@@ -100,22 +134,24 @@ const wrapComponentInStrictMode = (component: ComponentWithMetadata): ComponentW
   }
 
   if (typeof component === 'function') {
-    const cachedComponent = wrappedFunctionComponents.get(component);
+    const componentCache = getWrappedFunctionComponents();
+    const cachedComponent = componentCache.get(component);
     if (cachedComponent) {
       return cachedComponent;
     }
 
     const wrappedComponent = createStrictModeWrapper(component);
-    wrappedFunctionComponents.set(component, wrappedComponent);
+    componentCache.set(component, wrappedComponent);
     return wrappedComponent;
   }
 
-  const cachedComponent = wrappedObjectComponents.get(component);
+  const objectComponentCache = getWrappedObjectComponents();
+  const cachedComponent = objectComponentCache.get(component);
   if (cachedComponent) {
     return cachedComponent;
   }
   const wrappedComponent = createStrictModeWrapper(component);
-  wrappedObjectComponents.set(component, wrappedComponent);
+  objectComponentCache.set(component, wrappedComponent);
   return wrappedComponent;
 };
 
@@ -155,7 +191,8 @@ const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderF
     return renderFunction;
   }
 
-  const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
+  const renderFunctionCache = getWrappedRenderFunctions();
+  const cachedRenderFunction = renderFunctionCache.get(renderFunction);
   if (cachedRenderFunction) {
     return cachedRenderFunction;
   }
@@ -171,7 +208,7 @@ const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderF
     wrappedRenderFunction.renderFunction = true;
   }
 
-  wrappedRenderFunctions.set(renderFunction, wrappedRenderFunction);
+  renderFunctionCache.set(renderFunction, wrappedRenderFunction);
   return wrappedRenderFunction;
 };
 

--- a/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx
@@ -32,6 +32,7 @@ const REACT_OBJECT_COMPONENT_TYPES = new Set<symbol | number>([
   Symbol.for('react.lazy'),
   Symbol.for('react.memo'),
 ]);
+const useStrictMode = process.env.NODE_ENV !== 'production';
 
 const wrappedFunctionComponents = new WeakMap<CallableComponent | RenderFunction, ComponentWithMetadata>();
 const wrappedRenderFunctions = new WeakMap<RenderFunction, RenderFunction>();
@@ -94,6 +95,10 @@ const createStrictModeWrapper = (Component: ComponentWithMetadata): React.FC<Rec
 };
 
 const wrapComponentInStrictMode = (component: ComponentWithMetadata): ComponentWithMetadata => {
+  if (!useStrictMode) {
+    return component;
+  }
+
   if (typeof component === 'function') {
     const cachedComponent = wrappedFunctionComponents.get(component);
     if (cachedComponent) {
@@ -114,11 +119,14 @@ const wrapComponentInStrictMode = (component: ComponentWithMetadata): ComponentW
   return wrappedComponent;
 };
 
-export const wrapElementInStrictMode = (reactElement: React.ReactElement): React.ReactElement => (
-  <React.StrictMode>{reactElement}</React.StrictMode>
-);
+export const wrapElementInStrictMode = (reactElement: React.ReactElement): React.ReactElement =>
+  useStrictMode ? <React.StrictMode>{reactElement}</React.StrictMode> : reactElement;
 
 const wrapRenderFunctionResult = (result: unknown): unknown => {
+  if (!useStrictMode) {
+    return result;
+  }
+
   if (isPromiseLike(result)) {
     return result.then(wrapRenderFunctionResult);
   }
@@ -143,6 +151,10 @@ const wrapRenderFunctionResult = (result: unknown): unknown => {
 // orders the renderer check before the render-function check so a 3-arg renderer never reaches
 // this helper through the registry, but direct callers should treat this as a precondition.
 const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderFunction => {
+  if (!useStrictMode) {
+    return renderFunction;
+  }
+
   const cachedRenderFunction = wrappedRenderFunctions.get(renderFunction);
   if (cachedRenderFunction) {
     return cachedRenderFunction;
@@ -163,8 +175,12 @@ const wrapRenderFunctionInStrictMode = (renderFunction: RenderFunction): RenderF
   return wrappedRenderFunction;
 };
 
-export const wrapRegisteredComponentsWithStrictMode = (components: ComponentRegistry): ComponentRegistry =>
-  Object.fromEntries(
+export const wrapRegisteredComponentsWithStrictMode = (components: ComponentRegistry): ComponentRegistry => {
+  if (!useStrictMode) {
+    return components;
+  }
+
+  return Object.fromEntries(
     Object.entries(components).map(([name, component]) => {
       if (isRendererFunction(component)) {
         return [name, component];
@@ -181,8 +197,13 @@ export const wrapRegisteredComponentsWithStrictMode = (components: ComponentRegi
       return [name, wrapComponentInStrictMode(component)];
     }),
   );
+};
 
 export const enableStrictModeForReactOnRails = <T extends ReactOnRailsWithRegister>(reactOnRails: T): T => {
+  if (!useStrictMode) {
+    return reactOnRails;
+  }
+
   if (reactOnRails[STRICT_MODE_PATCHED]) {
     return reactOnRails;
   }


### PR DESCRIPTION
### Summary

Disable the dummy apps' React StrictMode wrapping in production builds so production benchmark runs do not include StrictMode double-render or wrapper overhead.

The OSS and Pro dummy `strictModeSupport` helpers now:

- return components, render functions, and elements unchanged when `NODE_ENV === 'production'`
- return the original registry unchanged before wrapping registered components in production
- lazy-initialize the StrictMode component type Set and wrapper WeakMaps so production imports avoid those cache allocations

The OSS client bundle and Pro ReactOnRails shims keep an outer production guard before monkey-patching `ReactOnRails.register`. The Pro shim guard names are aligned on `useStrictMode` for consistency, and the Pro Node shim no longer has the duplicate default export from the intermediate review-fix commit.

### CI Fix

After rebasing on `origin/main`, the `build` job failed during `react_on_rails` Bundler setup on Ruby 3.4.9 because the OSS lockfile selected `sqlite3-1.7.3-x86_64-linux`, whose gemspec requires Ruby `< 3.4.dev`.

This PR now also aligns the OSS development sqlite dependency with Pro by using `sqlite3 ~> 2.0` and regenerating the OSS package and dummy app lockfiles. The resulting lockfiles use `sqlite3 2.9.4` with the Ruby 3.4-compatible `x86_64-linux-gnu` platform entry.

### Scope

This changes dummy test-app StrictMode files:

- `react_on_rails/spec/dummy/client/app/`
- `react_on_rails_pro/spec/dummy/client/app/`

It also changes OSS development/test dependency metadata:

- `react_on_rails/Gemfile.development_dependencies`
- `react_on_rails/Gemfile.lock`
- `react_on_rails/spec/dummy/Gemfile.lock`

No shipped gem or npm package runtime source is changed. The StrictMode change is part of investigating #3218 by removing dummy-app StrictMode overhead from production benchmark runs; any user-facing runtime remediation should land separately.

### Review Notes

- The branch is rebased on `origin/main` as of `2026-05-27`.
- No unresolved review threads remain as of the latest `/address-review` pass.
- Optional allocation feedback was addressed by lazy-initializing the React object-type Set and wrapper WeakMaps.
- Discuss item advice: this intentionally keeps StrictMode active for `NODE_ENV=test`. If a benchmark is run under `NODE_ENV=test`, this PR will not remove StrictMode overhead for that run; production benchmark jobs should set `NODE_ENV=production`.
- Changelog remains intentionally skipped because the changed files are dummy/spec app scaffolding, not shipped library code.

### CI Note

The `claude-review` check failure is not a code failure in this PR. The job reaches Claude Code startup and fails with `You've hit your weekly limit - resets May 29, 3am (UTC)`. It can continue failing until the Claude quota resets or the workflow/secret quota issue is handled.

### Validation

- `bundle _2.5.9_ check || bundle _2.5.9_ install` in `react_on_rails`
- `bundle _2.5.9_ check || bundle _2.5.9_ install` in `react_on_rails/spec/dummy`
- `ruby script/check-gemfile-lock-platforms`
- `bundle exec rubocop` in `react_on_rails`
- `bundle exec rake rbs:validate` in `react_on_rails`
- `bundle exec rake react_on_rails:generate_packs` in `react_on_rails/spec/dummy`
- `pnpm exec prettier --check react_on_rails/spec/dummy/client/app/packs/client-bundle.js react_on_rails/spec/dummy/client/app/strictModeSupport.jsx react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsPro.js react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProClient.js react_on_rails_pro/spec/dummy/client/app/strictModeReactOnRailsProNode.js react_on_rails_pro/spec/dummy/client/app/strictModeSupport.tsx`
- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run build:test` in `react_on_rails/spec/dummy`
- `pnpm run build:test` in `react_on_rails_pro/spec/dummy`

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ - dummy-app shims only; bundle builds cover the changed entrypoints.
- ~[ ] Update documentation~ - internal dummy-app scaffolding only.
- ~[ ] Update CHANGELOG file~ - dummy apps are not shipped in either gem/package.
