### PR TITLE
Document live Hacker News demo

### DIFF
--- a/docs/oss/getting-started/examples-and-references.md
+++ b/docs/oss/getting-started/examples-and-references.md
@@ -70,6 +70,7 @@ For detailed proof criteria and migration contribution guidance, see
 ### Hacker News RSC Demo
 
 - Repo: [shakacode/react-on-rails-demo-hacker-news-rsc](https://github.com/shakacode/react-on-rails-demo-hacker-news-rsc)
+- Live demo: [hn.reactonrails.com](https://hn.reactonrails.com/)
 - Use it when you want a compact public demo of React on Rails Pro with React
   Server Components on a familiar read-heavy UI.
 
@@ -91,6 +92,9 @@ For detailed proof criteria and migration contribution guidance, see
 
 ## Live Demos
 
+- [hn.reactonrails.com](https://hn.reactonrails.com/) — Hacker News reader
+  showing React on Rails Pro with React 19 and React Server Components on a
+  familiar read-heavy UI.
 - [reactrails.com](https://reactrails.com) — production-style React on Rails app
   you can click through in your browser without any local setup. Backed by the
   legacy [shakacode/react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial)


### PR DESCRIPTION
## Summary
- Add https://hn.reactonrails.com as the live deployment for the Hacker News RSC demo
- Add the Hacker News app to the live demos section of the examples/reference docs

## Test Plan
- `script/check-docs-sidebar`
- `pnpm start format.listDifferent`
- pre-commit: trailing-newlines, offline markdown-links, prettier
- pre-push: branch-lint, online markdown-links
- `curl -I https://hn.reactonrails.com/` returns HTTP 200

Labels: none. Docs-only change; no CI expansion needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only link additions with no runtime or application code changes.
> 
> **Overview**
> Documents the deployed **Hacker News RSC** app at `hn.reactonrails.com` in the canonical examples index.
> 
> Under **Hacker News RSC Demo**, a **Live demo** bullet is added next to the existing repo link. The **Live Demos** section now lists that URL first (before `reactrails.com`) with a short blurb about React on Rails Pro, React 19, and RSC on a read-heavy UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767bbfadbda1ea72b47ec3629e095522b5cf45bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added live demo link for Hacker News RSC example, allowing users to access and explore the working application.
  * Included demo link in the Live Demos section with context about React on Rails Pro featuring React 19 and React Server Components support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->