### PR TITLE
Improve RSC render failure diagnostics

### DIFF
--- a/.bundle-size-skip-branch
+++ b/.bundle-size-skip-branch
@@ -4,3 +4,4 @@
 # Usage: Run `bin/skip-bundle-size-check` to set the current branch, then commit and push.
 #
 # This is useful when you have an intentional size increase that exceeds the 0.5KB threshold.
+jg-conductor/fix-3182

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Destructive git operations: `reset --hard` on a branch with work, branch deletion, or force-push that drops/squashes commits, republishes a conflicted rebase, or runs when the remote has commits you don't have locally. (Force-push after a clean rebase — no conflicts, all commits preserved — is OK without asking.)
 - Changes to CI workflows (`.github/workflows/`)
 - Changes to build configuration (`package.json` scripts, webpack config)
+- Modifying the Pro package (`react_on_rails_pro/`)
 
 ### Never
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,6 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Destructive git operations: `reset --hard` on a branch with work, branch deletion, or force-push that drops/squashes commits, republishes a conflicted rebase, or runs when the remote has commits you don't have locally. (Force-push after a clean rebase — no conflicts, all commits preserved — is OK without asking.)
 - Changes to CI workflows (`.github/workflows/`)
 - Changes to build configuration (`package.json` scripts, webpack config)
-- Modifying the Pro package (`react_on_rails_pro/`)
 
 ### Never
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **RSC client-hook runtime errors now explain the missing client boundary**: React on Rails Pro now rewrites RSC runtime hook failures such as `useState is not a function` with a diagnostic that names the registered component, points to the likely missing `"use client";` directive, and clarifies that `.client`/`.server` suffixes only control bundle placement. Fixes [Issue 3184](https://github.com/shakacode/react_on_rails/issues/3184).
 - **Test asset compiler output is now bundler-neutral**: Test asset compilation now prints "Building assets..." and "Completed building assets." instead of Webpack-specific wording, and failure guidance tells users to rerun their configured `build_test_command` instead of naming Shakapacker. Fixes [Issue 3455](https://github.com/shakacode/react_on_rails/issues/3455). [PR 3462](https://github.com/shakacode/react_on_rails/pull/3462) by [justin808](https://github.com/justin808).
+- **[Pro]** **RSC stream failures now surface original diagnostics**: RSC payload stream metadata now preserves the original RSC bundle exception message, stack, component name, and module path where available across server-bundle rendering, Rails `PrerenderError`, and browser fetch paths. Fixes [Issue 3182](https://github.com/shakacode/react_on_rails/issues/3182). [PR 3463](https://github.com/shakacode/react_on_rails/pull/3463) by [justin808](https://github.com/justin808).
 
 ### [16.7.0.rc.3] - 2026-05-25
 

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -118,6 +118,10 @@ const createFromFetch = async (
   });
 
   const renderPromise = createFromReadableStream<React.ReactNode>(transformedStream);
+  // `rscDiagnosticError` is populated synchronously while the stream is parsed in the
+  // ReadableStream `start` callback above. React cannot produce a render error until it has
+  // consumed that stream, so by the time `renderPromise` rejects the diagnostic — if the
+  // stream carried one — is already set; it is never undefined purely because of timing.
   return wrapInNewPromise(renderPromise).catch((error: unknown) => {
     throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
   });

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -118,7 +118,7 @@ const createFromFetch = async (
   return wrapInNewPromise(renderPromise)
     .then((result) => {
       if (result instanceof Error && rscDiagnosticError) {
-        throw mergeRSCStreamDiagnosticError(result, rscDiagnosticError);
+        throw result;
       }
       return result;
     })

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -159,12 +159,15 @@ const fetchRSC = ({
     const propsString = JSON.stringify(componentProps);
     const strippedUrlPath = rscPayloadGenerationUrlPath.replace(/^\/|\/$/g, '');
     const encodedParams = new URLSearchParams({ props: propsString }).toString();
-    const fetchUrl = `/${strippedUrlPath}/${componentName}?${encodedParams}`;
+    const sourcePath = `/${strippedUrlPath}/${componentName}`;
+    const fetchUrl = `${sourcePath}?${encodedParams}`;
 
     return createFromFetch(fetch(fetchUrl), {
       componentName,
       cspNonce: railsContext.cspNonce,
-      source: fetchUrl,
+      // Keep `source` query-string free so serialized props aren't echoed into error messages
+      // or attached error-monitoring events. The outer wrapper below retains `fetchUrl` for reproducibility.
+      source: sourcePath,
     }).catch((error: unknown) => {
       // RSC stream diagnostic errors already carry component/source context — preserve them
       // (including .cause and the merged stack) instead of flattening to a plain Error.

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -86,7 +86,6 @@ const createFromFetch = async (
     const diagnosticError = buildRSCStreamDiagnosticError(metadata, { componentName, source });
     if (diagnosticError && !rscDiagnosticError) {
       rscDiagnosticError = diagnosticError;
-      console.error(diagnosticError);
     }
   };
 

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -18,6 +18,7 @@ import { RailsContext } from 'react-on-rails/types';
 import { createRSCPayloadKey, fetch, wrapInNewPromise, extractErrorMessage } from './utils.ts';
 import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import LengthPrefixedStreamParser from './parseLengthPrefixedStream.ts';
+import { buildRSCStreamDiagnosticError, mergeRSCStreamDiagnosticError } from './rscDiagnostics.ts';
 
 declare global {
   interface Window {
@@ -56,7 +57,18 @@ const replayConsole = (consoleReplayScript: string, nonce?: string) => {
  *
  * Extracts raw Flight data for React, replays console from metadata.
  */
-const createFromFetch = async (fetchPromise: Promise<Response>, cspNonce?: string) => {
+const createFromFetch = async (
+  fetchPromise: Promise<Response>,
+  {
+    componentName,
+    cspNonce,
+    source,
+  }: {
+    componentName: string;
+    cspNonce?: string;
+    source: string;
+  },
+) => {
   const response = await fetchPromise;
   const { body } = response;
   if (!body) {
@@ -65,6 +77,14 @@ const createFromFetch = async (fetchPromise: Promise<Response>, cspNonce?: strin
 
   const nonce = sanitizeNonce(cspNonce);
   const parser = new LengthPrefixedStreamParser();
+  let rscDiagnosticError: Error | undefined;
+  const reportDiagnosticError = (metadata: Record<string, unknown>) => {
+    const diagnosticError = buildRSCStreamDiagnosticError(metadata, { componentName, source });
+    if (diagnosticError && !rscDiagnosticError) {
+      rscDiagnosticError = diagnosticError;
+      console.error(diagnosticError);
+    }
+  };
 
   const transformedStream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -77,6 +97,7 @@ const createFromFetch = async (fetchPromise: Promise<Response>, cspNonce?: strin
           done = readResult.done;
           if (readResult.value) {
             parser.feed(readResult.value, (content, metadata) => {
+              reportDiagnosticError(metadata);
               controller.enqueue(content);
               const consoleScript = (metadata.consoleReplayScript as string) ?? '';
               if (consoleScript) {
@@ -94,7 +115,16 @@ const createFromFetch = async (fetchPromise: Promise<Response>, cspNonce?: strin
   });
 
   const renderPromise = createFromReadableStream<React.ReactNode>(transformedStream);
-  return wrapInNewPromise(renderPromise);
+  return wrapInNewPromise(renderPromise)
+    .then((result) => {
+      if (result instanceof Error && rscDiagnosticError) {
+        throw mergeRSCStreamDiagnosticError(result, rscDiagnosticError);
+      }
+      return result;
+    })
+    .catch((error: unknown) => {
+      throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
+    });
 };
 
 /**
@@ -134,7 +164,11 @@ const fetchRSC = ({
     const encodedParams = new URLSearchParams({ props: propsString }).toString();
     const fetchUrl = `/${strippedUrlPath}/${componentName}?${encodedParams}`;
 
-    return createFromFetch(fetch(fetchUrl), railsContext.cspNonce).catch((error: unknown) => {
+    return createFromFetch(fetch(fetchUrl), {
+      componentName,
+      cspNonce: railsContext.cspNonce,
+      source: fetchUrl,
+    }).catch((error: unknown) => {
       throw new Error(
         `Failed to fetch RSC payload for component "${componentName}" from "${fetchUrl}": ${extractErrorMessage(error)}`,
       );

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -18,7 +18,11 @@ import { RailsContext } from 'react-on-rails/types';
 import { createRSCPayloadKey, fetch, wrapInNewPromise, extractErrorMessage } from './utils.ts';
 import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import LengthPrefixedStreamParser from './parseLengthPrefixedStream.ts';
-import { buildRSCStreamDiagnosticError, mergeRSCStreamDiagnosticError } from './rscDiagnostics.ts';
+import {
+  buildRSCStreamDiagnosticError,
+  mergeRSCStreamDiagnosticError,
+  RSC_STREAM_DIAGNOSTIC_ERROR_NAME,
+} from './rscDiagnostics.ts';
 
 declare global {
   interface Window {
@@ -115,16 +119,9 @@ const createFromFetch = async (
   });
 
   const renderPromise = createFromReadableStream<React.ReactNode>(transformedStream);
-  return wrapInNewPromise(renderPromise)
-    .then((result) => {
-      if (result instanceof Error && rscDiagnosticError) {
-        throw result;
-      }
-      return result;
-    })
-    .catch((error: unknown) => {
-      throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
-    });
+  return wrapInNewPromise(renderPromise).catch((error: unknown) => {
+    throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
+  });
 };
 
 /**
@@ -169,9 +166,14 @@ const fetchRSC = ({
       cspNonce: railsContext.cspNonce,
       source: fetchUrl,
     }).catch((error: unknown) => {
-      throw new Error(
+      // RSC stream diagnostic errors already carry component/source context — preserve them
+      // (including .cause and the merged stack) instead of flattening to a plain Error.
+      if (error instanceof Error && error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME) throw error;
+      const wrapper: Error & { cause?: unknown } = new Error(
         `Failed to fetch RSC payload for component "${componentName}" from "${fetchUrl}": ${extractErrorMessage(error)}`,
       );
+      wrapper.cause = error;
+      throw wrapper;
     });
   } catch (error: unknown) {
     // Handle JSON.stringify errors or other synchronous errors

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -236,12 +236,24 @@ const createRSCStreamFromArray = (payloads: string[]) => {
  * the payload is already embedded in the page.
  *
  * @param payloads - Array of raw Flight data strings from the global array
+ * @param componentName - Name of the server component, used for error context
  * @returns A Promise resolving to the rendered React element
  */
-const createFromPreloadedPayloads = (payloads: string[]) => {
+const createFromPreloadedPayloads = (payloads: string[], componentName: string) => {
   const stream = createRSCStreamFromArray(payloads);
   const renderPromise = createFromReadableStream<React.ReactNode>(stream);
-  return wrapInNewPromise(renderPromise);
+  return wrapInNewPromise(renderPromise).catch((error: unknown) => {
+    // Preloaded payloads carry only raw Flight data — the server consumes the length-prefixed
+    // `renderingError` metadata during injection (see injectRSCPayload), so there is no RSC
+    // bundle diagnostic to merge here. Still, name the failing component (and preserve the
+    // original error as `cause`) so a hydration failure is attributable instead of surfacing a
+    // bare React error.
+    const wrapper: Error & { cause?: unknown } = new Error(
+      `Failed to hydrate preloaded RSC payload for component "${componentName}": ${extractErrorMessage(error)}`,
+    );
+    wrapper.cause = error;
+    throw wrapper;
+  });
 };
 
 /**
@@ -283,7 +295,7 @@ const getReactServerComponent =
       const rscPayloadKey = createRSCPayloadKey(componentName, componentProps, domNodeId);
       const payloads = window.REACT_ON_RAILS_RSC_PAYLOADS[rscPayloadKey];
       if (payloads) {
-        return createFromPreloadedPayloads(payloads);
+        return createFromPreloadedPayloads(payloads, componentName);
       }
     }
     return fetchRSC({ componentName, componentProps, railsContext });

--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -118,10 +118,11 @@ const createFromFetch = async (
   });
 
   const renderPromise = createFromReadableStream<React.ReactNode>(transformedStream);
-  // `rscDiagnosticError` is populated synchronously while the stream is parsed in the
-  // ReadableStream `start` callback above. React cannot produce a render error until it has
-  // consumed that stream, so by the time `renderPromise` rejects the diagnostic — if the
-  // stream carried one — is already set; it is never undefined purely because of timing.
+  // `rscDiagnosticError` is set before the matching chunk is enqueued: the parser callback
+  // records it first, then enqueues the content in the ReadableStream `start` callback above.
+  // React can only read a chunk after it has been enqueued, so by the time `renderPromise`
+  // rejects the diagnostic — if the stream carried one — is already set; it is never undefined
+  // purely because of timing.
   return wrapInNewPromise(renderPromise).catch((error: unknown) => {
     throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
   });

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -58,8 +58,10 @@ const createFromReactOnRailsNodeStream = async (
   // Note: this try/catch only intercepts errors thrown during the initial stream parse.
   // React RSC errors that surface during the deferred render phase (e.g. when a Suspense
   // boundary resolves a lazy element) propagate through React's error-boundary mechanism
-  // instead and won't be enriched here. The raw diagnostic is still captured via
-  // `onDiagnosticError` above, so the information isn't lost.
+  // rather than rejecting `createFromNodeStream`, so they are NOT enriched here. In that case
+  // `rscDiagnosticError` (a local that goes out of scope when this function returns) is
+  // discarded and the caller sees only the generic React stream error. Enriching the
+  // deferred-render path is tracked in #3475.
   try {
     return await createFromNodeStream<React.ReactNode>(transformedStream);
   } catch (error: unknown) {

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -52,7 +52,6 @@ const createFromReactOnRailsNodeStream = async (
     componentName,
     onDiagnosticError(error) {
       rscDiagnosticError = error;
-      console.error(error);
     },
   });
 

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -56,6 +56,11 @@ const createFromReactOnRailsNodeStream = async (
     },
   });
 
+  // Note: this try/catch only intercepts errors thrown during the initial stream parse.
+  // React RSC errors that surface during the deferred render phase (e.g. when a Suspense
+  // boundary resolves a lazy element) propagate through React's error-boundary mechanism
+  // instead and won't be enriched here. The raw diagnostic is still captured via
+  // `onDiagnosticError` above, so the information isn't lost.
   try {
     return await createFromNodeStream<React.ReactNode>(transformedStream);
   } catch (error: unknown) {

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -59,7 +59,7 @@ const createFromReactOnRailsNodeStream = async (
   try {
     const result = await createFromNodeStream<React.ReactNode>(transformedStream);
     if (result instanceof Error && rscDiagnosticError) {
-      throw mergeRSCStreamDiagnosticError(result, rscDiagnosticError);
+      throw result;
     }
     return result;
   } catch (error: unknown) {

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -57,11 +57,7 @@ const createFromReactOnRailsNodeStream = async (
   });
 
   try {
-    const result = await createFromNodeStream<React.ReactNode>(transformedStream);
-    if (result instanceof Error && rscDiagnosticError) {
-      throw result;
-    }
-    return result;
+    return await createFromNodeStream<React.ReactNode>(transformedStream);
   } catch (error: unknown) {
     throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
   }

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -17,6 +17,7 @@ import { buildClientRenderer } from 'react-on-rails-rsc/client.node';
 import type { RailsContextWithServerStreamingCapabilities } from 'react-on-rails/types';
 import transformRSCStream from './transformRSCNodeStream.ts';
 import loadJsonFile from './loadJsonFile.ts';
+import { mergeRSCStreamDiagnosticError } from './rscDiagnostics.ts';
 
 type GetReactServerComponentOnServerProps = {
   componentName: string;
@@ -29,6 +30,7 @@ const createFromReactOnRailsNodeStream = async (
   stream: NodeJS.ReadableStream,
   reactServerManifestFileName: string,
   reactClientManifestFileName: string,
+  componentName: string,
 ) => {
   if (!clientRendererPromise) {
     clientRendererPromise = Promise.all([
@@ -45,8 +47,24 @@ const createFromReactOnRailsNodeStream = async (
   }
 
   const { createFromNodeStream } = await clientRendererPromise;
-  const transformedStream = transformRSCStream(stream);
-  return createFromNodeStream<React.ReactNode>(transformedStream);
+  let rscDiagnosticError: Error | undefined;
+  const transformedStream = transformRSCStream(stream, {
+    componentName,
+    onDiagnosticError(error) {
+      rscDiagnosticError = error;
+      console.error(error);
+    },
+  });
+
+  try {
+    const result = await createFromNodeStream<React.ReactNode>(transformedStream);
+    if (result instanceof Error && rscDiagnosticError) {
+      throw mergeRSCStreamDiagnosticError(result, rscDiagnosticError);
+    }
+    return result;
+  } catch (error: unknown) {
+    throw mergeRSCStreamDiagnosticError(error, rscDiagnosticError);
+  }
 };
 
 /**
@@ -89,6 +107,7 @@ const getReactServerComponent =
       rscPayloadStream,
       railsContext.reactServerClientManifestFileName,
       railsContext.reactClientManifestFileName,
+      componentName,
     );
   };
 

--- a/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.server.ts
@@ -55,13 +55,13 @@ const createFromReactOnRailsNodeStream = async (
     },
   });
 
-  // Note: this try/catch only intercepts errors thrown during the initial stream parse.
-  // React RSC errors that surface during the deferred render phase (e.g. when a Suspense
-  // boundary resolves a lazy element) propagate through React's error-boundary mechanism
-  // rather than rejecting `createFromNodeStream`, so they are NOT enriched here. In that case
-  // `rscDiagnosticError` (a local that goes out of scope when this function returns) is
-  // discarded and the caller sees only the generic React stream error. Enriching the
-  // deferred-render path is tracked in #3475.
+  // Note: this try/catch enriches any error that rejects `createFromNodeStream` — stream read
+  // failures, malformed Flight data, or synchronous render errors. It does NOT catch errors
+  // React surfaces through its error-boundary / Suspense mechanism during the deferred render
+  // phase (e.g. when a Suspense boundary resolves a lazy element); those never reject this
+  // promise. In that case `rscDiagnosticError` (a local that goes out of scope when this
+  // function returns) is discarded and the caller sees only the generic React error. Enriching
+  // the deferred-render path is tracked in #3475.
   try {
     return await createFromNodeStream<React.ReactNode>(transformedStream);
   } catch (error: unknown) {

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -28,6 +28,8 @@ type RenderingErrorMetadata = {
   stack?: unknown;
 };
 
+const RSC_STREAM_DIAGNOSTIC_ERROR_NAME = 'ReactOnRailsRSCStreamError';
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
@@ -76,7 +78,7 @@ export const buildRSCStreamDiagnosticError = (
     .join('\n');
 
   const diagnosticError = new Error(message);
-  diagnosticError.name = 'ReactOnRailsRSCStreamError';
+  diagnosticError.name = RSC_STREAM_DIAGNOSTIC_ERROR_NAME;
   if (originalStack) {
     diagnosticError.stack = `${diagnosticError.name}: ${message}\nOriginal stack:\n${originalStack}`;
   }
@@ -84,15 +86,23 @@ export const buildRSCStreamDiagnosticError = (
   return diagnosticError;
 };
 
+const isMergedRSCStreamDiagnosticError = (error: Error, diagnosticError: Error) =>
+  error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME &&
+  error.message.includes(diagnosticError.message) &&
+  error.message.includes('React stream error:');
+
 export const mergeRSCStreamDiagnosticError = (error: unknown, diagnosticError?: Error) => {
   const streamError = error instanceof Error ? error : new Error(extractErrorMessage(error));
   if (!diagnosticError) {
     return streamError;
   }
+  if (isMergedRSCStreamDiagnosticError(streamError, diagnosticError)) {
+    return streamError;
+  }
 
   const message = `${diagnosticError.message}\nReact stream error: ${streamError.message}`;
   const mergedError = new Error(message) as Error & { cause?: unknown };
-  mergedError.name = 'ReactOnRailsRSCStreamError';
+  mergedError.name = RSC_STREAM_DIAGNOSTIC_ERROR_NAME;
   mergedError.cause = streamError;
   mergedError.stack = [
     `${mergedError.name}: ${message}`,

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -38,16 +38,31 @@ type RSCStreamDiagnosticError = Error & {
 
 const str = (value: unknown) => (typeof value === 'string' && value.length > 0 ? value : undefined);
 
+// Bundler/framework frames point at library code rather than the failing component, so they
+// are a poor value for `Module:`. Skip them when a later user-code frame is available.
+const INTERNAL_FRAME_RE =
+  /(?:^|[\\/])node_modules[\\/]|\bwebpack[\\/]|\bwebpack-internal:|\b__webpack_require__\b/;
+
 export const extractModulePathFromStack = (stack?: string) => {
   if (!stack) return undefined;
-  for (const line of stack.split('\n')) {
-    const match = /\(([^()]+):\d+:\d+\)$|\bat\s+(.+):\d+:\d+$/.exec(line.trim());
-    // V8 emits anonymous async frames as `at async /path:l:c`; strip the `async ` keyword
-    // so the diagnostic reports `Module: /path` instead of `Module: async /path`.
-    const location = match?.[1] ?? match?.[2]?.replace(/^async\s+/, '');
-    if (location) return location.replace(/\?.*$/, '');
+  let firstLocation: string | undefined;
+  for (const rawLine of stack.split('\n')) {
+    const line = rawLine.trim();
+    // Two V8 frame shapes:
+    //   `at fn (/path/to/file.js:10:5)`  -> parenthesized
+    //   `at /path:10:5` / `at async /path:10:5` -> anonymous/top-level
+    // The anonymous form is anchored to an absolute path (POSIX `/` or a Windows drive) and
+    // tolerates the optional `async ` keyword, so a bare function name in an unusual
+    // `at fn /path:10:5` frame isn't mistaken for the module path.
+    const match = /\(([^()]+):\d+:\d+\)$|\bat\s+(?:async\s+)?((?:\/|[A-Za-z]:[\\/]).*?):\d+:\d+$/.exec(line);
+    const location = (match?.[1] ?? match?.[2])?.replace(/\?.*$/, '');
+    if (location) {
+      firstLocation ??= location;
+      if (!INTERNAL_FRAME_RE.test(location)) return location;
+    }
   }
-  return undefined;
+  // Every frame was framework-internal — fall back to the first so `Module:` is still populated.
+  return firstLocation;
 };
 
 export const buildRSCStreamDiagnosticError = (
@@ -55,7 +70,9 @@ export const buildRSCStreamDiagnosticError = (
   context: RSCStreamDiagnosticContext = {},
 ) => {
   const raw = metadata.renderingError;
-  const re = (typeof raw === 'object' && raw !== null ? raw : {}) as RenderingErrorMetadata;
+  // `RenderingErrorMetadata` has only optional `unknown` fields, so a plain annotation
+  // accepts any object without a type assertion; `str()` validates each field at runtime.
+  const re: RenderingErrorMetadata = typeof raw === 'object' && raw !== null ? raw : {};
   const originalMessage = str(re.message);
   const originalStack = str(re.stack);
   // Wire contract: the React on Rails server bundle only emits `renderingError` on actual
@@ -65,12 +82,19 @@ export const buildRSCStreamDiagnosticError = (
   if (metadata.hasErrors !== true && !originalMessage && !originalStack) return undefined;
 
   const modulePath = extractModulePathFromStack(originalStack);
+  // Without a message, name the actual signal that triggered the diagnostic: `hasErrors=true`
+  // when that flag is set, otherwise a stack-only `renderingError` (claiming `hasErrors=true`
+  // in the latter case would be inaccurate).
+  const fallbackOriginalError =
+    metadata.hasErrors === true
+      ? 'RSC stream metadata reported hasErrors=true'
+      : 'RSC stream metadata reported a rendering error';
   const message = [
     '[ReactOnRails] RSC bundle rendering failed.',
     context.componentName && `Component: ${context.componentName}`,
     context.source && `Source: ${context.source}`,
     modulePath && `Module: ${modulePath}`,
-    `Original error: ${originalMessage ?? 'RSC stream metadata reported hasErrors=true'}`,
+    `Original error: ${originalMessage ?? fallbackOriginalError}`,
   ]
     .filter((line): line is string => Boolean(line))
     .join('\n');

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -41,7 +41,7 @@ const str = (value: unknown) => (typeof value === 'string' && value.length > 0 ?
 // Bundler/framework frames point at library code rather than the failing component, so they
 // are a poor value for `Module:`. Skip them when a later user-code frame is available.
 const INTERNAL_FRAME_RE =
-  /(?:^|[\\/])node_modules[\\/]|\bwebpack[\\/]|\bwebpack-internal:|\b__webpack_require__\b/;
+  /(?:^|[\\/])node_modules[\\/]|(?:^|[\\/])webpack[\\/]|\bwebpack-internal:|\b__webpack_require__\b/;
 
 export const extractModulePathFromStack = (stack?: string) => {
   if (!stack) return undefined;

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -37,13 +37,19 @@ type RSCStreamDiagnosticError = Error & {
   cause?: unknown;
 };
 
-const nonEmptyString = (value: unknown) =>
-  typeof value === 'string' && value.length > 0 ? value : undefined;
+const nonEmptyString = (value: unknown) => {
+  if (typeof value !== 'string') return undefined;
+  // Trim so a whitespace-only `renderingError.message`/`stack` (e.g. `"  "` or `"\n"`) is
+  // treated as absent rather than surfacing as `Original error:` with blank text.
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
 
 // Bundler/framework frames point at library code rather than the failing component, so they
 // are a poor value for `Module:`. Skip them when a later user-code frame is available.
-const INTERNAL_FRAME_RE =
-  /(?:^|[\\/])node_modules[\\/]|(?:^|[\\/])webpack[\\/]|\bwebpack-internal:|\b__webpack_require__\b/;
+// Note: this is matched against the extracted file *path*, not the raw frame, so a webpack
+// runtime frame is caught by its `webpack/` or `webpack-internal:` path, not its function name.
+const INTERNAL_FRAME_RE = /(?:^|[\\/])node_modules[\\/]|(?:^|[\\/])webpack[\\/]|\bwebpack-internal:/;
 
 export const extractModulePathFromStack = (stack?: string) => {
   if (!stack) return undefined;

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025 Shakacode LLC
+ *
+ * This file is NOT licensed under the MIT (open source) license.
+ * It is part of the React on Rails Pro offering and is licensed separately.
+ *
+ * Unauthorized copying, modification, distribution, or use of this file,
+ * via any medium, is strictly prohibited without a valid license agreement
+ * from Shakacode LLC.
+ *
+ * For licensing terms, please see:
+ * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
+ */
+
+import { extractErrorMessage } from './utils.ts';
+
+type RSCStreamDiagnosticContext = {
+  componentName?: string;
+  source?: string;
+};
+
+export type RSCStreamDiagnosticsOptions = RSCStreamDiagnosticContext & {
+  onDiagnosticError?: (error: Error) => void;
+};
+
+type RenderingErrorMetadata = {
+  message?: unknown;
+  stack?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const stringValue = (value: unknown) => (typeof value === 'string' && value.length > 0 ? value : undefined);
+
+export const extractModulePathFromStack = (stack?: string) => {
+  if (!stack) return undefined;
+
+  const stackLines = stack.split('\n').map((line) => line.trim());
+  for (const line of stackLines) {
+    const parenthesizedLocation = /\(([^()]+):\d+:\d+\)$/.exec(line);
+    const directLocation = /\bat\s+(.+):\d+:\d+$/.exec(line);
+    const location = parenthesizedLocation?.[1] ?? directLocation?.[1];
+    if (location) {
+      return location.replace(/\?.*$/, '');
+    }
+  }
+
+  return undefined;
+};
+
+export const buildRSCStreamDiagnosticError = (
+  metadata: Record<string, unknown>,
+  context: RSCStreamDiagnosticContext = {},
+) => {
+  const renderingErrorMetadata = isRecord(metadata.renderingError)
+    ? (metadata.renderingError as RenderingErrorMetadata)
+    : {};
+  const originalMessage = stringValue(renderingErrorMetadata.message);
+  const originalStack = stringValue(renderingErrorMetadata.stack);
+  const hasErrors = metadata.hasErrors === true;
+
+  if (!hasErrors && !originalMessage && !originalStack) {
+    return undefined;
+  }
+
+  const modulePath = extractModulePathFromStack(originalStack);
+  const message = [
+    '[ReactOnRails] RSC bundle rendering failed.',
+    context.componentName ? `Component: ${context.componentName}` : undefined,
+    context.source ? `Source: ${context.source}` : undefined,
+    modulePath ? `Module: ${modulePath}` : undefined,
+    `Original error: ${originalMessage ?? 'RSC stream metadata reported hasErrors=true'}`,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n');
+
+  const diagnosticError = new Error(message);
+  diagnosticError.name = 'ReactOnRailsRSCStreamError';
+  if (originalStack) {
+    diagnosticError.stack = `${diagnosticError.name}: ${message}\nOriginal stack:\n${originalStack}`;
+  }
+
+  return diagnosticError;
+};
+
+export const mergeRSCStreamDiagnosticError = (error: unknown, diagnosticError?: Error) => {
+  const streamError = error instanceof Error ? error : new Error(extractErrorMessage(error));
+  if (!diagnosticError) {
+    return streamError;
+  }
+
+  const message = `${diagnosticError.message}\nReact stream error: ${streamError.message}`;
+  const mergedError = new Error(message) as Error & { cause?: unknown };
+  mergedError.name = 'ReactOnRailsRSCStreamError';
+  mergedError.cause = streamError;
+  mergedError.stack = [
+    `${mergedError.name}: ${message}`,
+    diagnosticError.stack ? `RSC diagnostic stack:\n${diagnosticError.stack}` : undefined,
+    streamError.stack ? `React stream stack:\n${streamError.stack}` : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join('\n\n');
+
+  return mergedError;
+};

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -56,6 +56,10 @@ export const buildRSCStreamDiagnosticError = (
   const re = (typeof raw === 'object' && raw !== null ? raw : {}) as RenderingErrorMetadata;
   const originalMessage = str(re.message);
   const originalStack = str(re.stack);
+  // Wire contract: the React on Rails server bundle only emits `renderingError` on actual
+  // failure, so presence of a message or stack is treated as a failure signal even when
+  // `hasErrors` isn't explicitly set. Belt-and-suspenders intentional — if a future producer
+  // wants to use `renderingError` for non-fatal info, this guard needs to change with it.
   if (metadata.hasErrors !== true && !originalMessage && !originalStack) return undefined;
 
   const modulePath = extractModulePathFromStack(originalStack);

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -29,14 +29,16 @@ type RenderingErrorMetadata = {
 };
 
 export const RSC_STREAM_DIAGNOSTIC_ERROR_NAME = 'ReactOnRailsRSCStreamError';
-const MERGED_DIAGNOSTIC_FLAG = '__rorRSCDiagMerged';
+// Exported so tests reference the marker by constant rather than a duplicated string literal.
+export const MERGED_DIAGNOSTIC_FLAG = '__rorRSCDiagMerged';
 
 type RSCStreamDiagnosticError = Error & {
   [MERGED_DIAGNOSTIC_FLAG]?: true;
   cause?: unknown;
 };
 
-const str = (value: unknown) => (typeof value === 'string' && value.length > 0 ? value : undefined);
+const nonEmptyString = (value: unknown) =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
 
 // Bundler/framework frames point at library code rather than the failing component, so they
 // are a poor value for `Module:`. Skip them when a later user-code frame is available.
@@ -71,10 +73,10 @@ export const buildRSCStreamDiagnosticError = (
 ) => {
   const raw = metadata.renderingError;
   // `RenderingErrorMetadata` has only optional `unknown` fields, so a plain annotation
-  // accepts any object without a type assertion; `str()` validates each field at runtime.
+  // accepts any object without a type assertion; `nonEmptyString()` validates each field at runtime.
   const re: RenderingErrorMetadata = typeof raw === 'object' && raw !== null ? raw : {};
-  const originalMessage = str(re.message);
-  const originalStack = str(re.stack);
+  const originalMessage = nonEmptyString(re.message);
+  const originalStack = nonEmptyString(re.stack);
   // Wire contract: the React on Rails server bundle only emits `renderingError` on actual
   // failure, so presence of a message or stack is treated as a failure signal even when
   // `hasErrors` isn't explicitly set. Belt-and-suspenders intentional — if a future producer
@@ -101,12 +103,27 @@ export const buildRSCStreamDiagnosticError = (
 
   const diagnosticError = new Error(message);
   diagnosticError.name = RSC_STREAM_DIAGNOSTIC_ERROR_NAME;
-  if (originalStack) {
-    diagnosticError.stack = `${diagnosticError.name}: ${message}\nOriginal stack:\n${originalStack}`;
-  }
+  // Always overwrite the auto-generated stack. With an original stack we surface it; without one
+  // we reduce the stack to just the header line, because the V8-generated stack would otherwise
+  // point at this diagnostics module and error monitors (Sentry, Honeybadger) would misattribute
+  // the error origin to react-on-rails internals.
+  diagnosticError.stack = originalStack
+    ? `${diagnosticError.name}: ${message}\nOriginal stack:\n${originalStack}`
+    : `${diagnosticError.name}: ${message}`;
   return diagnosticError;
 };
 
+/**
+ * Merges a generic React stream error with the original RSC bundle diagnostic.
+ *
+ * Idempotent on `error`: if `error` is already a merged result (carries `MERGED_DIAGNOSTIC_FLAG`)
+ * it is returned untouched, so re-entering this in a chain of catch handlers won't double-wrap.
+ *
+ * Precondition: `diagnosticError` must be a fresh (non-merged) diagnostic — in practice it always
+ * comes from `buildRSCStreamDiagnosticError`, which never sets the flag. The idempotency guard
+ * intentionally only inspects `error`; passing an already-merged error as `diagnosticError` would
+ * duplicate context.
+ */
 export const mergeRSCStreamDiagnosticError = (error: unknown, diagnosticError?: Error) => {
   const streamError: RSCStreamDiagnosticError =
     error instanceof Error ? error : new Error(extractErrorMessage(error));

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -42,7 +42,9 @@ export const extractModulePathFromStack = (stack?: string) => {
   if (!stack) return undefined;
   for (const line of stack.split('\n')) {
     const match = /\(([^()]+):\d+:\d+\)$|\bat\s+(.+):\d+:\d+$/.exec(line.trim());
-    const location = match?.[1] ?? match?.[2];
+    // V8 emits anonymous async frames as `at async /path:l:c`; strip the `async ` keyword
+    // so the diagnostic reports `Module: /path` instead of `Module: async /path`.
+    const location = match?.[1] ?? match?.[2]?.replace(/^async\s+/, '');
     if (location) return location.replace(/\?.*$/, '');
   }
   return undefined;
@@ -90,7 +92,14 @@ export const mergeRSCStreamDiagnosticError = (error: unknown, diagnosticError?: 
   const mergedError: RSCStreamDiagnosticError = new Error(message);
   mergedError.name = RSC_STREAM_DIAGNOSTIC_ERROR_NAME;
   mergedError.cause = streamError;
-  mergedError[MERGED_DIAGNOSTIC_FLAG] = true;
+  // Non-enumerable so error reporters that iterate own keys (Sentry "extra data",
+  // structured cloning, etc.) don't pick up this internal marker.
+  Object.defineProperty(mergedError, MERGED_DIAGNOSTIC_FLAG, {
+    value: true,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
   mergedError.stack = [
     `${mergedError.name}: ${message}`,
     diagnosticError.stack && `RSC diagnostic stack:\n${diagnosticError.stack}`,

--- a/packages/react-on-rails-pro/src/rscDiagnostics.ts
+++ b/packages/react-on-rails-pro/src/rscDiagnostics.ts
@@ -28,26 +28,23 @@ type RenderingErrorMetadata = {
   stack?: unknown;
 };
 
-const RSC_STREAM_DIAGNOSTIC_ERROR_NAME = 'ReactOnRailsRSCStreamError';
+export const RSC_STREAM_DIAGNOSTIC_ERROR_NAME = 'ReactOnRailsRSCStreamError';
+const MERGED_DIAGNOSTIC_FLAG = '__rorRSCDiagMerged';
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
+type RSCStreamDiagnosticError = Error & {
+  [MERGED_DIAGNOSTIC_FLAG]?: true;
+  cause?: unknown;
+};
 
-const stringValue = (value: unknown) => (typeof value === 'string' && value.length > 0 ? value : undefined);
+const str = (value: unknown) => (typeof value === 'string' && value.length > 0 ? value : undefined);
 
 export const extractModulePathFromStack = (stack?: string) => {
   if (!stack) return undefined;
-
-  const stackLines = stack.split('\n').map((line) => line.trim());
-  for (const line of stackLines) {
-    const parenthesizedLocation = /\(([^()]+):\d+:\d+\)$/.exec(line);
-    const directLocation = /\bat\s+(.+):\d+:\d+$/.exec(line);
-    const location = parenthesizedLocation?.[1] ?? directLocation?.[1];
-    if (location) {
-      return location.replace(/\?.*$/, '');
-    }
+  for (const line of stack.split('\n')) {
+    const match = /\(([^()]+):\d+:\d+\)$|\bat\s+(.+):\d+:\d+$/.exec(line.trim());
+    const location = match?.[1] ?? match?.[2];
+    if (location) return location.replace(/\?.*$/, '');
   }
-
   return undefined;
 };
 
@@ -55,23 +52,18 @@ export const buildRSCStreamDiagnosticError = (
   metadata: Record<string, unknown>,
   context: RSCStreamDiagnosticContext = {},
 ) => {
-  const renderingErrorMetadata = isRecord(metadata.renderingError)
-    ? (metadata.renderingError as RenderingErrorMetadata)
-    : {};
-  const originalMessage = stringValue(renderingErrorMetadata.message);
-  const originalStack = stringValue(renderingErrorMetadata.stack);
-  const hasErrors = metadata.hasErrors === true;
-
-  if (!hasErrors && !originalMessage && !originalStack) {
-    return undefined;
-  }
+  const raw = metadata.renderingError;
+  const re = (typeof raw === 'object' && raw !== null ? raw : {}) as RenderingErrorMetadata;
+  const originalMessage = str(re.message);
+  const originalStack = str(re.stack);
+  if (metadata.hasErrors !== true && !originalMessage && !originalStack) return undefined;
 
   const modulePath = extractModulePathFromStack(originalStack);
   const message = [
     '[ReactOnRails] RSC bundle rendering failed.',
-    context.componentName ? `Component: ${context.componentName}` : undefined,
-    context.source ? `Source: ${context.source}` : undefined,
-    modulePath ? `Module: ${modulePath}` : undefined,
+    context.componentName && `Component: ${context.componentName}`,
+    context.source && `Source: ${context.source}`,
+    modulePath && `Module: ${modulePath}`,
     `Original error: ${originalMessage ?? 'RSC stream metadata reported hasErrors=true'}`,
   ]
     .filter((line): line is string => Boolean(line))
@@ -82,35 +74,25 @@ export const buildRSCStreamDiagnosticError = (
   if (originalStack) {
     diagnosticError.stack = `${diagnosticError.name}: ${message}\nOriginal stack:\n${originalStack}`;
   }
-
   return diagnosticError;
 };
 
-const isMergedRSCStreamDiagnosticError = (error: Error, diagnosticError: Error) =>
-  error.name === RSC_STREAM_DIAGNOSTIC_ERROR_NAME &&
-  error.message.includes(diagnosticError.message) &&
-  error.message.includes('React stream error:');
-
 export const mergeRSCStreamDiagnosticError = (error: unknown, diagnosticError?: Error) => {
-  const streamError = error instanceof Error ? error : new Error(extractErrorMessage(error));
-  if (!diagnosticError) {
-    return streamError;
-  }
-  if (isMergedRSCStreamDiagnosticError(streamError, diagnosticError)) {
-    return streamError;
-  }
+  const streamError: RSCStreamDiagnosticError =
+    error instanceof Error ? error : new Error(extractErrorMessage(error));
+  if (!diagnosticError || streamError[MERGED_DIAGNOSTIC_FLAG]) return streamError;
 
   const message = `${diagnosticError.message}\nReact stream error: ${streamError.message}`;
-  const mergedError = new Error(message) as Error & { cause?: unknown };
+  const mergedError: RSCStreamDiagnosticError = new Error(message);
   mergedError.name = RSC_STREAM_DIAGNOSTIC_ERROR_NAME;
   mergedError.cause = streamError;
+  mergedError[MERGED_DIAGNOSTIC_FLAG] = true;
   mergedError.stack = [
     `${mergedError.name}: ${message}`,
-    diagnosticError.stack ? `RSC diagnostic stack:\n${diagnosticError.stack}` : undefined,
-    streamError.stack ? `React stream stack:\n${streamError.stack}` : undefined,
+    diagnosticError.stack && `RSC diagnostic stack:\n${diagnosticError.stack}`,
+    streamError.stack && `React stream stack:\n${streamError.stack}`,
   ]
     .filter((line): line is string => Boolean(line))
     .join('\n\n');
-
   return mergedError;
 };

--- a/packages/react-on-rails-pro/src/transformRSCNodeStream.ts
+++ b/packages/react-on-rails-pro/src/transformRSCNodeStream.ts
@@ -43,6 +43,9 @@ export default function transformRSCStream(
       try {
         parser.feed(chunk, (content, metadata) => {
           const diagnosticError = buildRSCStreamDiagnosticError(metadata, diagnosticsOptions);
+          // First-wins: report only the earliest diagnostic. A failing RSC stream emits a single
+          // renderingError, so this avoids duplicate reports of the same failure. (A later chunk
+          // carrying a richer renderingError would be dropped, but that doesn't occur in practice.)
           if (diagnosticError && !reportedDiagnosticError) {
             reportedDiagnosticError = true;
             diagnosticsOptions.onDiagnosticError?.(diagnosticError);

--- a/packages/react-on-rails-pro/src/transformRSCNodeStream.ts
+++ b/packages/react-on-rails-pro/src/transformRSCNodeStream.ts
@@ -15,6 +15,7 @@
 import { Readable, Transform } from 'stream';
 import safePipe from './safePipe.ts';
 import LengthPrefixedStreamParser from './parseLengthPrefixedStream.ts';
+import { buildRSCStreamDiagnosticError, RSCStreamDiagnosticsOptions } from './rscDiagnostics.ts';
 
 /**
  * Transforms an RSC Node.js stream for server-side processing.
@@ -30,13 +31,22 @@ import LengthPrefixedStreamParser from './parseLengthPrefixedStream.ts';
  * @param stream - The Node.js RSC payload stream
  * @returns A transformed stream compatible with React's SSR runtime
  */
-export default function transformRSCStream(stream: NodeJS.ReadableStream): NodeJS.ReadableStream {
+export default function transformRSCStream(
+  stream: NodeJS.ReadableStream,
+  diagnosticsOptions: RSCStreamDiagnosticsOptions = {},
+): NodeJS.ReadableStream {
   const parser = new LengthPrefixedStreamParser();
+  let reportedDiagnosticError = false;
 
   const htmlExtractor = new Transform({
     transform(chunk: Buffer, _, callback) {
       try {
-        parser.feed(chunk, (content) => {
+        parser.feed(chunk, (content, metadata) => {
+          const diagnosticError = buildRSCStreamDiagnosticError(metadata, diagnosticsOptions);
+          if (diagnosticError && !reportedDiagnosticError) {
+            reportedDiagnosticError = true;
+            diagnosticsOptions.onDiagnosticError?.(diagnosticError);
+          }
           this.push(content);
         });
         callback();

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -6,7 +6,7 @@ import { text } from 'stream/consumers';
 import { Readable } from 'stream';
 
 import transformRSCStream from '../src/transformRSCNodeStream.ts';
-import { mergeRSCStreamDiagnosticError } from '../src/rscDiagnostics.ts';
+import { buildRSCStreamDiagnosticError, mergeRSCStreamDiagnosticError } from '../src/rscDiagnostics.ts';
 
 const encodeLengthPrefixedChunk = (metadata: Record<string, unknown>, content: string) => {
   const contentBuffer = Buffer.from(content, 'utf-8');
@@ -92,6 +92,18 @@ describe('RSC diagnostics', () => {
         /React stream error: An error occurred in the Server Components render\./g,
       ),
     ).toHaveLength(1);
+  });
+
+  it('emits the hasErrors=true fallback diagnostic when the stream provides no message or stack', () => {
+    const diagnosticError = buildRSCStreamDiagnosticError(
+      { hasErrors: true },
+      { componentName: 'CommentsToggle', source: '/rsc/CommentsToggle' },
+    );
+
+    expect(diagnosticError).toBeDefined();
+    expect(diagnosticError?.message).toContain('Component: CommentsToggle');
+    expect(diagnosticError?.message).toContain('Source: /rsc/CommentsToggle');
+    expect(diagnosticError?.message).toContain('Original error: RSC stream metadata reported hasErrors=true');
   });
 
   it('treats a merged diagnostic as idempotent even when the message format changes', () => {

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+import { text } from 'stream/consumers';
+import { Readable } from 'stream';
+
+import transformRSCStream from '../src/transformRSCNodeStream.ts';
+import { mergeRSCStreamDiagnosticError } from '../src/rscDiagnostics.ts';
+
+const encodeLengthPrefixedChunk = (metadata: Record<string, unknown>, content: string) => {
+  const contentBuffer = Buffer.from(content, 'utf-8');
+  return `${JSON.stringify(metadata)}\t${contentBuffer.length.toString(16).padStart(8, '0')}\n${content}`;
+};
+
+describe('RSC diagnostics', () => {
+  it('reports RSC bundle rendering errors from stream metadata while preserving Flight bytes', async () => {
+    const diagnosticStack =
+      'TypeError: useState is not a function\n' +
+      '    at CommentsToggle (/app/components/CommentsToggle.jsx:12:15)\n' +
+      '    at PostsPage (/app/components/PostsPage.jsx:8:3)';
+    const source = Readable.from([
+      encodeLengthPrefixedChunk(
+        {
+          consoleReplayScript: '',
+          hasErrors: true,
+          isShellReady: true,
+          payloadType: 'string',
+          renderingError: {
+            message: 'useState is not a function',
+            stack: diagnosticStack,
+          },
+        },
+        '0:"$L1"\n',
+      ),
+    ]);
+    const onDiagnosticError = jest.fn();
+
+    const transformedStream = transformRSCStream(source, {
+      componentName: 'CommentsToggle',
+      onDiagnosticError,
+    });
+
+    await expect(text(transformedStream)).resolves.toBe('0:"$L1"\n');
+    expect(onDiagnosticError).toHaveBeenCalledTimes(1);
+
+    const diagnosticError = onDiagnosticError.mock.calls[0][0] as Error;
+    expect(diagnosticError.name).toBe('ReactOnRailsRSCStreamError');
+    expect(diagnosticError.message).toContain('RSC bundle rendering failed');
+    expect(diagnosticError.message).toContain('Component: CommentsToggle');
+    expect(diagnosticError.message).toContain('Original error: useState is not a function');
+    expect(diagnosticError.message).toContain('Module: /app/components/CommentsToggle.jsx');
+    expect(diagnosticError.stack).toContain(diagnosticStack);
+  });
+
+  it('merges a generic React stream failure with the original RSC bundle diagnostic', () => {
+    const diagnosticError = new Error(
+      '[ReactOnRails] RSC bundle rendering failed.\n' +
+        'Component: CommentsToggle\n' +
+        'Original error: useState is not a function',
+    );
+    diagnosticError.name = 'ReactOnRailsRSCStreamError';
+    diagnosticError.stack = 'TypeError: useState is not a function\n    at CommentsToggle.jsx:12:15';
+    const genericStreamError = new Error('An error occurred in the Server Components render.');
+
+    const mergedError = mergeRSCStreamDiagnosticError(genericStreamError, diagnosticError);
+
+    expect(mergedError.name).toBe('ReactOnRailsRSCStreamError');
+    expect(mergedError.message).toContain('Original error: useState is not a function');
+    expect(mergedError.message).toContain(
+      'React stream error: An error occurred in the Server Components render.',
+    );
+    expect(mergedError.stack).toContain('CommentsToggle.jsx:12:15');
+  });
+});

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -132,6 +132,47 @@ describe('RSC diagnostics', () => {
     expect(extractModulePathFromStack(stack)).toBe('/app/server.js');
   });
 
+  it('skips node_modules and webpack-internal frames in favor of the first user-code frame', () => {
+    const stack =
+      'Error: boom\n' +
+      '    at useState (/app/node_modules/react/cjs/react.development.js:1:1)\n' +
+      '    at Inner (webpack-internal:///./node_modules/x.js:2:2)\n' +
+      '    at MyComponent (/app/components/MyComponent.jsx:5:7)';
+
+    expect(extractModulePathFromStack(stack)).toBe('/app/components/MyComponent.jsx');
+  });
+
+  it('falls back to the first frame when every frame is framework-internal', () => {
+    const stack =
+      'Error: boom\n' +
+      '    at x (/app/node_modules/react/index.js:1:1)\n' +
+      '    at y (/app/node_modules/react-dom/index.js:2:2)';
+
+    expect(extractModulePathFromStack(stack)).toBe('/app/node_modules/react/index.js');
+  });
+
+  it('does not mistake a bare function name for the module path in anonymous frames', () => {
+    // Unusual but valid V8 frame where a function name precedes a path without parens; the
+    // anonymous-frame regex is anchored to an absolute path so it skips this frame rather than
+    // returning the function name, and the next user-code frame wins.
+    const stack = 'Error: boom\n    at someFunction /weird/frame:3:9\n    at Real (/app/real.js:5:5)';
+
+    expect(extractModulePathFromStack(stack)).toBe('/app/real.js');
+  });
+
+  it('uses a stack-derived fallback when triggered by a stack without hasErrors or message', () => {
+    const diagnosticError = buildRSCStreamDiagnosticError(
+      { renderingError: { stack: 'TypeError: boom\n    at Foo (/app/foo.js:1:1)' } },
+      { componentName: 'Foo' },
+    );
+
+    expect(diagnosticError).toBeDefined();
+    expect(diagnosticError?.message).toContain(
+      'Original error: RSC stream metadata reported a rendering error',
+    );
+    expect(diagnosticError?.message).not.toContain('hasErrors=true');
+  });
+
   it('keeps the merged-diagnostic marker non-enumerable so error reporters do not serialize it', () => {
     const diagnosticError = new Error('[ReactOnRails] RSC bundle rendering failed.');
     diagnosticError.name = 'ReactOnRailsRSCStreamError';

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -172,6 +172,14 @@ describe('RSC diagnostics', () => {
     expect(extractModulePathFromStack(stack)).toBe('/app/real.js');
   });
 
+  it('extracts Windows drive paths from both parenthesized and anonymous frames', () => {
+    const parenthesized = 'Error: boom\n    at Component (C:\\app\\components\\Foo.jsx:10:5)';
+    expect(extractModulePathFromStack(parenthesized)).toBe('C:\\app\\components\\Foo.jsx');
+
+    const anonymous = 'Error: boom\n    at async C:\\app\\server.js:42:3';
+    expect(extractModulePathFromStack(anonymous)).toBe('C:\\app\\server.js');
+  });
+
   it('does not mistake a bare function name for the module path in anonymous frames', () => {
     // Unusual but valid V8 frame where a function name precedes a path without parens; the
     // anonymous-frame regex is anchored to an absolute path so it skips this frame rather than

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -93,4 +93,19 @@ describe('RSC diagnostics', () => {
       ),
     ).toHaveLength(1);
   });
+
+  it('treats a merged diagnostic as idempotent even when the message format changes', () => {
+    const diagnosticError = new Error('[ReactOnRails] RSC bundle rendering failed.');
+    diagnosticError.name = 'ReactOnRailsRSCStreamError';
+    const genericStreamError = new Error('boom');
+
+    const mergedError = mergeRSCStreamDiagnosticError(genericStreamError, diagnosticError);
+
+    // Tampering with the merged error's message should still leave it recognized as merged
+    // because the guard is now structural (flag property), not message-text based.
+    mergedError.message = 'unrelated message';
+    const mergedAgainError = mergeRSCStreamDiagnosticError(mergedError, diagnosticError);
+
+    expect(mergedAgainError).toBe(mergedError);
+  });
 });

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -106,6 +106,19 @@ describe('RSC diagnostics', () => {
     expect(diagnosticError?.message).toContain('Original error: RSC stream metadata reported hasErrors=true');
   });
 
+  it('treats a renderingError message as a failure signal even when hasErrors is not set', () => {
+    // Locks in the wire contract: the server bundle only emits `renderingError` on actual
+    // failure, so a message alone is enough to trigger the diagnostic. If this ever needs
+    // to change, the guard in buildRSCStreamDiagnosticError must change with it.
+    const diagnosticError = buildRSCStreamDiagnosticError(
+      { hasErrors: false, renderingError: { message: 'useState is not a function' } },
+      { componentName: 'CommentsToggle' },
+    );
+
+    expect(diagnosticError).toBeDefined();
+    expect(diagnosticError?.message).toContain('Original error: useState is not a function');
+  });
+
   it('treats a merged diagnostic as idempotent even when the message format changes', () => {
     const diagnosticError = new Error('[ReactOnRails] RSC bundle rendering failed.');
     diagnosticError.name = 'ReactOnRailsRSCStreamError';

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -72,4 +72,25 @@ describe('RSC diagnostics', () => {
     );
     expect(mergedError.stack).toContain('CommentsToggle.jsx:12:15');
   });
+
+  it('keeps diagnostic merges idempotent when a merged error reaches another catch handler', () => {
+    const diagnosticError = new Error(
+      '[ReactOnRails] RSC bundle rendering failed.\n' +
+        'Component: CommentsToggle\n' +
+        'Original error: useState is not a function',
+    );
+    diagnosticError.name = 'ReactOnRailsRSCStreamError';
+    const genericStreamError = new Error('An error occurred in the Server Components render.');
+
+    const mergedError = mergeRSCStreamDiagnosticError(genericStreamError, diagnosticError);
+    const mergedAgainError = mergeRSCStreamDiagnosticError(mergedError, diagnosticError);
+
+    expect(mergedAgainError).toBe(mergedError);
+    expect(mergedAgainError.message.match(/Original error: useState is not a function/g)).toHaveLength(1);
+    expect(
+      mergedAgainError.message.match(
+        /React stream error: An error occurred in the Server Components render\./g,
+      ),
+    ).toHaveLength(1);
+  });
 });

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -10,6 +10,7 @@ import {
   buildRSCStreamDiagnosticError,
   extractModulePathFromStack,
   mergeRSCStreamDiagnosticError,
+  MERGED_DIAGNOSTIC_FLAG,
 } from '../src/rscDiagnostics.ts';
 
 const encodeLengthPrefixedChunk = (metadata: Record<string, unknown>, content: string) => {
@@ -193,6 +194,18 @@ describe('RSC diagnostics', () => {
     expect(diagnosticError?.message).not.toContain('hasErrors=true');
   });
 
+  it('reduces the stack to the header line when no original stack is present', () => {
+    // Without an original stack, the V8-generated stack would point at this diagnostics module
+    // and mislead error monitors about the error origin.
+    const diagnosticError = buildRSCStreamDiagnosticError(
+      { hasErrors: true },
+      { componentName: 'CommentsToggle' },
+    );
+
+    expect(diagnosticError?.stack).toBe(`${diagnosticError?.name}: ${diagnosticError?.message}`);
+    expect(diagnosticError?.stack).not.toContain('rscDiagnostics');
+  });
+
   it('keeps the merged-diagnostic marker non-enumerable so error reporters do not serialize it', () => {
     const diagnosticError = new Error('[ReactOnRails] RSC bundle rendering failed.');
     diagnosticError.name = 'ReactOnRailsRSCStreamError';
@@ -200,8 +213,8 @@ describe('RSC diagnostics', () => {
 
     const mergedError = mergeRSCStreamDiagnosticError(genericStreamError, diagnosticError);
 
-    expect(Object.keys(mergedError)).not.toContain('__rorRSCDiagMerged');
-    expect(Object.prototype.hasOwnProperty.call(mergedError, '__rorRSCDiagMerged')).toBe(true);
+    expect(Object.keys(mergedError)).not.toContain(MERGED_DIAGNOSTIC_FLAG);
+    expect(Object.prototype.hasOwnProperty.call(mergedError, MERGED_DIAGNOSTIC_FLAG)).toBe(true);
   });
 
   it('treats a merged diagnostic as idempotent even when the message format changes', () => {

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -151,6 +151,26 @@ describe('RSC diagnostics', () => {
     expect(extractModulePathFromStack(stack)).toBe('/app/node_modules/react/index.js');
   });
 
+  it('treats a user directory like "my-webpack/" as user code, not a framework frame', () => {
+    // The webpack arm is anchored to a path separator, so `webpack` preceded by `-` (a word
+    // boundary) is not misclassified as a bundler-internal frame.
+    const stack =
+      'Error: boom\n' +
+      '    at Comp (/app/my-webpack/Component.jsx:1:1)\n' +
+      '    at Real (/app/real.js:2:2)';
+
+    expect(extractModulePathFromStack(stack)).toBe('/app/my-webpack/Component.jsx');
+  });
+
+  it('still treats a real /webpack/ runtime frame as framework-internal', () => {
+    const stack =
+      'Error: boom\n' +
+      '    at __webpack_require__ (/app/webpack/runtime.js:9:9)\n' +
+      '    at Real (/app/real.js:2:2)';
+
+    expect(extractModulePathFromStack(stack)).toBe('/app/real.js');
+  });
+
   it('does not mistake a bare function name for the module path in anonymous frames', () => {
     // Unusual but valid V8 frame where a function name precedes a path without parens; the
     // anonymous-frame regex is anchored to an absolute path so it skips this frame rather than

--- a/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
+++ b/packages/react-on-rails-pro/tests/rscDiagnostics.test.ts
@@ -6,7 +6,11 @@ import { text } from 'stream/consumers';
 import { Readable } from 'stream';
 
 import transformRSCStream from '../src/transformRSCNodeStream.ts';
-import { buildRSCStreamDiagnosticError, mergeRSCStreamDiagnosticError } from '../src/rscDiagnostics.ts';
+import {
+  buildRSCStreamDiagnosticError,
+  extractModulePathFromStack,
+  mergeRSCStreamDiagnosticError,
+} from '../src/rscDiagnostics.ts';
 
 const encodeLengthPrefixedChunk = (metadata: Record<string, unknown>, content: string) => {
   const contentBuffer = Buffer.from(content, 'utf-8');
@@ -117,6 +121,26 @@ describe('RSC diagnostics', () => {
 
     expect(diagnosticError).toBeDefined();
     expect(diagnosticError?.message).toContain('Original error: useState is not a function');
+  });
+
+  it('strips the V8 `async ` keyword from anonymous async stack frames', () => {
+    const stack =
+      'TypeError: useState is not a function\n' +
+      '    at async /app/server.js:42:3\n' +
+      '    at PostsPage (/app/components/PostsPage.jsx:8:3)';
+
+    expect(extractModulePathFromStack(stack)).toBe('/app/server.js');
+  });
+
+  it('keeps the merged-diagnostic marker non-enumerable so error reporters do not serialize it', () => {
+    const diagnosticError = new Error('[ReactOnRails] RSC bundle rendering failed.');
+    diagnosticError.name = 'ReactOnRailsRSCStreamError';
+    const genericStreamError = new Error('boom');
+
+    const mergedError = mergeRSCStreamDiagnosticError(genericStreamError, diagnosticError);
+
+    expect(Object.keys(mergedError)).not.toContain('__rorRSCDiagMerged');
+    expect(Object.prototype.hasOwnProperty.call(mergedError, '__rorRSCDiagMerged')).toBe(true);
   });
 
   it('treats a merged diagnostic as idempotent even when the message format changes', () => {

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -724,8 +724,18 @@ module ReactOnRails
       return if message.blank?
 
       error = StandardError.new(message)
-      error.set_backtrace(rendering_error["stack"].to_s.lines.map(&:chomp))
+      error.set_backtrace(normalize_js_stack_lines(rendering_error["stack"]))
       error
+    end
+
+    # V8 stack strings typically begin with a `"TypeError: ..."` header line that does
+    # not match Ruby's `file:line:in 'method'` backtrace format. Drop the leading header
+    # so backtrace cleaners and error reporters can parse the remaining `at <frame>` lines.
+    # Frames are also `.strip`-ed to drop V8's leading indentation, which Ruby backtraces never carry.
+    def normalize_js_stack_lines(stack)
+      lines = stack.to_s.lines.map { |line| line.chomp.strip }
+      frames = lines.drop_while { |line| !line.start_with?("at ") }
+      frames.empty? ? lines : frames
     end
 
     def should_raise_streaming_prerender_error?(chunk_json_result, render_options)

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -720,26 +720,30 @@ module ReactOnRails
       rendering_error = json_result["renderingError"]
       return unless rendering_error.is_a?(Hash)
 
-      message = rendering_error["message"]
-      return if message.blank?
+      stack = rendering_error["stack"]
+      # Mirror the JS `buildRSCStreamDiagnosticError` fallback: a renderingError that carries only
+      # a stack (no message) should still surface a diagnostic rather than be silently dropped.
+      message = rendering_error["message"].presence ||
+                (stack.present? ? "RSC stream metadata reported a rendering error" : nil)
+      return if message.nil?
 
       error = StandardError.new(message)
-      frames = normalize_js_stack_lines(rendering_error["stack"])
+      frames = normalize_js_stack_lines(stack)
       error.set_backtrace(frames) unless frames.empty?
       error
     end
 
-    # V8 stack strings typically begin with a `"TypeError: ..."` header line that does
-    # not match Ruby's `file:line:in 'method'` backtrace format. Drop the leading header
-    # so backtrace cleaners and error reporters can parse the remaining `at <frame>` lines.
+    # V8 stack strings begin with a `"TypeError: ..."` header line — and chained-exception stacks
+    # add further non-frame headers mid-stack (e.g. `Caused by: ...`) — none of which match Ruby's
+    # `file:line:in 'method'` backtrace format. Keep only the `at <frame>` lines so backtrace
+    # cleaners and APM tools that ship the array raw don't choke on unparseable strings.
     # Frames are also `.strip`-ed to drop V8's leading indentation, which Ruby backtraces never carry.
     #
-    # When the stack has no `at <frame>` lines (e.g. a header-only or non-V8 string) this
-    # returns `[]`, leaving the backtrace nil rather than seeding it with an unparseable
-    # header line that Rails/APM backtrace cleaners would silently drop or misgroup.
+    # When the stack has no `at <frame>` lines (e.g. a header-only or non-V8 string) this returns
+    # `[]`, leaving the backtrace nil rather than seeding it with unparseable header lines.
     def normalize_js_stack_lines(stack)
       lines = stack.to_s.lines.map { |line| line.chomp.strip }
-      lines.drop_while { |line| !line.start_with?("at ") }
+      lines.select { |line| line.start_with?("at ") }
     end
 
     def should_raise_streaming_prerender_error?(chunk_json_result, render_options)

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -742,8 +742,12 @@ module ReactOnRails
     # When the stack has no `at <frame>` lines (e.g. a header-only or non-V8 string) this returns
     # `[]`, leaving the backtrace nil rather than seeding it with unparseable header lines.
     def normalize_js_stack_lines(stack)
-      lines = stack.to_s.lines.map { |line| line.chomp.strip }
-      lines.select { |line| line.start_with?("at ") }
+      # Only V8 string stacks are parseable here. A non-String stack (e.g. an array of frames
+      # from a non-V8 serializer) would otherwise be `to_s`-ed into Ruby array syntax and yield
+      # no usable frames — guard explicitly so the no-backtrace path is intentional, not garbage.
+      return [] unless stack.is_a?(String)
+
+      stack.lines.map { |line| line.chomp.strip }.select { |line| line.start_with?("at ") }
     end
 
     def should_raise_streaming_prerender_error?(chunk_json_result, render_options)

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -733,10 +733,13 @@ module ReactOnRails
     # not match Ruby's `file:line:in 'method'` backtrace format. Drop the leading header
     # so backtrace cleaners and error reporters can parse the remaining `at <frame>` lines.
     # Frames are also `.strip`-ed to drop V8's leading indentation, which Ruby backtraces never carry.
+    #
+    # When the stack has no `at <frame>` lines (e.g. a header-only or non-V8 string) this
+    # returns `[]`, leaving the backtrace nil rather than seeding it with an unparseable
+    # header line that Rails/APM backtrace cleaners would silently drop or misgroup.
     def normalize_js_stack_lines(stack)
       lines = stack.to_s.lines.map { |line| line.chomp.strip }
-      frames = lines.drop_while { |line| !line.start_with?("at ") }
-      frames.empty? ? lines : frames
+      lines.drop_while { |line| !line.start_with?("at ") }
     end
 
     def should_raise_streaming_prerender_error?(chunk_json_result, render_options)

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -710,10 +710,22 @@ module ReactOnRails
       raise ReactOnRails::PrerenderError.new(
         component_name: react_component_name,
         props: sanitized_props_string(props),
-        err: nil,
+        err: rendering_error_from_result(json_result),
         js_code: js_code,
         console_messages: json_result["consoleReplayScript"]
       )
+    end
+
+    def rendering_error_from_result(json_result)
+      rendering_error = json_result["renderingError"]
+      return unless rendering_error.is_a?(Hash)
+
+      message = rendering_error["message"]
+      return if message.blank?
+
+      error = StandardError.new(message)
+      error.set_backtrace(rendering_error["stack"].to_s.lines.map(&:chomp))
+      error
     end
 
     def should_raise_streaming_prerender_error?(chunk_json_result, render_options)

--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -724,7 +724,8 @@ module ReactOnRails
       return if message.blank?
 
       error = StandardError.new(message)
-      error.set_backtrace(normalize_js_stack_lines(rendering_error["stack"]))
+      frames = normalize_js_stack_lines(rendering_error["stack"])
+      error.set_backtrace(frames) unless frames.empty?
       error
     end
 

--- a/react_on_rails/lib/react_on_rails/prerender_error.rb
+++ b/react_on_rails/lib/react_on_rails/prerender_error.rb
@@ -99,15 +99,8 @@ module ReactOnRails
       return nil if error_backtrace.nil? || error_backtrace.empty?
       return error_backtrace.join("\n") if Utils.full_text_errors_enabled?
 
-      cleaned = Rails.backtrace_cleaner.clean(error_backtrace)
-      cleaned_text = cleaned.join("\n")
-      # Only advertise FULL_TEXT_ERRORS when cleaning actually dropped frames. JS backtraces
-      # (e.g. `at CommentsToggle (/app/components/Foo.jsx:12:15)`) don't match Rails' default
-      # silencers, so they pass through unchanged and the tip would falsely imply more frames
-      # are hidden.
-      return cleaned_text unless cleaned.length < error_backtrace.length
-
-      "#{cleaned_text}\n#{Rainbow('💡 Tip: Set FULL_TEXT_ERRORS=true to see the full backtrace').yellow}"
+      "#{Rails.backtrace_cleaner.clean(error_backtrace).join("\n")}\n" +
+        Rainbow("💡 Tip: Set FULL_TEXT_ERRORS=true to see the full backtrace").yellow
     end
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/react_on_rails/lib/react_on_rails/prerender_error.rb
+++ b/react_on_rails/lib/react_on_rails/prerender_error.rb
@@ -61,10 +61,16 @@ module ReactOnRails
 
         MSG
 
-        backtrace = if Utils.full_text_errors_enabled?
-                      err.backtrace.join("\n")
+        error_backtrace = err.backtrace
+        backtrace = if error_backtrace.nil? || error_backtrace.empty?
+                      # JS-originated errors (e.g. an RSC renderingError carrying a message but
+                      # no parseable stack) have no Ruby backtrace. Skip it rather than crashing
+                      # on `nil.join` / `Rails.backtrace_cleaner.clean(nil)`.
+                      nil
+                    elsif Utils.full_text_errors_enabled?
+                      error_backtrace.join("\n")
                     else
-                      "#{Rails.backtrace_cleaner.clean(err.backtrace).join("\n")}\n" +
+                      "#{Rails.backtrace_cleaner.clean(error_backtrace).join("\n")}\n" +
                         Rainbow("💡 Tip: Set FULL_TEXT_ERRORS=true to see the full backtrace").yellow
                     end
       else

--- a/react_on_rails/lib/react_on_rails/prerender_error.rb
+++ b/react_on_rails/lib/react_on_rails/prerender_error.rb
@@ -61,18 +61,7 @@ module ReactOnRails
 
         MSG
 
-        error_backtrace = err.backtrace
-        backtrace = if error_backtrace.nil? || error_backtrace.empty?
-                      # JS-originated errors (e.g. an RSC renderingError carrying a message but
-                      # no parseable stack) have no Ruby backtrace. Skip it rather than crashing
-                      # on `nil.join` / `Rails.backtrace_cleaner.clean(nil)`.
-                      nil
-                    elsif Utils.full_text_errors_enabled?
-                      error_backtrace.join("\n")
-                    else
-                      "#{Rails.backtrace_cleaner.clean(error_backtrace).join("\n")}\n" +
-                        Rainbow("💡 Tip: Set FULL_TEXT_ERRORS=true to see the full backtrace").yellow
-                    end
+        backtrace = formatted_backtrace(err)
       else
         backtrace = nil
       end
@@ -99,6 +88,26 @@ module ReactOnRails
 
       [backtrace, message]
       # rubocop:enable Metrics/AbcSize
+    end
+
+    # Formats `err.backtrace` for display, or returns nil when there are no frames.
+    def formatted_backtrace(err)
+      error_backtrace = err.backtrace
+      # JS-originated errors (e.g. an RSC renderingError carrying a message but no parseable
+      # stack) have no Ruby backtrace. Skip it rather than crashing on `nil.join` /
+      # `Rails.backtrace_cleaner.clean(nil)`.
+      return nil if error_backtrace.nil? || error_backtrace.empty?
+      return error_backtrace.join("\n") if Utils.full_text_errors_enabled?
+
+      cleaned = Rails.backtrace_cleaner.clean(error_backtrace)
+      cleaned_text = cleaned.join("\n")
+      # Only advertise FULL_TEXT_ERRORS when cleaning actually dropped frames. JS backtraces
+      # (e.g. `at CommentsToggle (/app/components/Foo.jsx:12:15)`) don't match Rails' default
+      # silencers, so they pass through unchanged and the tip would falsely imply more frames
+      # are hidden.
+      return cleaned_text unless cleaned.length < error_backtrace.length
+
+      "#{cleaned_text}\n#{Rainbow('💡 Tip: Set FULL_TEXT_ERRORS=true to see the full backtrace').yellow}"
     end
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -597,6 +597,24 @@ describe ReactOnRailsHelper do
         expect(error.message).to include("/app/components/CommentsToggle.jsx:12:15")
       }
     end
+
+    it "drops the V8 error-type header line from the backtrace built from renderingError" do
+      json_result = {
+        "renderingError" => {
+          "message" => "useState is not a function",
+          "stack" => <<~STACK.chomp
+            TypeError: useState is not a function
+                at CommentsToggle (/app/components/CommentsToggle.jsx:12:15)
+                at PostsPage (/app/components/PostsPage.jsx:8:3)
+          STACK
+        }
+      }
+
+      error = helper.send(:rendering_error_from_result, json_result)
+
+      expect(error.backtrace.first).to start_with("at CommentsToggle")
+      expect(error.backtrace).not_to include(/^TypeError:/)
+    end
   end
 
   describe "#redux_store" do

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -616,6 +616,44 @@ describe ReactOnRailsHelper do
       expect(error.backtrace).not_to include(/^TypeError:/)
     end
 
+    it "filters non-`at` header lines that appear mid-stack (chained exceptions)" do
+      json_result = {
+        "renderingError" => {
+          "message" => "boom",
+          "stack" => <<~STACK.chomp
+            TypeError: boom
+                at A (/app/a.js:1:1)
+            Caused by: Error: root
+                at B (/app/b.js:2:2)
+          STACK
+        }
+      }
+
+      error = helper.send(:rendering_error_from_result, json_result)
+
+      expect(error.backtrace).to eq(["at A (/app/a.js:1:1)", "at B (/app/b.js:2:2)"])
+    end
+
+    it "builds a diagnostic from a stack-only renderingError with no message" do
+      json_result = {
+        "renderingError" => {
+          "stack" => "TypeError: boom\n    at Foo (/app/foo.js:1:1)"
+        }
+      }
+
+      error = helper.send(:rendering_error_from_result, json_result)
+
+      expect(error).not_to be_nil
+      expect(error.message).to eq("RSC stream metadata reported a rendering error")
+      expect(error.backtrace.first).to start_with("at Foo")
+    end
+
+    it "returns nil when renderingError has neither message nor stack" do
+      error = helper.send(:rendering_error_from_result, { "renderingError" => {} })
+
+      expect(error).to be_nil
+    end
+
     it "leaves backtrace nil when renderingError has no stack so error reporters can enrich it" do
       json_result = {
         "renderingError" => {

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -627,6 +627,51 @@ describe ReactOnRailsHelper do
 
       expect(error.backtrace).to be_nil
     end
+
+    it "leaves backtrace nil when the stack is a header line with no parseable frames" do
+      json_result = {
+        "renderingError" => {
+          "message" => "useState is not a function",
+          "stack" => "TypeError: useState is not a function"
+        }
+      }
+
+      error = helper.send(:rendering_error_from_result, json_result)
+
+      expect(error.backtrace).to be_nil
+    end
+
+    it "raises PrerenderError without crashing when renderingError has no stack (full text errors)" do
+      allow(ReactOnRails::Utils).to receive(:full_text_errors_enabled?).and_return(true)
+
+      chunk_result = {
+        "consoleReplayScript" => "",
+        "hasErrors" => true,
+        "renderingError" => { "message" => "useState is not a function" }
+      }
+
+      expect do
+        helper.send(:raise_prerender_error, chunk_result, "CommentsToggle", {}, "generated js")
+      end.to raise_error(ReactOnRails::PrerenderError) { |error|
+        expect(error.message).to include("useState is not a function")
+      }
+    end
+
+    it "raises PrerenderError without crashing when renderingError has no stack (cleaned backtrace)" do
+      allow(ReactOnRails::Utils).to receive(:full_text_errors_enabled?).and_return(false)
+
+      chunk_result = {
+        "consoleReplayScript" => "",
+        "hasErrors" => true,
+        "renderingError" => { "message" => "useState is not a function" }
+      }
+
+      expect do
+        helper.send(:raise_prerender_error, chunk_result, "CommentsToggle", {}, "generated js")
+      end.to raise_error(ReactOnRails::PrerenderError) { |error|
+        expect(error.message).to include("useState is not a function")
+      }
+    end
   end
 
   describe "#redux_store" do

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -654,6 +654,19 @@ describe ReactOnRailsHelper do
       expect(error).to be_nil
     end
 
+    it "ignores a non-String stack (e.g. an array of frames) instead of producing garbage frames" do
+      json_result = {
+        "renderingError" => {
+          "message" => "boom",
+          "stack" => ["at A (/app/a.js:1:1)"]
+        }
+      }
+
+      error = helper.send(:rendering_error_from_result, json_result)
+
+      expect(error.backtrace).to be_nil
+    end
+
     it "leaves backtrace nil when renderingError has no stack so error reporters can enrich it" do
       json_result = {
         "renderingError" => {

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -574,6 +574,29 @@ describe ReactOnRailsHelper do
         server_render_js("(function() { throw 42; })()", throw_js_errors: true)
       end.to raise_error(ReactOnRails::PrerenderError)
     end
+
+    it "includes streaming renderingError metadata in PrerenderError details" do
+      allow(ReactOnRails::Utils).to receive(:full_text_errors_enabled?).and_return(true)
+
+      chunk_result = {
+        "consoleReplayScript" => "",
+        "hasErrors" => true,
+        "renderingError" => {
+          "message" => "useState is not a function",
+          "stack" => <<~STACK.chomp
+            TypeError: useState is not a function
+                at CommentsToggle (/app/components/CommentsToggle.jsx:12:15)
+          STACK
+        }
+      }
+
+      expect do
+        helper.send(:raise_prerender_error, chunk_result, "CommentsToggle", {}, "generated js")
+      end.to raise_error(ReactOnRails::PrerenderError) { |error|
+        expect(error.message).to include("useState is not a function")
+        expect(error.message).to include("/app/components/CommentsToggle.jsx:12:15")
+      }
+    end
   end
 
   describe "#redux_store" do

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -615,6 +615,18 @@ describe ReactOnRailsHelper do
       expect(error.backtrace.first).to start_with("at CommentsToggle")
       expect(error.backtrace).not_to include(/^TypeError:/)
     end
+
+    it "leaves backtrace nil when renderingError has no stack so error reporters can enrich it" do
+      json_result = {
+        "renderingError" => {
+          "message" => "useState is not a function"
+        }
+      }
+
+      error = helper.send(:rendering_error_from_result, json_result)
+
+      expect(error.backtrace).to be_nil
+    end
   end
 
   describe "#redux_store" do


### PR DESCRIPTION
### Summary

Improves React on Rails Pro RSC stream diagnostics so failures such as `useState is not a function` keep the original RSC bundle message, stack, component name, and module path when available across server-bundle rendering, Rails `PrerenderError`, and browser fetch paths.

The helper `mergeRSCStreamDiagnosticError` is idempotent (structural `__rorRSCDiagMerged` flag) so an already-merged diagnostic that re-enters another catch handler is not double-merged. The browser `fetchRSC` wrapper preserves `ReactOnRailsRSCStreamError` instances unchanged and attaches `.cause` on the plain wrapper for other errors so Sentry/Node default formatting can walk the chain. Dead `result instanceof Error` branches were removed from the server/client paths.

On the Rails side, `rendering_error_from_result` builds a `StandardError` with the RSC message and strips V8's leading `TypeError: …` header line from the stack so `set_backtrace` receives only `at <frame>` lines that Rails backtrace cleaners and error reporters can parse.

Fixes #3182.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] ~Update documentation~
- [x] Update CHANGELOG file

### Review and CI notes

- Addressed Cursor Bugbot's double-merge thread plus the three subsequent Claude reviews (cause-chain preservation, structural idempotency flag, JS-stack normalization, dead-branch removal).
- Bundle-size delta from the new diagnostic code is ~30–60 bytes past the 0.5 KB dynamic threshold on `registerServerComponent` / `wrapServerComponentRenderer` client bundles. Added `jg-conductor/fix-3182` to `.bundle-size-skip-branch` — this is the documented escape hatch for intentional size growth.
- CodeRabbit skipped review while the PR was a draft.

### Validation

- `pnpm --filter react-on-rails-pro exec jest tests/rscDiagnostics.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro run test:non-rsc`
- `pnpm --filter react-on-rails-pro run test:rsc`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm --filter react-on-rails-pro run build`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `(cd react_on_rails && bundle exec rubocop lib/react_on_rails/helper.rb spec/dummy/spec/helpers/react_on_rails_helper_spec.rb)`
- `(cd react_on_rails/spec/dummy && bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb -e "renderingError")` — new `drops the V8 error-type header line` spec passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on the RSC render path (client fetch, server streams, Rails prerender) where mis-parsing metadata could affect failure visibility, but behavior is additive with extensive tests and guarded fallbacks.
> 
> **Overview**
> **Pro RSC failures now surface the original bundle error** instead of generic React stream messages. A new `rscDiagnostics` module reads length-prefixed stream metadata (`renderingError`, `hasErrors`), builds `ReactOnRailsRSCStreamError` with component, source, module path, and original message/stack, and merges that into React’s stream rejection via an idempotent `mergeRSCStreamDiagnosticError` helper.
> 
> **Client and server Pro paths** wire this through fetch parsing, preloaded hydration, and Node stream transformation: diagnostics are captured from metadata before Flight bytes are consumed, and fetch/hydration wrappers preserve merged errors (including `.cause`) instead of flattening them.
> 
> **Rails `PrerenderError`** now attaches a `StandardError` built from JSON `renderingError` (message plus V8 `at` frames only), and backtrace formatting no longer crashes when JS-originated errors have no Ruby stack.
> 
> CHANGELOG and bundle-size skip for the branch are included; coverage is in `rscDiagnostics.test.ts` and helper specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13b4d3185c6516cf1a79cfdfe143f2f8beca587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved React Server Component (RSC) error diagnostics that now preserve original component names, module paths, and stack traces for clearer failure reporting.

* **Bug Fixes**
  * Enhanced error context preservation during RSC stream rendering failures.

* **Tests**
  * Added comprehensive test coverage for RSC diagnostic error handling.

* **Chores**
  * Updated CI configuration for bundle size checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->