### PR TITLE
Clarify resolved Shakapacker config path warnings

### DIFF
--- a/react_on_rails/lib/react_on_rails/engine.rb
+++ b/react_on_rails/lib/react_on_rails/engine.rb
@@ -170,7 +170,8 @@ module ReactOnRails
       return if env_config_path.to_s.empty?
 
       Rails.logger&.warn(
-        "[React on Rails] SHAKAPACKER_CONFIG is set to '#{env_config_path}' but the file " \
+        "[React on Rails] SHAKAPACKER_CONFIG is set to '#{env_config_path}' " \
+        "(resolved to '#{shakapacker_config_path}') but the file " \
         "does not exist. Bundler detection treated Shakapacker as not configured for this app; " \
         "fix the path or unset the variable if this is unintended."
       )

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1570,6 +1570,82 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     end
   end
 
+  describe ".shakapacker_config_base_dir" do
+    it "uses Rails.root when Rails is loaded" do
+      rails_root = Pathname.new("/tmp/rails-root")
+      allow(Rails).to receive(:root).and_return(rails_root)
+
+      expect(described_class.send(:shakapacker_config_base_dir)).to eq(rails_root.to_s)
+    end
+
+    it "falls back to the current working directory when Rails is not loaded" do
+      Dir.mktmpdir("react-on-rails-cwd") do |cwd|
+        Dir.chdir(cwd) do
+          hide_const("Rails")
+
+          expect(described_class.send(:shakapacker_config_base_dir)).to eq(Dir.pwd)
+        end
+      end
+    end
+  end
+
+  describe ".shakapacker_config_path" do
+    let(:rails_root) { Pathname.new(Dir.mktmpdir("react-on-rails-root")) }
+
+    around do |example|
+      original_config_path = ENV.fetch("SHAKAPACKER_CONFIG", nil)
+      original_cwd = Dir.pwd
+      ENV.delete("SHAKAPACKER_CONFIG")
+      example.run
+    ensure
+      ENV["SHAKAPACKER_CONFIG"] = original_config_path
+      Dir.chdir(original_cwd)
+      FileUtils.remove_entry(rails_root) if rails_root.exist?
+    end
+
+    before do
+      allow(Rails).to receive(:root).and_return(rails_root)
+    end
+
+    it "defaults to config/shakapacker.yml under Rails.root" do
+      expect(described_class.send(:shakapacker_config_path)).to eq(
+        rails_root.join("config", "shakapacker.yml").to_s
+      )
+    end
+
+    it "resolves a relative SHAKAPACKER_CONFIG path against Rails.root" do
+      ENV["SHAKAPACKER_CONFIG"] = "config/custom-shakapacker.yml"
+
+      Dir.mktmpdir("react-on-rails-cwd") do |unrelated_cwd|
+        Dir.chdir(unrelated_cwd) do
+          expect(described_class.send(:shakapacker_config_path)).to eq(
+            rails_root.join("config", "custom-shakapacker.yml").to_s
+          )
+        end
+      end
+    end
+
+    it "preserves an absolute SHAKAPACKER_CONFIG path" do
+      config_path = "/tmp/custom-shakapacker.yml"
+      ENV["SHAKAPACKER_CONFIG"] = config_path
+
+      expect(described_class.send(:shakapacker_config_path)).to eq(config_path)
+    end
+
+    it "uses the current working directory for relative config when Rails is not loaded" do
+      hide_const("Rails")
+      ENV["SHAKAPACKER_CONFIG"] = "config/custom-shakapacker.yml"
+
+      Dir.mktmpdir("react-on-rails-cwd") do |cwd|
+        Dir.chdir(cwd) do
+          expect(described_class.send(:shakapacker_config_path)).to eq(
+            File.expand_path("config/custom-shakapacker.yml", Dir.pwd)
+          )
+        end
+      end
+    end
+  end
+
   describe ".run_test_watch" do
     before do
       allow(described_class).to receive(:puts)

--- a/react_on_rails/spec/react_on_rails/engine_spec.rb
+++ b/react_on_rails/spec/react_on_rails/engine_spec.rb
@@ -431,6 +431,27 @@ module ReactOnRails
           expect(Rails.logger).to have_received(:warn)
             .with(a_string_including("SHAKAPACKER_CONFIG is set to '#{missing_config_path}'"))
         end
+
+        context "when the configured path is relative" do
+          let(:app_root) { Pathname.new(Dir.mktmpdir("react-on-rails-root")) }
+          let(:missing_config_path) { "config/custom-shakapacker.yml" }
+          let(:resolved_config_path) { app_root.join(missing_config_path) }
+
+          before do
+            allow(Rails).to receive(:root).and_return(app_root)
+          end
+
+          after do
+            FileUtils.remove_entry(app_root)
+          end
+
+          it "logs the resolved path that was checked" do
+            described_class.suppress_shakapacker_package_manager_check_if_not_bundler!
+
+            expect(Rails.logger).to have_received(:warn)
+              .with(a_string_including("resolved to '#{resolved_config_path}'"))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Summary

Adds the resolved Shakapacker config path to the missing `SHAKAPACKER_CONFIG` warning so relative-path typos show the exact Rails-root-expanded path that was checked.

Adds regression coverage for:

- `Engine` warning output when a relative `SHAKAPACKER_CONFIG` path resolves under `Rails.root`
- `ServerManager` default config resolution under `Rails.root`
- relative `SHAKAPACKER_CONFIG` resolution against `Rails.root`
- absolute `SHAKAPACKER_CONFIG` preservation
- `Dir.pwd` fallback when Rails is not loaded

Fixes #3436.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Validation

Validated locally after rebasing on current `origin/main`:

- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/engine_spec.rb spec/react_on_rails/dev/server_manager_spec.rb)`
- `(cd react_on_rails && bundle exec rubocop)`
- `git diff --check origin/main...HEAD`

### CI and review triage

- Rebased onto current `origin/main` and force-pushed head `46d2ed68`.
- The previous Ruby CI failures were setup failures on the old merge ref: `sqlite3-1.7.3-x86_64-linux` rejected Ruby 3.4.9. Current `origin/main` updates the `react_on_rails` and dummy lockfiles to `sqlite3 2.9.4`, and the rebased PR now includes those lockfile updates from the base branch.
- The previous `claude-review` run failed because the workflow file did not yet match the repository default branch. The rebase includes the default-branch workflow state, so the fresh run should use the matching workflow.
- `/address-review` triage found no unresolved inline review threads, no submitted review summaries, and no must-fix or optional items. The only review-related comment was CodeRabbit's draft/status message, classified as skipped/status noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change to a boot-time warning plus test additions; no auth, security, or runtime behavior changes beyond clearer diagnostics.
>
> **Overview**
> When `SHAKAPACKER_CONFIG` points at a file that does not exist, the React on Rails engine boot warning now includes the **resolved** path via `shakapacker_config_path`, not only the raw env value, so relative paths show the Rails-root-expanded location that was actually checked.
>
> Specs lock this in for a relative env path on `Engine`, and add coverage for `Dev::ServerManager` Shakapacker config resolution: default under `Rails.root`, relative vs absolute `SHAKAPACKER_CONFIG`, and `Dir.pwd` when Rails is not loaded.
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced boot-time warning message to display both the raw configuration value and its resolved absolute path when Shakapacker configuration file is missing, providing clearer diagnostic information for troubleshooting configuration issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->