### PR TITLE
[codex] Use neutral test asset build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **[Pro]** **RSC client-hook runtime errors now explain the missing client boundary**: React on Rails Pro now rewrites RSC runtime hook failures such as `useState is not a function` with a diagnostic that names the registered component, points to the likely missing `"use client";` directive, and clarifies that `.client`/`.server` suffixes only control bundle placement. Fixes [Issue 3184](https://github.com/shakacode/react_on_rails/issues/3184).
+- **Test asset compiler output is now bundler-neutral**: Stale test asset compilation now prints "Building assets..." and "Completed building assets." instead of Webpack-specific wording, avoiding misleading output in Rspack apps. Fixes [Issue 3455](https://github.com/shakacode/react_on_rails/issues/3455). [PR 3462](https://github.com/shakacode/react_on_rails/pull/3462) by [justin808](https://github.com/justin808).
 
 ### [16.7.0.rc.3] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **[Pro]** **RSC client-hook runtime errors now explain the missing client boundary**: React on Rails Pro now rewrites RSC runtime hook failures such as `useState is not a function` with a diagnostic that names the registered component, points to the likely missing `"use client";` directive, and clarifies that `.client`/`.server` suffixes only control bundle placement. Fixes [Issue 3184](https://github.com/shakacode/react_on_rails/issues/3184).
-- **Test asset compiler output is now bundler-neutral**: Test asset compilation now prints "Building assets..." and "Completed building assets." instead of Webpack-specific wording, avoiding misleading output in Rspack apps. Fixes [Issue 3455](https://github.com/shakacode/react_on_rails/issues/3455). [PR 3462](https://github.com/shakacode/react_on_rails/pull/3462) by [justin808](https://github.com/justin808).
+- **Test asset compiler output is now bundler-neutral**: Test asset compilation now prints "Building assets..." and "Completed building assets." instead of Webpack-specific wording, and failure guidance tells users to rerun their configured `build_test_command` instead of naming Shakapacker. Fixes [Issue 3455](https://github.com/shakacode/react_on_rails/issues/3455). [PR 3462](https://github.com/shakacode/react_on_rails/pull/3462) by [justin808](https://github.com/justin808).
 
 ### [16.7.0.rc.3] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **[Pro]** **RSC client-hook runtime errors now explain the missing client boundary**: React on Rails Pro now rewrites RSC runtime hook failures such as `useState is not a function` with a diagnostic that names the registered component, points to the likely missing `"use client";` directive, and clarifies that `.client`/`.server` suffixes only control bundle placement. Fixes [Issue 3184](https://github.com/shakacode/react_on_rails/issues/3184).
-- **Test asset compiler output is now bundler-neutral**: Stale test asset compilation now prints "Building assets..." and "Completed building assets." instead of Webpack-specific wording, avoiding misleading output in Rspack apps. Fixes [Issue 3455](https://github.com/shakacode/react_on_rails/issues/3455). [PR 3462](https://github.com/shakacode/react_on_rails/pull/3462) by [justin808](https://github.com/justin808).
+- **Test asset compiler output is now bundler-neutral**: Test asset compilation now prints "Building assets..." and "Completed building assets." instead of Webpack-specific wording, avoiding misleading output in Rspack apps. Fixes [Issue 3455](https://github.com/shakacode/react_on_rails/issues/3455). [PR 3462](https://github.com/shakacode/react_on_rails/pull/3462) by [justin808](https://github.com/justin808).
 
 ### [16.7.0.rc.3] - 2026-05-25
 

--- a/docs/oss/building-features/dev-server-and-testing.md
+++ b/docs/oss/building-features/dev-server-and-testing.md
@@ -264,15 +264,15 @@ HMR assets cannot be reused for tests — they exist in webpack-dev-server memor
 
 **Fix:** Use `bin/dev static` instead, or run `bin/dev test-watch` alongside HMR. If you have TestHelper configured, this is just informational — it will compile test assets separately.
 
-### `React on Rails: Error building webpack assets!`
+### `React on Rails: Error building test assets!`
 
 ```text
-React on Rails: Error building webpack assets!
+React on Rails: Error building test assets!
 
 The build_test_command failed. This means test assets could not be compiled.
 ```
 
-**Fix:** Check the build output above this message for the actual webpack error. Quick workaround: `bin/dev static` or `RAILS_ENV=test bin/shakapacker` to compile manually.
+**Fix:** Check the build output above this message for the actual build error. Quick workarounds: `bin/dev static`, `bin/dev test-watch`, or rerun your configured `build_test_command` manually.
 
 ### Blank pages in Capybara system tests (no Ruby error)
 

--- a/react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb
+++ b/react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb
@@ -56,7 +56,7 @@ module ReactOnRails
           Quick alternatives to get unblocked:
             • Run 'bin/dev static' in another terminal (assets auto-reuse for tests)
             • Run 'bin/dev test-watch' to keep test assets fresh in the background
-            • Run 'RAILS_ENV=test bin/shakapacker' manually to compile once
+            • Run '#{ReactOnRails.configuration.build_test_command}' manually to compile once
 
           For full details: #{TESTING_DOCS_URL}
           Run 'bin/dev --help' for development server modes.

--- a/react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb
+++ b/react_on_rails/lib/react_on_rails/test_helper/webpack_assets_compiler.rb
@@ -13,7 +13,7 @@ module ReactOnRails
           exit!(1)
         end
 
-        puts "\nBuilding Webpack assets..."
+        puts "\nBuilding assets..."
 
         cmd = ReactOnRails::Utils.prepend_cd_node_modules_directory(
           ReactOnRails.configuration.build_test_command
@@ -21,7 +21,7 @@ module ReactOnRails
 
         ReactOnRails::Utils.invoke_and_exit_if_failed(cmd, compilation_failed_message)
 
-        puts "Completed building Webpack assets."
+        puts "Completed building assets."
       end
 
       private
@@ -49,7 +49,7 @@ module ReactOnRails
 
       def compilation_failed_message
         <<~MSG
-          React on Rails: Error building webpack assets!
+          React on Rails: Error building test assets!
 
           The build_test_command failed. This means test assets could not be compiled.
 

--- a/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
+++ b/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
@@ -3,8 +3,8 @@
 require_relative "../spec_helper"
 
 describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
-  describe "#ensureAssetsCompiled" do
-    let(:invalid_command) { "sh -c 'exit 1'" }
+  describe "#compile_assets" do
+    let(:invalid_command) { "false" }
     let(:valid_command) { "true" }
 
     context "when assets compiler command succeeds" do
@@ -48,6 +48,20 @@ describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
           "React on Rails: Error building test assets!.*" \
           "cmd: cd \"#{escaped_root}\" && #{escaped_cmd}.*" \
           "exitstatus: 1",
+          Regexp::MULTILINE
+        )
+
+        expect do
+          described_class.new.compile_assets
+        rescue SystemExit
+          # No op
+        end.to output(expected_pattern).to_stderr
+      end
+
+      it "suggests rerunning the configured build command without naming a specific bundler" do
+        expected_command = Regexp.escape("Run '#{invalid_command}' manually to compile once")
+        expected_pattern = Regexp.new(
+          "\\A(?=.*#{expected_command})(?!.*bin/shakapacker).*\\z",
           Regexp::MULTILINE
         )
 

--- a/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
+++ b/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
@@ -19,6 +19,9 @@ describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
         expect do
           described_class.new.compile_assets
         end.to output("\nBuilding assets...\nCompleted building assets.\n").to_stdout
+
+        # Assert the compile step actually ran, so the example fails if it is skipped.
+        expect(ReactOnRails::Utils).to have_received(:invoke_and_exit_if_failed)
       end
     end
 
@@ -58,18 +61,20 @@ describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
         end.to output(expected_pattern).to_stderr
       end
 
-      it "suggests rerunning the configured build command without naming a specific bundler" do
-        expected_command = Regexp.escape("Run '#{invalid_command}' manually to compile once")
-        expected_pattern = Regexp.new(
-          "\\A(?=.*#{expected_command})(?!.*bin/shakapacker).*\\z",
-          Regexp::MULTILINE
-        )
-
+      it "suggests rerunning the configured build command" do
         expect do
           described_class.new.compile_assets
         rescue SystemExit
           # No op
-        end.to output(expected_pattern).to_stderr
+        end.to output(include("Run '#{invalid_command}' manually to compile once")).to_stderr
+      end
+
+      it "does not name a specific bundler in the rerun suggestion" do
+        expect do
+          described_class.new.compile_assets
+        rescue SystemExit
+          # No op
+        end.not_to output(include("bin/shakapacker")).to_stderr
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
+++ b/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
@@ -5,7 +5,7 @@ require_relative "../spec_helper"
 describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
   describe "#ensureAssetsCompiled" do
     let(:invalid_command) { "sh -c 'exit 1'" }
-    let(:valid_command) { "RAILS_ENV=test bin/shakapacker" }
+    let(:valid_command) { "true" }
 
     context "when assets compiler command succeeds" do
       before do

--- a/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
+++ b/react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb
@@ -5,6 +5,22 @@ require_relative "../spec_helper"
 describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
   describe "#ensureAssetsCompiled" do
     let(:invalid_command) { "sh -c 'exit 1'" }
+    let(:valid_command) { "RAILS_ENV=test bin/shakapacker" }
+
+    context "when assets compiler command succeeds" do
+      before do
+        allow(ReactOnRails.configuration)
+          .to receive(:build_test_command)
+          .and_return(valid_command)
+        allow(ReactOnRails::Utils).to receive(:invoke_and_exit_if_failed)
+      end
+
+      it "prints bundler-neutral build messages" do
+        expect do
+          described_class.new.compile_assets
+        end.to output("\nBuilding assets...\nCompleted building assets.\n").to_stdout
+      end
+    end
 
     context "when assets compiler command is invalid" do
       before do
@@ -29,7 +45,7 @@ describe ReactOnRails::TestHelper::WebpackAssetsCompiler do
         escaped_cmd = Regexp.escape(invalid_command)
         expected_pattern = Regexp.new(
           "React on Rails FATAL ERROR!.*" \
-          "React on Rails: Error building webpack assets!.*" \
+          "React on Rails: Error building test assets!.*" \
           "cmd: cd \"#{escaped_root}\" && #{escaped_cmd}.*" \
           "exitstatus: 1",
           Regexp::MULTILINE


### PR DESCRIPTION
## Summary

- Use bundler-neutral wording when the test asset compiler starts and finishes.
- Update the test asset compiler failure banner to say "test assets" instead of "webpack assets".
- Add a regression spec for the compiler output.

Fixes #3455.

## Test Plan

- `bundle exec rspec react_on_rails/spec/react_on_rails/test_helper/webpack_assets_compiler_spec.rb`
- `(cd react_on_rails && bundle exec rubocop)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing log and error text only in the test helper; compile behavior is unchanged.
> 
> **Overview**
> Test asset compilation output and failure guidance no longer assume Shakapacker/Webpack. **Progress and error copy** in `WebpackAssetsCompiler` now say “Building assets…” / “test assets” instead of “Webpack assets,” and the failure banner tells users to rerun their configured `build_test_command` (interpolated from config) rather than hard-coding `RAILS_ENV=test bin/shakapacker`.
> 
> **Docs and changelog** mirror the same wording in the dev-server/testing troubleshooting section. **Specs** were expanded around `#compile_assets` to lock in the neutral stdout messages and to assert the stderr rerun hint uses the configured command and does not mention `bin/shakapacker`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad3bebc41cff57eb2b44bd72f51b2244d606921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test asset compilation now displays bundler-neutral status messages ("Building assets..." / "Completed building assets.")
  * Error messages and recovery guidance updated to reference the configured build command rather than specific bundler names.

* **Documentation**
  * Updated troubleshooting section for test asset compilation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->