### PR TITLE
Draft demo fleet orchestrator design for cross-repo gem upgrades

### DIFF
--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -26,6 +26,8 @@ Lives at [demo-fleet.yml](demo-fleet.yml). Schema documented in the file's heade
 
 The manifest captures **data**, not docs. Headlines and per-repo appendix text stay in the RC plan; the orchestrator only references the `headline` field for PR-body templating.
 
+Package references are structured as `{ ecosystem: gem|npm, name: ... }`, not inferred from underscores or dashes. `DemoFleet` validates every package ref against the manifest's `age_gate.own_packages` set for ShakaCode-owned packages or against an explicit allowlist for third-party package bumps before it can compute registry lookups or lockfile updates.
+
 ## Orchestrator skeleton
 
 Convention in this repo: orchestration lives in Rake (`rakelib/release.rake`), with `script/*` as a thin shim. Demo-fleet follows the same pattern.
@@ -34,37 +36,40 @@ Convention in this repo: orchestration lives in Rake (`rakelib/release.rake`), w
 
 ```ruby
 # Release track — invoked per RC and per final
-task "demo_fleet:release_track", [:react_on_rails, :shakapacker, :pro, :cpflow] do |_, args|
+task "demo_fleet:release_track", [:react_on_rails, :shakapacker, :react_on_rails_pro, :cpflow] do |_, args|
   fleet = DemoFleet.load("internal/contributor-info/demo-fleet.yml")
-  versions = args.to_h.compact
+  versions = VersionSet.from_rake_args(args.to_h.compact) # keys match manifest package names
   tracking_issue = TrackingIssue.create_or_update(versions)
+  target_repos = fleet.repos.select { |repo| repo.consumes?(versions.package_refs) }
 
-  fleet.repos.each do |repo|
-    next unless repo.consumes?(versions.keys)
+  results = DemoFleet::Runner.run_concurrently(target_repos, concurrency: fleet.concurrency) do |repo|
     pr = DemoPR.open_or_update(repo, versions, mode: :release_track)
     pr.wait_for_ci_and_review_app(timeout: 90.minutes)
-    tracking_issue.record(repo, pr.result)
+    pr.result
   end
 
+  tracking_issue.record_all(results)
   tracking_issue.gate_check!  # fails if any hard_gate PR is red
 end
 
 # Freshness track — weekly scheduled
 task "demo_fleet:freshness_track" do
   fleet = DemoFleet.load("internal/contributor-info/demo-fleet.yml")
+  target_repos = fleet.repos.reject { |repo| DemoPR.open_release_pr?(repo) }
 
-  fleet.repos.each do |repo|
-    next if DemoPR.open_release_pr?(repo)  # don't fight an in-flight RC PR
+  results = DemoFleet::Runner.run_concurrently(target_repos, concurrency: fleet.concurrency) do |repo|
     proposed_bumps = DependencyBumps.compute(repo, age_gate: fleet.age_gate)
-    next if proposed_bumps.empty?
+    next DemoResult.skipped(repo, "no permitted bumps") if proposed_bumps.empty?
     pr = DemoPR.open_or_update(repo, proposed_bumps, mode: :freshness)
     pr.wait_for_ci_and_review_app(timeout: 90.minutes)
-    pr.file_issue_if_red(repo)  # freshness failures file issues, do not block
+    pr.result
   end
+
+  results.each { |result| FreshnessIssue.file_if_red(result) unless result.green? } # freshness failures file issues, do not block
 end
 
 # Local-only: show what a release would propose, without opening anything
-task "demo_fleet:plan", [:react_on_rails, :shakapacker, :pro, :cpflow] do |_, args|
+task "demo_fleet:plan", [:react_on_rails, :shakapacker, :react_on_rails_pro, :cpflow] do |_, args|
   # ...prints a table; no network mutations
 end
 ```
@@ -80,10 +85,18 @@ exec bundle exec rake "demo_fleet:${1:-plan}"
 ### Pieces the skeleton hides
 
 - `DemoFleet` — manifest loader; validates `schema_version` and rejects unknown keys.
+- `DemoFleet::Runner` — bounded parallel executor. It records per-repo exceptions as red `DemoResult` objects, keeps processing the remaining repos, and re-raises only after `tracking_issue.record_all` and `tracking_issue.gate_check!` have made the failure visible.
 - `DemoPR` — opens/updates the bump PR in a demo repo via a GitHub App installation token (see Credentials). Generates the PR body from the RC plan's RC Test Report template, prefilled with the demo's manifest data.
 - `DependencyBumps` — computes proposed version bumps with the age gate (next section).
 - `TrackingIssue` — creates/updates the per-RC tracking issue in `shakacode/react_on_rails` from `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`; ticks checkboxes as PRs land.
-- `pr.wait_for_ci_and_review_app` — polls GitHub Checks API for `cpflow/review-app`, then hits each `smoke` URL against the review-app deploy URL exposed by the workflow.
+- `ReviewApp` — validates `review_app.cpflow_app_name`, polls GitHub Checks API for `review_app.status_check`, asks CPFlow for that app's review URL for the PR branch, and hits each `smoke` path against that base URL. It never derives the URL from the repo slug.
+- `pr.wait_for_ci_and_review_app` — coordinates CI polling plus `ReviewApp` smoke checks.
+
+### Parallel execution and failure recording
+
+Release-track and freshness-track both dispatch repo work in parallel with a bounded concurrency limit (default 8, overridable by CI). Wall time is therefore capped by the slowest repo, not by `repos.count * 90.minutes`.
+
+The runner treats each repo as an independent result. Network failures, rate limits, missing review-app checks, and timeouts are rescued at the repo boundary and recorded on the tracking issue as red results. The overall task can still exit non-zero after all repos have reported, but it must not abandon later repos or skip `gate_check!` because an earlier repo raised.
 
 ## Age-gate logic
 
@@ -107,9 +120,12 @@ def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:)
 
   return true if age_days >= min_days
 
-  # Allow break-glass override via a labelled tracking issue. Operator must
-  # add the `age-gate-override` label and a one-line justification.
-  return true if AgeGateOverride.active?(package, candidate_version)
+  return true if AgeGateOverride.active?(
+    package,
+    candidate_version,
+    tracking_issue: ReleaseTrackingIssue.current,
+    now: Time.now
+  )
 
   false
 end
@@ -142,10 +158,12 @@ Layers, in order:
 
 For CVEs that need a sub-min-days patched version:
 
-1. Operator opens or updates a tracking issue in `shakacode/react_on_rails` titled `age-gate override: <pkg>@<version>`.
-2. Issue body includes the CVE link and a justification.
-3. Operator applies the `age-gate-override` label. The orchestrator's next run sees the label and permits that exact `pkg@version` for 7 days.
-4. The override is logged in the tracking issue and in the resulting PR body.
+1. Release manager opens or updates a tracking issue in `shakacode/react_on_rails` titled `age-gate override: <pkg>@<version>`.
+2. Issue body includes the CVE link, affected package, candidate version, and justification.
+3. A second maintainer approves the override in an issue comment.
+4. Release manager applies the `age-gate-override` label after approval. The orchestrator reads GitHub issue timeline events and uses the most recent label-applied timestamp as the start of the 7-day window; `updated_at` is not used because ordinary edits would extend the window accidentally.
+5. `AgeGateOverride.active?` permits only the exact `ecosystem/name@version` named in the issue title/body and only while `now - label_applied_at <= 7.days`.
+6. The override, approver, and expiry timestamp are logged in the tracking issue and in the resulting PR body.
 
 This keeps audit trail in GitHub, not in shell history or env vars.
 
@@ -180,9 +198,8 @@ When a release-track run lands while a freshness PR is open:
 ## Open items requiring user input
 
 1. **Manifest verification owner.** Who runs the one-time pass to clear `verify: true` flags? Default: assigned during the next RC cycle, one demo per release manager.
-2. **Default freshness conflict mode.** Confirmed default is `close + reopen`?
-3. **Pro gem source credential model.** Confirmed App installation, or do we need a separate machine user for the Pro source specifically?
-4. **`react-on-rails-demos` promotion criteria.** What "stable" means before we move the runtime out of `react_on_rails`. Suggested: orchestrator has driven two consecutive successful RC cycles end-to-end without manual fixups.
+2. **Pro gem source credential model.** Confirmed App installation, or do we need a separate machine user for the Pro source specifically?
+3. **`react-on-rails-demos` promotion criteria.** What "stable" means before we move the runtime out of `react_on_rails`. Suggested: orchestrator has driven two consecutive successful RC cycles end-to-end without manual fixups.
 
 ## Out of scope (v1)
 

--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -49,7 +49,7 @@ task "demo_fleet:release_track", [:react_on_rails, :shakapacker, :react_on_rails
   end
 
   tracking_issue.record_all(results)
-  tracking_issue.gate_check!  # fails if any hard_gate PR is red
+  tracking_issue.gate_check!  # fails unless every hard_gate checkbox is ticked (CI green + manual sign-off)
 end
 
 # Freshness track — weekly scheduled
@@ -88,7 +88,7 @@ exec bundle exec rake "demo_fleet:${1:-plan}"
 - `DemoFleet::Runner` — bounded parallel executor. It records per-repo exceptions as red `DemoResult` objects, keeps processing the remaining repos, and re-raises only after `tracking_issue.record_all` and `tracking_issue.gate_check!` have made the failure visible.
 - `DemoPR` — opens/updates the bump PR in a demo repo via a GitHub App installation token (see Credentials). Generates the PR body from the RC plan's RC Test Report template, prefilled with the demo's manifest data.
 - `DependencyBumps` — computes proposed version bumps with the age gate (next section).
-- `TrackingIssue` — creates/updates the per-RC tracking issue in `shakacode/react_on_rails` from `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`; ticks checkboxes as PRs land.
+- `TrackingIssue` — creates/updates the per-RC tracking issue in `shakacode/react_on_rails` from `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`. `record_all` ticks only the _automated_ sub-items (CI green + review-app smoke) from each `DemoResult`; the _manual_ RC-checklist items stay for a human to tick. `gate_check!` gates on the issue's checkbox state, not on the raw `DemoResult`s — so a hard_gate demo that is automated-green but still has an unchecked manual item blocks the final release. This keeps the RC plan the owner of release policy; the orchestrator only fills in the mechanical checkboxes.
 - `ReviewApp` — when `review_app.cpflow_app_name` is non-null, polls the GitHub Checks API for `review_app.status_check`, asks CPFlow for that app's review URL for the PR branch, and hits each `smoke` path against that base URL (it never derives the URL from the repo slug). When `cpflow_app_name` is null — a demo with no review-app pipeline yet — it short-circuits: no status-check poll, no URL lookup, no smoke run. A repo with a `review_app` block cannot clear `verify: true` while `cpflow_app_name` is null; demos that genuinely have no pipeline set `review_app: null` instead.
 - `pr.wait_for_ci_and_review_app` — coordinates CI polling plus `ReviewApp` smoke checks.
 
@@ -160,9 +160,9 @@ For CVEs that need a sub-min-days patched version:
 
 1. Release manager opens or updates a tracking issue in `shakacode/react_on_rails` titled `age-gate override: <pkg>@<version>`.
 2. Issue body includes the CVE link, affected package, candidate version, and justification.
-3. A second maintainer approves the override in an issue comment.
+3. A second maintainer approves the override in an issue comment. The approval is only honored if the commenter is a verified member of the designated maintainers team (e.g. `shakacode/maintainers`): `AgeGateOverride.active?` checks `GET /orgs/shakacode/teams/maintainers/memberships/<user>` for both the issue author and the approver, so a free-text "approved" from anyone outside the team is ignored.
 4. Release manager applies the `age-gate-override` label after approval. The orchestrator reads GitHub issue timeline events and uses the most recent label-applied timestamp as the start of the 7-day window; `updated_at` is not used because ordinary edits would extend the window accidentally.
-5. `AgeGateOverride.active?` permits only the exact `ecosystem/name@version` named in the issue title/body and only while `now - label_applied_at <= 7.days`.
+5. `AgeGateOverride.active?` permits only the exact `ecosystem/name@version` named in the issue title/body, only while `now - label_applied_at <= 7.days`, and only when both the issue author and the approver pass the team-membership check from step 3.
 6. The override, approver, and expiry timestamp are logged in the tracking issue and in the resulting PR body.
 
 This keeps audit trail in GitHub, not in shell history or env vars.

--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -43,7 +43,7 @@ task "demo_fleet:release_track", [:react_on_rails, :shakapacker, :react_on_rails
   target_repos = fleet.repos.select { |repo| repo.consumes?(versions.package_refs) }
 
   results = DemoFleet::Runner.run_concurrently(target_repos, concurrency: fleet.concurrency) do |repo|
-    pr = DemoPR.open_or_update(repo, versions, mode: :release_track)
+    pr = DemoPR.open_or_update(repo, versions, mode: :release_track, age_gate: fleet.age_gate)
     pr.wait_for_ci_and_review_app(timeout: 90.minutes)
     pr.result
   end
@@ -107,11 +107,12 @@ The supply-chain defense. Uniform across package managers so policy is consisten
 - `age_gate.npm_min_days`, `age_gate.gem_min_days`, `age_gate.actions_min_days` from the manifest.
 - `age_gate.own_packages.{npm,gem}` — our own packages bypass the gate on release-track runs.
 - Mode (`:release_track` vs `:freshness`).
+- The open break-glass override issue, if any (`override_issue`), resolved once per run and passed down to `permitted?` — never read from a global, so concurrent checks in the parallel runner stay thread-safe.
 
 ### Per-package decision
 
 ```ruby
-def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:)
+def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:, override_issue: nil)
   min_days = age_gate.min_days_for(package.ecosystem)
   return true if mode == :release_track && age_gate.own?(package)
 
@@ -120,12 +121,17 @@ def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:)
 
   return true if age_days >= min_days
 
-  return true if AgeGateOverride.active?(
-    package,
-    candidate_version,
-    tracking_issue: ReleaseTrackingIssue.current,
-    now: Time.now
-  )
+  # Break-glass override: resolved once by the caller and passed in explicitly
+  # (never read from a global) so concurrent calls in the parallel runner stay
+  # thread-safe. nil when no override issue is open — e.g. an ordinary freshness
+  # run — in which case a too-young bump is simply not permitted.
+  return true if override_issue &&
+                 AgeGateOverride.active?(
+                   package,
+                   candidate_version,
+                   tracking_issue: override_issue,
+                   now: Time.now
+                 )
 
   false
 end
@@ -197,7 +203,7 @@ When a release-track run lands while a freshness PR is open:
 
 ## Open items requiring user input
 
-1. **Manifest verification owner.** Who runs the one-time pass to clear `verify: true` flags? Default: assigned during the next RC cycle, one demo per release manager.
+1. **Manifest verification owner.** Who runs the one-time pass to clear `verify: true` flags? Default: assigned during the next RC cycle, one demo per release manager. The pass must also supply a real `cpflow_app_name` for each repo (or set `review_app: null` for demos with no CPFlow pipeline) — every repo currently inherits the `null` default, which holds the `verify: true` gate shut.
 2. **Pro gem source credential model.** Confirmed App installation, or do we need a separate machine user for the Pro source specifically?
 3. **`react-on-rails-demos` promotion criteria.** What "stable" means before we move the runtime out of `react_on_rails`. Suggested: orchestrator has driven two consecutive successful RC cycles end-to-end without manual fixups.
 

--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -26,7 +26,7 @@ Lives at [demo-fleet.yml](demo-fleet.yml). Schema documented in the file's heade
 
 The manifest captures **data**, not docs. Headlines and per-repo appendix text stay in the RC plan; the orchestrator only references the `headline` field for PR-body templating.
 
-Package references are structured as `{ ecosystem: gem|npm, name: ... }`, not inferred from underscores or dashes. `DemoFleet` validates every package ref against the manifest's `age_gate.own_packages` set for ShakaCode-owned packages or against an explicit allowlist for third-party package bumps before it can compute registry lookups or lockfile updates.
+Package references are structured as `{ ecosystem: gem|npm, name: ... }`, not inferred from underscores or dashes. `DemoFleet` resolves each ref's ecosystem so it queries the right registry and updates the right lockfile. ShakaCode-owned packages (the `age_gate.own_packages` set) bypass the age gate on release-track runs; every other package — including the transitive third-party bumps the freshness track proposes — is governed by the age gate, not a separate allowlist.
 
 ## Orchestrator skeleton
 
@@ -65,7 +65,7 @@ task "demo_fleet:freshness_track" do
     pr.result
   end
 
-  results.each { |result| FreshnessIssue.file_if_red(result) unless result.green? } # freshness failures file issues, do not block
+  results.each { |result| FreshnessIssue.file_if_red(result) } # freshness failures file issues, do not block
 end
 
 # Local-only: show what a release would propose, without opening anything
@@ -89,12 +89,12 @@ exec bundle exec rake "demo_fleet:${1:-plan}"
 - `DemoPR` — opens/updates the bump PR in a demo repo via a GitHub App installation token (see Credentials). Generates the PR body from the RC plan's RC Test Report template, prefilled with the demo's manifest data.
 - `DependencyBumps` — computes proposed version bumps with the age gate (next section).
 - `TrackingIssue` — creates/updates the per-RC tracking issue in `shakacode/react_on_rails` from `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`; ticks checkboxes as PRs land.
-- `ReviewApp` — validates `review_app.cpflow_app_name`, polls GitHub Checks API for `review_app.status_check`, asks CPFlow for that app's review URL for the PR branch, and hits each `smoke` path against that base URL. It never derives the URL from the repo slug.
+- `ReviewApp` — when `review_app.cpflow_app_name` is non-null, polls the GitHub Checks API for `review_app.status_check`, asks CPFlow for that app's review URL for the PR branch, and hits each `smoke` path against that base URL (it never derives the URL from the repo slug). When `cpflow_app_name` is null — a demo with no review-app pipeline yet — it short-circuits: no status-check poll, no URL lookup, no smoke run. A repo with a `review_app` block cannot clear `verify: true` while `cpflow_app_name` is null; demos that genuinely have no pipeline set `review_app: null` instead.
 - `pr.wait_for_ci_and_review_app` — coordinates CI polling plus `ReviewApp` smoke checks.
 
 ### Parallel execution and failure recording
 
-Release-track and freshness-track both dispatch repo work in parallel with a bounded concurrency limit (default 8, overridable by CI). Wall time is therefore capped by the slowest repo, not by `repos.count * 90.minutes`.
+Release-track and freshness-track both dispatch repo work in parallel with a bounded concurrency limit (`concurrency` in the manifest, default 8; override per-run with the `DEMO_FLEET_CONCURRENCY` env var). Wall time is therefore capped by the slowest repo, not by `repos.count * 90.minutes`.
 
 The runner treats each repo as an independent result. Network failures, rate limits, missing review-app checks, and timeouts are rescued at the repo boundary and recorded on the tracking issue as red results. The overall task can still exit non-zero after all repos have reported, but it must not abandon later repos or skip `gate_check!` because an earlier repo raised.
 

--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -1,0 +1,183 @@
+# Demo Fleet Orchestrator — Design Sketch
+
+**Status:** Draft, pending user review
+**Date:** 2026-05-27
+**Companion to:** [rc-testing-plan-design.md](rc-testing-plan-design.md)
+
+## Purpose
+
+Make cross-repo gem/npm bumps across the demo fleet repeatable and safe. Two modes:
+
+1. **Release track** — triggered on `react_on_rails` / `shakapacker` / `react_on_rails_pro` / `cpflow` RC and final releases. Executes the RC PR cycle defined in the RC plan. Tier 1 demos hard-block the final release.
+2. **Freshness track** — scheduled (weekly), bumps transitive deps within each demo to catch upstream breakage early. Tier 1 review-app smoke must pass; failures file issues, not block.
+
+The orchestrator is the executor of the existing RC plan, not a parallel system. The RC plan owns policy (tiers, checklists, gating); this orchestrator owns mechanics (open PRs, bump lockfiles, wait for CI + review-app smoke, post results to the tracking issue).
+
+## Layering
+
+- **`react_on_rails` (this repo)** — owns the manifest ([demo-fleet.yml](demo-fleet.yml)), the RC plan, the orchestrator Rake tasks, and the tracking-issue template. Nothing in this repo opens cross-repo PRs at runtime by itself — see the credential model below.
+- **Per demo repo** — owns its own CI, CPFlow review-app workflow, and Playwright smoke. The orchestrator dispatches and observes; it does not push CI definitions into demos.
+- **No separate `react-on-rails-demos` repo, yet.** Defer until the orchestrator is stable here. When promoted, the manifest stays in `react_on_rails` (it's policy); only the runtime moves.
+
+## Manifest
+
+Lives at [demo-fleet.yml](demo-fleet.yml). Schema documented in the file's header. Every entry currently carries `verify: true` because the per-demo `package_manager`, `smoke` paths, and `needs_pro` flags must be confirmed by inspecting each repo before the manifest is treated as authoritative — same convention as the RC plan's `*` markers.
+
+The manifest captures **data**, not docs. Headlines and per-repo appendix text stay in the RC plan; the orchestrator only references the `headline` field for PR-body templating.
+
+## Orchestrator skeleton
+
+Convention in this repo: orchestration lives in Rake (`rakelib/release.rake`), with `script/*` as a thin shim. Demo-fleet follows the same pattern.
+
+### Rake tasks (`rakelib/demo_fleet.rake`)
+
+```ruby
+# Release track — invoked per RC and per final
+task "demo_fleet:release_track", [:react_on_rails, :shakapacker, :pro, :cpflow] do |_, args|
+  fleet = DemoFleet.load("internal/contributor-info/demo-fleet.yml")
+  versions = args.to_h.compact
+  tracking_issue = TrackingIssue.create_or_update(versions)
+
+  fleet.repos.each do |repo|
+    next unless repo.consumes?(versions.keys)
+    pr = DemoPR.open_or_update(repo, versions, mode: :release_track)
+    pr.wait_for_ci_and_review_app(timeout: 90.minutes)
+    tracking_issue.record(repo, pr.result)
+  end
+
+  tracking_issue.gate_check!  # fails if any hard_gate PR is red
+end
+
+# Freshness track — weekly scheduled
+task "demo_fleet:freshness_track" do
+  fleet = DemoFleet.load("internal/contributor-info/demo-fleet.yml")
+
+  fleet.repos.each do |repo|
+    next if DemoPR.open_release_pr?(repo)  # don't fight an in-flight RC PR
+    proposed_bumps = DependencyBumps.compute(repo, age_gate: fleet.age_gate)
+    next if proposed_bumps.empty?
+    pr = DemoPR.open_or_update(repo, proposed_bumps, mode: :freshness)
+    pr.wait_for_ci_and_review_app(timeout: 90.minutes)
+    pr.file_issue_if_red(repo)  # freshness failures file issues, do not block
+  end
+end
+
+# Local-only: show what a release would propose, without opening anything
+task "demo_fleet:plan", [:react_on_rails, :shakapacker, :pro, :cpflow] do |_, args|
+  # ...prints a table; no network mutations
+end
+```
+
+### Shim (`script/demo-fleet`)
+
+```bash
+#!/bin/bash
+# Thin shim — see `rake -D demo_fleet`
+exec bundle exec rake "demo_fleet:${1:-plan}"
+```
+
+### Pieces the skeleton hides
+
+- `DemoFleet` — manifest loader; validates `schema_version` and rejects unknown keys.
+- `DemoPR` — opens/updates the bump PR in a demo repo via a GitHub App installation token (see Credentials). Generates the PR body from the RC plan's RC Test Report template, prefilled with the demo's manifest data.
+- `DependencyBumps` — computes proposed version bumps with the age gate (next section).
+- `TrackingIssue` — creates/updates the per-RC tracking issue in `shakacode/react_on_rails` from `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`; ticks checkboxes as PRs land.
+- `pr.wait_for_ci_and_review_app` — polls GitHub Checks API for `cpflow/review-app`, then hits each `smoke` URL against the review-app deploy URL exposed by the workflow.
+
+## Age-gate logic
+
+The supply-chain defense. Uniform across package managers so policy is consistent — npm `minimumReleaseAge` is pnpm-only and recent, and Bundler has no native equivalent, so we don't rely on either.
+
+### Inputs
+
+- `age_gate.npm_min_days`, `age_gate.gem_min_days`, `age_gate.actions_min_days` from the manifest.
+- `age_gate.own_packages.{npm,gem}` — our own packages bypass the gate on release-track runs.
+- Mode (`:release_track` vs `:freshness`).
+
+### Per-package decision
+
+```ruby
+def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:)
+  min_days = age_gate.min_days_for(package.ecosystem)
+  return true if mode == :release_track && age_gate.own?(package)
+
+  published_at = Registry.published_at(package, candidate_version)
+  age_days = (Time.now - published_at) / 86_400
+
+  return true if age_days >= min_days
+
+  # Allow break-glass override via a labelled tracking issue. Operator must
+  # add the `age-gate-override` label and a one-line justification.
+  return true if AgeGateOverride.active?(package, candidate_version)
+
+  false
+end
+```
+
+### Registry lookups
+
+- **npm** — `GET https://registry.npmjs.org/<pkg>` → `time[<version>]` is the publish timestamp. No auth required.
+- **RubyGems** — `GET https://rubygems.org/api/v1/versions/<gem>.json` → array of `{number, created_at, yanked}`. Pick matching `number`. No auth required.
+- **GitHub Actions** — `GET https://api.github.com/repos/<owner>/<repo>/releases/tags/<tag>` → `published_at`. Auth via the orchestrator's installation token.
+
+Cache responses for the duration of a single orchestrator run (TTL 1h) to avoid hammering registries when many demos consume the same package.
+
+### Why uniform-in-orchestrator instead of per-PM config
+
+Demos in the fleet span pnpm, yarn classic, yarn berry, and bare npm (see manifest `package_manager` field). pnpm's `minimumReleaseAge` would only cover the pnpm demos and only after upgrading them all to pnpm 10+. The orchestrator computes bumps anyway (it has to know which versions to propose), so it's the natural enforcement point. Each demo's own Dependabot config keeps its `cooldown` for routine background updates; the orchestrator is the second layer for the bumps it drives.
+
+### Break-glass
+
+For CVEs that need a sub-min-days patched version:
+
+1. Operator opens or updates a tracking issue in `shakacode/react_on_rails` titled `age-gate override: <pkg>@<version>`.
+2. Issue body includes the CVE link and a justification.
+3. Operator applies the `age-gate-override` label. The orchestrator's next run sees the label and permits that exact `pkg@version` for 7 days.
+4. The override is logged in the tracking issue and in the resulting PR body.
+
+This keeps audit trail in GitHub, not in shell history or env vars.
+
+## Credentials
+
+A ShakaCode GitHub App, installed on:
+
+- `shakacode/react_on_rails` (read code, write issues/PRs)
+- Every demo repo in the manifest (write contents for the bump branch, write PRs)
+- The Pro gem source for repos with `needs_pro: true`
+
+The orchestrator uses the App installation token. No long-lived PATs in CI.
+
+Demos with `needs_pro: true` must additionally be able to `bundle install` the Pro gem during their own CI — that's a per-demo CI secret, not the orchestrator's problem, but the manifest flag is the discovery surface.
+
+## Conflict policy
+
+When the weekly freshness train runs and a demo has an open release-track PR:
+
+- Freshness skips that demo for the cycle.
+- Logged in the freshness summary so it's visible the demo was deliberately skipped, not silently missed.
+
+When a release-track run lands while a freshness PR is open:
+
+- Release-track takes priority. The orchestrator rebases or closes the open freshness PR (configurable per demo; default: close + reopen after the release-track PR merges).
+
+## Cadence
+
+- **Release track** — triggered manually by the release manager from `rake demo_fleet:release_track[X.Y.Z-rcN,A.B.C-rcM,...]` when an RC is cut, and again when the final ships. The post-release final-bump step in the RC plan is just `release_track` invoked with non-RC versions.
+- **Freshness track** — GitHub Actions schedule, weekly, Monday 08:00 PT. Workflow at `.github/workflows/demo-fleet-freshness.yml` in this repo.
+
+## Open items requiring user input
+
+1. **Manifest verification owner.** Who runs the one-time pass to clear `verify: true` flags? Default: assigned during the next RC cycle, one demo per release manager.
+2. **Default freshness conflict mode.** Confirmed default is `close + reopen`?
+3. **Pro gem source credential model.** Confirmed App installation, or do we need a separate machine user for the Pro source specifically?
+4. **`react-on-rails-demos` promotion criteria.** What "stable" means before we move the runtime out of `react_on_rails`. Suggested: orchestrator has driven two consecutive successful RC cycles end-to-end without manual fixups.
+
+## Out of scope (v1)
+
+- Auto-generating per-demo Playwright smokes (covered by the RC plan's automation roadmap).
+- Notifying Slack / Discord on freshness failures — start with GitHub issues; add chatops later.
+- Cross-demo dependency dedup (e.g., harmonising React version across the fleet).
+
+## Lifecycle
+
+This file is a design spec. Once approved and the orchestrator lands, the canonical implementation lives in `rakelib/demo_fleet.rake` + `internal/contributor-info/demo-fleet.yml`. Delete this design doc in the implementing PR — same rule as `rc-testing-plan-design.md`.

--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -58,7 +58,7 @@ task "demo_fleet:freshness_track" do
   target_repos = fleet.repos.reject { |repo| DemoPR.open_release_pr?(repo) }
 
   results = DemoFleet::Runner.run_concurrently(target_repos, concurrency: fleet.concurrency) do |repo|
-    proposed_bumps = DependencyBumps.compute(repo, age_gate: fleet.age_gate)
+    proposed_bumps = DependencyBumps.compute(repo, age_gate: fleet.age_gate, skip_own: true) # own packages ship via release-track
     next DemoResult.skipped(repo, "no permitted bumps") if proposed_bumps.empty?
     pr = DemoPR.open_or_update(repo, proposed_bumps, mode: :freshness)
     pr.wait_for_ci_and_review_app(timeout: 90.minutes)
@@ -87,7 +87,7 @@ exec bundle exec rake "demo_fleet:${1:-plan}"
 - `DemoFleet` — manifest loader; validates `schema_version` and rejects unknown keys.
 - `DemoFleet::Runner` — bounded parallel executor. It records per-repo exceptions as red `DemoResult` objects, keeps processing the remaining repos, and re-raises only after `tracking_issue.record_all` and `tracking_issue.gate_check!` have made the failure visible.
 - `DemoPR` — opens/updates the bump PR in a demo repo via a GitHub App installation token (see Credentials). Generates the PR body from the RC plan's RC Test Report template, prefilled with the demo's manifest data.
-- `DependencyBumps` — computes proposed version bumps with the age gate (next section).
+- `DependencyBumps` — computes proposed version bumps with the age gate (next section). On the freshness track (`skip_own: true`) it proposes only third-party/transitive bumps; our own packages (`age_gate.own_packages`, including `cpflow`) are driven exclusively by the release track, so the weekly train never bumps a deploy tool on its own cadence.
 - `TrackingIssue` — creates/updates the per-RC tracking issue in `shakacode/react_on_rails` from `.github/ISSUE_TEMPLATE/rc-release-tracking.yml`. `record_all` ticks only the _automated_ sub-items (CI green + review-app smoke) from each `DemoResult`; the _manual_ RC-checklist items stay for a human to tick. `gate_check!` gates on the issue's checkbox state, not on the raw `DemoResult`s — so a hard_gate demo that is automated-green but still has an unchecked manual item blocks the final release. This keeps the RC plan the owner of release policy; the orchestrator only fills in the mechanical checkboxes.
 - `ReviewApp` — when `review_app.cpflow_app_name` is non-null, polls the GitHub Checks API for `review_app.status_check`, asks CPFlow for that app's review URL for the PR branch, and hits each `smoke` path against that base URL (it never derives the URL from the repo slug). When `cpflow_app_name` is null — a demo with no review-app pipeline yet — it short-circuits: no status-check poll, no URL lookup, no smoke run. A repo with a `review_app` block cannot clear `verify: true` while `cpflow_app_name` is null; demos that genuinely have no pipeline set `review_app: null` instead.
 - `pr.wait_for_ci_and_review_app` — coordinates CI polling plus `ReviewApp` smoke checks.
@@ -112,25 +112,27 @@ The supply-chain defense. Uniform across package managers so policy is consisten
 ### Per-package decision
 
 ```ruby
-def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:, override_issue: nil)
+def DependencyBumps.permitted?(package, candidate_version, mode:, age_gate:, override_issue: nil, now: Time.now)
   min_days = age_gate.min_days_for(package.ecosystem)
   return true if mode == :release_track && age_gate.own?(package)
 
   published_at = Registry.published_at(package, candidate_version)
-  age_days = (Time.now - published_at) / 86_400
+  age_days = (now - published_at) / 86_400
 
   return true if age_days >= min_days
 
   # Break-glass override: resolved once by the caller and passed in explicitly
   # (never read from a global) so concurrent calls in the parallel runner stay
   # thread-safe. nil when no override issue is open — e.g. an ordinary freshness
-  # run — in which case a too-young bump is simply not permitted.
+  # run — in which case a too-young bump is simply not permitted. `now` is a
+  # single injectable snapshot so the age check and the expiry check share one
+  # clock (and tests can pin it).
   return true if override_issue &&
                  AgeGateOverride.active?(
                    package,
                    candidate_version,
                    tracking_issue: override_issue,
-                   now: Time.now
+                   now: now
                  )
 
   false
@@ -139,8 +141,8 @@ end
 
 ### Registry lookups
 
-- **npm** — `GET https://registry.npmjs.org/<pkg>` → `time[<version>]` is the publish timestamp. No auth required.
-- **RubyGems** — `GET https://rubygems.org/api/v1/versions/<gem>.json` → array of `{number, created_at, yanked}`. Pick matching `number`. No auth required.
+- **npm** — `GET https://registry.npmjs.org/<pkg>` → `time[<version>]` is the publish timestamp. Percent-encode the package name unconditionally (`URI.encode_www_form_component`) so scoped names like `@scope/pkg` resolve to `@scope%2Fpkg`. No auth required.
+- **RubyGems** — `GET https://rubygems.org/api/v1/versions/<gem>.json` → array of `{number, created_at, yanked}`. Reject `yanked: true` entries before matching `number`, so a yanked version that clears the age threshold can't pass the gate. No auth required.
 - **GitHub Actions** — `GET https://api.github.com/repos/<owner>/<repo>/releases/tags/<tag>` → `published_at`. Auth via the orchestrator's installation token.
 
 Cache responses for the duration of a single orchestrator run (TTL 1h) to avoid hammering registries when many demos consume the same package.
@@ -166,9 +168,9 @@ For CVEs that need a sub-min-days patched version:
 
 1. Release manager opens or updates a tracking issue in `shakacode/react_on_rails` titled `age-gate override: <pkg>@<version>`.
 2. Issue body includes the CVE link, affected package, candidate version, and justification.
-3. A second maintainer approves the override in an issue comment. The approval is only honored if the commenter is a verified member of the designated maintainers team (e.g. `shakacode/maintainers`): `AgeGateOverride.active?` checks `GET /orgs/shakacode/teams/maintainers/memberships/<user>` for both the issue author and the approver, so a free-text "approved" from anyone outside the team is ignored.
+3. A second maintainer — **different from the issue author** — approves the override in an issue comment. The approval is only honored if the commenter is a verified member of the designated maintainers team (e.g. `shakacode/maintainers`): `AgeGateOverride.active?` checks `GET /orgs/shakacode/teams/maintainers/memberships/<user>` for both the issue author and the approver, so a free-text "approved" from anyone outside the team is ignored.
 4. Release manager applies the `age-gate-override` label after approval. The orchestrator reads GitHub issue timeline events and uses the most recent label-applied timestamp as the start of the 7-day window; `updated_at` is not used because ordinary edits would extend the window accidentally.
-5. `AgeGateOverride.active?` permits only the exact `ecosystem/name@version` named in the issue title/body, only while `now - label_applied_at <= 7.days`, and only when both the issue author and the approver pass the team-membership check from step 3.
+5. `AgeGateOverride.active?` permits only the exact `ecosystem/name@version` named in the issue title/body, only while `now - label_applied_at <= 7.days`, and only when both the issue author and the approver pass the team-membership check from step 3 **and are distinct accounts** — self-approval (the same login opening and approving) is rejected, so a single compromised account cannot clear the gate alone.
 6. The override, approver, and expiry timestamp are logged in the tracking issue and in the resulting PR body.
 
 This keeps audit trail in GitHub, not in shell history or env vars.
@@ -180,6 +182,8 @@ A ShakaCode GitHub App, installed on:
 - `shakacode/react_on_rails` (read code, write issues/PRs)
 - Every demo repo in the manifest (write contents for the bump branch, write PRs)
 - The Pro gem source for repos with `needs_pro: true`
+
+The App also needs the org-level `members: read` permission so the break-glass flow can verify maintainers-team membership (`GET /orgs/shakacode/teams/maintainers/memberships/<user>`); without it that lookup 404s the first time an override is exercised.
 
 The orchestrator uses the App installation token. No long-lived PATs in CI.
 
@@ -194,7 +198,7 @@ When the weekly freshness train runs and a demo has an open release-track PR:
 
 When a release-track run lands while a freshness PR is open:
 
-- Release-track takes priority. The orchestrator rebases or closes the open freshness PR (configurable per demo; default: close + reopen after the release-track PR merges).
+- Release-track takes priority. v1 behavior is fixed: the orchestrator closes the open freshness PR and reopens it after the release-track PR merges. (A per-repo `conflict_mode` override — e.g. `rebase` instead of `close_and_reopen` — is a future enhancement and is intentionally not in the manifest schema yet.)
 
 ## Cadence
 

--- a/internal/contributor-info/demo-fleet-design.md
+++ b/internal/contributor-info/demo-fleet-design.md
@@ -18,6 +18,7 @@ The orchestrator is the executor of the existing RC plan, not a parallel system.
 - **`react_on_rails` (this repo)** — owns the manifest ([demo-fleet.yml](demo-fleet.yml)), the RC plan, the orchestrator Rake tasks, and the tracking-issue template. Nothing in this repo opens cross-repo PRs at runtime by itself — see the credential model below.
 - **Per demo repo** — owns its own CI, CPFlow review-app workflow, and Playwright smoke. The orchestrator dispatches and observes; it does not push CI definitions into demos.
 - **No separate `react-on-rails-demos` repo, yet.** Defer until the orchestrator is stable here. When promoted, the manifest stays in `react_on_rails` (it's policy); only the runtime moves.
+- **`reactonrails.com` is deliberately not the control plane.** It's a public documentation/marketing surface, not an operational repo. The control plane belongs in a contributor-only repo where credentials, manifests, and tracking issues already live.
 
 ## Manifest
 
@@ -125,6 +126,17 @@ Cache responses for the duration of a single orchestrator run (TTL 1h) to avoid 
 ### Why uniform-in-orchestrator instead of per-PM config
 
 Demos in the fleet span pnpm, yarn classic, yarn berry, and bare npm (see manifest `package_manager` field). pnpm's `minimumReleaseAge` would only cover the pnpm demos and only after upgrading them all to pnpm 10+. The orchestrator computes bumps anyway (it has to know which versions to propose), so it's the natural enforcement point. Each demo's own Dependabot config keeps its `cooldown` for routine background updates; the orchestrator is the second layer for the bumps it drives.
+
+### Defense-in-depth, not just the age gate
+
+The age gate stops the orchestrator from introducing a too-young package, but it does not catch a package that is old enough yet known-vulnerable. Each demo's PR-side CI must also run [`actions/dependency-review-action`](https://github.com/actions/dependency-review-action) on every PR — it diffs the lockfile against the base branch and fails the PR if any newly-introduced dependency (direct or transitive) is on the GitHub Advisory Database. The orchestrator does not enforce this directly; instead, the demo-fleet manifest documents it as a required check, and the verification pass that clears `verify: true` flags also confirms each demo's CI runs the action.
+
+Layers, in order:
+
+1. **Per-demo Dependabot `cooldown`** — already in use in this repo (3-day default); catches routine background updates before they reach the orchestrator.
+2. **Orchestrator age gate** — uniform across ecosystems for the bumps the orchestrator drives (7-day default; see `age_gate` in the manifest).
+3. **Per-demo `dependency-review-action` on every PR** — fails the PR if any newly-introduced dep is vulnerable, regardless of age.
+4. **Break-glass override** — labelled tracking issue, audited in the PR body (next section).
 
 ### Break-glass
 

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -1,0 +1,144 @@
+# Demo fleet manifest — canonical list of demo repos under cross-repo
+# upgrade automation. Read by `rake demo_fleet:*` tasks and by humans
+# running the RC testing workflow described in rc-testing-plan-design.md.
+#
+# Schema version is bumped on breaking changes. Consumers must check it.
+#
+# Field semantics:
+#   tier           — hard_gate (Tier 1) | soft_track (Tier 2). Matches the
+#                    RC plan. hard_gate failures block a final release.
+#   packages       — which of our gems/npm packages the demo consumes. The
+#                    orchestrator only proposes bumps for listed packages.
+#   needs_pro      — demo consumes private react_on_rails_pro source. The
+#                    automation credentials must have access to the Pro
+#                    gem source for these repos.
+#   package_manager — npm | yarn_classic | yarn_berry | pnpm. Determines
+#                    the install + lockfile-update strategy.
+#   ruby_test      — command run inside the repo for Ruby tests.
+#   js_test        — command run inside the repo for JS tests. nil if none.
+#   build          — command that must succeed before deploy (asset compile).
+#   review_app     — CPFlow review-app workflow file and the status check
+#                    name the orchestrator polls. nil if the demo has no
+#                    review-app pipeline yet.
+#   smoke          — list of paths the orchestrator hits against the
+#                    review-app URL after deploy. Each must return 2xx.
+#   headline       — short name of the per-repo appendix in the RC plan.
+#                    The orchestrator uses this only for PR-body templating.
+#
+# Items marked `verify: true` have not been confirmed by inspecting the
+# demo repo. A one-time verification pass (per the RC plan's `*` convention)
+# must clear every verify flag before the manifest is treated as authoritative.
+
+schema_version: 1
+
+defaults:
+  package_manager: pnpm
+  ruby_test: bundle exec rspec
+  js_test: null
+  build: bin/shakapacker
+  branch_prefix: chore/demo-fleet
+  review_app:
+    workflow: cpflow-review-app.yml
+    status_check: cpflow/review-app
+  age_gate:
+    npm_min_days: 7
+    gem_min_days: 7
+    actions_min_days: 7
+    # Our own packages bypass the gate when the orchestrator is invoked
+    # with --release-track. Listed here so policy lives with the manifest.
+    own_packages:
+      npm:
+        - react-on-rails
+        - react-on-rails-pro
+      gem:
+        - react_on_rails
+        - react_on_rails_pro
+        - shakapacker
+        - cpflow
+
+repos:
+  # ---------- Tier 1 (hard gate) ----------
+
+  - name: shakacode/react-on-rails-rsc-demo
+    tier: hard_gate
+    headline: Minimal RSC starter
+    packages: [react_on_rails, react-on-rails, shakapacker]
+    needs_pro: false
+    smoke: [/]
+    verify: true
+
+  - name: shakacode/react-on-rails-demo-hacker-news-rsc
+    tier: hard_gate
+    headline: RSC streaming with comment trees
+    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    needs_pro: true
+    smoke: [/, /news]
+    verify: true
+
+  - name: shakacode/react-on-rails-demo-marketplace-rsc
+    tier: hard_gate
+    headline: RSC product grid + filter
+    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    needs_pro: true
+    smoke: [/, /products]
+    verify: true
+
+  - name: shakacode/react-on-rails-demo-gumroad-rsc
+    tier: hard_gate
+    headline: RSC dashboards + performance
+    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    needs_pro: true
+    smoke: [/]
+    verify: true
+
+  - name: shakacode/react_on_rails-demo-octochangelog-on-rails-pro
+    tier: hard_gate
+    headline: RSC + server-rendered markdown
+    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    needs_pro: true
+    smoke: [/]
+    verify: true
+
+  - name: shakacode/react-on-rails-demo-ssr-hmr
+    tier: hard_gate
+    headline: SSR + HMR coexistence
+    packages: [react_on_rails, react-on-rails, shakapacker]
+    needs_pro: false
+    smoke: [/]
+    verify: true
+
+  - name: shakacode/react-on-rails-demo-v16-bundle-splitting
+    tier: hard_gate
+    headline: On-demand bundle loading
+    packages: [react_on_rails, react-on-rails, shakapacker]
+    needs_pro: false
+    smoke: [/]
+    verify: true
+
+  # ---------- Tier 2 (soft track) ----------
+
+  - name: shakacode/react-on-rails-example-open-flights
+    tier: soft_track
+    headline: Larger migrated app (search + map)
+    packages: [react_on_rails, react-on-rails, shakapacker]
+    needs_pro: false
+    package_manager: yarn_classic
+    smoke: [/]
+    verify: true
+
+  - name: shakacode/react-on-rails-example-migration
+    tier: soft_track
+    headline: react-rails → React on Rails migration
+    packages: [react_on_rails, react-on-rails, shakapacker]
+    needs_pro: false
+    smoke: [/]
+    verify: true
+
+  - name: shakacode/react-webpack-rails-tutorial
+    tier: soft_track
+    headline: Legacy tutorial reference app
+    packages: [react_on_rails, react-on-rails, shakapacker]
+    needs_pro: false
+    package_manager: yarn_classic
+    smoke: [/]
+    verify: true

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -22,9 +22,11 @@
 #   build          — command that must succeed before deploy (asset compile).
 #   review_app     — CPFlow review-app workflow file, the status check name the
 #                    orchestrator polls, and the CPFlow app name used to derive
-#                    the review-app base URL. nil if the demo has no review-app
-#                    pipeline yet. `cpflow_app_name` must be non-null before
-#                    a repo's `verify: true` flag can be cleared.
+#                    the review-app base URL. Set the whole block to null (or
+#                    leave `cpflow_app_name: null`) for a demo with no review-app
+#                    pipeline yet; the orchestrator then skips smoke for that
+#                    repo. `cpflow_app_name` must be non-null before a repo's
+#                    `verify: true` flag can be cleared.
 #   smoke          — list of paths the orchestrator hits against the
 #                    review-app URL after deploy. Each must return 2xx.
 #   headline       — short name of the per-repo appendix in the RC plan.
@@ -35,6 +37,11 @@
 # must clear every verify flag before the manifest is treated as authoritative.
 
 schema_version: 1
+
+# Bounded parallelism for a single release/freshness run. Caps wall time at the
+# slowest repo rather than the sum of all repos. Override per-run with the
+# DEMO_FLEET_CONCURRENCY env var (read by the demo_fleet:* Rake tasks).
+concurrency: 8
 
 defaults:
   package_manager: pnpm
@@ -74,6 +81,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -88,6 +96,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: true
     smoke: [/, /news]
     verify: true
@@ -102,6 +111,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: true
     smoke: [/, /products]
     verify: true
@@ -116,6 +126,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: true
     smoke: [/]
     verify: true
@@ -130,6 +141,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails-pro }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: true
     smoke: [/]
     verify: true
@@ -142,6 +154,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -154,6 +167,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -168,6 +182,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     package_manager: yarn_classic
     smoke: [/]
@@ -181,6 +196,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -193,6 +209,7 @@ repos:
       - { ecosystem: npm, name: react-on-rails }
       - { ecosystem: gem, name: shakapacker }
       - { ecosystem: npm, name: shakapacker }
+      - { ecosystem: gem, name: cpflow }
     needs_pro: false
     package_manager: yarn_classic
     smoke: [/]

--- a/internal/contributor-info/demo-fleet.yml
+++ b/internal/contributor-info/demo-fleet.yml
@@ -7,8 +7,11 @@
 # Field semantics:
 #   tier           — hard_gate (Tier 1) | soft_track (Tier 2). Matches the
 #                    RC plan. hard_gate failures block a final release.
-#   packages       — which of our gems/npm packages the demo consumes. The
-#                    orchestrator only proposes bumps for listed packages.
+#   packages       — which of our packages the demo consumes. Each entry must
+#                    declare an ecosystem (`gem` | `npm`) and a package name.
+#                    The orchestrator only proposes bumps for listed packages,
+#                    queries the matching registry, and updates that ecosystem's
+#                    lockfile.
 #   needs_pro      — demo consumes private react_on_rails_pro source. The
 #                    automation credentials must have access to the Pro
 #                    gem source for these repos.
@@ -17,9 +20,11 @@
 #   ruby_test      — command run inside the repo for Ruby tests.
 #   js_test        — command run inside the repo for JS tests. nil if none.
 #   build          — command that must succeed before deploy (asset compile).
-#   review_app     — CPFlow review-app workflow file and the status check
-#                    name the orchestrator polls. nil if the demo has no
-#                    review-app pipeline yet.
+#   review_app     — CPFlow review-app workflow file, the status check name the
+#                    orchestrator polls, and the CPFlow app name used to derive
+#                    the review-app base URL. nil if the demo has no review-app
+#                    pipeline yet. `cpflow_app_name` must be non-null before
+#                    a repo's `verify: true` flag can be cleared.
 #   smoke          — list of paths the orchestrator hits against the
 #                    review-app URL after deploy. Each must return 2xx.
 #   headline       — short name of the per-repo appendix in the RC plan.
@@ -40,6 +45,7 @@ defaults:
   review_app:
     workflow: cpflow-review-app.yml
     status_check: cpflow/review-app
+    cpflow_app_name: null
   age_gate:
     npm_min_days: 7
     gem_min_days: 7
@@ -50,6 +56,7 @@ defaults:
       npm:
         - react-on-rails
         - react-on-rails-pro
+        - shakapacker
       gem:
         - react_on_rails
         - react_on_rails_pro
@@ -62,7 +69,11 @@ repos:
   - name: shakacode/react-on-rails-rsc-demo
     tier: hard_gate
     headline: Minimal RSC starter
-    packages: [react_on_rails, react-on-rails, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -70,7 +81,13 @@ repos:
   - name: shakacode/react-on-rails-demo-hacker-news-rsc
     tier: hard_gate
     headline: RSC streaming with comment trees
-    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: true
     smoke: [/, /news]
     verify: true
@@ -78,7 +95,13 @@ repos:
   - name: shakacode/react-on-rails-demo-marketplace-rsc
     tier: hard_gate
     headline: RSC product grid + filter
-    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: true
     smoke: [/, /products]
     verify: true
@@ -86,7 +109,13 @@ repos:
   - name: shakacode/react-on-rails-demo-gumroad-rsc
     tier: hard_gate
     headline: RSC dashboards + performance
-    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: true
     smoke: [/]
     verify: true
@@ -94,7 +123,13 @@ repos:
   - name: shakacode/react_on_rails-demo-octochangelog-on-rails-pro
     tier: hard_gate
     headline: RSC + server-rendered markdown
-    packages: [react_on_rails, react-on-rails, react_on_rails_pro, react-on-rails-pro, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: react_on_rails_pro }
+      - { ecosystem: npm, name: react-on-rails-pro }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: true
     smoke: [/]
     verify: true
@@ -102,7 +137,11 @@ repos:
   - name: shakacode/react-on-rails-demo-ssr-hmr
     tier: hard_gate
     headline: SSR + HMR coexistence
-    packages: [react_on_rails, react-on-rails, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -110,7 +149,11 @@ repos:
   - name: shakacode/react-on-rails-demo-v16-bundle-splitting
     tier: hard_gate
     headline: On-demand bundle loading
-    packages: [react_on_rails, react-on-rails, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -120,7 +163,11 @@ repos:
   - name: shakacode/react-on-rails-example-open-flights
     tier: soft_track
     headline: Larger migrated app (search + map)
-    packages: [react_on_rails, react-on-rails, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     package_manager: yarn_classic
     smoke: [/]
@@ -129,7 +176,11 @@ repos:
   - name: shakacode/react-on-rails-example-migration
     tier: soft_track
     headline: react-rails → React on Rails migration
-    packages: [react_on_rails, react-on-rails, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     smoke: [/]
     verify: true
@@ -137,7 +188,11 @@ repos:
   - name: shakacode/react-webpack-rails-tutorial
     tier: soft_track
     headline: Legacy tutorial reference app
-    packages: [react_on_rails, react-on-rails, shakapacker]
+    packages:
+      - { ecosystem: gem, name: react_on_rails }
+      - { ecosystem: npm, name: react-on-rails }
+      - { ecosystem: gem, name: shakapacker }
+      - { ecosystem: npm, name: shakapacker }
     needs_pro: false
     package_manager: yarn_classic
     smoke: [/]


### PR DESCRIPTION
### Summary

Adds an internal contributor design sketch for a cross-repo demo-fleet orchestrator that automates `react_on_rails`, `shakapacker`, `react_on_rails_pro`, and `cpflow` gem bumps across the 10 demo repos covered by the RC testing plan. `internal/contributor-info/demo-fleet.yml` is a schema-versioned canonical manifest (tiers, packages, review-app smoke paths, age-gate policy) with every entry flagged `verify: true` pending a one-time per-repo verification pass. `internal/contributor-info/demo-fleet-design.md` describes the Rake-task skeleton, a uniform npm/RubyGems/Actions age-gate enforced in the orchestrator so supply-chain policy stays consistent across the fleet's mixed package managers, the GitHub App credential model (including Pro gem source access), and conflict policy between release-track and weekly freshness runs. Both files are self-deleting once a canonical implementation lands, matching the lifecycle of [rc-testing-plan-design.md](https://github.com/shakacode/react_on_rails/blob/main/internal/contributor-info/rc-testing-plan-design.md). No product code or user-facing docs changed.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~ — design docs only
- [x] Update documentation — this PR is the doc
- [x] ~Update CHANGELOG file~ — internal contributor design spec, not user-facing

### Other Information

Three open items at the bottom of the design doc need input before any implementation: manifest verification owner, Pro gem credential model, and the criteria for promoting the runtime out of this repo into a dedicated automation repo. (The release-track/freshness conflict mode is resolved in the Conflict policy section: default is to close the freshness PR and reopen it after the release-track PR merges.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only internal contributor specs with no executable changes to product code, CI, or release automation.
> 
> **Overview**
> Adds **internal contributor-only** specs for a future **demo fleet orchestrator** that would automate cross-repo gem/npm bumps across the RC testing demo repos—no runtime code, workflows, or user-facing docs yet.
> 
> **`demo-fleet-design.md`** sketches how this would plug into the existing RC plan: **release track** (RC/final bumps, Tier 1 hard-gates final release) vs **weekly freshness track** (transitive deps; failures become issues). It proposes Rake tasks (`demo_fleet:release_track`, `freshness_track`, `plan`), parallel execution with per-repo failure recording, GitHub App credentials, CPFlow review-app smoke, tracking-issue checkboxes, and conflict rules (freshness skips when a release PR is open; release closes/reopens freshness PRs). Supply-chain policy is spelled out: uniform **7-day age gate** across npm/RubyGems/Actions, defense-in-depth with per-demo `dependency-review-action`, and a **break-glass** override flow with maintainer-team approval.
> 
> **`demo-fleet.yml`** introduces a **schema-versioned manifest** (`schema_version: 1`) listing **10 repos** (7 Tier 1 `hard_gate`, 3 Tier 2 `soft_track`) with structured `{ecosystem, name}` package refs, defaults (pnpm, age gate, review-app placeholders), and **`verify: true` on every entry** until a one-time repo inspection clears flags. Both files follow the same lifecycle as `rc-testing-plan-design.md` (delete when implementation lands).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0c9711f90783040eb58ed8f8b8ea549ee8f6ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design specification for a Demo Fleet orchestrator: operational modes (release vs weekly freshness), orchestration flow, parallel execution with per-repo failure handling, age-gate and override policy, credential/access model, conflict/cadence guidance, and open items.
  * Added a canonical, schemaed demo-fleet manifest format: concurrency/defaults, package/test settings, repo tiers and verification flags, review-app and smoke-test configuration, pro-access indicators, and per-repo overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
