### PR TITLE
Bump Shakapacker 9.6.1 to 10.1.0 in spec dummy apps

### DIFF
--- a/.github/workflows/check-markdown-links.yml
+++ b/.github/workflows/check-markdown-links.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
-          node-version: '22.11.0'
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
+          node-version: '22.12.0'
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Install Node modules with pnpm
@@ -126,9 +126,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -112,9 +112,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -212,9 +212,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -399,9 +399,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -111,9 +111,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -212,9 +212,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -317,9 +317,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Pin to 22.11.0 (LTS) to avoid V8 bug in 22.21.0
+          # Pin to 22.12.0 (Shakapacker 10.1 floor) to avoid V8 bug in 22.21.0
           # https://github.com/nodejs/node/issues/56010
-          node-version: '22.11.0'
+          node-version: '22.12.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,10 +114,10 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-config-shakacode:
         specifier: ^19.0.0
-        version: 19.0.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+        version: 19.0.0(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-import-resolver-alias:
         specifier: ^1.1.2
-        version: 1.1.2(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))
+        version: 1.1.2(eslint-plugin-import@2.32.0)
       eslint-import-resolver-typescript:
         specifier: ^4.3.2
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
@@ -420,13 +420,13 @@ importers:
         version: 4.18.1
       mini-css-extract-plugin:
         specifier: ^2.4.4
-        version: 2.10.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 2.10.0(webpack@5.105.2)
       node-libs-browser:
         specifier: ^2.2.1
         version: 2.2.1
       null-loader:
         specifier: ^4.0.0
-        version: 4.0.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 4.0.1(webpack@5.105.2)
       prop-types:
         specifier: ^15.7.2
         version: 15.8.1
@@ -472,7 +472,7 @@ importers:
         version: 1.58.2
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.1
-        version: 0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)))(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@5.2.4)(webpack@5.105.2)
       '@rescript/react':
         specifier: ^0.13.0
         version: 0.13.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -487,25 +487,25 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       babel-loader:
         specifier: 8.2.4
-        version: 8.2.4(@babel/core@7.28.5)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 8.2.4(@babel/core@7.28.5)(webpack@5.105.2)
       babel-plugin-transform-react-remove-prop-types:
         specifier: ^0.4.24
         version: 0.4.24
       compression-webpack-plugin:
         specifier: '9'
-        version: 9.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 9.2.0(webpack@5.105.2)
       css-loader:
         specifier: ^6.5.1
-        version: 6.11.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 6.11.0(webpack@5.105.2)
       expose-loader:
         specifier: ^1.0.3
-        version: 1.0.3(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 1.0.3(webpack@5.105.2)
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 6.2.0(webpack@5.105.2)
       imports-loader:
         specifier: ^1.2.0
-        version: 1.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 1.2.0(webpack@5.105.2)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
@@ -523,31 +523,31 @@ importers:
         version: 1.97.3
       sass-loader:
         specifier: ^12.3.0
-        version: 12.6.0(sass@1.97.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 12.6.0(sass@1.97.3)(webpack@5.105.2)
       sass-resources-loader:
         specifier: ^2.1.0
         version: 2.2.5
       shakapacker:
-        specifier: 9.6.1
-        version: 9.6.1(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(compression-webpack-plugin@9.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(css-loader@6.11.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(mini-css-extract-plugin@2.10.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-assets-manifest@5.2.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        specifier: 10.1.0
+        version: 10.1.0(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.105.2))(compression-webpack-plugin@9.2.0(webpack@5.105.2))(css-loader@6.11.0(webpack@5.105.2))(mini-css-extract-plugin@2.10.0(webpack@5.105.2))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.105.2))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.105.2))(webpack-assets-manifest@5.2.1(webpack@5.105.2))(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2)
       style-loader:
         specifier: ^3.3.1
-        version: 3.3.4(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 3.3.4(webpack@5.105.2)
       swc-loader:
         specifier: ^0.2.6
-        version: 0.2.6(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 0.2.6(@swc/core@1.15.3)(webpack@5.105.2)
       terser-webpack-plugin:
         specifier: 5.3.1
-        version: 5.3.1(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.3.1(@swc/core@1.15.3)(webpack@5.105.2)
       url-loader:
         specifier: ^4.0.0
-        version: 4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.105.2))(webpack@5.105.2)
       webpack:
         specifier: ^5.104.1
         version: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-assets-manifest:
         specifier: '5'
-        version: 5.2.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.2.1(webpack@5.105.2)
       webpack-cli:
         specifier: ^6.0.1
         version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
@@ -598,7 +598,7 @@ importers:
         version: 5.16.7(@loadable/component@5.16.7(react@19.2.3))(react@19.2.3)
       '@loadable/webpack-plugin':
         specifier: ^5.15.2
-        version: 5.15.2(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.15.2(webpack@5.104.1)
       '@sentry/node':
         specifier: ^7.120.0
         version: 7.120.4
@@ -616,7 +616,7 @@ importers:
         version: 10.4.24(postcss@8.5.15)
       babel-loader:
         specifier: '8'
-        version: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1)
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -628,7 +628,7 @@ importers:
         version: 0.4.24
       compression-webpack-plugin:
         specifier: '9'
-        version: 9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 9.2.0(webpack@5.104.1)
       core-js:
         specifier: '3'
         version: 3.48.0
@@ -640,19 +640,19 @@ importers:
         version: 3.2.0
       css-loader:
         specifier: ^6.5.1
-        version: 6.11.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 6.11.0(webpack@5.104.1)
       css-minimizer-webpack-plugin:
         specifier: ^3.1.4
-        version: 3.4.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 3.4.1(webpack@5.104.1)
       es5-shim:
         specifier: ^4.5.9
         version: 4.6.7
       expose-loader:
         specifier: 1.0.3
-        version: 1.0.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 1.0.3(webpack@5.104.1)
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 6.2.0(webpack@5.104.1)
       graphql:
         specifier: ^16.8.1
         version: 16.12.0
@@ -661,13 +661,13 @@ importers:
         version: 4.10.1
       imports-loader:
         specifier: ^1.2.0
-        version: 1.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 1.2.0(webpack@5.104.1)
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
       mini-css-extract-plugin:
         specifier: ^2.4.5
-        version: 2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 2.10.0(webpack@5.104.1)
       moment:
         specifier: ^2.29.4
         version: 2.30.1
@@ -685,7 +685,7 @@ importers:
         version: 8.5.15
       postcss-loader:
         specifier: ^7.1.0
-        version: 7.3.4(postcss@8.5.15)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 7.3.4(postcss@8.5.15)(typescript@5.9.3)(webpack@5.104.1)
       prop-types:
         specifier: ^15.7.2
         version: 15.8.1
@@ -706,7 +706,7 @@ importers:
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
         specifier: ^19.0.4
-        version: 19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -733,37 +733,37 @@ importers:
         version: 1.97.3
       sass-loader:
         specifier: ^12.3.0
-        version: 12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 12.6.0(sass@1.97.3)(webpack@5.104.1)
       sass-resources-loader:
         specifier: ^2.0.0
         version: 2.2.5
       shakapacker:
-        specifier: 9.6.1
-        version: 9.6.1(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(compression-webpack-plugin@9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(css-loader@6.11.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(mini-css-extract-plugin@2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-assets-manifest@5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        specifier: 10.1.0
+        version: 10.1.0(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1))(compression-webpack-plugin@9.2.0(webpack@5.104.1))(css-loader@6.11.0(webpack@5.104.1))(mini-css-extract-plugin@2.10.0(webpack@5.104.1))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1))(webpack-assets-manifest@5.2.1(webpack@5.104.1))(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1)
       style-loader:
         specifier: ^3.3.1
-        version: 3.3.4(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 3.3.4(webpack@5.104.1)
       tailwindcss:
         specifier: ^3.2.7
         version: 3.4.19(yaml@2.8.3)
       terser-webpack-plugin:
         specifier: '5'
-        version: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1)
       turbolinks:
         specifier: ^5.2.0
         version: 5.2.0
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 4.1.1(file-loader@6.2.0(webpack@5.104.1))(webpack@5.104.1)
       webpack:
         specifier: '5'
         version: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-assets-manifest:
         specifier: '5'
-        version: 5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.2.1(webpack@5.104.1)
       webpack-manifest-plugin:
         specifier: ^2.0.4
-        version: 2.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 2.2.0(webpack@5.104.1)
       webpack-merge:
         specifier: '5'
         version: 5.10.0
@@ -800,7 +800,7 @@ importers:
         version: 13.1.2
       preload-webpack-plugin:
         specifier: ^3.0.0-alpha.1
-        version: 3.0.0-beta.4(html-webpack-plugin@5.6.6(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 3.0.0-beta.4(html-webpack-plugin@5.6.6(webpack@5.104.1))(webpack@5.104.1)
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -833,10 +833,10 @@ importers:
         version: 7.20.5
       '@types/webpack':
         specifier: '5'
-        version: 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))
+        version: 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
       babel-loader:
         specifier: '8'
-        version: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1)
       babel-plugin-macros:
         specifier: ^3.1.0
         version: 3.1.0
@@ -845,16 +845,16 @@ importers:
         version: 0.4.24
       compression-webpack-plugin:
         specifier: '9'
-        version: 9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 9.2.0(webpack@5.104.1)
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 7.1.3(webpack@5.104.1)
       css-minimizer-webpack-plugin:
         specifier: ^7.0.0
-        version: 7.0.4(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 7.0.4(webpack@5.104.1)
       mini-css-extract-plugin:
         specifier: ^2.9.0
-        version: 2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 2.10.0(webpack@5.104.1)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -868,20 +868,20 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails
       shakapacker:
-        specifier: 9.6.1
-        version: 9.6.1(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(compression-webpack-plugin@9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(css-loader@7.1.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(mini-css-extract-plugin@2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-assets-manifest@5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        specifier: 10.1.0
+        version: 10.1.0(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1))(compression-webpack-plugin@9.2.0(webpack@5.104.1))(css-loader@7.1.3(webpack@5.104.1))(mini-css-extract-plugin@2.10.0(webpack@5.104.1))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1))(webpack-assets-manifest@5.2.1(webpack@5.104.1))(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1)
       style-loader:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 4.0.0(webpack@5.104.1)
       terser-webpack-plugin:
         specifier: '5'
-        version: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1)
       webpack:
         specifier: '5'
         version: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-assets-manifest:
         specifier: '5'
-        version: 5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 5.2.1(webpack@5.104.1)
       webpack-cli:
         specifier: ^6.0.1
         version: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
@@ -891,7 +891,7 @@ importers:
     devDependencies:
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.15
-        version: 0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+        version: 0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4)(webpack@5.104.1)
       react-refresh:
         specifier: ^0.14.2
         version: 0.14.2
@@ -2616,24 +2616,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.3':
     resolution: {integrity: sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.3':
     resolution: {integrity: sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.3':
     resolution: {integrity: sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.3':
     resolution: {integrity: sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==}
@@ -6499,6 +6503,16 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  pack-config-diff@0.1.0:
+    resolution: {integrity: sha512-gx60G4pnT4GFQ7WECdf7SCq9vdsvBhodLXXzwisy37/t0zkAZ3hMgLCdOGivudF1l0gcLZhIWVYreS89be15QA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      ts-node: '>=10'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+
   package-manager-detector@1.5.0:
     resolution: {integrity: sha512-uBj69dVlYe/+wxj8JOpr97XfsxH/eumMt6HqjNTmJDf/6NO9s+0uxeOneIz3AsPt2m6y9PqzDzd3ATcU17MNfw==}
 
@@ -7667,24 +7681,25 @@ packages:
     engines: {node: '>= 0.10'}
     hasBin: true
 
-  shakapacker@9.6.1:
-    resolution: {integrity: sha512-xE1RAm6c1C6o1Erj+8Iih/WqmauKpcGUiZ2t8NJRBlKmOypvWpyk+h2DQ3u02ii3aiOYlDDSboJMk/yzmaIOPA==}
-    engines: {node: '>= 20', yarn: '>=1 <5'}
+  shakapacker@10.1.0:
+    resolution: {integrity: sha512-FMo4nXpM21rZyNNhXt5jn/rm40olFF1udWC0BPE9QO9QVY6utJAEv1bkKhM/mXY/k3/nDT8ur8B3ZcEs+HoLFg==}
+    engines: {node: ^20.19.0 || >=22.12.0, yarn: '>=1 <5'}
+    hasBin: true
     peerDependencies:
       '@babel/core': ^7.17.9
       '@babel/plugin-transform-runtime': ^7.17.0
       '@babel/preset-env': ^7.16.11
       '@babel/runtime': ^7.17.9
-      '@rspack/cli': ^1.0.0
-      '@rspack/core': ^1.0.0
-      '@rspack/plugin-react-refresh': ^1.0.0
+      '@rspack/cli': ^1.0.0 || ^2.0.0-0
+      '@rspack/core': ^1.0.0 || ^2.0.0-0
+      '@rspack/plugin-react-refresh': ^1.0.0 || ^2.0.0
       '@swc/core': ^1.3.0
       '@types/babel__core': ^7.0.0
       '@types/webpack': ^5.0.0
       babel-loader: ^8.2.4 || ^9.0.0 || ^10.0.0
       compression-webpack-plugin: ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
       css-loader: ^6.8.1 || ^7.0.0
-      esbuild: ^0.14.0 || ^0.15.0 || ^0.16.0 || ^0.17.0 || ^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0
+      esbuild: '>=0.14.0 <1.0.0'
       esbuild-loader: ^2.0.0 || ^3.0.0 || ^4.0.0
       mini-css-extract-plugin: ^2.0.0
       rspack-manifest-plugin: ^5.0.0
@@ -7692,10 +7707,10 @@ packages:
       sass-loader: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
       swc-loader: ^0.1.15 || ^0.2.0
       terser-webpack-plugin: ^5.3.1
-      webpack: ^5.76.0
+      webpack: ^5.101.0
       webpack-assets-manifest: ^5.0.6 || ^6.0.0
-      webpack-cli: ^4.9.2 || ^5.0.0 || ^6.0.0
-      webpack-dev-server: ^4.15.2 || ^5.2.2
+      webpack-cli: ^4.9.2 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      webpack-dev-server: ^5.2.2
       webpack-subresource-integrity: ^5.1.0
     peerDependenciesMeta:
       '@babel/core':
@@ -10347,7 +10362,7 @@ snapshots:
       lodash: 4.18.1
       react: 19.2.3
 
-  '@loadable/webpack-plugin@5.15.2(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@loadable/webpack-plugin@5.15.2(webpack@5.104.1)':
     dependencies:
       make-dir: 3.1.0
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
@@ -10724,23 +10739,7 @@ snapshots:
     dependencies:
       playwright: 1.58.2
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))':
-    dependencies:
-      ansi-html: 0.0.9
-      core-js-pure: 3.48.0
-      error-stack-parser: 2.1.4
-      html-entities: 2.6.0
-      loader-utils: 2.0.4
-      react-refresh: 0.14.2
-      schema-utils: 4.3.3
-      source-map: 0.7.6
-      webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
-    optionalDependencies:
-      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))
-      type-fest: 4.41.0
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
-
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)))(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@5.2.4)(webpack@5.105.2)':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.48.0
@@ -10752,9 +10751,25 @@ snapshots:
       source-map: 0.7.6
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
     optionalDependencies:
-      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
       type-fest: 4.41.0
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2)
+
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@5.2.4)(webpack@5.104.1)':
+    dependencies:
+      ansi-html: 0.0.9
+      core-js-pure: 3.48.0
+      error-stack-parser: 2.1.4
+      html-entities: 2.6.0
+      loader-utils: 2.0.4
+      react-refresh: 0.14.2
+      schema-utils: 4.3.3
+      source-map: 0.7.6
+      webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
+    optionalDependencies:
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
+      type-fest: 4.41.0
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -11287,18 +11302,7 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))':
-    dependencies:
-      '@types/node': 20.19.25
-      tapable: 2.3.0
-      webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))':
+  '@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)':
     dependencies:
       '@types/node': 20.19.25
       tapable: 2.3.0
@@ -11308,7 +11312,6 @@ snapshots:
       - esbuild
       - uglify-js
       - webpack-cli
-    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -11554,34 +11557,34 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
-  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
 
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
 
-  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
 
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1)':
     dependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     optionalDependencies:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
 
-  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))':
+  '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2)':
     dependencies:
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
@@ -11634,10 +11637,6 @@ snapshots:
   acorn-import-phases@1.0.4(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
-
-  acorn-import-phases@1.0.4(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -11897,7 +11896,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 3.3.2
@@ -11906,7 +11905,7 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.105.2):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 3.3.2
@@ -12416,13 +12415,13 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression-webpack-plugin@9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  compression-webpack-plugin@9.2.0(webpack@5.104.1):
     dependencies:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  compression-webpack-plugin@9.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  compression-webpack-plugin@9.2.0(webpack@5.105.2):
     dependencies:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
@@ -12581,7 +12580,7 @@ snapshots:
 
   css-functions-list@3.2.3: {}
 
-  css-loader@6.11.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  css-loader@6.11.0(webpack@5.104.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -12594,7 +12593,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  css-loader@6.11.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  css-loader@6.11.0(webpack@5.105.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -12607,7 +12606,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  css-loader@7.1.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  css-loader@7.1.3(webpack@5.104.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -12620,7 +12619,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  css-minimizer-webpack-plugin@3.4.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  css-minimizer-webpack-plugin@3.4.1(webpack@5.104.1):
     dependencies:
       cssnano: 5.1.15(postcss@8.5.15)
       jest-worker: 27.5.1
@@ -12630,7 +12629,7 @@ snapshots:
       source-map: 0.6.1
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  css-minimizer-webpack-plugin@7.0.4(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  css-minimizer-webpack-plugin@7.0.4(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.2(postcss@8.5.15)
@@ -13183,7 +13182,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.39.1(jiti@2.6.1)
@@ -13192,10 +13191,10 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -13207,11 +13206,11 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
 
-  eslint-config-shakacode@19.0.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-config-shakacode@19.0.0(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -13225,7 +13224,7 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
     dependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
 
@@ -13252,7 +13251,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -13274,7 +13273,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13510,13 +13509,13 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expose-loader@1.0.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  expose-loader@1.0.3(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  expose-loader@1.0.3(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  expose-loader@1.0.3(webpack@5.105.2):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -13669,13 +13668,13 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  file-loader@6.2.0(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  file-loader@6.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  file-loader@6.2.0(webpack@5.105.2):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -14060,7 +14059,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.6(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  html-webpack-plugin@5.6.6(webpack@5.104.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -14203,7 +14202,7 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
-  imports-loader@1.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  imports-loader@1.2.0(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -14211,7 +14210,7 @@ snapshots:
       strip-comments: 2.0.1
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  imports-loader@1.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  imports-loader@1.2.0(webpack@5.105.2):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -15268,13 +15267,13 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  mini-css-extract-plugin@2.10.0(webpack@5.104.1):
     dependencies:
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.3
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  mini-css-extract-plugin@2.10.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  mini-css-extract-plugin@2.10.0(webpack@5.105.2):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -15432,7 +15431,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  null-loader@4.0.1(webpack@5.105.2):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -15610,6 +15609,10 @@ snapshots:
     dependencies:
       degenerator: 5.0.1
       netmask: 2.0.2
+
+  pack-config-diff@0.1.0:
+    dependencies:
+      js-yaml: 4.1.1
 
   package-manager-detector@1.5.0: {}
 
@@ -15857,7 +15860,7 @@ snapshots:
       postcss: 8.5.15
       yaml: 2.8.3
 
-  postcss-loader@7.3.4(postcss@8.5.15)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  postcss-loader@7.3.4(postcss@8.5.15)(typescript@5.9.3)(webpack@5.104.1):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.9.3)
       jiti: 1.21.7
@@ -16184,9 +16187,9 @@ snapshots:
       is-object: 1.0.2
       starts-with: 1.0.2
 
-  preload-webpack-plugin@3.0.0-beta.4(html-webpack-plugin@5.6.6(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  preload-webpack-plugin@3.0.0-beta.4(html-webpack-plugin@5.6.6(webpack@5.104.1))(webpack@5.104.1):
     dependencies:
-      html-webpack-plugin: 5.6.6(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      html-webpack-plugin: 5.6.6(webpack@5.104.1)
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
   prelude-ls@1.2.1: {}
@@ -16404,7 +16407,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  react-on-rails-rsc@19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -16677,7 +16680,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
@@ -16685,7 +16688,7 @@ snapshots:
     optionalDependencies:
       sass: 1.97.3
 
-  sass-loader@12.6.0(sass@1.97.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  sass-loader@12.6.0(sass@1.97.3)(webpack@5.105.2):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
@@ -16846,9 +16849,10 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
 
-  ? shakapacker@9.6.1(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(compression-webpack-plugin@9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(css-loader@6.11.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(mini-css-extract-plugin@2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-assets-manifest@5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-  : dependencies:
+  shakapacker@10.1.0(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1))(compression-webpack-plugin@9.2.0(webpack@5.104.1))(css-loader@6.11.0(webpack@5.104.1))(mini-css-extract-plugin@2.10.0(webpack@5.104.1))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1))(webpack-assets-manifest@5.2.1(webpack@5.104.1))(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1):
+    dependencies:
       js-yaml: 4.1.1
+      pack-config-diff: 0.1.0
       path-complete-extname: 1.0.0
       webpack-merge: 5.10.0
       yargs: 17.7.2
@@ -16859,23 +16863,26 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@swc/core': 1.15.3
       '@types/babel__core': 7.20.5
-      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))
-      babel-loader: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      compression-webpack-plugin: 9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      css-loader: 6.11.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      mini-css-extract-plugin: 2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
+      babel-loader: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1)
+      compression-webpack-plugin: 9.2.0(webpack@5.104.1)
+      css-loader: 6.11.0(webpack@5.104.1)
+      mini-css-extract-plugin: 2.10.0(webpack@5.104.1)
       sass: 1.97.3
-      sass-loader: 12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      swc-loader: 0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      terser-webpack-plugin: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      sass-loader: 12.6.0(sass@1.97.3)(webpack@5.104.1)
+      swc-loader: 0.2.6(@swc/core@1.15.3)(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1)
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
-      webpack-assets-manifest: 5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      webpack-assets-manifest: 5.2.1(webpack@5.104.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
+    transitivePeerDependencies:
+      - ts-node
 
-  ? shakapacker@9.6.1(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(compression-webpack-plugin@9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(css-loader@7.1.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(mini-css-extract-plugin@2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-assets-manifest@5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-  : dependencies:
+  shakapacker@10.1.0(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.104.1))(compression-webpack-plugin@9.2.0(webpack@5.104.1))(css-loader@7.1.3(webpack@5.104.1))(mini-css-extract-plugin@2.10.0(webpack@5.104.1))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1))(webpack-assets-manifest@5.2.1(webpack@5.104.1))(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1):
+    dependencies:
       js-yaml: 4.1.1
+      pack-config-diff: 0.1.0
       path-complete-extname: 1.0.0
       webpack-merge: 5.10.0
       yargs: 17.7.2
@@ -16886,23 +16893,25 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@swc/core': 1.15.3
       '@types/babel__core': 7.20.5
-      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))
-      babel-loader: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      compression-webpack-plugin: 9.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      css-loader: 7.1.3(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      mini-css-extract-plugin: 2.10.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
+      babel-loader: 8.2.4(@babel/core@7.28.5)(webpack@5.104.1)
+      compression-webpack-plugin: 9.2.0(webpack@5.104.1)
+      css-loader: 7.1.3(webpack@5.104.1)
+      mini-css-extract-plugin: 2.10.0(webpack@5.104.1)
       sass: 1.97.3
-      sass-loader: 12.6.0(sass@1.97.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      swc-loader: 0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      terser-webpack-plugin: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      swc-loader: 0.2.6(@swc/core@1.15.3)(webpack@5.104.1)
+      terser-webpack-plugin: 5.3.1(@swc/core@1.15.3)(webpack@5.104.1)
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
-      webpack-assets-manifest: 5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      webpack-assets-manifest: 5.2.1(webpack@5.104.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1)
+    transitivePeerDependencies:
+      - ts-node
 
-  ? shakapacker@9.6.1(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(compression-webpack-plugin@9.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(css-loader@6.11.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(mini-css-extract-plugin@2.10.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-assets-manifest@5.2.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-  : dependencies:
+  shakapacker@10.1.0(@babel/core@7.28.5)(@babel/plugin-transform-runtime@7.17.0(@babel/core@7.28.5))(@babel/preset-env@7.28.5(@babel/core@7.28.5))(@babel/runtime@7.28.4)(@swc/core@1.15.3)(@types/babel__core@7.20.5)(@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1))(babel-loader@8.2.4(@babel/core@7.28.5)(webpack@5.105.2))(compression-webpack-plugin@9.2.0(webpack@5.105.2))(css-loader@6.11.0(webpack@5.105.2))(mini-css-extract-plugin@2.10.0(webpack@5.105.2))(sass-loader@12.6.0(sass@1.97.3)(webpack@5.105.2))(sass@1.97.3)(swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2))(terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.105.2))(webpack-assets-manifest@5.2.1(webpack@5.105.2))(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2):
+    dependencies:
       js-yaml: 4.1.1
+      pack-config-diff: 0.1.0
       path-complete-extname: 1.0.0
       webpack-merge: 5.10.0
       yargs: 17.7.2
@@ -16913,19 +16922,21 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@swc/core': 1.15.3
       '@types/babel__core': 7.20.5
-      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))
-      babel-loader: 8.2.4(@babel/core@7.28.5)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      compression-webpack-plugin: 9.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      css-loader: 6.11.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      mini-css-extract-plugin: 2.10.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
+      babel-loader: 8.2.4(@babel/core@7.28.5)(webpack@5.105.2)
+      compression-webpack-plugin: 9.2.0(webpack@5.105.2)
+      css-loader: 6.11.0(webpack@5.105.2)
+      mini-css-extract-plugin: 2.10.0(webpack@5.105.2)
       sass: 1.97.3
-      sass-loader: 12.6.0(sass@1.97.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      swc-loader: 0.2.6(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      terser-webpack-plugin: 5.3.1(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      sass-loader: 12.6.0(sass@1.97.3)(webpack@5.105.2)
+      swc-loader: 0.2.6(@swc/core@1.15.3)(webpack@5.105.2)
+      terser-webpack-plugin: 5.3.1(@swc/core@1.15.3)(webpack@5.105.2)
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
-      webpack-assets-manifest: 5.2.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      webpack-assets-manifest: 5.2.1(webpack@5.105.2)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2)
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2)
+    transitivePeerDependencies:
+      - ts-node
 
   shallow-clone@3.0.1:
     dependencies:
@@ -17224,15 +17235,15 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  style-loader@3.3.4(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  style-loader@3.3.4(webpack@5.104.1):
     dependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  style-loader@3.3.4(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  style-loader@3.3.4(webpack@5.105.2):
     dependencies:
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  style-loader@4.0.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  style-loader@4.0.0(webpack@5.104.1):
     dependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
@@ -17381,24 +17392,24 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.104.1):
     dependencies:
       '@swc/core': 1.15.3
       '@swc/counter': 0.1.3
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
     optional: true
 
-  swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
-    dependencies:
-      '@swc/core': 1.15.3
-      '@swc/counter': 0.1.3
-      webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
-
   swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       '@swc/core': 1.15.3
       '@swc/counter': 0.1.3
       webpack: 5.105.2(@swc/core@1.15.3)
+
+  swc-loader@0.2.6(@swc/core@1.15.3)(webpack@5.105.2):
+    dependencies:
+      '@swc/core': 1.15.3
+      '@swc/counter': 0.1.3
+      webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
   symbol-observable@4.0.0: {}
 
@@ -17471,7 +17482,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.104.1):
     dependencies:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
@@ -17482,7 +17493,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.3
 
-  terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  terser-webpack-plugin@5.3.1(@swc/core@1.15.3)(webpack@5.105.2):
     dependencies:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
@@ -17493,36 +17504,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.3
 
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 7.0.5
-      terser: 5.48.0
-      webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
-    optionalDependencies:
-      '@swc/core': 1.15.3
-
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 7.0.5
-      terser: 5.48.0
-      webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))
-    optionalDependencies:
-      '@swc/core': 1.15.3
-
-  terser-webpack-plugin@5.3.16(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.3)(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       terser: 5.46.0
-      webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
+      webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.3
 
@@ -17532,8 +17521,19 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      terser: 5.48.0
+      terser: 5.46.0
       webpack: 5.105.2(@swc/core@1.15.3)
+    optionalDependencies:
+      '@swc/core': 1.15.3
+
+  terser-webpack-plugin@5.3.16(@swc/core@1.15.3)(webpack@5.105.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 7.0.5
+      terser: 5.46.0
+      webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.3
 
@@ -17841,23 +17841,23 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.104.1))(webpack@5.104.1):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      file-loader: 6.2.0(webpack@5.104.1)
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.105.2))(webpack@5.105.2):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      file-loader: 6.2.0(webpack@5.105.2)
 
   url-parse@1.5.10:
     dependencies:
@@ -17944,7 +17944,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-assets-manifest@5.2.1(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  webpack-assets-manifest@5.2.1(webpack@5.104.1):
     dependencies:
       chalk: 4.1.2
       deepmerge: 4.3.1
@@ -17955,7 +17955,7 @@ snapshots:
       tapable: 2.3.0
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
 
-  webpack-assets-manifest@5.2.1(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  webpack-assets-manifest@5.2.1(webpack@5.105.2):
     dependencies:
       chalk: 4.1.2
       deepmerge: 4.3.1
@@ -17969,9 +17969,9 @@ snapshots:
   webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.104.1))(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)
+      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.104.1)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.104.1)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -17988,9 +17988,9 @@ snapshots:
   webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2):
     dependencies:
       '@discoveryjs/json-ext': 0.6.3
-      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
-      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2))(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      '@webpack-cli/configtest': 3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)
+      '@webpack-cli/info': 3.0.1(webpack-cli@6.0.1)(webpack@5.105.2)
+      '@webpack-cli/serve': 3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.4)(webpack@5.105.2)
       colorette: 2.0.20
       commander: 12.1.0
       cross-spawn: 7.0.6
@@ -18004,7 +18004,7 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.105.2)
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.104.1):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -18017,7 +18017,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.2):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.2(tslib@2.8.1)
@@ -18058,7 +18058,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.104.1)
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)
@@ -18098,7 +18098,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2)
       ws: 8.21.0
     optionalDependencies:
       webpack: 5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1)
@@ -18110,7 +18110,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-manifest-plugin@2.2.0(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1)):
+  webpack-manifest-plugin@2.2.0(webpack@5.104.1):
     dependencies:
       fs-extra: 7.0.1
       lodash: 4.18.1
@@ -18156,7 +18156,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.3)(webpack@5.104.1(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.3)(webpack@5.104.1)
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -18174,8 +18174,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.19.0
@@ -18189,44 +18189,10 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.3
+      tapable: 2.3.0
       terser-webpack-plugin: 5.3.16(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3))
       watchpack: 2.5.1
       webpack-sources: 3.3.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.19.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)))
-      watchpack: 2.5.1
-      webpack-sources: 3.3.3
-    optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.4)(webpack@5.104.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -18256,7 +18222,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(@swc/core@1.15.3)(webpack@5.105.2(@swc/core@1.15.3)(webpack-cli@6.0.1))
+      terser-webpack-plugin: 5.3.16(@swc/core@1.15.3)(webpack@5.105.2)
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     optionalDependencies:

--- a/react_on_rails/Gemfile.development_dependencies
+++ b/react_on_rails/Gemfile.development_dependencies
@@ -2,7 +2,7 @@
 
 eval_gemfile File.expand_path("../Gemfile.shared_dev_dependencies", __dir__)
 
-gem "shakapacker", "9.6.1"
+gem "shakapacker", "10.1.0"
 gem "bootsnap", require: false
 gem "rails", "~> 7.1.0"
 

--- a/react_on_rails/Gemfile.lock
+++ b/react_on_rails/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -360,7 +360,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.6.1)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -475,7 +475,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   sdoc
   selenium-webdriver (= 4.9.0)
-  shakapacker (= 9.6.1)
+  shakapacker (= 10.1.0)
   simplecov (~> 0.16.1)
   spring (~> 4.0)
   sprockets (~> 4.0)

--- a/react_on_rails/spec/dummy/Gemfile.lock
+++ b/react_on_rails/spec/dummy/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -348,7 +348,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.6.1)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -463,7 +463,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   sdoc
   selenium-webdriver (= 4.9.0)
-  shakapacker (= 9.6.1)
+  shakapacker (= 10.1.0)
   simplecov (~> 0.16.1)
   spring (~> 4.0)
   sprockets (~> 4.0)

--- a/react_on_rails/spec/dummy/package.json
+++ b/react_on_rails/spec/dummy/package.json
@@ -53,7 +53,7 @@
     "sass": "^1.43.4",
     "sass-loader": "^12.3.0",
     "sass-resources-loader": "^2.1.0",
-    "shakapacker": "9.6.1",
+    "shakapacker": "10.1.0",
     "style-loader": "^3.3.1",
     "swc-loader": "^0.2.6",
     "terser-webpack-plugin": "5.3.1",

--- a/react_on_rails_pro/Gemfile.development_dependencies
+++ b/react_on_rails_pro/Gemfile.development_dependencies
@@ -8,7 +8,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "react_on_rails", path: "../"
 
-gem "shakapacker", "9.6.1"
+gem "shakapacker", "10.1.0"
 gem "bootsnap", require: false
 gem "rails", "~> 7.1"
 gem "puma", "~> 6"

--- a/react_on_rails_pro/Gemfile.lock
+++ b/react_on_rails_pro/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -425,7 +425,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.6.1)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -539,7 +539,7 @@ DEPENDENCIES
   sass-rails
   scss_lint
   selenium-webdriver (= 4.9.0)
-  shakapacker (= 9.6.1)
+  shakapacker (= 10.1.0)
   simplecov (~> 0.16.1)
   spring
   spring-watcher-listen

--- a/react_on_rails_pro/spec/dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/dummy/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -455,7 +455,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.6.1)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -589,7 +589,7 @@ DEPENDENCIES
   sass-rails
   scss_lint
   selenium-webdriver (= 4.9.0)
-  shakapacker (= 9.6.1)
+  shakapacker (= 10.1.0)
   simplecov (~> 0.16.1)
   spring
   spring-watcher-listen

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -64,7 +64,7 @@
     "sass": "^1.43.4",
     "sass-loader": "^12.3.0",
     "sass-resources-loader": "^2.0.0",
-    "shakapacker": "9.6.1",
+    "shakapacker": "10.1.0",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.2.7",
     "terser-webpack-plugin": "5",

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
@@ -67,7 +67,7 @@ group :test do
   gem "selenium-webdriver"
 end
 
-gem "shakapacker", "= 9.6.1"
+gem "shakapacker", "= 10.1.0"
 
 gem "react_on_rails", path: "../../.."
 gem "react_on_rails_pro", path: "../.."

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (2.1.1)
       base64 (>= 0.1.0)
@@ -304,7 +304,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.6.1)
+    shakapacker (10.1.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -368,7 +368,7 @@ DEPENDENCIES
   react_on_rails!
   react_on_rails_pro!
   selenium-webdriver
-  shakapacker (= 9.6.1)
+  shakapacker (= 10.1.0)
   sprockets-rails
   sqlite3 (~> 1.4)
   tzinfo-data

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/package.json
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/package.json
@@ -29,7 +29,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-on-rails": "workspace:*",
-    "shakapacker": "9.6.1",
+    "shakapacker": "10.1.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "5",
     "webpack": "5",


### PR DESCRIPTION
## Summary

Prerequisite version bump (**"PR 1"**) that moves all three spec dummy apps to **Shakapacker `10.1.0`**, unblocking the Shakapacker 10.1 modular-package follow-ups — `shakapacker-webpack` (#3480) and `shakapacker-rspack` CI coverage (#3481).

This is **not** a user-facing change: the gem dependency stays `shakapacker >= 6.0`; only the dummy apps pin the version they test against, and they remain on **plain Shakapacker core + Webpack** (no modular packages, no Rspack yet).

## Why the major bump is narrow

- **Shakapacker 10.0.0** breaking changes are only `webpack >= 5.101.0` and `webpack-dev-server >= 5.2.2` — already satisfied by the dummy apps' current pins.
- **Shakapacker 10.1.0**'s only breaking change is the tightened `engines.node` floor `^20.19.0 || >=22.12.0`.
- No `config/shakapacker.yml` key changes, no Ruby/API changes.

## Changes

- **Version pins `9.6.1` → `10.1.0`** (gem + npm) in `react_on_rails/spec/dummy`, `react_on_rails_pro/spec/dummy`, and `react_on_rails_pro/spec/execjs-compatible-dummy`.
- **Lockfiles**: 5 tracked `Gemfile.lock` updated conservatively (only `shakapacker` + its dependency `rack-proxy 0.7.7 → 0.8.2`) plus `pnpm-lock.yaml`.
- **CI Node floor**: `22.11.0` → `22.12.0` in `pro-integration-tests`, `pro-test-package-and-gem`, `lint-js-and-ruby`, and `check-markdown-links` — satisfies the 10.1 floor while staying below the 22.21.0 V8 bug those pins were avoiding.

## Out of scope (the follow-ups)

- `shakapacker-webpack` modular swap (#3480)
- `shakapacker-rspack` Rspack CI coverage (#3481)
- Generator default-bundler changes

## Verification (local)

- ✅ **OSS dummy** webpack build green — bundles + `manifest.json` (CSS extraction working).
- ✅ **Pro dummy** all 3 bundles incl. RSC green — `manifest.json`, `react-client-manifest.json`, and `ssr-generated/rsc-bundle.js` emitted.
- ✅ `packer_utils_spec` 36 examples, 0 failures (covers the `MINIMUM_SHAKAPACKER_VERSION_FOR_AUTO_BUNDLING` boundary).
- ✅ `bundle exec rubocop` and `actionlint` clean.
- ✅ `pnpm install --frozen-lockfile` consistent (mirrors CI's `latest` leg).

> Note: the execjs-compatible dummy's webpack build isn't a standalone CI step; its babel config hardcodes a relative `./node_modules/shakapacker/...` preset path that doesn't resolve under pnpm's hoisted `node_modules` from the app's cwd. That's a pre-existing, version-independent quirk (the preset ships at the same path in 10.1.0), not a regression from this bump.

Prerequisite for #3480 and #3481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is dummy apps, CI Node pins, and lockfiles; the shipped gem still allows shakapacker >= 6.0 with no runtime or config changes in this PR.
> 
> **Overview**
> **Test-only prerequisite:** pins **Shakapacker `9.6.1` → `10.1.0`** (Ruby gem + npm) across the OSS dummy, Pro dummy, and execjs-compatible dummy, plus matching **`Gemfile.lock`** / **`pnpm-lock.yaml`** updates. The published **`react_on_rails` gem dependency stays `shakapacker >= 6.0`** — this does not change what end users install.
> 
> **CI alignment:** GitHub Actions Node pins move **`22.11.0` → `22.12.0`** in markdown-link, lint-js-and-ruby, pro-integration-tests, and pro-test-package-and-gem workflows so runners satisfy Shakapacker 10.1’s Node floor while still avoiding the known **22.21.0** V8 issue noted in comments.
> 
> **Lockfile fallout:** Ruby side picks up **`rack-proxy` `0.7.7` → `0.8.2`** with Shakapacker 10.1; pnpm reflects the new **`shakapacker@10.1.0`** tree (including **`pack-config-diff`**) and normalized webpack peer resolution strings — no app webpack config edits in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c95abfae0ea92f31ce82547f46df11d244f8757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version in CI workflows.
  * Upgraded shakapacker dependency version across development and dummy app configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react_on_rails/pull/3490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->