### PR TITLE
fix(ci): skip benchmarks for comment-only changes under app/ dirs

### DIFF
--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -262,8 +262,8 @@ while IFS= read -r file; do
       fi
       ;;
 
-    # Ruby core source code (non-generator lib files)
-    react_on_rails/lib/*.rb|react_on_rails/lib/**/*.rb|Gemfile|Gemfile.lock|rakelib/run_rspec.rake|rakelib/node_package.rake|rakelib/dummy_apps.rake)
+    # Ruby core source code (non-generator lib + app files)
+    react_on_rails/lib/*.rb|react_on_rails/lib/**/*.rb|react_on_rails/app/*.rb|react_on_rails/app/**/*.rb|Gemfile|Gemfile.lock|rakelib/run_rspec.rake|rakelib/node_package.rake|rakelib/dummy_apps.rake)
       DOCS_ONLY=false
       if source_file_comment_only_change "$file"; then
         SOURCE_COMMENT_ONLY_CHANGED=true
@@ -302,8 +302,8 @@ while IFS= read -r file; do
       fi
       ;;
 
-    # React on Rails Pro source code
-    react_on_rails_pro/lib/*|react_on_rails_pro/lib/**/*)
+    # React on Rails Pro source code (lib + app)
+    react_on_rails_pro/lib/*|react_on_rails_pro/lib/**/*|react_on_rails_pro/app/*|react_on_rails_pro/app/**/*)
       DOCS_ONLY=false
       if source_file_comment_only_change "$file"; then
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -94,6 +94,8 @@ setup_repo() {
   mkdir -p docs react_on_rails/lib/react_on_rails packages/react-on-rails/src
   mkdir -p packages/react-on-rails-pro-node-renderer/src
   mkdir -p react_on_rails/spec/react_on_rails
+  mkdir -p react_on_rails/app/helpers
+  mkdir -p react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy
   cat > docs/guide.md <<'DOC'
 # Guide
 DOC
@@ -125,6 +127,26 @@ TS
 RSpec.describe "example" do
   it "works" do
     expect(true).to be(true)
+  end
+end
+RUBY
+  cat > react_on_rails/app/helpers/react_on_rails_helper.rb <<'RUBY'
+module ReactOnRails
+  module Helper
+    def react_component
+      "ok"
+    end
+  end
+end
+RUBY
+  cat > react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb <<'RUBY'
+module ReactOnRailsPro
+  module RollingDeploy
+    class BundlesController
+      def call
+        "ok"
+      end
+    end
   end
 end
 RUBY
@@ -313,6 +335,66 @@ test_spec_comment_only_change_skips_rspec() {
   assert_contains "$out" '"run_ruby_tests": false' "spec comment output"
 }
 
+test_core_app_comment_only_change_skips_heavy_tests_but_keeps_lint() {
+  setup_repo
+  perl -0pi -e 's/    def react_component/    # Document the helper.\n    def react_component/' \
+    react_on_rails/app/helpers/react_on_rails_helper.rb
+  commit_change "core app comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "core app comment output"
+  assert_contains "$out" '"non_runtime_only": true' "core app comment output"
+  assert_contains "$out" '"run_lint": true' "core app comment output"
+  assert_contains "$out" '"run_ruby_tests": false' "core app comment output"
+}
+
+test_core_app_source_change_remains_runtime_affecting() {
+  setup_repo
+  perl -0pi -e 's/"ok"/"changed"/' react_on_rails/app/helpers/react_on_rails_helper.rb
+  commit_change "core app source"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "core app source output"
+  assert_contains "$out" '"run_ruby_tests": true' "core app source output"
+}
+
+# Regression for PR #3474: a comment-only change to a controller under
+# react_on_rails_pro/app/ used to fall through to the uncategorized catch-all,
+# which forced the entire test + benchmark suite to run.
+test_pro_app_comment_only_change_runs_pro_lint_only() {
+  setup_repo
+  perl -0pi -e 's/    class BundlesController/    class BundlesController\n      # Document the controller./' \
+    react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+  commit_change "pro app comment"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "pro app comment output"
+  assert_contains "$out" '"non_runtime_only": true' "pro app comment output"
+  assert_contains "$out" '"run_lint": false' "pro app comment output"
+  assert_contains "$out" '"run_pro_lint": true' "pro app comment output"
+  assert_contains "$out" '"run_pro_tests": false' "pro app comment output"
+  assert_contains "$out" '"run_ruby_tests": false' "pro app comment output"
+}
+
+test_pro_app_source_change_runs_pro_tests_only() {
+  setup_repo
+  perl -0pi -e 's/"ok"/"changed"/' \
+    react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+  commit_change "pro app source"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "pro app source output"
+  assert_contains "$out" '"run_pro_tests": true' "pro app source output"
+  # Scoped to Pro: a Pro app change must not drag in the core gem suite the way
+  # the old uncategorized catch-all did.
+  assert_contains "$out" '"run_ruby_tests": false' "pro app source output"
+  assert_contains "$out" '"run_js_tests": false' "pro app source output"
+}
+
 test_pro_node_renderer_comment_only_change_runs_pro_lint_only() {
   setup_repo
   perl -0pi -e 's/export function/\/\/ Explains the Pro node renderer fixture.\nexport function/' \
@@ -484,6 +566,10 @@ run_test test_typescript_suppression_comment_remains_runtime_affecting
 run_test test_code_line_starting_with_plus_plus_remains_runtime_affecting
 run_test test_comment_like_template_literal_change_remains_runtime_affecting
 run_test test_spec_comment_only_change_skips_rspec
+run_test test_core_app_comment_only_change_skips_heavy_tests_but_keeps_lint
+run_test test_core_app_source_change_remains_runtime_affecting
+run_test test_pro_app_comment_only_change_runs_pro_lint_only
+run_test test_pro_app_source_change_runs_pro_tests_only
 run_test test_pro_node_renderer_comment_only_change_runs_pro_lint_only
 run_test test_mixed_comment_and_code_change_remains_runtime_affecting
 run_test test_ruby_magic_comment_remains_runtime_affecting


### PR DESCRIPTION
## Problem

PR #3474 changed only Markdown docs and made a comment-only edit to a Pro
controller, yet CI ran the **full** test + benchmark suite (Core benchmarks,
Pro Node Renderer benchmarks, core gem tests, JS tests, dummy tests,
generators, and E2E).

## Root cause

`script/ci-changes-detector` categorizes `react_on_rails/lib/**` and
`react_on_rails_pro/lib/**` and runs comment-only detection on them, but it has
**no branch for either gem's `app/` directory** (controllers, helpers, views).
Any change under `app/` — even a pure comment edit — fell through to the
uncategorized catch-all:

```sh
*)
  DOCS_ONLY=false
  UNCATEGORIZED_CHANGED=true   # forces the entire test + benchmark suite
  ;;
```

`react_on_rails_pro/app/controllers/.../bundles_controller.rb` (comment-only in
#3474) hit this branch, which is why every benchmark suite ran.

## Fix

Add `app/` to each gem's source category, mirroring its existing `lib/`
convention:

- **Core** — extend the Ruby-core branch with `react_on_rails/app/*.rb|react_on_rails/app/**/*.rb` (`.rb`-scoped, like core `lib/`).
- **Pro** — extend the Pro-source branch with `react_on_rails_pro/app/*|react_on_rails_pro/app/**/*` (all files, like Pro `lib/`).

Comment-only `app/` changes now set the `SOURCE_COMMENT_ONLY` flags (lint only —
no heavy tests, no benchmarks). Real `app/` changes are scoped to the owning
gem instead of triggering everything.

### Detector output for #3474, before vs after

| flag | before | after |
|---|---|---|
| `run_ruby_tests` / `run_js_tests` / `run_dummy_tests` | true | **false** |
| `run_generators` / `run_e2e_tests` | true | **false** |
| `run_pro_node_renderer_tests` | true | **false** |
| `run_pro_lint` / `run_pro_tests` / `run_pro_dummy_tests` | true | true |

Net effect on #3474: **Core benchmarks and Pro Node Renderer benchmarks no
longer run**, and the core gem suite / E2E are skipped.

> [!NOTE]
> Pro benchmarks + Pro tests still run for #3474, and that is correct: the PR
> also edited a **string literal** in `react_on_rails_pro/lib/.../configuration.rb`
> (a validation error message's doc reference). That is a genuine non-comment
> source change, so the detector rightly flags it. This PR intentionally does
> **not** weaken string-literal handling — treating arbitrary string changes as
> non-runtime would be unsafe (regexes, SQL, format strings, etc.).

## Tests

Adds 4 regression tests to `script/ci-changes-detector-test.bash`:

- comment-only change under core `app/` → `non_runtime_only`, lint only
- runtime change under core `app/` → runs Ruby tests
- comment-only change under Pro `app/` (the #3474 regression) → `non_runtime_only`, Pro lint only
- runtime change under Pro `app/` → Pro tests only (scoped, not the whole suite)

All 31 detector tests pass; `shellcheck -x` is clean on both files (matches the
`git-diff-base-tests.yml` CI invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI path categorization and test fixtures; no runtime gem or app behavior is modified.
> 
> **Overview**
> **CI change detection** now treats each gem’s **`app/`** tree like its existing **`lib/`** rules, so edits under helpers/controllers no longer hit the uncategorized catch-all that forced the full test and benchmark suite.
> 
> For **core**, `react_on_rails/app/**/*.rb` joins the Ruby-core branch: comment-only diffs set **`non_runtime_only`** (lint only, no Ruby/dummy/benchmark jobs); real code changes still flag **`run_ruby_tests`**. For **Pro**, `react_on_rails_pro/app/**` joins the Pro Ruby branch with the same comment-only vs **`run_pro_tests`** / **`run_pro_lint`** behavior, without pulling core JS/Ruby suites.
> 
> **`script/ci-changes-detector-test.bash`** adds fixture paths and four regression tests (core/Pro app comment-only and source changes), including the #3474 Pro controller comment-only case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737f76b27c37ebf08e0c6fe19fd51ca7e24f238b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI change detection logic to improve categorization of Ruby source file changes.

* **Tests**
  * Expanded test coverage for change detection validation, including new test cases for core and Pro application file modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->