### PR TITLE
Harden Pro rolling deploy bundle responses

### DIFF
--- a/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+++ b/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
@@ -159,6 +159,8 @@ module ReactOnRailsPro
 
       def set_no_store_headers
         response.headers["Cache-Control"] = "no-store"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["X-Content-Type-Options"] = "nosniff"
       end
 
       # Wraps bundle_sources to absorb the "bundle file not present yet" case

--- a/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/rolling_deploy_adapters/http.rb
@@ -175,13 +175,14 @@ module ReactOnRailsPro
             )
             return nil
           end
-          # `response.body` buffers the full tarball (up to DEFAULT_MAX_SIZE)
-          # into a single Ruby String, and `Tarball.extract` then re-reads it
-          # through a `StringIO`. For v1 this is acceptable: build CI fetches
-          # are infrequent and the 200 MB ceiling fits in heap. A future
-          # follow-up should stream the body into a Tempfile (mirroring the
-          # controller's `compose_to_tempfile`) to reduce build-CI heap
-          # pressure for very large bundles.
+          # `response.body` buffers the full compressed tarball into a single
+          # Ruby String before `Tarball.extract` can enforce DEFAULT_MAX_SIZE on
+          # uncompressed bytes. For v1 this is acceptable: build CI fetches are
+          # infrequent, the 200 MB uncompressed ceiling fits in heap, and the
+          # read timeout bounds slow responses. A future follow-up should stream
+          # the body into a Tempfile with its own compressed-byte cap (mirroring
+          # the controller's `compose_to_tempfile`) so an oversized wire payload
+          # cannot fill build-CI heap before extraction aborts.
           response.body
         end
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
@@ -68,6 +68,23 @@ describe ReactOnRailsPro::RollingDeploy::BundlesController do
     end
   end
 
+  describe "#set_no_store_headers" do
+    it "sets no-store and content-sniffing guard headers" do
+      controller = described_class.new
+      headers = {}
+
+      allow(controller).to receive(:response).and_return(instance_double(ActionDispatch::Response, headers: headers))
+
+      controller.send(:set_no_store_headers)
+
+      expect(headers).to eq(
+        "Cache-Control" => "no-store",
+        "Pragma" => "no-cache",
+        "X-Content-Type-Options" => "nosniff"
+      )
+    end
+  end
+
   describe "#tarball_entries" do
     let(:controller) { described_class.new }
 


### PR DESCRIPTION
### Summary

Harden the Pro rolling deploy manifest and bundle endpoints by adding `Pragma: no-cache` and `X-Content-Type-Options: nosniff` alongside the existing `Cache-Control: no-store` header. The controller spec now covers the complete no-store header set, and the HTTP rolling deploy adapter comment clarifies the current compressed-body buffering behavior and future streaming follow-up.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update CHANGELOG file
- [x] Review comments triaged

### Validation

- `(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)`
- `(cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb)`
- `pnpm exec prettier --check packages/react-on-rails-pro/tests/tanstackRouter.test.ts`
- `pnpm exec prettier --check . --ignore-path .prettierignore --ignore-path /Users/justin/conductor/repos/react_on_rails/.git/info/exclude`

### Review and CI notes

No unresolved review threads were present when rechecked after merge. CodeRabbit only reported that the PR was already closed, and Greptile marked the change safe to merge.

The old `Lint JS and Ruby / build` failure was a pre-merge Prettier failure on `packages/react-on-rails-pro/tests/tanstackRouter.test.ts`; that file now passes Prettier on current `main`. The failed `claude-review` jobs were caused by the Claude weekly limit, not by this branch code.
