### PR TITLE
Clarify RSC clientReferences migration helper contracts

### DIFF
--- a/docs/superpowers/specs/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
@@ -1,0 +1,223 @@
+# Issue #3258 — RSC Migration Parser Helper Clarity Cleanup
+
+**Status:** Approved
+**Author:** Justin Gordon (drafted with Claude Code)
+**Date:** 2026-05-21
+**Related PR:** #3219 (`codex/fix-rsc-client-reference-scope`)
+**Branch strategy:** Stacked follow-up PR on top of `codex/fix-rsc-client-reference-scope` so review of the behavioral fix in #3219 stays isolated from this clarity cleanup.
+
+## Background
+
+PR #3219 (`fix: scope RSC client reference discovery`) ships a behavioral fix
+that scopes `RSCWebpackPlugin#clientReferences` to the Shakapacker
+`config.source_path` for both new installs and existing webpack configs. The PR
+introduces a sizeable migration path in
+`react_on_rails/lib/generators/react_on_rails/rsc_setup.rb` that detects an
+existing `RSCWebpackPlugin(...)` call, parses its options block with a
+lightweight JS scanner, and either rewrites the options or warns when a rewrite
+is unsafe.
+
+The cloud reviews on #3219 flagged three non-blocking clarity items. They were
+intentionally deferred from #3219 to keep that PR focused on behavior. Issue
+\#3258 tracks them.
+
+This spec covers only those three items. No behavior changes.
+
+## In Scope
+
+1. Rename `rsc_plugin_without_client_references?` so the per-section
+   ("any one of the sections lacks `clientReferences`") semantics are explicit.
+2. Tighten the scanner-supported-surface documentation around regex literals
+   with curly braces. No parser changes.
+3. Remove the duplicate defensive guards at the top of
+   `add_rsc_client_references_setup`, and document its precondition.
+
+All three changes are confined to `rsc_setup.rb` and its existing spec file.
+
+## Out of Scope
+
+- Behavioral changes to the migration logic.
+- Expanding the JS scanner to handle regex-literal brace quantifiers
+  (e.g. `/a{2}/`). The generated configs never produce such regexes, and
+  existing-config rewrites already emit a warning rather than guess when the
+  scanner cannot parse a block. Revisit only if a future RSC plugin option
+  requires it.
+- Touching any other PR #3219 review feedback. Each remaining cloud-review item
+  either has its own follow-up issue or was already addressed in #3219.
+
+## Item 1 — Rename `rsc_plugin_without_client_references?`
+
+### Current state
+
+```ruby
+def rsc_plugin_without_client_references?(content, is_server:)
+  rsc_plugin_option_sections(content, is_server: is_server).any? do |section|
+    !rsc_plugin_options_without_comments(section.fetch(:body)).match?(/\bclientReferences\s*:/)
+  end
+end
+```
+
+The implementation uses `.any?`, but the method name suggests an all-or-nothing
+check ("the plugin has no clientReferences"). When two plugin instances share
+the same `isServer` value and one already has `clientReferences` while the
+other does not, the method correctly returns `true` and the rewrite proceeds —
+but a reader who only inspects the name would expect that case to return
+`false`.
+
+### New name
+
+`any_rsc_plugin_section_without_client_references?`
+
+- Keeps the existing predicate suffix (`?`).
+- Adds the `any_` prefix that mirrors the `.any?` in the body.
+- Replaces `plugin` with `plugin_section` to match `rsc_plugin_option_sections`
+  (the data the method iterates over).
+
+### Affected sites
+
+Only one call site exists in `rsc_setup.rb`:
+
+```
+react_on_rails/lib/generators/react_on_rails/rsc_setup.rb:576
+```
+
+The method is private to the generator class; no spec asserts on the method
+name directly. A repo-wide grep confirms no other production or test code
+references the symbol.
+
+### Acceptance
+
+- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/rsc_setup.rb`
+  passes.
+- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
+  passes unchanged.
+
+## Item 2 — Document scanner-supported surface for regex-literal braces
+
+### Current state
+
+`rsc_plugin_options_without_comments` (around line 671 on the PR branch) carries
+a comment noting that regex literals like `/a{2}/` are outside the scanner's
+supported surface because brace quantifiers can confuse
+`matching_js_closing_brace`'s depth counter.
+
+`matching_js_closing_brace` itself (the helper that actually does the brace
+tracking) carries no such note. A reader who lands on that helper directly —
+e.g. via a stack trace from a future bug — has no inline indication that regex
+literals are an unsupported input class.
+
+### Change
+
+Add a brief comment block above `matching_js_closing_brace` that lists what it
+supports (strings, line and block comments) and what it does not (regex
+literals — specifically brace quantifiers like `/a{2}/` and character classes
+like `/[{]/`). Cross-reference `rsc_plugin_options_without_comments` so readers
+can see why the limitation is acceptable in the current call graph.
+
+Tighten the existing comment on `rsc_plugin_options_without_comments` to use
+the same phrasing for "unsupported constructs," so both comments read as one
+documented contract instead of two slightly different warnings.
+
+The warning text emitted by `warn_unparseable_rsc_plugin_sections` already
+explains the user-facing failure mode (`"most often a regex literal with an
+unmatched '{' or '}', e.g. '/\{/' or '/[{]/'"`), so no warning-message change
+is needed.
+
+### Acceptance
+
+- No code changes outside of comments.
+- `bundle exec rubocop` passes.
+
+## Item 3 — Remove duplicate defensive guards in `add_rsc_client_references_setup`
+
+### Current state
+
+```ruby
+def add_rsc_client_references_setup(config_path, content, is_server:)
+  return if scoped_rsc_client_references_defined?(content)
+  return if rsc_client_references_defined?(content)
+
+  existing_imports_content = content_before_rsc_setup_anchor(content, is_server: is_server)
+  replace_rsc_client_references_setup_anchor(config_path, content, is_server: is_server) do |anchor|
+    [
+      anchor,
+      shakapacker_config_import_statement(existing_imports_content),
+      path_resolve_import_statement(existing_imports_content),
+      "",
+      rsc_client_references_js
+    ].compact.join("\n")
+  end
+end
+```
+
+The sole caller, `ensure_rsc_client_references_setup`, already performs both
+checks before invoking this method:
+
+```ruby
+def ensure_rsc_client_references_setup(config_path, content, is_server:)
+  return true if scoped_rsc_client_references_defined?(content)
+
+  if rsc_client_references_defined?(content)
+    warn_unscoped_rsc_client_references_helper(config_path)
+    return false
+  end
+  ...
+  add_rsc_client_references_setup(config_path, content, is_server: is_server)
+  ...
+end
+```
+
+The duplicated guards inside `add_rsc_client_references_setup` are unreachable
+in the current call graph. CLAUDE.md guidance: "Don't add error handling,
+fallbacks, or validation for scenarios that can't happen. Trust internal code
+and framework guarantees."
+
+### Change
+
+- Remove the two `return if ...` guards.
+- Replace the existing leading comment with one that names the precondition:
+  must only be called via `ensure_rsc_client_references_setup`, which has
+  already verified that no `rscClientReferences` declaration (scoped or
+  otherwise) exists at module scope and that the import anchor is present.
+
+### Acceptance
+
+- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
+  passes — existing specs already exercise the `ensure_*` path on every code
+  path that ends up calling `add_*`.
+- `bundle exec rubocop` passes.
+- Manual code reading: no other call site to `add_rsc_client_references_setup`
+  appears in the repo (verified via `grep`).
+
+## Risk Assessment
+
+- **Item 1:** Pure rename of a private method with a single call site. Risk:
+  near zero. Worst case: a missed reference produces an immediate
+  `NoMethodError` caught by the existing spec suite.
+- **Item 2:** Comments only. Zero runtime risk.
+- **Item 3:** Removes dead code. The risk is that a future caller could be
+  added without re-applying the guards. Mitigated by the precondition comment;
+  the helper is private and lives in the same file as its caller, so a future
+  contributor sees both within the same edit window.
+
+## Test Plan
+
+- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
+- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/rsc_setup.rb react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
+- Manual `grep` for the old method name across the repo to confirm zero stale
+  references after the rename.
+
+## Out of Scope (Reiterated)
+
+No changes to:
+
+- `react_on_rails/lib/generators/react_on_rails/templates/**`
+- Any documentation file outside this design spec.
+- The behavior or wording of `GeneratorMessages` warnings.
+
+## Follow-ups
+
+None planned. If a future RSC plugin option introduces regex literals with
+brace quantifiers, file a new issue to expand `matching_js_closing_brace` (or
+adopt a real JS parser); the warning emitted today gives users a clear manual
+remediation in the meantime.

--- a/docs/superpowers/specs/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
@@ -77,7 +77,7 @@ but a reader who only inspects the name would expect that case to return
 
 Only one call site exists in `rsc_setup.rb`:
 
-```
+```text
 react_on_rails/lib/generators/react_on_rails/rsc_setup.rb:576
 ```
 
@@ -133,11 +133,10 @@ is needed.
 ### Current state
 
 ```ruby
-def add_rsc_client_references_setup(config_path, content, is_server:)
-  return if scoped_rsc_client_references_defined?(content)
-  return if rsc_client_references_defined?(content)
+def add_rsc_client_references_setup(config_path, content, existing_imports_content, is_server:)
+  return false if scoped_rsc_client_references_defined?(content)
+  return false if rsc_client_references_defined?(content)
 
-  existing_imports_content = content_before_rsc_setup_anchor(content, is_server: is_server)
   replace_rsc_client_references_setup_anchor(config_path, content, is_server: is_server) do |anchor|
     [
       anchor,
@@ -162,7 +161,7 @@ def ensure_rsc_client_references_setup(config_path, content, is_server:)
     return false
   end
   ...
-  add_rsc_client_references_setup(config_path, content, is_server: is_server)
+  add_rsc_client_references_setup(config_path, content, existing_imports_content, is_server: is_server)
   ...
 end
 ```

--- a/internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
+++ b/internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
@@ -1,6 +1,6 @@
 # Issue #3258 — RSC Migration Parser Helper Clarity Cleanup
 
-**Status:** Approved
+**Status:** Design approved; implementation in review
 **Author:** Justin Gordon (drafted with Claude Code)
 **Date:** 2026-05-21
 **Related PR:** #3219 (`codex/fix-rsc-client-reference-scope`)
@@ -12,7 +12,7 @@ PR #3219 (`fix: scope RSC client reference discovery`) ships a behavioral fix
 that scopes `RSCWebpackPlugin#clientReferences` to the Shakapacker
 `config.source_path` for both new installs and existing webpack configs. The PR
 introduces a sizeable migration path in
-`react_on_rails/lib/generators/react_on_rails/rsc_setup.rb` that detects an
+`react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb` that detects an
 existing `RSCWebpackPlugin(...)` call, parses its options block with a
 lightweight JS scanner, and either rewrites the options or warns when a rewrite
 is unsafe.
@@ -32,7 +32,7 @@ This spec covers only those three items. No behavior changes.
 3. Remove the duplicate defensive guards at the top of
    `add_rsc_client_references_setup`, and document its precondition.
 
-All three changes are confined to `rsc_setup.rb` and its existing spec file.
+All three changes are confined to `client_references.rb` and its existing spec file.
 
 ## Out of Scope
 
@@ -75,10 +75,11 @@ but a reader who only inspects the name would expect that case to return
 
 ### Affected sites
 
-Only one call site exists in `rsc_setup.rb`:
+Only two call sites exist in `client_references.rb`:
 
 ```text
-react_on_rails/lib/generators/react_on_rails/rsc_setup.rb:576
+react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb:141
+react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb:163
 ```
 
 The method is private to the generator class; no spec asserts on the method
@@ -87,7 +88,7 @@ references the symbol.
 
 ### Acceptance
 
-- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/rsc_setup.rb`
+- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb`
   passes.
 - `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
   passes unchanged.
@@ -202,7 +203,7 @@ and framework guarantees."
 ## Test Plan
 
 - `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
-- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/rsc_setup.rb react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
+- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb`
 - Manual `grep` for the old method name across the repo to confirm zero stale
   references after the rename.
 

--- a/internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
+++ b/internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
@@ -25,7 +25,7 @@ This spec covers only those three items. No behavior changes.
 
 ## In Scope
 
-1. Rename `rsc_plugin_without_client_references?` so the per-section
+1. Rename `any_rsc_plugin_missing_client_references?` so the per-section
    ("any one of the sections lacks `clientReferences`") semantics are explicit.
 2. Tighten the scanner-supported-surface documentation around regex literals
    with curly braces. No parser changes.
@@ -45,24 +45,23 @@ All three changes are confined to `client_references.rb` and its existing spec f
 - Touching any other PR #3219 review feedback. Each remaining cloud-review item
   either has its own follow-up issue or was already addressed in #3219.
 
-## Item 1 — Rename `rsc_plugin_without_client_references?`
+## Item 1 — Rename `any_rsc_plugin_missing_client_references?`
 
 ### Current state
 
 ```ruby
-def rsc_plugin_without_client_references?(content, is_server:)
+def any_rsc_plugin_missing_client_references?(content, is_server:)
   rsc_plugin_option_sections(content, is_server: is_server).any? do |section|
-    !rsc_plugin_options_without_comments(section.fetch(:body)).match?(/\bclientReferences\s*:/)
+    !rsc_plugin_body_has_top_level_key?(section.fetch(:body), "clientReferences")
   end
 end
 ```
 
-The implementation uses `.any?`, but the method name suggests an all-or-nothing
-check ("the plugin has no clientReferences"). When two plugin instances share
-the same `isServer` value and one already has `clientReferences` while the
-other does not, the method correctly returns `true` and the rewrite proceeds —
-but a reader who only inspects the name would expect that case to return
-`false`.
+The implementation uses `.any?`, but the method name does not make the
+per-section scan explicit. When two plugin instances share the same `isServer`
+value and one already has `clientReferences` while the other does not, the
+method correctly returns `true` and the rewrite proceeds. The new name spells
+out that this is an existential section check, not a whole-file/plugin summary.
 
 ### New name
 

--- a/internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
+++ b/internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md
@@ -76,11 +76,7 @@ but a reader who only inspects the name would expect that case to return
 ### Affected sites
 
 Only two call sites exist in `client_references.rb`:
-
-```text
-react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb:141
-react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb:163
-```
+`rsc_plugin_needs_client_references_rewrite?` and `rewritable_rsc_plugin?`.
 
 The method is private to the generator class; no spec asserts on the method
 name directly. A repo-wide grep confirms no other production or test code
@@ -97,10 +93,9 @@ references the symbol.
 
 ### Current state
 
-`rsc_plugin_options_without_comments` (around line 671 on the PR branch) carries
-a comment noting that regex literals like `/a{2}/` are outside the scanner's
-supported surface because brace quantifiers can confuse
-`matching_js_closing_brace`'s depth counter.
+`rsc_plugin_options_without_comments` carries a comment noting that regex
+literals like `/a{2}/` are outside the scanner's supported surface because
+brace quantifiers can confuse `matching_js_closing_brace`'s depth counter.
 
 `matching_js_closing_brace` itself (the helper that actually does the brace
 tracking) carries no such note. A reader who lands on that helper directly —
@@ -139,13 +134,16 @@ def add_rsc_client_references_setup(config_path, content, existing_imports_conte
   return false if rsc_client_references_defined?(content)
 
   replace_rsc_client_references_setup_anchor(config_path, content, is_server: is_server) do |anchor|
-    [
-      anchor,
-      shakapacker_config_import_statement(existing_imports_content),
-      path_resolve_import_statement(existing_imports_content),
-      "",
-      rsc_client_references_js
-    ].compact.join("\n")
+    join_rsc_client_references_setup(
+      content,
+      [
+        anchor,
+        shakapacker_config_import_statement(existing_imports_content),
+        path_resolve_import_statement(existing_imports_content),
+        "",
+        rsc_client_references_js
+      ]
+    )
   end
 end
 ```

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
@@ -441,12 +441,15 @@ module ReactOnRails
         end
 
         # Expects `content[open_index] == "{"`; callers pass the options-object opening brace.
-        # See `advance_js_scan_state` for the scanner's supported surface — in short, simple
-        # `${...}` interpolations inside template literals stay inside the string state, while
-        # nested template literals and regex literals fall outside the scanner. When the depth
-        # counter is confused by either, the section is caught downstream via
-        # `rsc_plugin_options_followed_by_close_paren?` and marked unparseable so the migration
-        # warns the user instead of corrupting the rewrite.
+        # This lightweight scanner supports strings (including template literals for simple
+        # `${...}` interpolation) plus JS line/block comments. It does not classify regex
+        # literals, so braces inside constructs such as `/a{2}/` or `/[{]/` can be counted as
+        # object braces. Nested template literals (for example, `outer ${`inner`}`) are also
+        # unsupported: the inner backtick falsely closes the outer string state, exposing later
+        # braces to the depth counter. `rsc_plugin_options_without_comments` shares the same
+        # supported surface, and callers detect corrupted sections via
+        # `rsc_plugin_options_followed_by_close_paren?` so the migration warns instead of
+        # producing a corrupt rewrite.
         def matching_js_closing_brace(content, open_index)
           depth = 0
           index = open_index

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
@@ -146,7 +146,7 @@ module ReactOnRails
         end
 
         def rsc_plugin_needs_client_references_rewrite?(content, is_server:)
-          any_rsc_plugin_missing_client_references?(content, is_server: is_server)
+          any_rsc_plugin_section_without_client_references?(content, is_server: is_server)
         end
 
         # Detects RSCWebpackPlugin option blocks that the lightweight JS scanner could not parse
@@ -166,7 +166,7 @@ module ReactOnRails
         def rewritable_rsc_plugin?(config_path, content, is_server:)
           # Mixed same-target plugins are still rewritable: the later rewrite only updates plugins
           # missing clientReferences and leaves sibling custom clientReferences untouched.
-          return true if any_rsc_plugin_missing_client_references?(content, is_server: is_server)
+          return true if any_rsc_plugin_section_without_client_references?(content, is_server: is_server)
 
           if rsc_plugin_defines_client_references?(content, is_server: is_server)
             GeneratorMessages.add_warning(
@@ -269,14 +269,15 @@ module ReactOnRails
         # which uses the same any-section semantics for the opposite condition. The two are not
         # complements when multiple plugin sections exist — a file with one configured plugin and
         # one unconfigured plugin returns true from both.
-        def any_rsc_plugin_missing_client_references?(content, is_server:)
+        def any_rsc_plugin_section_without_client_references?(content, is_server:)
           rsc_plugin_option_sections(content, is_server: is_server).any? do |section|
             !rsc_plugin_body_has_top_level_key?(section.fetch(:body), "clientReferences")
           end
         end
 
         # Strips JavaScript line and block comments while preserving string-literal contents,
-        # so `clientReferences:` / `isServer:` substrings inside strings are not mis-detected.
+        # including simple `${...}` template-literal interpolation, so `clientReferences:` /
+        # `isServer:` substrings inside strings are not mis-detected.
         # Shares the `advance_js_scan_state` family used by `js_top_level_position?` and
         # `matching_js_closing_brace` so all JS-aware passes follow the same comment/string rules.
         # See `advance_js_scan_state` for the scanner's supported surface (including the regex-
@@ -960,20 +961,10 @@ module ReactOnRails
         # generator has already confirmed `RSCWebpackPlugin` is imported in the file. That's why
         # this helper deliberately omits the `RSCWebpackPlugin` import that `inject_rsc_*_imports`
         # adds on the from-scratch path — adding it here would produce a duplicate import.
+        # Must only be called via `ensure_rsc_client_references_setup`, which has already verified
+        # that no module-scope `rscClientReferences` declaration exists and that the import anchor
+        # is present and not yet consumed by a previous call.
         def add_rsc_client_references_setup(config_path, content, existing_imports_content, is_server:)
-          # The only caller, `ensure_rsc_client_references_setup`, already runs these same checks
-          # before delegating here, so in normal flow both conditions evaluate to `false` and no
-          # early return is triggered. They are kept (rather than deleted) so a future second
-          # caller — or a refactor that bypasses `ensure_rsc_client_references_setup` — cannot
-          # accidentally splice a second `const rscClientReferences = { ... }` into a file that
-          # already declares one. JavaScript would reject that with an
-          # `Identifier 'rscClientReferences' has already been declared` SyntaxError at config
-          # load, and the cost of the duplicate check is two boolean ops on the already-loaded
-          # file body. Leaving the method defensive is cheaper than re-deriving the precondition
-          # at each new call site.
-          return false if scoped_rsc_client_references_defined?(content)
-          return false if rsc_client_references_defined?(content)
-
           replace_rsc_client_references_setup_anchor(config_path, content, is_server: is_server) do |anchor|
             join_rsc_client_references_setup(
               content,

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
@@ -966,7 +966,9 @@ module ReactOnRails
         # adds on the from-scratch path — adding it here would produce a duplicate import.
         # Must only be called via `ensure_rsc_client_references_setup`, which has already verified
         # that no module-scope `rscClientReferences` declaration exists and that the import anchor
-        # is present and not yet consumed by a previous call.
+        # is present and not yet consumed by a previous call. Bypassing that guard can write a
+        # duplicate `const rscClientReferences` declaration and leave the user's webpack config with
+        # a Node SyntaxError at load time.
         def add_rsc_client_references_setup(config_path, content, existing_imports_content, is_server:)
           replace_rsc_client_references_setup_anchor(config_path, content, is_server: is_server) do |anchor|
             join_rsc_client_references_setup(


### PR DESCRIPTION
### Summary

Clarifies the RSC `clientReferences` migration helper cleanup tracked by #3258.

This PR keeps migration behavior unchanged while making the private helper contracts easier to read:

- Renames the section-scoped `clientReferences` predicate to `any_rsc_plugin_section_without_client_references?`, making the `any?` semantics explicit.
- Keeps the rebased `prepare_rsc_client_references_rewrite!` flow from `main` and routes its rewrite predicate through the renamed helper.
- Documents the scanner's supported surface, including simple template-literal interpolation, unsupported nested template literals, and unsupported regex-literal brace cases.
- Removes duplicate defensive guards from `add_rsc_client_references_setup` because `ensure_rsc_client_references_setup` already enforces the preconditions.
- Adds the internal design note under `internal/planning/`, keeping the published `docs/` tree reserved for OSS/Pro docs.

### Review Handling

- Fixed the CodeRabbit markdown fence warning by adding the missing language identifier.
- Restored the nested-template-literal limitation in the scanner comment while keeping the regex-literal brace guidance.
- Corrected the design note's stale helper signature, guard return values, call-site count, helper-file references, and removed-body snippet.
- Moved the design note from `docs/superpowers/specs/` to `internal/planning/`.
- Clarified that the design status is approved while the implementation remains in PR review.
- Added the requested symmetry note for simple `${...}` template-literal interpolation in `rsc_plugin_options_without_comments`.
- Expanded the `add_rsc_client_references_setup` precondition comment to say the import anchor must be present and not yet consumed.
- Replaced brittle design-note line references with method names.
- The later double-scan review note is stale after the rebase: the second `rsc_plugin_needs_client_references_rewrite?` call no longer exists in `update_existing_rsc_webpack_config`.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~ Existing generator specs cover the unchanged behavior.
- [x] ~Update documentation~ Internal design note added under `internal/planning/`.
- [x] ~Update CHANGELOG file~ No user-visible change.

### Verification

- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb` - 183 examples, 0 failures
- `(cd react_on_rails && bundle exec rubocop)` - 204 files inspected, no offenses detected
- `pnpm exec prettier --check internal/planning/2026-05-21-3258-rsc-parser-helper-cleanup-design.md` - passed
- `git diff --check` - passed
- Pre-push hook - branch RuboCop and online Lychee passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal rewrite eligibility logic to operate at a finer, section-scoped level, increasing precision and reducing unnecessary rewrites.

* **Documentation**
  * Added design documentation and clarified scanner behavior and failure modes, improving transparency and guidance for maintainers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and a private-method rename only; migration logic and user-facing warnings are unchanged, with existing generator specs covering the paths.
> 
> **Overview**
> Documentation-only clarity for the RSC **`clientReferences`** webpack migration helpers in **`client_references.rb`**, with **no migration behavior changes**.
> 
> The private predicate **`any_rsc_plugin_missing_client_references?`** is renamed to **`any_rsc_plugin_section_without_client_references?`** at its two call sites so the per-section **`.any?`** semantics are obvious. Comments on **`matching_js_closing_brace`** and **`rsc_plugin_options_without_comments`** now document the lightweight scanner contract (supported strings/comments/simple template interpolation vs unsupported regex-literal braces and nested template literals). **`add_rsc_client_references_setup`** drops duplicate early returns that **`ensure_rsc_client_references_setup`** already enforces, and documents that it must only be called through that path.
> 
> An internal design note is added under **`internal/planning/`** for issue #3258.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31afd320dc871503aa2b37e1fb3d191d1206d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->