### PR TITLE
Default fresh installs to Rspack (--webpack or --no-rspack for Webpack)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **Ruby 3.3+ is required for React on Rails v17**: The open-source gem now requires Ruby `>= 3.3.0`, aligning it with React on Rails Pro, `create-react-on-rails-app`, and the CI minimum matrix. React on Rails v16 remains the upgrade path for applications that must stay on Ruby 3.2 or older. [PR 3500](https://github.com/shakacode/react_on_rails/pull/3500) by [justin808](https://github.com/justin808).
 
+#### Changed
+
+- **Generator defaults to Rspack for fresh installs**: `rails generate react_on_rails:install` and `create-react-on-rails-app` now default to the Rspack bundler on fresh installs (significantly faster builds via SWC), instead of Webpack. Pass `--no-rspack` to use Webpack. This only affects fresh installs — existing apps that already declare an `assets_bundler` in `config/shakapacker.yml` are left unchanged, an explicit `--rspack`/`--no-rspack` always wins, and the default falls back to Webpack on Shakapacker versions below 9.0 (where Rspack is unsupported). [PR 3484](https://github.com/shakacode/react_on_rails/pull/3484) by [justin808](https://github.com/justin808).
+
 #### Fixed
 
 - **Shakapacker config warnings now report resolved relative paths**: When `SHAKAPACKER_CONFIG` is set to a relative missing path, the Rails boot warning now includes the Rails-root-resolved path that React on Rails actually checked. Fixes [Issue 3436](https://github.com/shakacode/react_on_rails/issues/3436). [PR 3441](https://github.com/shakacode/react_on_rails/pull/3441) by [justin808](https://github.com/justin808).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Changed
 
-- **Generator defaults to Rspack for fresh installs**: `rails generate react_on_rails:install` and `create-react-on-rails-app` now default to the Rspack bundler on fresh installs (significantly faster builds via SWC), instead of Webpack. Pass `--no-rspack` to use Webpack. This only affects fresh installs — existing apps that already declare an `assets_bundler` in `config/shakapacker.yml` are left unchanged, an explicit `--rspack`/`--no-rspack` always wins, and the default falls back to Webpack on Shakapacker versions below 9.0 (where Rspack is unsupported). [PR 3484](https://github.com/shakacode/react_on_rails/pull/3484) by [justin808](https://github.com/justin808).
+- **Generator defaults to Rspack for fresh installs**: `rails generate react_on_rails:install` and `create-react-on-rails-app` now default to the Rspack bundler on fresh installs (significantly faster builds via SWC), instead of Webpack. Pass `--no-rspack` (or its alias `--webpack`) to use Webpack. This only affects fresh installs — existing apps that already declare an `assets_bundler` in `config/shakapacker.yml` are left unchanged, an explicit `--rspack`/`--no-rspack`/`--webpack` always wins, and the default falls back to Webpack on Shakapacker versions below 9.0 (where Rspack is unsupported). [PR 3484](https://github.com/shakacode/react_on_rails/pull/3484) by [justin808](https://github.com/justin808).
 
 #### Fixed
 

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -1,6 +1,6 @@
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off — for example, the default for `-R` is that `redux` is off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off — for example, the default for `-R` is that `redux` is off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` (or its alias `--webpack`) if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 
@@ -12,6 +12,7 @@ Options:
   -R, [--redux], [--no-redux]                      # Install Redux package and Redux version of Hello World Example. Default: false
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
       [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
+      [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack)
       [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer. Default: false
       [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro). Default: false
       [--ignore-warnings], [--no-ignore-warnings]  # Skip warnings. Default: false
@@ -41,10 +42,10 @@ can pass the redux option if you'd like to have redux setup for you automaticall
 * Rspack (default)
 
     Rspack is the default bundler for fresh installs, providing significantly
-    faster builds (~20x improvement with SWC). Pass --no-rspack to use Webpack
-    instead. Either way you get a unified configuration that works with both
-    bundlers and a bin/switch-bundler utility to switch between them
-    post-installation.
+    faster builds (~20x improvement with SWC). Pass --no-rspack (or its alias
+    --webpack) to use Webpack instead. Either way you get a unified
+    configuration that works with both bundlers and a bin/switch-bundler
+    utility to switch between them post-installation.
 
 * Pro
 
@@ -146,11 +147,11 @@ Rspack is the default bundler for fresh installs, so a plain install gives you R
 # Rspack (default)
 rails generate react_on_rails:install
 
-# Webpack instead
+# Webpack instead (--webpack is an alias for --no-rspack)
 rails generate react_on_rails:install --no-rspack
 ```
 
-The default applies only to fresh installs. If `config/shakapacker.yml` already declares an `assets_bundler`, the generator keeps your existing choice. An explicit `--rspack` / `--no-rspack` always wins. (Rspack requires Shakapacker 9.0+; on older Shakapacker the generator falls back to Webpack.)
+The default applies only to fresh installs. If `config/shakapacker.yml` already declares an `assets_bundler`, the generator keeps your existing choice. An explicit `--rspack` / `--no-rspack` (or its `--webpack` alias) always wins. (Rspack requires Shakapacker 9.0+; on older Shakapacker the generator falls back to Webpack.)
 
 **Benefits:**
 

--- a/docs/oss/api-reference/generator-details.md
+++ b/docs/oss/api-reference/generator-details.md
@@ -1,6 +1,6 @@
 # Generator Details
 
-The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating Webpack with Rails. Defaults for options are such that the default is for the flag to be off. For example, the default for `-R` is that `redux` is off.
+The `react_on_rails:install` generator combined with the example pull requests of generator runs will get you up and running efficiently. There's a fair bit of setup with integrating a bundler with Rails. Most options default to off — for example, the default for `-R` is that `redux` is off. The exception is the bundler: **fresh installs now default to Rspack**, so pass `--no-rspack` if you want Webpack instead. Existing apps that already declare a bundler in `config/shakapacker.yml` are left unchanged.
 
 Run `rails generate react_on_rails:install --help` for descriptions of all available options:
 
@@ -11,7 +11,7 @@ Usage:
 Options:
   -R, [--redux], [--no-redux]                      # Install Redux package and Redux version of Hello World Example. Default: false
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
-      [--rspack], [--no-rspack]                    # Use Rspack instead of Webpack as the bundler. Default: false
+      [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
       [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer. Default: false
       [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro). Default: false
       [--ignore-warnings], [--no-ignore-warnings]  # Skip warnings. Default: false
@@ -38,12 +38,13 @@ can pass the redux option if you'd like to have redux setup for you automaticall
     Passing the --typescript generator option generates TypeScript files (.tsx)
     instead of JavaScript files (.jsx) and sets up TypeScript configuration.
 
-* Rspack
+* Rspack (default)
 
-    Passing the --rspack generator option uses Rspack instead of Webpack as the
-    bundler, providing significantly faster builds (~20x improvement with SWC).
-    Includes unified configuration that works with both bundlers and a
-    bin/switch-bundler utility to switch between bundlers post-installation.
+    Rspack is the default bundler for fresh installs, providing significantly
+    faster builds (~20x improvement with SWC). Pass --no-rspack to use Webpack
+    instead. Either way you get a unified configuration that works with both
+    bundlers and a bin/switch-bundler utility to switch between them
+    post-installation.
 
 * Pro
 
@@ -139,11 +140,17 @@ This creates `.tsx` files instead of `.jsx` and adds TypeScript configuration.
 
 ### Rspack Support
 
-The generator supports a `--rspack` option for using Rspack instead of Webpack as the bundler:
+Rspack is the default bundler for fresh installs, so a plain install gives you Rspack:
 
 ```bash
-rails generate react_on_rails:install --rspack
+# Rspack (default)
+rails generate react_on_rails:install
+
+# Webpack instead
+rails generate react_on_rails:install --no-rspack
 ```
+
+The default applies only to fresh installs. If `config/shakapacker.yml` already declares an `assets_bundler`, the generator keeps your existing choice. An explicit `--rspack` / `--no-rspack` always wins. (Rspack requires Shakapacker 9.0+; on older Shakapacker the generator falls back to Webpack.)
 
 **Benefits:**
 
@@ -187,13 +194,13 @@ For apps with custom webpack configurations, review the generated config templat
 **Combining with other options:**
 
 ```bash
-# Rspack with TypeScript
-rails generate react_on_rails:install --rspack --typescript
+# Rspack (default) with TypeScript
+rails generate react_on_rails:install --typescript
 
-# Rspack with Redux
-rails generate react_on_rails:install --rspack --redux
+# Webpack with Redux
+rails generate react_on_rails:install --no-rspack --redux
 
-# All options combined
+# Explicit Rspack with TypeScript and Redux
 rails generate react_on_rails:install --rspack --typescript --redux
 ```
 

--- a/packages/create-react-on-rails-app/src/create-app.ts
+++ b/packages/create-react-on-rails-app/src/create-app.ts
@@ -155,9 +155,9 @@ export function buildGeneratorArgs(options: CliOptions): string[] {
     args.push('--typescript');
   }
 
-  // Always forward the resolved bundler explicitly so the generator never falls back to its
-  // own default. This keeps create-app's choice authoritative even as the generator default
-  // changes (the generator now defaults fresh installs to Rspack).
+  // Always forward an explicit --rspack / --no-rspack so the generator never falls back to
+  // its own default. This keeps create-app's resolved choice authoritative regardless of what
+  // the generator's fresh-install default happens to be (now, or if it changes again later).
   args.push(options.rspack ? '--rspack' : '--no-rspack');
 
   // --rsc supersedes --pro because RSC mode already requires Pro and the generator accepts a single mode flag.

--- a/packages/create-react-on-rails-app/src/create-app.ts
+++ b/packages/create-react-on-rails-app/src/create-app.ts
@@ -155,9 +155,10 @@ export function buildGeneratorArgs(options: CliOptions): string[] {
     args.push('--typescript');
   }
 
-  if (options.rspack) {
-    args.push('--rspack');
-  }
+  // Always forward the resolved bundler explicitly so the generator never falls back to its
+  // own default. This keeps create-app's choice authoritative even as the generator default
+  // changes (the generator now defaults fresh installs to Rspack).
+  args.push(options.rspack ? '--rspack' : '--no-rspack');
 
   // --rsc supersedes --pro because RSC mode already requires Pro and the generator accepts a single mode flag.
   if (options.pro && !options.rsc) {

--- a/packages/create-react-on-rails-app/src/index.ts
+++ b/packages/create-react-on-rails-app/src/index.ts
@@ -77,9 +77,14 @@ async function run(appName: string, rawOpts: Record<string, unknown>, command?: 
     template,
     packageManager: packageManager as 'npm' | 'pnpm',
     // Rspack is the default; an explicit --no-rspack or its --webpack alias selects Webpack.
-    // (Footgun: re-adding `.option('--rspack', desc, false)` would default rawOpts.rspack to
-    // false and silently flip the default back to Webpack.)
-    rspack: webpackRequested ? false : rawOpts.rspack !== false,
+    // (rawOpts.rspack ?? true) makes the three inputs explicit: undefined (no flag) -> true,
+    // true (--rspack) -> true, false (--no-rspack) -> false.
+    // Footgun: re-adding `.option('--rspack', desc, false)` would default rawOpts.rspack to
+    // false and silently flip the default back to Webpack.
+    // Note: buildGeneratorArgs always forwards an explicit --rspack/--no-rspack to the Ruby
+    // generator, so the generator's own fresh-install fallback (fresh_install_rspack_default,
+    // which consults the Shakapacker version) is never reached via create-react-on-rails-app.
+    rspack: webpackRequested ? false : (rawOpts.rspack ?? true) === true,
     pro,
     rsc,
   };

--- a/packages/create-react-on-rails-app/src/index.ts
+++ b/packages/create-react-on-rails-app/src/index.ts
@@ -64,7 +64,8 @@ async function run(appName: string, rawOpts: Record<string, unknown>): Promise<v
   const options: CliOptions = {
     template,
     packageManager: packageManager as 'npm' | 'pnpm',
-    rspack: Boolean(rawOpts.rspack),
+    // Rspack is the default; only an explicit --no-rspack (rawOpts.rspack === false) selects Webpack.
+    rspack: rawOpts.rspack !== false,
     pro,
     rsc,
   };
@@ -112,7 +113,7 @@ async function run(appName: string, rawOpts: Record<string, unknown>): Promise<v
     modeLabel = ', mode: pro';
   }
   logInfo(
-    `Creating "${appName}" with template: ${options.template}, package manager: ${options.packageManager}${options.rspack ? ', bundler: rspack' : ''}${modeLabel}`,
+    `Creating "${appName}" with template: ${options.template}, package manager: ${options.packageManager}, bundler: ${options.rspack ? 'rspack' : 'webpack'}${modeLabel}`,
   );
 
   createApp(appName, options);
@@ -131,7 +132,8 @@ program
   .argument('<app-name>', 'Name of the application to create')
   .option('-t, --template <type>', 'javascript or typescript', 'typescript')
   .option('-p, --package-manager <pm>', 'npm or pnpm (auto-detected if not specified)')
-  .option('--rspack', 'Use Rspack instead of Webpack (~20x faster builds)', false)
+  .option('--rspack', 'Use Rspack as the bundler (default, ~20x faster builds)')
+  .option('--no-rspack', 'Use Webpack instead of Rspack')
   .option('--standard', 'Generate open-source React on Rails setup (skip prompt)')
   .option('--pro', 'Generate React on Rails Pro setup (installs react_on_rails_pro)')
   .option('--rsc', 'Generate React Server Components setup (installs react_on_rails_pro)')
@@ -144,8 +146,8 @@ Examples:
   $ npx create-react-on-rails-app my-app --pro                  # skip prompt, use Pro
   $ npx create-react-on-rails-app my-app --standard             # skip prompt, use Standard
   $ npx create-react-on-rails-app my-app --template javascript
-  $ npx create-react-on-rails-app my-app --rspack
-  $ npx create-react-on-rails-app my-app --rspack --rsc
+  $ npx create-react-on-rails-app my-app --no-rspack             # use Webpack instead of Rspack
+  $ npx create-react-on-rails-app my-app --no-rspack --rsc
   $ npx create-react-on-rails-app my-app --package-manager pnpm
 
 When no mode flag (--standard, --pro, or --rsc) is given, an interactive prompt

--- a/packages/create-react-on-rails-app/src/index.ts
+++ b/packages/create-react-on-rails-app/src/index.ts
@@ -10,7 +10,7 @@ import { promptForMode, PROMPT_CANCELLED } from './prompt.js';
 // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
 const packageJson = require('../package.json') as { version: string };
 
-async function run(appName: string, rawOpts: Record<string, unknown>): Promise<void> {
+async function run(appName: string, rawOpts: Record<string, unknown>, command?: Command): Promise<void> {
   const { template } = rawOpts;
   if (typeof template !== 'string' || (template !== 'javascript' && template !== 'typescript')) {
     logError(`Invalid template "${String(template)}". Must be "javascript" or "typescript".`);
@@ -29,6 +29,18 @@ async function run(appName: string, rawOpts: Record<string, unknown>): Promise<v
 
   if (rawOpts.standard && (rawOpts.pro || rawOpts.rsc)) {
     logError('--standard cannot be combined with --pro or --rsc.');
+    process.exit(1);
+  }
+
+  // --webpack is a friendly alias for --no-rspack. Commander reports --no-rspack's declared
+  // default as rawOpts.rspack === true, so we use the option source to distinguish an explicit
+  // --rspack from the default and reject contradictory flags (--rspack --webpack).
+  const rspackExplicitlyTrue = rawOpts.rspack === true && command?.getOptionValueSource('rspack') === 'cli';
+  const webpackRequested = rawOpts.webpack === true;
+  if (webpackRequested && rspackExplicitlyTrue) {
+    logError(
+      'Conflicting bundler flags: pass either --rspack or --webpack (alias for --no-rspack), not both.',
+    );
     process.exit(1);
   }
 
@@ -64,11 +76,10 @@ async function run(appName: string, rawOpts: Record<string, unknown>): Promise<v
   const options: CliOptions = {
     template,
     packageManager: packageManager as 'npm' | 'pnpm',
-    // Commander's `--no-rspack` negation option defaults rawOpts.rspack to `true`, so an
-    // omitted flag selects Rspack and only an explicit --no-rspack (=== false) selects Webpack.
-    // Footgun: re-adding `.option('--rspack', desc, false)` would default this to false and
-    // silently flip the default back to Webpack.
-    rspack: rawOpts.rspack !== false,
+    // Rspack is the default; an explicit --no-rspack or its --webpack alias selects Webpack.
+    // (Footgun: re-adding `.option('--rspack', desc, false)` would default rawOpts.rspack to
+    // false and silently flip the default back to Webpack.)
+    rspack: webpackRequested ? false : rawOpts.rspack !== false,
     pro,
     rsc,
   };
@@ -137,6 +148,7 @@ program
   .option('-p, --package-manager <pm>', 'npm or pnpm (auto-detected if not specified)')
   .option('--rspack', 'Use Rspack as the bundler (default, ~20x faster builds)')
   .option('--no-rspack', 'Use Webpack instead of Rspack')
+  .option('--webpack', 'Use Webpack as the bundler (alias for --no-rspack)')
   .option('--standard', 'Generate open-source React on Rails setup (skip prompt)')
   .option('--pro', 'Generate React on Rails Pro setup (installs react_on_rails_pro)')
   .option('--rsc', 'Generate React Server Components setup (installs react_on_rails_pro)')
@@ -150,6 +162,7 @@ Examples:
   $ npx create-react-on-rails-app my-app --standard             # skip prompt, use Standard
   $ npx create-react-on-rails-app my-app --template javascript
   $ npx create-react-on-rails-app my-app --no-rspack             # use Webpack instead of Rspack
+  $ npx create-react-on-rails-app my-app --webpack               # same as --no-rspack
   $ npx create-react-on-rails-app my-app --no-rspack --rsc
   $ npx create-react-on-rails-app my-app --package-manager pnpm
 
@@ -181,9 +194,9 @@ The generated app includes one git commit per logical setup step.`,
 
 Documentation: https://reactonrails.com/docs/`,
   )
-  .action(async (appName: string, opts: Record<string, unknown>) => {
+  .action(async (appName: string, opts: Record<string, unknown>, command: Command) => {
     try {
-      await run(appName, opts);
+      await run(appName, opts, command);
     } catch (error) {
       if (error instanceof Error && error.message === PROMPT_CANCELLED) {
         console.log('');

--- a/packages/create-react-on-rails-app/src/index.ts
+++ b/packages/create-react-on-rails-app/src/index.ts
@@ -64,7 +64,10 @@ async function run(appName: string, rawOpts: Record<string, unknown>): Promise<v
   const options: CliOptions = {
     template,
     packageManager: packageManager as 'npm' | 'pnpm',
-    // Rspack is the default; only an explicit --no-rspack (rawOpts.rspack === false) selects Webpack.
+    // Commander's `--no-rspack` negation option defaults rawOpts.rspack to `true`, so an
+    // omitted flag selects Rspack and only an explicit --no-rspack (=== false) selects Webpack.
+    // Footgun: re-adding `.option('--rspack', desc, false)` would default this to false and
+    // silently flip the default back to Webpack.
     rspack: rawOpts.rspack !== false,
     pro,
     rsc,

--- a/packages/create-react-on-rails-app/tests/create-app.test.ts
+++ b/packages/create-react-on-rails-app/tests/create-app.test.ts
@@ -162,14 +162,10 @@ describe('buildGeneratorArgs', () => {
     ]);
   });
 
-  it('adds --no-rspack when rspack is disabled', () => {
-    expect(buildGeneratorArgs({ ...baseOptions, rspack: false })).toEqual([
-      '--new-app',
-      '--no-rspack',
-      '--force',
-      '--ignore-warnings',
-    ]);
-  });
+  // The rspack:false -> --no-rspack mapping is already asserted by the default test above
+  // ('includes ignore-warnings by default'); the rspack:true -> --rspack mapping by
+  // 'adds rspack flag when enabled'. The CLI default-path resolution (no flag -> --rspack)
+  // is covered in index-tty.test.ts ('selects Rspack by default when no bundler flag is passed').
 
   it('adds rsc flag when enabled', () => {
     expect(buildGeneratorArgs({ ...baseOptions, rsc: true })).toEqual([

--- a/packages/create-react-on-rails-app/tests/create-app.test.ts
+++ b/packages/create-react-on-rails-app/tests/create-app.test.ts
@@ -135,13 +135,19 @@ describe('validateAppName', () => {
 
 describe('buildGeneratorArgs', () => {
   it('includes ignore-warnings by default', () => {
-    expect(buildGeneratorArgs(baseOptions)).toEqual(['--new-app', '--force', '--ignore-warnings']);
+    expect(buildGeneratorArgs(baseOptions)).toEqual([
+      '--new-app',
+      '--no-rspack',
+      '--force',
+      '--ignore-warnings',
+    ]);
   });
 
   it('adds typescript flag when template is typescript', () => {
     expect(buildGeneratorArgs({ ...baseOptions, template: 'typescript' })).toEqual([
       '--new-app',
       '--typescript',
+      '--no-rspack',
       '--force',
       '--ignore-warnings',
     ]);
@@ -156,9 +162,19 @@ describe('buildGeneratorArgs', () => {
     ]);
   });
 
+  it('adds --no-rspack when rspack is disabled', () => {
+    expect(buildGeneratorArgs({ ...baseOptions, rspack: false })).toEqual([
+      '--new-app',
+      '--no-rspack',
+      '--force',
+      '--ignore-warnings',
+    ]);
+  });
+
   it('adds rsc flag when enabled', () => {
     expect(buildGeneratorArgs({ ...baseOptions, rsc: true })).toEqual([
       '--new-app',
+      '--no-rspack',
       '--rsc',
       '--force',
       '--ignore-warnings',
@@ -168,6 +184,7 @@ describe('buildGeneratorArgs', () => {
   it('adds pro flag when enabled', () => {
     expect(buildGeneratorArgs({ ...baseOptions, pro: true })).toEqual([
       '--new-app',
+      '--no-rspack',
       '--pro',
       '--force',
       '--ignore-warnings',
@@ -208,6 +225,7 @@ describe('buildGeneratorArgs', () => {
   it('prefers --rsc over --pro when both are set', () => {
     expect(buildGeneratorArgs({ ...baseOptions, pro: true, rsc: true })).toEqual([
       '--new-app',
+      '--no-rspack',
       '--rsc',
       '--force',
       '--ignore-warnings',
@@ -358,6 +376,7 @@ describe('createApp', () => {
         'generate',
         'react_on_rails:install',
         '--new-app',
+        '--no-rspack',
         '--rsc',
         '--force',
         '--ignore-warnings',
@@ -409,6 +428,7 @@ describe('createApp', () => {
         'generate',
         'react_on_rails:install',
         '--new-app',
+        '--no-rspack',
         '--pro',
         '--force',
         '--ignore-warnings',
@@ -541,6 +561,7 @@ describe('createApp', () => {
         'generate',
         'react_on_rails:install',
         '--new-app',
+        '--no-rspack',
         '--rsc',
         '--force',
         '--ignore-warnings',
@@ -556,6 +577,7 @@ describe('createApp', () => {
         'generate',
         'react_on_rails:install',
         '--new-app',
+        '--no-rspack',
         '--pro',
         '--force',
         '--ignore-warnings',
@@ -582,7 +604,16 @@ describe('createApp', () => {
     expect(mockedExecLiveArgs).toHaveBeenCalledWith('bundle', ['add', 'react_on_rails', '--strict'], appPath);
     expect(mockedExecLiveArgs).toHaveBeenCalledWith(
       'bundle',
-      ['exec', 'rails', 'generate', 'react_on_rails:install', '--new-app', '--force', '--ignore-warnings'],
+      [
+        'exec',
+        'rails',
+        'generate',
+        'react_on_rails:install',
+        '--new-app',
+        '--no-rspack',
+        '--force',
+        '--ignore-warnings',
+      ],
       appPath,
       expect.objectContaining({ REACT_ON_RAILS_PACKAGE_MANAGER: 'npm' }),
     );
@@ -619,7 +650,16 @@ describe('createApp', () => {
 
     expect(mockedExecLiveArgs).toHaveBeenCalledWith(
       'bundle',
-      ['exec', 'rails', 'generate', 'react_on_rails:install', '--new-app', '--force', '--ignore-warnings'],
+      [
+        'exec',
+        'rails',
+        'generate',
+        'react_on_rails:install',
+        '--new-app',
+        '--no-rspack',
+        '--force',
+        '--ignore-warnings',
+      ],
       appPath,
       expect.objectContaining({ REACT_ON_RAILS_PACKAGE_MANAGER: 'pnpm' }),
     );

--- a/packages/create-react-on-rails-app/tests/index-tty.test.ts
+++ b/packages/create-react-on-rails-app/tests/index-tty.test.ts
@@ -139,3 +139,60 @@ describe('TTY detection branching in run()', () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 });
+
+describe('bundler flag resolution in run()', () => {
+  const originalArgv = process.argv;
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStdoutIsTTY = process.stdout.isTTY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+    // Non-interactive so no mode prompt fires; standard mode is used automatically.
+    Object.defineProperty(process.stdin, 'isTTY', { value: undefined, writable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, writable: true });
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, writable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, writable: true });
+    jest.restoreAllMocks();
+  });
+
+  it('selects Rspack by default when no bundler flag is passed', async () => {
+    process.argv = ['node', 'create-react-on-rails-app', 'my-app'];
+
+    await loadIndex();
+
+    expect(mockedCreateApp).toHaveBeenCalledWith('my-app', expect.objectContaining({ rspack: true }));
+  });
+
+  it('selects Webpack when --webpack is passed (alias for --no-rspack)', async () => {
+    process.argv = ['node', 'create-react-on-rails-app', 'my-app', '--webpack'];
+
+    await loadIndex();
+
+    expect(mockedCreateApp).toHaveBeenCalledWith('my-app', expect.objectContaining({ rspack: false }));
+  });
+
+  it('accepts --no-rspack and --webpack together (both select Webpack)', async () => {
+    process.argv = ['node', 'create-react-on-rails-app', 'my-app', '--no-rspack', '--webpack'];
+
+    await loadIndex();
+
+    expect(mockedLogError).not.toHaveBeenCalled();
+    expect(mockedCreateApp).toHaveBeenCalledWith('my-app', expect.objectContaining({ rspack: false }));
+  });
+
+  it('exits with error when --rspack and --webpack are combined', async () => {
+    process.argv = ['node', 'create-react-on-rails-app', 'my-app', '--rspack', '--webpack'];
+
+    await loadIndex();
+
+    expect(mockedLogError).toHaveBeenCalledWith(
+      'Conflicting bundler flags: pass either --rspack or --webpack (alias for --no-rspack), not both.',
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -32,6 +32,12 @@ module ReactOnRails
                    type: :boolean,
                    desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"
 
+      # --webpack: friendly alias for --no-rspack (reconciled in GeneratorHelper#explicit_bundler_choice).
+      # No `default:` here either — same load-bearing reason as --rspack above.
+      class_option :webpack,
+                   type: :boolean,
+                   desc: "Use Webpack as the bundler (alias for --no-rspack)"
+
       # --pro
       class_option :pro,
                    type: :boolean,

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -28,6 +28,7 @@ module ReactOnRails
       # GeneratorHelper#using_rspack? tells an explicit choice from "no flag given" (the latter
       # falls back to rspack_bundler_default). Adding `default: false` would make
       # options.key?(:rspack) always true and silently break the fresh-install Rspack default.
+      # (Thor's omit-when-no-default behavior verified against Thor 1.5.0; see Gemfile.lock.)
       class_option :rspack,
                    type: :boolean,
                    desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"
@@ -36,7 +37,7 @@ module ReactOnRails
       # No `default:` here either — same load-bearing reason as --rspack above.
       class_option :webpack,
                    type: :boolean,
-                   desc: "Use Webpack as the bundler (alias for --no-rspack)"
+                   desc: "Use Webpack as the bundler (alias for --no-rspack; --no-webpack is equivalent to --rspack)"
 
       # --pro
       class_option :pro,
@@ -325,6 +326,8 @@ module ReactOnRails
 
       # Fresh-install context: default to Rspack (when Shakapacker supports it) unless the
       # app already declares a bundler. See GeneratorHelper#fresh_install_rspack_default.
+      # NOTE: InstallGenerator#rspack_bundler_default is an intentional twin of this override
+      # (both generators are independently CLI-invocable); keep the two in sync.
       def rspack_bundler_default
         fresh_install_rspack_default
       end

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -22,11 +22,10 @@ module ReactOnRails
                    desc: "Install Redux package and Redux version of Hello World Example",
                    aliases: "-R"
 
-      # --rspack
+      # --rspack / --no-rspack (Rspack is the default on fresh installs; --no-rspack selects Webpack)
       class_option :rspack,
                    type: :boolean,
-                   default: false,
-                   desc: "Use Rspack instead of Webpack as the bundler"
+                   desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"
 
       # --pro
       class_option :pro,
@@ -312,6 +311,12 @@ module ReactOnRails
       STR
 
       private
+
+      # Fresh-install context: default to Rspack (when Shakapacker supports it) unless the
+      # app already declares a bundler. See GeneratorHelper#fresh_install_rspack_default.
+      def rspack_bundler_default
+        fresh_install_rspack_default
+      end
 
       def generate_new_app_home_page?
         options.new_app? && new_app_root_route_added?

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -23,6 +23,11 @@ module ReactOnRails
                    aliases: "-R"
 
       # --rspack / --no-rspack (Rspack is the default on fresh installs; --no-rspack selects Webpack)
+      # IMPORTANT: do NOT add a `default:` here. The absence of a default is load-bearing — Thor
+      # only includes :rspack in the options hash when the flag is explicitly passed, which is how
+      # GeneratorHelper#using_rspack? tells an explicit choice from "no flag given" (the latter
+      # falls back to rspack_bundler_default). Adding `default: false` would make
+      # options.key?(:rspack) always true and silently break the fresh-install Rspack default.
       class_option :rspack,
                    type: :boolean,
                    desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -147,6 +147,7 @@ module GeneratorHelper
   # is absent — options.key?(:rspack)/(:webpack) is true only when the user passed that flag.
   # Re-adding `default:` to either class_option would make the key always present and break both
   # the "no flag given" fallback and the conflict detection here.
+  # (Thor's omit-when-no-default behavior verified against Thor 1.5.0; see Gemfile.lock.)
   #
   # Passing contradictory flags (e.g. --rspack --webpack) raises a Thor::Error.
   def explicit_bundler_choice
@@ -374,11 +375,7 @@ module GeneratorHelper
   # `assets_bundler` inside the `default: &default` block, and our generator writes
   # it there too via configure_rspack_in_shakapacker.
   def rspack_configured_in_project?
-    shakapacker_yml_path = File.join(destination_root, "config/shakapacker.yml")
-    return false unless File.exist?(shakapacker_yml_path)
-
-    config = parse_shakapacker_yml(shakapacker_yml_path)
-    config.dig("default", "assets_bundler") == "rspack"
+    shakapacker_assets_bundler_value == "rspack"
   end
 
   # Fresh-install bundler default used by InstallGenerator/BaseGenerator: prefer Rspack
@@ -393,13 +390,19 @@ module GeneratorHelper
 
   # True when config/shakapacker.yml exists and its default: section declares an
   # assets_bundler (i.e., the project has already made an explicit bundler choice).
-  # Same default-section assumption as rspack_configured_in_project?.
   def project_declares_assets_bundler?
-    shakapacker_yml_path = File.join(destination_root, "config/shakapacker.yml")
-    return false unless File.exist?(shakapacker_yml_path)
+    !shakapacker_assets_bundler_value.nil?
+  end
 
-    config = parse_shakapacker_yml(shakapacker_yml_path)
-    !config.dig("default", "assets_bundler").nil?
+  # Single source for the config/shakapacker.yml default-section read shared by
+  # rspack_configured_in_project? and project_declares_assets_bundler?. Returns the
+  # assets_bundler value (e.g. "rspack"), or nil when the file is absent or the key is unset.
+  # Only the default: section is inspected (see rspack_configured_in_project? for the rationale).
+  def shakapacker_assets_bundler_value
+    shakapacker_yml_path = File.join(destination_root, "config/shakapacker.yml")
+    return nil unless File.exist?(shakapacker_yml_path)
+
+    parse_shakapacker_yml(shakapacker_yml_path).dig("default", "assets_bundler")
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -154,7 +154,9 @@ module GeneratorHelper
     choices = []
     choices << options[:rspack] if options.key?(:rspack)
     # --webpack means "use Webpack" (rspack = false); --no-webpack means "use Rspack".
-    choices << !options[:webpack] if options.key?(:webpack)
+    # Name the inverted webpack flag so the rspack-boolean intent reads directly.
+    rspack_via_webpack_flag = !options[:webpack]
+    choices << rspack_via_webpack_flag if options.key?(:webpack)
     return nil if choices.empty?
 
     if choices.uniq.length > 1

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -128,11 +128,24 @@ module GeneratorHelper
   def using_rspack?
     return @using_rspack if defined?(@using_rspack)
 
-    # options.key?(:rspack) is true when the generator declares --rspack (e.g. InstallGenerator),
-    # false when it does not (e.g. RscGenerator, ProGenerator). Using .key? rather than .nil?
-    # check on the value makes the intent explicit and avoids relying on Thor returning nil for
-    # undeclared options.
-    @using_rspack = options.key?(:rspack) ? options[:rspack] : rspack_configured_in_project?
+    # The --rspack option declares no default (see InstallGenerator/BaseGenerator), so
+    # options.key?(:rspack) is true only when the user explicitly passed --rspack or
+    # --no-rspack. An explicit flag always wins. When the flag is unset (or the generator
+    # doesn't declare it, e.g. RscGenerator/ProGenerator), we fall back to the bundler
+    # default, which each generator defines for its own context.
+    @using_rspack = if options.key?(:rspack)
+                      options[:rspack]
+                    else
+                      rspack_bundler_default
+                    end
+  end
+
+  # Bundler to use when neither --rspack nor --no-rspack was passed.
+  # Default (standalone generators like RscGenerator/ProGenerator): respect the existing
+  # project's shakapacker.yml and never impose a bundler. InstallGenerator/BaseGenerator
+  # override this to default fresh installs to Rspack.
+  def rspack_bundler_default
+    rspack_configured_in_project?
   end
 
   # Remap a config path from config/webpack/ to config/rspack/ when using rspack.
@@ -335,5 +348,26 @@ module GeneratorHelper
 
     config = parse_shakapacker_yml(shakapacker_yml_path)
     config.dig("default", "assets_bundler") == "rspack"
+  end
+
+  # Fresh-install bundler default used by InstallGenerator/BaseGenerator: prefer Rspack
+  # when Shakapacker supports it (Rspack landed in Shakapacker 9.0), but never override an
+  # existing app's explicit assets_bundler choice. On a brand-new install where Shakapacker
+  # isn't loaded yet, shakapacker_version_9_or_higher? optimistically returns true.
+  def fresh_install_rspack_default
+    return rspack_configured_in_project? if project_declares_assets_bundler?
+
+    shakapacker_version_9_or_higher?
+  end
+
+  # True when config/shakapacker.yml exists and its default: section declares an
+  # assets_bundler (i.e., the project has already made an explicit bundler choice).
+  # Same default-section assumption as rspack_configured_in_project?.
+  def project_declares_assets_bundler?
+    shakapacker_yml_path = File.join(destination_root, "config/shakapacker.yml")
+    return false unless File.exist?(shakapacker_yml_path)
+
+    config = parse_shakapacker_yml(shakapacker_yml_path)
+    !config.dig("default", "assets_bundler").nil?
   end
 end

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -2,6 +2,7 @@
 
 require "json"
 
+# rubocop:disable Metrics/ModuleLength
 module GeneratorHelper
   def package_json
     # Lazy load package_json gem only when actually needed for dependency management
@@ -128,24 +129,49 @@ module GeneratorHelper
   def using_rspack?
     return @using_rspack if defined?(@using_rspack)
 
-    # The --rspack option declares no default (see InstallGenerator/BaseGenerator), so
-    # options.key?(:rspack) is true only when the user explicitly passed --rspack or
-    # --no-rspack. An explicit flag always wins. When the flag is unset (or the generator
-    # doesn't declare it, e.g. RscGenerator/ProGenerator), we fall back to the bundler
-    # default, which each generator defines for its own context.
-    #
-    # IMPORTANT: this relies on Thor NOT including a nil-defaulted option in the hash when
-    # the flag is absent. Re-adding `default: false` to the `--rspack` class_option would
-    # break this — the key would always be present (as false), overriding the fresh-install
-    # Rspack default below.
-    @using_rspack = if options.key?(:rspack)
-                      options[:rspack]
-                    else
-                      rspack_bundler_default
-                    end
+    # An explicit bundler flag always wins. When none was passed (or the generator doesn't
+    # declare the flags, e.g. RscGenerator/ProGenerator), fall back to the bundler default,
+    # which each generator defines for its own context.
+    explicit = explicit_bundler_choice
+    @using_rspack = explicit.nil? ? rspack_bundler_default : explicit
   end
 
-  # Bundler to use when neither --rspack nor --no-rspack was passed.
+  # Resolve the explicit bundler flags into a single choice.
+  #
+  # --rspack selects Rspack; --no-rspack and --webpack select Webpack (--webpack is a friendly
+  # alias for --no-rspack, and the auto-generated --no-webpack mirrors --rspack). Returns true
+  # for Rspack, false for Webpack, or nil when no bundler flag was passed (so the caller falls
+  # back to rspack_bundler_default).
+  #
+  # IMPORTANT: this relies on Thor NOT including a nil-defaulted option in the hash when the flag
+  # is absent — options.key?(:rspack)/(:webpack) is true only when the user passed that flag.
+  # Re-adding `default:` to either class_option would make the key always present and break both
+  # the "no flag given" fallback and the conflict detection here.
+  #
+  # Passing contradictory flags (e.g. --rspack --webpack) raises a Thor::Error.
+  def explicit_bundler_choice
+    choices = []
+    choices << options[:rspack] if options.key?(:rspack)
+    # --webpack means "use Webpack" (rspack = false); --no-webpack means "use Rspack".
+    choices << !options[:webpack] if options.key?(:webpack)
+    return nil if choices.empty?
+
+    if choices.uniq.length > 1
+      raise Thor::Error,
+            "Conflicting bundler flags: pass either Rspack (--rspack) or Webpack " \
+            "(--webpack / --no-rspack), not both."
+    end
+
+    choices.first
+  end
+
+  # True when the user passed any explicit bundler flag
+  # (--rspack/--no-rspack/--webpack/--no-webpack).
+  def bundler_flag_given?
+    options.key?(:rspack) || options.key?(:webpack)
+  end
+
+  # Bundler to use when no explicit bundler flag was passed.
   # Default (standalone generators like RscGenerator/ProGenerator): respect the existing
   # project's shakapacker.yml and never impose a bundler. InstallGenerator/BaseGenerator
   # override this to default fresh installs to Rspack.
@@ -376,3 +402,4 @@ module GeneratorHelper
     !config.dig("default", "assets_bundler").nil?
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -133,6 +133,11 @@ module GeneratorHelper
     # --no-rspack. An explicit flag always wins. When the flag is unset (or the generator
     # doesn't declare it, e.g. RscGenerator/ProGenerator), we fall back to the bundler
     # default, which each generator defines for its own context.
+    #
+    # IMPORTANT: this relies on Thor NOT including a nil-defaulted option in the hash when
+    # the flag is absent. Re-adding `default: false` to the `--rspack` class_option would
+    # break this — the key would always be present (as false), overriding the fresh-install
+    # Rspack default below.
     @using_rspack = if options.key?(:rspack)
                       options[:rspack]
                     else

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -697,7 +697,9 @@ module ReactOnRails
         flags << "--typescript" if options.typescript?
         # Echo the bundler choice only when it was explicit; an unset flag re-resolves to the
         # fresh-install default on re-run, so we don't pin it in the recovery command.
-        flags << (options[:rspack] ? "--rspack" : "--no-rspack") if options.key?(:rspack)
+        # `== true` keeps the intent explicit: only a genuine true echoes --rspack. The
+        # options.key? guard already excludes the unset case, so this never coerces nil.
+        flags << (options[:rspack] == true ? "--rspack" : "--no-rspack") if options.key?(:rspack)
 
         if options.rsc?
           flags << "--rsc"

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -51,6 +51,12 @@ module ReactOnRails
                    type: :boolean,
                    desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"
 
+      # --webpack: friendly alias for --no-rspack (reconciled in GeneratorHelper#explicit_bundler_choice).
+      # No `default:` here either — same load-bearing reason as --rspack above.
+      class_option :webpack,
+                   type: :boolean,
+                   desc: "Use Webpack as the bundler (alias for --no-rspack)"
+
       # --ignore-warnings
       class_option :ignore_warnings,
                    type: :boolean,
@@ -700,11 +706,10 @@ module ReactOnRails
         flags = []
         flags << "--redux" if options.redux?
         flags << "--typescript" if options.typescript?
-        # Echo the bundler choice only when it was explicit; an unset flag re-resolves to the
-        # fresh-install default on re-run, so we don't pin it in the recovery command.
-        # `== true` keeps the intent explicit: only a genuine true echoes --rspack. The
-        # options.key? guard already excludes the unset case, so this never coerces nil.
-        flags << (options[:rspack] == true ? "--rspack" : "--no-rspack") if options.key?(:rspack)
+        # Echo the resolved bundler choice (normalized to --rspack/--no-rspack, so a --webpack
+        # alias re-runs as --no-rspack) only when the user passed one explicitly. An unset choice
+        # re-resolves to the fresh-install default on re-run, so we don't pin it here.
+        flags << (using_rspack? ? "--rspack" : "--no-rspack") if bundler_flag_given?
 
         if options.rsc?
           flags << "--rsc"

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -41,11 +41,10 @@ module ReactOnRails
                    desc: "Generate TypeScript files and install TypeScript dependencies. Default: false",
                    aliases: "-T"
 
-      # --rspack
+      # --rspack / --no-rspack (Rspack is the default on fresh installs; --no-rspack selects Webpack)
       class_option :rspack,
                    type: :boolean,
-                   default: false,
-                   desc: "Use Rspack instead of Webpack as the bundler. Default: false"
+                   desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"
 
       # --ignore-warnings
       class_option :ignore_warnings,
@@ -196,6 +195,12 @@ module ReactOnRails
 
       private
 
+      # Fresh-install context: default to Rspack (when Shakapacker supports it) unless the
+      # app already declares a bundler. See GeneratorHelper#fresh_install_rspack_default.
+      def rspack_bundler_default
+        fresh_install_rspack_default
+      end
+
       def invoke_generators
         ensure_shakapacker_installed
         if options.typescript?
@@ -206,7 +211,7 @@ module ReactOnRails
         # `invoke` instantiates child generators with a fresh options hash, so
         # --pretend/--force/--skip must be forwarded explicitly at each boundary.
         invoke "react_on_rails:base", [],
-               { typescript: options.typescript?, redux: options.redux?, rspack: options.rspack?,
+               { typescript: options.typescript?, redux: options.redux?, rspack: using_rspack?,
                  pro: use_pro?, rsc: use_rsc?, new_app: options.new_app?,
                  shakapacker_just_installed: shakapacker_just_installed?,
                  force: options[:force], skip: options[:skip], pretend: options[:pretend] }
@@ -690,7 +695,9 @@ module ReactOnRails
         flags = []
         flags << "--redux" if options.redux?
         flags << "--typescript" if options.typescript?
-        flags << "--rspack" if options.rspack?
+        # Echo the bundler choice only when it was explicit; an unset flag re-resolves to the
+        # fresh-install default on re-run, so we don't pin it in the recovery command.
+        flags << (options[:rspack] ? "--rspack" : "--no-rspack") if options.key?(:rspack)
 
         if options.rsc?
           flags << "--rsc"
@@ -838,11 +845,14 @@ module ReactOnRails
 
         seed_package_manager_in_package_json_from_lockfile!
 
-        # Then run the shakapacker installer
-        # Use options.rspack? directly (not using_rspack?): shakapacker.yml doesn't exist yet at this
-        # point, so using_rspack? would fall back to rspack_configured_in_project? which returns false,
-        # causing Shakapacker to install webpack configs into config/webpack/ instead of rspack.
-        shakapacker_install_env = options.rspack? ? { "SHAKAPACKER_ASSETS_BUNDLER" => "rspack" } : {}
+        # Then run the shakapacker installer.
+        # Resolve the bundler via using_rspack?. shakapacker.yml doesn't exist yet at this point,
+        # so the fresh-install default applies: an unset --rspack flag resolves to Rspack when
+        # Shakapacker supports it (shakapacker_version_9_or_higher? is optimistically true on a
+        # brand-new install where Shakapacker isn't loaded yet). An explicit --no-rspack still
+        # selects Webpack. using_rspack? memoizes, so the rest of the run (e.g.
+        # configure_rspack_in_shakapacker) stays consistent with this decision.
+        shakapacker_install_env = using_rspack? ? { "SHAKAPACKER_ASSETS_BUNDLER" => "rspack" } : {}
         success = Bundler.with_unbundled_env do
           system(shakapacker_install_env, "bundle exec rails shakapacker:install")
         end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -42,6 +42,11 @@ module ReactOnRails
                    aliases: "-T"
 
       # --rspack / --no-rspack (Rspack is the default on fresh installs; --no-rspack selects Webpack)
+      # IMPORTANT: do NOT add a `default:` here. The absence of a default is load-bearing — Thor
+      # only includes :rspack in the options hash when the flag is explicitly passed, which is how
+      # GeneratorHelper#using_rspack? tells an explicit choice from "no flag given" (the latter
+      # falls back to rspack_bundler_default). Adding `default: false` would make
+      # options.key?(:rspack) always true and silently break the fresh-install Rspack default.
       class_option :rspack,
                    type: :boolean,
                    desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -47,6 +47,7 @@ module ReactOnRails
       # GeneratorHelper#using_rspack? tells an explicit choice from "no flag given" (the latter
       # falls back to rspack_bundler_default). Adding `default: false` would make
       # options.key?(:rspack) always true and silently break the fresh-install Rspack default.
+      # (Thor's omit-when-no-default behavior verified against Thor 1.5.0; see Gemfile.lock.)
       class_option :rspack,
                    type: :boolean,
                    desc: "Use Rspack (default) as the bundler; pass --no-rspack to use Webpack"
@@ -55,7 +56,7 @@ module ReactOnRails
       # No `default:` here either — same load-bearing reason as --rspack above.
       class_option :webpack,
                    type: :boolean,
-                   desc: "Use Webpack as the bundler (alias for --no-rspack)"
+                   desc: "Use Webpack as the bundler (alias for --no-rspack; --no-webpack is equivalent to --rspack)"
 
       # --ignore-warnings
       class_option :ignore_warnings,
@@ -208,6 +209,8 @@ module ReactOnRails
 
       # Fresh-install context: default to Rspack (when Shakapacker supports it) unless the
       # app already declares a bundler. See GeneratorHelper#fresh_install_rspack_default.
+      # NOTE: BaseGenerator#rspack_bundler_default is an intentional twin of this override
+      # (both generators are independently CLI-invocable); keep the two in sync.
       def rspack_bundler_default
         fresh_install_rspack_default
       end

--- a/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
@@ -202,6 +202,13 @@ RSpec.describe ReactOnRails::Generators::BaseGenerator, type: :generator do
     before { FileUtils.rm_rf(destination) }
     after { FileUtils.rm_rf(destination) }
 
+    it "declares --rspack without a static default so the fresh-install default applies" do
+      # Regression guard (see install_generator_spec for full rationale): a `default:` on the
+      # --rspack class_option would make options.key?(:rspack) always true and silently break the
+      # fresh-install Rspack default for unflagged CLI runs.
+      expect(described_class.class_options[:rspack].default).to be_nil
+    end
+
     it "defaults a fresh install (no flag, no existing config) to Rspack" do
       expect(base_generator.using_rspack?).to be(true)
     end

--- a/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
@@ -180,4 +180,63 @@ RSpec.describe ReactOnRails::Generators::BaseGenerator, type: :generator do
       expect(File.directory?(webpack_dir)).to be(true)
     end
   end
+
+  describe "#using_rspack? default bundler resolution" do
+    let(:destination) { File.expand_path("../dummy-for-generators", __dir__) }
+
+    def base_generator(options = {})
+      described_class.new([], options, { destination_root: destination })
+    end
+
+    def write_shakapacker_yml(assets_bundler)
+      FileUtils.mkdir_p(File.join(destination, "config"))
+      File.write(File.join(destination, "config/shakapacker.yml"), <<~YAML)
+        default: &default
+          source_path: app/javascript
+          assets_bundler: #{assets_bundler}
+        development:
+          <<: *default
+      YAML
+    end
+
+    before { FileUtils.rm_rf(destination) }
+    after { FileUtils.rm_rf(destination) }
+
+    it "defaults a fresh install (no flag, no existing config) to Rspack" do
+      expect(base_generator.using_rspack?).to be(true)
+    end
+
+    it "falls back to Webpack on a fresh install when Rspack is unsupported (Shakapacker < 9.0)" do
+      generator = base_generator
+      allow(generator).to receive(:shakapacker_version_9_or_higher?).and_return(false)
+
+      expect(generator.using_rspack?).to be(false)
+    end
+
+    it "honors an explicit --no-rspack" do
+      expect(base_generator(rspack: false).using_rspack?).to be(false)
+    end
+
+    it "honors an explicit --rspack" do
+      expect(base_generator(rspack: true).using_rspack?).to be(true)
+    end
+
+    it "does not flip an existing Webpack app that omits the flag" do
+      write_shakapacker_yml("webpack")
+
+      expect(base_generator.using_rspack?).to be(false)
+    end
+
+    it "keeps Rspack for an existing Rspack app that omits the flag" do
+      write_shakapacker_yml("rspack")
+
+      expect(base_generator.using_rspack?).to be(true)
+    end
+
+    it "lets an explicit --no-rspack override an existing Rspack app" do
+      write_shakapacker_yml("rspack")
+
+      expect(base_generator(rspack: false).using_rspack?).to be(false)
+    end
+  end
 end

--- a/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/base_generator_spec.rb
@@ -228,6 +228,19 @@ RSpec.describe ReactOnRails::Generators::BaseGenerator, type: :generator do
       expect(base_generator(rspack: true).using_rspack?).to be(true)
     end
 
+    it "treats --webpack as an alias for --no-rspack" do
+      expect(base_generator(webpack: true).using_rspack?).to be(false)
+    end
+
+    it "treats --no-webpack as selecting Rspack" do
+      expect(base_generator(webpack: false).using_rspack?).to be(true)
+    end
+
+    it "raises on contradictory --rspack and --webpack flags" do
+      expect { base_generator(rspack: true, webpack: true).using_rspack? }
+        .to raise_error(Thor::Error, /Conflicting bundler flags/)
+    end
+
     it "does not flip an existing Webpack app that omits the flag" do
       write_shakapacker_yml("webpack")
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -1330,7 +1330,9 @@ describe InstallGenerator, type: :generator do
   end
 
   context "with --pro" do
-    before(:all) { run_generator_test_with_args(%w[--pro], package_json: true) }
+    # Pin to --no-rspack so this context keeps exercising the Webpack Pro transforms.
+    # Rspack is the default now and is covered by the "with --pro --rspack" context.
+    before(:all) { run_generator_test_with_args(%w[--pro --no-rspack], package_json: true) }
 
     include_examples "base_generator", application_js: true
     include_examples "no_redux_generator"
@@ -1646,7 +1648,9 @@ describe InstallGenerator, type: :generator do
   end
 
   context "with --rsc" do
-    before(:all) { run_generator_test_with_args(%w[--rsc], package_json: true) }
+    # Pin to --no-rspack so this context keeps exercising the Webpack RSC transforms.
+    # Rspack is the default now and is covered by the "with --rsc --rspack" context.
+    before(:all) { run_generator_test_with_args(%w[--rsc --no-rspack], package_json: true) }
 
     include_examples "rsc_common_files"
     include_examples "scaffold_ci_and_scripts"
@@ -2829,7 +2833,7 @@ describe InstallGenerator, type: :generator do
     let(:destination) { File.expand_path("../dummy-for-generators", __dir__) }
 
     context "when using webpack" do
-      let(:generator) { BaseGenerator.new([], {}, { destination_root: destination }) }
+      let(:generator) { BaseGenerator.new([], { rspack: false }, { destination_root: destination }) }
 
       it "returns .ts path when TypeScript config exists" do
         allow(File).to receive(:exist?).and_call_original
@@ -2984,14 +2988,26 @@ describe InstallGenerator, type: :generator do
       end
     end
 
-    context "when --rspack is false (default)" do
-      let(:install_generator) { described_class.new }
+    context "when --no-rspack is passed" do
+      let(:install_generator) { described_class.new([], { rspack: false }) }
 
-      # InstallGenerator declares --rspack with default: false, so options[:rspack]
-      # is false (not nil). using_rspack? returns false via the first branch without
-      # reaching the YAML fallback (rspack_configured_in_project?).
+      # --rspack declares no default, so options.key?(:rspack) is true only when the flag
+      # is explicitly passed. --no-rspack sets it to false, selecting Webpack.
       it "returns false" do
         expect(install_generator.send(:using_rspack?)).to be false
+      end
+    end
+
+    context "when no bundler flag is passed (fresh install)" do
+      let(:install_generator) { described_class.new }
+
+      # With no flag and no existing bundler choice, the default resolves to Rspack when
+      # Shakapacker supports it (Rspack landed in 9.0).
+      it "defaults to Rspack" do
+        allow(install_generator).to receive_messages(project_declares_assets_bundler?: false,
+                                                     shakapacker_version_9_or_higher?: true)
+
+        expect(install_generator.send(:using_rspack?)).to be true
       end
     end
   end
@@ -3011,8 +3027,8 @@ describe InstallGenerator, type: :generator do
       end
     end
 
-    context "without --rspack" do
-      let(:install_generator) { described_class.new }
+    context "with --no-rspack" do
+      let(:install_generator) { described_class.new([], { rspack: false }) }
 
       it "returns path unchanged" do
         expect(install_generator.send(:destination_config_path, "config/webpack/serverWebpackConfig.js"))
@@ -3025,7 +3041,9 @@ describe InstallGenerator, type: :generator do
   # Bundler subprocess commands must run in unbundled environment to prevent
   # BUNDLE_GEMFILE inheritance from parent process
   describe "bundler environment isolation" do
-    let(:install_generator) { described_class.new }
+    # Pin to Webpack (--no-rspack) so shakapacker:install runs with an empty env hash here;
+    # the SHAKAPACKER_ASSETS_BUNDLER=rspack env is covered by the dedicated example below.
+    let(:install_generator) { described_class.new([], { rspack: false }) }
 
     it "clears BUNDLE_GEMFILE when running bundle add" do
       allow(install_generator).to receive(:shakapacker_in_gemfile?).and_return(false)

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -2980,6 +2980,16 @@ describe InstallGenerator, type: :generator do
   end
 
   describe "#using_rspack?" do
+    # Regression guard for the load-bearing Thor invariant: --rspack must declare NO static
+    # default. If a `default:` is ever added, Thor always includes :rspack in the options hash,
+    # so options.key?(:rspack) is always true and the fresh-install Rspack default silently
+    # breaks (every unflagged CLI run would fall back to Webpack). Verified empirically against
+    # Thor 1.5.0: a no-default boolean option is absent from the options hash unless its flag is
+    # passed on the CLI, whereas a `default:`-bearing option (e.g. --typescript) is always present.
+    it "declares --rspack without a static default so the fresh-install default applies" do
+      expect(described_class.class_options[:rspack].default).to be_nil
+    end
+
     context "when --rspack option is provided" do
       let(:install_generator) { described_class.new([], { rspack: true }) }
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -2399,6 +2399,14 @@ describe InstallGenerator, type: :generator do
       expect(command).to eq("rails generate react_on_rails:install --pro")
     end
 
+    specify "recovery_install_command normalizes the --webpack alias to --no-rspack" do
+      install_generator = described_class.new([], { webpack: true })
+
+      command = install_generator.send(:recovery_install_command)
+
+      expect(command).to eq("rails generate react_on_rails:install --no-rspack")
+    end
+
     specify "shakapacker install error preserves original install flags" do
       install_generator = described_class.new([], { redux: true, typescript: true, ignore_warnings: true })
 
@@ -3004,6 +3012,39 @@ describe InstallGenerator, type: :generator do
       # --rspack declares no default, so options.key?(:rspack) is true only when the flag
       # is explicitly passed. --no-rspack sets it to false, selecting Webpack.
       it "returns false" do
+        expect(install_generator.send(:using_rspack?)).to be false
+      end
+    end
+
+    context "when --webpack is passed (alias for --no-rspack)" do
+      let(:install_generator) { described_class.new([], { webpack: true }) }
+
+      it "returns false" do
+        expect(install_generator.send(:using_rspack?)).to be false
+      end
+    end
+
+    context "when --no-webpack is passed" do
+      let(:install_generator) { described_class.new([], { webpack: false }) }
+
+      it "returns true" do
+        expect(install_generator.send(:using_rspack?)).to be true
+      end
+    end
+
+    context "when --rspack and --webpack contradict each other" do
+      let(:install_generator) { described_class.new([], { rspack: true, webpack: true }) }
+
+      it "raises a Thor::Error" do
+        expect { install_generator.send(:using_rspack?) }
+          .to raise_error(Thor::Error, /Conflicting bundler flags/)
+      end
+    end
+
+    context "when --no-rspack and --webpack agree (both Webpack)" do
+      let(:install_generator) { described_class.new([], { rspack: false, webpack: true }) }
+
+      it "returns false without raising" do
         expect(install_generator.send(:using_rspack?)).to be false
       end
     end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3060,6 +3060,16 @@ describe InstallGenerator, type: :generator do
 
         expect(install_generator.send(:using_rspack?)).to be true
       end
+
+      # Twin of base_generator_spec's fallback case: InstallGenerator has its own
+      # rspack_bundler_default override (delegating to fresh_install_rspack_default) and is the
+      # primary CLI entry point, so the < 9.0 fallback to Webpack is asserted here too.
+      it "falls back to Webpack when Rspack is unsupported (Shakapacker < 9.0)" do
+        allow(install_generator).to receive_messages(project_declares_assets_bundler?: false,
+                                                     shakapacker_version_9_or_higher?: false)
+
+        expect(install_generator.send(:using_rspack?)).to be false
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

Make the `react_on_rails:install` generator and `create-react-on-rails-app` default to **Rspack** for fresh installs (significantly faster builds via SWC) instead of Webpack; pass `--no-rspack` (or its alias `--webpack`) for Webpack. The flip is scoped to fresh installs — an explicit `--rspack`/`--no-rspack`/`--webpack` always wins, existing apps that already declare `assets_bundler` in `config/shakapacker.yml` are never silently flipped, and it falls back to Webpack on Shakapacker < 9.0 (where Rspack is unsupported). Internally, `--rspack` no longer declares a static default, so `using_rspack?` resolves an unset flag via a new `rspack_bundler_default` hook: standalone generators (`RscGenerator`/`ProGenerator`) keep "respect the existing project," while `InstallGenerator`/`BaseGenerator` override it to default fresh installs to Rspack. `create-react-on-rails-app` forwards the resolved bundler explicitly so its choice stays authoritative regardless of the generator default.

Both the Rails generator (`react_on_rails:install` / `react_on_rails:base`) and `create-react-on-rails-app` also accept `--webpack` as a friendly alias for `--no-rspack`; contradictory flags (e.g. `--rspack --webpack`) raise a clear error.

Adopting the modular `shakapacker-rspack` package when Shakapacker ≥ 10.1 is detected is intentionally **out of scope** here and is a follow-up tied to the Shakapacker 10.1 bump. Related dummy-app follow-ups: #3480, #3481.

### Pull Request checklist

- [x] Add/update test to cover these changes
- [x] Update documentation
- [x] Update CHANGELOG file

### Other Information

Local verification: generator specs (`base_generator`, `install_generator`, `rsc_generator`, `pro_generator`, `generator_helper`, `js_dependency_manager`) green, including new unit coverage for fresh-install → Rspack, `--no-rspack` → Webpack, existing-app-not-flipped, and the Shakapacker < 9.0 fallback; `create-react-on-rails-app` Jest 95/95, `tsc` type-check, ESLint, and Prettier clean; `bundle exec rubocop` clean on all changed Ruby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect install/scaffolding defaults and bundler resolution, but incorrect Thor option handling or fresh-install fallback could misconfigure new apps’ Shakapacker setup.
> 
> **Overview**
> **Fresh installs now default to Rspack** for `rails generate react_on_rails:install` and `create-react-on-rails-app`. Webpack is selected with `--no-rspack` or the new **`--webpack`** alias; conflicting `--rspack` + `--webpack` flags error on both the CLI and the Ruby generator.
> 
> Bundler choice is resolved through refactored **`GeneratorHelper`** logic: explicit flags win, **`fresh_install_rspack_default`** applies when no flag is passed (Rspack when Shakapacker ≥ 9, otherwise Webpack), and projects that already set **`assets_bundler`** in `config/shakapacker.yml` are not silently changed. **`--rspack`** no longer uses a Thor **`default:`** so an omitted flag stays distinguishable from an explicit **`--no-rspack`**.
> 
> **`InstallGenerator`** now drives Shakapacker install and child generator invocation from **`using_rspack?`** (not raw **`options.rspack?`**), and recovery commands echo **`--rspack`/`--no-rspack`** only when the user passed a bundler flag. **`create-react-on-rails-app`** defaults to Rspack, always forwards **`--rspack`/`--no-rspack`** to Rails, and logs the chosen bundler. Docs, CHANGELOG, and generator specs were updated; several integration contexts pin **`--no-rspack`** so Webpack-specific behavior stays tested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66824c5eaecbd6e809c378ea48125cd5da26081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rspack is the default bundler for fresh installs; use --no-rspack (or --webpack) to select Webpack. Explicit --rspack/--no-rspack overrides the default, the chosen bundler is shown during creation, and supplying both flags now errors.

* **Documentation**
  * Installation/generator docs and help examples updated with defaults, alias usage, combined-option guidance, and fallback rules for older toolchains.

* **Tests**
  * Coverage expanded to validate defaults, explicit flags, config-preservation, alias behavior, conflict detection, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
