### PR TITLE
chore(claude): add autoreview second-model code-review skill

### DIFF
--- a/.claude/skills/autoreview/SKILL.md
+++ b/.claude/skills/autoreview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoreview
-description: 'Run a structured second-model code review (Codex default, Claude optional) as a closeout gate on a local, branch, or commit diff, then verify every finding against the real code and loop until clean. Use before commit/push/ship in this repo.'
+description: 'Run a structured second-model code review as a closeout gate on a local, branch, or commit diff, then verify every finding against the real code and loop until clean. Use before commit/push/ship in this repo.'
 ---
 
 # Auto Review
@@ -9,17 +9,17 @@ Run a structured second-model review as a **closeout check** before commit, push
 then loop until the review reports no accepted/actionable findings. This is code review, not
 PR merge/approval routing.
 
-This skill is the _discipline layer_. It does not ship its own reviewer — it drives this
-repo's existing review tooling and adds the "verify every finding, fix at the right boundary,
-re-review until clean" loop on top.
+This skill is the discipline layer. It does not ship its own reviewer; it drives available
+review tooling and adds the "verify every finding, fix at the right boundary, re-review until
+clean" loop on top.
 
-- **Default engine: `/codex review`** (the gstack `/codex` skill → OpenAI Codex CLI, an
-  independent model). Codex usually gives the best closeout review and should stay the
-  default unless the user asks otherwise.
-- **Alternative engine: `/code-review`** (Claude's built-in reviewer; `/code-review ultra`
-  for the deep multi-agent cloud pass).
+- **Default engine: `codex review`**. It is a concrete CLI command and supports
+  local/branch/commit review modes.
+- **Alternative engine: Claude review tooling** when the current Claude Code environment provides
+  it, such as `/code-review` or `/code-review ultra`. Treat these as environment-specific, not
+  repo-local commands.
 - For PR-comment triage (reacting to review comments already on a GitHub PR), use
-  `/address-review` instead — that is a different job.
+  `/address-review` in Claude Code or `.agents/workflows/address-review.md` outside Claude Code.
 
 Use when:
 
@@ -36,30 +36,37 @@ This is the portable core. Hold it regardless of which engine runs.
 - Verify every finding by reading the real code path and adjacent files before acting.
 - Read dependency docs/source/types when a finding depends on external (gem/npm/Rails/React) behavior.
 - Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the code.
-- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class. This matches `AGENTS.md` → "never refactor unrelated code."
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class. This matches `AGENTS.md`: never refactor unrelated code.
 - Keep going until the review returns no accepted/actionable findings.
 - If a review-triggered fix changes code, rerun the focused tests for the changed surface and rerun the review.
 - Security perspective is always included, but it must not cripple legitimate functionality. Report a security finding only when the change creates a concrete, actionable risk or removes an important safety check.
-- Be patient. `codex review` runs an external model and can take several minutes on a large diff. Progress that looks quiet is usually still working — do not kill it before ~5 minutes unless it has clearly errored.
-- Do not nest reviewers or spawn reviewer panels from inside a review. One bundle, one selected engine, one structured result, then stop.
+- Be patient. `codex review` runs an external model and can take several minutes on a large diff. Progress that looks quiet is usually still working; do not kill it before about 5 minutes unless it has clearly errored.
+- Do not launch multiple reviewers by default. One selected engine, one structured result, then verify it.
+- A gated second-engine pass is appropriate only when the user asks or the diff falls into the
+  `AGENTS.md` high-risk / `full-ci` / `benchmark` categories. Run it after the primary review is
+  clean, keep it to one extra pass, and verify its findings the same way.
 - Stop as soon as the review comes back clean with no accepted/actionable findings. Do not run an extra review just to get nicer "clean" wording or a redundant second opinion.
 - If you reject a finding as intentional/not worth fixing, add a brief inline code comment only when it documents a real invariant or ownership decision a future reviewer should know.
 - **Do not push just to review.** Push only when the user asked for push/ship/PR. Follow `AGENTS.md` git boundaries (Pro package edits are ask-first; never force-push `main`/`master`).
 
-## Step 1 — Pick the target
+## Step 1 - Pick the target
 
 Inspect what changed and choose the diff scope. Base branch in this repo is `origin/main`.
 
 ```bash
-git status --short
+git status --short --untracked-files=all
 git diff --name-only origin/main...HEAD
 git diff --stat origin/main...HEAD
+git diff --stat
+git diff --cached --stat
+git ls-files --others --exclude-standard
 ```
 
 - **Dirty local work** (unstaged/staged/untracked in the working tree): review the working
-  tree. Use this only when there is an actual local patch — a clean local review just proves
+  tree with `codex review --uncommitted`. Use this only when there is an actual local patch; a clean local review just proves
   there is no local patch, not that the branch is good.
-- **Branch / PR work** (committed, maybe pushed): review the branch diff against its base.
+- **Branch / PR work** (committed, maybe pushed): review the branch diff against its base with
+  `codex review --base origin/main` or the PR's real base.
   If an open PR exists, use its real base instead of assuming `main`:
 
   ```bash
@@ -67,45 +74,95 @@ git diff --stat origin/main...HEAD
   git diff "origin/$base...HEAD" --stat
   ```
 
+- **Branch plus dirty local work**: either commit the intended local changes before the final
+  branch review, or run two reviews: one branch review for committed changes and one
+  `--uncommitted` review for staged/unstaged/untracked local changes. Staging alone does not put
+  changes into the branch diff. Do not let untracked files fall out of scope.
 - **Single landed commit** (already on `main`, or one commit in a stack): review that commit's
   diff (`git show <sha>`). Reviewing clean `main` against `origin/main` is an empty diff after
-  push — point at the commit instead.
+  push; point at the commit instead.
 
 Tell the user which target you picked and why.
 
-## Step 2 — Format and lint first
+## Step 2 - Format and lint first
 
 Formatting that moves line locations will stale the review and the engine's line references.
-Run autofix and the CI-equivalent lint gate **before** the review (see `AGENTS.md` → Commands /
-Boundaries, and `/verify` for the full scope map):
+Use `AGENTS.md` and `/verify` for the actual check set. Before a closeout review:
+
+- Run `git diff --check origin/main...HEAD` for committed branch content, plus `git diff --check`
+  and `git diff --cached --check` when there is local dirty work.
+- Run `rake autofix` when formatting or autocorrectable lint failures are present or likely. It
+  runs ESLint `--fix`, Prettier `--write`, Stylelint `--fix`, and RuboCop `-A`; let those tools
+  make formatting/autocorrect changes instead of hand-formatting.
+- Run the narrow lint/test checks that cover the changed surface. Before committing, include the
+  CI-equivalent Ruby lint gate required by `AGENTS.md`:
 
 ```bash
-rake autofix                                   # Prettier + RuboCop autocorrect (never hand-format)
 (cd react_on_rails && bundle exec rubocop)     # CI-equivalent OSS Ruby lint
 # Also, only when Pro Ruby or RuboCop config changed (Pro edits are ask-first per AGENTS.md):
 (cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)
 ```
 
-## Step 3 — Run the structured review
+## Step 3 - Run the structured review
 
-Default to Codex. Invoke the engine skill rather than re-deriving its CLI invocation:
+Default to Codex. Pick the command that matches Step 1:
 
-- **`/codex review`** — runs `codex review` against the branch diff with a pass/fail gate
-  (handles auth probe, timeout, and the diff-scope prompt for you). This is the default.
-- **`/code-review`** — Claude's built-in reviewer for the current diff. `/code-review ultra`
-  for the deep multi-agent cloud review (user-triggered, billed).
+```bash
+# Dirty local patch, including staged, unstaged, and untracked files.
+codex review --uncommitted
+
+# Branch or PR diff.
+base=$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)
+codex review --base "origin/$base"
+
+# Single commit.
+codex review --commit <sha>
+```
+
+Prefer explicit target selection over custom focus text. Some Codex CLI versions reject a custom
+prompt when `--base`, `--uncommitted`, or `--commit` is present. If that happens, keep the explicit
+target command and continue without the prompt rather than accidentally reviewing the wrong diff.
+
+When the intended diff is the only active review target and the installed CLI accepts a prompt, add
+focus instructions as the review prompt:
+
+```bash
+codex review "Focus on SSR/hydration regressions, generated output, and repo workflow correctness."
+```
+
+For longer instructions, keep them in `.context/` and read from stdin only when the selected review
+engine supports that mode:
+
+```bash
+codex review - < .context/autoreview-focus.md
+```
 
 Never silently switch the engine the user asked for. If the requested engine hits model
 capacity, retry the same engine a few times rather than swapping it.
 
-## Step 4 — Verify, fix, and loop
+### High-risk second pass
+
+For high-risk changes listed in `AGENTS.md` under `full-ci` or `benchmark`, or when the user asks
+for a panel/second model, run one additional review after the primary review is clean:
+
+- If the primary review used `codex review`, use Claude review tooling if it is available in the
+  current environment, such as `/code-review` or `/code-review ultra`.
+- If the primary review used Claude review tooling, use `codex review` with the same target and
+  any focus instructions the installed CLI supports.
+- If no second engine is available, say so and continue with the clean primary review plus local
+  verification.
+
+Do not run a panel for small focused PRs unless the user asks. This matches `AGENTS.md`: use at
+most one inline-commenting AI reviewer for small PRs.
+
+## Step 4 - Verify, fix, and loop
 
 For each finding the engine returns:
 
 1. Open the real code path and adjacent files. Confirm the finding is true here, not generic.
 2. Accept only concrete, actionable findings (correctness bugs, real regressions, genuine
    security gaps, clear inconsistencies with adjacent code). Reject speculation, nits, and
-   broad rewrites — note briefly why.
+   broad rewrites; note briefly why.
 3. Fix accepted findings with the smallest correct change at the right boundary.
 4. Rerun the **targeted** tests for the changed surface, then rerun the review. Use `/verify`'s
    Scope Guide to pick the narrowest covering tests, e.g.:
@@ -113,8 +170,8 @@ For each finding the engine returns:
    - Dummy/integration: `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`
    - TS package: `pnpm --filter react-on-rails exec jest <relative-test-file>`, plus `pnpm run type-check` / `pnpm run lint` for touched TS
 
-Loop Steps 3–4 until the review returns no accepted/actionable findings. Once a rerun comes
-back clean, stop — do not spend another long review cycle on redundant confirmation.
+Loop Steps 3-4 until the review returns no accepted/actionable findings. Once a rerun comes
+back clean, stop; do not spend another long review cycle on redundant confirmation.
 
 ### Parallel closeout (optional)
 
@@ -127,9 +184,11 @@ re-review until clean.
 Report:
 
 - diff target reviewed (local / branch / commit) and base
-- review engine used (`/codex review` or `/code-review`)
+- review engine used (`codex review` or the available Claude review command)
 - tests/proof run, with pass/fail
 - findings accepted vs rejected, briefly why
+- PR label recommendation from `AGENTS.md` (`Labels: none`, `Labels: full-ci`,
+  `Labels: benchmark`, or `Labels: full-ci, benchmark`) when the work is headed to a PR
 - the final clean review result, or why a remaining finding was consciously left unfixed
 
 Do not run another review solely to improve the report wording. If the final review came back

--- a/.claude/skills/autoreview/SKILL.md
+++ b/.claude/skills/autoreview/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: autoreview
+description: 'Run a structured second-model code review (Codex default, Claude optional) as a closeout gate on a local, branch, or commit diff, then verify every finding against the real code and loop until clean. Use before commit/push/ship in this repo.'
+---
+
+# Auto Review
+
+Run a structured second-model review as a **closeout check** before commit, push, or ship,
+then loop until the review reports no accepted/actionable findings. This is code review, not
+PR merge/approval routing.
+
+This skill is the _discipline layer_. It does not ship its own reviewer — it drives this
+repo's existing review tooling and adds the "verify every finding, fix at the right boundary,
+re-review until clean" loop on top.
+
+- **Default engine: `/codex review`** (the gstack `/codex` skill → OpenAI Codex CLI, an
+  independent model). Codex usually gives the best closeout review and should stay the
+  default unless the user asks otherwise.
+- **Alternative engine: `/code-review`** (Claude's built-in reviewer; `/code-review ultra`
+  for the deep multi-agent cloud pass).
+- For PR-comment triage (reacting to review comments already on a GitHub PR), use
+  `/address-review` instead — that is a different job.
+
+Use when:
+
+- user asks for "autoreview", "codex review", "Claude review", "second-model review",
+  or a final review before commit/ship
+- after non-trivial code edits, before the final commit/push/PR
+- reviewing a local working tree, a branch, or a single landed commit after fixes
+
+## Contract
+
+This is the portable core. Hold it regardless of which engine runs.
+
+- Treat review output as **advisory**. Never blindly apply it.
+- Verify every finding by reading the real code path and adjacent files before acting.
+- Read dependency docs/source/types when a finding depends on external (gem/npm/Rails/React) behavior.
+- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the code.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class. This matches `AGENTS.md` → "never refactor unrelated code."
+- Keep going until the review returns no accepted/actionable findings.
+- If a review-triggered fix changes code, rerun the focused tests for the changed surface and rerun the review.
+- Security perspective is always included, but it must not cripple legitimate functionality. Report a security finding only when the change creates a concrete, actionable risk or removes an important safety check.
+- Be patient. `codex review` runs an external model and can take several minutes on a large diff. Progress that looks quiet is usually still working — do not kill it before ~5 minutes unless it has clearly errored.
+- Do not nest reviewers or spawn reviewer panels from inside a review. One bundle, one selected engine, one structured result, then stop.
+- Stop as soon as the review comes back clean with no accepted/actionable findings. Do not run an extra review just to get nicer "clean" wording or a redundant second opinion.
+- If you reject a finding as intentional/not worth fixing, add a brief inline code comment only when it documents a real invariant or ownership decision a future reviewer should know.
+- **Do not push just to review.** Push only when the user asked for push/ship/PR. Follow `AGENTS.md` git boundaries (Pro package edits are ask-first; never force-push `main`/`master`).
+
+## Step 1 — Pick the target
+
+Inspect what changed and choose the diff scope. Base branch in this repo is `origin/main`.
+
+```bash
+git status --short
+git diff --name-only origin/main...HEAD
+git diff --stat origin/main...HEAD
+```
+
+- **Dirty local work** (unstaged/staged/untracked in the working tree): review the working
+  tree. Use this only when there is an actual local patch — a clean local review just proves
+  there is no local patch, not that the branch is good.
+- **Branch / PR work** (committed, maybe pushed): review the branch diff against its base.
+  If an open PR exists, use its real base instead of assuming `main`:
+
+  ```bash
+  base=$(gh pr view --json baseRefName --jq .baseRefName 2>/dev/null || echo main)
+  git diff "origin/$base...HEAD" --stat
+  ```
+
+- **Single landed commit** (already on `main`, or one commit in a stack): review that commit's
+  diff (`git show <sha>`). Reviewing clean `main` against `origin/main` is an empty diff after
+  push — point at the commit instead.
+
+Tell the user which target you picked and why.
+
+## Step 2 — Format and lint first
+
+Formatting that moves line locations will stale the review and the engine's line references.
+Run autofix and the CI-equivalent lint gate **before** the review (see `AGENTS.md` → Commands /
+Boundaries, and `/verify` for the full scope map):
+
+```bash
+rake autofix                                   # Prettier + RuboCop autocorrect (never hand-format)
+(cd react_on_rails && bundle exec rubocop)     # CI-equivalent OSS Ruby lint
+# Also, only when Pro Ruby or RuboCop config changed (Pro edits are ask-first per AGENTS.md):
+(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion)
+```
+
+## Step 3 — Run the structured review
+
+Default to Codex. Invoke the engine skill rather than re-deriving its CLI invocation:
+
+- **`/codex review`** — runs `codex review` against the branch diff with a pass/fail gate
+  (handles auth probe, timeout, and the diff-scope prompt for you). This is the default.
+- **`/code-review`** — Claude's built-in reviewer for the current diff. `/code-review ultra`
+  for the deep multi-agent cloud review (user-triggered, billed).
+
+Never silently switch the engine the user asked for. If the requested engine hits model
+capacity, retry the same engine a few times rather than swapping it.
+
+## Step 4 — Verify, fix, and loop
+
+For each finding the engine returns:
+
+1. Open the real code path and adjacent files. Confirm the finding is true here, not generic.
+2. Accept only concrete, actionable findings (correctness bugs, real regressions, genuine
+   security gaps, clear inconsistencies with adjacent code). Reject speculation, nits, and
+   broad rewrites — note briefly why.
+3. Fix accepted findings with the smallest correct change at the right boundary.
+4. Rerun the **targeted** tests for the changed surface, then rerun the review. Use `/verify`'s
+   Scope Guide to pick the narrowest covering tests, e.g.:
+   - Ruby gem: `bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb` (+ RBS validate if signatures changed)
+   - Dummy/integration: `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`
+   - TS package: `pnpm --filter react-on-rails exec jest <relative-test-file>`, plus `pnpm run type-check` / `pnpm run lint` for touched TS
+
+Loop Steps 3–4 until the review returns no accepted/actionable findings. Once a rerun comes
+back clean, stop — do not spend another long review cycle on redundant confirmation.
+
+### Parallel closeout (optional)
+
+After Step 2 formatting is done, it is fine to run the focused tests and the review
+concurrently to save wall-clock. If either forces a code edit, rerun the affected tests and
+re-review until clean.
+
+## Final report
+
+Report:
+
+- diff target reviewed (local / branch / commit) and base
+- review engine used (`/codex review` or `/code-review`)
+- tests/proof run, with pass/fail
+- findings accepted vs rejected, briefly why
+- the final clean review result, or why a remaining finding was consciously left unfixed
+
+Do not run another review solely to improve the report wording. If the final review came back
+with no accepted/actionable findings, report that run as clean.

--- a/.claude/skills/autoreview/SKILL.md
+++ b/.claude/skills/autoreview/SKILL.md
@@ -37,7 +37,7 @@ This is the portable core. Hold it regardless of which engine runs.
 - Read dependency docs/source/types when a finding depends on external (gem/npm/Rails/React) behavior.
 - Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the code.
 - Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class. This matches `AGENTS.md`: never refactor unrelated code.
-- Keep going until the review returns no accepted/actionable findings.
+- Keep going until the review returns no accepted/actionable findings; once it comes back clean, stop. Do not run an extra review just to get nicer "clean" wording or a redundant second opinion.
 - If a review-triggered fix changes code, rerun the focused tests for the changed surface and rerun the review.
 - Security perspective is always included, but it must not cripple legitimate functionality. Report a security finding only when the change creates a concrete, actionable risk or removes an important safety check.
 - Be patient. `codex review` runs an external model and can take several minutes on a large diff. Progress that looks quiet is usually still working; do not kill it before about 5 minutes unless it has clearly errored.
@@ -45,7 +45,6 @@ This is the portable core. Hold it regardless of which engine runs.
 - A gated second-engine pass is appropriate only when the user asks or the diff falls into the
   `AGENTS.md` high-risk / `full-ci` / `benchmark` categories. Run it after the primary review is
   clean, keep it to one extra pass, and verify its findings the same way.
-- Stop as soon as the review comes back clean with no accepted/actionable findings. Do not run an extra review just to get nicer "clean" wording or a redundant second opinion.
 - If you reject a finding as intentional/not worth fixing, add a brief inline code comment only when it documents a real invariant or ownership decision a future reviewer should know.
 - **Do not push just to review.** Push only when the user asked for push/ship/PR. Follow `AGENTS.md` git boundaries (Pro package edits are ask-first; never force-push `main`/`master`).
 
@@ -105,7 +104,7 @@ Use `AGENTS.md` and `/verify` for the actual check set. Before a closeout review
 
 ## Step 3 - Run the structured review
 
-Default to Codex. Pick the command that matches Step 1:
+Default to Codex. Verify it is available first (`command -v codex`); if not, fall back to the Claude review tooling described in the intro. Pick the command that matches Step 1:
 
 ```bash
 # Dirty local patch, including staged, unstaged, and untracked files.
@@ -130,11 +129,11 @@ focus instructions as the review prompt:
 codex review "Focus on SSR/hydration regressions, generated output, and repo workflow correctness."
 ```
 
-For longer instructions, keep them in `.context/` and read from stdin only when the selected review
-engine supports that mode:
+For longer instructions, create a scratch file in `.context/` or substitute your own path, then
+read from stdin only when the selected review engine supports that mode:
 
 ```bash
-codex review - < .context/autoreview-focus.md
+codex review - < .context/autoreview-focus.md   # create this file with your focus instructions first
 ```
 
 Never silently switch the engine the user asked for. If the requested engine hits model
@@ -166,7 +165,7 @@ For each finding the engine returns:
 3. Fix accepted findings with the smallest correct change at the right boundary.
 4. Rerun the **targeted** tests for the changed surface, then rerun the review. Use `/verify`'s
    Scope Guide to pick the narrowest covering tests, e.g.:
-   - Ruby gem: `bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb` (+ RBS validate if signatures changed)
+   - Ruby gem: `bundle exec rspec react_on_rails/spec/react_on_rails/path/to/spec.rb`; also run `bundle exec rake rbs:validate` if RBS signatures changed
    - Dummy/integration: `cd react_on_rails/spec/dummy && bundle exec rspec spec/path/to/spec.rb`
    - TS package: `pnpm --filter react-on-rails exec jest <relative-test-file>`, plus `pnpm run type-check` / `pnpm run lint` for touched TS
 

--- a/.claude/skills/autoreview/SKILL.md
+++ b/.claude/skills/autoreview/SKILL.md
@@ -104,7 +104,10 @@ Use `AGENTS.md` and `/verify` for the actual check set. Before a closeout review
 
 ## Step 3 - Run the structured review
 
-Default to Codex. Verify it is available first (`command -v codex`); if not, fall back to the Claude review tooling described in the intro. Pick the command that matches Step 1:
+Default to Codex. Verify it is available first (`command -v codex`); if not, fall back to the Claude
+review tooling described in the intro. If neither engine exists in the current environment, stop and
+tell the user which review engines are missing instead of improvising a different review scope. Pick
+the command that matches Step 1:
 
 ```bash
 # Dirty local patch, including staged, unstaged, and untracked files.
@@ -129,11 +132,13 @@ Step 1 and append the prompt there:
 codex review --base "origin/$base" "Focus on SSR/hydration regressions, generated output, and repo workflow correctness."
 ```
 
-For longer instructions, create a scratch file in `.context/` or substitute your own path, then
-read from stdin only when the selected review engine supports that mode without dropping the target:
+For longer instructions, create an ignored scratch file, for example
+`.context/autoreview-focus.md` if your workspace provides `.context/`, or substitute another ignored
+path. Read from stdin only when the selected review engine supports that mode without dropping the
+target:
 
 ```bash
-codex review --base "origin/$base" - < .context/autoreview-focus.md   # create this file with your focus instructions first
+codex review --base "origin/$base" - < .context/autoreview-focus.md   # create this ignored scratch file first
 ```
 
 Never silently switch the engine the user asked for. If the requested engine hits model
@@ -171,6 +176,8 @@ For each finding the engine returns:
 
 Loop Steps 3-4 until the review returns no accepted/actionable findings. Once a rerun comes
 back clean, stop; do not spend another long review cycle on redundant confirmation.
+If the same finding recurs after two fix attempts, or the review starts cycling through speculative
+issues, stop, report the loop, and ask the user whether to continue.
 
 ### Parallel closeout (optional)
 

--- a/.claude/skills/autoreview/SKILL.md
+++ b/.claude/skills/autoreview/SKILL.md
@@ -122,18 +122,18 @@ Prefer explicit target selection over custom focus text. Some Codex CLI versions
 prompt when `--base`, `--uncommitted`, or `--commit` is present. If that happens, keep the explicit
 target command and continue without the prompt rather than accidentally reviewing the wrong diff.
 
-When the intended diff is the only active review target and the installed CLI accepts a prompt, add
-focus instructions as the review prompt:
+When the installed CLI accepts focus text with the selected target flag, keep the same target from
+Step 1 and append the prompt there:
 
 ```bash
-codex review "Focus on SSR/hydration regressions, generated output, and repo workflow correctness."
+codex review --base "origin/$base" "Focus on SSR/hydration regressions, generated output, and repo workflow correctness."
 ```
 
 For longer instructions, create a scratch file in `.context/` or substitute your own path, then
-read from stdin only when the selected review engine supports that mode:
+read from stdin only when the selected review engine supports that mode without dropping the target:
 
 ```bash
-codex review - < .context/autoreview-focus.md   # create this file with your focus instructions first
+codex review --base "origin/$base" - < .context/autoreview-focus.md   # create this file with your focus instructions first
 ```
 
 Never silently switch the engine the user asked for. If the requested engine hits model

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 
 - `AGENTS.md`: canonical entry point for agent instructions and workflow discovery
 - `.claude/commands/`: Claude Code slash commands
+- `.claude/skills/`: Claude Code skills
 - `.agents/workflows/`: shared prompt templates and reusable workflows for Codex, GPT, and other non-Claude tools
 - When the user asks to address PR review comments outside Claude slash commands, follow `.agents/workflows/address-review.md`
 


### PR DESCRIPTION
### Summary

Adds `.claude/skills/autoreview/SKILL.md`, a closeout-review discipline layer for Claude Code in this repo. It does not ship its own reviewer — it drives the repo's existing review tooling (defaults to `/codex review`, with `/code-review`/`/code-review ultra` as the Claude alternative) and adds the "format/lint first, verify every finding against the real code, fix at the right ownership boundary, re-review until clean" loop on top. It codifies diff-target selection (local / branch / commit), respects `AGENTS.md` git and no-unrelated-refactor boundaries, and is distinct from `/address-review` (which triages comments already on a GitHub PR).

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (N/A — prose skill definition, no testable code)
- ~[ ] Update documentation~ (N/A — the file is self-documenting Claude Code tooling)
- ~[ ] Update CHANGELOG file~ (N/A — internal developer tooling, not part of the published gem/npm package)

### Other Information

Internal Claude Code tooling only; no runtime/library code is affected. The file passes the repo's pre-commit checks (Prettier, trailing-newlines, markdown-links), verified manually since this Conductor workspace has no installed `node_modules`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent workflows; no runtime, gem, or npm behavior is modified.
> 
> **Overview**
> Adds a new Claude Code skill at **`.claude/skills/autoreview/SKILL.md`** that defines a **closeout review** workflow before commit, push, or ship. It treats review as a discipline layer on top of existing engines (default **`codex review`**, with Claude **`/code-review`** as fallback), not a built-in reviewer.
> 
> The skill documents a four-step loop: pick the diff target (uncommitted, branch vs PR base, or single commit), run format/lint gates aligned with **`AGENTS.md`** and **`/verify`**, run one structured review, then verify each finding in real code, fix at the right boundary, rerun targeted tests, and re-review until clean. It also covers optional parallel closeout, a gated second-engine pass for high-risk/**`full-ci`**/**`benchmark`** work, and a final report checklist (including PR label guidance).
> 
> **`AGENTS.md`** is updated in **Reusable Workflows** to list **`.claude/skills/`** alongside commands and **`.agents/workflows/`**, so agents can discover the new skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fa3285ca40b92799bdbe76c0591d2fd40ded5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing guidance for an autoreview closeout workflow: pre-review formatting/lint checks, a structured second-model review with verify→fix→targeted-tests→re-review loop (optional parallelism), optional high-risk second pass, and a final report checklist with outcomes and labeling guidance.
  * Documented a new reusable location for Claude Code skill instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->