### PR TITLE
Skip heavy CI for docs and comment-only main pushes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ on:
   push:
     branches:
       - main
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths-ignore:
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +105,12 @@ jobs:
       - name: Detect relevant changes
         id: detect
         run: |
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -120,12 +126,12 @@ jobs:
     # The 'full-ci' label is intentionally excluded — it controls test workflows,
     # not benchmarks. Use the dedicated 'benchmark' label to trigger perf runs on PRs.
     # See https://bencher.dev/docs/how-to/github-actions/#pull-requests for the extra pull_request condition
-    # Skip docs-only pushes to main to avoid wasting CI resources on non-code changes.
+    # Skip non-runtime-only pushes to main to avoid wasting CI resources on non-code changes.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -105,12 +105,7 @@ jobs:
       - name: Detect relevant changes
         id: detect
         run: |
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -6,6 +6,9 @@ on:
       docs_only:
         description: 'Only documentation files changed'
         value: ${{ jobs.detect.outputs.docs_only }}
+      non_runtime_only:
+        description: 'Only documentation or source comments changed'
+        value: ${{ jobs.detect.outputs.non_runtime_only }}
       run_lint:
         description: 'Should run linting'
         value: ${{ jobs.detect.outputs.run_lint }}
@@ -30,6 +33,7 @@ jobs:
       actions: read
     outputs:
       docs_only: ${{ steps.changes.outputs.docs_only }}
+      non_runtime_only: ${{ steps.changes.outputs.non_runtime_only }}
       run_lint: ${{ steps.changes.outputs.run_lint }}
       run_ruby_tests: ${{ steps.changes.outputs.run_ruby_tests }}
       run_js_tests: ${{ steps.changes.outputs.run_js_tests }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -70,12 +70,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_lint: ${{ steps.detect.outputs.run_lint }}
       run_js_tests: ${{ steps.detect.outputs.run_js_tests }}
       run_ruby_tests: ${{ steps.detect.outputs.run_ruby_tests }}
@@ -65,10 +66,16 @@ jobs:
             echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_generators=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -105,7 +112,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches:
       - 'main'
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     paths-ignore:
       - '**.md'
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_lint: ${{ steps.detect.outputs.run_lint }}
       run_js_tests: ${{ steps.detect.outputs.run_js_tests }}
       run_ruby_tests: ${{ steps.detect.outputs.run_ruby_tests }}
@@ -65,10 +66,16 @@ jobs:
             echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_generators=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Set gem tests matrix
@@ -96,14 +103,14 @@ jobs:
 
   rspec-package-tests:
     needs: detect-changes
-    # Skip only if: main push AND docs-only changes
+    # Skip only if: main push AND non-runtime-only changes
     # Otherwise run if: on main OR Ruby tests needed
-    # This allows docs-only commits to skip heavy jobs while ensuring full CI on main for code changes
+    # This allows docs/comment-only commits to skip heavy jobs while ensuring full CI on main for code changes
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         needs.detect-changes.outputs.run_ruby_tests == 'true'

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -70,12 +70,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Set gem tests matrix

--- a/.github/workflows/git-diff-base-tests.yml
+++ b/.github/workflows/git-diff-base-tests.yml
@@ -1,4 +1,4 @@
-name: Git Diff Base Library Tests
+name: Git Diff Base and CI Detector Tests
 
 permissions:
   contents: read
@@ -9,11 +9,15 @@ on:
     paths:
       - 'script/lib/git-diff-base'
       - 'script/lib/git-diff-base-test.bash'
+      - 'script/ci-changes-detector'
+      - 'script/ci-changes-detector-test.bash'
       - '.github/workflows/git-diff-base-tests.yml'
   pull_request:
     paths:
       - 'script/lib/git-diff-base'
       - 'script/lib/git-diff-base-test.bash'
+      - 'script/ci-changes-detector'
+      - 'script/ci-changes-detector-test.bash'
       - '.github/workflows/git-diff-base-tests.yml'
   workflow_dispatch:
 
@@ -25,8 +29,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Shellcheck library and test harness
-        run: shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash
+      - name: Shellcheck detector scripts and test harnesses
+        run: shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/ci-changes-detector-test.bash
 
       - name: Run git-diff-base test harness
         run: bash script/lib/git-diff-base-test.bash
+
+      - name: Run CI changes detector test harness
+        run: bash script/ci-changes-detector-test.bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,12 +66,7 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
           else
-            PR_BEFORE="${{ github.event.before || '' }}"
-            if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-              BASE_REF="$PR_BEFORE"
-            else
-              BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-            fi
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
             script/ci-changes-detector "$BASE_REF"
           fi
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches:
       - 'main'
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     paths-ignore:
       - '**.md'
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_lint: ${{ steps.detect.outputs.run_lint }}
       run_js_tests: ${{ steps.detect.outputs.run_js_tests }}
       run_ruby_tests: ${{ steps.detect.outputs.run_ruby_tests }}
@@ -63,8 +64,14 @@ jobs:
             echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_generators=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
           else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+            PR_BEFORE="${{ github.event.before || '' }}"
+            if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+              BASE_REF="$PR_BEFORE"
+            else
+              BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+            fi
             script/ci-changes-detector "$BASE_REF"
           fi
         shell: bash
@@ -97,14 +104,14 @@ jobs:
 
   build-dummy-app-webpack-test-bundles:
     needs: [detect-changes, setup-integration-matrix]
-    # Skip only if: main push AND docs-only changes
+    # Skip only if: main push AND non-runtime-only changes
     # Otherwise run if: on main OR workflow_dispatch OR dummy tests needed
-    # This allows docs-only commits to skip heavy jobs while ensuring full CI on main for code changes
+    # This allows docs/comment-only commits to skip heavy jobs while ensuring full CI on main for code changes
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
@@ -191,7 +198,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -62,12 +62,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_lint: ${{ steps.detect.outputs.run_lint }}
       run_js_tests: ${{ steps.detect.outputs.run_js_tests }}
       run_ruby_tests: ${{ steps.detect.outputs.run_ruby_tests }}
@@ -57,10 +58,16 @@ jobs:
             echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_generators=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -66,12 +66,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - 'main'
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     paths-ignore:
       - '**.md'
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_lint: ${{ steps.detect.outputs.run_lint }}
       run_js_tests: ${{ steps.detect.outputs.run_js_tests }}
       run_ruby_tests: ${{ steps.detect.outputs.run_ruby_tests }}
@@ -61,10 +62,16 @@ jobs:
             echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
             echo "run_generators=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -81,7 +88,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         needs.detect-changes.outputs.run_js_tests == 'true'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ concurrency:
 on:
   push:
     branches: [main]
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   workflow_dispatch:
 
 jobs:
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,7 +47,7 @@ jobs:
       github.event_name == 'workflow_dispatch' || !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       )
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -54,12 +54,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - 'main'
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     paths-ignore:
       - '**.md'
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_dummy_tests: ${{ steps.detect.outputs.run_dummy_tests }}
       has_full_ci_label: ${{ steps.check-label.outputs.result }}
     steps:
@@ -49,10 +50,16 @@ jobs:
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
             echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -64,13 +71,13 @@ jobs:
 
   precompile-check:
     needs: detect-changes
-    # Skip only if: main push AND docs-only changes
+    # Skip only if: main push AND non-runtime-only changes
     # Otherwise run if: on main OR workflow_dispatch OR dummy tests needed
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -70,12 +70,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - 'main'
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     paths-ignore:
       - '**.md'
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_pro_lint: ${{ steps.detect.outputs.run_pro_lint }}
       run_pro_tests: ${{ steps.detect.outputs.run_pro_tests }}
       has_full_ci_label: ${{ steps.check-label.outputs.result }}
@@ -65,10 +66,16 @@ jobs:
             echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
             echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -85,7 +92,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
@@ -185,7 +192,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
@@ -361,7 +368,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -70,12 +70,7 @@ jobs:
             exit 0
           fi
 
-          PR_BEFORE="${{ github.event.before || '' }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
-            BASE_REF="$PR_BEFORE"
-          else
-            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
-          fi
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -88,15 +83,9 @@ jobs:
   pro-lint:
     needs: detect-changes
     if: |
-      !(
-        github.event_name == 'push' &&
-        github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.non_runtime_only == 'true'
-      ) && (
-        github.ref == 'refs/heads/main' ||
-        github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_lint == 'true'
-      )
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.run_pro_lint == 'true'
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - 'main'
-    # Always trigger on main; docs-only detection handles skipping heavy jobs
+    # Always trigger on main; non-runtime detection handles skipping heavy jobs
   pull_request:
     paths-ignore:
       - '**.md'
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_pro_lint: ${{ steps.detect.outputs.run_pro_lint }}
       run_pro_tests: ${{ steps.detect.outputs.run_pro_tests }}
       has_full_ci_label: ${{ steps.check-label.outputs.result }}
@@ -65,10 +66,16 @@ jobs:
             echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
             echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          PR_BEFORE="${{ github.event.before || '' }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$PR_BEFORE" ] && [[ ! "$PR_BEFORE" =~ ^0+$ ]]; then
+            BASE_REF="$PR_BEFORE"
+          else
+            BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+          fi
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -84,7 +91,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
@@ -179,7 +186,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
@@ -279,7 +286,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
@@ -379,7 +386,7 @@ jobs:
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
-        needs.detect-changes.outputs.docs_only == 'true'
+        needs.detect-changes.outputs.non_runtime_only == 'true'
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -83,9 +83,15 @@ jobs:
   pro-lint:
     needs: detect-changes
     if: |
-      github.ref == 'refs/heads/main' ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.run_pro_lint == 'true'
+      !(
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        needs.detect-changes.outputs.docs_only == 'true'
+      ) && (
+        github.ref == 'refs/heads/main' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.run_pro_lint == 'true'
+      )
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -89,19 +89,26 @@ comment_line_is_runtime_directive() {
   esac
 
   local comment_body="$trimmed"
+  # NOTE: `/*` is quoted so the pattern strips the literal two-char prefix
+  # rather than `/` plus a zero-length glob (which is what `${var#/*}` does).
   case "$comment_body" in
     '//'*) comment_body="${comment_body#//}" ;;
     '#'* ) comment_body="${comment_body#\#}" ;;
-    '/*'*) comment_body="${comment_body#/*}" ;;
+    '/*'*) comment_body="${comment_body#'/*'}" ;;
     '*'*) comment_body="${comment_body#\*}" ;;
   esac
+  # Strip remaining leading `*` characters (handles `/**` JSDoc openers and
+  # continuation lines like ` ** @param`).
+  while [ "${comment_body#\*}" != "$comment_body" ]; do
+    comment_body="${comment_body#\*}"
+  done
   comment_body="${comment_body#"${comment_body%%[![:space:]]*}"}"
 
   case "$comment_body" in
     frozen_string_literal:*|encoding:*|coding:*|shareable_constant_value:*|\
     webpackChunkName:*|webpackMode:*|webpackPrefetch:*|webpackPreload:*|\
     webpackInclude:*|webpackExclude:*|webpackIgnore:*|webpackExports:*|webpackFetchPriority:*|\
-    @vite-ignore*|@jsxImportSource*|@jsx*|@babel*|'#'__PURE__*|\
+    @vite-ignore*|@jsxImportSource*|@jsx*|@babel*|'#'__PURE__*|@__PURE__*|\
     @ts-ignore*|@ts-expect-error*|@ts-nocheck*|@ts-check*|\
     sourceMappingURL*|@preserve*|@license*)
       return 0
@@ -123,12 +130,37 @@ diff_line_is_comment_or_blank() {
     return 1
   fi
 
-  [ "$in_block_comment" = true ] && return 0
+  local after_close after_trimmed
+  if [ "$in_block_comment" = true ]; then
+    case "$trimmed" in
+      *'*/'*)
+        # Block closes on this line — require no executable code after `*/`.
+        after_close="${trimmed##*'*/'}"
+        after_trimmed="${after_close#"${after_close%%[![:space:]]*}"}"
+        [ -z "$after_trimmed" ] && return 0
+        return 1
+        ;;
+      *) return 0 ;;
+    esac
+  fi
   [ "$in_ruby_block_comment" = true ] && return 0
 
   case "$trimmed" in
     '#'*|'//'*) return 0 ;;
-    '/*'*) return 0 ;;
+    '/*'*)
+      # Single-line `/* ... */` is comment-only only when nothing follows the
+      # close. Lines like `/* istanbul ignore next */ exports.foo = bar` must
+      # not be classified as comment-only.
+      case "$trimmed" in
+        *'*/'*)
+          after_close="${trimmed##*'*/'}"
+          after_trimmed="${after_close#"${after_close%%[![:space:]]*}"}"
+          [ -z "$after_trimmed" ] && return 0
+          return 1
+          ;;
+        *) return 0 ;;
+      esac
+      ;;
     '=begin'*) return 0 ;;
   esac
 
@@ -190,7 +222,7 @@ source_file_comment_only_change() {
               *) in_block_comment=true ;;
             esac
             ;;
-          *'*/'*) in_block_comment=false ;;
+          *'*/'*) [ "$in_block_comment" = true ] && in_block_comment=false ;;
         esac
         case "${changed_line:1}" in
           '=begin'*) in_ruby_block_comment=true ;;

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -83,7 +83,9 @@ comment_line_is_runtime_directive() {
 
   case "$line" in
     *"frozen_string_literal:"*|*"encoding:"*|*"coding:"*|*"shareable_constant_value:"*|\
-    *"webpack"*|*"vite-ignore"*|*"@jsxImportSource"*|*"@jsx"*|*"@babel"*|*"#__PURE__"*|\
+    *"webpackChunkName"*|*"webpackMode"*|*"webpackPrefetch"*|*"webpackPreload"*|\
+    *"webpackInclude"*|*"webpackExclude"*|*"webpackIgnore"*|*"webpackExports"*|\
+    *"webpackFetchPriority"*|*"vite-ignore"*|*"@jsxImportSource"*|*"@jsx"*|*"@babel"*|*"#__PURE__"*|\
     *"sourceMappingURL"*|*"@preserve"*|*"@license"*)
       return 0
       ;;
@@ -101,6 +103,7 @@ comment_line_is_runtime_directive() {
 
 diff_line_is_comment_or_blank() {
   local line="$1"
+  local in_block_comment="${2:-false}"
   local trimmed="${line#"${line%%[![:space:]]*}"}"
 
   [ -z "$trimmed" ] && return 0
@@ -112,6 +115,7 @@ diff_line_is_comment_or_blank() {
   case "$trimmed" in
     '#'*|'//'*) return 0 ;;
     '/*'*|'*/'*) return 0 ;;
+    '*'*) [ "$in_block_comment" = true ] && return 0 ;;
     '=begin'*|'=end'*) return 0 ;;
   esac
 
@@ -128,15 +132,24 @@ source_file_comment_only_change() {
     *) return 1 ;;
   esac
 
-  local changed_line saw_changed_line=false
+  local changed_line saw_changed_line=false in_block_comment=false
   while IFS= read -r changed_line; do
     case "$changed_line" in
-      '+++'*|'---'*) continue ;;
+      '+++ '*|'--- '*) continue ;;
       '+'*|'-'*)
         saw_changed_line=true
-        if ! diff_line_is_comment_or_blank "${changed_line:1}"; then
+        if ! diff_line_is_comment_or_blank "${changed_line:1}" "$in_block_comment"; then
           return 1
         fi
+        case "${changed_line:1}" in
+          *'/*'*)
+            case "${changed_line:1}" in
+              *'*/'*) ;;
+              *) in_block_comment=true ;;
+            esac
+            ;;
+          *'*/'*) in_block_comment=false ;;
+        esac
         ;;
     esac
   done < <(git diff --no-ext-diff --unified=0 "$MERGE_BASE" "$CURRENT_REF" -- "$file")

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -80,20 +80,30 @@ PRO_SOURCE_COMMENT_ONLY_CHANGED=false
 
 comment_line_is_runtime_directive() {
   local line="$1"
+  local trimmed="${line#"${line%%[![:space:]]*}"}"
 
-  case "$line" in
-    *"frozen_string_literal:"*|*"encoding:"*|*"coding:"*|*"shareable_constant_value:"*|\
-    *"webpackChunkName"*|*"webpackMode"*|*"webpackPrefetch"*|*"webpackPreload"*|\
-    *"webpackInclude"*|*"webpackExclude"*|*"webpackIgnore"*|*"webpackExports"*|\
-    *"webpackFetchPriority"*|*"vite-ignore"*|*"@jsxImportSource"*|*"@jsx"*|*"@babel"*|*"#__PURE__"*|\
-    *"sourceMappingURL"*|*"@preserve"*|*"@license"*)
+  case "$trimmed" in
+    '#!'*)
       return 0
       ;;
   esac
 
-  local trimmed="${line#"${line%%[![:space:]]*}"}"
-  case "$trimmed" in
-    '#!'*)
+  local comment_body="$trimmed"
+  case "$comment_body" in
+    '//'*) comment_body="${comment_body#//}" ;;
+    '#'* ) comment_body="${comment_body#\#}" ;;
+    '/*'*) comment_body="${comment_body#/*}" ;;
+    '*'*) comment_body="${comment_body#\*}" ;;
+  esac
+  comment_body="${comment_body#"${comment_body%%[![:space:]]*}"}"
+
+  case "$comment_body" in
+    frozen_string_literal:*|encoding:*|coding:*|shareable_constant_value:*|\
+    webpackChunkName:*|webpackMode:*|webpackPrefetch:*|webpackPreload:*|\
+    webpackInclude:*|webpackExclude:*|webpackIgnore:*|webpackExports:*|webpackFetchPriority:*|\
+    @vite-ignore*|@jsxImportSource*|@jsx*|@babel*|'#'__PURE__*|\
+    @ts-ignore*|@ts-expect-error*|@ts-nocheck*|@ts-check*|\
+    sourceMappingURL*|@preserve*|@license*)
       return 0
       ;;
   esac
@@ -104,6 +114,7 @@ comment_line_is_runtime_directive() {
 diff_line_is_comment_or_blank() {
   local line="$1"
   local in_block_comment="${2:-false}"
+  local in_ruby_block_comment="${3:-false}"
   local trimmed="${line#"${line%%[![:space:]]*}"}"
 
   [ -z "$trimmed" ] && return 0
@@ -112,11 +123,13 @@ diff_line_is_comment_or_blank() {
     return 1
   fi
 
+  [ "$in_block_comment" = true ] && return 0
+  [ "$in_ruby_block_comment" = true ] && return 0
+
   case "$trimmed" in
     '#'*|'//'*) return 0 ;;
-    '/*'*|'*/'*) return 0 ;;
-    '*'*) [ "$in_block_comment" = true ] && return 0 ;;
-    '=begin'*|'=end'*) return 0 ;;
+    '/*'*) return 0 ;;
+    '=begin'*) return 0 ;;
   esac
 
   return 1
@@ -157,13 +170,17 @@ source_file_comment_only_change() {
       ;;
   esac
 
-  local changed_line saw_changed_line=false in_block_comment=false
+  local changed_line saw_changed_line=false in_block_comment=false in_ruby_block_comment=false
   while IFS= read -r changed_line; do
     case "$changed_line" in
+      '@@ '*)
+        [ "$in_block_comment" = true ] && return 1
+        [ "$in_ruby_block_comment" = true ] && return 1
+        ;;
       '+++ '*|'--- '*) continue ;;
       '+'*|'-'*)
         saw_changed_line=true
-        if ! diff_line_is_comment_or_blank "${changed_line:1}" "$in_block_comment"; then
+        if ! diff_line_is_comment_or_blank "${changed_line:1}" "$in_block_comment" "$in_ruby_block_comment"; then
           return 1
         fi
         case "${changed_line:1}" in
@@ -175,10 +192,16 @@ source_file_comment_only_change() {
             ;;
           *'*/'*) in_block_comment=false ;;
         esac
+        case "${changed_line:1}" in
+          '=begin'*) in_ruby_block_comment=true ;;
+          '=end'*) in_ruby_block_comment=false ;;
+        esac
         ;;
     esac
   done <<< "$diff_output"
 
+  [ "$in_block_comment" = true ] && return 1
+  [ "$in_ruby_block_comment" = true ] && return 1
   [ "$saw_changed_line" = true ]
 }
 
@@ -289,7 +312,7 @@ while IFS= read -r file; do
     packages/react-on-rails-pro-node-renderer/src/*|packages/react-on-rails-pro-node-renderer/src/**/*|packages/react-on-rails-pro-node-renderer/tests/*|packages/react-on-rails-pro-node-renderer/tests/**/*|packages/react-on-rails-pro-node-renderer/scripts/*|packages/react-on-rails-pro-node-renderer/scripts/**/*|packages/react-on-rails-pro-node-renderer/package.json|packages/react-on-rails-pro-node-renderer/tsconfig.json|.github/workflows/node-renderer-tests.yml)
       DOCS_ONLY=false
       if source_file_comment_only_change "$file"; then
-        SOURCE_COMMENT_ONLY_CHANGED=true
+        PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_NODE_RENDERER_CHANGED=true
       fi

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -122,9 +122,32 @@ diff_line_is_comment_or_blank() {
   return 1
 }
 
+source_file_has_multiline_string_construct() {
+  local file="$1"
+  local content
+
+  content="$(git show "$CURRENT_REF:$file" 2>/dev/null || cat "$file" 2>/dev/null || true)"
+
+  case "$file" in
+    *.rb|Gemfile|*.rake)
+      grep -Eq "<<[-~]?[[:space:]]*['\"]?[A-Za-z_][A-Za-z0-9_]*" <<< "$content"
+      ;;
+    *.js|*.jsx|*.ts|*.tsx)
+      grep -q '`' <<< "$content"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 source_file_comment_only_change() {
   local file="$1"
   local status
+
+  if source_file_has_multiline_string_construct "$file"; then
+    return 1
+  fi
 
   status="$(git diff --name-status "$MERGE_BASE" "$CURRENT_REF" -- "$file" | awk 'NR == 1 { print $1 }')"
   case "$status" in

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -143,16 +143,18 @@ source_file_has_multiline_string_construct() {
 
 source_file_comment_only_change() {
   local file="$1"
-  local status
+  local diff_output
 
   if source_file_has_multiline_string_construct "$file"; then
     return 1
   fi
 
-  status="$(git diff --name-status "$MERGE_BASE" "$CURRENT_REF" -- "$file" | awk 'NR == 1 { print $1 }')"
-  case "$status" in
-    M) ;;
-    *) return 1 ;;
+  diff_output="$(git diff --no-ext-diff --unified=0 "$MERGE_BASE" "$CURRENT_REF" -- "$file")"
+  case "$diff_output" in
+    *$'\nnew file mode '*|*$'\ndeleted file mode '*|*$'\nrename from '*|*$'\nrename to '*|\
+    *$'\ncopy from '*|*$'\ncopy to '*|*$'\n--- /dev/null'*|*$'\n+++ /dev/null'*)
+      return 1
+      ;;
   esac
 
   local changed_line saw_changed_line=false in_block_comment=false
@@ -175,7 +177,7 @@ source_file_comment_only_change() {
         esac
         ;;
     esac
-  done < <(git diff --no-ext-diff --unified=0 "$MERGE_BASE" "$CURRENT_REF" -- "$file")
+  done <<< "$diff_output"
 
   [ "$saw_changed_line" = true ]
 }

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -75,6 +75,74 @@ PRO_JS_CHANGED=false
 PRO_DUMMY_CHANGED=false
 PRO_NODE_RENDERER_CHANGED=false
 UNCATEGORIZED_CHANGED=false
+SOURCE_COMMENT_ONLY_CHANGED=false
+PRO_SOURCE_COMMENT_ONLY_CHANGED=false
+
+comment_line_is_runtime_directive() {
+  local line="$1"
+
+  case "$line" in
+    *"frozen_string_literal:"*|*"encoding:"*|*"coding:"*|*"shareable_constant_value:"*|\
+    *"webpack"*|*"vite-ignore"*|*"@jsxImportSource"*|*"@jsx"*|*"@babel"*|*"#__PURE__"*|\
+    *"sourceMappingURL"*|*"@preserve"*|*"@license"*)
+      return 0
+      ;;
+  esac
+
+  local trimmed="${line#"${line%%[![:space:]]*}"}"
+  case "$trimmed" in
+    '#!'*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+diff_line_is_comment_or_blank() {
+  local line="$1"
+  local trimmed="${line#"${line%%[![:space:]]*}"}"
+
+  [ -z "$trimmed" ] && return 0
+
+  if comment_line_is_runtime_directive "$trimmed"; then
+    return 1
+  fi
+
+  case "$trimmed" in
+    '#'*|'//'*) return 0 ;;
+    '/*'*|'*/'*) return 0 ;;
+    '=begin'*|'=end'*) return 0 ;;
+  esac
+
+  return 1
+}
+
+source_file_comment_only_change() {
+  local file="$1"
+  local status
+
+  status="$(git diff --name-status "$MERGE_BASE" "$CURRENT_REF" -- "$file" | awk 'NR == 1 { print $1 }')"
+  case "$status" in
+    M) ;;
+    *) return 1 ;;
+  esac
+
+  local changed_line saw_changed_line=false
+  while IFS= read -r changed_line; do
+    case "$changed_line" in
+      '+++'*|'---'*) continue ;;
+      '+'*|'-'*)
+        saw_changed_line=true
+        if ! diff_line_is_comment_or_blank "${changed_line:1}"; then
+          return 1
+        fi
+        ;;
+    esac
+  done < <(git diff --no-ext-diff --unified=0 "$MERGE_BASE" "$CURRENT_REF" -- "$file")
+
+  [ "$saw_changed_line" = true ]
+}
 
 # Analyze each changed file
 while IFS= read -r file; do
@@ -92,61 +160,101 @@ while IFS= read -r file; do
     # Generators (MUST be before Ruby source code to avoid being caught by lib/**/*.rb)
     react_on_rails/lib/generators/*|react_on_rails/lib/generators/**/*|react_on_rails/spec/react_on_rails/generators/*|react_on_rails/spec/react_on_rails/generators/**/*|rakelib/example_type.rb|rakelib/examples_config.yml|rakelib/shakapacker_examples.rake|.github/workflows/examples.yml)
       DOCS_ONLY=false
-      GENERATORS_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        GENERATORS_CHANGED=true
+      fi
       ;;
 
     # Ruby core source code (non-generator lib files)
     react_on_rails/lib/*.rb|react_on_rails/lib/**/*.rb|Gemfile|Gemfile.lock|rakelib/run_rspec.rake|rakelib/node_package.rake|rakelib/dummy_apps.rake)
       DOCS_ONLY=false
-      RUBY_CORE_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        RUBY_CORE_CHANGED=true
+      fi
       ;;
 
     # Ruby gem-specific specs (MUST be after Generators since this pattern catches ALL specs including generator specs)
     react_on_rails/spec/react_on_rails/*|react_on_rails/spec/react_on_rails/**/*|.github/workflows/gem-tests.yml)
       DOCS_ONLY=false
-      RSPEC_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        RSPEC_CHANGED=true
+      fi
       ;;
 
     # JavaScript/TypeScript source (including tests, scripts, and package files)
     package.json|pnpm-lock.yaml|packages/react-on-rails/src/*|packages/react-on-rails/src/**/*|packages/react-on-rails/tests/*|packages/react-on-rails/tests/**/*|packages/react-on-rails/scripts/*|packages/react-on-rails/scripts/**/*|packages/react-on-rails/package.json|packages/react-on-rails/tsconfig.json|.github/workflows/package-js-tests.yml)
       DOCS_ONLY=false
-      JS_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        JS_CHANGED=true
+      fi
       ;;
 
     # Dummy app
     react_on_rails/spec/dummy/*|react_on_rails/spec/dummy/**/*|.github/workflows/integration-tests.yml)
       DOCS_ONLY=false
-      SPEC_DUMMY_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        SPEC_DUMMY_CHANGED=true
+      fi
       ;;
 
     # React on Rails Pro source code
     react_on_rails_pro/lib/*|react_on_rails_pro/lib/**/*)
       DOCS_ONLY=false
-      PRO_RUBY_CORE_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        PRO_SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        PRO_RUBY_CORE_CHANGED=true
+      fi
       ;;
 
     # JavaScript/TypeScript Pro source (including tests, scripts, and package files)
     packages/react-on-rails-pro/src/*|packages/react-on-rails-pro/src/**/*|packages/react-on-rails-pro/tests/*|packages/react-on-rails-pro/tests/**/*|packages/react-on-rails-pro/scripts/*|packages/react-on-rails-pro/scripts/**/*|packages/react-on-rails-pro/package.json|packages/react-on-rails-pro/tsconfig.json)
       DOCS_ONLY=false
-      PRO_JS_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        PRO_SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        PRO_JS_CHANGED=true
+      fi
       ;;
 
     # Ruby Pro gem-specific specs
     react_on_rails_pro/spec/react_on_rails/*|react_on_rails_pro/spec/react_on_rails/**/*|.github/workflows/pro-gem-tests.yml)
       DOCS_ONLY=false
-      PRO_RSPEC_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        PRO_SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        PRO_RSPEC_CHANGED=true
+      fi
       ;;
 
     # React on Rails Pro package / dummy app
     react_on_rails_pro/spec/dummy/*|react_on_rails_pro/spec/dummy/**/*|react_on_rails_pro/spec/execjs-compatible-dummy/*|react_on_rails_pro/spec/execjs-compatible-dummy/**/*|.github/workflows/pro-integration-tests.yml)
       DOCS_ONLY=false
-      PRO_DUMMY_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        PRO_SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        PRO_DUMMY_CHANGED=true
+      fi
       ;;
 
     # React on Rails Pro Node Renderer package (JS/TS source, tests, configs)
     packages/react-on-rails-pro-node-renderer/src/*|packages/react-on-rails-pro-node-renderer/src/**/*|packages/react-on-rails-pro-node-renderer/tests/*|packages/react-on-rails-pro-node-renderer/tests/**/*|packages/react-on-rails-pro-node-renderer/scripts/*|packages/react-on-rails-pro-node-renderer/scripts/**/*|packages/react-on-rails-pro-node-renderer/package.json|packages/react-on-rails-pro-node-renderer/tsconfig.json|.github/workflows/node-renderer-tests.yml)
       DOCS_ONLY=false
-      PRO_NODE_RENDERER_CHANGED=true
+      if source_file_comment_only_change "$file"; then
+        SOURCE_COMMENT_ONLY_CHANGED=true
+      else
+        PRO_NODE_RENDERER_CHANGED=true
+      fi
       ;;
 
     # Lint/format configuration
@@ -185,6 +293,27 @@ while IFS= read -r file; do
   esac
 done <<< "$CHANGED_FILES"
 
+NON_RUNTIME_ONLY=false
+if [ "$DOCS_ONLY" = true ]; then
+  NON_RUNTIME_ONLY=true
+elif [ "$SOURCE_COMMENT_ONLY_CHANGED" = true ] || [ "$PRO_SOURCE_COMMENT_ONLY_CHANGED" = true ]; then
+  if [ "$LINT_CONFIG_CHANGED" = false ] &&
+    [ "$PRO_LINT_CONFIG_CHANGED" = false ] &&
+    [ "$RUBY_CORE_CHANGED" = false ] &&
+    [ "$RSPEC_CHANGED" = false ] &&
+    [ "$SPEC_DUMMY_CHANGED" = false ] &&
+    [ "$JS_CHANGED" = false ] &&
+    [ "$GENERATORS_CHANGED" = false ] &&
+    [ "$PRO_RUBY_CORE_CHANGED" = false ] &&
+    [ "$PRO_RSPEC_CHANGED" = false ] &&
+    [ "$PRO_JS_CHANGED" = false ] &&
+    [ "$PRO_DUMMY_CHANGED" = false ] &&
+    [ "$PRO_NODE_RENDERER_CHANGED" = false ] &&
+    [ "$UNCATEGORIZED_CHANGED" = false ]; then
+    NON_RUNTIME_ONLY=true
+  fi
+fi
+
 # Output results
 echo "=== CI Changes Analysis ==="
 echo "Base: $BASE_REF | Current: $CURRENT_REF | Merge base: $MERGE_BASE"
@@ -195,6 +324,7 @@ if [ "$DOCS_ONLY" = true ]; then
   # Format: "flag_name:value" pairs
   CI_FLAGS=(
     "docs_only:true"
+    "non_runtime_only:true"
     "run_lint:false"
     "run_ruby_tests:false"
     "run_js_tests:false"
@@ -251,6 +381,8 @@ echo "Changed file categories:"
 [ "$PRO_NODE_RENDERER_CHANGED" = true ] && echo -e "${YELLOW}  • React on Rails Pro Node Renderer package${NC}"
 [ "$LINT_CONFIG_CHANGED" = true ] && echo -e "${YELLOW}  • Lint/format configuration${NC}"
 [ "$PRO_LINT_CONFIG_CHANGED" = true ] && echo -e "${YELLOW}  • React on Rails Pro lint configuration${NC}"
+[ "$SOURCE_COMMENT_ONLY_CHANGED" = true ] && echo -e "${YELLOW}  • Source comments only${NC}"
+[ "$PRO_SOURCE_COMMENT_ONLY_CHANGED" = true ] && echo -e "${YELLOW}  • React on Rails Pro source comments only${NC}"
 [ "$UNCATEGORIZED_CHANGED" = true ] && echo -e "${YELLOW}  • Uncategorized changes (running full suite for safety)${NC}"
 
 echo ""
@@ -268,6 +400,10 @@ RUN_PRO_DUMMY_TESTS=false
 RUN_PRO_NODE_RENDERER_TESTS=false
 
 if [ "$LINT_CONFIG_CHANGED" = true ] || [ "$RUBY_CORE_CHANGED" = true ] || [ "$JS_CHANGED" = true ] || [ "$SPEC_DUMMY_CHANGED" = true ] || [ "$PRO_JS_CHANGED" = true ] || [ "$PRO_DUMMY_CHANGED" = true ] || [ "$PRO_NODE_RENDERER_CHANGED" = true ]; then
+  RUN_LINT=true
+fi
+
+if [ "$SOURCE_COMMENT_ONLY_CHANGED" = true ]; then
   RUN_LINT=true
 fi
 
@@ -290,6 +426,10 @@ if [ "$GENERATORS_CHANGED" = true ] || [ "$JS_CHANGED" = true ]; then
 fi
 
 if [ "$PRO_LINT_CONFIG_CHANGED" = true ] || [ "$PRO_RUBY_CORE_CHANGED" = true ] || [ "$PRO_JS_CHANGED" = true ] || [ "$PRO_DUMMY_CHANGED" = true ] || [ "$RUBY_CORE_CHANGED" = true ] || [ "$PRO_NODE_RENDERER_CHANGED" = true ]; then
+  RUN_PRO_LINT=true
+fi
+
+if [ "$PRO_SOURCE_COMMENT_ONLY_CHANGED" = true ]; then
   RUN_PRO_LINT=true
 fi
 
@@ -332,6 +472,7 @@ fi
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
     echo "docs_only=$DOCS_ONLY"
+    echo "non_runtime_only=$NON_RUNTIME_ONLY"
     echo "run_lint=$RUN_LINT"
     echo "run_ruby_tests=$RUN_RUBY_TESTS"
     echo "run_js_tests=$RUN_JS_TESTS"
@@ -349,6 +490,7 @@ if [ "${CI_JSON_OUTPUT:-}" = "1" ]; then
   cat << EOF
 {
   "docs_only": $DOCS_ONLY,
+  "non_runtime_only": $NON_RUNTIME_ONLY,
   "run_lint": $RUN_LINT,
   "run_ruby_tests": $RUN_RUBY_TESTS,
   "run_js_tests": $RUN_JS_TESTS,

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Test harness for script/ci-changes-detector. Self-contained: no extra
+# binaries beyond bash + git. Run with `bash script/ci-changes-detector-test.bash`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DETECTOR="$SCRIPT_DIR/ci-changes-detector"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  echo "  FAIL: $message" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      fail "$label: expected to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+  esac
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local tmpdir before_failed had_errexit=false
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/ci-changes-detector-test.XXXXXX")"
+  before_failed="$TESTS_FAILED"
+
+  case "$-" in
+    *e*) had_errexit=true ;;
+  esac
+
+  set +e
+  (
+    set -euo pipefail
+    cd "$tmpdir" || exit 1
+    "$test_fn"
+  )
+  local rc=$?
+  if [ "$had_errexit" = true ]; then
+    set -e
+  fi
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+}
+
+setup_repo() {
+  git init -b main >/dev/null
+  git config user.email test@example.com
+  git config user.name "CI Detector Test"
+
+  mkdir -p docs react_on_rails/lib/react_on_rails packages/react-on-rails/src
+  mkdir -p react_on_rails/spec/react_on_rails
+  cat > docs/guide.md <<'DOC'
+# Guide
+DOC
+  cat > react_on_rails/lib/react_on_rails/example.rb <<'RUBY'
+module ReactOnRails
+  class Example
+    def call
+      "ok"
+    end
+  end
+end
+RUBY
+  cat > packages/react-on-rails/src/example.ts <<'TS'
+export function example(): string {
+  return 'ok';
+}
+TS
+  cat > react_on_rails/spec/react_on_rails/example_spec.rb <<'RUBY'
+RSpec.describe "example" do
+  it "works" do
+    expect(true).to be(true)
+  end
+end
+RUBY
+
+  git add .
+  git commit -m "initial fixture" >/dev/null
+}
+
+detector_output() {
+  CI=true CI_JSON_OUTPUT=1 "$DETECTOR" HEAD~1 HEAD
+}
+
+commit_change() {
+  local message="$1"
+  git add .
+  git commit -m "$message" >/dev/null
+}
+
+test_docs_changes_are_non_runtime_only() {
+  setup_repo
+  printf '\nMore docs.\n' >> docs/guide.md
+  commit_change "docs"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "docs output"
+  assert_contains "$out" '"non_runtime_only": true' "docs output"
+  assert_contains "$out" '"run_lint": false' "docs output"
+}
+
+test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint() {
+  setup_repo
+  perl -0pi -e 's/class Example/class Example\n    # Explain the fixture./' \
+    react_on_rails/lib/react_on_rails/example.rb
+  commit_change "ruby comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "ruby comment output"
+  assert_contains "$out" '"non_runtime_only": true' "ruby comment output"
+  assert_contains "$out" '"run_lint": true' "ruby comment output"
+  assert_contains "$out" '"run_ruby_tests": false' "ruby comment output"
+  assert_contains "$out" '"run_dummy_tests": false' "ruby comment output"
+}
+
+test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint() {
+  setup_repo
+  perl -0pi -e 's/export function/\/** Explains the fixture. *\/\nexport function/' \
+    packages/react-on-rails/src/example.ts
+  commit_change "js comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": true' "js comment output"
+  assert_contains "$out" '"run_lint": true' "js comment output"
+  assert_contains "$out" '"run_js_tests": false' "js comment output"
+}
+
+test_spec_comment_only_change_skips_rspec() {
+  setup_repo
+  perl -0pi -e 's/it "works"/# Fixture intent.\n  it "works"/' \
+    react_on_rails/spec/react_on_rails/example_spec.rb
+  commit_change "spec comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": true' "spec comment output"
+  assert_contains "$out" '"run_lint": true' "spec comment output"
+  assert_contains "$out" '"run_ruby_tests": false' "spec comment output"
+}
+
+test_ruby_magic_comment_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/module ReactOnRails/# frozen_string_literal: true\n\nmodule ReactOnRails/' \
+    react_on_rails/lib/react_on_rails/example.rb
+  commit_change "ruby magic comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "ruby magic output"
+  assert_contains "$out" '"run_ruby_tests": true' "ruby magic output"
+}
+
+test_executable_source_change_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/"ok"/"changed"/' react_on_rails/lib/react_on_rails/example.rb
+  commit_change "runtime source"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "runtime source output"
+  assert_contains "$out" '"run_ruby_tests": true' "runtime source output"
+}
+
+run_test test_docs_changes_are_non_runtime_only
+run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_spec_comment_only_change_skips_rspec
+run_test test_ruby_magic_comment_remains_runtime_affecting
+run_test test_executable_source_change_remains_runtime_affecting
+
+echo
+echo "CI changes detector tests: $TESTS_RUN run, $TESTS_FAILED failed"
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  printf '\nFailures:\n' >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -71,6 +71,7 @@ setup_repo() {
   git config user.name "CI Detector Test"
 
   mkdir -p docs react_on_rails/lib/react_on_rails packages/react-on-rails/src
+  mkdir -p packages/react-on-rails-pro-node-renderer/src
   mkdir -p react_on_rails/spec/react_on_rails
   cat > docs/guide.md <<'DOC'
 # Guide
@@ -93,6 +94,11 @@ TS
 export const template = `
 // runtime fixture text
 `;
+TS
+  cat > packages/react-on-rails-pro-node-renderer/src/example.ts <<'TS'
+export function render(): string {
+  return 'ok';
+}
 TS
   cat > react_on_rails/spec/react_on_rails/example_spec.rb <<'RUBY'
 RSpec.describe "example" do
@@ -143,9 +149,34 @@ test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   assert_contains "$out" '"run_dummy_tests": false' "ruby comment output"
 }
 
+test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint() {
+  setup_repo
+  perl -0pi -e 's/module ReactOnRails/=begin\nExplains the fixture.\n=end\nmodule ReactOnRails/' \
+    react_on_rails/lib/react_on_rails/example.rb
+  commit_change "ruby block comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": true' "ruby block comment output"
+  assert_contains "$out" '"run_lint": true' "ruby block comment output"
+  assert_contains "$out" '"run_ruby_tests": false' "ruby block comment output"
+}
+
+test_wrapping_ruby_code_with_block_comment_delimiters_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/module ReactOnRails/=begin\nmodule ReactOnRails/' react_on_rails/lib/react_on_rails/example.rb
+  printf '\n=end\n' >> react_on_rails/lib/react_on_rails/example.rb
+  commit_change "comment out ruby code"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "commented ruby code output"
+  assert_contains "$out" '"run_ruby_tests": true' "commented ruby code output"
+}
+
 test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   setup_repo
-  perl -0pi -e 's/export function/\/**\n * Explains the fixture.\n *\/\nexport function/' \
+  perl -0pi -e 's/export function/\/\*\n * Explains the fixture.\n *\/\nexport function/' \
     packages/react-on-rails/src/example.ts
   commit_change "js comment"
 
@@ -154,6 +185,18 @@ test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   assert_contains "$out" '"non_runtime_only": true' "js comment output"
   assert_contains "$out" '"run_lint": true' "js comment output"
   assert_contains "$out" '"run_js_tests": false' "js comment output"
+}
+
+test_wrapping_code_with_block_comment_delimiters_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/export function/\/\*\nexport function/' packages/react-on-rails/src/example.ts
+  printf '\n*/\n' >> packages/react-on-rails/src/example.ts
+  commit_change "comment out code"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "commented code output"
+  assert_contains "$out" '"run_js_tests": true' "commented code output"
 }
 
 test_prose_comment_containing_webpack_is_not_a_runtime_directive() {
@@ -166,6 +209,42 @@ test_prose_comment_containing_webpack_is_not_a_runtime_directive() {
   out="$(detector_output)"
   assert_contains "$out" '"non_runtime_only": true' "webpack prose output"
   assert_contains "$out" '"run_js_tests": false' "webpack prose output"
+}
+
+test_webpack_magic_comment_keyword_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/export function/\/\/ webpackChunkName: "example"\nexport function/' \
+    packages/react-on-rails/src/example.ts
+  commit_change "webpack directive comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "webpack directive output"
+  assert_contains "$out" '"run_js_tests": true' "webpack directive output"
+}
+
+test_prose_comment_containing_encoding_is_not_a_runtime_directive() {
+  setup_repo
+  perl -0pi -e 's/class Example/class Example\n    # Documents response encoding: utf-8./' \
+    react_on_rails/lib/react_on_rails/example.rb
+  commit_change "encoding prose comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": true' "encoding prose output"
+  assert_contains "$out" '"run_ruby_tests": false' "encoding prose output"
+}
+
+test_typescript_suppression_comment_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/export function/\/\/ \@ts-expect-error documents expected type failure\nexport function/' \
+    packages/react-on-rails/src/example.ts
+  commit_change "typescript directive comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "typescript directive output"
+  assert_contains "$out" '"run_js_tests": true' "typescript directive output"
 }
 
 test_code_line_starting_with_plus_plus_remains_runtime_affecting() {
@@ -202,6 +281,20 @@ test_spec_comment_only_change_skips_rspec() {
   assert_contains "$out" '"non_runtime_only": true' "spec comment output"
   assert_contains "$out" '"run_lint": true' "spec comment output"
   assert_contains "$out" '"run_ruby_tests": false' "spec comment output"
+}
+
+test_pro_node_renderer_comment_only_change_runs_pro_lint_only() {
+  setup_repo
+  perl -0pi -e 's/export function/\/\/ Explains the Pro node renderer fixture.\nexport function/' \
+    packages/react-on-rails-pro-node-renderer/src/example.ts
+  commit_change "pro node renderer comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": true' "pro node renderer comment output"
+  assert_contains "$out" '"run_lint": false' "pro node renderer comment output"
+  assert_contains "$out" '"run_pro_lint": true' "pro node renderer comment output"
+  assert_contains "$out" '"run_pro_node_renderer_tests": false' "pro node renderer comment output"
 }
 
 test_mixed_comment_and_code_change_remains_runtime_affecting() {
@@ -242,11 +335,18 @@ test_executable_source_change_remains_runtime_affecting() {
 
 run_test test_docs_changes_are_non_runtime_only
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_wrapping_ruby_code_with_block_comment_delimiters_remains_runtime_affecting
 run_test test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_wrapping_code_with_block_comment_delimiters_remains_runtime_affecting
 run_test test_prose_comment_containing_webpack_is_not_a_runtime_directive
+run_test test_webpack_magic_comment_keyword_remains_runtime_affecting
+run_test test_prose_comment_containing_encoding_is_not_a_runtime_directive
+run_test test_typescript_suppression_comment_remains_runtime_affecting
 run_test test_code_line_starting_with_plus_plus_remains_runtime_affecting
 run_test test_comment_like_template_literal_change_remains_runtime_affecting
 run_test test_spec_comment_only_change_skips_rspec
+run_test test_pro_node_renderer_comment_only_change_runs_pro_lint_only
 run_test test_mixed_comment_and_code_change_remains_runtime_affecting
 run_test test_ruby_magic_comment_remains_runtime_affecting
 run_test test_executable_source_change_remains_runtime_affecting

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Test harness for script/ci-changes-detector. Self-contained: no extra
-# binaries beyond bash + git. Run with `bash script/ci-changes-detector-test.bash`.
+# Test harness for script/ci-changes-detector. Requires bash, git, and perl
+# (perl is used for inline fixture rewrites). Run with
+# `bash script/ci-changes-detector-test.bash`.
 
 set -uo pipefail
 
@@ -16,6 +17,12 @@ fail() {
   local message="$1"
   TESTS_FAILED=$((TESTS_FAILED + 1))
   FAILURES+=("$CURRENT_TEST: $message")
+  # When invoked from inside a run_test subshell, also persist the message so
+  # the outer summary can show the specific assertion rather than a generic
+  # "subshell exited" line.
+  if [ -n "${SUBSHELL_FAILURES_FILE:-}" ]; then
+    printf '%s\n' "$CURRENT_TEST: $message" >> "$SUBSHELL_FAILURES_FILE"
+  fi
   echo "  FAIL: $message" >&2
 }
 
@@ -38,8 +45,10 @@ run_test() {
   TESTS_RUN=$((TESTS_RUN + 1))
   echo "-> $test_fn"
 
-  local tmpdir before_failed had_errexit=false
+  local tmpdir before_failed had_errexit=false subshell_failures
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/ci-changes-detector-test.XXXXXX")"
+  subshell_failures="$tmpdir/failures.log"
+  : > "$subshell_failures"
   before_failed="$TESTS_FAILED"
 
   case "$-" in
@@ -49,12 +58,24 @@ run_test() {
   set +e
   (
     set -euo pipefail
+    SUBSHELL_FAILURES_FILE="$subshell_failures"
+    export SUBSHELL_FAILURES_FILE
     cd "$tmpdir" || exit 1
     "$test_fn"
   )
   local rc=$?
   if [ "$had_errexit" = true ]; then
     set -e
+  fi
+
+  # Ingest detailed failure messages recorded inside the subshell so the final
+  # summary reflects the actual assertion text instead of a generic exit code.
+  if [ -s "$subshell_failures" ]; then
+    while IFS= read -r failure_line; do
+      [ -n "$failure_line" ] || continue
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      FAILURES+=("$failure_line")
+    done < "$subshell_failures"
   fi
   rm -rf "$tmpdir"
 
@@ -333,6 +354,54 @@ test_executable_source_change_remains_runtime_affecting() {
   assert_contains "$out" '"run_ruby_tests": true' "runtime source output"
 }
 
+test_jsdoc_jsx_import_source_pragma_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's{export function}{/** \@jsxImportSource @emotion/react */\nexport function}' \
+    packages/react-on-rails/src/example.ts
+  commit_change "jsdoc jsx import source pragma"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "jsdoc pragma output"
+  assert_contains "$out" '"run_js_tests": true' "jsdoc pragma output"
+}
+
+test_inline_block_comment_license_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's{export function}{/* \@license MIT */\nexport function}' \
+    packages/react-on-rails/src/example.ts
+  commit_change "inline block comment license"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "license directive output"
+  assert_contains "$out" '"run_js_tests": true' "license directive output"
+}
+
+test_pure_annotation_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's{export function}{/* \@__PURE__ */\nexport function}' \
+    packages/react-on-rails/src/example.ts
+  commit_change "pure annotation"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "pure annotation output"
+  assert_contains "$out" '"run_js_tests": true' "pure annotation output"
+}
+
+test_block_comment_with_trailing_code_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's{export function}{/* note */ exports.flag = true;\nexport function}' \
+    packages/react-on-rails/src/example.ts
+  commit_change "block comment plus trailing code"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "trailing code after block close output"
+  assert_contains "$out" '"run_js_tests": true' "trailing code after block close output"
+}
+
 run_test test_docs_changes_are_non_runtime_only
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint
@@ -350,6 +419,10 @@ run_test test_pro_node_renderer_comment_only_change_runs_pro_lint_only
 run_test test_mixed_comment_and_code_change_remains_runtime_affecting
 run_test test_ruby_magic_comment_remains_runtime_affecting
 run_test test_executable_source_change_remains_runtime_affecting
+run_test test_jsdoc_jsx_import_source_pragma_remains_runtime_affecting
+run_test test_inline_block_comment_license_remains_runtime_affecting
+run_test test_pure_annotation_remains_runtime_affecting
+run_test test_block_comment_with_trailing_code_remains_runtime_affecting
 
 echo
 echo "CI changes detector tests: $TESTS_RUN run, $TESTS_FAILED failed"

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -140,7 +140,7 @@ test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint() {
 
 test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   setup_repo
-  perl -0pi -e 's/export function/\/** Explains the fixture. *\/\nexport function/' \
+  perl -0pi -e 's/export function/\/**\n * Explains the fixture.\n *\/\nexport function/' \
     packages/react-on-rails/src/example.ts
   commit_change "js comment"
 
@@ -149,6 +149,30 @@ test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   assert_contains "$out" '"non_runtime_only": true' "js comment output"
   assert_contains "$out" '"run_lint": true' "js comment output"
   assert_contains "$out" '"run_js_tests": false' "js comment output"
+}
+
+test_prose_comment_containing_webpack_is_not_a_runtime_directive() {
+  setup_repo
+  perl -0pi -e 's/export function/\/\/ Documents a webpack migration note.\nexport function/' \
+    packages/react-on-rails/src/example.ts
+  commit_change "webpack prose comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": true' "webpack prose output"
+  assert_contains "$out" '"run_js_tests": false' "webpack prose output"
+}
+
+test_code_line_starting_with_plus_plus_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/  return .ok.;/  \/\/ Count calls.\n  ++counter;\n  return counter.toString();/' \
+    packages/react-on-rails/src/example.ts
+  commit_change "prefix increment code"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "prefix increment output"
+  assert_contains "$out" '"run_js_tests": true' "prefix increment output"
 }
 
 test_spec_comment_only_change_skips_rspec() {
@@ -190,6 +214,8 @@ test_executable_source_change_remains_runtime_affecting() {
 run_test test_docs_changes_are_non_runtime_only
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_prose_comment_containing_webpack_is_not_a_runtime_directive
+run_test test_code_line_starting_with_plus_plus_remains_runtime_affecting
 run_test test_spec_comment_only_change_skips_rspec
 run_test test_ruby_magic_comment_remains_runtime_affecting
 run_test test_executable_source_change_remains_runtime_affecting

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -89,6 +89,11 @@ export function example(): string {
   return 'ok';
 }
 TS
+  cat > packages/react-on-rails/src/template.ts <<'TS'
+export const template = `
+// runtime fixture text
+`;
+TS
   cat > react_on_rails/spec/react_on_rails/example_spec.rb <<'RUBY'
 RSpec.describe "example" do
   it "works" do
@@ -175,6 +180,17 @@ test_code_line_starting_with_plus_plus_remains_runtime_affecting() {
   assert_contains "$out" '"run_js_tests": true' "prefix increment output"
 }
 
+test_comment_like_template_literal_change_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/runtime fixture text/changed fixture text/' packages/react-on-rails/src/template.ts
+  commit_change "template literal text"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "template literal output"
+  assert_contains "$out" '"run_js_tests": true' "template literal output"
+}
+
 test_spec_comment_only_change_skips_rspec() {
   setup_repo
   perl -0pi -e 's/it "works"/# Fixture intent.\n  it "works"/' \
@@ -186,6 +202,19 @@ test_spec_comment_only_change_skips_rspec() {
   assert_contains "$out" '"non_runtime_only": true' "spec comment output"
   assert_contains "$out" '"run_lint": true' "spec comment output"
   assert_contains "$out" '"run_ruby_tests": false' "spec comment output"
+}
+
+test_mixed_comment_and_code_change_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/    def call/    # Explain the fixture.\n    def call/' \
+    react_on_rails/lib/react_on_rails/example.rb
+  perl -0pi -e 's/"ok"/"changed"/' react_on_rails/lib/react_on_rails/example.rb
+  commit_change "mixed comment and code"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "mixed output"
+  assert_contains "$out" '"run_ruby_tests": true' "mixed output"
 }
 
 test_ruby_magic_comment_remains_runtime_affecting() {
@@ -216,7 +245,9 @@ run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_javascript_block_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_prose_comment_containing_webpack_is_not_a_runtime_directive
 run_test test_code_line_starting_with_plus_plus_remains_runtime_affecting
+run_test test_comment_like_template_literal_change_remains_runtime_affecting
 run_test test_spec_comment_only_change_skips_rspec
+run_test test_mixed_comment_and_code_change_remains_runtime_affecting
 run_test test_ruby_magic_comment_remains_runtime_affecting
 run_test test_executable_source_change_remains_runtime_affecting
 

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -564,9 +564,9 @@ test_resolve_logs_deepen_progress() {
   fi
   local stderr_text
   stderr_text="$(cat "$err_file")"
-  assert_contains "$stderr_text" "Deepening shallow history (attempt 1/3, depth 2)" "first deepen progress line"
-  assert_contains "$stderr_text" "Deepening shallow history (attempt 2/3, depth 4)" "second deepen progress line"
-  assert_contains "$stderr_text" "Deepening shallow history (attempt 3/3, depth 8)" "third deepen progress line"
+  assert_contains "$stderr_text" "Deepening shallow history (attempt 1/3, fetching 2 more commits)" "first deepen progress line"
+  assert_contains "$stderr_text" "Deepening shallow history (attempt 2/3, fetching 4 more commits)" "second deepen progress line"
+  assert_contains "$stderr_text" "Deepening shallow history (attempt 3/3, fetching 8 more commits)" "third deepen progress line"
   assert_contains "$stderr_text" "falling back to --unshallow" "unshallow fallback fires after budget exhausted"
 }
 


### PR DESCRIPTION
## Summary

- Adds a `non_runtime_only` CI detector signal for docs-only and conservative source comment-only changes.
- Lets `main` pushes skip heavyweight runtime suites for non-runtime-only changes while keeping lint active for source comment-only edits.
- Keeps required PR workflows on the PR base diff so a docs/comment-only follow-up cannot hide earlier runtime changes on the latest SHA.
- Treats comment directives that affect Ruby, TypeScript, webpack, Vite, Babel, JSX, sourcemaps, and license preservation as runtime-affecting.
  - Detects directives whether they appear in `//`, `#`, `/* … */`, JSDoc `/** … */`, or JSDoc-continuation `* …` form.
  - Recognises both Babel's `#__PURE__` and Rollup/Terser/esbuild's `@__PURE__` tree-shaking annotations.
- Keeps block-comment delimiter changes conservative when they can wrap existing Ruby or JavaScript/TypeScript code.
- Rejects single-line `/* … */ <code>` and `*/<code>` patterns (e.g., `/* istanbul ignore next */ exports.foo = bar;`) so a closed block comment followed by executable code is never misclassified as comment-only.
- Routes Pro Node Renderer comment-only changes through Pro lint, not standard lint.
- Adds CI detector shell coverage for docs, source comments, runtime directives, multiline comments, template literals, Pro Node Renderer routing, JSDoc / inline `/* @directive */` forms, `@__PURE__` annotations, trailing-code-after-`*/` lines, and mixed runtime edits.
- Test harness: declares its `perl` dependency in the header and propagates per-assertion failure messages out of the run-test subshell into the final summary instead of collapsing them to `subshell exited $rc`.

Fixes #3451

## Test Plan

- `bash script/ci-changes-detector-test.bash`
- `bash script/lib/git-diff-base-test.bash`
- `shellcheck -x script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/ci-changes-detector-test.bash`
- `actionlint -shellcheck= .github/workflows/benchmark.yml .github/workflows/detect-changes.yml .github/workflows/examples.yml .github/workflows/gem-tests.yml .github/workflows/git-diff-base-tests.yml .github/workflows/integration-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/package-js-tests.yml .github/workflows/playwright.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml`

## Notes

- `actionlint` was run with shellcheck integration disabled because existing unrelated workflow shell snippets emit shellcheck info/style findings under full actionlint; the workflow syntax pass itself is clean.
- Required PR checks intentionally continue using the PR base diff. True last-green incremental routing should be designed separately so branch protection cannot be bypassed by a lightweight follow-up commit.
- Comment-only classification is intentionally conservative: ambiguous multiline-string and block-comment cases run more CI rather than risk skipping runtime checks. Known coarse guards (full-file backtick presence for JS/TS, heredoc-shaped tokens for Ruby, unseeded `in_block_comment` across `--unified=0` hunk boundaries) are documented in PR threads and intentionally left as-is until traffic data justifies a tokenizer-backed replacement; see the address-review summary comments for the precise conditions that would change that.
