### PR TITLE
Document TanStack starter upstream branch testing

### DIFF
--- a/docs/oss/getting-started/examples-and-references.md
+++ b/docs/oss/getting-started/examples-and-references.md
@@ -29,6 +29,18 @@ source, while others require React on Rails Pro.
 - Note: this repo uses React on Rails Pro. See [OSS vs Pro](./oss-vs-pro.md)
   for evaluation guidance.
 
+### React on Rails + TanStack Starter (Pro)
+
+- Repo: [shakacode/react-on-rails-starter-tanstack](https://github.com/shakacode/react-on-rails-starter-tanstack)
+- Use it when you want the maintained Rails 8 + React on Rails Pro + TanStack
+  Router/Query/Table starter with React Server Components, Rspack, Tailwind, and
+  shadcn/ui.
+- Upstream branch testing: the starter documents how to validate unreleased
+  `react_on_rails` and `react_on_rails_rsc` branches in
+  [Testing Upstream Branches](https://github.com/shakacode/react-on-rails-starter-tanstack/blob/main/docs/12-upstream-branch-testing.md).
+- Note: this repo uses React on Rails Pro. See [OSS vs Pro](./oss-vs-pro.md)
+  for evaluation guidance.
+
 ## In-Repo Reference
 
 ### Spec Dummy App


### PR DESCRIPTION
## Summary

- Adds the React on Rails + TanStack starter to the examples/reference index.
- Links to the starter's `docs/12-upstream-branch-testing.md` workflow for validating unreleased `react_on_rails` and `react_on_rails_rsc` branches.

## Validation

- `git diff --check`

Docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the getting-started examples index; no runtime or application code affected.
> 
> **Overview**
> Adds a **React on Rails + TanStack Starter (Pro)** entry to the canonical examples index in `examples-and-references.md`, alongside the existing SSR+HMR and RSC starters.
> 
> The new section points readers to the `react-on-rails-starter-tanstack` repo and describes when to use it (Rails 8, TanStack Router/Query/Table, RSC, Rspack, Tailwind, shadcn/ui). It also links to the starter’s **Testing Upstream Branches** doc for validating unreleased `react_on_rails` / `react_on_rails_rsc` branches, and repeats the standard Pro evaluation note with a link to OSS vs Pro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d108b5dc87d39741449dc4db7261a7d52e791915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new starter repository reference for React on Rails + TanStack Starter (Pro), including GitHub repository link, framework stack details (Rails 8, TanStack, Rspack, Tailwind, shadcn/ui), and OSS vs Pro evaluation guidance for developers exploring available starter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->