### PR TITLE
docs: clarify Node Renderer and async props diagrams

### DIFF
--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -111,8 +111,7 @@ flowchart TB
         L3 -- "miss" --> L4{"L4 · on-disk bundle cache<br/>cache/hash/hash.js"}
         L4 -- "hit" --> Exec
         L4 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
-        Upload -- "writes bundle" --> L4
-        L4 -- "now cached" --> Exec
+        Upload -- "seeds L4 · execute" --> Exec
     end
     Exec --> Done
     Exec -. "during this render only" .-> L5["L5 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>dedupes repeated reads — no cross-request reuse"]

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -18,21 +18,21 @@ ExecJS embeds a JavaScript runtime (mini_racer/V8) inside the Ruby process. This
 
 The Pro Node Renderer solves all of these by running a standalone Node.js server that handles rendering requests from Rails over HTTP.
 
-The contrast in one picture — embedded V8 inside each Ruby process vs. a separate, pooled Node service that Rails calls over HTTP/2:
+The contrast in one picture — the old way runs JavaScript inside Rails, while the Node Renderer runs it in a separate service:
 
 ```mermaid
 flowchart LR
-    subgraph Exec["ExecJS — in-process (OSS default)"]
+    subgraph Exec["ExecJS — JavaScript inside Rails"]
         direction TB
-        E1["Rails worker process"] --> E2["Embedded V8 runtime pool<br/>(mini_racer)"]
-        E2 --> E3["Render JS <b>in-process</b><br/>blocks the Ruby thread"]
+        E1["Rails process"] --> E2["JavaScript runtime<br/>inside the same process"]
+        E2 --> E3["Rails waits while<br/>JavaScript renders HTML"]
     end
-    subgraph Node["Node Renderer — out-of-process (Pro)"]
+    subgraph Node["Node Renderer — JavaScript in a separate service"]
         direction TB
-        N1["Rails worker process<br/>(thin HTTP client)"] -- "HTTP/2 render request" --> N2["Node Renderer<br/>master process"]
-        N2 --> N3["Worker 1<br/>VM + bundle cache"]
-        N2 --> N4["Worker 2<br/>VM + bundle cache"]
-        N2 --> N5["Worker N<br/>VM + bundle cache"]
+        N1["Rails process"] -- "render request" --> N2["Node Renderer"]
+        N2 --> N3["Worker 1<br/>renders HTML"]
+        N2 --> N4["Worker 2<br/>renders HTML"]
+        N2 --> N5["Worker N<br/>renders HTML"]
     end
     style Exec fill:#fff4e5,stroke:#e0a000,color:#000
     style E3 fill:#ffe5e5,stroke:#d1242f,color:#000
@@ -65,19 +65,19 @@ Because rendering runs out-of-process, the renderer scales concurrency across a 
 
 ```mermaid
 flowchart TB
-    subgraph Rails["Rails — async server (Puma / Falcon)"]
+    subgraph Rails["Rails receives many page requests"]
         direction LR
-        Req1["request 1"]
-        Req2["request 2"]
-        Req3["… request N"]
+        Req1["page request 1"]
+        Req2["page request 2"]
+        Req3["page request N"]
     end
-    Req1 -- "HTTP/2 (multiplexed)" --> Master
-    Req2 -- "HTTP/2 (multiplexed)" --> Master
-    Req3 -- "HTTP/2 (multiplexed)" --> Master
+    Req1 -- "send render job" --> Master
+    Req2 -- "send render job" --> Master
+    Req3 -- "send render job" --> Master
     subgraph Renderer["Node Renderer"]
-        Master["master process<br/>forks workers · auto-restarts crashes · rolling restarts"]
-        Master --> WA["worker A — event loop<br/>many concurrent renders / streams<br/>per-request <b>sharedExecutionContext</b> (isolated)"]
-        Master --> WB["worker B — event loop<br/>many concurrent renders / streams<br/>per-request <b>sharedExecutionContext</b> (isolated)"]
+        Master["Dispatcher<br/>hands jobs to workers"]
+        Master --> WA["Worker A<br/>renders several pages at once"]
+        Master --> WB["Worker B<br/>renders several pages at once"]
     end
     style Rails fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Renderer fill:#e6ffed,stroke:#2da44e,color:#000
@@ -100,22 +100,22 @@ React on Rails Pro stacks several caches, each skipping more work than the one b
 
 ```mermaid
 flowchart TB
-    Req["SSR render for a component"] --> L1{"L1 · Rails fragment cache<br/>cached_react_component · you choose the key<br/>hit skips props assembly + serialization + JS eval"}
-    L1 -- "hit" --> Done["Return cached HTML"]
-    L1 -- "miss" --> L2{"L2 · Rails prerender cache<br/>config.prerender_caching · key = bundle hash + MD5(JS incl. props)<br/>hit skips JS eval (props still assembled)"}
-    L2 -- "hit" --> Done
-    L2 -- "miss" --> L3
+    Req["Need HTML for a component"] --> L1{"Does Rails already<br/>have the final HTML?"}
+    L1 -- "yes" --> Done["Return HTML"]
+    L1 -- "no" --> L2{"Does Rails have<br/>a saved render result?"}
+    L2 -- "yes" --> Done
+    L2 -- "no" --> L3
     subgraph Renderer["Node Renderer"]
-        L3{"L3 · VM execution-context pool<br/>(LRU, MAX_VM_POOL_SIZE)<br/>reuse a warm bundle context"}
-        L3 -- "hit" --> Exec["Execute SSR in cached VM context"]
-        L3 -- "miss" --> L4{"L4 · on-disk bundle cache<br/>cache/hash/hash.js"}
-        L4 -- "hit" --> Exec
-        L4 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
-        Upload -- "seeds L4 · execute" --> Exec
+        L3{"Is the JS bundle<br/>already warm in memory?"}
+        L3 -- "yes" --> Exec["Run JavaScript<br/>to make HTML"]
+        L3 -- "no" --> L4{"Is the JS bundle<br/>saved on disk?"}
+        L4 -- "yes" --> Exec
+        L4 -- "no" --> Upload["Rails sends<br/>the bundle once"]
+        Upload --> Exec
     end
     Exec --> Done
-    Exec -. "during this render only" .-> L5["L5 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>dedupes repeated reads — no cross-request reuse"]
-    Browser["Browser hydration"] -. "separate asset requests" .-> L6["L6 · client chunks<br/>Cache-Control: max-age=1y<br/>(hydration assets, not server render)"]
+    Exec -. "during one render" .-> L5["Repeated data reads<br/>share one result"]
+    Browser["Browser starts the page"] -. "later" .-> L6["Browser code chunks<br/>cached by the browser"]
     style L1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style L2 fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Done fill:#e6ffed,stroke:#2da44e,color:#000
@@ -218,15 +218,15 @@ That round-trip is the difference between a warm and a cold render request:
 sequenceDiagram
     autonumber
     participant Rails
-    participant Renderer as Node Renderer worker
-    Rails->>Renderer: POST /bundles/{hash}/render/{digest}<br/>(renderingRequest, no bundle)
-    alt bundle already cached (warm)
-        Renderer-->>Rails: 200 OK + rendered HTML
-    else bundle missing (cold start)
-        Renderer-->>Rails: 410 Gone — send bundle
-        Rails->>Renderer: POST /upload-assets<br/>(server bundle + companion assets)
-        Rails->>Renderer: retry render request
-        Renderer-->>Rails: 200 OK + rendered HTML
+    participant Renderer as Node Renderer
+    Rails->>Renderer: Please render this page
+    alt renderer already has the bundle
+        Renderer-->>Rails: HTML
+    else renderer is missing the bundle
+        Renderer-->>Rails: I need that bundle first
+        Rails->>Renderer: Upload the bundle
+        Rails->>Renderer: Please render again
+        Renderer-->>Rails: HTML
     end
 ```
 
@@ -409,22 +409,16 @@ As a trace, the spans nest under the root `ror.ssr.request`. On the warm path th
 
 ```mermaid
 flowchart TB
-    Root["ror.ssr.request<br/>(root — one per SSR request)"]
-    Root --> BEC1["ror.bundle.build_execution_context<br/>cache.strategy = cache-first<br/>⚠ may end ERROR on a cache miss"]
-    Root -. "cold path only" .-> Up["ror.bundle.upload<br/>bundle.count · bytes.total"]
-    Root -. "cold path only" .-> BEC2["ror.bundle.build_execution_context<br/>cache.strategy = cache-miss"]
-    Root --> Vm["ror.vm.execute<br/>bundle.timestamp"]
-    Vm --> Prep["ror.result.prepare<br/>response.bytes"]
-    Vm -. "auto HttpInstrumentation" .-> Http["outbound HTTP child spans<br/>(fetch from your bundle)"]
-    Root -. "incremental / async-props renders" .-> Inc["ror.incremental.stream"]
-    Inc --> Chunk["ror.incremental.process_chunk<br/>(one per NDJSON update chunk)"]
+    Root["One server-render trace"]
+    Root --> Warm["Warm path<br/>load bundle -> run JavaScript -> prepare result"]
+    Root -. "cold start" .-> Cold["Upload bundle first<br/>then load it"]
+    Warm -. "if JavaScript fetches data" .-> Http["Data-fetch spans"]
+    Root -. "if slow data is streamed" .-> Inc["Streaming-data spans"]
+    Inc --> Chunk["One span for each<br/>incoming data chunk"]
     style Root fill:#e6f0ff,stroke:#2c6ecb,color:#000
-    style BEC1 fill:#fff4e5,stroke:#e0a000,color:#000
-    style Prep fill:#e6f0ff,stroke:#2c6ecb,color:#000
-    style Vm fill:#e6ffed,stroke:#2da44e,color:#000
+    style Warm fill:#e6ffed,stroke:#2da44e,color:#000
+    style Cold fill:#fff4e5,stroke:#e0a000,color:#000
     style Http fill:#fff4e5,stroke:#e0a000,color:#000
-    style Up fill:#fff4e5,stroke:#e0a000,color:#000
-    style BEC2 fill:#fff4e5,stroke:#e0a000,color:#000
     style Inc fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Chunk fill:#e6ffed,stroke:#2da44e,color:#000
 ```

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -69,11 +69,11 @@ flowchart TB
         direction LR
         Req1["request 1"]
         Req2["request 2"]
-        Req3["request N"]
+        Req3["… request N"]
     end
-    Req1 -- "HTTP/2" --> Master
+    Req1 -- "HTTP/2 (multiplexed)" --> Master
     Req2 -- "HTTP/2 (multiplexed)" --> Master
-    Req3 -- "HTTP/2" --> Master
+    Req3 -- "HTTP/2 (multiplexed)" --> Master
     subgraph Renderer["Node Renderer"]
         Master["master process<br/>forks workers · auto-restarts crashes · rolling restarts"]
         Master --> WA["worker A — event loop<br/>many concurrent renders / streams<br/>per-request <b>sharedExecutionContext</b> (isolated)"]
@@ -111,7 +111,8 @@ flowchart TB
         L3 -- "miss" --> L4{"L4 · on-disk bundle cache<br/>cache/hash/hash.js"}
         L4 -- "hit" --> Exec
         L4 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
-        Upload --> Exec
+        Upload -- "writes bundle" --> L4
+        L4 -- "now cached" --> Exec
     end
     Exec --> Done
     Exec -. "during this render only" .-> L5["L5 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>dedupes repeated reads — no cross-request reuse"]
@@ -405,7 +406,7 @@ Outbound HTTP calls inside your SSR bundle are automatically captured by `HttpIn
 
 **Cache-miss note:** On a cache-miss path `ror.bundle.build_execution_context` appears twice. The first span has `cache.strategy=cache-first` and can end with ERROR status when the VM cache probe misses. The second span has `cache.strategy=cache-miss` for the real VM build after bundle upload or bundle discovery. Scope error alerts to exclude `cache.strategy=cache-first` when that miss is expected.
 
-As a trace, the spans nest under the root `ror.ssr.request`. The upload and `cache-miss` build spans appear only on a cold path; outbound `fetch` calls from your bundle are captured automatically as HTTP child spans; and incremental (async-props) renders add their own stream/chunk spans:
+As a trace, the spans nest under the root `ror.ssr.request`. On the warm path the spans fire in order: `ror.bundle.build_execution_context` (`cache-first`) → `ror.vm.execute` → `ror.result.prepare`. Cold-path spans (upload and `cache-miss` build) appear only between the first two; outbound `fetch` calls from your bundle are captured automatically as HTTP child spans; and incremental (async-props) renders add their own stream/chunk spans:
 
 ```mermaid
 flowchart TB

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -96,30 +96,35 @@ By contrast, ExecJS renders one request per V8 context and blocks the Ruby threa
 - **Shared secret authentication** — Secure communication between Rails and Node
 - **Prerender caching** — Combined with [prerender caching](../oss/building-features/caching.md#level-1-prerender-caching), rendering results are cached across requests
 
-These caches stack, and each layer avoids the cost of the one below it — a prerender-cache hit skips the renderer entirely; a warm VM context skips reloading the bundle; an on-disk bundle skips the cold-start upload:
+React on Rails Pro stacks several caches, each skipping more work than the one below it. The two Rails-side caches differ in **scope**: a [fragment-cache](../oss/building-features/caching.md#level-2-fragment-caching) hit skips even props assembly (the props block never runs), while [prerender caching](../oss/building-features/caching.md#level-1-prerender-caching) still assembles props but skips the JavaScript evaluation. The remaining layers live in the renderer, per request, and the browser:
 
 ```mermaid
 flowchart TB
-    Req["SSR render for a component"] --> L1{"L1 · Rails prerender cache<br/>Rails.cache · key = component + your cache_key<br/>+ RoR/Pro versions + bundle hash"}
-    L1 -- "hit" --> Done["Return cached HTML<br/>(renderer never called)"]
-    L1 -- "miss" --> L2
+    Req["SSR render for a component"] --> L1{"L1 · Rails fragment cache<br/>cached_react_component · you choose the key<br/>hit skips props assembly + serialization + JS eval"}
+    L1 -- "hit" --> Done["Return cached HTML"]
+    L1 -- "miss" --> L2{"L2 · Rails prerender cache<br/>config.prerender_caching · key = bundle hash + MD5(JS incl. props)<br/>hit skips JS eval (props still assembled)"}
+    L2 -- "hit" --> Done
+    L2 -- "miss" --> L3
     subgraph Renderer["Node Renderer"]
-        L2{"L2 · VM execution-context pool<br/>(LRU, MAX_VM_POOL_SIZE)"}
-        L2 -- "hit" --> Exec["Execute in cached VM context"]
-        L2 -- "miss" --> L3{"L3 · on-disk bundle cache<br/>cache/hash/hash.js"}
-        L3 -- "hit" --> Exec
-        L3 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
+        L3{"L3 · VM execution-context pool<br/>(LRU, MAX_VM_POOL_SIZE)<br/>reuse a warm bundle context"}
+        L3 -- "hit" --> Exec["Execute SSR in cached VM context"]
+        L3 -- "miss" --> L4{"L4 · on-disk bundle cache<br/>cache/hash/hash.js"}
+        L4 -- "hit" --> Exec
+        L4 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
         Upload --> Exec
     end
-    Exec --> L4["L4 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>(one fetch per request)"]
-    L4 --> Browser["L5 · Browser — client chunks<br/>Cache-Control: max-age=1y (immutable, hash-versioned)"]
+    Exec --> L5["L5 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>dedupes within one render only — no cross-request reuse"]
+    L5 --> Browser["L6 · Browser — client chunks<br/>Cache-Control: max-age=1y (hydration assets, not server render)"]
     style L1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style L2 fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Done fill:#e6ffed,stroke:#2da44e,color:#000
     style Renderer fill:#e6ffed,stroke:#2da44e,color:#000
-    style L3 fill:#fff4e5,stroke:#e0a000,color:#000
+    style L4 fill:#fff4e5,stroke:#e0a000,color:#000
     style Upload fill:#ffe5e5,stroke:#d1242f,color:#000
     style Browser fill:#e6f0ff,stroke:#2c6ecb,color:#000
 ```
+
+(Fragment caching subsumes prerender caching: on a fragment-cache hit the prerender cache is never consulted.)
 
 ## Getting Started
 
@@ -432,6 +437,7 @@ The `renderingRequest` payload and rendered response body are **never** included
 
 - [Streaming SSR](./streaming-ssr.md) — Progressive HTML streaming and the async-props data flow (with diagrams)
 - [React Server Components rendering flow](./react-server-components/rendering-flow.md) — How the RSC, server, and client bundles fit together
+- [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md) — How Rails data reaches components during render (async props vs. direct fetch)
 - [Rolling-Deploy Adapters](./rolling-deploy-adapters.md) — Protocol spec and reference implementations for `rolling_deploy_adapter`
 - [Node Renderer basics](../oss/building-features/node-renderer/basics.md) — Architecture and core concepts
 - [JavaScript configuration](../oss/building-features/node-renderer/js-configuration.md) — Node-side config options

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -419,14 +419,14 @@ flowchart TB
     Root -. "incremental / async-props renders" .-> Inc["ror.incremental.stream"]
     Inc --> Chunk["ror.incremental.process_chunk<br/>(one per NDJSON update chunk)"]
     style Root fill:#e6f0ff,stroke:#2c6ecb,color:#000
-    style BEC1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style BEC1 fill:#fff4e5,stroke:#e0a000,color:#000
     style Prep fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Vm fill:#e6ffed,stroke:#2da44e,color:#000
     style Http fill:#fff4e5,stroke:#e0a000,color:#000
     style Up fill:#fff4e5,stroke:#e0a000,color:#000
     style BEC2 fill:#fff4e5,stroke:#e0a000,color:#000
     style Inc fill:#e6f0ff,stroke:#2c6ecb,color:#000
-    style Chunk fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style Chunk fill:#e6ffed,stroke:#2da44e,color:#000
 ```
 
 ### Production defaults

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -96,7 +96,7 @@ By contrast, ExecJS renders one request per V8 context and blocks the Ruby threa
 - **Shared secret authentication** — Secure communication between Rails and Node
 - **Prerender caching** — Combined with [prerender caching](../oss/building-features/caching.md#level-1-prerender-caching), rendering results are cached across requests
 
-React on Rails Pro stacks several caches, each skipping more work than the one below it. The two Rails-side caches differ in **scope**: a [fragment-cache](../oss/building-features/caching.md#level-2-fragment-caching) hit skips even props assembly (the props block never runs), while [prerender caching](../oss/building-features/caching.md#level-1-prerender-caching) still assembles props but skips the JavaScript evaluation. The remaining layers live in the renderer, per request, and the browser:
+React on Rails Pro stacks several caches, each skipping more work than the one below it. The two Rails-side caches differ in **scope**: a [fragment-cache](../oss/building-features/caching.md#level-2-fragment-caching) hit skips even props assembly (the props block never runs), while [prerender caching](../oss/building-features/caching.md#level-1-prerender-caching) still assembles props but skips the JavaScript evaluation. The renderer cache layers sit on the server-side render path; request-scoped deduplication and browser chunk caching are shown as side optimizations because they do not feed into each other:
 
 ```mermaid
 flowchart TB
@@ -113,15 +113,19 @@ flowchart TB
         L4 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
         Upload --> Exec
     end
-    Exec --> L5["L5 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>dedupes within one render only — no cross-request reuse"]
-    L5 --> Browser["L6 · Browser — client chunks<br/>Cache-Control: max-age=1y (hydration assets, not server render)"]
+    Exec --> Done
+    Exec -. "during this render only" .-> L5["L5 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>dedupes repeated reads — no cross-request reuse"]
+    Browser["Browser hydration"] -. "separate asset requests" .-> L6["L6 · client chunks<br/>Cache-Control: max-age=1y<br/>(hydration assets, not server render)"]
     style L1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style L2 fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Done fill:#e6ffed,stroke:#2da44e,color:#000
     style Renderer fill:#e6ffed,stroke:#2da44e,color:#000
+    style L3 fill:#e6ffed,stroke:#2da44e,color:#000
     style L4 fill:#fff4e5,stroke:#e0a000,color:#000
     style Upload fill:#ffe5e5,stroke:#d1242f,color:#000
     style Browser fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style L5 fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style L6 fill:#e6f0ff,stroke:#2c6ecb,color:#000
 ```
 
 (Fragment caching subsumes prerender caching: on a fragment-cache hit the prerender cache is never consulted.)
@@ -409,18 +413,20 @@ flowchart TB
     Root --> BEC1["ror.bundle.build_execution_context<br/>cache.strategy = cache-first<br/>⚠ may end ERROR on a cache miss"]
     Root -. "cold path only" .-> Up["ror.bundle.upload<br/>bundle.count · bytes.total"]
     Root -. "cold path only" .-> BEC2["ror.bundle.build_execution_context<br/>cache.strategy = cache-miss"]
-    Root --> Prep["ror.result.prepare<br/>response.bytes"]
-    Prep --> Vm["ror.vm.execute<br/>bundle.timestamp"]
+    Root --> Vm["ror.vm.execute<br/>bundle.timestamp"]
+    Vm --> Prep["ror.result.prepare<br/>response.bytes"]
     Vm -. "auto HttpInstrumentation" .-> Http["outbound HTTP child spans<br/>(fetch from your bundle)"]
     Root -. "incremental / async-props renders" .-> Inc["ror.incremental.stream"]
     Inc --> Chunk["ror.incremental.process_chunk<br/>(one per NDJSON update chunk)"]
     style Root fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style BEC1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Prep fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Vm fill:#e6ffed,stroke:#2da44e,color:#000
     style Http fill:#fff4e5,stroke:#e0a000,color:#000
     style Up fill:#fff4e5,stroke:#e0a000,color:#000
     style BEC2 fill:#fff4e5,stroke:#e0a000,color:#000
     style Inc fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style Chunk fill:#e6f0ff,stroke:#2c6ecb,color:#000
 ```
 
 ### Production defaults

--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -18,6 +18,30 @@ ExecJS embeds a JavaScript runtime (mini_racer/V8) inside the Ruby process. This
 
 The Pro Node Renderer solves all of these by running a standalone Node.js server that handles rendering requests from Rails over HTTP.
 
+The contrast in one picture — embedded V8 inside each Ruby process vs. a separate, pooled Node service that Rails calls over HTTP/2:
+
+```mermaid
+flowchart LR
+    subgraph Exec["ExecJS — in-process (OSS default)"]
+        direction TB
+        E1["Rails worker process"] --> E2["Embedded V8 runtime pool<br/>(mini_racer)"]
+        E2 --> E3["Render JS <b>in-process</b><br/>blocks the Ruby thread"]
+    end
+    subgraph Node["Node Renderer — out-of-process (Pro)"]
+        direction TB
+        N1["Rails worker process<br/>(thin HTTP client)"] -- "HTTP/2 render request" --> N2["Node Renderer<br/>master process"]
+        N2 --> N3["Worker 1<br/>VM + bundle cache"]
+        N2 --> N4["Worker 2<br/>VM + bundle cache"]
+        N2 --> N5["Worker N<br/>VM + bundle cache"]
+    end
+    style Exec fill:#fff4e5,stroke:#e0a000,color:#000
+    style E3 fill:#ffe5e5,stroke:#d1242f,color:#000
+    style Node fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style N3 fill:#e6ffed,stroke:#2da44e,color:#000
+    style N4 fill:#e6ffed,stroke:#2da44e,color:#000
+    style N5 fill:#e6ffed,stroke:#2da44e,color:#000
+```
+
 ## Performance Benefits
 
 | Metric               | ExecJS                      | Node Renderer            |
@@ -37,6 +61,33 @@ At [Popmenu](https://www.shakacode.com/recent-work/popmenu/) (a ShakaCode client
 3. The rendered HTML is returned to Rails and inserted into the view
 4. Workers are pooled and can be automatically restarted to mitigate memory leaks
 
+Because rendering runs out-of-process, the renderer scales concurrency across a worker pool instead of blocking the Ruby request cycle. Rails (on an async server such as Puma or Falcon) multiplexes many requests over HTTP/2; the master process forks workers (default: CPU count − 1), auto-restarts crashed ones, and can do scheduled rolling restarts. Each request is rendered in its own per-request `sharedExecutionContext`, so concurrent renders never leak data into one another:
+
+```mermaid
+flowchart TB
+    subgraph Rails["Rails — async server (Puma / Falcon)"]
+        direction LR
+        Req1["request 1"]
+        Req2["request 2"]
+        Req3["request N"]
+    end
+    Req1 -- "HTTP/2" --> Master
+    Req2 -- "HTTP/2 (multiplexed)" --> Master
+    Req3 -- "HTTP/2" --> Master
+    subgraph Renderer["Node Renderer"]
+        Master["master process<br/>forks workers · auto-restarts crashes · rolling restarts"]
+        Master --> WA["worker A — event loop<br/>many concurrent renders / streams<br/>per-request <b>sharedExecutionContext</b> (isolated)"]
+        Master --> WB["worker B — event loop<br/>many concurrent renders / streams<br/>per-request <b>sharedExecutionContext</b> (isolated)"]
+    end
+    style Rails fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style Renderer fill:#e6ffed,stroke:#2da44e,color:#000
+    style Master fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style WA fill:#e6ffed,stroke:#2da44e,color:#000
+    style WB fill:#e6ffed,stroke:#2da44e,color:#000
+```
+
+By contrast, ExecJS renders one request per V8 context and blocks the Ruby thread for the duration. For concurrent _streaming_ specifically, see [Streaming SSR](./streaming-ssr.md).
+
 ## Key Features
 
 - **Worker pool** — Configurable number of workers (defaults to CPU count minus 1)
@@ -44,6 +95,31 @@ At [Popmenu](https://www.shakacode.com/recent-work/popmenu/) (a ShakaCode client
 - **Bundle caching** — Server bundles are cached on the Node side for fast re-renders
 - **Shared secret authentication** — Secure communication between Rails and Node
 - **Prerender caching** — Combined with [prerender caching](../oss/building-features/caching.md#level-1-prerender-caching), rendering results are cached across requests
+
+These caches stack, and each layer avoids the cost of the one below it — a prerender-cache hit skips the renderer entirely; a warm VM context skips reloading the bundle; an on-disk bundle skips the cold-start upload:
+
+```mermaid
+flowchart TB
+    Req["SSR render for a component"] --> L1{"L1 · Rails prerender cache<br/>Rails.cache · key = component + your cache_key<br/>+ RoR/Pro versions + bundle hash"}
+    L1 -- "hit" --> Done["Return cached HTML<br/>(renderer never called)"]
+    L1 -- "miss" --> L2
+    subgraph Renderer["Node Renderer"]
+        L2{"L2 · VM execution-context pool<br/>(LRU, MAX_VM_POOL_SIZE)"}
+        L2 -- "hit" --> Exec["Execute in cached VM context"]
+        L2 -- "miss" --> L3{"L3 · on-disk bundle cache<br/>cache/hash/hash.js"}
+        L3 -- "hit" --> Exec
+        L3 -- "miss (cold)" --> Upload["410 → Rails uploads bundle"]
+        Upload --> Exec
+    end
+    Exec --> L4["L4 · request-scoped dedup<br/>React.cache() / async-prop Promise<br/>(one fetch per request)"]
+    L4 --> Browser["L5 · Browser — client chunks<br/>Cache-Control: max-age=1y (immutable, hash-versioned)"]
+    style L1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style Done fill:#e6ffed,stroke:#2da44e,color:#000
+    style Renderer fill:#e6ffed,stroke:#2da44e,color:#000
+    style L3 fill:#fff4e5,stroke:#e0a000,color:#000
+    style Upload fill:#ffe5e5,stroke:#d1242f,color:#000
+    style Browser fill:#e6f0ff,stroke:#2c6ecb,color:#000
+```
 
 ## Getting Started
 
@@ -126,6 +202,26 @@ To rotate the renderer password:
 ## Eliminating Cold-Start Latency in Docker Deployments
 
 When a new container starts, the Node Renderer has an empty bundle cache. The first SSR request triggers a costly 410→retry round-trip where Rails sends the full bundle over HTTP, adding 200ms–1s+ of latency depending on bundle size. In rolling deploys, this affects every new pod.
+
+That round-trip is the difference between a warm and a cold render request:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Rails
+    participant Renderer as Node Renderer worker
+    Rails->>Renderer: POST /bundles/{hash}/render/{digest}<br/>(renderingRequest, no bundle)
+    alt bundle already cached (warm)
+        Renderer-->>Rails: 200 OK + rendered HTML
+    else bundle missing (cold start)
+        Renderer-->>Rails: 410 Gone — send bundle
+        Rails->>Renderer: POST /upload-assets<br/>(server bundle + companion assets)
+        Rails->>Renderer: retry render request
+        Renderer-->>Rails: 200 OK + rendered HTML
+    end
+```
+
+Pre-seeding the cache (below) makes every fresh renderer take the warm path on its very first request.
 
 ### Pre-seeding the bundle cache
 
@@ -300,6 +396,28 @@ Outbound HTTP calls inside your SSR bundle are automatically captured by `HttpIn
 
 **Cache-miss note:** On a cache-miss path `ror.bundle.build_execution_context` appears twice. The first span has `cache.strategy=cache-first` and can end with ERROR status when the VM cache probe misses. The second span has `cache.strategy=cache-miss` for the real VM build after bundle upload or bundle discovery. Scope error alerts to exclude `cache.strategy=cache-first` when that miss is expected.
 
+As a trace, the spans nest under the root `ror.ssr.request`. The upload and `cache-miss` build spans appear only on a cold path; outbound `fetch` calls from your bundle are captured automatically as HTTP child spans; and incremental (async-props) renders add their own stream/chunk spans:
+
+```mermaid
+flowchart TB
+    Root["ror.ssr.request<br/>(root — one per SSR request)"]
+    Root --> BEC1["ror.bundle.build_execution_context<br/>cache.strategy = cache-first<br/>⚠ may end ERROR on a cache miss"]
+    Root -. "cold path only" .-> Up["ror.bundle.upload<br/>bundle.count · bytes.total"]
+    Root -. "cold path only" .-> BEC2["ror.bundle.build_execution_context<br/>cache.strategy = cache-miss"]
+    Root --> Prep["ror.result.prepare<br/>response.bytes"]
+    Prep --> Vm["ror.vm.execute<br/>bundle.timestamp"]
+    Vm -. "auto HttpInstrumentation" .-> Http["outbound HTTP child spans<br/>(fetch from your bundle)"]
+    Root -. "incremental / async-props renders" .-> Inc["ror.incremental.stream"]
+    Inc --> Chunk["ror.incremental.process_chunk<br/>(one per NDJSON update chunk)"]
+    style Root fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style Prep fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style Vm fill:#e6ffed,stroke:#2da44e,color:#000
+    style Http fill:#fff4e5,stroke:#e0a000,color:#000
+    style Up fill:#fff4e5,stroke:#e0a000,color:#000
+    style BEC2 fill:#fff4e5,stroke:#e0a000,color:#000
+    style Inc fill:#e6f0ff,stroke:#2c6ecb,color:#000
+```
+
 ### Production defaults
 
 - **Span processor**: `BatchSpanProcessor` in production (`NODE_ENV=production` or `RAILS_ENV=production`), `SimpleSpanProcessor` otherwise. Override with `init({ spanProcessor })`.
@@ -312,6 +430,8 @@ The `renderingRequest` payload and rendered response body are **never** included
 
 ## Further Reading
 
+- [Streaming SSR](./streaming-ssr.md) — Progressive HTML streaming and the async-props data flow (with diagrams)
+- [React Server Components rendering flow](./react-server-components/rendering-flow.md) — How the RSC, server, and client bundles fit together
 - [Rolling-Deploy Adapters](./rolling-deploy-adapters.md) — Protocol spec and reference implementations for `rolling_deploy_adapter`
 - [Node Renderer basics](../oss/building-features/node-renderer/basics.md) — Architecture and core concepts
 - [JavaScript configuration](../oss/building-features/node-renderer/js-configuration.md) — Node-side config options

--- a/docs/pro/react-server-components/rendering-flow.md
+++ b/docs/pro/react-server-components/rendering-flow.md
@@ -79,7 +79,7 @@ flowchart LR
         RSC -- "Flight payload<br/>server components + client refs" --> Server
         Server --> HTML["HTML + embedded RSC payload"]
     end
-    HTML -- "single streamed response" --> Browser["Browser"]
+    HTML -- "streamed response (HTML + RSC payload)" --> Browser["Browser"]
     Browser --> Hydrate["Hydrate from embedded payload"]
     Hydrate -- "load on demand" --> Chunks["Client bundle chunks"]
     style NodeVM fill:#e6ffed,stroke:#2da44e,color:#000

--- a/docs/pro/react-server-components/rendering-flow.md
+++ b/docs/pro/react-server-components/rendering-flow.md
@@ -69,23 +69,24 @@ Even with CommonJS execution mode enabled, `resolve.fallback` remains the safer 
 
 For `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal`, see [Node Renderer JavaScript Configuration](../../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc).
 
-At runtime those three bundles map onto two environments — the Node renderer's VM contexts and the browser — and interact like this:
+Traditional SSR without RSC is the simpler server-bundle-to-HTML path covered in the [Node Renderer](../node-renderer.md) and [Streaming SSR](../streaming-ssr.md) docs. The RSC path adds the RSC bundle and an embedded RSC payload:
 
 ```mermaid
-flowchart LR
-    subgraph NodeVM["Node Renderer — isolated VM contexts"]
+flowchart TB
+    subgraph NodeVM["Node Renderer"]
         direction TB
-        Server["Server bundle<br/>RSCServerRoot"] -- "generateRSCPayload(component, props)<br/>via runOnOtherBundle()" --> RSC["RSC bundle<br/>(react-server condition)"]
-        RSC -- "Flight payload<br/>server components + client refs" --> Server
-        Server --> HTML["HTML + embedded RSC payload"]
+        ServerStart["Server bundle<br/>starts the page"] --> RSC["RSC bundle<br/>builds the Server Component output"]
+        RSC --> Payload["RSC payload<br/>what to show + browser code links"]
+        Payload --> ServerHTML["Server bundle<br/>streams HTML with the payload inside"]
     end
-    HTML -- "streamed response (HTML + RSC payload)" --> Browser["Browser"]
-    Browser --> Hydrate["Hydrate from embedded payload"]
-    Hydrate -- "load on demand" --> Chunks["Client bundle chunks"]
+    ServerHTML --> Browser["Browser<br/>receives one response"]
+    Browser --> Hydrate["React uses the payload<br/>to wake up the page"]
+    Hydrate --> Chunks["Browser code chunks<br/>load as needed"]
     style NodeVM fill:#e6ffed,stroke:#2da44e,color:#000
-    style Server fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style ServerStart fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style RSC fill:#e6f0ff,stroke:#2c6ecb,color:#000
-    style HTML fill:#e6ffed,stroke:#2da44e,color:#000
+    style Payload fill:#e6ffed,stroke:#2da44e,color:#000
+    style ServerHTML fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style Browser fill:#fff4e5,stroke:#e0a000,color:#000
     style Hydrate fill:#fff4e5,stroke:#e0a000,color:#000
     style Chunks fill:#fff4e5,stroke:#e0a000,color:#000
@@ -100,23 +101,22 @@ When a request is made to a page using React Server Components, the following op
 1. Initial Request Processing:
    - The `stream_react_component` helper is called in the view
    - Makes a request to the node renderer
-   - Server bundle's rendering function calls `generateRSCPayload` with the component name and props
-   - This executes the component rendering in the RSC bundle
-   - RSC bundle generates the payload containing server component data and client component references
+   - The server bundle starts the RSC page render with the component name and props
+   - The RSC bundle renders the Server Component tree
+   - The RSC bundle generates the payload containing server component data and client component references
    - The payload is returned to the server bundle
 
-2. Server-Side Rendering with RSC Payload:
-   - The server bundle uses the RSC payload to generate HTML for server components using `RSCServerRoot`
-   - `RSCServerRoot` splits the RSC payload stream into two parts:
-     - One stream for rendering server components as HTML
-     - Another stream for embedding the RSC payload in the response
-   - `RSCPayloadContainer` component embeds the RSC payload within the HTML response
+2. HTML Rendering with RSC Payload:
+   - The server bundle uses the RSC payload to generate HTML for the page
+   - The payload stream is split internally:
+     - One copy renders the Server Component output as HTML
+     - Another copy is embedded in the response for browser hydration
    - HTML and embedded RSC payload are streamed together to the client
 
 3. Client Hydration:
    - Browser displays HTML immediately
    - React runtime uses the embedded RSC payload for hydration
-   - Client components are hydrated progressively without requiring a separate HTTP request
+   - Client components are hydrated progressively without requiring a separate RSC payload request
 
 This approach offers significant advantages:
 
@@ -127,27 +127,28 @@ This approach offers significant advantages:
 ```mermaid
 sequenceDiagram
     participant Browser
-    participant RailsView
-    participant NodeRenderer
-    participant RSCBundle
-    participant ServerBundle
+    participant Rails
+    participant Renderer as Node renderer
+    participant Server as Server bundle
+    participant RSC as RSC bundle
 
-    Note over Browser,ServerBundle: 1. Initial Request
-    Browser->>RailsView: Request page
-    RailsView->>NodeRenderer: stream_react_component
-    NodeRenderer->>ServerBundle: Execute rendering request
-    ServerBundle->>RSCBundle: generateRSCPayload(component, props)
-    RSCBundle-->>ServerBundle: RSC payload with:<br/>- Server components<br/>- Client component refs
-    ServerBundle-->>NodeRenderer: Generate HTML using RSC payload
+    Note over Browser,RSC: 1. Initial Request
+    Browser->>Rails: Request page
+    Rails->>Renderer: Ask renderer to render
+    Renderer->>Server: Start the page render
+    Server->>RSC: Build the Server Component output<br/>(component name + data)
+    RSC-->>Server: RSC payload<br/>(what to show + browser code links)
+    Server-->>Renderer: HTML stream with payload inside
 
-    Note over Browser,ServerBundle: 2. Single Response
-    NodeRenderer-->>Browser: Stream HTML with embedded RSC payload
+    Note over Browser,RSC: 2. Single Response
+    Renderer-->>Rails: Stream HTML with payload inside
+    Rails-->>Browser: Forward streamed response
 
     Note over Browser: 3. Client Hydration
-    Browser->>Browser: Process embedded RSC payload
+    Browser->>Browser: Read the embedded payload
     loop For each client component
-        Browser->>Browser: Fetch component chunk
-        Browser->>Browser: Hydrate component
+        Browser->>Browser: Load needed browser code
+        Browser->>Browser: Make that part interactive
     end
 ```
 

--- a/docs/pro/react-server-components/rendering-flow.md
+++ b/docs/pro/react-server-components/rendering-flow.md
@@ -69,6 +69,29 @@ Even with CommonJS execution mode enabled, `resolve.fallback` remains the safer 
 
 For `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal`, see [Node Renderer JavaScript Configuration](../../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc).
 
+At runtime those three bundles map onto two environments — the Node renderer's VM contexts and the browser — and interact like this:
+
+```mermaid
+flowchart LR
+    subgraph NodeVM["Node Renderer — isolated VM contexts"]
+        direction TB
+        Server["Server bundle<br/>RSCServerRoot"] -- "generateRSCPayload(component, props)<br/>via runOnOtherBundle()" --> RSC["RSC bundle<br/>(react-server condition)"]
+        RSC -- "Flight payload<br/>server components + client refs" --> Server
+        Server --> HTML["HTML + embedded RSC payload"]
+    end
+    HTML -- "single streamed response" --> Browser["Browser"]
+    Browser --> Hydrate["Hydrate from embedded payload"]
+    Hydrate -- "load on demand" --> Chunks["Client bundle chunks"]
+    style NodeVM fill:#e6ffed,stroke:#2da44e,color:#000
+    style Server fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style RSC fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style HTML fill:#e6ffed,stroke:#2da44e,color:#000
+    style Browser fill:#fff4e5,stroke:#e0a000,color:#000
+    style Chunks fill:#fff4e5,stroke:#e0a000,color:#000
+```
+
+The sequence below traces the same interaction over time.
+
 ## React Server Component Rendering Flow
 
 When a request is made to a page using React Server Components, the following optimized sequence occurs:

--- a/docs/pro/react-server-components/rendering-flow.md
+++ b/docs/pro/react-server-components/rendering-flow.md
@@ -87,6 +87,7 @@ flowchart LR
     style RSC fill:#e6f0ff,stroke:#2c6ecb,color:#000
     style HTML fill:#e6ffed,stroke:#2da44e,color:#000
     style Browser fill:#fff4e5,stroke:#e0a000,color:#000
+    style Hydrate fill:#fff4e5,stroke:#e0a000,color:#000
     style Chunks fill:#fff4e5,stroke:#e0a000,color:#000
 ```
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -83,6 +83,7 @@ The view helper is `stream_react_component_with_async_props`, which yields an em
 
 ```erb
 <%= stream_react_component_with_async_props("Dashboard") do |emit|
+      # Sequential: posts waits for users. For parallel queries, see the fan-out pattern below.
       emit.call("users", User.active.limit(50).as_json(only: [:id, :name]))
       emit.call("posts", Post.recent.limit(20).as_json(only: [:id, :title]))
     end %>

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -88,6 +88,8 @@ The view helper is `stream_react_component_with_async_props`, which yields an em
     end %>
 ```
 
+When several slow sources are independent, use the [parallel fan-out pattern below](#loading-multiple-slow-sources-in-parallel) so one query does not block the next.
+
 For the full data-fetching guidance — synchronous props, parallelizing independent queries, and React Query / SWR interop — see [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
 
 ### The discouraged alternative: direct `fetch` from the renderer

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -20,6 +20,24 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 3. As each `<Suspense>` boundary resolves (e.g., an async data fetch completes), the rendered HTML chunk is streamed to the browser
 4. The browser replaces placeholders with real content — no full-page reload needed
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Browser
+    participant Rails
+    participant Renderer as Node Renderer
+    Note over Rails: ActionController::Live (ReactOnRailsPro::Stream)
+    Browser->>Rails: GET page
+    Rails->>Renderer: streaming render request
+    Renderer->>Renderer: renderToPipeableStream() — onShellReady
+    Renderer-->>Rails: HTML shell chunk
+    Rails-->>Browser: shell paints immediately (fast TTFB)
+    loop each Suspense boundary resolves
+        Renderer-->>Rails: length-prefixed HTML chunk
+        Rails-->>Browser: append chunk — progressive paint + selective hydration
+    end
+```
+
 ## Prerequisites
 
 - React on Rails Pro
@@ -252,6 +270,47 @@ For example, with our `MyStreamingComponent`, the sequence is:
 ```
 
 To render more of the page progressively, add an async prop and a `<Suspense>` boundary for each slow section — emit each one from the block as Rails resolves it, and every boundary streams in independently. This keeps the whole page in a single component tree (shared layout, context, and props) rather than splitting it across multiple `stream_react_component` calls.
+
+## Progressive Data with Async Props
+
+Streaming SSR sends HTML as React renders it. **Async props** (a React Server Components feature, so it requires `enable_rsc_support`) go one step further: Rails emits each prop _as its data becomes ready_ and streams the matching Suspense boundary to the browser the moment it resolves.
+
+This is the recommended answer to "my component needs Rails data during render": **Rails owns the data and pushes it in**, preserving your controller / model / authorization / caching layers — the renderer never has to call back into Rails.
+
+> [!NOTE]
+> A Server Component _can_ `fetch` a Rails API directly, but the renderer's VM has no `fetch`, `Headers`, `Request`, or `Response` by default — you must bundle an HTTP client or inject them via `additionalContext` — and doing so bypasses Rails' auth and caching. `'use server'` Server Actions are **not** supported (the renderer has no DB/session/cookie access). Prefer props / async props. See [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
+
+Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Rails
+    participant Renderer as Node Renderer
+    participant Browser
+    Note over Renderer: per-request sharedExecutionContext (isolated)
+    Rails->>Renderer: open bidirectional HTTP/2 NDJSON stream<br/>first line: renderingRequest
+    Renderer->>Renderer: render begins; a Server Component awaits an async-prop Promise
+    Renderer-->>Browser: HTML shell + Suspense fallbacks stream out
+    loop each prop resolves in Rails (emit.call)
+        Rails->>Renderer: NDJSON updateChunk — asyncPropsManager.setProp('users', ...)
+        Renderer->>Renderer: resolve Promise — React continues rendering
+        Renderer-->>Browser: flush that boundary's HTML
+    end
+    Rails->>Renderer: close stream (END_STREAM)
+    Renderer->>Renderer: asyncPropsManager.endStream()
+```
+
+The view helper is `stream_react_component_with_async_props`, which yields an emitter:
+
+```erb
+<%= stream_react_component_with_async_props("Dashboard") do |emit|
+      emit.call("users", User.all.to_a)     # streamed as soon as it's ready
+      emit.call("posts", Post.recent.to_a)  # streamed independently
+    end %>
+```
+
+For the full data-fetching guidance — synchronous props, parallelizing independent queries, and React Query / SWR interop — see [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -77,6 +77,7 @@ sequenceDiagram
     end
     Rails->>Renderer: close stream (END_STREAM)
     Renderer->>Renderer: reject any unresolved async props
+    Rails-->>Browser: remaining Suspense boundaries stay on fallback
 ```
 
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
@@ -84,6 +85,7 @@ The view helper is `stream_react_component_with_async_props`, which yields an em
 ```erb
 <%= stream_react_component_with_async_props("Dashboard") do |emit|
       # Sequential: posts waits for users. For parallel queries, see the fan-out pattern below.
+      # Treat users as the slow source here; fast data can use ordinary synchronous props.
       emit.call("users", User.active.limit(50).as_json(only: [:id, :name]))
       emit.call("posts", Post.recent.limit(20).as_json(only: [:id, :title]))
     end %>

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -26,15 +26,13 @@ sequenceDiagram
     participant Browser
     participant Rails
     participant Renderer as Node Renderer
-    Note over Rails: ActionController::Live (ReactOnRailsPro::Stream)
-    Browser->>Rails: GET page
-    Rails->>Renderer: streaming render request
-    Renderer->>Renderer: renderToPipeableStream() — onShellReady
-    Renderer-->>Rails: HTML shell chunk
-    Rails-->>Browser: shell paints immediately (fast TTFB)
-    loop each Suspense boundary resolves
-        Renderer-->>Rails: length-prefixed HTML chunk
-        Rails-->>Browser: append chunk — progressive paint + selective hydration
+    Browser->>Rails: Ask for a page
+    Rails->>Renderer: Start rendering the page
+    Renderer-->>Rails: First HTML piece
+    Rails-->>Browser: Browser can paint right away
+    loop more page parts become ready
+        Renderer-->>Rails: Next HTML piece
+        Rails-->>Browser: Browser adds it to the page
     end
 ```
 
@@ -63,21 +61,15 @@ sequenceDiagram
     participant Browser
     participant Rails
     participant Renderer as Node Renderer
-    Note over Renderer: per-request sharedExecutionContext (isolated)
-    Browser->>Rails: GET page
-    Rails->>Renderer: open incremental-render NDJSON stream<br/>first line: renderingRequest
-    Renderer->>Renderer: render begins — a Server Component awaits getReactOnRailsAsyncProp('users')
-    Renderer-->>Rails: HTML shell + Suspense fallbacks
-    Rails-->>Browser: stream shell + fallbacks
-    loop each prop resolves in Rails (emit.call)
-        Rails->>Renderer: NDJSON updateChunk — resolve async-prop Promise
-        Renderer->>Renderer: Promise resolves in sharedExecutionContext — React continues
-        Renderer-->>Rails: flush that boundary's HTML
-        Rails-->>Browser: append boundary HTML
+    Browser->>Rails: Ask for a page
+    Rails->>Renderer: Start page with placeholders
+    Renderer-->>Rails: HTML shell + loading states
+    Rails-->>Browser: Browser shows the shell
+    loop each slow data value becomes ready
+        Rails->>Renderer: Send the data value
+        Renderer-->>Rails: HTML for that page section
+        Rails-->>Browser: Browser replaces the loading state
     end
-    Rails->>Renderer: close stream (END_STREAM)
-    Renderer->>Renderer: reject any unresolved async props
-    Rails-->>Browser: remaining Suspense boundaries stay on fallback
 ```
 
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
@@ -102,15 +94,15 @@ For contrast, a Server Component _can_ reach Rails by calling `fetch` itself. Th
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Renderer as Node Renderer VM
+    participant Renderer as Node Renderer
     participant Rails as Rails API
-    participant Data as Rails data layer
-    Note over Renderer: discouraged — see caveats below
-    Renderer->>Rails: fetch('/api/...') — network hop, not in-process access
-    Rails->>Data: handle request (auth, cache, services, database)
-    Data-->>Rails: JSON-ready data
-    Rails-->>Renderer: JSON
-    Renderer->>Renderer: continue rendering
+    participant Data as Rails data
+    Note over Renderer: Discouraged — usually let Rails pass the data instead
+    Renderer->>Rails: Ask Rails API for data
+    Rails->>Data: Load and authorize data
+    Data-->>Rails: Data
+    Rails-->>Renderer: JSON data
+    Renderer->>Renderer: Continue rendering
 ```
 
 Caveats: `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal` are **not** in the VM by default (bundle an HTTP client or inject them via [runtime globals](../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc)); cookies, auth, session, and CSRF are **not** forwarded automatically; and it bypasses Rails' authorization and caching layers.

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -273,14 +273,14 @@ To render more of the page progressively, add an async prop and a `<Suspense>` b
 
 ## Progressive Data with Async Props
 
-Streaming SSR sends HTML as React renders it. **Async props** (a React Server Components feature, so it requires `enable_rsc_support`) go one step further: Rails emits each prop _as its data becomes ready_ and streams the matching Suspense boundary to the browser the moment it resolves.
+Streaming SSR sends HTML as React renders it. **Async props** (a React Server Components feature, so it requires `enable_rsc_support`) go one step further: Rails emits each prop _as its data becomes ready_ and forwards the matching Suspense boundary to the browser the moment it resolves.
 
 This is the recommended answer to "my component needs Rails data during render": **Rails owns the data and pushes it in**, preserving your controller / model / authorization / caching layers — the renderer never has to call back into Rails.
 
 > [!NOTE]
 > A Server Component _can_ `fetch` a Rails API directly, but the renderer's VM has no `fetch`, `Headers`, `Request`, or `Response` by default — you must bundle an HTTP client or inject them via `additionalContext` — and doing so bypasses Rails' auth and caching. `'use server'` Server Actions are **not** supported (the renderer has no DB/session/cookie access). Prefer props / async props. See [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
 
-Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML:
+Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML back to Rails for forwarding to the browser:
 
 ```mermaid
 sequenceDiagram
@@ -292,11 +292,13 @@ sequenceDiagram
     Browser->>Rails: GET page
     Rails->>Renderer: open incremental-render NDJSON stream<br/>first line: renderingRequest
     Renderer->>Renderer: render begins — a Server Component awaits getReactOnRailsAsyncProp('users')
-    Renderer-->>Browser: HTML shell + Suspense fallbacks stream out
+    Renderer-->>Rails: HTML shell + Suspense fallbacks
+    Rails-->>Browser: stream shell + fallbacks
     loop each prop resolves in Rails (emit.call)
         Rails->>Renderer: NDJSON updateChunk — asyncPropsManager.setProp('users', ...)
         Renderer->>Renderer: resolve Promise in sharedExecutionContext — React continues
-        Renderer-->>Browser: flush that boundary's HTML
+        Renderer-->>Rails: flush that boundary's HTML
+        Rails-->>Browser: append boundary HTML
     end
     Rails->>Renderer: close stream (END_STREAM)
     Renderer->>Renderer: asyncPropsManager.endStream() — any unresolved props reject

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -291,7 +291,7 @@ sequenceDiagram
     Note over Renderer: per-request sharedExecutionContext (isolated)
     Browser->>Rails: GET page
     Rails->>Renderer: open incremental-render NDJSON stream<br/>first line: renderingRequest
-    Renderer->>Renderer: render begins; a Server Component awaits getReactOnRailsAsyncProp('users')
+    Renderer->>Renderer: render begins — a Server Component awaits getReactOnRailsAsyncProp('users')
     Renderer-->>Browser: HTML shell + Suspense fallbacks stream out
     loop each prop resolves in Rails (emit.call)
         Rails->>Renderer: NDJSON updateChunk — asyncPropsManager.setProp('users', ...)

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -285,20 +285,21 @@ Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer
 ```mermaid
 sequenceDiagram
     autonumber
+    participant Browser
     participant Rails
     participant Renderer as Node Renderer
-    participant Browser
     Note over Renderer: per-request sharedExecutionContext (isolated)
-    Rails->>Renderer: open bidirectional HTTP/2 NDJSON stream<br/>first line: renderingRequest
-    Renderer->>Renderer: render begins; a Server Component awaits an async-prop Promise
+    Browser->>Rails: GET page
+    Rails->>Renderer: open incremental-render NDJSON stream<br/>first line: renderingRequest
+    Renderer->>Renderer: render begins; a Server Component awaits getReactOnRailsAsyncProp('users')
     Renderer-->>Browser: HTML shell + Suspense fallbacks stream out
     loop each prop resolves in Rails (emit.call)
         Rails->>Renderer: NDJSON updateChunk — asyncPropsManager.setProp('users', ...)
-        Renderer->>Renderer: resolve Promise — React continues rendering
+        Renderer->>Renderer: resolve Promise in sharedExecutionContext — React continues
         Renderer-->>Browser: flush that boundary's HTML
     end
     Rails->>Renderer: close stream (END_STREAM)
-    Renderer->>Renderer: asyncPropsManager.endStream()
+    Renderer->>Renderer: asyncPropsManager.endStream() — any unresolved props reject
 ```
 
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
@@ -311,6 +312,26 @@ The view helper is `stream_react_component_with_async_props`, which yields an em
 ```
 
 For the full data-fetching guidance — synchronous props, parallelizing independent queries, and React Query / SWR interop — see [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
+
+### The discouraged alternative: direct `fetch` from the renderer
+
+For contrast, a Server Component _can_ reach Rails by calling `fetch` itself. This is a plain **network round-trip** — the renderer's VM has no in-process access to Rails models, sessions, or cookies — and it gives up what async props provide for free, so prefer async props for Rails-owned data:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Renderer as Node Renderer VM
+    participant Rails as Rails API
+    participant DB
+    Note over Renderer: discouraged — see caveats below
+    Renderer->>Rails: fetch('/api/...') — network hop, not in-process access
+    Rails->>DB: query (no shared session/auth context)
+    DB-->>Rails: rows
+    Rails-->>Renderer: JSON
+    Renderer->>Renderer: continue rendering
+```
+
+Caveats: `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal` are **not** in the VM by default (bundle an HTTP client or inject them via [runtime globals](../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc)); cookies, auth, session, and CSRF are **not** forwarded automatically; and it bypasses Rails' authorization and caching layers.
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -46,6 +46,70 @@ sequenceDiagram
 - Node Renderer running (streaming requires Node.js, not ExecJS)
 - For async props (streaming each slow prop independently): React Server Components enabled — `config.enable_rsc_support = true`
 
+## Progressive Data with Async Props
+
+Streaming SSR sends HTML as React renders it. **Async props** (a React Server Components feature, so it requires `enable_rsc_support`) go one step further: Rails emits each prop _as its data becomes ready_ and forwards the matching Suspense boundary to the browser the moment it resolves.
+
+This is the recommended answer to "my component needs Rails data during render": **Rails owns the data and pushes it in**, preserving your controller / model / authorization / caching layers — the renderer never has to call back into Rails.
+
+> [!NOTE]
+> A Server Component _can_ `fetch` a Rails API directly, but the renderer's VM has no `fetch`, `Headers`, `Request`, or `Response` by default — you must bundle an HTTP client or inject them via `additionalContext` — and doing so bypasses Rails' auth and caching. `'use server'` Server Actions are **not** supported (the renderer has no DB/session/cookie access). Prefer props / async props. See [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
+
+Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML back to Rails for forwarding to the browser:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Browser
+    participant Rails
+    participant Renderer as Node Renderer
+    Note over Renderer: per-request sharedExecutionContext (isolated)
+    Browser->>Rails: GET page
+    Rails->>Renderer: open incremental-render NDJSON stream<br/>first line: renderingRequest
+    Renderer->>Renderer: render begins — a Server Component awaits getReactOnRailsAsyncProp('users')
+    Renderer-->>Rails: HTML shell + Suspense fallbacks
+    Rails-->>Browser: stream shell + fallbacks
+    loop each prop resolves in Rails (emit.call)
+        Rails->>Renderer: NDJSON updateChunk — resolve async-prop Promise
+        Renderer->>Renderer: Promise resolves in sharedExecutionContext — React continues
+        Renderer-->>Rails: flush that boundary's HTML
+        Rails-->>Browser: append boundary HTML
+    end
+    Rails->>Renderer: close stream (END_STREAM)
+    Renderer->>Renderer: reject any unresolved async props
+```
+
+The view helper is `stream_react_component_with_async_props`, which yields an emitter:
+
+```erb
+<%= stream_react_component_with_async_props("Dashboard") do |emit|
+      emit.call("users", User.active.limit(50).as_json(only: [:id, :name]))
+      emit.call("posts", Post.recent.limit(20).as_json(only: [:id, :title]))
+    end %>
+```
+
+For the full data-fetching guidance — synchronous props, parallelizing independent queries, and React Query / SWR interop — see [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
+
+### The discouraged alternative: direct `fetch` from the renderer
+
+For contrast, a Server Component _can_ reach Rails by calling `fetch` itself. This is a plain **network round-trip** — the renderer's VM has no in-process access to Rails models, sessions, or cookies — and it gives up what async props provide for free, so prefer async props for Rails-owned data:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Renderer as Node Renderer VM
+    participant Rails as Rails API
+    participant Data as Rails data layer
+    Note over Renderer: discouraged — see caveats below
+    Renderer->>Rails: fetch('/api/...') — network hop, not in-process access
+    Rails->>Data: handle request (auth, cache, services, database)
+    Data-->>Rails: JSON-ready data
+    Rails-->>Renderer: JSON
+    Renderer->>Renderer: continue rendering
+```
+
+Caveats: `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal` are **not** in the VM by default (bundle an HTTP client or inject them via [runtime globals](../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc)); cookies, auth, session, and CSRF are **not** forwarded automatically; and it bypasses Rails' authorization and caching layers.
+
 ## Implementation Steps
 
 > **This example uses async props**, which build on React Server Components. Enable RSC before you start: set `config.enable_rsc_support = true` in your React on Rails Pro configuration (see the [RSC tutorial](./react-server-components/tutorial.md)). Without it, the `async function` server component won't render and `stream_react_component_with_async_props` raises `ReactOnRailsPro::Error`. If all your data is fast and you don't need progressive streaming, you can skip RSC and use the synchronous [`stream_react_component`](../oss/migrating/rsc-data-fetching.md#data-fetching-in-react-on-rails-pro) with all props passed at once (no `enable_rsc_support` required).
@@ -270,70 +334,6 @@ For example, with our `MyStreamingComponent`, the sequence is:
 ```
 
 To render more of the page progressively, add an async prop and a `<Suspense>` boundary for each slow section — emit each one from the block as Rails resolves it, and every boundary streams in independently. This keeps the whole page in a single component tree (shared layout, context, and props) rather than splitting it across multiple `stream_react_component` calls.
-
-## Progressive Data with Async Props
-
-Streaming SSR sends HTML as React renders it. **Async props** (a React Server Components feature, so it requires `enable_rsc_support`) go one step further: Rails emits each prop _as its data becomes ready_ and forwards the matching Suspense boundary to the browser the moment it resolves.
-
-This is the recommended answer to "my component needs Rails data during render": **Rails owns the data and pushes it in**, preserving your controller / model / authorization / caching layers — the renderer never has to call back into Rails.
-
-> [!NOTE]
-> A Server Component _can_ `fetch` a Rails API directly, but the renderer's VM has no `fetch`, `Headers`, `Request`, or `Response` by default — you must bundle an HTTP client or inject them via `additionalContext` — and doing so bypasses Rails' auth and caching. `'use server'` Server Actions are **not** supported (the renderer has no DB/session/cookie access). Prefer props / async props. See [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
-
-Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML back to Rails for forwarding to the browser:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Browser
-    participant Rails
-    participant Renderer as Node Renderer
-    Note over Renderer: per-request sharedExecutionContext (isolated)
-    Browser->>Rails: GET page
-    Rails->>Renderer: open incremental-render NDJSON stream<br/>first line: renderingRequest
-    Renderer->>Renderer: render begins — a Server Component awaits getReactOnRailsAsyncProp('users')
-    Renderer-->>Rails: HTML shell + Suspense fallbacks
-    Rails-->>Browser: stream shell + fallbacks
-    loop each prop resolves in Rails (emit.call)
-        Rails->>Renderer: NDJSON updateChunk — asyncPropsManager.setProp('users', ...)
-        Renderer->>Renderer: resolve Promise in sharedExecutionContext — React continues
-        Renderer-->>Rails: flush that boundary's HTML
-        Rails-->>Browser: append boundary HTML
-    end
-    Rails->>Renderer: close stream (END_STREAM)
-    Renderer->>Renderer: asyncPropsManager.endStream() — any unresolved props reject
-```
-
-The view helper is `stream_react_component_with_async_props`, which yields an emitter:
-
-```erb
-<%= stream_react_component_with_async_props("Dashboard") do |emit|
-      emit.call("users", User.all.to_a)     # streamed as soon as it's ready
-      emit.call("posts", Post.recent.to_a)  # streamed independently
-    end %>
-```
-
-For the full data-fetching guidance — synchronous props, parallelizing independent queries, and React Query / SWR interop — see [RSC data fetching patterns](../oss/migrating/rsc-data-fetching.md).
-
-### The discouraged alternative: direct `fetch` from the renderer
-
-For contrast, a Server Component _can_ reach Rails by calling `fetch` itself. This is a plain **network round-trip** — the renderer's VM has no in-process access to Rails models, sessions, or cookies — and it gives up what async props provide for free, so prefer async props for Rails-owned data:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Renderer as Node Renderer VM
-    participant Rails as Rails API
-    participant DB
-    Note over Renderer: discouraged — see caveats below
-    Renderer->>Rails: fetch('/api/...') — network hop, not in-process access
-    Rails->>DB: query (no shared session/auth context)
-    DB-->>Rails: rows
-    Rails-->>Renderer: JSON
-    Renderer->>Renderer: continue rendering
-```
-
-Caveats: `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal` are **not** in the VM by default (bundle an HTTP client or inject them via [runtime globals](../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc)); cookies, auth, session, and CSRF are **not** forwarded automatically; and it bypasses Rails' authorization and caching layers.
 
 ## Compression Middleware Compatibility
 


### PR DESCRIPTION
## What

Adds and refines Mermaid diagrams for React on Rails Pro Node Renderer, streaming SSR, and RSC rendering-flow docs.

This PR is docs-only. It now includes the review follow-ups from CodeRabbit, Greptile, and Claude:

- separates server-side cache layers from request-scoped deduplication and browser chunk caching
- clarifies that cold bundle uploads seed the on-disk bundle cache before execution without implying a second cache probe
- normalizes HTTP/2 multiplexing labels and request numbering in the concurrency diagram
- fixes the OpenTelemetry span order so `ror.vm.execute` precedes `ror.result.prepare`
- adds prose for the warm-path OTel span order
- styles all nodes in the OTel span diagram consistently
- styles the RSC rendering-flow `Hydrate` node consistently with the browser-side nodes
- clarifies the RSC flowchart response as a streamed HTML + RSC payload response
- moves the async-props visual overview before the detailed implementation walkthrough
- changes the async-props example to scoped, limited, JSON-serializable values
- cross-links the async-props example to the parallel fan-out pattern for multiple independent slow sources
- notes the browser-visible fallback behavior when unresolved async props are rejected
- avoids internal `asyncPropsManager` names in public diagram labels
- softens the discouraged direct-`fetch` diagram to use a generic Rails data layer instead of a direct DB-only path

## Why

`docs/pro/node-renderer.md` explains an architectural topic that is easier to understand visually: in-process ExecJS versus the out-of-process Node service, streaming, RSC, async data, caching, concurrency, and tracing.

The review follow-ups keep those visuals accurate enough to copy into docs without teaching misleading cache dependencies or unsafe data-loading examples.

## Verification

- `pnpm --filter react-on-rails-pro run build`
- `(cd react_on_rails && bundle exec rubocop)`
- `pnpm run eslint .`
- `pnpm exec prettier --check docs/pro/node-renderer.md docs/pro/streaming-ssr.md docs/pro/react-server-components/rendering-flow.md`
- `script/check-docs-sidebar`
- `bin/check-links`
- `git diff --check`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`
- pre-commit hook: trailing newlines, offline markdown links, Prettier on changed files

Note: `pnpm start format.listDifferent` checks ignored local `.context/` workspace files and failed on pre-existing `.context` formatting only. The tracked docs touched by this PR pass the focused Prettier check and the pre-commit Prettier hook.

## CI Labels

Labels: none. This is a docs-only PR with no runtime, build, generator, dependency, lockfile, SSR, or hydration behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-only changes; no runtime, build, or application code paths are modified.
> 
> **Overview**
> **Docs-only** expansion of Pro architecture guides with Mermaid flowcharts and sequence diagrams, plus tighter prose so the visuals match how the system actually behaves.
> 
> **`docs/pro/node-renderer.md`** now contrasts ExecJS vs the out-of-process renderer, worker-pool concurrency (including per-request `sharedExecutionContext`), a layered cache decision tree (Rails fragment/prerender vs renderer memory/disk vs side-path dedup/browser chunks), cold-start 410→upload→retry vs warm render, and OpenTelemetry span nesting with corrected warm-path order (`build_execution_context` → `vm.execute` → `result.prepare`). **Further Reading** adds links to streaming SSR, RSC rendering flow, and RSC data fetching.
> 
> **`docs/pro/streaming-ssr.md`** adds diagrams for progressive HTML streaming, **async props** (Rails-owned data over HTTP/2 NDJSON), and the discouraged renderer→Rails `fetch` path. A new **Progressive Data with Async Props** section (before the step-by-step walkthrough) documents `stream_react_component_with_async_props`, scoped JSON-serializable `emit.call` examples, and parallel fan-out cross-links.
> 
> **`docs/pro/react-server-components/rendering-flow.md`** adds an RSC vs plain SSR flowchart, simplifies numbered steps and the sequence diagram (Rails as hop, clearer payload/stream wording), and notes that hydration no longer needs a separate RSC payload request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114dfe7735bab7db963dd49389ceb54244db857a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->