### PR TITLE
Pin Docker pnpm version and fix docs link check

### DIFF
--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -110,7 +110,7 @@ CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 Replace the Yarn lines with:
 
 ```dockerfile
-RUN corepack enable && corepack prepare pnpm@10 --activate  # pin to your project's major version
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate  # match packageManager in package.json
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/docs/oss/misc/style.md
+++ b/docs/oss/misc/style.md
@@ -30,7 +30,7 @@ Follow these style guidelines per the linter configuration. Basically, lint your
 
 ### Sass Coding Standards
 
-- [Sass Guidelines](https://sass-guidelin.es/) by [Kitty Giraudel](https://kittygiraudel.com/)
+- [Sass Guidelines](https://sass-guidelin.es/) by Kitty Giraudel
 - [Github Front End Guidelines](http://primercss.io/guidelines/)
 
 ## Git Usage

--- a/package.json
+++ b/package.json
@@ -159,7 +159,8 @@
       "pnpm 10 blocks lifecycle scripts by default. Allowlist packages we trust.",
       "When adding native or compiled dependencies, run pnpm ignored-builds and add trusted packages here.",
       "@swc/core: postinstall verifies the platform-specific native binary loads.",
-      "unrs-resolver: napi-postinstall check, used by eslint-import-resolver-typescript."
+      "unrs-resolver: napi-postinstall check, used by eslint-import-resolver-typescript.",
+      "protobufjs: intentionally omitted; its postinstall reports version-scheme warnings, not a build step."
     ],
     "onlyBuiltDependencies": [
       "@swc/core",


### PR DESCRIPTION
### Summary

Closes #3437.

- Pins the Docker deployment pnpm Corepack example to the exact workspace packageManager version.
- Documents why `protobufjs` is intentionally omitted from `pnpm.onlyBuiltDependencies`.
- Removes an unstable personal-site link that caused the markdown link checker to fail.
- Keeps the follow-up limited to documentation and package metadata comments; there is no runtime dependency behavior change.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Validation

- `git diff --check origin/main...HEAD`
- `corepack pnpm exec prettier --check docs/oss/misc/style.md docs/oss/deployment/docker-deployment.md package.json`
- `script/check-docs-sidebar`
- `corepack pnpm run lint`

CI note: rebased onto current `main` after stale jobs failed on an older merge base due to Ruby 3.4.9 rejecting the old `sqlite3-1.7.3-x86_64-linux` lockfile entry. Current `main` has the OSS lockfiles on `sqlite3 2.9.4`.

The markdown link-check failure was unrelated to the original PR files: lychee could not connect to `https://kittygiraudel.com/` from `docs/oss/misc/style.md`. The author credit is now plain text while preserving the Sass Guidelines link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only changes; no runtime or dependency install behavior changes.
> 
> **Overview**
> Aligns **Docker deployment** docs with the workspace by pinning the Corepack `pnpm` example to **`10.33.4`**, matching `packageManager` in `package.json`.
> 
> Adds a **`package.json` comment** explaining why **`protobufjs`** stays off `pnpm.onlyBuiltDependencies` (no real build step; noisy postinstall).
> 
> Fixes **docs link checking** in `style.md` by crediting Kitty Giraudel as plain text instead of linking a site that fails in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92d85151a29f313837425bf2435981eadbad2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker deployment documentation with explicit package manager version specification for improved reproducibility across environments
  * Refined documentation citation formatting and hyperlink structure

* **Chores**
  * Added clarifying comments to configuration explaining dependency override behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->