### PR TITLE
ci: declare turbolinks unconditionally to stabilize frozen installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Commit `package-lock.json`, `yarn.lock`, or other non-pnpm lock files
 - Add files to the `docs/` root — OSS docs go in `docs/oss/` subdirectories (`getting-started/`, `core-concepts/`, `building-features/`, `configuration/`, `api-reference/`, `deployment/`, `migrating/`, `upgrading/`, `misc/`); Pro docs go in `docs/pro/`
 - Force push to `main` or `master`
+- Reintroduce conditional gem declarations like `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil?` in `react_on_rails/Gemfile.development_dependencies`. Conditional inclusion produces a different dependency set than the lock file, which breaks `bundle install --frozen` in CI when the env var differs between `bundle lock` and `bundle install`. `DISABLE_TURBOLINKS` controls asset loading at the application layer, not gem inclusion.
 
 ## Main branch health
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Commit `package-lock.json`, `yarn.lock`, or other non-pnpm lock files
 - Add files to the `docs/` root — OSS docs go in `docs/oss/` subdirectories (`getting-started/`, `core-concepts/`, `building-features/`, `configuration/`, `api-reference/`, `deployment/`, `migrating/`, `upgrading/`, `misc/`); Pro docs go in `docs/pro/`
 - Force push to `main` or `master`
-- Reintroduce conditional gem declarations like `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil?` in `react_on_rails/Gemfile.development_dependencies`. Conditional inclusion produces a different dependency set than the lock file, which breaks `bundle install --frozen` in CI when the env var differs between `bundle lock` and `bundle install`. `DISABLE_TURBOLINKS` controls asset loading at the application layer, not gem inclusion.
+- Reintroduce conditional gem declarations like `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil?` in `react_on_rails/Gemfile.development_dependencies` — conditional inclusion diverges from the lockfile and breaks `bundle install --frozen` in CI. See the comment in that Gemfile for the full explanation.
 
 ## Main branch health
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -442,7 +442,7 @@ If you run `rspec` at the top level, you'll see this message: `require': cannot 
 
 If you run tests with `COVERAGE=true`, you can view the SimpleCov report at `coverage/index.html`.
 
-Turbolinks 5 is included in the test app, unless `DISABLE_TURBOLINKS=TRUE` is set in the environment.
+The Turbolinks 5 gem is always bundled in the test app. Setting `DISABLE_TURBOLINKS=TRUE` in the environment suppresses the `require_asset` call in `react_on_rails/spec/dummy/app/assets/javascripts/application_non_webpack.js.erb`, so Turbolinks does not load at runtime — but the gem itself stays in the bundle to keep the gemset consistent with `Gemfile.lock`.
 
 Run `rake -T` or `rake -D` to see testing options.
 

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -13,7 +13,11 @@ gem "jquery-rails"
 gem "puma", "~> 6.0"
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem "turbolinks" if ENV["DISABLE_TURBOLINKS"].nil? || ENV["DISABLE_TURBOLINKS"].strip.empty?
+# Declared unconditionally so the gemset always matches Gemfile.lock. DISABLE_TURBOLINKS
+# toggles Turbolinks at the application layer (the require_asset in
+# spec/dummy/app/assets/javascripts/application_non_webpack.js.erb), not gem inclusion.
+# A conditional declaration broke `bundle install --frozen` in CI (see AGENTS.md).
+gem "turbolinks"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder"

--- a/react_on_rails/rakelib/run_rspec.rake
+++ b/react_on_rails/rakelib/run_rspec.rake
@@ -69,8 +69,6 @@ namespace :run_rspec do
     env_vars_array = []
     env_vars_array << rbs_runtime_env_vars unless rbs_runtime_env_vars.empty?
     env_vars_array << "DISABLE_TURBOLINKS=TRUE"
-    # This task intentionally runs with a different Gemfile view where the turbolinks gem is excluded.
-    env_vars_array << "BUNDLE_FROZEN=false"
     env_vars = env_vars_array.join(" ")
     run_tests_in(spec_dummy_dir,
                  env_vars: env_vars,


### PR DESCRIPTION
## Summary

Declares the `turbolinks` development dependency **unconditionally** in `react_on_rails/Gemfile.development_dependencies`, replacing the `gem "turbolinks" if ENV["DISABLE_TURBOLINKS"]...` conditional.

The conditional resolved to a dependency set that differs from `Gemfile.lock` whenever `DISABLE_TURBOLINKS` is set — the lock file is generated without the env var, but `bundle install` runs with it — which breaks `bundle install --frozen` in CI. `main` currently works around this by forcing `BUNDLE_FROZEN=false` in the `dummy_no_turbolinks` rake task. This PR removes the root cause so the workaround is no longer needed.

## Why this is safe

`DISABLE_TURBOLINKS` already controls Turbolinks at the **application layer**, not via gem inclusion:

```erb
<%# react_on_rails/spec/dummy/app/assets/javascripts/application_non_webpack.js.erb %>
<% if ENV["DISABLE_TURBOLINKS"].blank? %>
  <% require_asset "turbolinks" %>
<% end %>
```

So with the gem always present, `DISABLE_TURBOLINKS=TRUE` still disables Turbolinks (the asset is not required). The `rake run_rspec:dummy_no_turbolinks` coverage is unchanged — it still exercises the no-Turbolinks code path.

`Gemfile.lock` is unaffected: it already pins `turbolinks (5.2.1)` because lock resolution runs without `DISABLE_TURBOLINKS`.

## Changes

- `react_on_rails/Gemfile.development_dependencies` — declare `gem "turbolinks"` unconditionally (+ explanatory comment).
- `react_on_rails/rakelib/run_rspec.rake` — drop the now-unnecessary `BUNDLE_FROZEN=false` workaround from `dummy_no_turbolinks`.
- `AGENTS.md` — document the footgun so the conditional declaration is not reintroduced.

## Context

Split out of #3354 as a focused, standalone fix. The broader Bundler-cache consolidation from that branch was superseded by #3429 (extract `setup-bundle`) and #3448 (independent benchmark suites) already on `main`; this is the one root-cause reliability fix from #3354 that `main` does not yet have.

## Test plan

- [x] `bundle exec rubocop rakelib/run_rspec.rake Gemfile.development_dependencies` — no offenses
- [x] `npx prettier --check AGENTS.md` — passes
- [x] Confirmed `Gemfile.lock` already contains `turbolinks (5.2.1)`; no lock change
- [x] Verified the app-layer `require_asset` guard handles `DISABLE_TURBOLINKS` independently of gem presence
- [ ] CI `rake run_rspec:dummy_no_turbolinks` (and frozen installs) pass on the branch

Related to #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/test dependency and CI wiring only; no production gem behavior change, and no-Turbolinks coverage stays via the existing asset guard.
> 
> **Overview**
> Fixes **CI `bundle install --frozen` failures** when `DISABLE_TURBOLINKS` is set by always declaring **`turbolinks`** in `react_on_rails/Gemfile.development_dependencies`, instead of omitting it based on that env var.
> 
> **`DISABLE_TURBOLINKS`** still turns Turbolinks off at runtime via the dummy app’s **`require_asset`** guard; only gem resolution changes. The **`dummy_no_turbolinks`** rake task no longer sets **`BUNDLE_FROZEN=false`**.
> 
> **AGENTS.md** and **CONTRIBUTING.md** document the rule so conditional turbolinks declarations are not reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a214e561647ce9440a6b86cf2db9ea6bb8a38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that certain dev-only assets remain bundled while runtime toggles disable them, to keep dependency sets consistent with the lockfile.
* **Chores**
  * Made development/test workflows more reliable by aligning gem declarations with the lockfile and adjusting test-run behavior to avoid frozen-bundle failures in CI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->