### PR TITLE
Extract reusable setup-bundle action

### DIFF
--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -1,0 +1,72 @@
+name: Setup Bundler dependencies
+description: Cache and install Ruby gems for a Bundler project.
+
+inputs:
+  working-directory:
+    description: Directory containing the Gemfile.
+    required: true
+  ruby-version:
+    description: Ruby version used by the job.
+    required: true
+  bundle-path:
+    description: Bundler install path, relative to the working directory.
+    required: false
+    default: vendor/bundle
+  frozen:
+    description: Whether to run Bundler in frozen mode. Cache saving is disabled when false; restore still runs.
+    required: false
+    default: 'true'
+  bundler-version:
+    description: Bundler version selector. Use lockfile, system, or x.y.z.
+    required: false
+    default: lockfile
+  install-args:
+    description: Arguments for bundle install.
+    required: false
+    default: --jobs=4 --retry=3
+
+runs:
+  using: composite
+  steps:
+    - name: Verify Gemfile.lock exists
+      shell: bash
+      run: |
+        lockfile="${{ inputs.working-directory }}/Gemfile.lock"
+        if ! git ls-files --error-unmatch "$lockfile" >/dev/null; then
+          echo "::error file=$lockfile::setup-bundle requires a committed Gemfile.lock in the working directory."
+          exit 1
+        fi
+
+    - name: Restore Ruby gems cache
+      id: restore-ruby-gems-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ inputs.working-directory }}/${{ inputs.bundle-path }}
+        # Update to bundle-...-v1 in the future to break the cache if necessary
+        # or v1-bundle-... if you want restore-keys not to trigger either (update the key there in that case)
+        key: bundle-${{ runner.os }}-${{ inputs.working-directory }}-${{ inputs.bundle-path }}-ruby${{ inputs.ruby-version }}-${{ hashFiles(format('{0}/Gemfile.lock', inputs.working-directory)) }}
+        restore-keys: |
+          bundle-${{ runner.os }}-${{ inputs.working-directory }}-${{ inputs.bundle-path }}-ruby${{ inputs.ruby-version }}-
+
+    - name: Install Ruby gems
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        BUNDLE_FROZEN: ${{ inputs.frozen }}
+        BUNDLE_INSTALL_ARGS: ${{ inputs.install-args }}
+        BUNDLE_PATH_CONFIG: ${{ inputs.bundle-path }}
+        BUNDLER_VERSION_CONFIG: ${{ inputs.bundler-version }}
+      run: |
+        bundle config set --local path "$BUNDLE_PATH_CONFIG"
+        bundle config set --local version "$BUNDLER_VERSION_CONFIG"
+        # shellcheck disable=SC2086
+        # Intentionally allow install args to split into separate bundle arguments
+        bundle check || bundle install $BUNDLE_INSTALL_ARGS
+
+    - name: Save Ruby gems cache
+      # We don't want to overwrite the cache for non-frozen Bundler runs
+      if: inputs.frozen == 'true' && steps.restore-ruby-gems-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ inputs.working-directory }}/${{ inputs.bundle-path }}
+        key: ${{ steps.restore-ruby-gems-cache.outputs.cache-primary-key }}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,8 +16,6 @@ on:
 
 jobs:
   actionlint:
-    env:
-      BUNDLE_FROZEN: true
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,9 +69,6 @@ concurrency:
 
 env:
   RUBY_VERSION: '3.3.7'
-  BUNDLER_VERSION: '2.5.4'
-  BUNDLE_FROZEN: true
-  BUNDLE_PATH: vendor/bundle
   K6_VERSION: '2.0.0'
   VEGETA_VERSION: '12.13.0'
   # Determine which apps/benchmarks to run (default is 'both' for all triggers)
@@ -204,7 +201,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: ${{ env.BUNDLER_VERSION }}
 
       - name: Get gem home directory
         run: echo "GEM_HOME_PATH=$(gem env home)" >> $GITHUB_ENV
@@ -279,18 +275,12 @@ jobs:
       - name: Build workspace packages
         run: pnpm run build
 
-      - name: Save Core dummy app ruby gems to cache
-        if: env.RUN_CORE
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/spec/dummy/vendor/bundle
-          key: v4-core-dummy-app-gem-cache-${{ hashFiles('react_on_rails/spec/dummy/Gemfile.lock') }}
-
       - name: Install Ruby Gems for Core dummy app
         if: env.RUN_CORE
-        run: |
-          cd react_on_rails/spec/dummy
-          bundle _${BUNDLER_VERSION}_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Prepare Core production assets
         if: env.RUN_CORE
@@ -403,18 +393,12 @@ jobs:
       # STEP 5: SETUP PRO APPLICATION SERVER
       # ============================================
 
-      - name: Cache Pro dummy app Ruby gems
-        if: env.RUN_PRO
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/spec/dummy/vendor/bundle
-          key: v5-pro-dummy-app-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/spec/dummy/Gemfile.lock') }}
-
       - name: Install Ruby Gems for Pro dummy app
         if: env.RUN_PRO
-        run: |
-          cd react_on_rails_pro/spec/dummy
-          bundle _${BUNDLER_VERSION}_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Generate file-system based entrypoints for Pro
         if: env.RUN_PRO

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -114,9 +114,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-    env:
-      BUNDLE_FROZEN: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
-      BUNDLE_PATH: vendor/bundle
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -155,11 +152,6 @@ jobs:
       - name: Run conversion script for older Node compatibility
         if: matrix.dependency-level == 'minimum'
         run: script/convert
-      - name: Save root ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails/Gemfile.lock') }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Install Node modules with pnpm
@@ -169,11 +161,11 @@ jobs:
         run: pnpm run build
 
       - name: Install Ruby Gems for package
-        run: |
-          cd react_on_rails
-          if ! bundle check; then
-            bundle _2.5.9_ install --jobs=4 --retry=3
-          fi
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails
+          ruby-version: ${{ matrix.ruby-version }}
+          frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Ensure minimum required Chrome version
         run: |
           echo -e "Already installed $(google-chrome --version)\n"

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -111,9 +111,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
-    env:
-      BUNDLE_FROZEN: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
-      BUNDLE_PATH: vendor/bundle
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -135,13 +132,12 @@ jobs:
       - name: run conversion script to use minimum supported dependency versions
         if: matrix.dependency-level == 'minimum'
         run: script/convert
-      - name: Save root ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails/Gemfile.lock') }}-${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
       - name: Install Ruby Gems for package
-        run: cd react_on_rails && (bundle check || bundle _2.5.9_ install --jobs=4 --retry=3)
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails
+          ruby-version: ${{ matrix.ruby-version }}
+          frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Git Stuff
         if: matrix.dependency-level == 'minimum'
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,9 +113,6 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.setup-integration-matrix.outputs.matrix) }}
     runs-on: ubuntu-22.04
-    env:
-      BUNDLE_FROZEN: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
-      BUNDLE_PATH: vendor/bundle
     steps:
       - uses: actions/checkout@v4
         with:
@@ -164,17 +161,12 @@ jobs:
         run: pnpm run build
       - name: Verify single React resolution for core dummy build
         run: node script/check-single-react-resolution.mjs react_on_rails/spec/dummy packages/react-on-rails
-      - name: Save dummy app ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails/spec/dummy/Gemfile.lock') }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
       - name: Install Ruby Gems for dummy app
-        run: |
-          cd react_on_rails/spec/dummy
-          if ! bundle check; then
-            bundle _2.5.9_ install --jobs=4 --retry=3
-          fi
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: ${{ matrix.ruby-version }}
+          frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: generate file system-based packs
         run: cd react_on_rails/spec/dummy && RAILS_ENV="test" bundle exec rake react_on_rails:generate_packs
       - name: Smoke check generated pack entrypoints
@@ -208,9 +200,6 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.setup-integration-matrix.outputs.matrix) }}
     runs-on: ubuntu-22.04
-    env:
-      BUNDLE_FROZEN: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
-      BUNDLE_PATH: vendor/bundle
     steps:
       - uses: actions/checkout@v4
         with:
@@ -248,16 +237,6 @@ jobs:
       - name: Run conversion script for older Node compatibility
         if: matrix.dependency-level == 'minimum'
         run: script/convert
-      - name: Save root ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails/Gemfile.lock') }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
-      - name: Save dummy app ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails/spec/dummy/Gemfile.lock') }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Save test Webpack bundles to cache (for build number checksum used by RSpec job)
@@ -273,17 +252,17 @@ jobs:
       - name: Dummy JS tests
         run: pnpm --filter "react_on_rails" run test:js
       - name: Install Ruby Gems for package
-        run: |
-          cd react_on_rails
-          if ! bundle check; then
-            bundle _2.5.9_ install --jobs=4 --retry=3
-          fi
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails
+          ruby-version: ${{ matrix.ruby-version }}
+          frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Install Ruby Gems for dummy app
-        run: |
-          cd react_on_rails/spec/dummy
-          if ! bundle check; then
-            bundle _2.5.9_ install --jobs=4 --retry=3
-          fi
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: ${{ matrix.ruby-version }}
+          frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Ensure minimum required Chrome version
         run: |
           echo -e "Already installed $(google-chrome --version)\n"

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -84,9 +84,6 @@ jobs:
         github.ref == 'refs/heads/main' ||
         needs.detect-changes.outputs.run_lint == 'true'
       )
-    env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -128,16 +125,14 @@ jobs:
           echo "Bundler version: "; bundle --version
       - name: Check Gemfile.lock platforms
         run: ruby script/check-gemfile-lock-platforms
-      - name: Save root ruby gems to cache
-        uses: actions/cache@v4
+      - name: Install Ruby Gems for package
+        uses: ./.github/actions/setup-bundle
         with:
-          path: vendor/bundle
-          key: package-app-gem-cache-${{ hashFiles('react_on_rails/Gemfile.lock') }}-lint
+          working-directory: react_on_rails
+          ruby-version: '3.4'
       - name: Install Node modules with pnpm
         run: pnpm install --frozen-lockfile
 
-      - name: Install Ruby Gems for package
-        run: cd react_on_rails && bundle check || bundle _2.5.9_ install --jobs=4 --retry=3
       - name: Lint Ruby
         run: cd react_on_rails && bundle exec rubocop
       - name: Validate RBS type signatures
@@ -146,17 +141,11 @@ jobs:
       # Currently disabled because 374 type errors need to be fixed first
       # - name: Run Steep type checker
       #   run: bundle exec rake rbs:steep
-      - name: Save dummy app ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails/spec/dummy/Gemfile.lock') }}-lint
       - name: Install Ruby Gems for dummy app
-        run: |
-          cd react_on_rails/spec/dummy
-          if ! bundle check; then
-            bundle _2.5.9_ install --jobs=4 --retry=3
-          fi
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: '3.4'
       - name: generate file system-based packs
         run: cd react_on_rails/spec/dummy && RAILS_ENV="test" bundle exec rake react_on_rails:generate_packs
       - name: Detect dead code

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -42,8 +42,6 @@ jobs:
   playwright:
     needs: detect-changes
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_PATH: ${{ github.workspace }}/react_on_rails/spec/dummy/vendor/bundle
     if: |
       github.event_name == 'workflow_dispatch' || !(
         github.event_name == 'push' &&
@@ -82,17 +80,11 @@ jobs:
       - name: Build workspace packages
         run: pnpm run build
 
-      - name: Cache dummy app Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails/spec/dummy/Gemfile.lock') }}-ruby3.3
-
       - name: Install dummy app Ruby dependencies
-        working-directory: react_on_rails/spec/dummy
-        env:
-          BUNDLE_FROZEN: true
-        run: bundle install
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: '3.3'
 
       - name: Install Playwright browsers
         working-directory: react_on_rails/spec/dummy

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -76,9 +76,6 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         needs.detect-changes.outputs.run_dummy_tests == 'true'
       )
-    env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -121,17 +118,11 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build workspace packages
         run: pnpm run build
-      - name: Save dummy app ruby gems to cache
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails/spec/dummy/vendor/bundle
-          key: dummy-app-gem-cache-${{ hashFiles('react_on_rails/spec/dummy/Gemfile.lock') }}-precompile
       - name: Install Ruby Gems for dummy app
-        run: |
-          cd react_on_rails/spec/dummy
-          if ! bundle check; then
-            bundle _2.5.9_ install --jobs=4 --retry=3
-          fi
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: '3.4'
       - name: Build ReScript files
         run: pnpm --filter "react_on_rails" run build:rescript
       - name: Generate file system-based packs

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -93,8 +93,6 @@ jobs:
       )
     runs-on: ubuntu-22.04
     env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     steps:
       - uses: actions/checkout@v4
@@ -139,12 +137,6 @@ jobs:
           echo "pnpm version: "; pnpm --version
           echo "Bundler version: "; bundle --version
 
-      - name: Cache Pro dummy app Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/spec/dummy/vendor/bundle
-          key: v5-pro-dummy-app-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/spec/dummy/Gemfile.lock') }}
-
       - name: Install Node modules with pnpm
         working-directory: .
         run: pnpm install --frozen-lockfile
@@ -160,10 +152,10 @@ jobs:
         run: node script/check-react-major-version.mjs react_on_rails_pro/spec/execjs-compatible-dummy 18
 
       - name: Install Ruby Gems for Pro dummy app
-        run: |
-          gem install bundler -v "2.5.4"
-          cd spec/dummy
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Generate file-system based entrypoints
         run: cd spec/dummy && bundle exec rake react_on_rails:generate_packs
@@ -201,8 +193,6 @@ jobs:
       )
     runs-on: ubuntu-22.04
     env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     steps:
       - uses: actions/checkout@v4
@@ -247,18 +237,6 @@ jobs:
           echo "pnpm version: "; pnpm --version
           echo "Bundler version: "; bundle --version
 
-      - name: Cache Pro package Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/vendor/bundle
-          key: v5-pro-package-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/react_on_rails_pro.gemspec') }}
-
-      - name: Cache Pro dummy app Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/spec/dummy/vendor/bundle
-          key: v5-pro-dummy-app-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/spec/dummy/Gemfile.lock') }}
-
       - name: Remove old webpack bundles
         run: |
           rm -rf spec/dummy/public/webpack
@@ -276,10 +254,10 @@ jobs:
           key: v4-pro-dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}
 
       - name: Install Ruby Gems for Pro dummy app
-        run: |
-          gem install bundler -v "2.5.4"
-          cd spec/dummy
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Install Node modules with pnpm
         working-directory: .
@@ -391,8 +369,6 @@ jobs:
       )
     runs-on: ubuntu-22.04
     env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     # Redis service container
     services:
@@ -448,18 +424,6 @@ jobs:
           echo "pnpm version: "; pnpm --version
           echo "Bundler version: "; bundle --version
 
-      - name: Cache Pro package Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/vendor/bundle
-          key: v5-pro-package-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/react_on_rails_pro.gemspec') }}
-
-      - name: Cache Pro dummy app Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/spec/dummy/vendor/bundle
-          key: v5-pro-dummy-app-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/spec/dummy/Gemfile.lock') }}
-
       - name: Remove old webpack bundles
         run: |
           rm -rf spec/dummy/public/webpack
@@ -477,10 +441,10 @@ jobs:
           key: v4-pro-dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}
 
       - name: Install Ruby Gems for Pro dummy app
-        run: |
-          gem install bundler -v "2.5.4"
-          cd spec/dummy
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Install Node modules with pnpm
         working-directory: .

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -92,8 +92,6 @@ jobs:
       )
     runs-on: ubuntu-22.04
     env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     steps:
       - uses: actions/checkout@v4
@@ -138,23 +136,11 @@ jobs:
           echo "pnpm version: "; pnpm --version
           echo "Bundler version: "; bundle --version
 
-      - name: Cache Pro package Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/vendor/bundle
-          key: v5-pro-package-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/react_on_rails_pro.gemspec') }}
-
-      - name: Cache Pro dummy app Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/spec/dummy/vendor/bundle
-          key: v5-pro-dummy-app-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/spec/dummy/Gemfile.lock') }}
-
       - name: Install Ruby Gems for Pro package
-        run: |
-          gem install bundler -v "2.5.4"
-          echo "Bundler version: "; bundle --version
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Install Node modules with pnpm
         working-directory: .
@@ -164,9 +150,10 @@ jobs:
         run: node script/check-react-major-version.mjs react_on_rails_pro/spec/execjs-compatible-dummy 18
 
       - name: Install Ruby Gems for Pro dummy app
-        run: |
-          cd spec/dummy
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Generate file-system based entrypoints
         run: cd spec/dummy && bundle exec rake react_on_rails:generate_packs
@@ -200,8 +187,6 @@ jobs:
       )
     runs-on: ubuntu-22.04
     env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     steps:
       - uses: actions/checkout@v4
@@ -246,12 +231,6 @@ jobs:
           echo "pnpm version: "; pnpm --version
           echo "Bundler version: "; bundle --version
 
-      - name: Cache Pro dummy app Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/spec/dummy/vendor/bundle
-          key: v5-pro-dummy-app-gem-cache-ubuntu-22.04-ruby${{ env.RUBY_VERSION }}-${{ hashFiles('react_on_rails_pro/spec/dummy/Gemfile.lock') }}
-
       - name: Install Node modules with pnpm
         working-directory: .
         run: pnpm install --frozen-lockfile
@@ -267,10 +246,10 @@ jobs:
         run: node script/check-react-major-version.mjs react_on_rails_pro/spec/execjs-compatible-dummy 18
 
       - name: Install Ruby Gems for Pro dummy app
-        run: |
-          gem install bundler -v "2.5.4"
-          cd spec/dummy
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Generate file-system based entrypoints
         run: cd spec/dummy && bundle exec rake react_on_rails:generate_packs
@@ -411,8 +390,6 @@ jobs:
         ruby-version: ['3.3.7']
     runs-on: ubuntu-22.04
     env:
-      BUNDLE_FROZEN: true
-      BUNDLE_PATH: vendor/bundle
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     steps:
       - uses: actions/checkout@v4
@@ -433,17 +410,11 @@ jobs:
           echo "Ruby version: "; ruby -v
           echo "Bundler version: "; bundle --version
 
-      - name: Cache Pro package Ruby gems
-        uses: actions/cache@v4
-        with:
-          path: react_on_rails_pro/vendor/bundle
-          key: v5-pro-package-gem-cache-ubuntu-22.04-ruby${{ matrix.ruby-version }}-${{ hashFiles('react_on_rails_pro/react_on_rails_pro.gemspec') }}
-
       - name: Install Ruby Gems for Pro package
-        run: |
-          gem install bundler -v "2.5.4"
-          echo "Bundler version: "; bundle --version
-          bundle _2.5.4_ check || bundle _2.5.4_ install --jobs=4 --retry=3
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro
+          ruby-version: ${{ matrix.ruby-version }}
 
       - name: Run RSpec tests for Pro package
         run: bundle exec rspec spec/react_on_rails_pro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,12 @@ expect { evaluate(sanitized_content) }.not_to raise_error
 
 Prettier handles all formatting. Never manually format — run `rake autofix` instead.
 
+### GitHub Actions
+
+For GitHub Actions jobs that install Ruby gems, prefer `.github/actions/setup-bundle` over hand-written `actions/cache` plus `bundle install` steps.
+The action validates a committed `Gemfile.lock`, configures the bundle path and Bundler version for later `bundle exec` steps,
+restores/saves the gem cache, and supports non-frozen installs via `frozen: 'false'` for minimum-dependency jobs.
+
 ## Git Workflow
 
 **Branch naming**: `type/descriptive-name` (e.g., `fix/ssr-hydration-mismatch`)


### PR DESCRIPTION
### Summary

Extracts the repeated Bundler cache and install logic into a reusable `.github/actions/setup-bundle` composite action.

The action verifies each Bundler project has a committed `Gemfile.lock`, restores a directory/Ruby-specific gem cache, installs the gems, and saves the cache only for frozen installs. It is now used by the OSS, Pro, benchmark, lint, precompile, Playwright, examples, and integration workflows.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Other Information

Validation run locally:

- `pnpm exec prettier --check .github/actions/setup-bundle/action.yml .github/workflows/benchmark.yml .github/workflows/examples.yml .github/workflows/gem-tests.yml .github/workflows/integration-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/playwright.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml`
- YAML parse for the action and touched workflows
- `actionlint -shellcheck= .github/workflows/benchmark.yml .github/workflows/examples.yml .github/workflows/gem-tests.yml .github/workflows/integration-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/playwright.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable CI action to standardize Ruby gem installation and caching across workflows.
  * Updated CI workflows to use the shared action, removing per-job bundle/cache steps and job-level Bundler env settings.
  * Gem installs are now parameterized by Ruby version and dependency-level for more consistent, maintainable CI runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->