### PR TITLE
Expose integration API hooks for OpenTelemetry

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/integrations/api.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/integrations/api.ts
@@ -35,6 +35,8 @@ export {
   MessageNotifier,
 } from '../shared/errorReporter.js';
 export {
+  resetTracing,
+  resetSubSpan,
   setupTracing,
   setupSubSpan,
   subSpan,
@@ -45,4 +47,17 @@ export {
   SubSpanFn,
   SubSpanController,
 } from '../shared/tracing.js';
-export { configureFastify, FastifyConfigFunction } from '../worker/fastifyConfig.js';
+export {
+  getOpenTelemetryTracerProvider,
+  setOpenTelemetryTracerProvider,
+} from '../shared/opentelemetryState.js';
+export {
+  configureFastify,
+  registerFastifyConfigFunction,
+  FastifyConfigFunction,
+} from '../worker/fastifyConfig.js';
+export {
+  registerWorkerShutdownHook,
+  WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS,
+  WorkerShutdownHook,
+} from '../worker/shutdownHooks.js';

--- a/packages/react-on-rails-pro-node-renderer/src/integrations/opentelemetry.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/integrations/opentelemetry.ts
@@ -5,20 +5,20 @@
 import type { Attributes } from '@opentelemetry/api';
 import type { NodeTracerProvider as NodeTracerProviderType } from '@opentelemetry/sdk-trace-node';
 import type { SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base';
-/* eslint-disable no-restricted-imports --
- * This integration needs internal worker/shared modules that the public
- * api.ts does not yet re-export (tracing adapter slots, OTel global state,
- * fastify config + worker shutdown hook registration). Tracked in #3419
- * — once api.ts surfaces these, remove this disable. */
-import { resetSubSpan, resetTracing, setupTracing, setupSubSpan, type SubSpanFn } from '../shared/tracing.js';
 import {
   getOpenTelemetryTracerProvider,
+  log,
+  message,
+  registerFastifyConfigFunction,
+  registerWorkerShutdownHook,
+  resetSubSpan,
+  resetTracing,
   setOpenTelemetryTracerProvider,
-} from '../shared/opentelemetryState.js';
-import { registerFastifyConfigFunction } from '../worker/fastifyConfig.js';
-import { WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS, registerWorkerShutdownHook } from '../worker/shutdownHooks.js';
-/* eslint-enable no-restricted-imports */
-import { log, message } from './api.js';
+  setupSubSpan,
+  setupTracing,
+  WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS,
+  type SubSpanFn,
+} from './api.js';
 
 declare module '../shared/tracing.js' {
   interface UnitOfWorkOptions {

--- a/packages/react-on-rails-pro-node-renderer/src/shared/tracing.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/tracing.ts
@@ -93,7 +93,7 @@ export function trace<T>(fn: UnitOfWork<T>, unitOfWorkOptions: UnitOfWorkOptions
 
 /**
  * Resets the installed tracing executor + startSsrRequestOptions back to
- * defaults. Internal integrations use this during lifecycle teardown.
+ * defaults. Integrations use this during lifecycle teardown or failed initialization cleanup.
  */
 export function resetTracing(): void {
   executor = (fn) => fn();
@@ -225,7 +225,7 @@ export function subSpan<T>(
 
 /**
  * Resets the installed sub-span implementation back to the default pass-through.
- * Internal integrations use this during lifecycle teardown.
+ * Integrations use this during lifecycle teardown or failed initialization cleanup.
  */
 export function resetSubSpan(): void {
   subSpanImpl = defaultSubSpan;

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/api.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/api.test.ts
@@ -12,8 +12,15 @@ import {
 } from '../../src/integrations/api';
 
 describe('integrations api', () => {
+  afterEach(() => {
+    resetSubSpan();
+    resetTracing();
+    setOpenTelemetryTracerProvider(null);
+  });
+
   test('exports lifecycle hooks needed by integrations', () => {
     const subSpan: SubSpanFn = (opts, fn) => fn({ setAttributes() {} });
+    const tracerProvider = {} as Parameters<typeof setOpenTelemetryTracerProvider>[0];
 
     expect(setupTracing({ executor: async (fn) => fn() })).toBe(true);
     expect(setupSubSpan(subSpan)).toBe(true);
@@ -21,11 +28,10 @@ describe('integrations api', () => {
     expect(typeof resetSubSpan).toBe('function');
     expect(getOpenTelemetryTracerProvider()).toBeNull();
     expect(typeof setOpenTelemetryTracerProvider).toBe('function');
+    setOpenTelemetryTracerProvider(tracerProvider);
+    expect(getOpenTelemetryTracerProvider()).toBe(tracerProvider);
     expect(typeof registerFastifyConfigFunction).toBe('function');
     expect(typeof registerWorkerShutdownHook).toBe('function');
     expect(WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS).toBeGreaterThan(0);
-
-    resetSubSpan();
-    resetTracing();
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/api.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/api.test.ts
@@ -1,0 +1,31 @@
+import {
+  getOpenTelemetryTracerProvider,
+  registerFastifyConfigFunction,
+  registerWorkerShutdownHook,
+  resetSubSpan,
+  resetTracing,
+  setOpenTelemetryTracerProvider,
+  setupSubSpan,
+  setupTracing,
+  WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS,
+  type SubSpanFn,
+} from '../../src/integrations/api';
+
+describe('integrations api', () => {
+  test('exports lifecycle hooks needed by integrations', () => {
+    const subSpan: SubSpanFn = (opts, fn) => fn({ setAttributes() {} });
+
+    expect(setupTracing({ executor: async (fn) => fn() })).toBe(true);
+    expect(setupSubSpan(subSpan)).toBe(true);
+    expect(typeof resetTracing).toBe('function');
+    expect(typeof resetSubSpan).toBe('function');
+    expect(getOpenTelemetryTracerProvider()).toBeNull();
+    expect(typeof setOpenTelemetryTracerProvider).toBe('function');
+    expect(typeof registerFastifyConfigFunction).toBe('function');
+    expect(typeof registerWorkerShutdownHook).toBe('function');
+    expect(WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS).toBeGreaterThan(0);
+
+    resetSubSpan();
+    resetTracing();
+  });
+});

--- a/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry-init.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/integrations/opentelemetry-init.test.ts
@@ -330,6 +330,7 @@ describe('opentelemetry integration: init() failure path', () => {
     };
 
     jest.doMock('../../src/integrations/api.js', () => ({
+      ...jest.requireActual<typeof import('../../src/integrations/api.js')>('../../src/integrations/api.js'),
       log,
       message: jest.fn(),
     }));
@@ -453,16 +454,19 @@ describe('opentelemetry integration: init() failure path', () => {
       };
       const shutdown = jest.fn(() => new Promise<void>(() => undefined));
 
-      jest.doMock('../../src/integrations/api.js', () => ({
-        log,
-        message: jest.fn(),
-      }));
       jest.doMock('../../src/worker/fastifyConfig.js', () => ({
         __resetFastifyConfigFunctionsForTest: jest.fn(),
         registerFastifyConfigFunction: jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
           configureFastifyCallback = callback;
           return jest.fn();
         }),
+      }));
+      jest.doMock('../../src/integrations/api.js', () => ({
+        ...jest.requireActual<typeof import('../../src/integrations/api.js')>(
+          '../../src/integrations/api.js',
+        ),
+        log,
+        message: jest.fn(),
       }));
       jest.doMock('@opentelemetry/sdk-trace-node', () => ({
         NodeTracerProvider: jest.fn(function NodeTracerProvider() {
@@ -575,16 +579,19 @@ describe('opentelemetry integration: init() failure path', () => {
           }),
       );
 
-      jest.doMock('../../src/integrations/api.js', () => ({
-        log,
-        message: jest.fn(),
-      }));
       jest.doMock('../../src/worker/fastifyConfig.js', () => ({
         __resetFastifyConfigFunctionsForTest: jest.fn(),
         registerFastifyConfigFunction: jest.fn((callback: (app: { addHook: jest.Mock }) => void) => {
           configureFastifyCallback = callback;
           return jest.fn();
         }),
+      }));
+      jest.doMock('../../src/integrations/api.js', () => ({
+        ...jest.requireActual<typeof import('../../src/integrations/api.js')>(
+          '../../src/integrations/api.js',
+        ),
+        log,
+        message: jest.fn(),
       }));
       jest.doMock('@opentelemetry/sdk-trace-node', () => ({
         NodeTracerProvider: jest.fn(function NodeTracerProvider() {


### PR DESCRIPTION
## Summary

- Expose node-renderer integration lifecycle hooks through `integrations/api.ts` so integrations can stay inside the public boundary.
- Update the OpenTelemetry integration to import those hooks from `./api.js`, removing the `no-restricted-imports` escape hatch.
- Add a regression test for the expanded integration API and keep existing OpenTelemetry API mocks aligned with the new import path.

Fixes #3419

## Root Cause

`src/integrations/opentelemetry.ts` needed tracing reset hooks, OpenTelemetry provider state, Fastify lifecycle registration, and worker shutdown registration. Those utilities existed only under `../shared/*` and `../worker/*`, while ESLint requires integration files to import through `./api.js` only.

## Test Plan

- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/integrations/api.test.ts tests/integrations/opentelemetry-init.test.ts tests/integrations/opentelemetry.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro-node-renderer type-check`
- `pnpm run lint`
- `pnpm start format.listDifferent`

## Notes

- `rake autofix` was attempted, but the task currently fails in `react_on_rails` because that subpackage has no `prettier` script. Prettier was run directly on the changed test file before rerunning the full formatting check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly re-exports and import-path refactors with added regression tests; no change to SSR or auth behavior.
> 
> **Overview**
> **Expands the public `integrations/api` surface** so third-party integrations can wire tracing teardown, OpenTelemetry provider state, Fastify config, and worker shutdown without reaching into `shared/` or `worker/` modules.
> 
> The OpenTelemetry integration now imports those hooks from `./api.js` only, which removes the ESLint `no-restricted-imports` exception. **`resetTracing` / `resetSubSpan`** are re-exported for integration lifecycle cleanup; comments in `tracing.ts` now describe them as integration-facing, not internal-only.
> 
> A new **`integrations/api` test** asserts the lifecycle exports are callable, and OpenTelemetry init tests **partially mock `api.js`** via `jest.requireActual` so stubs for `log`/`message` do not hide the newly exported hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f472810699119fe9e3135a3521cc7a7b6a1085db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded public integration API with additional tracing helpers and worker lifecycle management utilities.

* **Tests**
  * Added comprehensive test suite for integration API exports and behavior verification.

* **Documentation**
  * Updated documentation for tracing reset and teardown operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->