### PR TITLE
Improve RSC missing-client-boundary diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Fixed
+
+- **[Pro]** **RSC client-hook runtime errors now explain the missing client boundary**: React on Rails Pro now rewrites RSC runtime hook failures such as `useState is not a function` with a diagnostic that names the registered component, points to the likely missing `"use client";` directive, and clarifies that `.client`/`.server` suffixes only control bundle placement. Fixes [Issue 3184](https://github.com/shakacode/react_on_rails/issues/3184).
+
 ### [16.7.0.rc.3] - 2026-05-25
 
 #### Breaking Changes

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -37,8 +37,28 @@ import loadJsonFile from '../loadJsonFile.ts';
 
 let serverRendererPromise: Promise<ReturnType<typeof buildServerRenderer>> | undefined;
 
-const CLIENT_HOOK_RUNTIME_ERROR_REGEX =
-  /\b(?:React\.)?(useState|useEffect|useReducer|useCallback|useMemo|useRef|useLayoutEffect|useImperativeHandle|useContext|useSyncExternalStore|useTransition|useDeferredValue) is not a function\b/;
+const CLIENT_HOOK_NAMES = [
+  'useState',
+  'useEffect',
+  'useReducer',
+  'useCallback',
+  'useMemo',
+  'useRef',
+  'useLayoutEffect',
+  'useImperativeHandle',
+  'useContext',
+  'useSyncExternalStore',
+  'useTransition',
+  'useDeferredValue',
+  'useId',
+  'useDebugValue',
+  'useInsertionEffect',
+  'useOptimistic',
+  'useActionState',
+].join('|');
+const CLIENT_HOOK_RUNTIME_ERROR_REGEX = new RegExp(
+  `(?:(?:React\\.)|\\(0\\s*,\\s*[\\w$]+\\.)?(${CLIENT_HOOK_NAMES})\\)? is not a function\\b`,
+);
 
 const addRSCClientHookDiagnostic = (error: Error, componentName: string): Error => {
   const match = error.message.match(CLIENT_HOOK_RUNTIME_ERROR_REGEX);
@@ -59,7 +79,10 @@ const addRSCClientHookDiagnostic = (error: Error, componentName: string): Error 
 
   enhancedError.name = error.name;
   enhancedError.cause = error;
-  enhancedError.stack = `${enhancedError.name}: ${enhancedError.message}\nCaused by: ${error.stack || error.message}`;
+  const enhancedStackFrames = enhancedError.stack?.split('\n').slice(1).join('\n');
+  enhancedError.stack = `${enhancedError.name}: ${enhancedError.message}${
+    enhancedStackFrames ? `\n${enhancedStackFrames}` : ''
+  }\nCaused by: ${error.stack || error.message}`;
 
   return enhancedError;
 };
@@ -83,7 +106,7 @@ const streamRenderRSCComponent = (
   const { pipeToTransform, readableStream, emitError } =
     transformRenderStreamChunksToResultObject(renderState);
 
-  const reportError = (error: Error) => {
+  const reportError = (error: Error): Error => {
     const diagnosticError = addRSCClientHookDiagnostic(error, componentName);
     console.error('Error in RSC stream', diagnosticError);
     if (throwJsErrors) {

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -37,12 +37,39 @@ import loadJsonFile from '../loadJsonFile.ts';
 
 let serverRendererPromise: Promise<ReturnType<typeof buildServerRenderer>> | undefined;
 
+const CLIENT_HOOK_RUNTIME_ERROR_REGEX =
+  /\b(?:React\.)?(useState|useEffect|useReducer|useCallback|useMemo|useRef|useLayoutEffect|useImperativeHandle|useContext|useSyncExternalStore|useTransition|useDeferredValue) is not a function\b/;
+
+const addRSCClientHookDiagnostic = (error: Error, componentName: string): Error => {
+  const match = error.message.match(CLIENT_HOOK_RUNTIME_ERROR_REGEX);
+  if (!match) return error;
+
+  const hookName = match[1];
+  const enhancedError = new Error(
+    `[React on Rails Pro] Component "${componentName}" called client hook "${hookName}" while rendering in ` +
+      `the React Server Components runtime.\n\n` +
+      `Most likely cause: "${componentName}", or a component it imports, uses client-only APIs but is missing ` +
+      `the '"use client";' directive.\n\n` +
+      `Add '"use client";' as the first statement of the client component file, or move hooks, event handlers, ` +
+      `and class components into a separate client component.\n\n` +
+      `Note: .client/.server file suffixes only control bundle placement. The '"use client";' directive controls ` +
+      `RSC client/server classification.\n\n` +
+      `Original error: ${error.message}`,
+  ) as Error & { cause?: unknown };
+
+  enhancedError.name = error.name;
+  enhancedError.cause = error;
+  enhancedError.stack = `${enhancedError.name}: ${enhancedError.message}\nCaused by: ${error.stack || error.message}`;
+
+  return enhancedError;
+};
+
 const streamRenderRSCComponent = (
   reactRenderingResult: StreamableComponentResult,
   options: RSCRenderParams,
   streamingTrackers: StreamingTrackers,
 ): Readable => {
-  const { throwJsErrors } = options;
+  const { name: componentName, throwJsErrors } = options;
   const { railsContext } = options;
   assertRailsContextWithServerStreamingCapabilities(railsContext);
 
@@ -57,12 +84,15 @@ const streamRenderRSCComponent = (
     transformRenderStreamChunksToResultObject(renderState);
 
   const reportError = (error: Error) => {
-    console.error('Error in RSC stream', error);
+    const diagnosticError = addRSCClientHookDiagnostic(error, componentName);
+    console.error('Error in RSC stream', diagnosticError);
     if (throwJsErrors) {
-      emitError(error);
+      emitError(diagnosticError);
     }
     renderState.hasErrors = true;
-    renderState.error = error;
+    renderState.error = diagnosticError;
+
+    return diagnosticError;
   };
 
   const initializeAndRender = async () => {
@@ -86,8 +116,7 @@ const streamRenderRSCComponent = (
   };
 
   initializeAndRender().catch((e: unknown) => {
-    const error = convertToError(e);
-    reportError(error);
+    const error = reportError(convertToError(e));
     const errorHtml = handleError({ e: error, name: options.name, serverSide: true });
     pipeToTransform(errorHtml);
   });

--- a/packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx
+++ b/packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx
@@ -41,7 +41,14 @@ const PromiseContainer = ({ name }: { name: string }) => {
   );
 };
 
-ReactOnRails.register({ PromiseContainer });
+const HooksWithoutClientDirective = () => {
+  const { useState } = React;
+  useState('client state');
+
+  return <p>Client hook in RSC runtime</p>;
+};
+
+ReactOnRails.register({ HooksWithoutClientDirective, PromiseContainer });
 
 const manifestFileDirectory = path.resolve(__dirname, '../src');
 const clientManifestPath = path.join(manifestFileDirectory, 'react-client-manifest.json');
@@ -157,4 +164,31 @@ test('[bug] catches logs outside the component during reading the stream', async
   expect(content1).not.toContain('From Interval');
   // Here's the bug
   expect(content1).toContain('Outside The Component');
+});
+
+test('explains likely missing use client directive when a server component calls a client hook', async () => {
+  const readable = ReactOnRails.serverRenderRSCReactComponent({
+    railsContext: {
+      reactClientManifestFileName: 'react-client-manifest.json',
+      reactServerClientManifestFileName: 'react-server-client-manifest.json',
+    } as unknown as RailsContextWithServerStreamingCapabilities,
+    name: 'HooksWithoutClientDirective',
+    renderingReturnsPromises: true,
+    throwJsErrors: true,
+    domNodeId: 'dom-id',
+    props: {},
+  });
+
+  let error: unknown;
+  try {
+    await text(readable);
+  } catch (e) {
+    error = e;
+  }
+
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toContain('HooksWithoutClientDirective');
+  expect((error as Error).message).toContain('client hook');
+  expect((error as Error).message).toContain('"use client";');
+  expect((error as Error).message).toContain('Original error: useState is not a function');
 });

--- a/packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx
+++ b/packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx
@@ -4,12 +4,13 @@
 /// <reference types="react/experimental" />
 
 import * as React from 'react';
-import { Suspense } from 'react';
+import { Suspense, useInsertionEffect, useState } from 'react';
 import * as mock from 'mock-fs';
 import * as path from 'path';
 import { finished } from 'stream/promises';
 import { text } from 'stream/consumers';
 import ReactOnRails, { RailsContextWithServerStreamingCapabilities } from '../src/ReactOnRailsRSC.ts';
+import LengthPrefixedStreamParser from '../src/parseLengthPrefixedStream.ts';
 
 const PromiseWrapper = async ({ promise, name }: { promise: Promise<string>; name: string }) => {
   console.log(`[${name}] Before awaitng`);
@@ -42,16 +43,66 @@ const PromiseContainer = ({ name }: { name: string }) => {
 };
 
 const HooksWithoutClientDirective = () => {
-  const { useState } = React;
   useState('client state');
 
   return <p>Client hook in RSC runtime</p>;
 };
 
-ReactOnRails.register({ HooksWithoutClientDirective, PromiseContainer });
+const InsertionEffectWithoutClientDirective = () => {
+  useInsertionEffect(() => undefined);
+
+  return <p>Client insertion effect in RSC runtime</p>;
+};
+
+ReactOnRails.register({
+  HooksWithoutClientDirective,
+  InsertionEffectWithoutClientDirective,
+  PromiseContainer,
+});
 
 const manifestFileDirectory = path.resolve(__dirname, '../src');
 const clientManifestPath = path.join(manifestFileDirectory, 'react-client-manifest.json');
+
+type ParsedRSCChunk = {
+  html: string;
+  hasErrors?: boolean;
+  renderingError?: {
+    message?: string;
+    stack?: string;
+  };
+};
+
+const parseLengthPrefixedChunks = (str: string) => {
+  const parser = new LengthPrefixedStreamParser();
+  const results: ParsedRSCChunk[] = [];
+  parser.feed(new TextEncoder().encode(str), (content, metadata) => {
+    results.push({ html: new TextDecoder().decode(content), ...metadata });
+  });
+  return results;
+};
+
+const renderRSCComponent = (name: string, throwJsErrors: boolean) =>
+  ReactOnRails.serverRenderRSCReactComponent({
+    railsContext: {
+      reactClientManifestFileName: 'react-client-manifest.json',
+      reactServerClientManifestFileName: 'react-server-client-manifest.json',
+    } as unknown as RailsContextWithServerStreamingCapabilities,
+    name,
+    renderingReturnsPromises: true,
+    throwJsErrors,
+    domNodeId: 'dom-id',
+    props: {},
+  });
+
+const captureRenderedError = async (name: string) => {
+  let error: unknown;
+  try {
+    await text(renderRSCComponent(name, true));
+  } catch (e) {
+    error = e;
+  }
+  return error;
+};
 
 beforeEach(() => {
   mock({
@@ -167,28 +218,43 @@ test('[bug] catches logs outside the component during reading the stream', async
 });
 
 test('explains likely missing use client directive when a server component calls a client hook', async () => {
-  const readable = ReactOnRails.serverRenderRSCReactComponent({
-    railsContext: {
-      reactClientManifestFileName: 'react-client-manifest.json',
-      reactServerClientManifestFileName: 'react-server-client-manifest.json',
-    } as unknown as RailsContextWithServerStreamingCapabilities,
-    name: 'HooksWithoutClientDirective',
-    renderingReturnsPromises: true,
-    throwJsErrors: true,
-    domNodeId: 'dom-id',
-    props: {},
-  });
-
-  let error: unknown;
-  try {
-    await text(readable);
-  } catch (e) {
-    error = e;
-  }
+  const error = await captureRenderedError('HooksWithoutClientDirective');
 
   expect(error).toBeInstanceOf(Error);
   expect((error as Error).message).toContain('HooksWithoutClientDirective');
   expect((error as Error).message).toContain('client hook');
   expect((error as Error).message).toContain('"use client";');
-  expect((error as Error).message).toContain('Original error: useState is not a function');
+  expect((error as Error).message).toContain('Original error:');
+  expect((error as Error).message).toContain('useState');
+  expect((error as Error).message).toContain('is not a function');
+  expect((error as Error).message).toContain((error as Error & { cause: Error }).cause.message);
+  expect((error as Error & { cause: Error }).cause.message).toContain('useState');
+  expect((error as Error & { cause: Error }).cause.message).toContain('is not a function');
+  expect((error as Error).stack).toContain('addRSCClientHookDiagnostic');
+  expect((error as Error).stack).toContain('Caused by:');
+});
+
+test('explains likely missing use client directive for newer client hooks', async () => {
+  const error = await captureRenderedError('InsertionEffectWithoutClientDirective');
+
+  expect(error).toBeInstanceOf(Error);
+  expect((error as Error).message).toContain('InsertionEffectWithoutClientDirective');
+  expect((error as Error).message).toContain('client hook "useInsertionEffect"');
+  expect((error as Error).message).toContain('"use client";');
+  expect((error as Error).message).toContain('Original error:');
+  expect((error as Error).message).toContain('useInsertionEffect');
+  expect((error as Error).message).toContain('is not a function');
+});
+
+test('reports the client hook diagnostic in stream metadata when throwJsErrors is false', async () => {
+  const renderResult = await text(renderRSCComponent('HooksWithoutClientDirective', false));
+  const chunks = parseLengthPrefixedChunks(renderResult);
+  const errorChunk = chunks.find((chunk) => chunk.hasErrors);
+
+  expect(errorChunk?.renderingError?.message).toContain('HooksWithoutClientDirective');
+  expect(errorChunk?.renderingError?.message).toContain('client hook');
+  expect(errorChunk?.renderingError?.message).toContain('"use client";');
+  expect(errorChunk?.renderingError?.message).toContain('Original error:');
+  expect(errorChunk?.renderingError?.message).toContain('useState');
+  expect(errorChunk?.renderingError?.message).toContain('is not a function');
 });


### PR DESCRIPTION
### Summary

Improves React on Rails Pro RSC diagnostics for missing client boundaries. Client-hook runtime failures now name the registered component and hook, preserve the original error through `cause`, keep the wrapper stack before the original stack, and point users to the missing `"use client";` directive instead of surfacing only a low-level `is not a function` error.

This also handles direct hook imports compiled as `(0, react_1.useState) is not a function`, plus `React.useState` and bare `useState` forms. The hook matcher now covers additional React 18/19 client hooks including `useId`, `useDebugValue`, `useInsertionEffect`, `useOptimistic`, and `useActionState`.

### Review updates

- Expanded client-hook diagnostic coverage for newer React hooks.
- Preserved the wrapping diagnostic stack before appending the original stack.
- Made `reportError`'s `Error` return contract explicit.
- Added coverage for direct hook imports, the `cause` chain, and the `throwJsErrors: false` stream metadata path.
- Left React 19 `use` out of the client-hook list intentionally: `use` is valid in Server Components, so diagnosing `use is not a function` as a missing client boundary would be misleading.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Validation

- `NODE_CONDITIONS=react-server pnpm --filter react-on-rails-pro exec jest tests/serverRenderRSCReactComponent.rsc.test.tsx --runInBand`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm run lint`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/capabilities/proRSC.ts packages/react-on-rails-pro/tests/serverRenderRSCReactComponent.rsc.test.tsx`
- `git diff --check`

Note: `pnpm start format.listDifferent` currently fails only on the gitignored local Conductor attachment `.context/attachments/7UCCM9/PR instructions.md`; the PR files pass Prettier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for React Server Components to provide clearer, more targeted error messages when client hooks are used in server components, including guidance on establishing proper component boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->