### PR TITLE
[codex] Cover check-links CI invocation

### DIFF
--- a/bin/check-links
+++ b/bin/check-links
@@ -31,8 +31,5 @@ fi
 
 # shellcheck disable=SC2035
 # Word-split the globs so *.md and react_on_rails_pro/*.md expand, matching
-# Word-split the globs so *.md and react_on_rails_pro/*.md expand, matching
 # the workflow's `args: --config .lychee.toml docs/ *.md react_on_rails_pro/*.md`.
-# shellcheck disable=SC2035
-exec lychee --config .lychee.toml docs/ *.md react_on_rails_pro/*.md
 exec lychee --config .lychee.toml docs/ *.md react_on_rails_pro/*.md

--- a/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require "open3"
 require "tmpdir"
+require_relative "spec_helper"
 
 RSpec.describe "bin/check-links" do
   let(:repo_root) { File.expand_path("../../..", __dir__) }

--- a/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/check_links_script_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "tmpdir"
+
+RSpec.describe "bin/check-links" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:script_path) { File.join(repo_root, "bin/check-links") }
+
+  it "invokes lychee with the same inputs as the markdown link CI workflow" do
+    Dir.mktmpdir do |tmpdir|
+      args_file = File.join(tmpdir, "lychee.args")
+      lychee_stub = File.join(tmpdir, "lychee")
+      File.write(
+        lychee_stub,
+        <<~BASH
+          #!/usr/bin/env bash
+          printf '%s\\n' "$@" > "$LYCHEE_ARGS_FILE"
+        BASH
+      )
+      FileUtils.chmod("+x", lychee_stub)
+
+      _stdout, stderr, status = Open3.capture3(
+        {
+          "LYCHEE_ARGS_FILE" => args_file,
+          "PATH" => "#{tmpdir}:#{ENV.fetch('PATH')}"
+        },
+        script_path,
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+      expect(File.read(args_file).lines.map(&:chomp)).to eq(expected_lychee_args)
+    end
+  end
+
+  it "keeps the lychee invocation documented once" do
+    script_content = File.read(script_path)
+    executable_lines = script_content.lines.grep_v(/\A\s*(#|$)/).join
+
+    expect(script_content.scan(/^# Word-split the globs/).size).to eq(1)
+    expect(script_content.scan(/^exec lychee /).size).to eq(1)
+    expect(executable_lines).not_to include("--files-from")
+  end
+
+  def expected_lychee_args
+    Dir.chdir(repo_root) do
+      ["--config", ".lychee.toml", "docs/"] + Dir["*.md"] + Dir["react_on_rails_pro/*.md"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #3391.

This adds regression coverage for `bin/check-links` so the local helper keeps invoking `lychee` with the same inputs used by the Check Markdown Links workflow: `docs/`, root Markdown files, and `react_on_rails_pro/*.md`.

It also removes the duplicated comment and unreachable duplicate `exec lychee` line left in the helper after the CI-alignment change.

## Root Cause

`bin/check-links` had been updated to match the CI lychee inputs, but the behavior was not covered by a regression spec and the helper kept duplicated invocation text. The spec now stubs `lychee` and asserts the helper's expanded arguments match the CI-equivalent inputs, while also guarding against reintroducing a `--files-from` command path.

## Validation

- `cd react_on_rails && bundle exec rspec spec/react_on_rails/check_links_script_spec.rb`
- `lychee --version && bin/check-links`
- `cd react_on_rails && bundle exec rubocop`
- pre-commit hook: trailing newlines, changed-file RuboCop, autofix
- pre-push hook: branch RuboCop, changed Markdown link check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and script cleanup with no runtime or production behavior changes.
> 
> **Overview**
> Adds **RSpec coverage** for `bin/check-links` so local runs stay aligned with the Check Markdown Links workflow: a stubbed `lychee` on `PATH` records arguments and expects `--config .lychee.toml`, `docs/`, root `*.md`, and `react_on_rails_pro/*.md`—the same inputs as CI.
> 
> A second example asserts the helper documents the invocation **once** (single `exec lychee` and matching comment) and does not use `--files-from`, which would break relative link resolution for docs.
> 
> **`bin/check-links`** drops a duplicated comment and an unreachable duplicate `exec lychee` line left over from the CI-alignment change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f316bd2255d19f6310f3047675f70e95a59962d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments in the link-checking script to document the workflow-equivalent arguments and file globs used during the link validation process.

* **Tests**
  * Added test coverage for the link-checking script to verify correct invocation with expected arguments, environment variables, and configuration, ensuring reliable link validation behavior and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->