### PR TITLE
ci: cache gems via ruby/setup-ruby bundler-cache in setup-bundle

### DIFF
--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -1,5 +1,7 @@
 name: Setup Bundler dependencies
-description: Cache and install Ruby gems for a Bundler project.
+description: >
+  Setup Ruby, cache, and install gems for a Bundler project. On Linux,
+  ensure libyaml-dev is already present or install it before calling this action.
 
 inputs:
   working-directory:
@@ -8,22 +10,18 @@ inputs:
   ruby-version:
     description: Ruby version used by the job.
     required: true
-  bundle-path:
-    description: Bundler install path, relative to the working directory.
-    required: false
-    default: vendor/bundle
   frozen:
-    description: Whether to run Bundler in frozen mode. Cache saving is disabled when false; restore still runs.
+    description: Whether to run Bundler in frozen mode.
     required: false
     default: 'true'
   bundler-version:
-    description: Bundler version selector. Use lockfile, system, or x.y.z.
+    description: Bundler version selector. Use Gemfile.lock, default, latest, none, or x.y.z.
     required: false
-    default: lockfile
-  install-args:
-    description: Arguments for bundle install.
+    default: Gemfile.lock
+  cache-version:
+    description: Arbitrary cache-version value passed through to ruby/setup-ruby.
     required: false
-    default: --jobs=4 --retry=3
+    default: '0'
 
 runs:
   using: composite
@@ -37,36 +35,15 @@ runs:
           exit 1
         fi
 
-    - name: Restore Ruby gems cache
-      id: restore-ruby-gems-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: ${{ inputs.working-directory }}/${{ inputs.bundle-path }}
-        # Update to bundle-...-v1 in the future to break the cache if necessary
-        # or v1-bundle-... if you want restore-keys not to trigger either (update the key there in that case)
-        key: bundle-${{ runner.os }}-${{ inputs.working-directory }}-${{ inputs.bundle-path }}-ruby${{ inputs.ruby-version }}-${{ hashFiles(format('{0}/Gemfile.lock', inputs.working-directory)) }}
-        restore-keys: |
-          bundle-${{ runner.os }}-${{ inputs.working-directory }}-${{ inputs.bundle-path }}-ruby${{ inputs.ruby-version }}-
-
-    - name: Install Ruby gems
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
+    - name: Setup Ruby and install cached gems
+      uses: ruby/setup-ruby@v1
       env:
         BUNDLE_FROZEN: ${{ inputs.frozen }}
-        BUNDLE_INSTALL_ARGS: ${{ inputs.install-args }}
-        BUNDLE_PATH_CONFIG: ${{ inputs.bundle-path }}
-        BUNDLER_VERSION_CONFIG: ${{ inputs.bundler-version }}
-      run: |
-        bundle config set --local path "$BUNDLE_PATH_CONFIG"
-        bundle config set --local version "$BUNDLER_VERSION_CONFIG"
-        # shellcheck disable=SC2086
-        # Intentionally allow install args to split into separate bundle arguments
-        bundle check || bundle install $BUNDLE_INSTALL_ARGS
-
-    - name: Save Ruby gems cache
-      # We don't want to overwrite the cache for non-frozen Bundler runs
-      if: inputs.frozen == 'true' && steps.restore-ruby-gems-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
+        BUNDLE_RETRY: '3'
+        BUNDLE_JOBS: '4'
       with:
-        path: ${{ inputs.working-directory }}/${{ inputs.bundle-path }}
-        key: ${{ steps.restore-ruby-gems-cache.outputs.cache-primary-key }}
+        ruby-version: ${{ inputs.ruby-version }}
+        working-directory: ${{ inputs.working-directory }}
+        bundler: ${{ inputs.bundler-version }}
+        bundler-cache: true
+        cache-version: ${{ inputs.cache-version }}

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,0 +1,30 @@
+name: Setup Ruby runtime
+description: Install Ruby runtime prerequisites and setup Ruby without installing gems.
+
+inputs:
+  ruby-version:
+    description: Ruby version used by the job.
+    required: true
+  bundler-version:
+    description: Bundler version selector passed through to ruby/setup-ruby.
+    required: false
+    default: Gemfile.lock
+  install-libyaml:
+    description: Whether to install libyaml-dev before Ruby/Bundler steps.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install libyaml-dev
+      if: runner.os == 'Linux' && inputs.install-libyaml == 'true'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler: ${{ inputs.bundler-version }}
+        bundler-cache: false

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -6,9 +6,14 @@ inputs:
     description: Ruby version used by the job.
     required: true
   bundler-version:
-    description: Bundler version selector passed through to ruby/setup-ruby.
+    description: >
+      Bundler version selector passed through to ruby/setup-ruby.
+      Use default, latest, none, Gemfile.lock, or x.y.z. Defaults to "default"
+      (the bundler shipped with the chosen Ruby) rather than "Gemfile.lock",
+      because this action has no working-directory and the repo-root Gemfile.lock
+      is gitignored — reading it would be meaningless here.
     required: false
-    default: Gemfile.lock
+    default: default
   install-libyaml:
     description: Whether to install libyaml-dev before Ruby/Bundler steps.
     required: false

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -60,13 +60,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -91,13 +93,13 @@ jobs:
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ inputs.force_run }}" == "true" ]] || \
-             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+            [[ "${{ inputs.force_run }}" == "true" ]] || \
+            [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   examples:
@@ -122,10 +124,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -134,7 +136,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -167,6 +169,8 @@ jobs:
         with:
           working-directory: react_on_rails
           ruby-version: ${{ matrix.ruby-version }}
+          # Minimum-dependency legs intentionally install with frozen=false after script/convert,
+          # matching the historical bundle install behavior for converted dependency files.
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Ensure minimum required Chrome version
         run: |
@@ -184,7 +188,7 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Verify rake tasks exist
         run: |
           cd react_on_rails

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -93,8 +93,8 @@ jobs:
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-            [[ "${{ inputs.force_run }}" == "true" ]] || \
-            [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+             [[ "${{ inputs.force_run }}" == "true" ]] || \
+             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -60,13 +60,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -84,7 +86,7 @@ jobs:
              [[ "${{ steps.check-label.outputs.result }}" == "true" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions × 2 shards
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"generators"},{"ruby-version":"3.2","dependency-level":"minimum","shard":"unit"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback × 2 shards
             echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest","shard":"generators"},{"ruby-version":"3.4","dependency-level":"latest","shard":"unit"}]}' >> "$GITHUB_OUTPUT"
@@ -119,10 +121,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Print system information
         run: |
           echo "Linux release: "; cat /etc/issue
@@ -139,6 +141,8 @@ jobs:
         with:
           working-directory: react_on_rails
           ruby-version: ${{ matrix.ruby-version }}
+          # Minimum-dependency legs intentionally install with frozen=false after script/convert,
+          # matching the historical bundle install behavior for converted dependency files.
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: Git Stuff
         if: matrix.dependency-level == 'minimum'
@@ -148,7 +152,7 @@ jobs:
           git commit -am "stop generators from complaining about uncommitted code"
       - name: Set dependency level environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Run rspec tests
         env:
           SHARD: ${{ matrix.shard }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -90,8 +90,8 @@ jobs:
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-            [[ "${{ inputs.force_run }}" == "true" ]] || \
-            [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+             [[ "${{ inputs.force_run }}" == "true" ]] || \
+             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
             echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,13 +58,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
           else
             BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
             script/ci-changes-detector "$BASE_REF"
@@ -88,13 +90,13 @@ jobs:
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
-             [[ "${{ inputs.force_run }}" == "true" ]] || \
-             [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
+            [[ "${{ inputs.force_run }}" == "true" ]] || \
+            [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build-dummy-app-webpack-test-bundles:
@@ -120,14 +122,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
-      # libyaml-dev is needed for psych v5
-      # this gem depends on sdoc which depends on rdoc which depends on psych
-      - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -136,7 +134,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -207,10 +205,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.9
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -219,7 +217,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -290,7 +288,7 @@ jobs:
       - run: cd react_on_rails/spec/dummy && bundle info shakapacker
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Main CI
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -50,13 +50,15 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -117,10 +119,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
-          ruby-version: 3
-          bundler: 2.5.9
+          ruby-version: '3.4'
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -131,7 +133,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -158,9 +160,15 @@ jobs:
       - name: Install Node modules with pnpm
         run: pnpm install --frozen-lockfile
 
+      # Pin the package Gemfile explicitly for parity with pro-lint.yml and to
+      # stay robust if the package and dummy Gemfiles ever diverge.
       - name: Lint Ruby
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile
         run: cd react_on_rails && bundle exec rubocop
       - name: Validate RBS type signatures
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails/Gemfile
         run: cd react_on_rails && bundle exec rake rbs:validate
       # TODO: Re-enable Steep once RBS signatures are complete for all checked files
       # Currently disabled because 374 type errors need to be fixed first

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,10 +52,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -65,7 +61,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,6 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Ruby
+        uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: '3.3'
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -84,13 +84,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: '3.4'
-          bundler: 2.5.9
-      # libyaml-dev is needed for psych v5
-      - name: Fix dependency for libyaml-dev
-        run: sudo apt install libyaml-dev
+          bundler-version: 2.5.9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -63,10 +63,12 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -102,10 +104,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -119,7 +121,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -202,10 +204,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -219,7 +221,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -389,10 +391,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -406,7 +408,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -63,10 +63,12 @@ jobs:
         run: |
           # If force_run is true OR full-ci label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "non_runtime_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+              echo "non_runtime_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -101,10 +103,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -118,7 +120,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -164,10 +166,16 @@ jobs:
         working-directory: .
         run: pnpm --filter react-on-rails-pro build
 
+      # These steps need the Pro package Gemfile (which carries rubocop/rbs),
+      # so pin it via absolute path — robust to changes in defaults.run.
       - name: Lint Ruby
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails_pro/Gemfile
         run: bundle exec rubocop --ignore-parent-exclusion
 
       - name: Validate RBS type signatures
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/react_on_rails_pro/Gemfile
         run: bundle exec rake rbs:validate
 
       - name: Check TypeScript
@@ -196,10 +204,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -213,7 +221,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -318,7 +326,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -399,10 +407,10 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 2.5.4
+          bundler-version: 2.5.4
 
       - name: Print system information
         run: |


### PR DESCRIPTION
## Summary

Reworks the shared `setup-bundle` composite action to delegate Ruby setup **and** gem caching to `ruby/setup-ruby@v1` with `bundler-cache: true`, replacing the manual `actions/cache` restore/save logic plus the `bundle check || bundle install` step that #3429 extracted. Adds a companion `setup-ruby` action and rolls both out across the OSS, Pro, integration, examples, precompile, Playwright, and lint workflows.

This is the caching-mechanism half of the original #3354 work, re-derived cleanly on top of current `main`. (The other salvageable piece — the unconditional-turbolinks frozen-install fix — is split into #3482. The rest of #3354 was superseded by #3429 and #3448 and is dropped.)

## What changes

- **`.github/actions/setup-bundle`** — instead of `actions/cache/restore` → `bundle check || bundle install` → `actions/cache/save`, it now calls `ruby/setup-ruby@v1` with `bundler-cache: true`, which installs Ruby, restores/saves the gem cache, and runs `bundle install` in one step. Inputs simplified accordingly (`bundle-path`/`install-args` dropped; `cache-version` passthrough added; `bundler-version` uses ruby/setup-ruby's selector values — `Gemfile.lock`/`default`/`latest`/`none`/`x.y.z`).
- **`.github/actions/setup-ruby`** (new) — Ruby runtime + Linux `libyaml-dev`, no gems. Used by jobs that need Ruby before their first bundle install (e.g. `script/convert`, `script/check-gemfile-lock-platforms`).
- **Workflows** — `examples`, `gem-tests`, `integration-tests`, `playwright`, `precompile-check`, `pro-integration-tests`, `pro-test-package-and-gem`, and `lint-js-and-ruby` migrated to the `setup-ruby` + `setup-bundle` pattern.

## Why

`ruby/setup-ruby`'s built-in `bundler-cache` is the upstream-recommended caching path and removes the bespoke cache key / restore-keys / save-condition logic the action currently maintains by hand. Less custom CI code to keep correct.

## Tradeoff / discussion

This **reverses the caching mechanism** that #3429 extracted (manual `actions/cache`). #3429 was a refactor of pre-existing logic, not necessarily a deliberate rejection of `bundler-cache: true`, so this is offered as the follow-on improvement #3354 originally proposed — but it's worth a maintainer call.

`benchmark.yml` is intentionally **not** restructured: its `setup-benchmark-runner` (added by #3448) still installs Ruby for `foreman`, and the subsequent `setup-bundle` call now handles each dummy app's gems via bundler-cache. That means `ruby/setup-ruby` runs twice in benchmark jobs (once for the runner tools, once for the dummy bundle) — functional and matches the approved #3354 pattern, but flagging it in case reviewers prefer a deeper benchmark refactor.

## Test plan

- [x] `actionlint` (with `SHELLCHECK_OPTS='-S warning'`) — clean
- [x] Ruby `YAML.load_file` parses all changed action/workflow files
- [x] Verified every `setup-bundle` call site passes only supported inputs (`working-directory`/`ruby-version`/`frozen`); no `bundle-path`/`install-args`/`lockfile` anywhere
- [x] Verified every `setup-ruby` call site passes only supported inputs (`ruby-version`/`bundler-version`)
- [x] Trailing-newline check on all changed files
- [ ] Full GitHub Actions run is green (the double `ruby/setup-ruby` invocation in benchmark + bundler-cache behavior should be confirmed in CI)

Related to #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how every major workflow installs and caches gems; behavior shifts from custom cache keys to upstream bundler-cache, though frozen/minimum-dependency semantics are preserved intentionally.
> 
> **Overview**
> **Centralizes Ruby/Bundler setup in two composite actions** and rolls them through OSS, Pro, integration, examples, lint, precompile, and Playwright workflows.
> 
> `setup-bundle` no longer uses hand-rolled `actions/cache` restore/save plus `bundle check || bundle install`. It now calls `ruby/setup-ruby@v1` with **`bundler-cache: true`**, passing `BUNDLE_FROZEN`, jobs/retry env vars, and optional **`cache-version`**. Inputs **`bundle-path`** and **`install-args`** are removed; **`bundler-version`** aligns with upstream selectors (default **`Gemfile.lock`**).
> 
> A new **`setup-ruby`** action installs Linux **`libyaml-dev`** when needed and runs `ruby/setup-ruby` with **`bundler-cache: false`** for jobs that need Ruby/Bundler before the first Gemfile-scoped install (e.g. **`script/convert`**, platform checks). Workflows switch from inline `ruby/setup-ruby` to **`setup-ruby`** then **`setup-bundle`**, with **`bundler-version`** instead of **`bundler`**.
> 
> Minor workflow hardening: quoted **`$GITHUB_OUTPUT`** / **`$GITHUB_ENV`**, grouped detect-changes output writes, explicit **`BUNDLE_GEMFILE`** for package lint/RBS steps, and comments documenting **`frozen: false`** on minimum-dependency matrix legs. Per-job **`libyaml-dev`** apt steps are dropped where **`setup-ruby`** covers them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037489a57629e1828d99a96a7a65969f00441aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adopted a unified, repo-local Ruby setup for consistent Ruby/bundler across CI.
  * Simplified bundler inputs and caching behaviour, adding a cache-version toggle and clarifying frozen/bundler defaults.
  * Improved CI output and environment variable writing for more reliable workflow execution.
  * Added optional libyaml installation and standardized Ruby versions (including 3.4 in some jobs).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->