### PR TITLE
Run benchmark suites independently

### DIFF
--- a/.github/actions/setup-benchmark-runner/action.yml
+++ b/.github/actions/setup-benchmark-runner/action.yml
@@ -1,0 +1,109 @@
+name: Setup benchmark runner
+description: Install common tools and build packages needed by benchmark jobs.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Bencher CLI
+      # Pinned: alert-detection heuristics grep stderr for "Alert[s]",
+      # "threshold violation", and "boundary violation". Those strings
+      # are not a documented API contract, so upgrading the CLI requires
+      # re-verifying that the expected phrases still appear in alert output.
+      uses: bencherdev/bencher@v0.6.2
+
+    - name: Add tools directory to PATH
+      shell: bash
+      run: |
+        mkdir -p ~/bin
+        echo "$HOME/bin" >> "$GITHUB_PATH"
+
+    - name: Setup k6
+      uses: grafana/setup-k6-action@v1
+      with:
+        k6-version: ${{ env.K6_VERSION }}
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ env.RUBY_VERSION }}
+
+    - name: Get gem home directory
+      shell: bash
+      run: echo "GEM_HOME_PATH=$(gem env home)" >> "$GITHUB_ENV"
+
+    - name: Cache foreman gem
+      id: cache-foreman
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.GEM_HOME_PATH }}
+        key: foreman-gem-${{ runner.os }}-ruby-${{ env.RUBY_VERSION }}
+
+    - name: Install foreman
+      if: steps.cache-foreman.outputs.cache-hit != 'true'
+      shell: bash
+      run: gem install foreman
+
+    - name: Fix dependency for libyaml-dev
+      shell: bash
+      run: sudo apt install libyaml-dev -y
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v6
+      with:
+        cache: true
+        cache_dependency_path: '**/pnpm-lock.yaml'
+        run_install: false
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+
+    - name: Print system information
+      shell: bash
+      run: |
+        echo "Linux release: "
+        cat /etc/issue
+        echo "Current user: "
+        whoami
+        echo "Current directory: "
+        pwd
+        echo "Ruby version: "
+        ruby -v
+        echo "Node version: "
+        node -v
+        echo "Pnpm version: "
+        pnpm --version
+        echo "Bundler version: "
+        bundle --version
+
+    - name: Configure CPU pinning and process priority
+      shell: bash
+      run: |
+        NPROC=$(nproc)
+        echo "Available CPUs: $NPROC"
+
+        SERVER_CMD="nice -n -20 taskset -c 1-$((NPROC-1)) bin/prod"
+        BENCH_CMD="nice -n -10 taskset -c 0 ruby"
+
+        echo "SERVER_CMD=$SERVER_CMD" >> "$GITHUB_ENV"
+        echo "BENCH_CMD=$BENCH_CMD" >> "$GITHUB_ENV"
+
+        if [ -z "$WEB_CONCURRENCY" ]; then
+          WEB_CONCURRENCY=$((NPROC-1))
+          echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> "$GITHUB_ENV"
+          echo "WEB_CONCURRENCY (auto): $WEB_CONCURRENCY"
+        else
+          echo "WEB_CONCURRENCY (from input): $WEB_CONCURRENCY"
+        fi
+
+        echo "SERVER_CMD: $SERVER_CMD"
+        echo "BENCH_CMD: $BENCH_CMD"
+
+    - name: Install Node modules with pnpm
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Build workspace packages
+      shell: bash
+      run: pnpm run build

--- a/.github/actions/setup-benchmark-runner/action.yml
+++ b/.github/actions/setup-benchmark-runner/action.yml
@@ -23,6 +23,12 @@ runs:
         mkdir -p ~/bin
         echo "$HOME/bin" >> "$GITHUB_PATH"
 
+    - name: Install libyaml-dev
+      # Must precede any gem install/load: psych links libyaml dynamically. On warm caches the
+      # missing-lib failure is silent; cold runs hit it.
+      shell: bash
+      run: sudo apt-get install -y libyaml-dev
+
     - name: Setup k6
       if: inputs.install-k6 == 'true'
       uses: grafana/setup-k6-action@v1
@@ -49,10 +55,6 @@ runs:
       if: steps.cache-foreman.outputs.cache-hit != 'true'
       shell: bash
       run: gem install foreman
-
-    - name: Fix dependency for libyaml-dev
-      shell: bash
-      run: sudo apt install libyaml-dev -y
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v6

--- a/.github/actions/setup-benchmark-runner/action.yml
+++ b/.github/actions/setup-benchmark-runner/action.yml
@@ -104,7 +104,9 @@ runs:
         echo "BENCH_CMD=$BENCH_CMD" >> "$GITHUB_ENV"
 
         if [ -z "$WEB_CONCURRENCY" ]; then
-          WEB_CONCURRENCY=$((NPROC-1))
+          # Clamp to >=1 so single-CPU runners don't end up with WEB_CONCURRENCY=0 (Puma
+          # would start in single-mode, which the benchmarks aren't tuned for).
+          WEB_CONCURRENCY=$((NPROC > 1 ? NPROC - 1 : 1))
           echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> "$GITHUB_ENV"
           echo "WEB_CONCURRENCY (auto): $WEB_CONCURRENCY"
         else

--- a/.github/actions/setup-benchmark-runner/action.yml
+++ b/.github/actions/setup-benchmark-runner/action.yml
@@ -1,6 +1,12 @@
 name: Setup benchmark runner
 description: Install common tools and build packages needed by benchmark jobs.
 
+inputs:
+  install-k6:
+    description: Whether to install k6 for Rails benchmark jobs.
+    required: false
+    default: 'true'
+
 runs:
   using: composite
   steps:
@@ -18,6 +24,7 @@ runs:
         echo "$HOME/bin" >> "$GITHUB_PATH"
 
     - name: Setup k6
+      if: inputs.install-k6 == 'true'
       uses: grafana/setup-k6-action@v1
       with:
         k6-version: ${{ env.K6_VERSION }}

--- a/.github/actions/setup-benchmark-runner/action.yml
+++ b/.github/actions/setup-benchmark-runner/action.yml
@@ -90,8 +90,13 @@ runs:
         NPROC=$(nproc)
         echo "Available CPUs: $NPROC"
 
-        SERVER_CMD="nice -n -20 taskset -c 1-$((NPROC-1)) bin/prod"
-        BENCH_CMD="nice -n -10 taskset -c 0 ruby"
+        if [ "$NPROC" -le 1 ]; then
+          SERVER_CMD="bin/prod"
+          BENCH_CMD="ruby"
+        else
+          SERVER_CMD="nice -n -20 taskset -c 1-$((NPROC-1)) bin/prod"
+          BENCH_CMD="nice -n -10 taskset -c 0 ruby"
+        fi
 
         echo "SERVER_CMD=$SERVER_CMD" >> "$GITHUB_ENV"
         echo "BENCH_CMD=$BENCH_CMD" >> "$GITHUB_ENV"

--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -37,6 +37,13 @@ runs:
           exit 1
         fi
 
+    - name: Install libyaml-dev
+      # Required by psych (Ruby's YAML parser). Without it Ruby falls back to a gem load
+      # path that pulls in date_core.so and fails with cryptic glibc errors when the bundle
+      # cache was populated on a different ubuntu image.
+      shell: bash
+      run: sudo apt-get install -y libyaml-dev
+
     - name: Restore Ruby gems cache
       id: restore-ruby-gems-cache
       uses: actions/cache/restore@v5

--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -37,13 +37,6 @@ runs:
           exit 1
         fi
 
-    - name: Install libyaml-dev
-      # Required by psych (Ruby's YAML parser). Without it Ruby falls back to a gem load
-      # path that pulls in date_core.so and fails with cryptic glibc errors when the bundle
-      # cache was populated on a different ubuntu image.
-      shell: bash
-      run: sudo apt-get install -y libyaml-dev
-
     - name: Restore Ruby gems cache
       id: restore-ruby-gems-cache
       uses: actions/cache/restore@v5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,7 +75,6 @@ env:
   # Determine which apps/benchmarks to run (default is 'both' for all triggers)
   RUN_CORE: ${{ contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}
   RUN_PRO: ${{ (github.event.inputs.app_version || 'both') != 'core_only' && 'true' || '' }}
-  RUN_PRO_RAILS: ${{ contains(fromJSON('["both", "pro_only", "pro_rails_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}
   RUN_PRO_NODE_RENDERER: ${{ contains(fromJSON('["both", "pro_only", "pro_node_renderer_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}
   # Benchmark parameters (defaults in bench.rb unless overridden here for CI)
   ROUTES: ${{ github.event.inputs.routes }}
@@ -96,6 +95,7 @@ jobs:
       actions: read
     runs-on: ubuntu-22.04
     outputs:
+      docs_only: ${{ steps.detect.outputs.docs_only }}
       run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}
       run_pro_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_benchmarks }}
       run_pro_node_renderer_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_node_renderer_benchmarks }}
@@ -112,6 +112,18 @@ jobs:
           BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
+      - name: Install Ruby Gems for Core dummy app
+        if: steps.detect.outputs.docs_only != 'true'
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Install Ruby Gems for Pro dummy app
+        if: steps.detect.outputs.docs_only != 'true'
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
       - name: Set benchmark outputs
         id: benchmark-outputs
         if: steps.detect.outputs.non_runtime_only != 'true'
@@ -170,6 +182,7 @@ jobs:
     name: Core benchmarks (shard ${{ matrix.shard_label }})
     if: |
       contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') &&
+      needs.detect-changes.outputs.docs_only != 'true' &&
       (
         github.event_name == 'push' ||
         needs.detect-changes.outputs.run_core_benchmarks == 'true' ||
@@ -322,6 +335,7 @@ jobs:
     name: Pro benchmarks (shard ${{ matrix.shard_label }})
     if: |
       contains(fromJSON('["both", "pro_only", "pro_rails_only"]'), github.event.inputs.app_version || 'both') &&
+      needs.detect-changes.outputs.docs_only != 'true' &&
       (
         github.event_name == 'push' ||
         needs.detect-changes.outputs.run_pro_benchmarks == 'true' ||
@@ -418,15 +432,13 @@ jobs:
           set -e
           echo "🔍 Validating Pro benchmark results..."
 
-          if [ "$RUN_PRO_RAILS" = "true" ]; then
-            if [ ! -f "bench_results/summary.txt" ]; then
-              echo "❌ ERROR: Rails benchmark summary file not found"
-              exit 1
-            fi
-            echo "📊 Rails Benchmark Summary:"
-            column -t -s $'\t' "bench_results/summary.txt"
-            echo ""
+          if [ ! -f "bench_results/summary.txt" ]; then
+            echo "❌ ERROR: Rails benchmark summary file not found"
+            exit 1
           fi
+          echo "📊 Rails Benchmark Summary:"
+          column -t -s $'\t' "bench_results/summary.txt"
+          echo ""
 
           if [ ! -f "bench_results/benchmark.json" ]; then
             echo "❌ ERROR: benchmark JSON file not found"
@@ -468,28 +480,19 @@ jobs:
           echo "Run number: ${{ github.run_number }}"
           echo "Triggered by: ${{ github.actor }}"
           echo "Branch: ${{ github.ref_name }}"
-          echo "Run Pro Rails: ${{ env.RUN_PRO_RAILS || 'false' }}"
 
   benchmark-pro-node-renderer:
     needs: detect-changes
-    # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' / 'benchmark-pro' label.
+    # Run on: push to main, workflow_dispatch, or PRs with 'benchmark', 'benchmark-pro',
+    # or 'benchmark-pro-node-renderer' label.
     # The 'full-ci' label is intentionally excluded; use the dedicated
     # benchmark labels to trigger perf runs on PRs.
     if: |
       contains(fromJSON('["both", "pro_only", "pro_node_renderer_only"]'), github.event.inputs.app_version || 'both') &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_node_renderer_benchmarks == 'true' ||
-        (
-          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
-          (
-            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
-            contains(github.event.pull_request.labels.*.name, 'benchmark-pro-node-renderer')
-          )
-        )
-      ) &&
+      needs.detect-changes.outputs.docs_only != 'true' &&
       (
         github.event_name == 'push' ||
+        needs.detect-changes.outputs.run_pro_node_renderer_benchmarks == 'true' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -112,6 +112,19 @@ jobs:
           BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
+      - name: Guard docs-only main pushes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/ensure-main-docs-safety
+        with:
+          docs-only: ${{ steps.detect.outputs.docs_only }}
+          previous-sha: ${{ github.event.before }}
+      # Everything below is needed only to compute the benchmark matrix.
+      # Skip on docs-only triggers — every benchmark-* job is gated on `docs_only != 'true'` anyway.
+      - name: Setup Ruby
+        if: steps.detect.outputs.docs_only != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
       - name: Install Ruby Gems for Core dummy app
         if: steps.detect.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-bundle
@@ -584,7 +597,6 @@ jobs:
           exit 1
 
       - name: Execute Pro Node Renderer benchmark suite
-        if: env.RUN_PRO_NODE_RENDERER
         timeout-minutes: 30
         run: |
           set -e

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,11 +71,6 @@ env:
   RUBY_VERSION: '3.3.7'
   K6_VERSION: '2.0.0'
   VEGETA_VERSION: '12.13.0'
-  MAX_ROUTES_PER_SHARD: 60
-  # Determine which apps/benchmarks to run (default is 'both' for all triggers)
-  RUN_CORE: ${{ contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}
-  RUN_PRO: ${{ (github.event.inputs.app_version || 'both') != 'core_only' && 'true' || '' }}
-  RUN_PRO_NODE_RENDERER: ${{ contains(fromJSON('["both", "pro_only", "pro_node_renderer_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}
   # Benchmark parameters (defaults in bench.rb unless overridden here for CI)
   ROUTES: ${{ github.event.inputs.routes }}
   RATE: ${{ github.event.inputs.rate || 'max' }}
@@ -93,13 +88,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    # Must match benchmark-* jobs' runner image so the setup-bundle cache (whose key only
-    # carries `runner.os` = "Linux") doesn't bleed native gems across glibc versions.
-    runs-on: ubuntu-latest
-    env:
-      # `bundle exec rails routes` boots the Pro dummy app; some Pro initializers refuse
-      # to start without a license. Mirror the value the benchmark-pro / benchmark-pro-node-renderer jobs use.
-      REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+    runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}
@@ -124,25 +113,6 @@ jobs:
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
           previous-sha: ${{ github.event.before }}
-      # Everything below is needed only to compute the benchmark matrix.
-      # Skip on docs-only triggers — every benchmark-* job is gated on `docs_only != 'true'` anyway.
-      - name: Setup Ruby
-        if: steps.detect.outputs.docs_only != 'true'
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install Ruby Gems for Core dummy app
-        if: steps.detect.outputs.docs_only != 'true'
-        uses: ./.github/actions/setup-bundle
-        with:
-          working-directory: react_on_rails/spec/dummy
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install Ruby Gems for Pro dummy app
-        if: steps.detect.outputs.docs_only != 'true'
-        uses: ./.github/actions/setup-bundle
-        with:
-          working-directory: react_on_rails_pro/spec/dummy
-          ruby-version: ${{ env.RUBY_VERSION }}
       - name: Set benchmark outputs
         id: benchmark-outputs
         if: steps.detect.outputs.non_runtime_only != 'true'
@@ -175,9 +145,11 @@ jobs:
       - name: Set benchmark matrices
         id: benchmark-matrices
         if: steps.detect.outputs.docs_only != 'true'
+        # Bump shard totals here when a suite's route set outgrows its current shard count.
+        # The script is stdlib-only, so the runner's system Ruby is enough (no Bundler/Rails boot).
         run: |
-          CORE_BENCHMARK_MATRIX=$(BENCHMARK_SUITE_NAME=Core BENCHMARK_SUITE_PREFIX=CORE MAX_ROUTES_PER_SHARD="$MAX_ROUTES_PER_SHARD" ruby benchmarks/count_benchmark_shards.rb)
-          PRO_BENCHMARK_MATRIX=$(PRO=true BENCHMARK_SUITE_NAME=Pro BENCHMARK_SUITE_PREFIX=PRO MAX_ROUTES_PER_SHARD="$MAX_ROUTES_PER_SHARD" ruby benchmarks/count_benchmark_shards.rb)
+          CORE_BENCHMARK_MATRIX=$(BENCHMARK_TOTAL_SHARDS=1 BENCHMARK_SUITE_NAME=Core BENCHMARK_SUITE_PREFIX=CORE ruby benchmarks/count_benchmark_shards.rb)
+          PRO_BENCHMARK_MATRIX=$(BENCHMARK_TOTAL_SHARDS=2 BENCHMARK_SUITE_NAME=Pro BENCHMARK_SUITE_PREFIX=PRO ruby benchmarks/count_benchmark_shards.rb)
 
           {
             echo "core_benchmark_matrix<<EOF"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,7 +90,7 @@ jobs:
       actions: read
     runs-on: ubuntu-22.04
     outputs:
-      docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}
       run_pro_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_benchmarks }}
       run_pro_node_renderer_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_node_renderer_benchmarks }}
@@ -144,7 +144,7 @@ jobs:
         shell: bash
       - name: Set benchmark matrices
         id: benchmark-matrices
-        if: steps.detect.outputs.docs_only != 'true'
+        if: steps.detect.outputs.non_runtime_only != 'true'
         # Bump shard totals here when a suite's route set outgrows its current shard count.
         # The script is stdlib-only, so the runner's system Ruby is enough (no Bundler/Rails boot).
         run: |
@@ -173,7 +173,7 @@ jobs:
     name: Core benchmarks (shard ${{ matrix.shard_label }})
     if: |
       contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') &&
-      needs.detect-changes.outputs.docs_only != 'true' &&
+      needs.detect-changes.outputs.non_runtime_only != 'true' &&
       (
         github.event_name == 'push' ||
         needs.detect-changes.outputs.run_core_benchmarks == 'true' ||
@@ -326,7 +326,7 @@ jobs:
     name: Pro benchmarks (shard ${{ matrix.shard_label }})
     if: |
       contains(fromJSON('["both", "pro_only", "pro_rails_only"]'), github.event.inputs.app_version || 'both') &&
-      needs.detect-changes.outputs.docs_only != 'true' &&
+      needs.detect-changes.outputs.non_runtime_only != 'true' &&
       (
         github.event_name == 'push' ||
         needs.detect-changes.outputs.run_pro_benchmarks == 'true' ||
@@ -480,7 +480,7 @@ jobs:
     # benchmark labels to trigger perf runs on PRs.
     if: |
       contains(fromJSON('["both", "pro_only", "pro_node_renderer_only"]'), github.event.inputs.app_version || 'both') &&
-      needs.detect-changes.outputs.docs_only != 'true' &&
+      needs.detect-changes.outputs.non_runtime_only != 'true' &&
       (
         github.event_name == 'push' ||
         needs.detect-changes.outputs.run_pro_node_renderer_benchmarks == 'true' ||

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -580,6 +580,17 @@ jobs:
 
           echo "✅ Production assets built successfully"
 
+      - name: Pre-seed Node Renderer bundle cache
+        # Stages the just-built bundles into `.node-renderer-bundles/<hash>-production/`
+        # so bench-node-renderer.rb finds them at startup instead of waiting for the
+        # first SSR request to upload them.
+        run: |
+          set -e
+          echo "🔧 Pre-seeding node renderer bundle cache..."
+          cd react_on_rails_pro/spec/dummy
+          RAILS_ENV=production NODE_ENV=production \
+            bundle exec rake react_on_rails_pro:pre_seed_renderer_cache MODE=symlink
+
       - name: Start Pro node renderer
         run: |
           set -e

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -171,18 +171,8 @@ jobs:
     if: |
       contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') &&
       (
-        github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_core_benchmarks == 'true' ||
-        (
-          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
-          (
-            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
-            contains(github.event.pull_request.labels.*.name, 'benchmark-core')
-          )
-        )
-      ) &&
-      (
         github.event_name == 'push' ||
+        needs.detect-changes.outputs.run_core_benchmarks == 'true' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
@@ -333,18 +323,8 @@ jobs:
     if: |
       contains(fromJSON('["both", "pro_only", "pro_rails_only"]'), github.event.inputs.app_version || 'both') &&
       (
-        github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_benchmarks == 'true' ||
-        (
-          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
-          (
-            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
-            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
-          )
-        )
-      ) &&
-      (
         github.event_name == 'push' ||
+        needs.detect-changes.outputs.run_pro_benchmarks == 'true' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
@@ -421,7 +401,6 @@ jobs:
           exit 1
 
       - name: Execute Pro benchmark suite
-        if: env.RUN_PRO_RAILS
         timeout-minutes: 120
         run: |
           set -e

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,7 +93,13 @@ jobs:
     permissions:
       contents: read
       actions: read
-    runs-on: ubuntu-22.04
+    # Must match benchmark-* jobs' runner image so the setup-bundle cache (whose key only
+    # carries `runner.os` = "Linux") doesn't bleed native gems across glibc versions.
+    runs-on: ubuntu-latest
+    env:
+      # `bundle exec rails routes` boots the Pro dummy app; some Pro initializers refuse
+      # to start without a license. Mirror the value the benchmark-pro / benchmark-pro-node-renderer jobs use.
+      REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,7 +144,9 @@ jobs:
         shell: bash
       - name: Set benchmark matrices
         id: benchmark-matrices
-        if: steps.detect.outputs.non_runtime_only != 'true'
+        # Always runs. GitHub Actions evaluates `strategy.matrix` for downstream jobs at
+        # workflow-construction time, before their `if:` gates — so an empty output would
+        # crash `fromJSON('')` even when the consuming job is otherwise skipped.
         # Bump shard totals here when a suite's route set outgrows its current shard count.
         # The script is stdlib-only, so the runner's system Ruby is enough (no Bundler/Rails boot).
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -97,6 +97,7 @@ jobs:
     outputs:
       run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}
       run_pro_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_benchmarks }}
+      run_pro_node_renderer_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_node_renderer_benchmarks }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -114,6 +115,7 @@ jobs:
         run: |
           RUN_CORE_BENCHMARKS=false
           RUN_PRO_BENCHMARKS=false
+          RUN_PRO_NODE_RENDERER_BENCHMARKS=false
 
           if [ "${{ steps.detect.outputs.run_ruby_tests }}" = "true" ] ||
              [ "${{ steps.detect.outputs.run_js_tests }}" = "true" ] ||
@@ -123,13 +125,18 @@ jobs:
           fi
 
           if [ "${{ steps.detect.outputs.run_pro_tests }}" = "true" ] ||
-             [ "${{ steps.detect.outputs.run_pro_dummy_tests }}" = "true" ] ||
-             [ "${{ steps.detect.outputs.run_pro_node_renderer_tests }}" = "true" ]; then
+             [ "${{ steps.detect.outputs.run_pro_dummy_tests }}" = "true" ]; then
             RUN_PRO_BENCHMARKS=true
+          fi
+
+          if [ "${{ steps.detect.outputs.run_pro_node_renderer_tests }}" = "true" ]; then
+            RUN_PRO_BENCHMARKS=true
+            RUN_PRO_NODE_RENDERER_BENCHMARKS=true
           fi
 
           echo "run_core_benchmarks=$RUN_CORE_BENCHMARKS" >> "$GITHUB_OUTPUT"
           echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS" >> "$GITHUB_OUTPUT"
+          echo "run_pro_node_renderer_benchmarks=$RUN_PRO_NODE_RENDERER_BENCHMARKS" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Guard docs-only main pushes
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -299,7 +306,7 @@ jobs:
     # The 'full-ci' label is intentionally excluded; use the dedicated
     # benchmark labels to trigger perf runs on PRs.
     if: |
-      (github.event.inputs.app_version || 'both') != 'core_only' &&
+      contains(fromJSON('["both", "pro_only", "pro_rails_only"]'), github.event.inputs.app_version || 'both') &&
       (
         github.event_name == 'workflow_dispatch' ||
         needs.detect-changes.outputs.run_pro_benchmarks == 'true' ||
@@ -340,22 +347,6 @@ jobs:
 
       - name: Setup benchmark runner
         uses: ./.github/actions/setup-benchmark-runner
-
-      - name: Cache Vegeta binary
-        id: cache-vegeta
-        if: env.RUN_PRO_NODE_RENDERER
-        uses: actions/cache@v5
-        with:
-          path: ~/bin/vegeta
-          key: vegeta-${{ runner.os }}-${{ runner.arch }}-${{ env.VEGETA_VERSION }}
-
-      - name: Install Vegeta
-        if: env.RUN_PRO_NODE_RENDERER && steps.cache-vegeta.outputs.cache-hit != 'true'
-        run: |
-          echo "Installing Vegeta v${VEGETA_VERSION}"
-          wget -q "https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
-          tar -xzf "vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
-          mv vegeta ~/bin/
 
       - name: Install Ruby Gems for Pro dummy app
         uses: ./.github/actions/setup-bundle
@@ -415,20 +406,6 @@ jobs:
 
           echo "Benchmark suite completed successfully"
 
-      - name: Execute Pro Node Renderer benchmark suite
-        if: env.RUN_PRO_NODE_RENDERER
-        timeout-minutes: 30
-        run: |
-          set -e
-          echo "🏃 Running Pro Node Renderer benchmark suite..."
-
-          if ! $BENCH_CMD benchmarks/bench-node-renderer.rb; then
-            echo "❌ ERROR: Node Renderer benchmark execution failed"
-            exit 1
-          fi
-
-          echo "✅ Node Renderer benchmark suite completed successfully"
-
       - name: Validate Pro benchmark results
         run: |
           set -e
@@ -441,16 +418,6 @@ jobs:
             fi
             echo "📊 Rails Benchmark Summary:"
             column -t -s $'\t' "bench_results/summary.txt"
-            echo ""
-          fi
-
-          if [ "$RUN_PRO_NODE_RENDERER" = "true" ]; then
-            if [ ! -f "bench_results/node_renderer_summary.txt" ]; then
-              echo "❌ ERROR: Node Renderer benchmark summary file not found"
-              exit 1
-            fi
-            echo "📊 Node Renderer Benchmark Summary:"
-            column -t -s $'\t' "bench_results/node_renderer_summary.txt"
             echo ""
           fi
 
@@ -494,4 +461,179 @@ jobs:
           echo "Triggered by: ${{ github.actor }}"
           echo "Branch: ${{ github.ref_name }}"
           echo "Run Pro Rails: ${{ env.RUN_PRO_RAILS || 'false' }}"
-          echo "Run Pro Node Renderer: ${{ env.RUN_PRO_NODE_RENDERER || 'false' }}"
+
+  benchmark-pro-node-renderer:
+    needs: detect-changes
+    # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' / 'benchmark-pro' label.
+    # The 'full-ci' label is intentionally excluded; use the dedicated
+    # benchmark labels to trigger perf runs on PRs.
+    if: |
+      contains(fromJSON('["both", "pro_only", "pro_node_renderer_only"]'), github.event.inputs.app_version || 'both') &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.run_pro_node_renderer_benchmarks == 'true' ||
+        (
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
+          )
+        )
+      ) &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      checks: write
+    env:
+      SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
+      REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup benchmark runner
+        uses: ./.github/actions/setup-benchmark-runner
+        with:
+          install-k6: false
+
+      - name: Cache Vegeta binary
+        id: cache-vegeta
+        uses: actions/cache@v5
+        with:
+          path: ~/bin/vegeta
+          key: vegeta-${{ runner.os }}-${{ runner.arch }}-${{ env.VEGETA_VERSION }}
+
+      - name: Install Vegeta
+        if: steps.cache-vegeta.outputs.cache-hit != 'true'
+        run: |
+          echo "Installing Vegeta v${VEGETA_VERSION}"
+          wget -q "https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
+          tar -xzf "vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
+          mv vegeta ~/bin/
+
+      - name: Install Ruby Gems for Pro dummy app
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails_pro/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
+
+      - name: Generate file-system based entrypoints for Pro
+        run: cd react_on_rails_pro/spec/dummy && bundle exec rake react_on_rails:generate_packs
+
+      - name: Prepare Pro production assets
+        run: |
+          set -e
+          echo "🔨 Building Pro production assets..."
+          cd react_on_rails_pro/spec/dummy
+
+          if ! bin/prod-assets; then
+            echo "❌ ERROR: Failed to build production assets"
+            exit 1
+          fi
+
+          echo "✅ Production assets built successfully"
+
+      - name: Start Pro node renderer
+        run: |
+          set -e
+          echo "🚀 Starting Pro node renderer..."
+          cd react_on_rails_pro/spec/dummy
+
+          RENDERER_LOG_LEVEL=error RENDERER_PORT=3800 RAILS_ENV=production NODE_ENV=production node renderer/node-renderer.js &
+          echo "Node renderer started in background"
+
+          echo "⏳ Waiting for node renderer to be ready..."
+          for i in {1..30}; do
+            if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close"; then
+              echo "✅ Node renderer is ready and listening"
+              exit 0
+            fi
+            echo "  Attempt $i/30: Node renderer not ready yet..."
+            sleep 1
+          done
+
+          echo "❌ ERROR: Node renderer failed to start within 30 seconds"
+          exit 1
+
+      - name: Execute Pro Node Renderer benchmark suite
+        if: env.RUN_PRO_NODE_RENDERER
+        timeout-minutes: 30
+        run: |
+          set -e
+          echo "🏃 Running Pro Node Renderer benchmark suite..."
+
+          if ! $BENCH_CMD benchmarks/bench-node-renderer.rb; then
+            echo "❌ ERROR: Node Renderer benchmark execution failed"
+            exit 1
+          fi
+
+          echo "✅ Node Renderer benchmark suite completed successfully"
+
+      - name: Validate Pro Node Renderer benchmark results
+        run: |
+          set -e
+          echo "🔍 Validating Pro Node Renderer benchmark results..."
+
+          if [ ! -f "bench_results/node_renderer_summary.txt" ]; then
+            echo "❌ ERROR: Node Renderer benchmark summary file not found"
+            exit 1
+          fi
+          echo "📊 Node Renderer Benchmark Summary:"
+          column -t -s $'\t' "bench_results/node_renderer_summary.txt"
+          echo ""
+
+          if [ ! -f "bench_results/benchmark.json" ]; then
+            echo "❌ ERROR: benchmark JSON file not found"
+            exit 1
+          fi
+
+          echo "✅ Benchmark results validated"
+          echo ""
+          echo "Generated files:"
+          ls -lh bench_results/
+
+      - name: Upload Pro Node Renderer benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: benchmark-pro-node-renderer-results-${{ github.run_number }}
+          path: bench_results/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Track Pro Node Renderer benchmarks with Bencher
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_REPORT_MARKER: '<!-- BENCHER_REPORT_PRO_NODE_RENDERER -->'
+          BENCHMARK_SUITE_NAME: Pro Node Renderer
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+        run: ruby benchmarks/track_benchmarks.rb
+
+      - name: Pro Node Renderer workflow summary
+        if: always()
+        run: |
+          echo "📋 Benchmark Workflow Summary"
+          echo "===================================="
+          echo "Suite: Pro Node Renderer"
+          echo "Status: ${{ job.status }}"
+          echo "Run number: ${{ github.run_number }}"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "Branch: ${{ github.ref_name }}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,6 +71,7 @@ env:
   RUBY_VERSION: '3.3.7'
   K6_VERSION: '2.0.0'
   VEGETA_VERSION: '12.13.0'
+  MAX_ROUTES_PER_SHARD: 60
   # Determine which apps/benchmarks to run (default is 'both' for all triggers)
   RUN_CORE: ${{ contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') && 'true' || '' }}
   RUN_PRO: ${{ (github.event.inputs.app_version || 'both') != 'core_only' && 'true' || '' }}
@@ -98,6 +99,8 @@ jobs:
       run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}
       run_pro_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_benchmarks }}
       run_pro_node_renderer_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_node_renderer_benchmarks }}
+      core_benchmark_matrix: ${{ steps.benchmark-matrices.outputs.core_benchmark_matrix }}
+      pro_benchmark_matrix: ${{ steps.benchmark-matrices.outputs.pro_benchmark_matrix }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -138,19 +141,33 @@ jobs:
           echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS" >> "$GITHUB_OUTPUT"
           echo "run_pro_node_renderer_benchmarks=$RUN_PRO_NODE_RENDERER_BENCHMARKS" >> "$GITHUB_OUTPUT"
         shell: bash
-      - name: Guard docs-only main pushes
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: ./.github/actions/ensure-main-docs-safety
-        with:
-          docs-only: ${{ steps.detect.outputs.docs_only }}
-          previous-sha: ${{ github.event.before }}
+      - name: Set benchmark matrices
+        id: benchmark-matrices
+        if: steps.detect.outputs.docs_only != 'true'
+        run: |
+          CORE_BENCHMARK_MATRIX=$(BENCHMARK_SUITE_NAME=Core BENCHMARK_SUITE_PREFIX=CORE MAX_ROUTES_PER_SHARD="$MAX_ROUTES_PER_SHARD" ruby benchmarks/count_benchmark_shards.rb)
+          PRO_BENCHMARK_MATRIX=$(PRO=true BENCHMARK_SUITE_NAME=Pro BENCHMARK_SUITE_PREFIX=PRO MAX_ROUTES_PER_SHARD="$MAX_ROUTES_PER_SHARD" ruby benchmarks/count_benchmark_shards.rb)
+
+          {
+            echo "core_benchmark_matrix<<EOF"
+            echo "$CORE_BENCHMARK_MATRIX"
+            echo "EOF"
+            echo "pro_benchmark_matrix<<EOF"
+            echo "$PRO_BENCHMARK_MATRIX"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
 
   benchmark-core:
     needs: detect-changes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect-changes.outputs.core_benchmark_matrix) }}
     # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' / 'benchmark-core' label.
     # The 'full-ci' label is intentionally excluded — it controls test workflows,
     # not benchmarks. Use dedicated benchmark labels to trigger perf runs on PRs.
     # See https://bencher.dev/docs/how-to/github-actions/#pull-requests for the extra pull_request condition
+    name: Core benchmarks (shard ${{ matrix.shard_label }})
     if: |
       contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') &&
       (
@@ -183,6 +200,9 @@ jobs:
       checks: write
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
+      BENCHMARK_SHARD_INDEX: ${{ matrix.shard_index }}
+      BENCHMARK_TOTAL_SHARDS: ${{ matrix.shard_total }}
+      BENCHMARK_SHARD_LABEL: ${{ matrix.shard_label }}
 
     steps:
       - name: Checkout repository
@@ -274,7 +294,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: benchmark-core-results-${{ github.run_number }}
+          name: benchmark-core-results-${{ github.run_number }}-${{ matrix.shard_slug }}
           path: bench_results/
           retention-days: 30
           if-no-files-found: warn
@@ -282,8 +302,8 @@ jobs:
       - name: Track Core benchmarks with Bencher
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_REPORT_MARKER: '<!-- BENCHER_REPORT_CORE -->'
-          BENCHMARK_SUITE_NAME: Core
+          BENCHER_REPORT_MARKER: ${{ matrix.report_marker }}
+          BENCHMARK_SUITE_NAME: ${{ matrix.suite_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
@@ -295,6 +315,7 @@ jobs:
           echo "📋 Benchmark Workflow Summary"
           echo "===================================="
           echo "Suite: Core"
+          echo "Shard: ${{ matrix.shard_label }}"
           echo "Status: ${{ job.status }}"
           echo "Run number: ${{ github.run_number }}"
           echo "Triggered by: ${{ github.actor }}"
@@ -302,9 +323,13 @@ jobs:
 
   benchmark-pro:
     needs: detect-changes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.detect-changes.outputs.pro_benchmark_matrix) }}
     # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' / 'benchmark-pro' label.
     # The 'full-ci' label is intentionally excluded; use the dedicated
     # benchmark labels to trigger perf runs on PRs.
+    name: Pro benchmarks (shard ${{ matrix.shard_label }})
     if: |
       contains(fromJSON('["both", "pro_only", "pro_rails_only"]'), github.event.inputs.app_version || 'both') &&
       (
@@ -338,6 +363,9 @@ jobs:
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BENCHMARK_SHARD_INDEX: ${{ matrix.shard_index }}
+      BENCHMARK_TOTAL_SHARDS: ${{ matrix.shard_total }}
+      BENCHMARK_SHARD_LABEL: ${{ matrix.shard_label }}
 
     steps:
       - name: Checkout repository
@@ -435,7 +463,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: benchmark-pro-results-${{ github.run_number }}
+          name: benchmark-pro-results-${{ github.run_number }}-${{ matrix.shard_slug }}
           path: bench_results/
           retention-days: 30
           if-no-files-found: warn
@@ -443,8 +471,8 @@ jobs:
       - name: Track Pro benchmarks with Bencher
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_REPORT_MARKER: '<!-- BENCHER_REPORT_PRO -->'
-          BENCHMARK_SUITE_NAME: Pro
+          BENCHER_REPORT_MARKER: ${{ matrix.report_marker }}
+          BENCHMARK_SUITE_NAME: ${{ matrix.suite_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
@@ -456,6 +484,7 @@ jobs:
           echo "📋 Benchmark Workflow Summary"
           echo "===================================="
           echo "Suite: Pro"
+          echo "Shard: ${{ matrix.shard_label }}"
           echo "Status: ${{ job.status }}"
           echo "Run number: ${{ github.run_number }}"
           echo "Triggered by: ${{ github.actor }}"
@@ -476,7 +505,7 @@ jobs:
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
           (
             contains(github.event.pull_request.labels.*.name, 'benchmark') ||
-            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro-node-renderer')
           )
         )
       ) &&
@@ -487,7 +516,8 @@ jobs:
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
           (
             contains(github.event.pull_request.labels.*.name, 'benchmark') ||
-            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro-node-renderer')
           )
         )
       )

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -95,10 +95,10 @@ jobs:
       actions: read
     runs-on: ubuntu-22.04
     outputs:
-      docs_only: ${{ steps.detect.outputs.docs_only }}
-      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
+      run_core_benchmarks: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks }}
+      run_pro_benchmarks: ${{ steps.benchmark-outputs.outputs.run_pro_benchmarks }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 50
           persist-credentials: false
@@ -108,6 +108,29 @@ jobs:
           BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
+      - name: Set benchmark outputs
+        id: benchmark-outputs
+        if: steps.detect.outputs.non_runtime_only != 'true'
+        run: |
+          RUN_CORE_BENCHMARKS=false
+          RUN_PRO_BENCHMARKS=false
+
+          if [ "${{ steps.detect.outputs.run_ruby_tests }}" = "true" ] ||
+             [ "${{ steps.detect.outputs.run_js_tests }}" = "true" ] ||
+             [ "${{ steps.detect.outputs.run_dummy_tests }}" = "true" ]; then
+            RUN_CORE_BENCHMARKS=true
+            RUN_PRO_BENCHMARKS=true
+          fi
+
+          if [ "${{ steps.detect.outputs.run_pro_tests }}" = "true" ] ||
+             [ "${{ steps.detect.outputs.run_pro_dummy_tests }}" = "true" ] ||
+             [ "${{ steps.detect.outputs.run_pro_node_renderer_tests }}" = "true" ]; then
+            RUN_PRO_BENCHMARKS=true
+          fi
+
+          echo "run_core_benchmarks=$RUN_CORE_BENCHMARKS" >> "$GITHUB_OUTPUT"
+          echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS" >> "$GITHUB_OUTPUT"
+        shell: bash
       - name: Guard docs-only main pushes
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: ./.github/actions/ensure-main-docs-safety
@@ -115,24 +138,188 @@ jobs:
           docs-only: ${{ steps.detect.outputs.docs_only }}
           previous-sha: ${{ github.event.before }}
 
-  benchmark:
+  benchmark-core:
     needs: detect-changes
-    # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' label.
+    # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' / 'benchmark-core' label.
     # The 'full-ci' label is intentionally excluded — it controls test workflows,
-    # not benchmarks. Use the dedicated 'benchmark' label to trigger perf runs on PRs.
+    # not benchmarks. Use dedicated benchmark labels to trigger perf runs on PRs.
     # See https://bencher.dev/docs/how-to/github-actions/#pull-requests for the extra pull_request condition
-    # Skip non-runtime-only pushes to main to avoid wasting CI resources on non-code changes.
     if: |
-      !(
-        github.event_name == 'push' &&
-        github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.non_runtime_only == 'true'
-      ) && (
+      contains(fromJSON('["both", "core_only"]'), github.event.inputs.app_version || 'both') &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.run_core_benchmarks == 'true' ||
+        (
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-core')
+          )
+        )
+      ) &&
+      (
         github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
-          contains(github.event.pull_request.labels.*.name, 'benchmark')
+          (
+            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-core')
+          )
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      checks: write
+    env:
+      SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup benchmark runner
+        uses: ./.github/actions/setup-benchmark-runner
+
+      - name: Install Ruby Gems for Core dummy app
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: react_on_rails/spec/dummy
+          ruby-version: ${{ env.RUBY_VERSION }}
+
+      - name: Prepare Core production assets
+        run: |
+          set -e
+          echo "🔨 Building Core production assets..."
+          cd react_on_rails/spec/dummy
+
+          if ! bin/prod-assets; then
+            echo "❌ ERROR: Failed to build production assets"
+            exit 1
+          fi
+
+          echo "✅ Production assets built successfully"
+
+      - name: Start Core production server
+        run: |
+          set -e
+          echo "🚀 Starting Core production server..."
+          cd react_on_rails/spec/dummy
+
+          $SERVER_CMD &
+          echo "Server started in background"
+
+          echo "⏳ Waiting for server to be ready..."
+          for i in {1..30}; do
+            if curl -fsS http://localhost:3001 > /dev/null; then
+              echo "✅ Server is ready and responding"
+              exit 0
+            fi
+            echo "  Attempt $i/30: Server not ready yet..."
+            sleep 1
+          done
+
+          echo "❌ ERROR: Server failed to start within 30 seconds"
+          exit 1
+
+      - name: Execute Core benchmark suite
+        timeout-minutes: 120
+        run: |
+          set -e
+          echo "🏃 Running Core benchmark suite..."
+
+          if ! $BENCH_CMD benchmarks/bench.rb; then
+            echo "❌ ERROR: Benchmark execution failed"
+            exit 1
+          fi
+
+          echo "Benchmark suite completed successfully"
+
+      - name: Validate Core benchmark results
+        run: |
+          set -e
+          echo "🔍 Validating Core benchmark results..."
+
+          if [ ! -f "bench_results/summary.txt" ]; then
+            echo "❌ ERROR: benchmark summary file not found"
+            exit 1
+          fi
+
+          if [ ! -f "bench_results/benchmark.json" ]; then
+            echo "❌ ERROR: benchmark JSON file not found"
+            exit 1
+          fi
+
+          echo "✅ Benchmark results found"
+          echo ""
+          echo "📊 Summary:"
+          column -t -s $'\t' "bench_results/summary.txt"
+          echo ""
+          echo "Generated files:"
+          ls -lh bench_results/
+
+      - name: Upload Core benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: benchmark-core-results-${{ github.run_number }}
+          path: bench_results/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Track Core benchmarks with Bencher
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_REPORT_MARKER: '<!-- BENCHER_REPORT_CORE -->'
+          BENCHMARK_SUITE_NAME: Core
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+        run: ruby benchmarks/track_benchmarks.rb
+
+      - name: Core workflow summary
+        if: always()
+        run: |
+          echo "📋 Benchmark Workflow Summary"
+          echo "===================================="
+          echo "Suite: Core"
+          echo "Status: ${{ job.status }}"
+          echo "Run number: ${{ github.run_number }}"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "Branch: ${{ github.ref_name }}"
+
+  benchmark-pro:
+    needs: detect-changes
+    # Run on: push to main, workflow_dispatch, or PRs with 'benchmark' / 'benchmark-pro' label.
+    # The 'full-ci' label is intentionally excluded; use the dedicated
+    # benchmark labels to trigger perf runs on PRs.
+    if: |
+      (github.event.inputs.app_version || 'both') != 'core_only' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.run_pro_benchmarks == 'true' ||
+        (
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
+          )
+        )
+      ) &&
+      (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository &&
+          (
+            contains(github.event.pull_request.labels.*.name, 'benchmark') ||
+            contains(github.event.pull_request.labels.*.name, 'benchmark-pro')
+          )
         )
       )
     runs-on: ubuntu-latest
@@ -146,267 +333,40 @@ jobs:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
 
     steps:
-      # ============================================
-      # STEP 1: CHECKOUT CODE
-      # ============================================
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
-      # ============================================
-      # STEP 2: INSTALL BENCHMARKING TOOLS
-      # ============================================
-
-      - name: Install Bencher CLI
-        # Pinned: step 7a's alert-detection heuristic greps stderr for
-        # "Alert[s]" / "threshold violation" / "boundary violation". Those strings
-        # are not a documented API contract, so upgrading the CLI requires
-        # re-verifying that the expected phrases still appear in alert output.
-        # Expected stderr phrases at v0.6.2: "🚨 N Alerts", "Alert detected".
-        uses: bencherdev/bencher@v0.6.2
-
-      - name: Add tools directory to PATH
-        run: |
-          mkdir -p ~/bin
-          echo "$HOME/bin" >> $GITHUB_PATH
+      - name: Setup benchmark runner
+        uses: ./.github/actions/setup-benchmark-runner
 
       - name: Cache Vegeta binary
         id: cache-vegeta
-        if: env.RUN_PRO
-        uses: actions/cache@v4
+        if: env.RUN_PRO_NODE_RENDERER
+        uses: actions/cache@v5
         with:
           path: ~/bin/vegeta
           key: vegeta-${{ runner.os }}-${{ runner.arch }}-${{ env.VEGETA_VERSION }}
 
       - name: Install Vegeta
-        if: env.RUN_PRO && steps.cache-vegeta.outputs.cache-hit != 'true'
+        if: env.RUN_PRO_NODE_RENDERER && steps.cache-vegeta.outputs.cache-hit != 'true'
         run: |
-          echo "📦 Installing Vegeta v${VEGETA_VERSION}"
-
-          # Download and extract vegeta binary
-          wget -q https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz
-          tar -xzf vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz
-
-          # Store in cache directory
+          echo "Installing Vegeta v${VEGETA_VERSION}"
+          wget -q "https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
+          tar -xzf "vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz"
           mv vegeta ~/bin/
 
-      - name: Setup k6
-        uses: grafana/setup-k6-action@v1
-        with:
-          k6-version: ${{ env.K6_VERSION }}
-
-      # ============================================
-      # STEP 3: START APPLICATION SERVER
-      # ============================================
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-
-      - name: Get gem home directory
-        run: echo "GEM_HOME_PATH=$(gem env home)" >> $GITHUB_ENV
-
-      - name: Cache foreman gem
-        id: cache-foreman
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.GEM_HOME_PATH }}
-          key: foreman-gem-${{ runner.os }}-ruby-${{ env.RUBY_VERSION }}
-
-      - name: Install foreman
-        if: steps.cache-foreman.outputs.cache-hit != 'true'
-        run: gem install foreman
-
-      - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev -y
-
-      # Follow https://github.com/pnpm/action-setup?tab=readme-ov-file#use-cache-to-reduce-installation-time
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          cache: true
-          cache_dependency_path: '**/pnpm-lock.yaml'
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Print system information
-        run: |
-          echo "Linux release: "; cat /etc/issue
-          echo "Current user: "; whoami
-          echo "Current directory: "; pwd
-          echo "Ruby version: "; ruby -v
-          echo "Node version: "; node -v
-          echo "Pnpm version: "; pnpm --version
-          echo "Bundler version: "; bundle --version
-
-      - name: Configure CPU pinning and process priority
-        run: |
-          # CPU pinning: server gets CPUs 1-(nproc-1), benchmark script gets CPU 0
-          # This avoids contention and improves consistency on GitHub Actions runners
-          NPROC=$(nproc)
-          echo "Available CPUs: $NPROC"
-
-          # Server: high priority (-20), pinned to CPUs 1+
-          # Benchmark: elevated priority (-10), pinned to CPU 0
-          SERVER_CMD="nice -n -20 taskset -c 1-$((NPROC-1)) bin/prod"
-          BENCH_CMD="nice -n -10 taskset -c 0 ruby"
-
-          echo "SERVER_CMD=$SERVER_CMD" >> $GITHUB_ENV
-          echo "BENCH_CMD=$BENCH_CMD" >> $GITHUB_ENV
-
-          # Set Puma workers to match available server CPUs (only if not explicitly set)
-          if [ -z "$WEB_CONCURRENCY" ]; then
-            WEB_CONCURRENCY=$((NPROC-1))
-            echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> $GITHUB_ENV
-            echo "WEB_CONCURRENCY (auto): $WEB_CONCURRENCY"
-          else
-            echo "WEB_CONCURRENCY (from input): $WEB_CONCURRENCY"
-          fi
-
-          echo "SERVER_CMD: $SERVER_CMD"
-          echo "BENCH_CMD: $BENCH_CMD"
-
-      - name: Install Node modules with pnpm
-        run: pnpm install --frozen-lockfile
-
-      - name: Build workspace packages
-        run: pnpm run build
-
-      - name: Install Ruby Gems for Core dummy app
-        if: env.RUN_CORE
-        uses: ./.github/actions/setup-bundle
-        with:
-          working-directory: react_on_rails/spec/dummy
-          ruby-version: ${{ env.RUBY_VERSION }}
-
-      - name: Prepare Core production assets
-        if: env.RUN_CORE
-        run: |
-          set -e  # Exit on any error
-          echo "🔨 Building production assets..."
-          cd react_on_rails/spec/dummy
-
-          if ! bin/prod-assets; then
-            echo "❌ ERROR: Failed to build production assets"
-            exit 1
-          fi
-
-          echo "✅ Production assets built successfully"
-
-      - name: Start Core production server
-        if: env.RUN_CORE
-        run: |
-          set -e  # Exit on any error
-          echo "🚀 Starting production server..."
-          cd react_on_rails/spec/dummy
-
-          $SERVER_CMD &
-          echo "Server started in background"
-
-          # Wait for server to be ready (max 30 seconds)
-          echo "⏳ Waiting for server to be ready..."
-          for i in {1..30}; do
-            if curl -fsS http://localhost:3001 > /dev/null; then
-              echo "✅ Server is ready and responding"
-              exit 0
-            fi
-            echo "  Attempt $i/30: Server not ready yet..."
-            sleep 1
-          done
-
-          echo "❌ ERROR: Server failed to start within 30 seconds"
-          exit 1
-
-      # ============================================
-      # STEP 4: RUN CORE BENCHMARKS
-      # ============================================
-
-      - name: Execute Core benchmark suite
-        if: env.RUN_CORE
-        timeout-minutes: 120
-        run: |
-          set -e  # Exit on any error
-          echo "🏃 Running Core benchmark suite..."
-
-          if ! $BENCH_CMD benchmarks/bench.rb; then
-            echo "❌ ERROR: Benchmark execution failed"
-            exit 1
-          fi
-
-          echo "✅ Benchmark suite completed successfully"
-
-      - name: Validate Core benchmark results
-        if: env.RUN_CORE
-        run: |
-          set -e
-          echo "🔍 Validating benchmark results..."
-
-          if [ ! -f "bench_results/summary.txt" ]; then
-            echo "❌ ERROR: benchmark summary file not found"
-            exit 1
-          fi
-
-          echo "✅ Benchmark results found"
-          echo ""
-          echo "📊 Summary:"
-          column -t -s $'\t' "bench_results/summary.txt"
-          echo ""
-          echo "Generated files:"
-          ls -lh bench_results/
-
-      - name: Upload Core benchmark results
-        uses: actions/upload-artifact@v4
-        if: env.RUN_CORE && always()
-        with:
-          name: benchmark-core-results-${{ github.run_number }}
-          path: bench_results/
-          retention-days: 30
-          if-no-files-found: warn
-
-      - name: Stop Core production server
-        # RUN_PRO because we only need to stop it to run the Pro server
-        if: env.RUN_CORE && env.RUN_PRO && always()
-        run: |
-          echo "🛑 Stopping Core production server..."
-          # Kill all server-related processes (safe in isolated CI environment)
-          pkill -9 -f "ruby|node|foreman|overmind|puma" || true
-
-          # Wait for port 3001 to be free
-          echo "⏳ Waiting for port 3001 to be free..."
-          for _ in {1..10}; do
-            if ! lsof -ti:3001 > /dev/null 2>&1; then
-              echo "✅ Port 3001 is now free"
-              exit 0
-            fi
-            sleep 1
-          done
-
-          echo "❌ ERROR: Port 3001 is still in use after 10 seconds"
-          echo "Processes using port 3001:"
-          lsof -i:3001 || true
-          exit 1
-
-      # ============================================
-      # STEP 5: SETUP PRO APPLICATION SERVER
-      # ============================================
-
       - name: Install Ruby Gems for Pro dummy app
-        if: env.RUN_PRO
         uses: ./.github/actions/setup-bundle
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Generate file-system based entrypoints for Pro
-        if: env.RUN_PRO
         run: cd react_on_rails_pro/spec/dummy && bundle exec rake react_on_rails:generate_packs
 
       - name: Prepare Pro production assets
-        if: env.RUN_PRO
         run: |
           set -e
           echo "🔨 Building Pro production assets..."
@@ -420,7 +380,6 @@ jobs:
           echo "✅ Production assets built successfully"
 
       - name: Start Pro production server
-        if: env.RUN_PRO
         run: |
           set -e
           echo "🚀 Starting Pro production server..."
@@ -429,7 +388,6 @@ jobs:
           $SERVER_CMD &
           echo "Server started in background"
 
-          # Wait for server to be ready (max 30 seconds)
           echo "⏳ Waiting for server to be ready..."
           for i in {1..30}; do
             if curl -fsS http://localhost:3001 > /dev/null; then
@@ -443,10 +401,6 @@ jobs:
           echo "❌ ERROR: Server failed to start within 30 seconds"
           exit 1
 
-      # ============================================
-      # STEP 6: RUN PRO BENCHMARKS
-      # ============================================
-
       - name: Execute Pro benchmark suite
         if: env.RUN_PRO_RAILS
         timeout-minutes: 120
@@ -459,7 +413,7 @@ jobs:
             exit 1
           fi
 
-          echo "✅ Benchmark suite completed successfully"
+          echo "Benchmark suite completed successfully"
 
       - name: Execute Pro Node Renderer benchmark suite
         if: env.RUN_PRO_NODE_RENDERER
@@ -476,10 +430,9 @@ jobs:
           echo "✅ Node Renderer benchmark suite completed successfully"
 
       - name: Validate Pro benchmark results
-        if: env.RUN_PRO
         run: |
           set -e
-          echo "🔍 Validating benchmark results..."
+          echo "🔍 Validating Pro benchmark results..."
 
           if [ "$RUN_PRO_RAILS" = "true" ]; then
             if [ ! -f "bench_results/summary.txt" ]; then
@@ -501,361 +454,44 @@ jobs:
             echo ""
           fi
 
+          if [ ! -f "bench_results/benchmark.json" ]; then
+            echo "❌ ERROR: benchmark JSON file not found"
+            exit 1
+          fi
+
           echo "✅ Benchmark results validated"
           echo ""
           echo "Generated files:"
           ls -lh bench_results/
 
       - name: Upload Pro benchmark results
-        uses: actions/upload-artifact@v4
-        if: env.RUN_PRO && always()
+        uses: actions/upload-artifact@v7
+        if: always()
         with:
           name: benchmark-pro-results-${{ github.run_number }}
           path: bench_results/
           retention-days: 30
           if-no-files-found: warn
 
-      # ============================================
-      # STEP 7: STORE BENCHMARK DATA
-      # ============================================
-      # See: https://bencher.dev/docs/how-to/track-benchmarks/ and
-      #      https://bencher.dev/docs/how-to/github-actions/
-      #
-      # Threshold configuration using Student's t-test:
-      #   Uses historical data to detect statistically significant regressions
-      #   rather than a fixed percentage. The boundary value (0.95) is the
-      #   confidence interval — an alert fires when a new metric falls outside
-      #   the 95% CI of the historical distribution.
-      #   - rps: Lower Boundary (higher is better)
-      #   - p50/p90/p99_latency_ms: Upper Boundary (lower is better)
-      #   - failed_pct: Upper Boundary (lower is better)
-      #
-      #   max-sample-size limits historical data to the most recent 64 runs
-      #   to keep the baseline relevant as performance evolves.
-
-      - name: Track benchmarks with Bencher
+      - name: Track Pro benchmarks with Bencher
         env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          BENCHER_REPORT_MARKER: '<!-- BENCHER_REPORT_PRO -->'
+          BENCHMARK_SUITE_NAME: Pro
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Confidence interval for t-test (0.95 = 95% CI)
-          BOUNDARY=0.95
-          MAX_SAMPLE=64
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+        run: ruby benchmarks/track_benchmarks.rb
 
-          # Set branch and start-point based on event type.
-          # Main pushes don't need --start-point because main IS the base
-          # branch — new reports compare against main's own history.
-          # Feature branches (PRs, dispatch) use --start-point to inherit
-          # historical data and thresholds from main.
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BRANCH="main"
-            START_POINT_ARGS=""
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="$GITHUB_HEAD_REF"
-            START_POINT_ARGS="--start-point $GITHUB_BASE_REF --start-point-hash ${{ github.event.pull_request.base.sha }} --start-point-clone-thresholds --start-point-reset"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BRANCH="${{ github.ref_name }}"
-            if [ "$BRANCH" = "main" ]; then
-              START_POINT_ARGS=""
-            else
-              # Get merge-base from GitHub API (avoids needing deep fetch)
-              # See: https://stackoverflow.com/a/74710919
-              START_POINT_HASH=$(gh api "repos/${{ github.repository }}/compare/main...$BRANCH" --jq '.merge_base_commit.sha' || true)
-              if [ -n "$START_POINT_HASH" ]; then
-                echo "Found merge-base via API: $START_POINT_HASH"
-                START_POINT_ARGS="--start-point main --start-point-hash $START_POINT_HASH --start-point-clone-thresholds --start-point-reset"
-              else
-                echo "⚠️ Could not find merge-base with main via GitHub API, continuing without hash"
-                START_POINT_ARGS="--start-point main --start-point-clone-thresholds --start-point-reset"
-              fi
-            fi
-          else
-            echo "❌ ERROR: Unexpected event type: ${{ github.event_name }}"
-            exit 1
-          fi
-
-          # Wrap bencher run in a function so we can retry with different
-          # start-point args if the pinned hash isn't found in Bencher.
-          run_bencher() {
-            local sp_args="$1"
-            # Intentional word-splitting: sp_args contains multiple flags
-            # (e.g. "--start-point main --start-point-hash abc123") that must
-            # be split into separate argv entries.
-            # shellcheck disable=SC2086
-            bencher run \
-              --project react-on-rails-t8a9ncxo \
-              --token '${{ secrets.BENCHER_API_TOKEN }}' \
-              --branch "$BRANCH" \
-              $sp_args \
-              --testbed github-actions \
-              --adapter json \
-              --file bench_results/benchmark.json \
-              --err \
-              --quiet \
-              --format html \
-              --threshold-measure rps \
-              --threshold-test t_test \
-              --threshold-max-sample-size $MAX_SAMPLE \
-              --threshold-lower-boundary $BOUNDARY \
-              --threshold-upper-boundary _ \
-              --threshold-measure p50_latency \
-              --threshold-test t_test \
-              --threshold-max-sample-size $MAX_SAMPLE \
-              --threshold-lower-boundary _ \
-              --threshold-upper-boundary $BOUNDARY \
-              --threshold-measure p90_latency \
-              --threshold-test t_test \
-              --threshold-max-sample-size $MAX_SAMPLE \
-              --threshold-lower-boundary _ \
-              --threshold-upper-boundary $BOUNDARY \
-              --threshold-measure p99_latency \
-              --threshold-test t_test \
-              --threshold-max-sample-size $MAX_SAMPLE \
-              --threshold-lower-boundary _ \
-              --threshold-upper-boundary $BOUNDARY \
-              --threshold-measure failed_pct \
-              --threshold-test t_test \
-              --threshold-max-sample-size $MAX_SAMPLE \
-              --threshold-lower-boundary _ \
-              --threshold-upper-boundary $BOUNDARY
-          }
-
-          # Run bencher and capture HTML output (stdout) while letting stderr
-          # go to a file so we can inspect failure reasons.
-          BENCHER_STDERR=$(mktemp)
-          trap 'rm -f "$BENCHER_STDERR"' EXIT
-          set +e
-          run_bencher "$START_POINT_ARGS" > bench_results/bencher_report.html 2>"$BENCHER_STDERR"
-          BENCHER_EXIT_CODE=$?
-          set -e
-
-          # Print stderr for visibility in logs
-          cat "$BENCHER_STDERR" >&2
-
-          # If bencher failed because the start-point hash doesn't exist in
-          # Bencher (e.g., the base commit was a docs-only change skipped by
-          # paths-ignore), retry without --start-point-hash so the report
-          # still gets stored using the latest available baseline.
-          #
-          # Bencher emits: 'Head Version (..., Some(GitHash("<sha>"))) not found'
-          # when the pinned hash isn't in its DB. A single combined pattern
-          # avoids false-positive matches across unrelated lines.
-          if [ $BENCHER_EXIT_CODE -ne 0 ] && grep -q "Head Version.*not found" "$BENCHER_STDERR" && ! grep -qiE "alert|threshold violation|boundary violation" "$BENCHER_STDERR"; then
-            RETRY_ARGS=$(echo "$START_POINT_ARGS" | sed 's/--start-point-hash [^ ]*//')
-            if [ "$RETRY_ARGS" != "$START_POINT_ARGS" ]; then
-              echo ""
-              echo "⚠️ Start-point hash not found in Bencher — retrying without --start-point-hash (will use latest baseline)"
-              echo "::warning::Start-point hash not found in Bencher — falling back to latest baseline for comparison"
-              set +e
-              run_bencher "$RETRY_ARGS" > bench_results/bencher_report.html 2>"$BENCHER_STDERR"
-              BENCHER_EXIT_CODE=$?
-              set -e
-              cat "$BENCHER_STDERR" >&2
-            fi
-          fi
-
-          # Distinguish regression alerts from operational failures (auth/API/network/CLI)
-          # so that main can warn-only on the former while still failing hard on the latter.
-          # Match Bencher's actual alert output (e.g., "🚨 2 Alerts", "Alert detected") via
-          # a word-bounded, case-insensitive "Alert[s]". The word boundary (\b) already
-          # prevents matching lowercase "alerts" inside URL paths (e.g., "/v0/.../alerts"),
-          # so the case-insensitive flag adds robustness against future CLI wording changes
-          # (e.g., lowercase "1 alert") without reintroducing the URL-path false positive.
-          BENCHER_HAS_ALERT=0
-          if [ $BENCHER_EXIT_CODE -ne 0 ] && \
-             { grep -qiE "\bAlerts?\b" "$BENCHER_STDERR" || \
-               grep -qiE "threshold violation|boundary violation" "$BENCHER_STDERR"; }; then
-            BENCHER_HAS_ALERT=1
-          fi
-          # Cleanup is also handled by the `trap 'rm -f "$BENCHER_STDERR"' EXIT` above,
-          # so we don't need an explicit rm here.
-
-          # Export exit code and alert flag early so downstream steps (7b/7c/7d) always
-          # see them, even if the post-processing below (step summary, PR comments) fails.
-          echo "BENCHER_EXIT_CODE=$BENCHER_EXIT_CODE" >> "$GITHUB_ENV"
-          echo "BENCHER_HAS_ALERT=$BENCHER_HAS_ALERT" >> "$GITHUB_ENV"
-
-          # Post report to job summary and PR comment(s) if there's HTML output
-          if [ -s bench_results/bencher_report.html ]; then
-            echo "📊 Adding Bencher report to job summary..."
-            cat bench_results/bencher_report.html >> "$GITHUB_STEP_SUMMARY"
-
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
-              echo "📝 Splitting HTML report for PR comments..."
-              ruby benchmarks/split_html_report.rb bench_results/bencher_report.html bench_results/bencher_chunk
-
-              # Delete old Bencher report comments (identified by marker)
-              echo "🗑️ Deleting old Bencher report comments..."
-              gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-                --paginate --jq '.[] | select(.body | contains("<!-- BENCHER_REPORT -->")) | .id' | \
-              while read -r comment_id; do
-                echo "Deleting comment $comment_id"
-                gh api -X DELETE "repos/${{ github.repository }}/issues/comments/$comment_id"
-              done
-
-              # Post each chunk as a separate comment
-              COMMENT_FAILED=false
-              for chunk_file in bench_results/bencher_chunk*.html; do
-                if [ -f "$chunk_file" ]; then
-                  echo "Posting $chunk_file ($(wc -c < "$chunk_file") bytes)..."
-                  if ! gh pr comment ${{ github.event.pull_request.number }} --body-file "$chunk_file"; then
-                    echo "⚠️ Failed to post $chunk_file"
-                    COMMENT_FAILED=true
-                  fi
-                fi
-              done
-
-              # If any chunk failed to post, add a fallback comment
-              if [ "$COMMENT_FAILED" = "true" ]; then
-                echo "⚠️ Some chunks failed to post, adding fallback comment..."
-                FALLBACK_BODY="<!-- BENCHER_REPORT -->"
-                FALLBACK_BODY="${FALLBACK_BODY}"$'\n'"⚠️ **Bencher report chunks were too large to post as PR comments.**"
-                FALLBACK_BODY="${FALLBACK_BODY}"$'\n'$'\n'"View the full report in the [job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
-                gh pr comment ${{ github.event.pull_request.number }} --body "$FALLBACK_BODY" || true
-              fi
-            fi
-          else
-            echo "✅ No alerts - no Bencher report to post"
-          fi
-
-      # ============================================
-      # STEP 7b: ALERT ON MAIN REGRESSION
-      # ============================================
-      - name: Create GitHub Issue for main regression
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.BENCHER_EXIT_CODE != '0' && env.BENCHER_HAS_ALERT == '1'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          LABEL="performance-regression"
-          COMMIT_SHA="${{ github.sha }}"
-          COMMIT_SHORT="${COMMIT_SHA:0:7}"
-          COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${COMMIT_SHA}"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BENCHER_URL="https://bencher.dev/perf/react-on-rails-t8a9ncxo"
-          ACTOR="${{ github.actor }}"
-
-          # Ensure the label exists (idempotent)
-          gh label create "$LABEL" \
-            --description "Automated: benchmark regression detected on main" \
-            --color "D93F0B" \
-            --force 2>/dev/null || true
-
-          # Check for an existing open issue to avoid duplicates
-          EXISTING_ISSUE=$(gh issue list \
-            --label "$LABEL" \
-            --state open \
-            --limit 1 \
-            --json number \
-            --jq '.[0].number // empty')
-
-          # Build the benchmark summary snippet (defensive: don't let column failure block alerting)
-          SUMMARY=""
-          if [ -f bench_results/summary.txt ]; then
-            FORMATTED=$(column -t -s $'\t' "bench_results/summary.txt" 2>/dev/null) || FORMATTED=$(cat "bench_results/summary.txt")
-            SUMMARY=$(printf '\n### Benchmark Summary\n\n```\n%s\n```' "$FORMATTED")
-          fi
-
-          if [ -n "$EXISTING_ISSUE" ]; then
-            echo "Open regression issue already exists: #${EXISTING_ISSUE} — adding comment"
-
-            if ! gh issue comment "$EXISTING_ISSUE" --body "$(cat <<EOF
-          ## New regression detected
-
-          **Commit:** [\`${COMMIT_SHORT}\`](${COMMIT_URL}) by @${ACTOR}
-          **Workflow run:** [Run #${{ github.run_number }}](${RUN_URL})
-          ${SUMMARY}
-
-          > View the full Bencher report in the [workflow run summary](${RUN_URL}) or on the [Bencher dashboard](${BENCHER_URL}).
-          EOF
-          )"; then
-              echo "::warning::Failed to comment on regression issue #${EXISTING_ISSUE}"
-            fi
-          else
-            echo "No open regression issue found — creating one"
-
-            if ! gh issue create \
-              --title "Performance Regression Detected on main (${COMMIT_SHORT})" \
-              --label "$LABEL" \
-              --body "$(cat <<EOF
-          ## Performance Regression Detected on main
-
-          A statistically significant performance regression was detected by
-          [Bencher](${BENCHER_URL}) using a Student's t-test (95% confidence
-          interval, up to 64 sample history).
-
-          | Detail | Value |
-          |--------|-------|
-          | **Commit** | [\`${COMMIT_SHORT}\`](${COMMIT_URL}) |
-          | **Pushed by** | @${ACTOR} |
-          | **Workflow run** | [Run #${{ github.run_number }}](${RUN_URL}) |
-          | **Bencher dashboard** | [View history](${BENCHER_URL}) |
-          ${SUMMARY}
-
-          ### What to do
-
-          1. Check the [workflow run](${RUN_URL}) for the full Bencher HTML report
-          2. Review the [Bencher dashboard](${BENCHER_URL}) to see which metrics regressed
-          3. Investigate the commit — expected trade-off or unintended regression?
-          4. If unintended, open a fix PR and reference this issue
-          5. Close this issue once resolved — subsequent regressions will open a new one
-
-          ---
-          *This issue was created automatically by the benchmark CI workflow.*
-          EOF
-          )"; then
-              echo "::warning::Failed to create regression issue — check GitHub API permissions"
-            fi
-          fi
-
-      # ============================================
-      # STEP 7c: WARN ON MAIN REGRESSION
-      # ============================================
-      # Regressions are surfaced via the Bencher dashboard, the auto-opened tracking
-      # issue (Step 7b), and the job-summary report. Do not fail the workflow on regression
-      # alerts: single-run alerts on GitHub-hosted runners are dominated by environmental
-      # noise (alert sets across consecutive runs have ~0 overlap), so blocking main
-      # produces churn without signal. Re-enable a hard gate once thresholds/sample-size
-      # tolerate that noise. Operational errors (auth/API/network/CLI) are handled in
-      # step 7d and still fail the workflow.
-      - name: Warn if Bencher detected regression on main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.BENCHER_EXIT_CODE != '0' && env.BENCHER_HAS_ALERT == '1'
-        env:
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          echo "::warning::Bencher flagged a regression on main (exit ${BENCHER_EXIT_CODE:-1}). See the open regression issue (label: performance-regression), the Bencher dashboard, and the workflow run: ${RUN_URL}"
-
-      # ============================================
-      # STEP 7d: FAIL ON NON-REGRESSION BENCHER ERRORS
-      # ============================================
-      # If bencher exited non-zero but stderr did not contain regression alert
-      # indicators, this is an operational failure (auth/API/network/CLI) rather than
-      # a performance signal. These should still fail the workflow on main so a broken
-      # benchmark pipeline (missing uploads, bad credentials, Bencher outage, etc.) is
-      # not silently hidden behind a warning annotation.
-      - name: Fail on non-regression Bencher error on main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.BENCHER_EXIT_CODE != '0' && env.BENCHER_HAS_ALERT != '1'
-        run: |
-          echo "::error::Bencher exited ${BENCHER_EXIT_CODE:-1} on main with no regression alert in stderr — this indicates an operational failure (auth/API/network/CLI), not a performance regression. Check the logs above."
-          # Preserve the original Bencher exit code in CI logs for diagnostic context.
-          exit "${BENCHER_EXIT_CODE:-1}"
-
-      # ============================================
-      # STEP 8: WORKFLOW COMPLETION
-      # ============================================
-      - name: Workflow summary
+      - name: Pro workflow summary
         if: always()
         run: |
           echo "📋 Benchmark Workflow Summary"
           echo "===================================="
+          echo "Suite: Pro"
           echo "Status: ${{ job.status }}"
           echo "Run number: ${{ github.run_number }}"
           echo "Triggered by: ${{ github.actor }}"
           echo "Branch: ${{ github.ref_name }}"
-          echo "Run Core: ${{ env.RUN_CORE || 'false' }}"
           echo "Run Pro Rails: ${{ env.RUN_PRO_RAILS || 'false' }}"
           echo "Run Pro Node Renderer: ${{ env.RUN_PRO_NODE_RENDERER || 'false' }}"
-          echo ""
-          if [ "${{ job.status }}" == "success" ]; then
-            echo "✅ All steps completed successfully"
-          else
-            echo "❌ Workflow encountered errors - check logs above"
-          fi

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "open3"
 require "shellwords"
 require_relative "lib/benchmark_config"
 require_relative "lib/benchmark_helpers"
+require_relative "lib/benchmark_routes"
 require_relative "lib/bmf_helpers"
 
 # Script-specific parameters
@@ -14,80 +14,33 @@ ROUTES = env_or_default("ROUTES", nil)
 BASE_URL = env_or_default("BASE_URL", "localhost:3001")
 SUMMARY_TXT = "#{OUTDIR}/summary.txt".freeze
 BMF_SUFFIX = PRO ? ": Pro" : ": Core"
+BENCHMARK_SHARD_INDEX = Integer(env_or_default("BENCHMARK_SHARD_INDEX", 0))
+BENCHMARK_TOTAL_SHARDS = Integer(env_or_default("BENCHMARK_TOTAL_SHARDS", 1))
 
 # Local wrapper for add_summary_line to use local constant
 def add_to_summary(*parts)
   add_summary_line(SUMMARY_TXT, *parts)
 end
 
-# Check if a route has required parameters (e.g., /rsc_payload/:component_name)
-# Required parameters are :param NOT inside parentheses
-# Optional parameters are inside parentheses like (/:optional_param)
-def route_has_required_params?(path)
-  # Remove optional parameter sections (anything in parentheses)
-  path_without_optional = path.gsub(/\([^)]*\)/, "")
-  # Check if remaining path contains :param
-  path_without_optional.include?(":")
-end
+def shard_benchmark_routes(routes, shard_index, total_shards)
+  return routes if total_shards == 1
 
-# Strip optional parameters from route path for use in URLs
-# e.g., "/route(/:optional)(.:format)" -> "/route"
-def strip_optional_params(route)
-  route.gsub(/\([^)]*\)/, "")
-end
-
-# Sanitize route name for use in filenames
-# Removes characters that GitHub Actions disallows in artifacts and shell metacharacters
-def sanitize_route_name(route)
-  name = strip_optional_params(route).gsub(%r{^/}, "").tr("/", "_")
-  name = "root" if name.empty?
-  # Replace invalid characters: " : < > | * ? \r \n $ ` ; & ( ) [ ] { } ! #
-  name.gsub(/[":.<>|*?\r\n$`;&#!()\[\]{}]+/, "_").squeeze("_").gsub(/^_|_$/, "")
-end
-
-# Get routes from the Rails app filtered by pages# and react_router# controllers
-def get_benchmark_routes(app_dir)
-  routes_output, status = Open3.capture2e("bundle", "exec", "rails", "routes", chdir: app_dir)
-  raise "Failed to get routes from #{app_dir}" unless status.success?
-
-  routes = []
-  routes_output.each_line do |line|
-    # Parse lines like: "server_side_hello_world GET  /server_side_hello_world(.:format)  pages#server_side_hello_world"
-    # We want GET routes only (not POST, etc.) served by pages# or react_router# controllers
-    # Capture path up to (.:format) part using [^(\s]+ (everything except '(' and whitespace)
-    next unless (match = line.match(/GET\s+([^(\s]+).*(pages|react_router)#/))
-
-    path = match[1]
-    path = "/" if path.empty? # Handle root route
-
-    # Skip routes with required parameters (e.g., /rsc_payload/:component_name)
-    if route_has_required_params?(path)
-      puts "Skipping route with required parameters: #{path}"
-      next
-    end
-
-    # Skip "_for_testing" routes (test-only endpoints not meant for benchmarking)
-    if path.include?("_for_testing")
-      puts "Skipping test-only route: #{path}"
-      next
-    end
-
-    routes << path
+  routes.each_with_index.filter_map do |route, index|
+    route if (index % total_shards) == shard_index
   end
-  raise "No pages# or react_router# routes found in #{app_dir}" if routes.empty?
-
-  routes
 end
 
 # Get all routes to benchmark
-routes =
-  if ROUTES
-    ROUTES.split(",").map(&:strip).reject(&:empty?)
-  else
-    get_benchmark_routes(APP_DIR)
-  end
+all_routes = benchmark_routes_for_app(APP_DIR, ROUTES)
 
-raise "No routes to benchmark" if routes.empty?
+raise "No routes to benchmark" if all_routes.empty?
+
+validate_positive_integer(BENCHMARK_TOTAL_SHARDS, "BENCHMARK_TOTAL_SHARDS")
+raise "BENCHMARK_SHARD_INDEX must be between 0 and #{BENCHMARK_TOTAL_SHARDS - 1} (got: #{BENCHMARK_SHARD_INDEX})" unless
+  BENCHMARK_SHARD_INDEX.between?(0, BENCHMARK_TOTAL_SHARDS - 1)
+
+routes = shard_benchmark_routes(all_routes, BENCHMARK_SHARD_INDEX, BENCHMARK_TOTAL_SHARDS)
+raise "No routes assigned to shard #{BENCHMARK_SHARD_INDEX + 1}/#{BENCHMARK_TOTAL_SHARDS}" if routes.empty?
 
 validate_benchmark_config!
 
@@ -99,6 +52,9 @@ puts <<~PARAMS
     - APP_DIR: #{APP_DIR}
     - ROUTES: #{ROUTES || 'auto-detect from Rails'}
     - BASE_URL: #{BASE_URL}
+    - BENCHMARK_SHARD_INDEX: #{BENCHMARK_SHARD_INDEX}
+    - BENCHMARK_TOTAL_SHARDS: #{BENCHMARK_TOTAL_SHARDS}
+    - ROUTES_IN_SHARD: #{routes.length}/#{all_routes.length}
     - RATE: #{RATE}
     - DURATION: #{DURATION}
     - REQUEST_TIMEOUT: #{REQUEST_TIMEOUT}

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -164,5 +164,4 @@ end
 puts "\nSummary saved to #{SUMMARY_TXT}"
 system("column", "-t", "-s", "\t", SUMMARY_TXT)
 
-# Write BMF JSON for Bencher (append if Pro to combine with Core results)
-bmf_collector.write_bmf_json(BENCHMARK_JSON, append: PRO)
+bmf_collector.write_bmf_json(BENCHMARK_JSON)

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -17,7 +17,6 @@ BMF_SUFFIX = PRO ? ": Pro" : ": Core"
 BENCHMARK_SHARD_INDEX = Integer(env_or_default("BENCHMARK_SHARD_INDEX", 0))
 BENCHMARK_TOTAL_SHARDS = Integer(env_or_default("BENCHMARK_TOTAL_SHARDS", 1))
 
-# Local wrapper for add_summary_line to use local constant
 def add_to_summary(*parts)
   add_summary_line(SUMMARY_TXT, *parts)
 end
@@ -30,7 +29,6 @@ def shard_benchmark_routes(routes, shard_index, total_shards)
   end
 end
 
-# Get all routes to benchmark
 all_routes = benchmark_routes_for_app(APP_DIR, ROUTES)
 
 raise "No routes to benchmark" if all_routes.empty?

--- a/benchmarks/count_benchmark_shards.rb
+++ b/benchmarks/count_benchmark_shards.rb
@@ -1,33 +1,28 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "json"
-require_relative "lib/benchmark_config"
-require_relative "lib/benchmark_routes"
+# Emits the GitHub Actions matrix `include:` payload for one benchmark suite.
+# Stdlib-only so the workflow can invoke it with the runner's system Ruby — no
+# Bundler, no Rails boot. The actual route discovery happens later inside each
+# benchmark-* job, where bench.rb has the proper Ruby + gem setup.
 
-PRO = ENV.fetch("PRO", "false") == "true"
-APP_DIR = PRO ? "react_on_rails_pro/spec/dummy" : "react_on_rails/spec/dummy"
-MAX_ROUTES_PER_SHARD = Integer(env_or_default("MAX_ROUTES_PER_SHARD", 60))
+require "json"
+
+SHARD_TOTAL = Integer(ENV.fetch("BENCHMARK_TOTAL_SHARDS"))
 SUITE_NAME = ENV.fetch("BENCHMARK_SUITE_NAME")
 SUITE_PREFIX = ENV.fetch("BENCHMARK_SUITE_PREFIX")
-ROUTES = env_or_default("ROUTES", nil)
 
-routes = benchmark_routes_for_app(APP_DIR, ROUTES)
-raise "No routes to benchmark" if routes.empty?
-
-validate_positive_integer(MAX_ROUTES_PER_SHARD, "MAX_ROUTES_PER_SHARD")
-
-shard_total = [(routes.length.to_f / MAX_ROUTES_PER_SHARD).ceil, 1].max
+raise "BENCHMARK_TOTAL_SHARDS must be positive (got #{SHARD_TOTAL})" unless SHARD_TOTAL.positive?
 
 matrix = {
-  include: Array.new(shard_total) do |index|
+  include: Array.new(SHARD_TOTAL) do |index|
     shard_number = index + 1
-    shard_label = "#{shard_number}/#{shard_total}"
-    shard_slug = "shard-#{shard_number}-of-#{shard_total}"
+    shard_label = "#{shard_number}/#{SHARD_TOTAL}"
+    shard_slug = "shard-#{shard_number}-of-#{SHARD_TOTAL}"
 
     {
       shard_index: index,
-      shard_total: shard_total,
+      shard_total: SHARD_TOTAL,
       shard_label: shard_label,
       shard_slug: shard_slug,
       suite_name: "#{SUITE_NAME} (shard #{shard_label})",

--- a/benchmarks/count_benchmark_shards.rb
+++ b/benchmarks/count_benchmark_shards.rb
@@ -3,8 +3,7 @@
 
 # Emits the GitHub Actions matrix `include:` payload for one benchmark suite.
 # Stdlib-only so the workflow can invoke it with the runner's system Ruby — no
-# Bundler, no Rails boot. The actual route discovery happens later inside each
-# benchmark-* job, where bench.rb has the proper Ruby + gem setup.
+# Bundler, no Rails boot.
 
 require "json"
 

--- a/benchmarks/count_benchmark_shards.rb
+++ b/benchmarks/count_benchmark_shards.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "lib/benchmark_config"
+require_relative "lib/benchmark_routes"
+
+PRO = ENV.fetch("PRO", "false") == "true"
+APP_DIR = PRO ? "react_on_rails_pro/spec/dummy" : "react_on_rails/spec/dummy"
+MAX_ROUTES_PER_SHARD = Integer(env_or_default("MAX_ROUTES_PER_SHARD", 60))
+SUITE_NAME = ENV.fetch("BENCHMARK_SUITE_NAME")
+SUITE_PREFIX = ENV.fetch("BENCHMARK_SUITE_PREFIX")
+ROUTES = env_or_default("ROUTES", nil)
+
+routes = benchmark_routes_for_app(APP_DIR, ROUTES)
+raise "No routes to benchmark" if routes.empty?
+
+validate_positive_integer(MAX_ROUTES_PER_SHARD, "MAX_ROUTES_PER_SHARD")
+
+shard_total = [(routes.length.to_f / MAX_ROUTES_PER_SHARD).ceil, 1].max
+
+matrix = {
+  include: Array.new(shard_total) do |index|
+    shard_number = index + 1
+    shard_label = "#{shard_number}/#{shard_total}"
+    shard_slug = "shard-#{shard_number}-of-#{shard_total}"
+
+    {
+      shard_index: index,
+      shard_total: shard_total,
+      shard_label: shard_label,
+      shard_slug: shard_slug,
+      suite_name: "#{SUITE_NAME} (shard #{shard_label})",
+      report_marker: "<!-- BENCHER_REPORT_#{SUITE_PREFIX}_#{shard_slug.upcase.tr('-', '_')} -->"
+    }
+  end
+}
+
+puts JSON.generate(matrix)

--- a/benchmarks/lib/benchmark_config.rb
+++ b/benchmarks/lib/benchmark_config.rb
@@ -8,11 +8,11 @@ require "fileutils"
 require "net/http"
 require "uri"
 
-# Helper to get env var with default,
-# treating empty string and "0" as unset since they can come from the benchmark workflow.
+# Helper to get env var with default, treating empty string as unset
+# (the benchmark workflow passes "" when a workflow_dispatch input is omitted).
 def env_or_default(key, default)
   value = ENV[key].to_s
-  value.empty? || value == "0" ? default : value
+  value.empty? ? default : value
 end
 
 # Validation helpers

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -23,7 +23,10 @@ end
 def benchmark_routes_from_rails_routes(app_dir)
   stdout, stderr, status = Open3.capture3(
     {
-      "RAILS_ENV" => "test",
+      # Match the benchmark server environment so route discovery sees the same
+      # mounted engines and conditional routes as the production process.
+      "RAILS_ENV" => "production",
+      "NODE_ENV" => "production",
       "SECRET_KEY_BASE" => ENV.fetch("SECRET_KEY_BASE", "benchmark-secret-key-base")
     },
     "bundle",

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -74,8 +74,10 @@ end
 
 def benchmark_routes_for_app(app_dir, explicit_routes)
   if explicit_routes
+    # strip_optional_params keeps the BMF benchmark name (which bench.rb uses as-is) stable
+    # across runs when callers pass routes copied from `rails routes` output containing "(.:format)".
     return explicit_routes.split(",").map(&:strip).reject(&:empty?).map do |route|
-             normalize_route_path(route)
+             strip_optional_params(normalize_route_path(route))
            end
   end
 

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -2,6 +2,8 @@
 
 # Shared benchmark route discovery helpers.
 
+require "open3"
+
 def route_has_required_params?(path)
   path_without_optional = path.gsub(/\([^)]*\)/, "")
   path_without_optional.include?(":")
@@ -18,25 +20,45 @@ def sanitize_route_name(route)
   name.gsub(/[":.<>|*?\r\n$`;&#!()\[\]{}]+/, "_").squeeze("_").gsub(/^_|_$/, "")
 end
 
-def benchmark_routes_from_routes_file(routes_file)
-  routes = []
+def benchmark_routes_from_rails_routes(app_dir)
+  stdout, stderr, status = Open3.capture3(
+    {
+      "RAILS_ENV" => "test",
+      "SECRET_KEY_BASE" => ENV.fetch("SECRET_KEY_BASE", "benchmark-secret-key-base")
+    },
+    "bundle",
+    "exec",
+    "rails",
+    "routes",
+    "--expanded",
+    chdir: app_dir
+  )
+  warn stderr unless stderr.empty?
+  raise "Failed to get routes from #{app_dir}" unless status.success?
 
-  File.foreach(routes_file) do |line|
+  benchmark_routes_from_rails_routes_output(stdout)
+end
+
+def benchmark_routes_from_rails_routes_output(routes_output)
+  routes = []
+  current_route = {}
+
+  routes_output.each_line do |line|
     stripped = line.strip
 
     case stripped
-    when /\Aroot\s+"([^"]+)"\z/
-      controller_action = Regexp.last_match(1)
-      routes << "/" if benchmark_controller_action?(controller_action)
-    when /\Aget\s+"([^"]+)"\s*=>\s*"([^"]+)"/
-      path = Regexp.last_match(1)
-      controller_action = Regexp.last_match(2)
+    when /\APrefix\s+\|\s*(.*)\z/
+      current_route[:prefix] = Regexp.last_match(1)
+    when /\AVerb\s+\|\s*(.*)\z/
+      current_route[:verb] = Regexp.last_match(1)
+    when /\AURI\s+\|\s*(.*)\z/
+      current_route[:uri] = Regexp.last_match(1)
+    when /\AController#Action\s+\|\s*(.*)\z/
+      current_route[:controller_action] = Regexp.last_match(1)
 
-      next unless benchmark_controller_action?(controller_action)
-      next if route_has_required_params?(path)
-      next if path.include?("_for_testing")
-
-      routes << normalize_route_path(path)
+      route = benchmark_route_from_rails_output(current_route)
+      routes << route if route
+      current_route = {}
     end
   end
 
@@ -54,14 +76,22 @@ def benchmark_routes_for_app(app_dir, explicit_routes)
            end
   end
 
-  routes_file = File.join(app_dir, "config", "routes.rb")
-  raise "Routes file not found: #{routes_file}" unless File.exist?(routes_file)
-
-  benchmark_routes_from_routes_file(routes_file)
+  benchmark_routes_from_rails_routes(app_dir)
 end
 
 def normalize_route_path(route)
   return route if route.start_with?("/")
 
   "/#{route}"
+end
+
+def benchmark_route_from_rails_output(route)
+  return unless route[:verb] == "GET"
+  return unless benchmark_controller_action?(route[:controller_action])
+
+  path = route[:uri]
+  return if route_has_required_params?(path)
+  return if path.include?("_for_testing")
+
+  normalize_route_path(strip_optional_params(path))
 end

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# Shared benchmark route discovery helpers.
-
 require "open3"
 
 def route_has_required_params?(path)
@@ -16,7 +14,7 @@ end
 def sanitize_route_name(route)
   name = strip_optional_params(route).gsub(%r{^/}, "").tr("/", "_")
   name = "root" if name.empty?
-  # Replace invalid characters: " : < > | * ? \r \n $ ` ; & ( ) [ ] { } ! #
+  # Strip shell metacharacters and GitHub Actions artifact-name disallowed characters.
   name.gsub(/[":.<>|*?\r\n$`;&#!()\[\]{}]+/, "_").squeeze("_").gsub(/^_|_$/, "")
 end
 

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Shared benchmark route discovery helpers.
+
+def route_has_required_params?(path)
+  path_without_optional = path.gsub(/\([^)]*\)/, "")
+  path_without_optional.include?(":")
+end
+
+def strip_optional_params(route)
+  route.gsub(/\([^)]*\)/, "")
+end
+
+def sanitize_route_name(route)
+  name = strip_optional_params(route).gsub(%r{^/}, "").tr("/", "_")
+  name = "root" if name.empty?
+  # Replace invalid characters: " : < > | * ? \r \n $ ` ; & ( ) [ ] { } ! #
+  name.gsub(/[":.<>|*?\r\n$`;&#!()\[\]{}]+/, "_").squeeze("_").gsub(/^_|_$/, "")
+end
+
+def benchmark_routes_from_routes_file(routes_file)
+  routes = []
+
+  File.foreach(routes_file) do |line|
+    stripped = line.strip
+
+    case stripped
+    when /\Aroot\s+"([^"]+)"\z/
+      controller_action = Regexp.last_match(1)
+      routes << "/" if benchmark_controller_action?(controller_action)
+    when /\Aget\s+"([^"]+)"\s*=>\s*"([^"]+)"/
+      path = Regexp.last_match(1)
+      controller_action = Regexp.last_match(2)
+
+      next unless benchmark_controller_action?(controller_action)
+      next if route_has_required_params?(path)
+      next if path.include?("_for_testing")
+
+      routes << normalize_route_path(path)
+    end
+  end
+
+  routes
+end
+
+def benchmark_controller_action?(controller_action)
+  controller_action.start_with?("pages#", "react_router#")
+end
+
+def benchmark_routes_for_app(app_dir, explicit_routes)
+  if explicit_routes
+    return explicit_routes.split(",").map(&:strip).reject(&:empty?).map do |route|
+             normalize_route_path(route)
+           end
+  end
+
+  routes_file = File.join(app_dir, "config", "routes.rb")
+  raise "Routes file not found: #{routes_file}" unless File.exist?(routes_file)
+
+  benchmark_routes_from_routes_file(routes_file)
+end
+
+def normalize_route_path(route)
+  return route if route.start_with?("/")
+
+  "/#{route}"
+end

--- a/benchmarks/split_html_report.rb
+++ b/benchmarks/split_html_report.rb
@@ -10,7 +10,7 @@ MAX_COMMENT_SIZE = 220 * 1024
 SAFETY_MARGIN = 500
 MAX_CHUNK_SIZE = MAX_COMMENT_SIZE - SAFETY_MARGIN
 
-MARKER = "<!-- BENCHER_REPORT -->"
+MARKER = ENV.fetch("BENCHER_REPORT_MARKER", "<!-- BENCHER_REPORT -->")
 
 # rubocop:disable Metrics/AbcSize
 def split_html_report(html)

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -15,6 +15,7 @@ end
 
 SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
 REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
+BENCHER_API_TOKEN = env!("BENCHER_API_TOKEN")
 BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
 REPORT_HTML = ENV.fetch("BENCHER_REPORT_HTML", "bench_results/bencher_report.html")
 
@@ -75,7 +76,6 @@ def bencher_args(branch, start_point_args)
   [
     "bencher", "run",
     "--project", "react-on-rails-t8a9ncxo",
-    "--token", ENV.fetch("BENCHER_API_TOKEN"),
     "--branch", branch,
     *start_point_args,
     "--testbed", "github-actions",
@@ -142,7 +142,9 @@ end
 
 def split_report_for_comments
   ENV["BENCHER_REPORT_MARKER"] = REPORT_MARKER
-  run_command("ruby", "benchmarks/split_html_report.rb", REPORT_HTML, "bench_results/bencher_chunk")
+  return if run_command("ruby", "benchmarks/split_html_report.rb", REPORT_HTML, "bench_results/bencher_chunk")
+
+  warn "Failed to split HTML report; skipping PR comments"
 end
 
 def stale_comment_ids
@@ -156,19 +158,23 @@ def stale_comment_ids
   stdout.lines.map(&:strip).reject(&:empty?)
 end
 
-def replace_pr_comments
-  return unless ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
-  return unless File.size?(REPORT_HTML)
-
-  split_report_for_comments
-
+def delete_stale_report_comments
   stale_comment_ids.each do |comment_id|
     puts "Deleting stale #{SUITE_NAME} Bencher report comment #{comment_id}"
     run_command("gh", "api", "-X", "DELETE", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/comments/#{comment_id}")
   end
+end
 
+def post_report_comment_chunks
   comment_failed = false
-  Dir["bench_results/bencher_chunk*.html"].each do |chunk_file|
+
+  chunk_files = Dir["bench_results/bencher_chunk*.html"].sort_by do |chunk_file|
+    chunk_file[/bencher_chunk(\d+)\.html\z/, 1].to_i
+  end
+
+  posted_any = false
+  any_failed = false
+  chunk_files.each do |chunk_file|
     puts "Posting #{chunk_file} (#{File.size(chunk_file)} bytes)..."
     next if run_command("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body-file", chunk_file)
 
@@ -176,7 +182,26 @@ def replace_pr_comments
     comment_failed = true
   end
 
-  return unless comment_failed
+  [posted_any, any_failed]
+end
+
+def replace_pr_comments
+  return unless ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+  return unless File.size?(REPORT_HTML)
+
+  return unless split_report_for_comments
+
+  # Post first, then GC stale comments. If every post fails, the prior run's comments stay
+  # visible — better than racing the user with an empty PR while the new report is broken.
+  posted_any, any_failed = post_report_comment_chunks
+
+  if posted_any
+    delete_stale_report_comments
+  else
+    warn "No #{SUITE_NAME} chunks were posted successfully; keeping prior Bencher comments in place."
+  end
+
+  return unless any_failed
 
   fallback_body = <<~MARKDOWN
     #{REPORT_MARKER}

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -23,12 +23,20 @@ def env!(key)
   end
 end
 
-SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
-REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
-env!("BENCHER_API_TOKEN")
 BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
 REPORT_HTML = ENV.fetch("BENCHER_REPORT_HTML", "bench_results/bencher_report.html")
 CHUNK_PREFIX = "bench_results/bencher_chunk"
+
+# Check the input file before validating env vars — a missing benchmark.json is the more
+# actionable failure (almost always upstream `bench.rb` didn't produce results).
+unless File.exist?(BENCHMARK_JSON)
+  warn "Benchmark JSON file not found: #{BENCHMARK_JSON}"
+  exit 1
+end
+
+SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
+REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
+env!("BENCHER_API_TOKEN")
 
 def capture_command(*args)
   stdout, stderr, status = Open3.capture3(*args)
@@ -320,11 +328,6 @@ end
 
 def main_push?
   ENV.fetch("GITHUB_EVENT_NAME") == "push" && ENV.fetch("GITHUB_REF") == "refs/heads/main"
-end
-
-unless File.exist?(BENCHMARK_JSON)
-  warn "Benchmark JSON file not found: #{BENCHMARK_JSON}"
-  exit 1
 end
 
 branch, start_point_args = branch_and_start_point_args

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -15,13 +15,9 @@ end
 
 SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
 REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
-BENCHER_API_TOKEN = env!("BENCHER_API_TOKEN")
+env!("BENCHER_API_TOKEN")
 BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
 REPORT_HTML = ENV.fetch("BENCHER_REPORT_HTML", "bench_results/bencher_report.html")
-
-def run_command(*args)
-  system(*args)
-end
 
 def capture_command(*args)
   stdout, stderr, status = Open3.capture3(*args)
@@ -142,9 +138,10 @@ end
 
 def split_report_for_comments
   ENV["BENCHER_REPORT_MARKER"] = REPORT_MARKER
-  return if run_command("ruby", "benchmarks/split_html_report.rb", REPORT_HTML, "bench_results/bencher_chunk")
+  return true if system("ruby", "benchmarks/split_html_report.rb", REPORT_HTML, "bench_results/bencher_chunk")
 
   warn "Failed to split HTML report; skipping PR comments"
+  false
 end
 
 def stale_comment_ids
@@ -161,25 +158,25 @@ end
 def delete_stale_report_comments
   stale_comment_ids.each do |comment_id|
     puts "Deleting stale #{SUITE_NAME} Bencher report comment #{comment_id}"
-    run_command("gh", "api", "-X", "DELETE", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/comments/#{comment_id}")
+    system("gh", "api", "-X", "DELETE", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/comments/#{comment_id}")
   end
 end
 
 def post_report_comment_chunks
-  comment_failed = false
-
-  chunk_files = Dir["bench_results/bencher_chunk*.html"].sort_by do |chunk_file|
-    chunk_file[/bencher_chunk(\d+)\.html\z/, 1].to_i
+  chunk_files = Dir["#{CHUNK_PREFIX}*.html"].sort_by do |chunk_file|
+    chunk_file[/bencher_chunk(?:\.(\d+))?\.html\z/, 1].to_i
   end
 
   posted_any = false
   any_failed = false
   chunk_files.each do |chunk_file|
     puts "Posting #{chunk_file} (#{File.size(chunk_file)} bytes)..."
-    next if run_command("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body-file", chunk_file)
-
-    warn "Failed to post #{chunk_file}"
-    comment_failed = true
+    if system("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body-file", chunk_file)
+      posted_any = true
+    else
+      warn "Failed to post #{chunk_file}"
+      any_failed = true
+    end
   end
 
   [posted_any, any_failed]
@@ -209,7 +206,7 @@ def replace_pr_comments
 
     View the full report in the job summary: #{github_run_url}
   MARKDOWN
-  run_command("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body", fallback_body)
+  system("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body", fallback_body)
 end
 
 def formatted_summary(title, path)
@@ -236,7 +233,7 @@ def benchmark_summary
 end
 
 def ensure_regression_label
-  run_command(
+  system(
     "gh", "label", "create", "performance-regression",
     "--description", "Automated: benchmark regression detected on main",
     "--color", "D93F0B",
@@ -271,7 +268,7 @@ def comment_on_regression_issue(issue_number, summary)
     > View the full Bencher report in the workflow run summary or on the [Bencher dashboard](#{BENCHER_URL}).
   MARKDOWN
 
-  run_command("gh", "issue", "comment", issue_number, "--body", body)
+  system("gh", "issue", "comment", issue_number, "--body", body)
 end
 
 def create_regression_issue(summary)
@@ -304,7 +301,7 @@ def create_regression_issue(summary)
     *This issue was created automatically by the benchmark CI workflow.*
   MARKDOWN
 
-  run_command(
+  system(
     "gh", "issue", "create",
     "--title", "Performance Regression Detected on main (#{commit_short})",
     "--label", "performance-regression",

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -5,6 +5,15 @@ require "open3"
 BOUNDARY = "0.95"
 MAX_SAMPLE = "64"
 BENCHER_URL = "https://bencher.dev/perf/react-on-rails-t8a9ncxo"
+# Threshold direction: :lower for "regression = drop" measures (rps),
+# :upper for "regression = climb" measures (latency, failure rate).
+THRESHOLDS = [
+  ["rps", :lower],
+  ["p50_latency", :upper],
+  ["p90_latency", :upper],
+  ["p99_latency", :upper],
+  ["failed_pct", :upper]
+].freeze
 
 def env!(key)
   ENV.fetch(key) do
@@ -15,9 +24,14 @@ end
 
 SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
 REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
+# Cleanup pattern matches every sharded marker of this suite ("<!-- BENCHER_REPORT_CORE_SHARD_") so
+# topology changes (e.g. 2 shards → 3) don't strand old comments on the PR. Falls back to the literal
+# marker for unsharded suites (Pro Node Renderer).
+REPORT_MARKER_PREFIX = REPORT_MARKER[/\A<!-- BENCHER_REPORT_[A-Z_]+_SHARD_/] || REPORT_MARKER
 env!("BENCHER_API_TOKEN")
 BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
 REPORT_HTML = ENV.fetch("BENCHER_REPORT_HTML", "bench_results/bencher_report.html")
+CHUNK_PREFIX = "bench_results/bencher_chunk"
 
 def capture_command(*args)
   stdout, stderr, status = Open3.capture3(*args)
@@ -68,6 +82,17 @@ def branch_and_start_point_args
   end
 end
 
+def threshold_args(measure, direction)
+  lower, upper = direction == :lower ? [BOUNDARY, "_"] : ["_", BOUNDARY]
+  [
+    "--threshold-measure", measure,
+    "--threshold-test", "t_test",
+    "--threshold-max-sample-size", MAX_SAMPLE,
+    "--threshold-lower-boundary", lower,
+    "--threshold-upper-boundary", upper
+  ]
+end
+
 def bencher_args(branch, start_point_args)
   [
     "bencher", "run",
@@ -80,31 +105,7 @@ def bencher_args(branch, start_point_args)
     "--err",
     "--quiet",
     "--format", "html",
-    "--threshold-measure", "rps",
-    "--threshold-test", "t_test",
-    "--threshold-max-sample-size", MAX_SAMPLE,
-    "--threshold-lower-boundary", BOUNDARY,
-    "--threshold-upper-boundary", "_",
-    "--threshold-measure", "p50_latency",
-    "--threshold-test", "t_test",
-    "--threshold-max-sample-size", MAX_SAMPLE,
-    "--threshold-lower-boundary", "_",
-    "--threshold-upper-boundary", BOUNDARY,
-    "--threshold-measure", "p90_latency",
-    "--threshold-test", "t_test",
-    "--threshold-max-sample-size", MAX_SAMPLE,
-    "--threshold-lower-boundary", "_",
-    "--threshold-upper-boundary", BOUNDARY,
-    "--threshold-measure", "p99_latency",
-    "--threshold-test", "t_test",
-    "--threshold-max-sample-size", MAX_SAMPLE,
-    "--threshold-lower-boundary", "_",
-    "--threshold-upper-boundary", BOUNDARY,
-    "--threshold-measure", "failed_pct",
-    "--threshold-test", "t_test",
-    "--threshold-max-sample-size", MAX_SAMPLE,
-    "--threshold-lower-boundary", "_",
-    "--threshold-upper-boundary", BOUNDARY
+    *THRESHOLDS.flat_map { |measure, direction| threshold_args(measure, direction) }
   ]
 end
 
@@ -116,9 +117,10 @@ def run_bencher(branch, start_point_args)
 end
 
 def retry_without_start_point_hash?(stderr, exit_code)
+  # \bAlerts?\b avoids false matches on URL paths like "/alerts/..." that Bencher prints in stderr.
   exit_code != 0 &&
     stderr.match?(/Head Version.*not found/) &&
-    !stderr.match?(/alert|threshold violation|boundary violation/i)
+    !stderr.match?(/\bAlerts?\b|threshold violation|boundary violation/i)
 end
 
 def alert?(stderr, exit_code)
@@ -137,18 +139,23 @@ def post_report_to_summary
 end
 
 def split_report_for_comments
-  ENV["BENCHER_REPORT_MARKER"] = REPORT_MARKER
-  return true if system("ruby", "benchmarks/split_html_report.rb", REPORT_HTML, "bench_results/bencher_chunk")
+  # Clear leftover chunks from prior runs so post_report_comment_chunks doesn't
+  # mix fresh output with stale data (matters on self-hosted/cached runners).
+  Dir.glob("#{CHUNK_PREFIX}*.html").each { |path| File.delete(path) }
+  return true if system({ "BENCHER_REPORT_MARKER" => REPORT_MARKER },
+                        "ruby", "benchmarks/split_html_report.rb", REPORT_HTML, CHUNK_PREFIX)
 
   warn "Failed to split HTML report; skipping PR comments"
   false
 end
 
 def stale_comment_ids
+  # startswith() pairs with split_html_report writing the marker at body start, so reviewers
+  # quoting the marker in their own comments aren't deleted as stale.
   stdout, status = capture_command(
     "gh", "api", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/#{ENV.fetch('PR_NUMBER')}/comments",
     "--paginate",
-    "--jq", ".[] | select(.body | contains(#{REPORT_MARKER.dump})) | .id"
+    "--jq", ".[] | select(.body | startswith(#{REPORT_MARKER_PREFIX.dump})) | .id"
   )
   return [] unless status.success?
 

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "open3"
+require "time"
 BOUNDARY = "0.95"
 MAX_SAMPLE = "64"
 BENCHER_URL = "https://bencher.dev/perf/react-on-rails-t8a9ncxo"
@@ -24,10 +25,6 @@ end
 
 SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
 REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
-# Cleanup pattern matches every sharded marker of this suite ("<!-- BENCHER_REPORT_CORE_SHARD_") so
-# topology changes (e.g. 2 shards → 3) don't strand old comments on the PR. Falls back to the literal
-# marker for unsharded suites (Pro Node Renderer).
-REPORT_MARKER_PREFIX = REPORT_MARKER[/\A<!-- BENCHER_REPORT_[A-Z_]+_SHARD_/] || REPORT_MARKER
 env!("BENCHER_API_TOKEN")
 BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
 REPORT_HTML = ENV.fetch("BENCHER_REPORT_HTML", "bench_results/bencher_report.html")
@@ -149,21 +146,24 @@ def split_report_for_comments
   false
 end
 
-def stale_comment_ids
-  # startswith() pairs with split_html_report writing the marker at body start, so reviewers
-  # quoting the marker in their own comments aren't deleted as stale.
-  stdout, status = capture_command(
+def stale_comment_ids(before:)
+  # Marker + cutoff are passed via env so the jq filter reads them through `env.X`,
+  # avoiding the Ruby-#dump vs jq-string-escape mismatch that interpolated strings invite.
+  # The cutoff makes the GC skip comments the current run just posted (same marker).
+  stdout, stderr, status = Open3.capture3(
+    { "MARKER" => REPORT_MARKER, "CUTOFF_TS" => before },
     "gh", "api", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/#{ENV.fetch('PR_NUMBER')}/comments",
     "--paginate",
-    "--jq", ".[] | select(.body | startswith(#{REPORT_MARKER_PREFIX.dump})) | .id"
+    "--jq", ".[] | select(.body | startswith(env.MARKER)) | select(.created_at < env.CUTOFF_TS) | .id"
   )
+  warn stderr unless stderr.empty?
   return [] unless status.success?
 
   stdout.lines.map(&:strip).reject(&:empty?)
 end
 
-def delete_stale_report_comments
-  stale_comment_ids.each do |comment_id|
+def delete_stale_report_comments(before:)
+  stale_comment_ids(before: before).each do |comment_id|
     puts "Deleting stale #{SUITE_NAME} Bencher report comment #{comment_id}"
     system("gh", "api", "-X", "DELETE", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/comments/#{comment_id}")
   end
@@ -195,12 +195,14 @@ def replace_pr_comments
 
   return unless split_report_for_comments
 
-  # Post first, then GC stale comments. If every post fails, the prior run's comments stay
-  # visible — better than racing the user with an empty PR while the new report is broken.
+  # Capture cutoff before posting so the GC sweeps only pre-existing comments and leaves
+  # the chunks this run just posted intact. If every post fails the GC is skipped entirely
+  # and the prior run's comments stay visible.
+  cutoff_ts = Time.now.utc.iso8601
   posted_any, any_failed = post_report_comment_chunks
 
   if posted_any
-    delete_stale_report_comments
+    delete_stale_report_comments(before: cutoff_ts)
   else
     warn "No #{SUITE_NAME} chunks were posted successfully; keeping prior Bencher comments in place."
   end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -1,0 +1,337 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "open3"
+BOUNDARY = "0.95"
+MAX_SAMPLE = "64"
+BENCHER_URL = "https://bencher.dev/perf/react-on-rails-t8a9ncxo"
+
+def env!(key)
+  ENV.fetch(key) do
+    warn "#{key} is required"
+    exit 1
+  end
+end
+
+SUITE_NAME = env!("BENCHMARK_SUITE_NAME")
+REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
+BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
+REPORT_HTML = ENV.fetch("BENCHER_REPORT_HTML", "bench_results/bencher_report.html")
+
+def run_command(*args)
+  system(*args)
+end
+
+def capture_command(*args)
+  stdout, stderr, status = Open3.capture3(*args)
+  warn stderr unless stderr.empty?
+  [stdout, status]
+end
+
+def github_run_url
+  "#{ENV.fetch('GITHUB_SERVER_URL')}/#{ENV.fetch('GITHUB_REPOSITORY')}/actions/runs/#{ENV.fetch('GITHUB_RUN_ID')}"
+end
+
+def branch_and_start_point_args
+  case ENV.fetch("GITHUB_EVENT_NAME")
+  when "push"
+    ["main", []]
+  when "pull_request"
+    [
+      ENV.fetch("GITHUB_HEAD_REF"),
+      [
+        "--start-point", ENV.fetch("GITHUB_BASE_REF"),
+        "--start-point-hash", ENV.fetch("GITHUB_BASE_SHA"),
+        "--start-point-clone-thresholds",
+        "--start-point-reset"
+      ]
+    ]
+  when "workflow_dispatch"
+    branch = ENV.fetch("GITHUB_REF_NAME")
+    return [branch, []] if branch == "main"
+
+    stdout, = capture_command(
+      "gh", "api", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/compare/main...#{branch}",
+      "--jq", ".merge_base_commit.sha"
+    )
+    start_point_args = ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
+    merge_base = stdout.strip
+
+    if merge_base.empty?
+      puts "Could not find merge-base with main via GitHub API, continuing without hash"
+    else
+      puts "Found merge-base via API: #{merge_base}"
+      start_point_args.insert(2, "--start-point-hash", merge_base)
+    end
+
+    [branch, start_point_args]
+  else
+    warn "Unexpected event type: #{ENV.fetch('GITHUB_EVENT_NAME')}"
+    exit 1
+  end
+end
+
+def bencher_args(branch, start_point_args)
+  [
+    "bencher", "run",
+    "--project", "react-on-rails-t8a9ncxo",
+    "--token", ENV.fetch("BENCHER_API_TOKEN"),
+    "--branch", branch,
+    *start_point_args,
+    "--testbed", "github-actions",
+    "--adapter", "json",
+    "--file", BENCHMARK_JSON,
+    "--err",
+    "--quiet",
+    "--format", "html",
+    "--threshold-measure", "rps",
+    "--threshold-test", "t_test",
+    "--threshold-max-sample-size", MAX_SAMPLE,
+    "--threshold-lower-boundary", BOUNDARY,
+    "--threshold-upper-boundary", "_",
+    "--threshold-measure", "p50_latency",
+    "--threshold-test", "t_test",
+    "--threshold-max-sample-size", MAX_SAMPLE,
+    "--threshold-lower-boundary", "_",
+    "--threshold-upper-boundary", BOUNDARY,
+    "--threshold-measure", "p90_latency",
+    "--threshold-test", "t_test",
+    "--threshold-max-sample-size", MAX_SAMPLE,
+    "--threshold-lower-boundary", "_",
+    "--threshold-upper-boundary", BOUNDARY,
+    "--threshold-measure", "p99_latency",
+    "--threshold-test", "t_test",
+    "--threshold-max-sample-size", MAX_SAMPLE,
+    "--threshold-lower-boundary", "_",
+    "--threshold-upper-boundary", BOUNDARY,
+    "--threshold-measure", "failed_pct",
+    "--threshold-test", "t_test",
+    "--threshold-max-sample-size", MAX_SAMPLE,
+    "--threshold-lower-boundary", "_",
+    "--threshold-upper-boundary", BOUNDARY
+  ]
+end
+
+def run_bencher(branch, start_point_args)
+  stdout, stderr, status = Open3.capture3(*bencher_args(branch, start_point_args))
+  File.write(REPORT_HTML, stdout)
+  warn stderr unless stderr.empty?
+  [stderr, status.exitstatus]
+end
+
+def retry_without_start_point_hash?(stderr, exit_code)
+  exit_code != 0 &&
+    stderr.match?(/Head Version.*not found/) &&
+    !stderr.match?(/alert|threshold violation|boundary violation/i)
+end
+
+def alert?(stderr, exit_code)
+  exit_code != 0 && stderr.match?(/\bAlerts?\b|threshold violation|boundary violation/i)
+end
+
+def append_step_summary(markdown)
+  File.open(ENV.fetch("GITHUB_STEP_SUMMARY"), "a") { |file| file.write(markdown) }
+end
+
+def post_report_to_summary
+  return unless File.size?(REPORT_HTML)
+
+  append_step_summary("## #{SUITE_NAME} Bencher Report\n")
+  append_step_summary(File.read(REPORT_HTML))
+end
+
+def split_report_for_comments
+  ENV["BENCHER_REPORT_MARKER"] = REPORT_MARKER
+  run_command("ruby", "benchmarks/split_html_report.rb", REPORT_HTML, "bench_results/bencher_chunk")
+end
+
+def stale_comment_ids
+  stdout, status = capture_command(
+    "gh", "api", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/#{ENV.fetch('PR_NUMBER')}/comments",
+    "--paginate",
+    "--jq", ".[] | select(.body | contains(#{REPORT_MARKER.dump})) | .id"
+  )
+  return [] unless status.success?
+
+  stdout.lines.map(&:strip).reject(&:empty?)
+end
+
+def replace_pr_comments
+  return unless ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+  return unless File.size?(REPORT_HTML)
+
+  split_report_for_comments
+
+  stale_comment_ids.each do |comment_id|
+    puts "Deleting stale #{SUITE_NAME} Bencher report comment #{comment_id}"
+    run_command("gh", "api", "-X", "DELETE", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/issues/comments/#{comment_id}")
+  end
+
+  comment_failed = false
+  Dir["bench_results/bencher_chunk*.html"].each do |chunk_file|
+    puts "Posting #{chunk_file} (#{File.size(chunk_file)} bytes)..."
+    next if run_command("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body-file", chunk_file)
+
+    warn "Failed to post #{chunk_file}"
+    comment_failed = true
+  end
+
+  return unless comment_failed
+
+  fallback_body = <<~MARKDOWN
+    #{REPORT_MARKER}
+    **#{SUITE_NAME} Bencher report chunks were too large to post as PR comments.**
+
+    View the full report in the job summary: #{github_run_url}
+  MARKDOWN
+  run_command("gh", "pr", "comment", ENV.fetch("PR_NUMBER"), "--body", fallback_body)
+end
+
+def formatted_summary(title, path)
+  return "" unless File.exist?(path)
+
+  stdout, status = Open3.capture2("column", "-t", "-s", "\t", path)
+  body = status.success? ? stdout : File.read(path)
+
+  <<~MARKDOWN
+
+    ### #{title}
+
+    ```
+    #{body}
+    ```
+  MARKDOWN
+end
+
+def benchmark_summary
+  [
+    formatted_summary("#{SUITE_NAME} Rails Benchmark Summary", "bench_results/summary.txt"),
+    formatted_summary("#{SUITE_NAME} Node Renderer Benchmark Summary", "bench_results/node_renderer_summary.txt")
+  ].join
+end
+
+def ensure_regression_label
+  run_command(
+    "gh", "label", "create", "performance-regression",
+    "--description", "Automated: benchmark regression detected on main",
+    "--color", "D93F0B",
+    "--force"
+  )
+end
+
+def existing_regression_issue
+  stdout, status = capture_command(
+    "gh", "issue", "list",
+    "--label", "performance-regression",
+    "--state", "open",
+    "--limit", "1",
+    "--json", "number",
+    "--jq", ".[0].number // empty"
+  )
+  return "" unless status.success?
+
+  stdout.strip
+end
+
+def comment_on_regression_issue(issue_number, summary)
+  commit_short = ENV.fetch("GITHUB_SHA")[0, 7]
+  commit_url = "#{ENV.fetch('GITHUB_SERVER_URL')}/#{ENV.fetch('GITHUB_REPOSITORY')}/commit/#{ENV.fetch('GITHUB_SHA')}"
+  body = <<~MARKDOWN
+    ## New #{SUITE_NAME} regression detected
+
+    **Commit:** [`#{commit_short}`](#{commit_url}) by @#{ENV.fetch('GITHUB_ACTOR')}
+    **Workflow run:** [Run ##{ENV.fetch('GITHUB_RUN_NUMBER')}](#{github_run_url})
+    #{summary}
+
+    > View the full Bencher report in the workflow run summary or on the [Bencher dashboard](#{BENCHER_URL}).
+  MARKDOWN
+
+  run_command("gh", "issue", "comment", issue_number, "--body", body)
+end
+
+def create_regression_issue(summary)
+  commit_short = ENV.fetch("GITHUB_SHA")[0, 7]
+  commit_url = "#{ENV.fetch('GITHUB_SERVER_URL')}/#{ENV.fetch('GITHUB_REPOSITORY')}/commit/#{ENV.fetch('GITHUB_SHA')}"
+  body = <<~MARKDOWN
+    ## Performance Regression Detected on main
+
+    A statistically significant #{SUITE_NAME} performance regression was detected by
+    [Bencher](#{BENCHER_URL}) using a Student's t-test (95% confidence
+    interval, up to 64 sample history).
+
+    | Detail | Value |
+    |--------|-------|
+    | **Commit** | [`#{commit_short}`](#{commit_url}) |
+    | **Pushed by** | @#{ENV.fetch('GITHUB_ACTOR')} |
+    | **Workflow run** | [Run ##{ENV.fetch('GITHUB_RUN_NUMBER')}](#{github_run_url}) |
+    | **Bencher dashboard** | [View history](#{BENCHER_URL}) |
+    #{summary}
+
+    ### What to do
+
+    1. Check the workflow run for the full Bencher HTML report
+    2. Review the Bencher dashboard to see which metrics regressed
+    3. Investigate the commit; expected trade-off or unintended regression?
+    4. If unintended, open a fix PR and reference this issue
+    5. Close this issue once resolved; subsequent regressions will open a new one
+
+    ---
+    *This issue was created automatically by the benchmark CI workflow.*
+  MARKDOWN
+
+  run_command(
+    "gh", "issue", "create",
+    "--title", "Performance Regression Detected on main (#{commit_short})",
+    "--label", "performance-regression",
+    "--body", body
+  )
+end
+
+def main_push?
+  ENV.fetch("GITHUB_EVENT_NAME") == "push" && ENV.fetch("GITHUB_REF") == "refs/heads/main"
+end
+
+unless File.exist?(BENCHMARK_JSON)
+  warn "Benchmark JSON file not found: #{BENCHMARK_JSON}"
+  exit 1
+end
+
+branch, start_point_args = branch_and_start_point_args
+stderr, bencher_exit_code = run_bencher(branch, start_point_args)
+
+if retry_without_start_point_hash?(stderr, bencher_exit_code)
+  retry_args = start_point_args.dup
+  if (hash_arg_index = retry_args.index("--start-point-hash"))
+    retry_args.slice!(hash_arg_index, 2)
+  end
+  puts "Start-point hash not found in Bencher; retrying without --start-point-hash"
+  puts "::warning::Start-point hash not found in Bencher; falling back to latest baseline for comparison"
+  stderr, bencher_exit_code = run_bencher(branch, retry_args)
+end
+
+post_report_to_summary
+replace_pr_comments
+
+if main_push? && bencher_exit_code != 0
+  if alert?(stderr, bencher_exit_code)
+    ensure_regression_label
+    summary = benchmark_summary
+    issue_number = existing_regression_issue
+
+    if issue_number.empty?
+      create_regression_issue(summary)
+    else
+      puts "Open regression issue already exists: ##{issue_number}; adding comment"
+      comment_on_regression_issue(issue_number, summary)
+    end
+
+    puts "::warning::Bencher flagged a #{SUITE_NAME} regression on main (exit #{bencher_exit_code}). " \
+         "See the open regression issue (label: performance-regression), the Bencher dashboard, " \
+         "and the workflow run: #{github_run_url}"
+  else
+    warn "::error::Bencher exited #{bencher_exit_code} on main with no regression alert in stderr for #{SUITE_NAME}; " \
+         "this indicates an operational failure (auth/API/network/CLI), not a performance regression. " \
+         "Check the logs above."
+    exit bencher_exit_code
+  end
+end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -122,7 +122,6 @@ def run_bencher(branch, start_point_args)
 end
 
 def retry_without_start_point_hash?(stderr, exit_code)
-  # \bAlerts?\b avoids false matches on URL paths like "/alerts/..." that Bencher prints in stderr.
   exit_code != 0 &&
     stderr.match?(/Head Version.*not found/) &&
     !stderr.match?(/\bAlerts?\b|threshold violation|boundary violation/i)
@@ -144,8 +143,8 @@ def post_report_to_summary
 end
 
 def split_report_for_comments
-  # Clear leftover chunks from prior runs so post_report_comment_chunks doesn't
-  # mix fresh output with stale data (matters on self-hosted/cached runners).
+  # Clear leftover chunks before splitting so a shorter new report doesn't leave
+  # numbered chunks from the previous run lying around for the post step to pick up.
   Dir.glob("#{CHUNK_PREFIX}*.html").each { |path| File.delete(path) }
   return true if system({ "BENCHER_REPORT_MARKER" => REPORT_MARKER },
                         "ruby", "benchmarks/split_html_report.rb", REPORT_HTML, CHUNK_PREFIX)

--- a/react_on_rails/spec/react_on_rails/benchmark_routes_spec.rb
+++ b/react_on_rails/spec/react_on_rails/benchmark_routes_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "tmpdir"
+require_relative "../../../benchmarks/lib/benchmark_routes"
+
+RSpec.describe "benchmark route discovery helpers" do
+  describe "#benchmark_routes_from_rails_routes_output" do
+    it "keeps benchmarkable GET routes and skips unsupported ones" do
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | root
+        Verb              | GET
+        URI               | /
+        Controller#Action | pages#index
+        --[ Route 2 ]-------------------------------------------------------------------
+        Prefix            | client_side_hello_world
+        Verb              | GET
+        URI               | /client_side_hello_world(.:format)
+        Controller#Action | pages#client_side_hello_world
+        --[ Route 3 ]-------------------------------------------------------------------
+        Prefix            | redis_receiver_for_testing
+        Verb              | GET
+        URI               | /redis_receiver_for_testing(.:format)
+        Controller#Action | pages#redis_receiver_for_testing
+        --[ Route 4 ]-------------------------------------------------------------------
+        Prefix            | rails_conductor_inbound_email
+        Verb              | GET
+        URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
+        Controller#Action | pages#show
+        --[ Route 5 ]-------------------------------------------------------------------
+        Prefix            | react_router
+        Verb              | GET
+        URI               | /react_router(/*all)(.:format)
+        Controller#Action | react_router#index
+        --[ Route 6 ]-------------------------------------------------------------------
+        Prefix            | turbo_stream_send_hello_world
+        Verb              | POST
+        URI               | /turbo_stream_send_hello_world(.:format)
+        Controller#Action | pages#turbo_stream_send_hello_world
+      TEXT
+
+      expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq(
+        ["/", "/client_side_hello_world", "/react_router"]
+      )
+    end
+  end
+
+  describe "#benchmark_routes_for_app" do
+    it "runs rails routes in the app directory" do
+      app_dir = Dir.mktmpdir
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | client_side_hello_world
+        Verb              | GET
+        URI               | /client_side_hello_world(.:format)
+        Controller#Action | pages#client_side_hello_world
+      TEXT
+      status = instance_double(Process::Status, success?: true)
+
+      allow(Open3).to receive(:capture3).with(
+        hash_including("RAILS_ENV" => "production"),
+        "bundle",
+        "exec",
+        "rails",
+        "routes",
+        "--expanded",
+        chdir: app_dir
+      ).and_return([routes_output, "", status])
+
+      expect(benchmark_routes_for_app(app_dir, nil)).to eq(["/client_side_hello_world"])
+    end
+
+    it "raises when rails routes fails" do
+      app_dir = Dir.mktmpdir
+      status = instance_double(Process::Status, success?: false)
+
+      allow(Open3).to receive(:capture3).and_return(["", "boom", status])
+
+      expect do
+        benchmark_routes_for_app(app_dir, nil)
+      end.to raise_error("Failed to get routes from #{app_dir}")
+    end
+  end
+end

--- a/react_on_rails/spec/react_on_rails/benchmark_routes_spec.rb
+++ b/react_on_rails/spec/react_on_rails/benchmark_routes_spec.rb
@@ -48,38 +48,40 @@ RSpec.describe "benchmark route discovery helpers" do
 
   describe "#benchmark_routes_for_app" do
     it "runs rails routes in the app directory" do
-      app_dir = Dir.mktmpdir
-      routes_output = <<~TEXT
-        --[ Route 1 ]-------------------------------------------------------------------
-        Prefix            | client_side_hello_world
-        Verb              | GET
-        URI               | /client_side_hello_world(.:format)
-        Controller#Action | pages#client_side_hello_world
-      TEXT
-      status = instance_double(Process::Status, success?: true)
+      Dir.mktmpdir do |app_dir|
+        routes_output = <<~TEXT
+          --[ Route 1 ]-------------------------------------------------------------------
+          Prefix            | client_side_hello_world
+          Verb              | GET
+          URI               | /client_side_hello_world(.:format)
+          Controller#Action | pages#client_side_hello_world
+        TEXT
+        status = instance_double(Process::Status, success?: true)
 
-      allow(Open3).to receive(:capture3).with(
-        hash_including("RAILS_ENV" => "production"),
-        "bundle",
-        "exec",
-        "rails",
-        "routes",
-        "--expanded",
-        chdir: app_dir
-      ).and_return([routes_output, "", status])
+        allow(Open3).to receive(:capture3).with(
+          hash_including("RAILS_ENV" => "production"),
+          "bundle",
+          "exec",
+          "rails",
+          "routes",
+          "--expanded",
+          chdir: app_dir
+        ).and_return([routes_output, "", status])
 
-      expect(benchmark_routes_for_app(app_dir, nil)).to eq(["/client_side_hello_world"])
+        expect(benchmark_routes_for_app(app_dir, nil)).to eq(["/client_side_hello_world"])
+      end
     end
 
     it "raises when rails routes fails" do
-      app_dir = Dir.mktmpdir
-      status = instance_double(Process::Status, success?: false)
+      Dir.mktmpdir do |app_dir|
+        status = instance_double(Process::Status, success?: false)
 
-      allow(Open3).to receive(:capture3).and_return(["", "boom", status])
+        allow(Open3).to receive(:capture3).and_return(["", "boom", status])
 
-      expect do
-        benchmark_routes_for_app(app_dir, nil)
-      end.to raise_error("Failed to get routes from #{app_dir}")
+        expect do
+          benchmark_routes_for_app(app_dir, nil)
+        end.to raise_error("Failed to get routes from #{app_dir}")
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Split the benchmark workflow so Core and Pro benchmarks run as independent jobs on separate GitHub-hosted runners. The workflow now derives Core/Pro benchmark eligibility from the existing change detector outputs, supports explicit `benchmark-core` and `benchmark-pro` PR labels, and keeps Bencher reporting isolated per suite.

Shared setup and Bencher reporting logic were moved into reusable helpers to avoid duplicating the runner setup and reporting behavior across jobs. The touched workflow actions were also updated away from deprecated Node.js 20 action versions.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~
- [x] ~Update documentation~
- [x] ~Update CHANGELOG file~

### Other Information

Validation run locally:

- `SHELLCHECK_OPTS="-S warning" actionlint`
- YAML parse for `.github/workflows/benchmark.yml` and `.github/actions/setup-benchmark-runner/action.yml`
- `bundle exec rubocop benchmarks/track_benchmarks.rb benchmarks/split_html_report.rb`
- `git diff --check`

The `benchmark` label is attached so benchmark CI runs for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized CI benchmark runner action that prepares tooling, builds assets, and runs benchmarks.
  * Sharded benchmark execution with computed shard matrices and per-shard reports.
  * Automated Bencher integration that posts split PR report comments and files push-time regression issues.

* **Chores**
  * Streamlined benchmark workflows, shared route-discovery helpers, configurable report marker, and standardized results upload and workflow summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->