### PR TITLE
docs: add changelog entry for PR #3428

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **Upgrade contributor pnpm tooling to 10.33.4**: The monorepo now pins pnpm 10.33.4 with Corepack's hash-qualified `packageManager` format, keeps the install-generator CI fallback on the same pnpm version, and relies on the root workspace pin instead of duplicate workspace `packageManager` declarations. [PR 3400](https://github.com/shakacode/react_on_rails/pull/3400) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
 - **[Pro]** **Updated Pino in the Node Renderer**: Raised the `react-on-rails-pro-node-renderer` `pino` dependency range to `^9.14.0 || ^10.1.0`, aligning with the current Fastify dependency. [PR 3401](https://github.com/shakacode/react_on_rails/pull/3401) by [alexeyr-ci2](https://github.com/alexeyr-ci2).
+- **[Pro]** **Per-scheduler persistent HTTP connections for Node Renderer**: `RendererHttpClient` now reuses HTTP/2 connections across requests within the same Fiber scheduler (Falcon, async Puma), eliminating per-request TCP+TLS+HTTP/2 handshake overhead. Standalone requests (no outer scheduler) continue using ephemeral connections with guaranteed cleanup. The internal connection pool automatically recovers from broken connections without manual eviction. [PR 3428](https://github.com/shakacode/react_on_rails/pull/3428) by [AbanoubGhadban](https://github.com/AbanoubGhadban).
 
 #### Fixed
 


### PR DESCRIPTION
## Summary

Adds missing changelog entry for PR #3428 (per-scheduler persistent HTTP connections).

## Test plan

- [ ] Verify changelog entry is correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog documenting upcoming Pro feature for persistent HTTP connections in the Node Renderer with automatic recovery capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->