### PR TITLE
fix(docs): replace direct DB access claims with Rails-props pattern

### DIFF
--- a/docs/pro/major-performance-breakthroughs-upgrade-guide.md
+++ b/docs/pro/major-performance-breakthroughs-upgrade-guide.md
@@ -31,7 +31,7 @@ Server Components execute on the server and stream HTML to the client—no serve
 Please note that only the first of these directly compares performance of equivalent applications with and without React Server Components.
 Other migrations may include React or other dependency upgrades and so on.
 
-> **React on Rails note:** These benefits carry over to React on Rails Pro, but the data-delivery model differs from the Next.js case studies above. In React on Rails, Rails owns database queries, authentication, and caching; components receive data as props rather than fetching it directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md).
+> **React on Rails note:** These benefits carry over to React on Rails Pro, but the data-delivery model differs from the Next.js case studies above. In React on Rails, Rails owns database queries, authentication, and caching; components receive data as props rather than fetching it directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
 
 ## 🌊 SSR Streaming
 

--- a/docs/pro/major-performance-breakthroughs-upgrade-guide.md
+++ b/docs/pro/major-performance-breakthroughs-upgrade-guide.md
@@ -31,7 +31,7 @@ Server Components execute on the server and stream HTML to the client—no serve
 Please note that only the first of these directly compares performance of equivalent applications with and without React Server Components.
 Other migrations may include React or other dependency upgrades and so on.
 
-> **React on Rails note:** These benefits carry over to React on Rails Pro, but the data-delivery model differs from the Next.js case studies above. In React on Rails, Rails owns database queries, authentication, and caching; components receive data as props (or streamed async props via `stream_react_component`) rather than fetching it directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md).
+> **React on Rails note:** These benefits carry over to React on Rails Pro, but the data-delivery model differs from the Next.js case studies above. In React on Rails, Rails owns database queries, authentication, and caching; components receive data as props rather than fetching it directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md).
 
 ## 🌊 SSR Streaming
 

--- a/docs/pro/major-performance-breakthroughs-upgrade-guide.md
+++ b/docs/pro/major-performance-breakthroughs-upgrade-guide.md
@@ -31,6 +31,8 @@ Server Components execute on the server and stream HTML to the client—no serve
 Please note that only the first of these directly compares performance of equivalent applications with and without React Server Components.
 Other migrations may include React or other dependency upgrades and so on.
 
+> **React on Rails note:** These benefits carry over to React on Rails Pro, but the data-delivery model differs from the Next.js case studies above. In React on Rails, Rails owns database queries, authentication, and caching; components receive data as props (or streamed async props via `stream_react_component`) rather than fetching it directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md).
+
 ## 🌊 SSR Streaming
 
 SSR Streaming sends HTML to the browser in chunks as it's generated, enabling progressive rendering:

--- a/docs/pro/release-notes/4.0.md
+++ b/docs/pro/release-notes/4.0.md
@@ -8,7 +8,7 @@ React on Rails Pro now provides comprehensive support for React Server Component
 
 - **Full RSC Integration**: Seamlessly use React Server Components in your Rails apps with zero configuration
 - **Bundle Optimization**: Automatic client/server code splitting that significantly reduces client-side JavaScript
-- **Server-Side Data Fetching**: Direct access to databases, APIs, and server resources from React components
+- **Server-Side Data Fetching**: Data flows from Rails controllers as props; [`stream_react_component`](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) streams async props via Suspense boundaries as they resolve
 - **Progressive Hydration**: Client components hydrate independently for optimal performance
 - **RSC Payload Streaming**: Efficient streaming of component data with embedded payloads
 - **Compatible with React Router**: [Use React Router with RSC](../react-server-components/inside-client-components.md)

--- a/docs/pro/release-notes/4.0.md
+++ b/docs/pro/release-notes/4.0.md
@@ -8,7 +8,7 @@ React on Rails Pro now provides comprehensive support for React Server Component
 
 - **Full RSC Integration**: Seamlessly use React Server Components in your Rails apps with zero configuration
 - **Bundle Optimization**: Automatic client/server code splitting that significantly reduces client-side JavaScript
-- **Server-Side Data Fetching**: Rails controllers deliver data as props via [`stream_react_component`](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) — components never access the database directly
+- **Server-Side Data Fetching**: Rails controllers deliver data to components as [props](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) — components never access the database directly
 - **Progressive Hydration**: Client components hydrate independently for optimal performance
 - **RSC Payload Streaming**: Efficient streaming of component data with embedded payloads
 - **Compatible with React Router**: [Use React Router with RSC](../react-server-components/inside-client-components.md)

--- a/docs/pro/release-notes/4.0.md
+++ b/docs/pro/release-notes/4.0.md
@@ -8,7 +8,7 @@ React on Rails Pro now provides comprehensive support for React Server Component
 
 - **Full RSC Integration**: Seamlessly use React Server Components in your Rails apps with zero configuration
 - **Bundle Optimization**: Automatic client/server code splitting that significantly reduces client-side JavaScript
-- **Server-Side Data Fetching**: Data flows from Rails controllers as props; [`stream_react_component`](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) streams async props via Suspense boundaries as they resolve
+- **Server-Side Data Fetching**: Rails controllers deliver data as props via [`stream_react_component`](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) — components never access the database directly
 - **Progressive Hydration**: Client components hydrate independently for optimal performance
 - **RSC Payload Streaming**: Efficient streaming of component data with embedded payloads
 - **Compatible with React Router**: [Use React Router with RSC](../react-server-components/inside-client-components.md)

--- a/docs/pro/release-notes/v4-react-server-components.md
+++ b/docs/pro/release-notes/v4-react-server-components.md
@@ -38,6 +38,8 @@ SSR Streaming sends HTML to the browser in chunks as it’s generated, enabling 
 - **50% lower** server response time with Server Components [[5]]
 - **15% improvement** in Core Web Vitals and **23% reduction** in Time to First Byte at Airbnb after RSC migration [[5]]
 
+> **React on Rails note:** These performance benefits carry over to React on Rails Pro. In React on Rails, data delivery is prop-based — Rails controllers handle database queries, authentication, and caching, then pass data to components as props via [`stream_react_component`](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro). Components do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../../oss/migrating/rsc-data-fetching.md).
+
 ---
 
 Adopting these features in React on Rails Pro will help you deliver faster, leaner, and more SEO‑friendly applications with fewer client‑side resources.

--- a/docs/pro/release-notes/v4-react-server-components.md
+++ b/docs/pro/release-notes/v4-react-server-components.md
@@ -38,7 +38,7 @@ SSR Streaming sends HTML to the browser in chunks as it’s generated, enabling 
 - **50% lower** server response time with Server Components [[5]]
 - **15% improvement** in Core Web Vitals and **23% reduction** in Time to First Byte at Airbnb after RSC migration [[5]]
 
-> **React on Rails note:** These performance benefits carry over to React on Rails Pro. In React on Rails, data delivery is prop-based — Rails controllers handle database queries, authentication, and caching, then pass data to components as props via [`stream_react_component`](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro). Components do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../../oss/migrating/rsc-data-fetching.md).
+> **React on Rails note:** These performance benefits carry over to React on Rails Pro. In React on Rails, data delivery is prop-based — Rails controllers handle database queries, authentication, and caching, then pass data to components as [props](../../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro). Components do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../../oss/migrating/rsc-data-fetching.md).
 
 ---
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -135,49 +135,26 @@ callers should not use an empty stream as a success signal.
 
 ### 6. What Happens During Streaming
 
-When a user visits the page, they'll experience the following sequence:
+`stream_react_component` calls React's `renderToPipeableStream`, which streams HTML to the browser progressively as React renders the component tree:
 
-1. The initial HTML shell is sent immediately, including:
-   - The page layout
-   - Any static content (like the `<h1>` and footer)
-   - Placeholder content for the React component (typically a loading state)
+1. The HTML response starts immediately — the browser doesn't wait for the entire page to finish rendering
+2. React renders sections of the tree and flushes HTML chunks to the browser
+3. The browser parses and displays each chunk as it arrives
 
-2. As the React component processes and suspense boundaries resolve:
-   - HTML chunks are streamed to the browser progressively
-   - Each chunk updates a specific part of the page
-   - The browser renders these updates without a full-page reload
+With synchronous props (as in this example), all data is available when rendering starts. React renders the full tree in one pass, and `renderToPipeableStream` flushes the HTML progressively — the browser receives the header, posts, and footer as a stream rather than waiting for the complete response. This reduces Time to First Byte (TTFB) on large pages.
 
-For example, with our `MyStreamingComponent`, the sequence might be:
+For pages with independent data sources that load at different speeds, use separate `stream_react_component` calls so each section streams as its data becomes ready:
 
-1. The initial HTML includes the header, footer, and Suspense placeholder.
-
-```html
-<header>
-  <h1>Hello, Streaming World!</h1>
-</header>
-<template id="s0">
-  <div>Loading...</div>
-</template>
-<footer>
-  <p>Footer content</p>
-</footer>
+```erb
+<%# Each component streams independently %>
+<%= stream_react_component("Header", props: { title: "Dashboard" }) %>
+<%= stream_react_component("PostFeed",
+      props: { posts: @posts.as_json(only: [:id, :title]) }) %>
+<%= stream_react_component("Sidebar",
+      props: { stats: @stats.as_json }) %>
 ```
 
-2. As `renderToPipeableStream` finishes rendering the post list, the HTML chunk is streamed to the browser:
-
-```html
-<template hidden id="b0">
-  <ul>
-    <li>First Post</li>
-    <li>Second Post</li>
-  </ul>
-</template>
-
-<script>
-  // This implementation is slightly simplified
-  document.getElementById('s0').replaceChildren(document.getElementById('b0'));
-</script>
-```
+When combined with React Server Components (async components), `<Suspense>` boundaries show a fallback while the async content resolves, then the rendered HTML streams to the browser as a replacement — creating a progressive loading experience. See the [RSC tutorial](./react-server-components/tutorial.md) for details.
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -85,7 +85,7 @@ const MyStreamingComponent = ({ greeting, getReactOnRailsAsyncProp }) => {
 export default MyStreamingComponent;
 ```
 
-> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the prop-based data model this builds on.
+> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the root component's props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`, and type each async child's prop as a `Promise` (e.g. `posts: Promise<Post[]>`) — `getReactOnRailsAsyncProp` returns a Promise, not the resolved value. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the prop-based data model this builds on.
 
 > **Handle failures:** if a prop's query rejects, the `await` throws inside the async component and React propagates it up the tree. In production, wrap each `<Suspense>` in an error boundary so a single failed source degrades to a fallback instead of breaking the whole render. React does not ship an `ErrorBoundary` — use the [`react-error-boundary`](https://github.com/bvaughn/react-error-boundary) package (or your own class component):
 >
@@ -175,7 +175,7 @@ When several sources are slow and independent, run them concurrently with the [`
   # query resolves — the slowest source no longer blocks the others.
   tasks = [
     parent.async { emit.call('posts', Post.for_user(user_id).recent.limit(20).as_json(only: [:id, :title])) },
-    parent.async { emit.call('stats', DashboardStats.for(user_id).as_json) },
+    parent.async { emit.call('stats', DashboardStats.for(user_id).as_json(only: [:metric, :value])) },
     parent.async { emit.call('feed',  FeedService.for(user_id).as_json(only: [:id, :title])) },
   ]
   tasks.each(&:wait) # block stays open until each task finishes
@@ -187,7 +187,7 @@ On the React side, give each async prop its own `<Suspense>` boundary (as in Ste
 > **Error handling — two distinct failure modes:**
 >
 > - An error raised in the task **body before `emit.call`** (e.g. a query raising `ActiveRecord::StatementInvalid`) propagates through `wait` and closes the stream, so the remaining props may not be sent. If one source failing shouldn't cut off the others, wrap each task body in a `rescue` and emit a fallback (or skip that prop).
-> - An error raised **inside `emit.call`** (a non-serializable value, a write failure) is caught and logged by the emitter without re-raising — the task completes normally and `wait` sees nothing, but the prop is never delivered and its `<Suspense>` boundary never resolves. Pass only JSON-serializable values (e.g. `.as_json(only: [...])`) to `emit.call` to avoid a silently hanging boundary.
+> - An error raised **inside `emit.call`** (a non-serializable value, a write failure) may be swallowed by the emitter — logged rather than re-raised — so the task completes normally and `wait` sees nothing, yet the prop is never delivered and its `<Suspense>` boundary never resolves. Pass only JSON-serializable values (e.g. `.as_json(only: [...])`) to `emit.call` to avoid a silently hanging boundary.
 
 **Requirements and footguns for concurrent async props:**
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -85,7 +85,7 @@ const MyStreamingComponent = ({ greeting, getReactOnRailsAsyncProp }) => {
 export default MyStreamingComponent;
 ```
 
-> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the full pattern.
+> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the prop-based data model this builds on.
 
 With `auto_load_bundle` enabled (recommended), `MyStreamingComponent` is registered automatically. Otherwise, register it as a server component — server components use `registerServerComponent`, **not** `ReactOnRails.register`:
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -26,6 +26,7 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 - React 19
 - React on Rails v16.0.0 or higher
 - Node Renderer running (streaming requires Node.js, not ExecJS)
+- For async props (streaming each slow prop independently): React Server Components enabled — `config.enable_rsc_support = true`
 
 ## Implementation Steps
 
@@ -44,39 +45,44 @@ Ensure you're using React 19 in your `package.json`:
 
 ### 2. Prepare Your React Components
 
-Create async React Server Components that receive data as props from Rails. Wrap them in `<Suspense>` boundaries to define which sections stream independently — React sends the fallback first, then streams the rendered content when the async component resolves.
+For a Suspense boundary to actually stream — show a fallback first, then swap in real content — something inside it must suspend on a Promise. In React on Rails, that data still comes from Rails: with **async props**, Rails sends the fast props immediately and emits each slow prop as it resolves. The component receives a `getReactOnRailsAsyncProp` helper that returns a Promise for each async prop; an async child `await`s it inside a `<Suspense>` boundary.
 
 ```jsx
 // app/javascript/components/MyStreamingComponent.jsx
 import React, { Suspense } from 'react';
 
-const MyStreamingComponent = ({ greeting, posts }) => {
-  return (
-    <>
-      <header>
-        <h1>{greeting}</h1>
-      </header>
-      <Suspense fallback={<div>Loading posts...</div>}>
-        <PostList posts={posts} />
-      </Suspense>
-    </>
-  );
-};
-
+// Async Server Component — awaits the streamed `posts` prop, then renders.
 async function PostList({ posts }) {
+  const resolved = await posts;
   return (
     <ul>
-      {posts.map((post) => (
+      {resolved.map((post) => (
         <li key={post.id}>{post.title}</li>
       ))}
     </ul>
   );
 }
 
+const MyStreamingComponent = ({ greeting, getReactOnRailsAsyncProp }) => {
+  // Returns a Promise that resolves when Rails emits the `posts` prop.
+  const postsPromise = getReactOnRailsAsyncProp('posts');
+
+  return (
+    <>
+      <header>
+        <h1>{greeting}</h1>
+      </header>
+      <Suspense fallback={<div>Loading posts...</div>}>
+        <PostList posts={postsPromise} />
+      </Suspense>
+    </>
+  );
+};
+
 export default MyStreamingComponent;
 ```
 
-> **React on Rails note:** The `async function` component pattern is a React Server Components feature — it requires [RSC support](./react-server-components/tutorial.md) enabled in React on Rails Pro. Database queries, authentication, and API calls happen on the Rails side — in controllers and models. Components receive the results as props via [`stream_react_component`](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro); they do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md) for the full explanation.
+> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Async Props: Stream Each Slow Prop Independently](../oss/migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) for the full pattern.
 
 ```jsx
 // app/javascript/packs/registration.jsx
@@ -88,18 +94,24 @@ ReactOnRails.register({ MyStreamingComponent });
 
 ### 3. Add The Component To Your Rails View
 
+Use `stream_react_component_with_async_props`. Fast props go in `props:`; each `emit.call(name, value)` streams one more prop to the browser as soon as Rails has it. Rails still runs the query — it just emits the result when ready.
+
 ```erb
 <!-- app/views/example/show.html.erb -->
 
-<%= stream_react_component('MyStreamingComponent', props: {
-  greeting: 'Hello, Streaming World!',
-  posts: @posts.as_json(only: [:id, :title])
-}) %>
+<%= stream_react_component_with_async_props('MyStreamingComponent',
+      props: { greeting: 'Hello, Streaming World!' }) do |emit|
+  # Rails owns the query, authorization, and caching. This streams the `posts`
+  # prop to the browser the moment Rails has it — the shell renders first.
+  emit.call('posts', Post.recent.limit(20).as_json(only: [:id, :title]))
+end %>
 
 <footer>
   <p>Footer content</p>
 </footer>
 ```
+
+> If every data source is fast, use the simpler `stream_react_component` and pass all props synchronously — React still streams the rendered HTML to the browser as it walks the tree. Reach for async props when one or more sources are slow. See the [sync vs. async props comparison](../oss/migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently).
 
 ### 4. Render The View Using The `stream_view_containing_react_components` Helper
 
@@ -115,11 +127,12 @@ class ExampleController < ApplicationController
   # but you can include it explicitly if you prefer.
 
   def show
-    @posts = Post.recent.limit(20)
     stream_view_containing_react_components(template: 'example/show')
   end
 end
 ```
+
+> **Note:** `stream_react_component_with_async_props` requires React Server Components — set `config.enable_rsc_support = true` in your React on Rails Pro configuration. It raises `ReactOnRailsPro::Error` otherwise.
 
 ### 5. Test Your Application
 
@@ -135,11 +148,11 @@ callers should not use an empty stream as a success signal.
 
 ### 6. What Happens During Streaming
 
-`stream_react_component` calls React's `renderToPipeableStream`, which streams HTML to the browser progressively as React renders the component tree:
+`stream_react_component_with_async_props` uses React's `renderToPipeableStream` to stream the shell first, then streams each async prop as Rails emits it:
 
-1. The HTML response starts immediately — the browser doesn't wait for the entire page to finish rendering
-2. React sends the shell (header, footer, and Suspense fallbacks) first
-3. When async components resolve, their rendered HTML streams to the browser as replacement chunks
+1. React renders everything outside the unresolved `<Suspense>` boundaries and streams that shell immediately — the header and footer appear, with the `Loading posts...` fallback in place
+2. When Rails runs `emit.call('posts', ...)`, the resolved value streams to the renderer and the `posts` Promise resolves
+3. The async `PostList` awaits that Promise, renders, and React streams the post-list HTML chunk that replaces the fallback
 
 For example, with our `MyStreamingComponent`, the sequence is:
 
@@ -157,7 +170,7 @@ For example, with our `MyStreamingComponent`, the sequence is:
 </footer>
 ```
 
-2. When the async `PostList` resolves, its rendered HTML streams to the browser:
+2. Once Rails emits `posts` and `PostList` resolves, its rendered HTML streams to the browser:
 
 ```html
 <template hidden id="b0">
@@ -173,7 +186,7 @@ For example, with our `MyStreamingComponent`, the sequence is:
 </script>
 ```
 
-For pages with independent data sources that load at different speeds, use separate `stream_react_component` calls so each section streams as its data becomes ready:
+For top-level sections that are fully independent, you can instead use separate `stream_react_component` calls — each renders as its own data becomes ready:
 
 ```erb
 <%# Each component streams independently %>

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -108,16 +108,17 @@ See [Create a React Server Component](./react-server-components/create-without-s
 
 ### 3. Add The Component To Your Rails View
 
-Use `stream_react_component_with_async_props`. Fast props go in `props:`; each `emit.call(name, value)` streams one more prop to the browser as soon as Rails has it. The controller still owns the query (see Step 4) — the view just emits the prepared result when ready.
+Use `stream_react_component_with_async_props`. Fast props go in `props:`; each `emit.call(name, value)` streams one more prop to the browser as soon as it resolves. Run the slow query **inside the block** — that's what lets the shell render first and the prop stream in afterward. (Loading it in the controller before this helper would block the shell until the query finished, defeating the point of async props.) Keep the block thin: call a model scope or query object, not business logic.
 
 ```erb
 <!-- app/views/example/show.html.erb -->
 
 <%= stream_react_component_with_async_props('MyStreamingComponent',
       props: { greeting: 'Hello, Streaming World!' }) do |emit|
-  # Streams the `posts` prop to the browser the moment Rails has it —
-  # the shell renders first, then this fills the Suspense boundary.
-  emit.call('posts', @posts.as_json(only: [:id, :title]))
+  # Runs in the streaming flow: the shell (greeting + Suspense fallback) is
+  # sent first, then this emits `posts` once the query resolves. Rails still
+  # owns the query, auth, and caching — `Post.recent` is a model scope.
+  emit.call('posts', Post.recent.limit(20).as_json(only: [:id, :title]))
 end %>
 
 <footer>
@@ -125,7 +126,7 @@ end %>
 </footer>
 ```
 
-> If every data source is fast, use the simpler `stream_react_component` and pass all props synchronously — React still streams the rendered HTML to the browser as it walks the tree. Reach for async props when one or more sources are slow. See the [sync vs. async props comparison](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
+> If every data source is fast, use the simpler `stream_react_component` and pass all props synchronously — React still streams the rendered HTML to the browser as it walks the tree. Reach for async props when one or more sources are slow. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
 
 ### 4. Render The View Using The `stream_view_containing_react_components` Helper
 
@@ -141,13 +142,12 @@ class ExampleController < ApplicationController
   # but you can include it explicitly if you prefer.
 
   def show
-    @posts = Post.recent.limit(20)
     stream_view_containing_react_components(template: 'example/show')
   end
 end
 ```
 
-The controller prepares `@posts`; the view's `emit.call` streams it. For one slow source like this, loading it in the controller is fine.
+The controller just renders — the async prop's query runs in the view's `emit` block (Step 3) so the shell can stream before the query finishes. The controller still owns request-level concerns: authentication, authorization, and any fast props you pass synchronously.
 
 #### Loading Multiple Slow Sources in Parallel
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -30,6 +30,8 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 
 ## Implementation Steps
 
+> **This example uses async props**, which build on React Server Components. Enable RSC before you start: set `config.enable_rsc_support = true` in your React on Rails Pro configuration (see the [RSC tutorial](./react-server-components/tutorial.md)). Without it, the `async function` server component won't render and `stream_react_component_with_async_props` raises `ReactOnRailsPro::Error`. If all your data is fast and you don't need progressive streaming, you can skip RSC and use the synchronous `stream_react_component` instead (see the note after Step 3).
+
 ### 1. Use React 19
 
 Ensure you're using React 19 in your `package.json`:
@@ -51,7 +53,8 @@ For a Suspense boundary to actually stream — show a fallback first, then swap 
 // app/javascript/components/MyStreamingComponent.jsx
 import React, { Suspense } from 'react';
 
-// Async Server Component — awaits the streamed `posts` prop, then renders.
+// Async Server Component (requires RSC — see callout above). Awaits the
+// streamed `posts` prop, then renders.
 async function PostList({ posts }) {
   const resolved = await posts;
   return (
@@ -82,28 +85,39 @@ const MyStreamingComponent = ({ greeting, getReactOnRailsAsyncProp }) => {
 export default MyStreamingComponent;
 ```
 
-> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Async Props: Stream Each Slow Prop Independently](../oss/migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) for the full pattern.
+> **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the full pattern.
 
-```jsx
-// app/javascript/packs/registration.jsx
-import ReactOnRails from 'react-on-rails';
+With `auto_load_bundle` enabled (recommended), `MyStreamingComponent` is registered automatically. Otherwise, register it as a server component — server components use `registerServerComponent`, **not** `ReactOnRails.register`:
+
+```js
+// Server bundle — bundles the actual component code
+import registerServerComponent from 'react-on-rails-pro/registerServerComponent/server';
 import MyStreamingComponent from '../components/MyStreamingComponent';
 
-ReactOnRails.register({ MyStreamingComponent });
+registerServerComponent({ MyStreamingComponent });
 ```
+
+```js
+// Client bundle — registers by name; the component code stays out of the client bundle
+import registerServerComponent from 'react-on-rails-pro/registerServerComponent/client';
+
+registerServerComponent('MyStreamingComponent');
+```
+
+See [Create a React Server Component](./react-server-components/create-without-ssr.md#register-the-react-server-component-page) for the full registration and RSC bundle setup.
 
 ### 3. Add The Component To Your Rails View
 
-Use `stream_react_component_with_async_props`. Fast props go in `props:`; each `emit.call(name, value)` streams one more prop to the browser as soon as Rails has it. Rails still runs the query — it just emits the result when ready.
+Use `stream_react_component_with_async_props`. Fast props go in `props:`; each `emit.call(name, value)` streams one more prop to the browser as soon as Rails has it. The controller still owns the query (see Step 4) — the view just emits the prepared result when ready.
 
 ```erb
 <!-- app/views/example/show.html.erb -->
 
 <%= stream_react_component_with_async_props('MyStreamingComponent',
       props: { greeting: 'Hello, Streaming World!' }) do |emit|
-  # Rails owns the query, authorization, and caching. This streams the `posts`
-  # prop to the browser the moment Rails has it — the shell renders first.
-  emit.call('posts', Post.recent.limit(20).as_json(only: [:id, :title]))
+  # Streams the `posts` prop to the browser the moment Rails has it —
+  # the shell renders first, then this fills the Suspense boundary.
+  emit.call('posts', @posts.as_json(only: [:id, :title]))
 end %>
 
 <footer>
@@ -111,7 +125,7 @@ end %>
 </footer>
 ```
 
-> If every data source is fast, use the simpler `stream_react_component` and pass all props synchronously — React still streams the rendered HTML to the browser as it walks the tree. Reach for async props when one or more sources are slow. See the [sync vs. async props comparison](../oss/migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently).
+> If every data source is fast, use the simpler `stream_react_component` and pass all props synchronously — React still streams the rendered HTML to the browser as it walks the tree. Reach for async props when one or more sources are slow. See the [sync vs. async props comparison](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro).
 
 ### 4. Render The View Using The `stream_view_containing_react_components` Helper
 
@@ -127,12 +141,13 @@ class ExampleController < ApplicationController
   # but you can include it explicitly if you prefer.
 
   def show
+    @posts = Post.recent.limit(20)
     stream_view_containing_react_components(template: 'example/show')
   end
 end
 ```
 
-> **Note:** `stream_react_component_with_async_props` requires React Server Components — set `config.enable_rsc_support = true` in your React on Rails Pro configuration. It raises `ReactOnRailsPro::Error` otherwise.
+The controller prepares `@posts`; the view's `emit.call` streams it. For one slow source like this, loading it in the controller is fine. When several sources are slow and independent, load them in parallel (e.g. Ruby threads) so no `emit.call` waits on an unrelated query — see [Avoiding Server-Side Waterfalls](../oss/migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
 
 ### 5. Test Your Application
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -147,7 +147,34 @@ class ExampleController < ApplicationController
 end
 ```
 
-The controller prepares `@posts`; the view's `emit.call` streams it. For one slow source like this, loading it in the controller is fine. When several sources are slow and independent, fetch them in parallel with the [`async` gem](https://github.com/socketry/async) rather than Ruby threads — Pro's streaming stack is fiber-based and already runs inside an Async reactor, so wrap each query in an `Async { ... }` task and await them. That way no `emit.call` waits on an unrelated query.
+The controller prepares `@posts`; the view's `emit.call` streams it. For one slow source like this, loading it in the controller is fine.
+
+#### Loading Multiple Slow Sources in Parallel
+
+When several sources are slow and independent, run them concurrently with the [`async` gem](https://github.com/socketry/async). Pro's streaming stack is already fiber-based, so fan out with fibers from the running reactor rather than introducing a separate Ruby-thread concurrency model. The emit block runs inside an `Async` task — capture it once and spawn one child task per source with `parent.async`, so each prop is emitted the moment its own query resolves:
+
+```erb
+<%= stream_react_component_with_async_props('Dashboard',
+      props: { title: 'Dashboard' }) do |emit|
+  parent  = Async::Task.current
+  user_id = current_user.id # capture request state before fanning out
+
+  # Each task runs its query concurrently and emits its prop as soon as that
+  # query resolves — the slowest source no longer blocks the others.
+  tasks = [
+    parent.async { emit.call('posts', Post.for_user(user_id).recent.limit(20).as_json(only: [:id, :title])) },
+    parent.async { emit.call('stats', DashboardStats.for(user_id).as_json) },
+    parent.async { emit.call('feed',  FeedService.for(user_id).as_json(only: [:id, :title])) },
+  ]
+  tasks.each(&:wait) # block stays open until each task finishes
+end %>
+```
+
+On the React side, give each async prop its own `<Suspense>` boundary (as in Step 2) so each section streams in independently as its query finishes.
+
+> **Error handling:** an unhandled error in a child task propagates through `wait` and closes the stream, so the remaining props may not be sent. If one source failing shouldn't cut off the others, wrap each task body in a `rescue` and emit a fallback (or skip that prop).
+
+> **Concurrent ActiveRecord needs fiber-aware connections.** Set `config.active_support.isolation_level = :fiber` (Rails 7.0.2+) so each fiber checks out its own pooled connection. Size your connection pool for the total number of DB-using fibers in flight across all concurrent requests — not just this one fan-out — or extra fibers block on connection checkout. Queries only truly overlap on a fiber-scheduler-aware driver such as `pg` (PostgreSQL); blocking drivers like `mysql2` and `sqlite3` serialize on the reactor. Capture request-scoped state (like `current_user.id`) **before** fanning out, since per-fiber isolation does not copy `CurrentAttributes` into child tasks.
 
 ### 5. Test Your Application
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -186,16 +186,7 @@ For example, with our `MyStreamingComponent`, the sequence is:
 </script>
 ```
 
-For top-level sections that are fully independent, you can instead use separate `stream_react_component` calls — each renders as its own data becomes ready:
-
-```erb
-<%# Each component streams independently %>
-<%= stream_react_component("Header", props: { title: "Dashboard" }) %>
-<%= stream_react_component("PostFeed",
-      props: { posts: @posts.as_json(only: [:id, :title]) }) %>
-<%= stream_react_component("Sidebar",
-      props: { stats: @stats.as_json }) %>
-```
+To render more of the page progressively, add an async prop and a `<Suspense>` boundary for each slow section — emit each one from the block as Rails resolves it, and every boundary streams in independently. This keeps the whole page in a single component tree (shared layout, context, and props) rather than splitting it across multiple `stream_react_component` calls.
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -30,7 +30,7 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 
 ## Implementation Steps
 
-> **This example uses async props**, which build on React Server Components. Enable RSC before you start: set `config.enable_rsc_support = true` in your React on Rails Pro configuration (see the [RSC tutorial](./react-server-components/tutorial.md)). Without it, the `async function` server component won't render and `stream_react_component_with_async_props` raises `ReactOnRailsPro::Error`. If all your data is fast and you don't need progressive streaming, you can skip RSC and use the synchronous `stream_react_component` with all props passed at once.
+> **This example uses async props**, which build on React Server Components. Enable RSC before you start: set `config.enable_rsc_support = true` in your React on Rails Pro configuration (see the [RSC tutorial](./react-server-components/tutorial.md)). Without it, the `async function` server component won't render and `stream_react_component_with_async_props` raises `ReactOnRailsPro::Error`. If all your data is fast and you don't need progressive streaming, you can skip RSC and use the synchronous [`stream_react_component`](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) with all props passed at once (no `enable_rsc_support` required).
 
 ### 1. Use React 19
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -44,40 +44,39 @@ Ensure you're using React 19 in your `package.json`:
 
 ### 2. Prepare Your React Components
 
-Create async React components that return a promise. Use the `Suspense` component to render a fallback UI while the component is loading.
+Create React components that receive data as props from Rails. Use `<Suspense>` boundaries to define which sections of the page stream independently via `renderToPipeableStream`.
 
 ```jsx
 // app/javascript/components/MyStreamingComponent.jsx
 import React, { Suspense } from 'react';
 
-const fetchData = async () => {
-  // Simulate API call
-  const response = await fetch('api/endpoint');
-  return response.json();
-};
-
-const MyStreamingComponent = () => {
+const MyStreamingComponent = ({ greeting, posts }) => {
   return (
     <>
       <header>
-        <h1>Streaming Server Rendering</h1>
+        <h1>{greeting}</h1>
       </header>
       <Suspense fallback={<div>Loading...</div>}>
-        <SlowDataComponent />
+        <PostList posts={posts} />
       </Suspense>
     </>
   );
 };
 
-const SlowDataComponent = async () => {
-  const data = await fetchData();
-  return <div>{data}</div>;
+const PostList = ({ posts }) => {
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.id}>{post.title}</li>
+      ))}
+    </ul>
+  );
 };
 
 export default MyStreamingComponent;
 ```
 
-> **Note:** The `async () => { ... }` function component pattern (`SlowDataComponent` above) is a React Server Components feature. If you are using streaming SSR without RSC, use a data-fetching library (such as React Query or SWR) with `<Suspense>` instead. For RSC-based streaming (which does support async components), see the [RSC tutorial](./react-server-components/tutorial.md).
+> **React on Rails note:** In React on Rails, database queries, authentication, and API calls happen on the Rails side — in controllers and models. Components receive the results as props via [`stream_react_component`](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro), and HTML streams to the browser as React renders the component tree. Components do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md) for the full explanation.
 
 ```jsx
 // app/javascript/packs/registration.jsx
@@ -92,7 +91,10 @@ ReactOnRails.register({ MyStreamingComponent });
 ```erb
 <!-- app/views/example/show.html.erb -->
 
-<%= stream_react_component('MyStreamingComponent', props: { greeting: 'Hello, Streaming World!' }) %>
+<%= stream_react_component('MyStreamingComponent', props: {
+  greeting: 'Hello, Streaming World!',
+  posts: @posts.as_json(only: [:id, :title])
+}) %>
 
 <footer>
   <p>Footer content</p>
@@ -113,6 +115,7 @@ class ExampleController < ApplicationController
   # but you can include it explicitly if you prefer.
 
   def show
+    @posts = Post.recent.limit(20)
     stream_view_containing_react_components(template: 'example/show')
   end
 end
@@ -146,11 +149,11 @@ When a user visits the page, they'll experience the following sequence:
 
 For example, with our `MyStreamingComponent`, the sequence might be:
 
-1. The initial HTML includes the header, footer, and loading state.
+1. The initial HTML includes the header, footer, and Suspense placeholder.
 
 ```html
 <header>
-  <h1>Streaming Server Rendering</h1>
+  <h1>Hello, Streaming World!</h1>
 </header>
 <template id="s0">
   <div>Loading...</div>
@@ -160,11 +163,14 @@ For example, with our `MyStreamingComponent`, the sequence might be:
 </footer>
 ```
 
-2. As the component resolves, HTML chunks are streamed to the browser:
+2. As `renderToPipeableStream` finishes rendering the post list, the HTML chunk is streamed to the browser:
 
 ```html
 <template hidden id="b0">
-  <div>[Fetched data]</div>
+  <ul>
+    <li>First Post</li>
+    <li>Second Post</li>
+  </ul>
 </template>
 
 <script>

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -47,7 +47,7 @@ Ensure you're using React 19 in your `package.json`:
 
 ### 2. Prepare Your React Components
 
-For a Suspense boundary to actually stream — show a fallback first, then swap in real content — something inside it must suspend on a Promise. In React on Rails, that data still comes from Rails: with **async props**, Rails sends the fast props immediately and emits each slow prop as it resolves. The component receives a `getReactOnRailsAsyncProp` helper that returns a Promise for each async prop; an async child `await`s it inside a `<Suspense>` boundary.
+For a Suspense boundary to actually stream — show a fallback first, then swap in real content — something inside it must suspend on a Promise. In React on Rails, that data still comes from Rails: with **async props**, Rails sends the fast props immediately and emits each slow prop as it resolves. React on Rails Pro injects a `getReactOnRailsAsyncProp` helper into the root component's props (alongside the `props:` you pass) — you don't import or create it. Calling it returns a Promise for the named async prop; an async child `await`s that Promise inside a `<Suspense>` boundary.
 
 ```jsx
 // app/javascript/components/MyStreamingComponent.jsx
@@ -87,14 +87,16 @@ export default MyStreamingComponent;
 
 > **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the prop-based data model this builds on.
 
-> **Handle failures:** if a prop's query rejects, the `await` throws inside the async component and React propagates it up the tree. In production, wrap each `<Suspense>` in an error boundary so a single failed source degrades to a fallback instead of breaking the whole render:
+> **Handle failures:** if a prop's query rejects, the `await` throws inside the async component and React propagates it up the tree. In production, wrap each `<Suspense>` in an error boundary so a single failed source degrades to a fallback instead of breaking the whole render. React does not ship an `ErrorBoundary` — use the [`react-error-boundary`](https://github.com/bvaughn/react-error-boundary) package (or your own class component):
 >
 > ```jsx
+> import { ErrorBoundary } from 'react-error-boundary';
+>
 > <ErrorBoundary fallback={<div>Posts unavailable</div>}>
 >   <Suspense fallback={<div>Loading posts...</div>}>
 >     <PostList posts={postsPromise} />
 >   </Suspense>
-> </ErrorBoundary>
+> </ErrorBoundary>;
 > ```
 
 With `auto_load_bundle` enabled (recommended), `MyStreamingComponent` is registered automatically. Otherwise, register it as a server component — server components use `registerServerComponent`, **not** `ReactOnRails.register`:

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -147,7 +147,7 @@ class ExampleController < ApplicationController
 end
 ```
 
-The controller prepares `@posts`; the view's `emit.call` streams it. For one slow source like this, loading it in the controller is fine. When several sources are slow and independent, load them in parallel (e.g. Ruby threads) so no `emit.call` waits on an unrelated query — see [Avoiding Server-Side Waterfalls](../oss/migrating/rsc-data-fetching.md#avoiding-server-side-waterfalls).
+The controller prepares `@posts`; the view's `emit.call` streams it. For one slow source like this, loading it in the controller is fine. When several sources are slow and independent, fetch them in parallel with the [`async` gem](https://github.com/socketry/async) rather than Ruby threads — Pro's streaming stack is fiber-based and already runs inside an Async reactor, so wrap each query in an `Async { ... }` task and await them. That way no `emit.call` waits on an unrelated query.
 
 ### 5. Test Your Application
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -44,7 +44,7 @@ Ensure you're using React 19 in your `package.json`:
 
 ### 2. Prepare Your React Components
 
-Create React components that receive data as props from Rails. Use `<Suspense>` boundaries to define which sections of the page stream independently via `renderToPipeableStream`.
+Create async React Server Components that receive data as props from Rails. Wrap them in `<Suspense>` boundaries to define which sections stream independently — React sends the fallback first, then streams the rendered content when the async component resolves.
 
 ```jsx
 // app/javascript/components/MyStreamingComponent.jsx
@@ -56,14 +56,14 @@ const MyStreamingComponent = ({ greeting, posts }) => {
       <header>
         <h1>{greeting}</h1>
       </header>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<div>Loading posts...</div>}>
         <PostList posts={posts} />
       </Suspense>
     </>
   );
 };
 
-const PostList = ({ posts }) => {
+async function PostList({ posts }) {
   return (
     <ul>
       {posts.map((post) => (
@@ -71,12 +71,12 @@ const PostList = ({ posts }) => {
       ))}
     </ul>
   );
-};
+}
 
 export default MyStreamingComponent;
 ```
 
-> **React on Rails note:** In React on Rails, database queries, authentication, and API calls happen on the Rails side — in controllers and models. Components receive the results as props via [`stream_react_component`](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro), and HTML streams to the browser as React renders the component tree. Components do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md) for the full explanation.
+> **React on Rails note:** The `async function` component pattern is a React Server Components feature — it requires [RSC support](./react-server-components/tutorial.md) enabled in React on Rails Pro. Database queries, authentication, and API calls happen on the Rails side — in controllers and models. Components receive the results as props via [`stream_react_component`](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro); they do not fetch data directly. See [RSC Migration: Data Fetching Patterns](../oss/migrating/rsc-data-fetching.md) for the full explanation.
 
 ```jsx
 // app/javascript/packs/registration.jsx
@@ -138,10 +138,40 @@ callers should not use an empty stream as a success signal.
 `stream_react_component` calls React's `renderToPipeableStream`, which streams HTML to the browser progressively as React renders the component tree:
 
 1. The HTML response starts immediately — the browser doesn't wait for the entire page to finish rendering
-2. React renders sections of the tree and flushes HTML chunks to the browser
-3. The browser parses and displays each chunk as it arrives
+2. React sends the shell (header, footer, and Suspense fallbacks) first
+3. When async components resolve, their rendered HTML streams to the browser as replacement chunks
 
-With synchronous props (as in this example), all data is available when rendering starts. React renders the full tree in one pass, and `renderToPipeableStream` flushes the HTML progressively — the browser receives the header, posts, and footer as a stream rather than waiting for the complete response. This reduces Time to First Byte (TTFB) on large pages.
+For example, with our `MyStreamingComponent`, the sequence is:
+
+1. The browser receives the shell immediately, including the Suspense fallback:
+
+```html
+<header>
+  <h1>Hello, Streaming World!</h1>
+</header>
+<template id="s0">
+  <div>Loading posts...</div>
+</template>
+<footer>
+  <p>Footer content</p>
+</footer>
+```
+
+2. When the async `PostList` resolves, its rendered HTML streams to the browser:
+
+```html
+<template hidden id="b0">
+  <ul>
+    <li>First Post</li>
+    <li>Second Post</li>
+  </ul>
+</template>
+
+<script>
+  // This implementation is slightly simplified
+  document.getElementById('s0').replaceChildren(document.getElementById('b0'));
+</script>
+```
 
 For pages with independent data sources that load at different speeds, use separate `stream_react_component` calls so each section streams as its data becomes ready:
 
@@ -153,8 +183,6 @@ For pages with independent data sources that load at different speeds, use separ
 <%= stream_react_component("Sidebar",
       props: { stats: @stats.as_json }) %>
 ```
-
-When combined with React Server Components (async components), `<Suspense>` boundaries show a fallback while the async content resolves, then the rendered HTML streams to the browser as a replacement — creating a progressive loading experience. See the [RSC tutorial](./react-server-components/tutorial.md) for details.
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -182,7 +182,10 @@ end %>
 
 On the React side, give each async prop its own `<Suspense>` boundary (as in Step 2) so each section streams in independently as its query finishes.
 
-> **Error handling:** an unhandled error in a child task propagates through `wait` and closes the stream, so the remaining props may not be sent. If one source failing shouldn't cut off the others, wrap each task body in a `rescue` and emit a fallback (or skip that prop).
+> **Error handling — two distinct failure modes:**
+>
+> - An error raised in the task **body before `emit.call`** (e.g. a query raising `ActiveRecord::StatementInvalid`) propagates through `wait` and closes the stream, so the remaining props may not be sent. If one source failing shouldn't cut off the others, wrap each task body in a `rescue` and emit a fallback (or skip that prop).
+> - An error raised **inside `emit.call`** (a non-serializable value, a write failure) is caught and logged by the emitter without re-raising — the task completes normally and `wait` sees nothing, but the prop is never delivered and its `<Suspense>` boundary never resolves. Pass only JSON-serializable values (e.g. `.as_json(only: [...])`) to `emit.call` to avoid a silently hanging boundary.
 
 **Requirements and footguns for concurrent async props:**
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -197,6 +197,8 @@ On the React side, give each async prop its own `<Suspense>` boundary (as in Ste
 - **Capture request state before fanning out** — read `current_user.id` (and any other `CurrentAttributes`) into locals _before_ `parent.async`. Per-fiber isolation does not copy `CurrentAttributes` into child tasks, and this fails silently as stale/missing data rather than an error.
 - **Reactor-only** — `Async::Task.current` only works inside the `emit` block (which runs in Pro's reactor). Don't copy this fan-out into a plain controller action, background job, or test that hasn't started an Async reactor — it raises `Async::Error`.
 
+> **Note:** Running queries concurrently this way relies on ActiveRecord and your database driver supporting fiber scheduling (non-blocking I/O under a `Fiber.scheduler`). Confirming and configuring that for your stack — adapter choice, gem versions, connection settings — is your responsibility and outside the scope of this guide. If fiber scheduling isn't in place, the queries still run correctly, just serialized rather than in parallel.
+
 ### 5. Test Your Application
 
 You can test your application by running `rails server` and navigating to the appropriate route.

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -30,7 +30,7 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 
 ## Implementation Steps
 
-> **This example uses async props**, which build on React Server Components. Enable RSC before you start: set `config.enable_rsc_support = true` in your React on Rails Pro configuration (see the [RSC tutorial](./react-server-components/tutorial.md)). Without it, the `async function` server component won't render and `stream_react_component_with_async_props` raises `ReactOnRailsPro::Error`. If all your data is fast and you don't need progressive streaming, you can skip RSC and use the synchronous `stream_react_component` instead (see the note after Step 3).
+> **This example uses async props**, which build on React Server Components. Enable RSC before you start: set `config.enable_rsc_support = true` in your React on Rails Pro configuration (see the [RSC tutorial](./react-server-components/tutorial.md)). Without it, the `async function` server component won't render and `stream_react_component_with_async_props` raises `ReactOnRailsPro::Error`. If all your data is fast and you don't need progressive streaming, you can skip RSC and use the synchronous `stream_react_component` with all props passed at once.
 
 ### 1. Use React 19
 
@@ -86,6 +86,16 @@ export default MyStreamingComponent;
 ```
 
 > **React on Rails note:** Database queries, authentication, authorization, and caching all stay on the Rails side — the controller and view own them. Async props just let Rails emit each result the moment it has it, instead of blocking the whole render on the slowest source. The component never fetches data directly. In TypeScript, type the props with `WithAsyncProps<AsyncProps, SyncProps>` from `react-on-rails-pro`. See [Data Fetching in React on Rails Pro](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) for the prop-based data model this builds on.
+
+> **Handle failures:** if a prop's query rejects, the `await` throws inside the async component and React propagates it up the tree. In production, wrap each `<Suspense>` in an error boundary so a single failed source degrades to a fallback instead of breaking the whole render:
+>
+> ```jsx
+> <ErrorBoundary fallback={<div>Posts unavailable</div>}>
+>   <Suspense fallback={<div>Loading posts...</div>}>
+>     <PostList posts={postsPromise} />
+>   </Suspense>
+> </ErrorBoundary>
+> ```
 
 With `auto_load_bundle` enabled (recommended), `MyStreamingComponent` is registered automatically. Otherwise, register it as a server component — server components use `registerServerComponent`, **not** `ReactOnRails.register`:
 
@@ -151,7 +161,7 @@ The controller just renders — the async prop's query runs in the view's `emit`
 
 #### Loading Multiple Slow Sources in Parallel
 
-When several sources are slow and independent, run them concurrently with the [`async` gem](https://github.com/socketry/async). Pro's streaming stack is already fiber-based, so fan out with fibers from the running reactor rather than introducing a separate Ruby-thread concurrency model. The emit block runs inside an `Async` task — capture it once and spawn one child task per source with `parent.async`, so each prop is emitted the moment its own query resolves:
+When several sources are slow and independent, run them concurrently with the [`async` gem](https://github.com/socketry/async) (already a dependency of React on Rails Pro and loaded by the streaming helper). Pro's streaming stack is fiber-based, so fan out with fibers from the running reactor rather than introducing a separate Ruby-thread concurrency model. The emit block runs inside an `Async` task — capture it with `Async::Task.current` and spawn one child task per source with `parent.async`, so each prop is emitted the moment its own query resolves:
 
 ```erb
 <%= stream_react_component_with_async_props('Dashboard',
@@ -174,7 +184,13 @@ On the React side, give each async prop its own `<Suspense>` boundary (as in Ste
 
 > **Error handling:** an unhandled error in a child task propagates through `wait` and closes the stream, so the remaining props may not be sent. If one source failing shouldn't cut off the others, wrap each task body in a `rescue` and emit a fallback (or skip that prop).
 
-> **Concurrent ActiveRecord needs fiber-aware connections.** Set `config.active_support.isolation_level = :fiber` (Rails 7.0.2+) so each fiber checks out its own pooled connection. Size your connection pool for the total number of DB-using fibers in flight across all concurrent requests — not just this one fan-out — or extra fibers block on connection checkout. Queries only truly overlap on a fiber-scheduler-aware driver such as `pg` (PostgreSQL); blocking drivers like `mysql2` and `sqlite3` serialize on the reactor. Capture request-scoped state (like `current_user.id`) **before** fanning out, since per-fiber isolation does not copy `CurrentAttributes` into child tasks.
+**Requirements and footguns for concurrent async props:**
+
+- **`config.active_support.isolation_level = :fiber`** (Rails 7.0.2+) — without it, fibers share one connection and concurrent queries corrupt each other; with it, each fiber checks out its own pooled connection.
+- **Connection pool size** — must cover the total DB-using fibers in flight across _all_ concurrent requests, not just this one fan-out, or extra fibers block on checkout.
+- **Driver matters** — queries only truly overlap on a fiber-scheduler-aware driver such as `pg` (PostgreSQL). Blocking drivers like `mysql2` and `sqlite3` serialize on the reactor, so the fan-out gives no speedup.
+- **Capture request state before fanning out** — read `current_user.id` (and any other `CurrentAttributes`) into locals _before_ `parent.async`. Per-fiber isolation does not copy `CurrentAttributes` into child tasks, and this fails silently as stale/missing data rather than an error.
+- **Reactor-only** — `Async::Task.current` only works inside the `emit` block (which runs in Pro's reactor). Don't copy this fan-out into a plain controller action, background job, or test that hasn't started an Async reactor — it raises `Async::Error`.
 
 ### 5. Test Your Application
 


### PR DESCRIPTION
## Summary
- **`pro/release-notes/4.0.md:11`** — Replaced "Direct access to databases, APIs, and server resources from React components" with accurate description: data flows from Rails controllers as props via `stream_react_component` async props
- **`pro/streaming-ssr.md:49-80`** — Removed in-component `await fetch('api/endpoint')` example; component now receives `{ greeting, posts }` as props from Rails. Updated ERB to pass `@posts.as_json`, controller to load data, and Step 6 HTML examples to match. Added "React on Rails note" linking `rsc-data-fetching.md`
- **`pro/release-notes/v4-react-server-components.md:39`** — Added blockquote noting that cited Next.js case-study performance benefits carry over to RoR Pro, but data delivery is prop-based via `stream_react_component`

## Context
Part of the docs overhaul (#2678). Sibling of #3468 (Pro RSC guide) and #3470 (OSS core-concepts). This PR addresses only the Pro release notes and streaming-ssr scope defined in #3469.

Closes #3469

## Test plan
- [ ] Verify `4.0.md` no longer claims direct DB access from components
- [ ] Verify `streaming-ssr.md` example uses Rails-prepared props, not in-component `fetch`
- [ ] Verify case-study section notes the prop-based delivery model
- [ ] Verify all cross-links to `rsc-data-fetching.md` resolve correctly
- [ ] Verify no changes overlap with #3468 or #3470 scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified React Server Components data fetching to emphasize server-streamed async props into components and Suspense-based updates.
  * Updated streaming SSR guide with props-driven examples and progressive rendering walkthroughs.
  * Added a note explaining that data is delivered from the server via props in React on Rails Pro and that RSC/SSR performance benefits apply.
  * Added guidance for independently streaming multiple page sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->