### PR TITLE
Clarify Shakapacker config warning for relative SHAKAPACKER_CONFIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **Ruby 3.3+ is required for React on Rails v17**: The open-source gem now requires Ruby `>= 3.3.0`, aligning it with React on Rails Pro, `create-react-on-rails-app`, and the CI minimum matrix. React on Rails v16 remains the upgrade path for applications that must stay on Ruby 3.2 or older. [PR 3500](https://github.com/shakacode/react_on_rails/pull/3500) by [justin808](https://github.com/justin808).
 
+#### Fixed
+
+- **Shakapacker config warnings now report resolved relative paths**: When `SHAKAPACKER_CONFIG` is set to a relative missing path, the Rails boot warning now includes the Rails-root-resolved path that React on Rails actually checked. Fixes [Issue 3436](https://github.com/shakacode/react_on_rails/issues/3436). [PR 3441](https://github.com/shakacode/react_on_rails/pull/3441) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.0] - 2026-05-30
 
 #### Breaking Changes

--- a/react_on_rails/lib/react_on_rails/engine.rb
+++ b/react_on_rails/lib/react_on_rails/engine.rb
@@ -169,9 +169,16 @@ module ReactOnRails
       env_config_path = ENV.fetch("SHAKAPACKER_CONFIG", nil)
       return if env_config_path.to_s.empty?
 
+      resolved_config_path = shakapacker_config_path.to_s
+      path_description =
+        if Pathname.new(env_config_path).absolute?
+          "'#{resolved_config_path}'"
+        else
+          "'#{env_config_path}' (resolved to '#{resolved_config_path}')"
+        end
+
       Rails.logger&.warn(
-        "[React on Rails] SHAKAPACKER_CONFIG is set to '#{env_config_path}' " \
-        "(resolved to '#{shakapacker_config_path}') but the file " \
+        "[React on Rails] SHAKAPACKER_CONFIG is set to #{path_description} but the file " \
         "does not exist. Bundler detection treated Shakapacker as not configured for this app; " \
         "fix the path or unset the variable if this is unintended."
       )

--- a/react_on_rails/spec/react_on_rails/engine_spec.rb
+++ b/react_on_rails/spec/react_on_rails/engine_spec.rb
@@ -445,11 +445,14 @@ module ReactOnRails
             FileUtils.remove_entry(app_root)
           end
 
-          it "logs the resolved path that was checked" do
+          it "names the raw env value and the Rails-root-resolved path" do
             described_class.suppress_shakapacker_package_manager_check_if_not_bundler!
 
             expect(Rails.logger).to have_received(:warn)
-              .with(a_string_including("resolved to '#{resolved_config_path}'"))
+              .with(
+                a_string_including("SHAKAPACKER_CONFIG is set to '#{missing_config_path}'")
+                  .and(a_string_including("resolved to '#{resolved_config_path}'"))
+              )
           end
         end
       end

--- a/react_on_rails/spec/react_on_rails/engine_spec.rb
+++ b/react_on_rails/spec/react_on_rails/engine_spec.rb
@@ -425,11 +425,14 @@ module ReactOnRails
           allow(Rails.logger).to receive(:warn)
         end
 
-        it "logs a warning naming the missing path" do
+        it "logs a warning naming the missing path without a redundant resolved-to clause" do
           described_class.suppress_shakapacker_package_manager_check_if_not_bundler!
 
           expect(Rails.logger).to have_received(:warn)
-            .with(a_string_including("SHAKAPACKER_CONFIG is set to '#{missing_config_path}'"))
+            .with(
+              a_string_including("SHAKAPACKER_CONFIG is set to '#{missing_config_path}'")
+                .and(satisfy("omits the redundant '(resolved to ...)' clause") { |msg| !msg.include?("resolved to") })
+            )
         end
 
         context "when the configured path is relative" do


### PR DESCRIPTION
### Summary

Fixes #3436 by making the missing `SHAKAPACKER_CONFIG` warning show the Rails-root-resolved path when the env value is relative, matching the path React on Rails actually checks. Absolute values still show the resolved path only (since it equals the raw value).

Also adds engine spec coverage asserting the warning includes the resolved path for relative `SHAKAPACKER_CONFIG` values.

### Changes

- `react_on_rails/lib/react_on_rails/engine.rb` — branch the warning text on `Pathname#absolute?`: absolute paths log `'…'`, relative paths log `'raw' (resolved to '…')`.
- `react_on_rails/spec/react_on_rails/engine_spec.rb` — new context covers the relative-path branch and verifies the resolved path appears in the warning.
- `CHANGELOG.md` — entry under `[Unreleased]` referencing this PR and #3436.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~ (boot-time log message only)
- [x] Update CHANGELOG file

### Other Information

Validated locally with `bundle exec rspec react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb react_on_rails/spec/react_on_rails/engine_spec.rb` (244 examples, 0 failures) and `bundle exec rubocop` on the changed files (clean).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log-message and test-only change at Rails boot; no runtime bundler or config resolution behavior is altered.
> 
> **Overview**
> Fixes confusing boot warnings when **`SHAKAPACKER_CONFIG`** points at a missing file and the env value is **relative**.
> 
> **`warn_if_shakapacker_env_config_missing`** now builds **`path_description`** from whether the env path is absolute: absolute values show only the resolved path (same as before, without duplicating “resolved to”); relative values show **`'raw' (resolved to '…')`** so the message matches the Rails-root path React on Rails actually checks.
> 
> Specs in **`engine_spec.rb`** assert absolute paths omit the redundant “resolved to” clause and relative paths include both the raw env value and the resolved path. **`CHANGELOG.md`** documents the fix for #3436.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2baaf7cc038e27ba29aab4ab614e7051c2ebedf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Shakapacker configuration warning messages to include the Rails-root-resolved path when `SHAKAPACKER_CONFIG` is set to a relative missing path. The warnings now clearly display both the user-provided environment variable value and the actual resolved configuration path, making it easier to identify exactly which file was checked and facilitating debugging configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->