### PR TITLE
[codex] Fix TanStack Router test formatting

### DIFF
--- a/.github/actions/check-full-ci-label/action.yml
+++ b/.github/actions/check-full-ci-label/action.yml
@@ -12,6 +12,7 @@ runs:
       uses: actions/github-script@v7
       with:
         result-encoding: string
+        retries: 3
         script: |
           // Only check labels on pull requests
           if (!context.payload.pull_request) {

--- a/packages/react-on-rails-pro/tests/tanstackRouter.test.ts
+++ b/packages/react-on-rails-pro/tests/tanstackRouter.test.ts
@@ -426,10 +426,10 @@ describe('tanstack-router integration (Pro)', () => {
   it('hydrates server-rendered HTML from actual router loader state without recoverable hydration errors', () =>
     withResponsePolyfill(async () => {
       // This narrow provider intentionally reads the first-render router state.
-    // Minimal stub: TanStack Router only checks `typeof Response !== 'undefined'` for
-    // its SSR helpers. If a future release constructs Response instances, this stub
-    // will need to be replaced with a more complete polyfill.
-    globalThis.Response = class Response {} as typeof Response;
+      // Minimal stub: TanStack Router only checks `typeof Response !== 'undefined'` for
+      // its SSR helpers. If a future release constructs Response instances, this stub
+      // will need to be replaced with a more complete polyfill.
+      globalThis.Response = class Response {} as typeof Response;
       // hydration test verifies that SSR-injected state is present before the
       // first client render, which is the hydration contract this adapter owns.
       // Using ActualRouterProvider here exercises TanStack's subscription layer


### PR DESCRIPTION
### Summary

Fixes Prettier formatting drift in the Pro TanStack Router hydration test by indenting the `Response` polyfill comment and assignment inside the callback.
Also retries the shared `check-full-ci-label` GitHub Script step so transient GitHub API `fetch failed` errors do not fail `detect-changes` jobs before package tests run.

### Pull Request checklist

- ~[x] Add/update test to cover these changes~
- ~[x] Update documentation~
- ~[x] Update CHANGELOG file~

### Other Information

Validation: `pnpm start format.listDifferent` passed before the PR instruction attachment was added; `actionlint -ignore 'shellcheck reported issue'`, `pnpm exec prettier --check .github/actions/check-full-ci-label/action.yml`, and YAML parsing for the action file passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic retry logic to CI validation processes for improved reliability.

* **Tests**
  * Enhanced test setup with better documentation and clarity for server-side rendering validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->