### PR TITLE
Document pnpm 10 Docker pin and protobufjs allowlist rationale

### DIFF
--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -110,7 +110,7 @@ CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 Replace the Yarn lines with:
 
 ```dockerfile
-RUN corepack enable && corepack prepare pnpm@10 --activate  # pin to your project's major version
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate  # match packageManager in package.json
 
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "// for onlyBuiltDependencies": [
       "pnpm 10 blocks lifecycle scripts by default. Allowlist packages we trust.",
       "When adding native or compiled dependencies, run pnpm ignored-builds and add trusted packages here.",
+      "protobufjs: intentionally NOT listed - its postinstall is a version-scheme warning, not a build step.",
       "@swc/core: postinstall verifies the platform-specific native binary loads.",
       "unrs-resolver: napi-postinstall check, used by eslint-import-resolver-typescript."
     ],


### PR DESCRIPTION
### Summary

Fixes #3437.

Documents the pnpm 10 follow-up choices from the build-script allowlist work:

- Pins the Docker deployment example to `pnpm@10.33.4`, matching the workspace `packageManager` value.
- Records why `protobufjs` is intentionally excluded from `pnpm.onlyBuiltDependencies`: its postinstall emits a version-scheme warning and is not a trusted native build step.

### Review and CI notes

- Rebased onto current `main` at `8edf6b79`.
- Review triage found no unresolved inline threads.
- Must-fix: none found.
- Optional: none found.
- Discuss/advice: future `packageManager` bumps should update the exact pnpm version in the Docker deployment snippet in the same change.
- CI: the previous pushed SHA failed on inherited CI issues: `claude-review` failed before repo code ran with a workflow validation/token exchange error, and the Ruby-backed checks hit a Ruby 3.4 incompatible `sqlite3-1.7.3-x86_64-linux` install. Current `main` includes the Claude workflow restoration and updated locks, so this rebase supersedes those failures.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Validation

- `git diff --check origin/main...HEAD`
- `corepack pnpm exec prettier --check package.json docs/oss/deployment/docker-deployment.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and inline comments only; no application, auth, or install logic changes.
> 
> **Overview**
> Documents follow-up from pnpm 10 **build-script allowlist** work: no runtime or install behavior changes beyond what was already configured.
> 
> The **Docker deployment** pnpm example now pins **`pnpm@10.33.4`** via Corepack (was a generic **`pnpm@10`**) and the comment tells maintainers to keep that pin aligned with **`packageManager`** in **`package.json`**.
> 
> A **`pnpm.onlyBuiltDependencies`** comment records that **`protobufjs`** is deliberately **not** allowlisted because its postinstall only prints a version-scheme warning, not a trusted native build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd263a932c587cab18c025a74684e8a995571fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deployment docs updated to pin pnpm to a specific release for more consistent Docker builds.

* **Chores**
  * Clarified dependency configuration: added a comment explaining why a package is intentionally excluded from built-dependencies (postinstall/version warning).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->