### PR TITLE
feat: implement per-scheduler persistent HTTP client storage

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -43,7 +43,9 @@ module ReactOnRailsPro
     DEFAULT_RENDERER_URL = "http://localhost:3800"
     DEFAULT_RENDERER_METHOD = "ExecJS"
     DEFAULT_RENDERER_FALLBACK_EXEC_JS = true
-    # async-http clients are scoped to each request, so this now limits streams on that request's client.
+    # Maximum concurrent HTTP/2 streams per persistent client. When Fiber.scheduler is available,
+    # clients are reused across requests within the same scheduler, making this limit effective.
+    # Without a scheduler, clients are per-request and this limits streams on that single request.
     DEFAULT_RENDERER_HTTP_POOL_SIZE = 10
     # TCP connect timeout. Request and response processing are still bounded by ssr_timeout.
     DEFAULT_RENDERER_HTTP_POOL_TIMEOUT = 5
@@ -71,24 +73,6 @@ module ReactOnRailsPro
     ROLLING_DEPLOY_UPLOAD_KEYWORD_PARAMS = %i[key keyreq].freeze
     ROLLING_DEPLOY_UPLOAD_ALL_KEYWORD_PARAMS = %i[keyrest].freeze
     ROLLING_DEPLOY_UPLOAD_REQUIRED_KEYWORDS = %i[bundle assets].freeze
-    RENDERER_HTTP_POOL_SIZE_WARNING = "[ReactOnRailsPro] config.renderer_http_pool_size currently has no effect. " \
-                                      "The async-http adapter creates a new client per request, so the pool limit " \
-                                      "is never reached. This setting is kept for forward-compatibility with " \
-                                      "planned persistent connection support (see issue #3283)."
-    RENDERER_HTTP_POOL_SIZE_WARNING_MUTEX = Mutex.new
-
-    private_constant :RENDERER_HTTP_POOL_SIZE_WARNING,
-                     :RENDERER_HTTP_POOL_SIZE_WARNING_MUTEX
-
-    @renderer_http_pool_size_warning_emitted = false
-
-    class << self
-      private
-
-      def reset_renderer_http_pool_size_warning!
-        RENDERER_HTTP_POOL_SIZE_WARNING_MUTEX.synchronize { @renderer_http_pool_size_warning_emitted = false }
-      end
-    end
 
     attr_accessor :renderer_url, :renderer_password, :tracing,
                   :server_renderer, :renderer_use_fallback_exec_js, :prerender_caching,
@@ -120,27 +104,32 @@ module ReactOnRailsPro
       @concurrent_component_streaming_buffer_size = value
     end
 
-    # Currently has no effect. The async-http adapter creates a new client per request,
-    # so this pool limit is never reached. Kept for forward-compatibility with planned
-    # persistent connection support (issue #3283).
+    # Sets the maximum concurrent HTTP/2 streams per persistent client.
+    #
+    # When Fiber.scheduler is available (e.g., inside Sync {} blocks), HTTP clients are
+    # reused across requests within the same scheduler context, making this limit effective
+    # for connection pooling. Without a scheduler, clients are created per-request.
+    #
+    # @param value [Integer, nil] A positive integer or nil (uses default)
+    # @raise [ReactOnRailsPro::Error] if value is not a positive integer or nil
     def renderer_http_pool_size=(value)
       validate_renderer_http_pool_size(value)
-      warn_renderer_http_pool_size_once unless value.nil? || value == DEFAULT_RENDERER_HTTP_POOL_SIZE
       @renderer_http_pool_size = value
     end
 
     # Sets the legacy keep-alive timeout configuration for node renderer HTTP connections.
     #
-    # This remains for configuration compatibility. The async-http adapter currently
-    # scopes clients to individual requests, so this value is validated but not applied.
+    # This setting is deprecated. The async-http adapter manages connection lifecycle
+    # automatically — connections are reused within the same Fiber.scheduler context
+    # and cleaned up when the scheduler ends.
     #
     # @param value [Numeric, nil] A positive number or nil
     # @raise [ReactOnRailsPro::Error] if value is not a positive number or nil
     def renderer_http_keep_alive_timeout=(value)
       validate_renderer_http_keep_alive_timeout(value)
       unless value.nil?
-        Rails.logger.warn "[ReactOnRailsPro] config.renderer_http_keep_alive_timeout is deprecated and has no effect " \
-                          "with the async-http adapter because clients are scoped per request."
+        Rails.logger.warn "[ReactOnRailsPro] config.renderer_http_keep_alive_timeout is deprecated. " \
+                          "Connection lifecycle is managed automatically by the async-http adapter."
       end
       @renderer_http_keep_alive_timeout = value
     end
@@ -246,15 +235,6 @@ module ReactOnRailsPro
     end
 
     private
-
-    def warn_renderer_http_pool_size_once
-      RENDERER_HTTP_POOL_SIZE_WARNING_MUTEX.synchronize do
-        unless self.class.instance_variable_get(:@renderer_http_pool_size_warning_emitted)
-          Rails.logger.warn RENDERER_HTTP_POOL_SIZE_WARNING
-          self.class.instance_variable_set(:@renderer_http_pool_size_warning_emitted, true)
-        end
-      end
-    end
 
     def assign_initial_renderer_http_pool_size(value)
       validate_renderer_http_pool_size(value)

--- a/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
@@ -351,14 +351,7 @@ module ReactOnRailsPro
       if outer_scheduler
         # Persistent mode: reuse client across requests within same long-lived scheduler.
         # Connection pool (limit) is now effective — multiple streams share pooled connections.
-        client = scheduler_scoped_client(outer_scheduler)
-        begin
-          yield(client)
-        rescue *CONNECTION_ERRORS
-          # Evict broken client so the next request gets a fresh one
-          evict_client_from_scheduler(outer_scheduler)
-          raise
-        end
+        yield(scheduler_scoped_client(outer_scheduler))
       else
         # Ephemeral mode: no outer scheduler means either we're outside an Async context,
         # or Sync created an ephemeral scheduler. Use block-form to ensure cleanup.

--- a/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
@@ -42,6 +42,16 @@ module ReactOnRailsPro
       Protocol::HTTP2::StreamError
     ].freeze
 
+    # Per-scheduler storage for persistent HTTP clients. When Fiber.scheduler is available,
+    # clients are stored on the scheduler object itself using this instance variable key.
+    # This enables connection reuse across requests within the same scheduler context.
+    # The hash maps origin URLs to Async::HTTP::Client instances.
+    SCHEDULER_CLIENTS_KEY = :@__ror_pro_http_clients__
+
+    # Mutex for thread-safe client creation in the per-scheduler storage.
+    # Uses double-check locking: fast path reads without lock, slow path acquires lock.
+    SCHEDULER_CLIENTS_MUTEX = Mutex.new
+
     # Uses only public, documented Wrapper APIs (connect with timeout:, set_timeout)
     # that have been stable since io-endpoint 0.15. No version pin needed —
     # async-http's own constraint (~> 0.14) governs the version.
@@ -281,8 +291,17 @@ module ReactOnRailsPro
     end
 
     def close
-      # No-op: async-http clients are scoped to individual requests so they never cross Async reactors.
-      # Request#reset_connection still calls close for adapter compatibility.
+      scheduler = Fiber.scheduler
+      return unless scheduler
+
+      SCHEDULER_CLIENTS_MUTEX.synchronize do
+        clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY)
+        return unless clients
+
+        client = clients.delete(@origin)
+        client&.close
+        scheduler.instance_variable_set(SCHEDULER_CLIENTS_KEY, nil) if clients.empty?
+      end
     end
 
     private
@@ -328,18 +347,43 @@ module ReactOnRailsPro
     end
 
     def with_client(&block)
-      # TODO: revisit persistent async-http clients for renderer requests once
-      # https://github.com/shakacode/react_on_rails/issues/3283 settles connection-reuse direction.
-      endpoint = endpoint_for(@origin)
-      Async::HTTP::Client.open(endpoint, protocol: endpoint.protocol, retries: 0, limit: pool_limit) do |client|
-        # Retries are owned by Request/StreamRequest so bundle-upload retry behavior remains centralized.
-        # Each client is request-scoped (one connection, one request), so limit has no practical effect.
-        # It is passed through for forward-compatibility with planned persistent connections (#3283).
-        # rubocop:disable Performance/RedundantBlockCall
-        # The block is captured with &block, so yield is unavailable in this nested block.
-        block.call(client)
-        # rubocop:enable Performance/RedundantBlockCall
+      scheduler = Fiber.scheduler
+
+      if scheduler
+        # Persistent mode: reuse client across requests within same scheduler.
+        # Connection pool (limit) is now effective — multiple streams share pooled connections.
+        client = scheduler_scoped_client(scheduler)
+        yield(client)
+      else
+        # Fallback: no scheduler means we're outside an Async context (e.g., plain thread).
+        # Create a fresh client per request to avoid cross-reactor issues.
+        with_ephemeral_client(&block)
       end
+    end
+
+    def scheduler_scoped_client(scheduler)
+      # Fast path: check for existing client without lock
+      clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY)
+      client = clients&.dig(@origin)
+      return client if client
+
+      # Slow path: create client with lock (double-check pattern)
+      SCHEDULER_CLIENTS_MUTEX.synchronize do
+        clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY) || {}
+        client = clients[@origin]
+        return client if client
+
+        endpoint = endpoint_for(@origin)
+        client = Async::HTTP::Client.new(endpoint, protocol: endpoint.protocol, retries: 0, limit: pool_limit)
+        clients[@origin] = client
+        scheduler.instance_variable_set(SCHEDULER_CLIENTS_KEY, clients)
+        client
+      end
+    end
+
+    def with_ephemeral_client(&block)
+      endpoint = endpoint_for(@origin)
+      Async::HTTP::Client.open(endpoint, protocol: endpoint.protocol, retries: 0, limit: pool_limit, &block)
     end
 
     def endpoint_for(origin)

--- a/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/renderer_http_client.rb
@@ -42,15 +42,16 @@ module ReactOnRailsPro
       Protocol::HTTP2::StreamError
     ].freeze
 
-    # Per-scheduler storage for persistent HTTP clients. When Fiber.scheduler is available,
-    # clients are stored on the scheduler object itself using this instance variable key.
-    # This enables connection reuse across requests within the same scheduler context.
+    # Per-scheduler storage for persistent HTTP clients. When an outer Fiber.scheduler
+    # exists BEFORE we enter `Sync {}`, clients are stored on the scheduler object using
+    # this instance variable key. This enables connection reuse across requests within
+    # the same long-lived scheduler context (e.g., Falcon, Puma with async scheduler).
     # The hash maps origin URLs to Async::HTTP::Client instances.
+    #
+    # IMPORTANT: We only use persistent mode when a scheduler already exists before
+    # `execute_request` enters `Sync {}`. If `Sync {}` creates an ephemeral scheduler,
+    # we use the ephemeral client path to ensure proper cleanup when the block exits.
     SCHEDULER_CLIENTS_KEY = :@__ror_pro_http_clients__
-
-    # Mutex for thread-safe client creation in the per-scheduler storage.
-    # Uses double-check locking: fast path reads without lock, slow path acquires lock.
-    SCHEDULER_CLIENTS_MUTEX = Mutex.new
 
     # Uses only public, documented Wrapper APIs (connect with timeout:, set_timeout)
     # that have been stable since io-endpoint 0.15. No version pin needed —
@@ -294,14 +295,7 @@ module ReactOnRailsPro
       scheduler = Fiber.scheduler
       return unless scheduler
 
-      SCHEDULER_CLIENTS_MUTEX.synchronize do
-        clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY)
-        return unless clients
-
-        client = clients.delete(@origin)
-        client&.close
-        scheduler.instance_variable_set(SCHEDULER_CLIENTS_KEY, nil) if clients.empty?
-      end
+      evict_client_from_scheduler(scheduler)
     end
 
     private
@@ -328,8 +322,13 @@ module ReactOnRailsPro
     def execute_request(method, path, request_body, yielder, status_assigner)
       headers, body = request_body
 
+      # Capture scheduler BEFORE entering Sync. If a scheduler already exists, we can
+      # use persistent mode. If Sync creates an ephemeral scheduler, we must use
+      # ephemeral clients to ensure cleanup when Sync exits.
+      outer_scheduler = Fiber.scheduler
+
       Sync do
-        with_client do |client|
+        with_client(outer_scheduler: outer_scheduler) do |client|
           raw_response = if method == :post
                            client.post(path, headers: Protocol::HTTP::Headers[headers], body: body)
                          else
@@ -346,39 +345,52 @@ module ReactOnRailsPro
       raise ConnectionError, e.message
     end
 
-    def with_client(&block)
-      scheduler = Fiber.scheduler
-
-      if scheduler
-        # Persistent mode: reuse client across requests within same scheduler.
+    def with_client(outer_scheduler:, &block)
+      # Only use persistent mode if a scheduler existed BEFORE entering Sync.
+      # If Sync created an ephemeral scheduler, use ephemeral clients to ensure cleanup.
+      if outer_scheduler
+        # Persistent mode: reuse client across requests within same long-lived scheduler.
         # Connection pool (limit) is now effective — multiple streams share pooled connections.
-        client = scheduler_scoped_client(scheduler)
-        yield(client)
+        client = scheduler_scoped_client(outer_scheduler)
+        begin
+          yield(client)
+        rescue *CONNECTION_ERRORS
+          # Evict broken client so the next request gets a fresh one
+          evict_client_from_scheduler(outer_scheduler)
+          raise
+        end
       else
-        # Fallback: no scheduler means we're outside an Async context (e.g., plain thread).
-        # Create a fresh client per request to avoid cross-reactor issues.
+        # Ephemeral mode: no outer scheduler means either we're outside an Async context,
+        # or Sync created an ephemeral scheduler. Use block-form to ensure cleanup.
         with_ephemeral_client(&block)
       end
     end
 
     def scheduler_scoped_client(scheduler)
-      # Fast path: check for existing client without lock
+      # Fiber.scheduler is per-OS-thread, and within a thread fibers are cooperatively
+      # scheduled (only one runs at a time). No mutex needed for per-scheduler operations.
       clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY)
-      client = clients&.dig(@origin)
+      client = clients&.[](@origin)
       return client if client
 
-      # Slow path: create client with lock (double-check pattern)
-      SCHEDULER_CLIENTS_MUTEX.synchronize do
-        clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY) || {}
-        client = clients[@origin]
-        return client if client
+      # Create new client and store it
+      clients ||= {}
+      endpoint = endpoint_for(@origin)
+      client = Async::HTTP::Client.new(endpoint, protocol: endpoint.protocol, retries: 0, limit: pool_limit)
+      clients[@origin] = client
+      scheduler.instance_variable_set(SCHEDULER_CLIENTS_KEY, clients)
+      client
+    end
 
-        endpoint = endpoint_for(@origin)
-        client = Async::HTTP::Client.new(endpoint, protocol: endpoint.protocol, retries: 0, limit: pool_limit)
-        clients[@origin] = client
-        scheduler.instance_variable_set(SCHEDULER_CLIENTS_KEY, clients)
-        client
-      end
+    def evict_client_from_scheduler(scheduler)
+      clients = scheduler.instance_variable_get(SCHEDULER_CLIENTS_KEY)
+      return unless clients
+
+      client = clients.delete(@origin)
+      scheduler.instance_variable_set(SCHEDULER_CLIENTS_KEY, nil) if clients.empty?
+
+      # Close after removing from hash to avoid any re-entrancy issues
+      client&.close
     end
 
     def with_ephemeral_client(&block)

--- a/react_on_rails_pro/sig/react_on_rails_pro/renderer_http_client.rbs
+++ b/react_on_rails_pro/sig/react_on_rails_pro/renderer_http_client.rbs
@@ -17,6 +17,8 @@ module ReactOnRailsPro
 
     CONNECTION_ERRORS: Array[Class]
 
+    SCHEDULER_CLIENTS_KEY: Symbol
+
     class ConnectTimeoutWrapper
       def initialize: (connect_timeout: Numeric?, ?read_timeout: Numeric?) -> void
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -725,13 +725,8 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
         expect(ReactOnRailsPro.configuration.renderer_http_pool_size).to eq(10)
       end
 
-      it "warns when configured because async-http changed the setting semantics" do
-        expect(Rails.logger).to receive(:warn).with(
-          "[ReactOnRailsPro] config.renderer_http_pool_size currently has no effect. " \
-          "The async-http adapter creates a new client per request, so the pool limit " \
-          "is never reached. This setting is kept for forward-compatibility with " \
-          "planned persistent connection support (see issue #3283)."
-        )
+      it "accepts custom values without warning (setting is now effective with scheduler)" do
+        expect(Rails.logger).not_to receive(:warn)
 
         ReactOnRailsPro.configure do |config|
           config.renderer_http_pool_size = 20
@@ -740,40 +735,7 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
         expect(ReactOnRailsPro.configuration.renderer_http_pool_size).to eq(20)
       end
 
-      it "does not warn for the default value assigned during configuration initialization" do
-        expect(Rails.logger).not_to receive(:warn).with(
-          "[ReactOnRailsPro] config.renderer_http_pool_size currently has no effect. " \
-          "The async-http adapter creates a new client per request, so the pool limit " \
-          "is never reached. This setting is kept for forward-compatibility with " \
-          "planned persistent connection support (see issue #3283)."
-        )
-
-        expect(ReactOnRailsPro.configuration.renderer_http_pool_size).to eq(10)
-      end
-
-      it "does not warn when explicitly configured with the default value" do
-        expect(Rails.logger).not_to receive(:warn).with(
-          "[ReactOnRailsPro] config.renderer_http_pool_size currently has no effect. " \
-          "The async-http adapter creates a new client per request, so the pool limit " \
-          "is never reached. This setting is kept for forward-compatibility with " \
-          "planned persistent connection support (see issue #3283)."
-        )
-
-        ReactOnRailsPro.configure do |config|
-          config.renderer_http_pool_size = 10
-        end
-
-        expect(ReactOnRailsPro.configuration.renderer_http_pool_size).to eq(10)
-      end
-
-      it "does not warn when explicitly cleared" do
-        expect(Rails.logger).not_to receive(:warn).with(
-          "[ReactOnRailsPro] config.renderer_http_pool_size currently has no effect. " \
-          "The async-http adapter creates a new client per request, so the pool limit " \
-          "is never reached. This setting is kept for forward-compatibility with " \
-          "planned persistent connection support (see issue #3283)."
-        )
-
+      it "accepts nil to clear the value" do
         ReactOnRailsPro.configure do |config|
           config.renderer_http_pool_size = nil
         end
@@ -819,10 +781,10 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
         expect(ReactOnRailsPro.configuration.renderer_http_keep_alive_timeout).to eq(30)
       end
 
-      it "accepts positive numbers" do
+      it "accepts positive numbers and warns about deprecation" do
         expect(Rails.logger).to receive(:warn).with(
-          "[ReactOnRailsPro] config.renderer_http_keep_alive_timeout is deprecated and has no effect " \
-          "with the async-http adapter because clients are scoped per request."
+          "[ReactOnRailsPro] config.renderer_http_keep_alive_timeout is deprecated. " \
+          "Connection lifecycle is managed automatically by the async-http adapter."
         )
 
         ReactOnRailsPro.configure do |config|

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       allow(Async::HTTP::Client).to receive(:open).and_yield(async_client)
 
       yielded_client = nil
-      client.__send__(:with_client) { |opened_client| yielded_client = opened_client }
+      client.__send__(:with_client, outer_scheduler: nil) { |opened_client| yielded_client = opened_client }
 
       expect(Async::HTTP::Client).to have_received(:open).with(
         endpoint,
@@ -551,10 +551,10 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
 
       # First call should create a client
       yielded_clients = []
-      client.__send__(:with_client) { |c| yielded_clients << c }
+      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |c| yielded_clients << c }
 
       # Second call should reuse the same client
-      client.__send__(:with_client) { |c| yielded_clients << c }
+      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |c| yielded_clients << c }
 
       expect(clients_created.size).to eq(1)
       expect(yielded_clients).to eq([fake_async_client, fake_async_client])
@@ -577,8 +577,9 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
         block.call(fake_client)
       end
 
-      client.__send__(:with_client) { |_c| }
-      client.__send__(:with_client) { |_c| }
+      # outer_scheduler: nil triggers ephemeral mode
+      client.__send__(:with_client, outer_scheduler: nil) { |_c| }
+      client.__send__(:with_client, outer_scheduler: nil) { |_c| }
 
       expect(open_calls).to eq(2)
     end
@@ -604,9 +605,9 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       fake_scheduler = Object.new
       allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
 
-      client1.__send__(:with_client) { |_c| }
-      client2.__send__(:with_client) { |_c| }
-      client1.__send__(:with_client) { |_c| }
+      client1.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
+      client2.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
+      client1.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
 
       expect(clients_created.size).to eq(2)
     end
@@ -631,7 +632,7 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
 
       # Create the client
-      client.__send__(:with_client) { |_c| }
+      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
 
       # Close should remove it from storage
       client.close
@@ -643,7 +644,7 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       allow(Async::HTTP::Client).to receive(:new).and_return(new_client)
 
       yielded_client = nil
-      client.__send__(:with_client) { |c| yielded_client = c }
+      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |c| yielded_client = c }
 
       expect(yielded_client).to be(new_client)
     end
@@ -653,6 +654,51 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       allow(Fiber).to receive(:scheduler).and_return(nil)
 
       expect { client.close }.not_to raise_error
+    end
+
+    it "evicts broken client from pool when connection error occurs" do
+      stub_const("FakeBrokenClient", Class.new do
+        attr_reader :closed
+
+        def close
+          @closed = true
+        end
+      end)
+
+      broken_client = FakeBrokenClient.new
+      working_client = FakeBrokenClient.new
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+
+      clients_created = []
+      allow(Async::HTTP::Client).to receive(:new) do |*_args|
+        created = clients_created.empty? ? broken_client : working_client
+        clients_created << created
+        created
+      end
+
+      fake_scheduler = Object.new
+      allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
+
+      # First call creates a client, then block raises a connection error
+      expect do
+        client.__send__(:with_client, outer_scheduler: fake_scheduler) do |_c|
+          raise Errno::ECONNRESET, "Connection reset by peer"
+        end
+      end.to raise_error(Errno::ECONNRESET)
+
+      # Broken client should be evicted and closed
+      expect(broken_client.closed).to be(true)
+      expect(clients_created.size).to eq(1)
+
+      # Next call should create a new client (not reuse the broken one)
+      yielded_client = nil
+      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |c| yielded_client = c }
+
+      expect(clients_created.size).to eq(2)
+      expect(yielded_client).to be(working_client)
     end
   end
 end

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -656,17 +656,8 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       expect { client.close }.not_to raise_error
     end
 
-    it "evicts broken client from pool when connection error occurs" do
-      stub_const("FakeBrokenClient", Class.new do
-        attr_reader :closed
-
-        def close
-          @closed = true
-        end
-      end)
-
-      broken_client = FakeBrokenClient.new
-      working_client = FakeBrokenClient.new
+    it "reuses the same client after connection errors (async-http handles recovery internally)" do
+      fake_client = instance_double(Async::HTTP::Client)
       endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
 
       client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
@@ -674,9 +665,8 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
 
       clients_created = []
       allow(Async::HTTP::Client).to receive(:new) do |*_args|
-        created = clients_created.empty? ? broken_client : working_client
-        clients_created << created
-        created
+        clients_created << fake_client
+        fake_client
       end
 
       fake_scheduler = Object.new
@@ -689,16 +679,14 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
         end
       end.to raise_error(Errno::ECONNRESET)
 
-      # Broken client should be evicted and closed
-      expect(broken_client.closed).to be(true)
       expect(clients_created.size).to eq(1)
 
-      # Next call should create a new client (not reuse the broken one)
+      # Next call should reuse the same client (async-http's pool handles broken connections)
       yielded_client = nil
       client.__send__(:with_client, outer_scheduler: fake_scheduler) { |c| yielded_client = c }
 
-      expect(clients_created.size).to eq(2)
-      expect(yielded_client).to be(working_client)
+      expect(clients_created.size).to eq(1)
+      expect(yielded_client).to be(fake_client)
     end
   end
 end

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -529,4 +529,130 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       expect(response_body.closed).to be(true)
     end
   end
+
+  describe "per-scheduler client storage" do
+    it "reuses the same async-http client within the same Fiber.scheduler context" do
+      stub_const("FakeAsyncClient", Class.new { def get(_path); end })
+      fake_async_client = instance_double(FakeAsyncClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+
+      clients_created = []
+      allow(Async::HTTP::Client).to receive(:new) do |*_args|
+        clients_created << fake_async_client
+        fake_async_client
+      end
+
+      # Simulate Fiber.scheduler being available
+      fake_scheduler = Object.new
+      allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
+
+      # First call should create a client
+      yielded_clients = []
+      client.__send__(:with_client) { |c| yielded_clients << c }
+
+      # Second call should reuse the same client
+      client.__send__(:with_client) { |c| yielded_clients << c }
+
+      expect(clients_created.size).to eq(1)
+      expect(yielded_clients).to eq([fake_async_client, fake_async_client])
+    end
+
+    it "creates a new client when Fiber.scheduler is not available (fallback mode)" do
+      stub_const("FakeEphemeralClient", Class.new { def get(_path); end })
+      fake_client = instance_double(FakeEphemeralClient)
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+
+      # Simulate no Fiber.scheduler
+      allow(Fiber).to receive(:scheduler).and_return(nil)
+
+      open_calls = 0
+      allow(Async::HTTP::Client).to receive(:open) do |*_args, &block|
+        open_calls += 1
+        block.call(fake_client)
+      end
+
+      client.__send__(:with_client) { |_c| }
+      client.__send__(:with_client) { |_c| }
+
+      expect(open_calls).to eq(2)
+    end
+
+    it "stores clients per origin on the same scheduler" do
+      stub_const("FakeOriginClient", Class.new { def get(_path); end })
+      endpoint1 = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+      endpoint2 = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client1 = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      client2 = described_class.new(origin: "http://localhost:3900", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+
+      allow(client1).to receive(:endpoint_for).and_return(endpoint1)
+      allow(client2).to receive(:endpoint_for).and_return(endpoint2)
+
+      clients_created = []
+      allow(Async::HTTP::Client).to receive(:new) do |*_args|
+        fake = instance_double(FakeOriginClient)
+        clients_created << fake
+        fake
+      end
+
+      fake_scheduler = Object.new
+      allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
+
+      client1.__send__(:with_client) { |_c| }
+      client2.__send__(:with_client) { |_c| }
+      client1.__send__(:with_client) { |_c| }
+
+      expect(clients_created.size).to eq(2)
+    end
+
+    it "close removes the client from scheduler storage" do
+      stub_const("FakeClosableClient", Class.new do
+        attr_reader :closed
+
+        def close
+          @closed = true
+        end
+      end)
+
+      fake_async_client = FakeClosableClient.new
+      endpoint = instance_double(Async::HTTP::Endpoint, protocol: :fake_protocol)
+
+      client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      allow(client).to receive(:endpoint_for).and_return(endpoint)
+      allow(Async::HTTP::Client).to receive(:new).and_return(fake_async_client)
+
+      fake_scheduler = Object.new
+      allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
+
+      # Create the client
+      client.__send__(:with_client) { |_c| }
+
+      # Close should remove it from storage
+      client.close
+
+      expect(fake_async_client.closed).to be(true)
+
+      # Next call should create a new client
+      new_client = FakeClosableClient.new
+      allow(Async::HTTP::Client).to receive(:new).and_return(new_client)
+
+      yielded_client = nil
+      client.__send__(:with_client) { |c| yielded_client = c }
+
+      expect(yielded_client).to be(new_client)
+    end
+
+    it "close is a no-op when Fiber.scheduler is not available" do
+      client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      allow(Fiber).to receive(:scheduler).and_return(nil)
+
+      expect { client.close }.not_to raise_error
+    end
+  end
 end

--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -578,8 +578,8 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       end
 
       # outer_scheduler: nil triggers ephemeral mode
-      client.__send__(:with_client, outer_scheduler: nil) { |_c| }
-      client.__send__(:with_client, outer_scheduler: nil) { |_c| }
+      client.__send__(:with_client, outer_scheduler: nil) { |_c| nil }
+      client.__send__(:with_client, outer_scheduler: nil) { |_c| nil }
 
       expect(open_calls).to eq(2)
     end
@@ -605,9 +605,9 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       fake_scheduler = Object.new
       allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
 
-      client1.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
-      client2.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
-      client1.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
+      client1.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| nil }
+      client2.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| nil }
+      client1.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| nil }
 
       expect(clients_created.size).to eq(2)
     end
@@ -632,7 +632,7 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       allow(Fiber).to receive(:scheduler).and_return(fake_scheduler)
 
       # Create the client
-      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| }
+      client.__send__(:with_client, outer_scheduler: fake_scheduler) { |_c| nil }
 
       # Close should remove it from storage
       client.close


### PR DESCRIPTION
## Summary

- Implement per-scheduler storage for `Async::HTTP::Client` instances using `Fiber.scheduler` instance variables
- When a scheduler is available (inside `Sync {}` blocks), clients are reused across requests within the same scheduler context
- Fall back to per-request clients when no scheduler is available (preserves current behavior for plain threads)
- `renderer_http_pool_size` config now effective for connection pooling when scheduler is available
- Updated configuration docs and removed obsolete warnings

## How it works

```ruby
Sync do                               # Creates Fiber.scheduler
  # Request 1 - creates client, stores on scheduler
  render_component("Header")          # TCP + HTTP/2 handshake

  # Request 2 - reuses same client  
  render_component("Footer")          # No handshake, connection reused!

  # Request 3 - still same client
  render_component("Sidebar")         # Connection pool in effect
end                                   # Scheduler ends, client GC'd
```

## Test plan

- [ ] Unit tests for per-scheduler client storage added
- [ ] Verify client reuse within same scheduler context
- [ ] Verify fallback to per-request clients when no scheduler
- [ ] Verify close() removes client from scheduler storage
- [ ] CI passes

Closes #3398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified renderer HTTP pool-size meaning; setter now only validates and accepts nil without one-time warnings
  * Updated keep-alive deprecation message to note automatic connection lifecycle management by the HTTP adapter
  * Client reuse improved when an async scheduler is present; explicit close evicts stored clients, while connection errors no longer force eviction

* **Tests**
  * Added specs for per-scheduler reuse, scheduler-absent behavior, close/cleanup, and connection-error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->