### PR TITLE
Add E2E CI change detection and label guidance

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -24,6 +24,10 @@ on:
       run_generators:
         description: 'Should run generator tests'
         value: ${{ jobs.detect.outputs.run_generators }}
+      run_e2e_tests:
+        description: 'Should run Playwright E2E tests'
+        # TODO: wire into .github/workflows/playwright.yml job gating.
+        value: ${{ jobs.detect.outputs.run_e2e_tests }}
 
 jobs:
   detect:
@@ -39,6 +43,7 @@ jobs:
       run_js_tests: ${{ steps.changes.outputs.run_js_tests }}
       run_dummy_tests: ${{ steps.changes.outputs.run_dummy_tests }}
       run_generators: ${{ steps.changes.outputs.run_generators }}
+      run_e2e_tests: ${{ steps.changes.outputs.run_e2e_tests }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,16 @@ restores/saves the gem cache, and supports non-frozen installs via `frozen: 'fal
 
 ## Review Workflow
 
+### PR CI Labels
+
+Agents should recommend PR labels based on change complexity and risk. The goal is to keep low-risk PRs mergeable on fast, path-relevant CI while still escalating high-risk PRs (HPRs) before merge.
+
+- **Default: no CI-expansion label.** For docs-only changes, focused tests, small isolated fixes, and refactors with no cross-package behavior change, rely on the standard path-based CI selection and local verification.
+- **Use `full-ci`** (or ask a maintainer to comment `/run-skipped-ci`) when the PR is high-risk or broad: CI workflow/detector changes, dependency or lockfile updates, package manager/Ruby/Node version changes, release/build/package publishing logic, generator output, dummy app boot/build behavior, SSR or hydration behavior, cross-cutting core Ruby changes, Pro/core boundary changes, or changes where skipped suites would leave a credible regression path.
+- **Use `benchmark`** for performance-sensitive changes: server rendering paths, Node renderer, caching, bundle generation, asset serving/precompile behavior, concurrency/pooling, or anything expected to affect throughput, latency, memory, or bundle size. `full-ci` does not trigger benchmarks; use both labels when a PR is both high-risk and performance-sensitive.
+- **Remove `full-ci` when no longer needed** with `/stop-run-skipped-ci` if the PR returns to a low-risk state after splitting or reverting broad changes.
+- In PR descriptions and handoffs, state the recommended label decision explicitly: `Labels: none`, `Labels: full-ci`, `Labels: benchmark`, or `Labels: full-ci, benchmark`, with one sentence explaining why.
+
 For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 
 - Use at most one AI reviewer that leaves inline comments. Additional AI tools should be summary-only or used manually.

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -3,6 +3,8 @@
 # Analyzes git changes to determine which CI jobs need to run
 # Usage: script/ci-changes-detector [base-ref]
 #
+# Tests: bash script/ci-changes-detector-test.bash
+#
 # Diff-base logic lives in script/lib/git-diff-base. Run its self-contained
 # tests with: bash script/lib/git-diff-base-test.bash
 # CI invokes the same harness via .github/workflows/git-diff-base-tests.yml.
@@ -423,6 +425,7 @@ if [ "$DOCS_ONLY" = true ]; then
     "run_js_tests:false"
     "run_dummy_tests:false"
     "run_generators:false"
+    "run_e2e_tests:false"
     "run_pro_lint:false"
     "run_pro_tests:false"
     "run_pro_dummy_tests:false"
@@ -487,6 +490,7 @@ RUN_RUBY_TESTS=false
 RUN_JS_TESTS=false
 RUN_DUMMY_TESTS=false
 RUN_GENERATORS=false
+RUN_E2E_TESTS=false
 RUN_PRO_LINT=false
 RUN_PRO_TESTS=false
 RUN_PRO_DUMMY_TESTS=false
@@ -510,6 +514,12 @@ fi
 
 if [ "$SPEC_DUMMY_CHANGED" = true ] || [ "$RUBY_CORE_CHANGED" = true ] || [ "$JS_CHANGED" = true ]; then
   RUN_DUMMY_TESTS=true
+fi
+
+if [ "$RUN_DUMMY_TESTS" = true ]; then
+  # E2E tests exercise the dummy app integration stack, so pure gem-spec or
+  # generator-only changes do not trigger them unless another dummy trigger does.
+  RUN_E2E_TESTS=true
 fi
 
 # JS changes trigger generator tests because generators do a full build
@@ -545,6 +555,7 @@ if [ "$UNCATEGORIZED_CHANGED" = true ]; then
   RUN_JS_TESTS=true
   RUN_DUMMY_TESTS=true
   RUN_GENERATORS=true
+  RUN_E2E_TESTS=true
   RUN_PRO_LINT=true
   RUN_PRO_TESTS=true
   RUN_PRO_DUMMY_TESTS=true
@@ -556,6 +567,7 @@ fi
 [ "$RUN_JS_TESTS" = true ] && echo "  ✓ JS unit tests"
 [ "$RUN_DUMMY_TESTS" = true ] && echo "  ✓ Dummy app integration tests"
 [ "$RUN_GENERATORS" = true ] && echo "  ✓ Generator tests"
+[ "$RUN_E2E_TESTS" = true ] && echo "  ✓ Playwright E2E tests"
 [ "$RUN_PRO_LINT" = true ] && echo "  ✓ React on Rails Pro Lint (Ruby + RBS + TypeScript)"
 [ "$RUN_PRO_TESTS" = true ] && echo "  ✓ React on Rails Pro RSpec unit tests (Ruby + JS)"
 [ "$RUN_PRO_DUMMY_TESTS" = true ] && echo "  ✓ React on Rails Pro Dummy app integration tests"
@@ -571,6 +583,7 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "run_js_tests=$RUN_JS_TESTS"
     echo "run_dummy_tests=$RUN_DUMMY_TESTS"
     echo "run_generators=$RUN_GENERATORS"
+    echo "run_e2e_tests=$RUN_E2E_TESTS"
     echo "run_pro_lint=$RUN_PRO_LINT"
     echo "run_pro_tests=$RUN_PRO_TESTS"
     echo "run_pro_dummy_tests=$RUN_PRO_DUMMY_TESTS"
@@ -589,6 +602,7 @@ if [ "${CI_JSON_OUTPUT:-}" = "1" ]; then
   "run_js_tests": $RUN_JS_TESTS,
   "run_dummy_tests": $RUN_DUMMY_TESTS,
   "run_generators": $RUN_GENERATORS,
+  "run_e2e_tests": $RUN_E2E_TESTS,
   "run_pro_lint": $RUN_PRO_LINT,
   "run_pro_tests": $RUN_PRO_TESTS,
   "run_pro_dummy_tests": $RUN_PRO_DUMMY_TESTS,

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -143,6 +143,15 @@ commit_change() {
   git commit -m "$message" >/dev/null
 }
 
+write_file_change() {
+  local path="$1"
+  local content="${2:-changed}"
+
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$content" > "$path"
+  commit_change "change $path"
+}
+
 test_docs_changes_are_non_runtime_only() {
   setup_repo
   printf '\nMore docs.\n' >> docs/guide.md
@@ -402,6 +411,66 @@ test_block_comment_with_trailing_code_remains_runtime_affecting() {
   assert_contains "$out" '"run_js_tests": true' "trailing code after block close output"
 }
 
+test_pro_only_changes_do_not_request_e2e() {
+  setup_repo
+  write_file_change "react_on_rails_pro/lib/react_on_rails_pro/example.rb"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_e2e_tests": false' "pro-only output"
+}
+
+test_rspec_only_changes_do_not_request_e2e() {
+  setup_repo
+  write_file_change "react_on_rails/spec/react_on_rails/some_spec.rb"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_ruby_tests": true' "rspec-only output"
+  assert_contains "$out" '"run_dummy_tests": false' "rspec-only output"
+  assert_contains "$out" '"run_e2e_tests": false' "rspec-only output"
+}
+
+test_generator_only_changes_do_not_request_e2e() {
+  setup_repo
+  write_file_change "react_on_rails/lib/generators/react_on_rails/install/example.rb"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_ruby_tests": true' "generator-only output"
+  assert_contains "$out" '"run_generators": true' "generator-only output"
+  assert_contains "$out" '"run_dummy_tests": false' "generator-only output"
+  assert_contains "$out" '"run_e2e_tests": false' "generator-only output"
+}
+
+test_dummy_app_changes_request_e2e() {
+  setup_repo
+  write_file_change "react_on_rails/spec/dummy/app/views/pages/example.html.erb"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_e2e_tests": true' "dummy app output"
+}
+
+test_core_ruby_changes_request_e2e() {
+  setup_repo
+  write_file_change "react_on_rails/lib/react_on_rails/example.rb"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_dummy_tests": true' "core ruby output"
+  assert_contains "$out" '"run_e2e_tests": true' "core ruby output"
+}
+
+test_core_js_changes_request_e2e() {
+  setup_repo
+  write_file_change "packages/react-on-rails/src/example.ts"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_e2e_tests": true' "core js output"
+}
+
 run_test test_docs_changes_are_non_runtime_only
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint
@@ -423,6 +492,12 @@ run_test test_jsdoc_jsx_import_source_pragma_remains_runtime_affecting
 run_test test_inline_block_comment_license_remains_runtime_affecting
 run_test test_pure_annotation_remains_runtime_affecting
 run_test test_block_comment_with_trailing_code_remains_runtime_affecting
+run_test test_pro_only_changes_do_not_request_e2e
+run_test test_rspec_only_changes_do_not_request_e2e
+run_test test_generator_only_changes_do_not_request_e2e
+run_test test_dummy_app_changes_request_e2e
+run_test test_core_ruby_changes_request_e2e
+run_test test_core_js_changes_request_e2e
 
 echo
 echo "CI changes detector tests: $TESTS_RUN run, $TESTS_FAILED failed"


### PR DESCRIPTION
### Summary

Adds a `run_e2e_tests` decision to the CI changes detector and exposes it from the reusable `detect-changes` workflow. The flag follows the OSS dummy/core change paths that should exercise Playwright E2E coverage, while staying false for docs-only and Pro-only changes.

Also adds a shell test harness for `script/ci-changes-detector`, wires that harness into the existing Git Diff Base Library Tests workflow, keeps the git-diff-base harness expectations current, and documents agent guidance for recommending `full-ci`, `benchmark`, or no CI-expansion label.

### Review handling

- Rebased on the latest `origin/main` and pushed the rebased PR branch.
- Addressed optional harness feedback by preserving the caller's original `errexit` state in `run_test`.
- Addressed optional harness feedback by including the actual output in `assert_contains` failure messages.
- Addressed optional harness parity feedback by adding the defensive `before_failed` guard, using the sibling harness's `git -c init.defaultBranch=main init` style, and making the copied `script/lib/git-diff-base` executable in fixtures.
- Addressed optional coverage feedback by adding docs-only, RSpec-only, generator-only, and Ruby-core boundary tests for `run_e2e_tests`.
- Addressed optional clarity feedback with a TODO on the exported-but-not-consumed workflow output and an inline note explaining why E2E follows dummy-app triggers rather than pure gem-spec or generator-only changes.
- Verified the repeated P1 detector-trigger concern against the rebased branch: the git-diff-base harness passes locally, so detector-only changes are not gated on a failing harness in the current branch.

### Discussion / follow-up advice

`run_e2e_tests` is currently exported but not consumed by `.github/workflows/playwright.yml`. That keeps this PR focused on detection and test coverage. The follow-up implementation should add PR-triggered Playwright gating that reads this output, likely by adding `run_e2e_tests` to the Playwright workflow's detect job outputs and using it in the Playwright job `if:` condition alongside `workflow_dispatch` and main-push behavior.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] ~Update CHANGELOG file~

### Test plan

- `bash script/ci-changes-detector-test.bash` (`7/7`)
- `bash script/lib/git-diff-base-test.bash` (`33/33`)
- `shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/ci-changes-detector-test.bash`
- `actionlint .github/workflows/detect-changes.yml .github/workflows/git-diff-base-tests.yml`
- `git diff --check`
- Pre-commit hook: trailing-newlines, prettier
- Pre-push hook: branch-lint, markdown-links

Labels: `full-ci` because this PR changes CI detection and workflow coverage. No `benchmark` label: the change does not affect runtime performance paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating logic and a reusable workflow output; incorrect E2E triggering could skip or over-run Playwright until playwright.yml is wired, but behavior is covered by new harness tests.
> 
> **Overview**
> Introduces a **`run_e2e_tests`** flag in the CI changes detector and surfaces it from the reusable **`detect-changes`** workflow. Playwright E2E is requested when the same paths that already trigger dummy integration tests change (core Ruby, JS package, dummy app); it stays **off** for docs-only, Pro-only, pure gem RSpec, and generator-only edits. The workflow output is documented with a **TODO** because **`playwright.yml` does not consume it yet**.
> 
> **`AGENTS.md`** adds guidance for when agents should recommend **`full-ci`**, **`benchmark`**, or no CI-expansion label on PRs.
> 
> The detector gains a **`write_file_change`** helper and six new harness cases that lock in **`run_e2e_tests`** behavior at those boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b15d2ce8223569b587d63c1c93903262fbe25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to detect when end-to-end tests should run based on code changes.
  * Enhanced test detection logic to flag relevant test categories.

* **Tests**
  * Added test coverage for CI change detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
