### PR TITLE
Fix aggregate SCSS lint task

### DIFF
--- a/react_on_rails/rakelib/lint.rake
+++ b/react_on_rails/rakelib/lint.rake
@@ -37,7 +37,7 @@ namespace :lint do # rubocop:disable Metrics/BlockLength
   private
 
   def stylelint_command
-    "pnpm run stylelint \"spec/dummy/app/assets/stylesheets/**/*.scss\" \"spec/dummy/client/**/*.scss\""
+    "pnpm run lint:scss"
   end
 
   def stylelint_fix_command


### PR DESCRIPTION
### Summary

Fixes `rake lint` so the SCSS step uses the existing `pnpm run lint:scss` package script instead of calling a missing `pnpm run stylelint` script directly.
This keeps the aggregate local lint workflow aligned with the repository's package scripts.

### Pull Request checklist

- ~[x] Add/update test to cover these changes~
- ~[x] Update documentation~
- ~[x] Update CHANGELOG file~

### Other Information

Validated with `rake lint`, `(cd react_on_rails && bundle exec rubocop)`, and the commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to which pnpm script Rake invokes for SCSS; no runtime or security impact.
> 
> **Overview**
> **`rake lint`** and **`rake autofix`** were failing on the SCSS step because Rake invoked a non-existent **`pnpm run stylelint`** script with inline globs.
> 
> **`stylelint_command`** in `lint.rake` now runs **`pnpm run lint:scss`**, matching the root **`package.json`** script and CI. **`lint:autofix`** still passes **`--fix`** through **`stylelint_fix_command`** unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9490c4b5cbb8b5987c76d51d35f9cc9b97809cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SCSS linting to use the project's configured linting script, ensuring consistent styling validation across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->