### PR TITLE
docs: define benchmark boundary tuning cadence (#3260)

### DIFF
--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -137,15 +137,49 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
      collecting runs.
 
 3. Prefer threshold changes that require stronger evidence before failure:
-   - widen the Bencher boundary from `0.95` toward `0.99`
+   - widen the Bencher boundary from `0.95` toward `0.99` using the boundary tuning cadence below
    - keep `--threshold-max-sample-size $MAX_SAMPLE` aligned with the available history; add a minimum-sample rule only
      if Bencher supports that flag for the configured threshold type
    - require manual tracking in Issue 3169 to see the same `(benchmark, measure)` pair alert on at least 2 consecutive
      runs before filing or failing (restated as Acceptance Criterion 2 below — the same gate, viewed from the tuning side)
 
-   If overlap remains below `0.40` after boundary widening, collect 5 more qualifying runs and re-evaluate from step 2
-   before escalating to step 4. Escalate to step 4 unconditionally after 2 such re-evaluation cycles, which means at
-   least 10 extra qualifying runs beyond the initial 30-run window, if overlap has not reached `0.40`.
+   **Boundary tuning cadence.** Widen the boundary in fixed `0.01` increments, dwelling at each setting long enough to
+   judge whether the widening is still reducing noise:
+   1. **Dwell.** Collect 10 qualifying main runs at the current boundary value before any advance/lock decision. The
+      initial 30-run baseline window (collected at `0.95`) counts as the dwell for `0.95`, so do not collect a separate
+      10-run dwell there; the first advance/lock decision uses overlap from the most recent 5 adjacent pairs within that
+      window. Do not re-collect a 30-run window at any widened boundary — each boundary past `0.95` gets the standard
+      10-run dwell. Boundary changes alone never trigger a baseline reset (see the Baseline reset exception above).
+   2. **Measure.** After the dwell, compute the mean Jaccard overlap across the most recent 5 adjacent qualifying-run
+      pairs at the current boundary, using the overlap method from step 2.
+   3. **Advance.** If mean overlap is below `0.40`, raise the boundary by `0.01` and return to step 1 of this cadence at
+      the new value: noise is still dominating, so requiring a wider boundary should help.
+   4. **Lock.** If mean overlap is at least `0.40`, stop widening and keep the current boundary; recurring alerts now
+      dominate the set, and widening further risks masking real regressions. Proceed to the Acceptance Criteria.
+   5. **Ceiling.** If the boundary reaches `0.99` and mean overlap is still below `0.40` after the dwell, do not widen
+      further; escalate to step 4 (larger or dedicated runners). Noise that survives the widest boundary is a
+      runner-environment problem, not a threshold problem.
+   6. **Small-sample fallback.** If a dwell window yields fewer than 5 unique alert pairs (so Jaccard is undefined or
+      unstable), extend that dwell by 5 more qualifying runs at the same boundary before deciding, mirroring the
+      small-sample caveat in step 2.
+
+   Record each boundary value, its dwell run IDs, and the resulting overlap in
+   [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). End to end this is at most 5 boundary values
+   (`0.95` through `0.99`); it locks earlier if overlap reaches `0.40` sooner.
+
+   **Interaction with the false-positive target and real regressions during tuning:**
+   - The 1-in-20 false-positive target (Acceptance Criteria 4-5) is evaluated only after the hard gate is restored, so it
+     does not gate cadence advancement — the overlap criterion above does. Still, before locking a candidate boundary,
+     sanity-check the noisy-alert rate at that setting: if overlap reads at least `0.40` but the noisy-alert rate is still
+     far worse than the target (for example, more than 5 noisy alerts per 20 runs), a few chronic flakes are probably
+     dominating the overlap rather than real recurring regressions, so keep widening and record the exception in Issue 3169.
+   - If a real regression is identified mid-cadence (manual recurrence check plus a matching performance-sensitive
+     commit), exclude the affected runs — and the runs for the commit that reverts it, which is itself
+     performance-sensitive — from the most-recent-5-pairs overlap computation, then continue the cadence. This is the
+     same exclusion the false-positive accounting applies to intentional-perf-change commits (Acceptance Criterion 5).
+   - Rollback at a locked boundary reuses Acceptance Criterion 5: if the restored hard gate later breaches the 1-in-20
+     target, revert to warning mode and re-enter this cadence at the most recently locked boundary rather than restarting
+     the widening from `0.95`.
 
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.
@@ -182,4 +216,5 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    baseline window and overlap data before trying to re-enable it again.
 
 See [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169) for the tracking discussion and historical
-alert-overlap evidence.
+alert-overlap evidence. The boundary tuning cadence in Tuning Sequence step 3 was specified in response to
+[Issue 3260](https://github.com/shakacode/react_on_rails/issues/3260).

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -166,9 +166,12 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    6. **Small-sample fallback.** If a dwell window yields fewer than 5 unique alert pairs (so Jaccard is undefined or
       unstable), extend that dwell by 5 more qualifying runs at the same boundary before deciding, mirroring the
       small-sample caveat in Tuning Sequence step 2. Keep extending in 5-run increments until 5 unique pairs form, but
-      cap the extension at 20 additional qualifying runs beyond the original dwell: if 5 unique pairs still cannot be
-      formed by then, treat the boundary as having hit the Ceiling (step 5) and escalate to step 4, since persistent
-      alert sparsity at a single boundary is itself a runner-environment signal rather than a threshold one.
+      cap the extension at 20 additional qualifying runs beyond the original dwell. If 5 unique pairs still cannot be
+      formed by then, there is too little signal to compute overlap, so decide on the noisy-alert rate instead (the same
+      sanity check used at Lock): if that rate already meets the 1-in-20 target the boundary is simply quiet — lock it;
+      if it is still worse than target, a chronic flake is dominating a sparse set, so apply the noisy-rate override
+      below (widen up to the `0.99` ceiling, then escalate to step 4 once there). Record the small sample in
+      Issue 3169 either way.
 
    Record each boundary value, its dwell run IDs, and the resulting overlap in
    [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). End to end this is at most 5 boundary values

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -150,19 +150,25 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
       10-run dwell there; the first advance/lock decision uses overlap from the most recent 5 adjacent pairs within that
       window. Do not re-collect a 30-run window at any widened boundary — each boundary past `0.95` gets the standard
       10-run dwell. Boundary changes alone never trigger a baseline reset (see the Baseline reset exception above).
-   2. **Measure.** After the dwell, compute the mean Jaccard overlap across the most recent 5 adjacent qualifying-run
-      pairs at the current boundary, using the overlap method from Tuning Sequence step 2 above.
+   2. **Measure.** After the dwell, compute the mean Jaccard overlap (the mean of the 5 per-pair Jaccard scores) across
+      the most recent 5 adjacent qualifying-run pairs at the current boundary, using the overlap method from Tuning
+      Sequence step 2 above. This 5-pair mean is intentionally stricter than the entry gate in Tuning Sequence step 2
+      (overlap at least `0.40` for 3 consecutive pairs), so entering this cadence does not guarantee an immediate Lock
+      at `0.95`.
    3. **Advance.** If mean overlap is below `0.40`, raise the boundary by `0.01` and return to step 1 of this cadence at
       the new value: noise is still dominating, so requiring a wider boundary should help.
-   4. **Lock.** If mean overlap is at least `0.40`, stop widening and keep the current boundary; recurring alerts now
-      dominate the set, and widening further risks masking real regressions. Proceed to the Acceptance Criteria.
+   4. **Lock.** If mean overlap is at least `0.40`, stop widening and keep the current boundary _(subject to the
+      noisy-alert rate sanity check in the Interaction section below)_; recurring alerts now dominate the set, and
+      widening further risks masking real regressions. Proceed to the Acceptance Criteria.
    5. **Ceiling.** If the boundary reaches `0.99` and mean overlap is still below `0.40` after the dwell, do not widen
       further; escalate to step 4 (larger or dedicated runners). Noise that survives the widest boundary is a
       runner-environment problem, not a threshold problem.
    6. **Small-sample fallback.** If a dwell window yields fewer than 5 unique alert pairs (so Jaccard is undefined or
       unstable), extend that dwell by 5 more qualifying runs at the same boundary before deciding, mirroring the
-      small-sample caveat in Tuning Sequence step 2. If 5 unique pairs still cannot be formed after the extension, keep
-      collecting in 5-run increments until they can.
+      small-sample caveat in Tuning Sequence step 2. Keep extending in 5-run increments until 5 unique pairs form, but
+      cap the extension at 20 additional qualifying runs beyond the original dwell: if 5 unique pairs still cannot be
+      formed by then, treat the boundary as having hit the Ceiling (step 5) and escalate to step 4, since persistent
+      alert sparsity at a single boundary is itself a runner-environment signal rather than a threshold one.
 
    Record each boundary value, its dwell run IDs, and the resulting overlap in
    [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). End to end this is at most 5 boundary values
@@ -172,7 +178,8 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
    - The 1-in-20 false-positive target (Acceptance Criteria 4 and 5) is evaluated only after the hard gate is restored, so
      it does not gate cadence advancement — the overlap criterion above does. Still, before locking a candidate boundary,
      sanity-check the noisy-alert rate at that setting: if overlap reads at least `0.40` but the noisy-alert rate is still
-     far worse than the target (for example, more than 5 noisy alerts per 20 runs), a few chronic flakes are probably
+     far worse than the target (for example, more than 5 noisy alerts per 20 runs — a rough "clearly dominating"
+     threshold, not a precisely calibrated bound like the `0.40` overlap signal), a few chronic flakes are probably
      dominating the overlap rather than real recurring regressions, so keep widening (up to the `0.99` ceiling in step 5
      above) and record the exception in Issue 3169. If the boundary is already at `0.99` when this override applies, there
      is nowhere left to widen: record the exception in Issue 3169 and escalate to step 4 (larger or dedicated runners)
@@ -183,7 +190,9 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
      same exclusion the false-positive accounting applies to intentional-perf-change commits (Acceptance Criterion 5).
    - Rollback at a locked boundary reuses Acceptance Criterion 5: if the restored hard gate later breaches the 1-in-20
      target, revert to warning mode and re-enter this cadence at the most recently locked boundary (starting a fresh
-     10-run dwell at that boundary) rather than restarting the widening from `0.95`.
+     10-run dwell at that boundary) rather than restarting the widening from `0.95`. This re-entry dwell is always the
+     standard 10-run dwell — even when `0.95` itself was the locked boundary, re-entry does not require a new 30-run
+     baseline window.
 
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -166,7 +166,7 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
 
    Record each boundary value, its dwell run IDs, and the resulting overlap in
    [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). End to end this is at most 5 boundary values
-   (`0.95` through `0.99`); it locks earlier if overlap reaches `0.40` sooner.
+   (`0.95` through `0.99`).
 
    **Interaction with the false-positive target and real regressions during tuning:**
    - The 1-in-20 false-positive target (Acceptance Criteria 4 and 5) is evaluated only after the hard gate is restored, so

--- a/internal/planning/library-benchmarking.md
+++ b/internal/planning/library-benchmarking.md
@@ -151,7 +151,7 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
       window. Do not re-collect a 30-run window at any widened boundary — each boundary past `0.95` gets the standard
       10-run dwell. Boundary changes alone never trigger a baseline reset (see the Baseline reset exception above).
    2. **Measure.** After the dwell, compute the mean Jaccard overlap across the most recent 5 adjacent qualifying-run
-      pairs at the current boundary, using the overlap method from step 2.
+      pairs at the current boundary, using the overlap method from Tuning Sequence step 2 above.
    3. **Advance.** If mean overlap is below `0.40`, raise the boundary by `0.01` and return to step 1 of this cadence at
       the new value: noise is still dominating, so requiring a wider boundary should help.
    4. **Lock.** If mean overlap is at least `0.40`, stop widening and keep the current boundary; recurring alerts now
@@ -161,25 +161,29 @@ The current Bencher invocation lives in `.github/workflows/benchmark.yml` inside
       runner-environment problem, not a threshold problem.
    6. **Small-sample fallback.** If a dwell window yields fewer than 5 unique alert pairs (so Jaccard is undefined or
       unstable), extend that dwell by 5 more qualifying runs at the same boundary before deciding, mirroring the
-      small-sample caveat in step 2.
+      small-sample caveat in Tuning Sequence step 2. If 5 unique pairs still cannot be formed after the extension, keep
+      collecting in 5-run increments until they can.
 
    Record each boundary value, its dwell run IDs, and the resulting overlap in
    [Issue 3169](https://github.com/shakacode/react_on_rails/issues/3169). End to end this is at most 5 boundary values
    (`0.95` through `0.99`); it locks earlier if overlap reaches `0.40` sooner.
 
    **Interaction with the false-positive target and real regressions during tuning:**
-   - The 1-in-20 false-positive target (Acceptance Criteria 4-5) is evaluated only after the hard gate is restored, so it
-     does not gate cadence advancement — the overlap criterion above does. Still, before locking a candidate boundary,
+   - The 1-in-20 false-positive target (Acceptance Criteria 4 and 5) is evaluated only after the hard gate is restored, so
+     it does not gate cadence advancement — the overlap criterion above does. Still, before locking a candidate boundary,
      sanity-check the noisy-alert rate at that setting: if overlap reads at least `0.40` but the noisy-alert rate is still
      far worse than the target (for example, more than 5 noisy alerts per 20 runs), a few chronic flakes are probably
-     dominating the overlap rather than real recurring regressions, so keep widening and record the exception in Issue 3169.
+     dominating the overlap rather than real recurring regressions, so keep widening (up to the `0.99` ceiling in step 5
+     above) and record the exception in Issue 3169. If the boundary is already at `0.99` when this override applies, there
+     is nowhere left to widen: record the exception in Issue 3169 and escalate to step 4 (larger or dedicated runners)
+     rather than locking on chronically noisy alerts.
    - If a real regression is identified mid-cadence (manual recurrence check plus a matching performance-sensitive
      commit), exclude the affected runs — and the runs for the commit that reverts it, which is itself
      performance-sensitive — from the most-recent-5-pairs overlap computation, then continue the cadence. This is the
      same exclusion the false-positive accounting applies to intentional-perf-change commits (Acceptance Criterion 5).
    - Rollback at a locked boundary reuses Acceptance Criterion 5: if the restored hard gate later breaches the 1-in-20
-     target, revert to warning mode and re-enter this cadence at the most recently locked boundary rather than restarting
-     the widening from `0.95`.
+     target, revert to warning mode and re-enter this cadence at the most recently locked boundary (starting a fresh
+     10-run dwell at that boundary) rather than restarting the widening from `0.95`.
 
 4. If shared-runner noise remains high, move benchmark jobs to larger GitHub-hosted runners or dedicated runners before
    restoring the hard gate.


### PR DESCRIPTION
## Summary

Resolves the follow-up tracked in #3260: the Main Gate Re-Enablement Plan in `internal/planning/library-benchmarking.md` said to widen `BOUNDARY` from `0.95` toward `0.99` but never defined the **increment**, the **runs collected per setting**, or how that cadence meshes with the 30-run baseline window and the 1-in-20 false-positive target from #3169.

This PR expands **Tuning Sequence step 3** into an explicit boundary tuning cadence (documentation only — no workflow/CI behavior changes).

## What the cadence specifies

- **Increment:** fixed `0.01` per step (`0.95` → `0.99`, ≤ 5 settings).
- **Dwell:** 10 qualifying main runs per setting. The existing 30-run baseline window doubles as the dwell for `0.95`; no widened boundary re-collects a 30-run window, and boundary changes alone never trigger a baseline reset.
- **Advance:** raise by `0.01` while mean Jaccard overlap over the most recent 5 adjacent qualifying-run pairs stays **< 0.40**.
- **Lock:** stop widening once overlap reaches **≥ 0.40** (recurring alerts now dominate; further widening risks masking real regressions).
- **Ceiling:** at `0.99` with overlap still **< 0.40**, escalate to larger/dedicated runners (existing step 4) — a runner-environment problem, not a threshold one.
- **Small-sample fallback:** dwell windows with fewer than 5 unique alert pairs get +5 runs before deciding.

## Interactions documented

- The **1-in-20 target** (Acceptance Criteria 4–5) is evaluated only after the hard gate is restored, so it does not gate cadence advancement — but a noisy rate far worse than target (e.g. > 5-in-20) keeps widening even if overlap reads ≥ 0.40.
- **Real regressions found mid-cadence** (plus the reverting commit) are excluded from the overlap computation, reusing the Acceptance Criterion 5 exclusion for intentional-perf-change commits.
- **Rollback** at a locked boundary reuses Acceptance Criterion 5 and re-enters the cadence at the most recently locked boundary.

The superseded "collect 5 more runs / escalate after 2 cycles" paragraph is replaced by the cadence's explicit advance and ceiling rules.

## Test Plan

- `pnpm exec prettier --check internal/planning/library-benchmarking.md` — passes
- `git diff --check` — clean
- pre-commit/pre-push hooks (trailing-newlines, lychee offline link check, prettier, branch-lint) — pass

Fixes #3260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal benchmarking runbooks; no workflow, CI, or runtime behavior is modified.
> 
> **Overview**
> **Tuning Sequence step 3** in `internal/planning/library-benchmarking.md` now spells out how to widen `BOUNDARY` from `0.95` to `0.99` instead of only saying to move toward `0.99`.
> 
> The new **boundary tuning cadence** fixes **0.01** steps, **10-run dwell** per setting (with the existing 30-run window counting as dwell at `0.95`), **advance/lock** from mean Jaccard over the latest **5** adjacent qualifying pairs vs **0.40**, a **0.99 ceiling** that escalates to larger runners, and a **small-sample** dwell extension cap. It also requires logging boundary, dwell run IDs, and overlap in Issue 3169.
> 
> A separate **Interaction** block clarifies that the **1-in-20** false-positive target does not gate cadence but can force continued widening; mid-cadence **real regressions** (and revert runs) drop out of overlap math; and **rollback** re-enters at the last locked boundary with a fresh 10-run dwell—not a full restart from `0.95`. The old “collect 5 more runs / two cycles then escalate” wording is removed in favor of these rules. Issue **3260** is referenced at the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a409a33f1eeb5206bd516babd10de70e3d4dbe05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified benchmarking tuning guidance with a structured boundary‑tuning cadence: fixed 0.01 increments, per‑boundary dwell of 10 qualifying runs, mean Jaccard computed over the most recent 5 adjacent qualifying alert pairs, advancement/locking rules with lock threshold 0.40 and a 0.99 ceiling escalation; added small‑sample fallback to extend dwell, required recording of boundary values/dwell run IDs/overlap results, exclusion of regression/revert runs from overlap computation, and rollback behavior to re-enter at the most recently locked boundary with a fresh dwell.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->