### PR TITLE
Auto-mount Pro rolling deploy bundle routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Added
 
 - **Ruby 4.0 CI support**: Updated OSS latest-runtime CI coverage, local CI switching guidance, and public compatibility docs to test Ruby 4.0 while keeping Ruby 3.3 as the minimum supported CI lane. [PR 3529](https://github.com/shakacode/react_on_rails/pull/3529) by [justin808](https://github.com/justin808).
+- **[Pro]** **HTTP rolling-deploy endpoint auto-mount**: Configuring `config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http` now automatically mounts `ReactOnRailsPro::RollingDeploy::BundlesController` at `config.rolling_deploy_mount_path` (default `/react_on_rails_pro/rolling_deploy`). Set the mount path to `nil` or blank to opt out and keep a manual `draw_routes` mount; apps that previously mounted the default route manually should remove that route or give secondary manual mounts a distinct `as_prefix:` to avoid duplicate named-route errors. Fixes [Issue 3476](https://github.com/shakacode/react_on_rails/issues/3476). [PR 3504](https://github.com/shakacode/react_on_rails/pull/3504) by [justin808](https://github.com/justin808).
 
 #### Changed
 

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -4,7 +4,7 @@ React on Rails Pro pre-seeds the Node Renderer cache so that during a **rolling 
 
 The **built-in HTTP adapter** does this with **no extra infrastructure**: the still-running deployment serves its own bundles over an authenticated endpoint, and the next deploy pulls them. This is the recommended setup for almost everyone.
 
-> **TL;DR** — Set three config values, mount one controller, and in-flight requests for draining bundle versions stop paying the `410 Gone` → re-upload → retry tax. No S3, IAM, or extra gem. **[Jump to setup](#set-up-the-http-adapter).**
+> **TL;DR** — Set three config values, use the auto-mounted controller, and in-flight requests for draining bundle versions stop paying the `410 Gone` → re-upload → retry tax. No S3, IAM, or extra gem. **[Jump to setup](#set-up-the-http-adapter).**
 
 ## The problem
 
@@ -95,28 +95,53 @@ end
 
 - **`rolling_deploy_token`** — the shared bearer token ("password"). Generate one with `SecureRandom.hex(32)` and set the **same** value on both the running server (which authenticates incoming pulls) and the build CI (which sends it). The config validator rejects tokens shorter than 32 bytes.
 - **`rolling_deploy_previous_url`** — the base URL where the previous deployment is reachable **from the build CI**, e.g. `https://app.example.com/react_on_rails_pro/rolling_deploy`. The adapter appends `/manifest` and `/bundles/:hash`. Leave it unset (or empty) to disable discovery on that build.
+- **`rolling_deploy_mount_path`** — the Rails path where the Pro engine auto-mounts the bundle-serving endpoint when the built-in HTTP adapter is configured. Defaults to `/react_on_rails_pro/rolling_deploy`. Set it to a custom path when your previous deployment is reachable elsewhere, or set it to `nil`/blank to opt out of auto-mounting and draw the routes yourself.
 
-### 2. Mount the server endpoint
+### 2. Server endpoint auto-mount
 
-The bundle-serving controller must be routed on the Rails side. Mount it explicitly:
+When `config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http`, React on Rails Pro automatically routes the bundle-serving controller at `config.rolling_deploy_mount_path`:
 
-```ruby
-# config/routes.rb
-ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
-  self,
-  path: "/react_on_rails_pro/rolling_deploy"
-)
-```
-
-That exposes two authenticated endpoints under the mount path:
+That exposes two authenticated endpoints under the mount path (default `/react_on_rails_pro/rolling_deploy`):
 
 | Endpoint             | Returns                                                                                                                   |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `GET /manifest`      | JSON: `{ hashes: [...], rsc_enabled: true\|false, generated_at: "ISO8601", protocol_version: 1 }` for the current deploy. |
 | `GET /bundles/:hash` | `application/gzip` tarball containing `bundle.js` plus that hash's companion assets.                                      |
 
-> [!IMPORTANT]
-> Engine auto-mount is planned for a follow-up release but is not yet wired — mount the controller explicitly with `draw_routes` as shown. When auto-mount lands and you still need a custom path, keep the explicit `draw_routes` call and pass a distinct `as_prefix:` keyword (e.g. `as_prefix: "my_rolling_deploy"`) to avoid duplicate named-route errors. If the auto-mount's default path suits you, you can remove the explicit call entirely.
+The auto-mounted routes are prepended ahead of application routes, so terminal catch-all routes do not shadow the endpoint. They also use an internal route-helper prefix, so apps that still have an older manual mount at the default path keep booting while you remove the redundant manual route.
+
+### Manual route override
+
+Most apps should use the auto-mount. Draw routes manually only when you need app-controlled routing behavior, such as a secondary endpoint or a wrapper around the built-in controller.
+
+To take over routing completely, opt out of the engine route and draw your own:
+
+```ruby
+# config/initializers/react_on_rails_pro.rb
+ReactOnRailsPro.configure do |config|
+  config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http
+  config.rolling_deploy_mount_path = nil
+end
+```
+
+```ruby
+# config/routes.rb
+ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
+  self,
+  path: "/internal/rolling-deploy"
+)
+```
+
+To keep the auto-mount and add one or more secondary manual mounts, pass a distinct `as_prefix:` for each manual mount so Rails' named-route registry does not collide:
+
+```ruby
+# config/routes.rb
+ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
+  self,
+  path: "/internal/rolling-deploy",
+  as_prefix: "internal_rolling_deploy"
+)
+```
 
 ### Security
 

--- a/docs/pro/rolling-deploy-adapters.md
+++ b/docs/pro/rolling-deploy-adapters.md
@@ -101,6 +101,15 @@ end
 
 When `config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http`, React on Rails Pro automatically routes the bundle-serving controller at `config.rolling_deploy_mount_path`:
 
+```ruby
+# config/initializers/react_on_rails_pro.rb
+ReactOnRailsPro.configure do |config|
+  config.rolling_deploy_adapter = ReactOnRailsPro::RollingDeployAdapters::Http
+  config.rolling_deploy_token = ENV.fetch("ROLLING_DEPLOY_TOKEN")
+  # No config/routes.rb entry is required for the default mount path.
+end
+```
+
 That exposes two authenticated endpoints under the mount path (default `/react_on_rails_pro/rolling_deploy`):
 
 | Endpoint             | Returns                                                                                                                   |
@@ -123,6 +132,8 @@ ReactOnRailsPro.configure do |config|
   config.rolling_deploy_mount_path = nil
 end
 ```
+
+Set `config.rolling_deploy_mount_path = ""` instead when your configuration source represents opt-outs as blank strings.
 
 ```ruby
 # config/routes.rb

--- a/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+++ b/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
@@ -13,11 +13,12 @@ module ReactOnRailsPro
     # ReactOnRailsPro::RollingDeployAdapters::Http adapter on the next
     # deploy's build CI consumes both endpoints.
     #
-    # Mount this in your application's routes with `draw_routes` so the Http
-    # adapter on the next deploy can reach it. (Engine auto-mount keyed on
-    # `config.rolling_deploy_adapter` is planned for a follow-up but is not
-    # wired yet, so an explicit mount is currently required.) You can also use
-    # a custom mount path or layer your own auth middleware:
+    # When `config.rolling_deploy_adapter` is the built-in Http adapter, the
+    # Pro engine auto-mounts this controller at
+    # `config.rolling_deploy_mount_path` (default:
+    # `/react_on_rails_pro/rolling_deploy`). Set the mount path to nil or blank
+    # to opt out of the auto-mount. Use `draw_routes` only when you need a
+    # manual mount, such as a secondary path or app-specific routing wrapper:
     #
     #   # config/routes.rb
     #   ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
@@ -25,10 +26,11 @@ module ReactOnRailsPro
     #     path: "/internal/rolling-deploy"
     #   )
     #
-    # Callers that mount the controller more than once (for example, a future
-    # engine auto-mount plus a user-controlled secondary path) must pass a
-    # distinct `as_prefix:` per call so Rails' named-route registry doesn't
-    # raise `ArgumentError: Invalid route name, already in use`.
+    # The engine auto-mount uses an internal route-helper prefix so existing
+    # manual mounts that use the default prefix keep booting during upgrades.
+    # Multiple manual mounts still need distinct `as_prefix:` values so Rails'
+    # named-route registry doesn't raise `ArgumentError: Invalid route name,
+    # already in use`.
     #
     # Security:
     #   * Bearer-token auth via `Authorization: Bearer <token>`, constant-time
@@ -56,10 +58,13 @@ module ReactOnRailsPro
       before_action :set_no_store_headers
 
       DEFAULT_ROUTE_PREFIX = "react_on_rails_pro_rolling_deploy"
+      ROUTE_HASH_PATTERN = /[A-Za-z0-9_][A-Za-z0-9_.\-]*/
 
       class << self
-        # Helper for mounting the controller in your application's routes. A
-        # planned engine auto-mount will reuse these same route definitions.
+        # Helper for manual route mounts. The Pro engine uses these same route
+        # definitions for the default auto-mount when the built-in Http adapter
+        # is configured, with an internal `as_prefix:` to avoid collisions with
+        # existing manual mounts.
         #
         # `as_prefix:` controls the generated named-route helpers
         # (`<prefix>_manifest`, `<prefix>_bundle`). Callers that mount the
@@ -72,7 +77,7 @@ module ReactOnRailsPro
                      as: :"#{as_prefix}_manifest")
           mapper.get("#{path}/bundles/:hash",
                      to: "react_on_rails_pro/rolling_deploy/bundles#show",
-                     constraints: { hash: SAFE_HASH_PATTERN },
+                     constraints: { hash: ROUTE_HASH_PATTERN },
                      as: :"#{as_prefix}_bundle")
         end
       end

--- a/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+++ b/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
@@ -58,11 +58,12 @@ module ReactOnRailsPro
       before_action :set_no_store_headers
 
       DEFAULT_ROUTE_PREFIX = "react_on_rails_pro_rolling_deploy"
+      SAFE_HASH_PATTERN = ReactOnRailsPro::RollingDeploy::SAFE_HASH_PATTERN
       # Rails route requirements reject anchor characters and apply segment
       # constraints to the full segment. Keep this route-safe form in sync with
       # SAFE_HASH_PATTERN's character rules; the controller still performs the
       # anchored defense-in-depth validation before any filesystem lookup.
-      ROUTE_HASH_PATTERN = /[A-Za-z0-9_][A-Za-z0-9_.\-]*/
+      ROUTE_HASH_PATTERN = Regexp.new(SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
 
       class << self
         # Helper for manual route mounts. The Pro engine uses these same route
@@ -90,8 +91,6 @@ module ReactOnRailsPro
       # path-traversal value through, the controller still rejects it
       # before any disk lookup because the hash must be in the
       # (regex-validated) current-hash set.
-      SAFE_HASH_PATTERN = ReactOnRailsPro::RollingDeploy::SAFE_HASH_PATTERN
-
       # Tarball entry name reserved for the server bundle. Companion assets
       # whose basename collides with this are skipped to keep the receiver
       # from extracting the wrong bytes into the bundle slot.

--- a/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+++ b/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
@@ -59,10 +59,11 @@ module ReactOnRailsPro
 
       DEFAULT_ROUTE_PREFIX = "react_on_rails_pro_rolling_deploy"
       SAFE_HASH_PATTERN = ReactOnRailsPro::RollingDeploy::SAFE_HASH_PATTERN
-      # Rails route requirements reject anchor characters and apply segment
-      # constraints to the full segment. Keep this route-safe form in sync with
-      # SAFE_HASH_PATTERN's character rules; the controller still performs the
-      # anchored defense-in-depth validation before any filesystem lookup.
+      # Rails route requirements reject anchor characters, while the route
+      # matcher applies segment constraints to the full segment. Derived from
+      # SAFE_HASH_PATTERN by stripping the \A/\z anchors; the controller still
+      # performs the anchored defense-in-depth validation before any filesystem
+      # lookup.
       ROUTE_HASH_PATTERN = Regexp.new(SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
 
       class << self

--- a/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+++ b/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
@@ -58,6 +58,10 @@ module ReactOnRailsPro
       before_action :set_no_store_headers
 
       DEFAULT_ROUTE_PREFIX = "react_on_rails_pro_rolling_deploy"
+      # Rails route requirements reject anchor characters and apply segment
+      # constraints to the full segment. Keep this route-safe form in sync with
+      # SAFE_HASH_PATTERN's character rules; the controller still performs the
+      # anchored defense-in-depth validation before any filesystem lookup.
       ROUTE_HASH_PATTERN = /[A-Za-z0-9_][A-Za-z0-9_.\-]*/
 
       class << self

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -180,6 +180,8 @@ module ReactOnRailsPro
       self.rolling_deploy_adapter = rolling_deploy_adapter
       self.rolling_deploy_token = rolling_deploy_token
       self.rolling_deploy_previous_url = rolling_deploy_previous_url
+      # Constructor nil/blank means "use the default"; configure-block assignment
+      # can still set nil/blank later to opt out of the engine auto-mount.
       self.rolling_deploy_mount_path = rolling_deploy_mount_path.presence || DEFAULT_ROLLING_DEPLOY_MOUNT_PATH
       self.ssr_pre_hook_js = ssr_pre_hook_js
       self.assets_to_copy = assets_to_copy

--- a/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
@@ -19,7 +19,7 @@ module ReactOnRailsPro
     initializer "react_on_rails_pro.rolling_deploy_routes" do |app|
       app.routes.prepend do
         pro_config = ReactOnRailsPro.configuration
-        mount_path = pro_config.rolling_deploy_mount_path.to_s
+        mount_path = pro_config.rolling_deploy_mount_path
 
         if pro_config.rolling_deploy_http_adapter? && mount_path.present?
           ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(

--- a/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
@@ -7,11 +7,28 @@ module ReactOnRailsPro
     LICENSE_URL = "https://pro.reactonrails.com/"
     # TODO: Remove this legacy migration warning path after 16.5.0 stable release (target: 2026-05-31).
     LEGACY_LICENSE_FILE = "config/react_on_rails_pro_license.key"
+    ROLLING_DEPLOY_AUTO_ROUTE_PREFIX = "react_on_rails_pro_auto_rolling_deploy"
     private_constant :LICENSE_URL
     private_constant :LEGACY_LICENSE_FILE
+    private_constant :ROLLING_DEPLOY_AUTO_ROUTE_PREFIX
 
     initializer "react_on_rails_pro.routes" do
       ActionDispatch::Routing::Mapper.include ReactOnRailsPro::Routes
+    end
+
+    initializer "react_on_rails_pro.rolling_deploy_routes" do |app|
+      app.routes.prepend do
+        pro_config = ReactOnRailsPro.configuration
+        mount_path = pro_config.rolling_deploy_mount_path.to_s
+
+        if pro_config.rolling_deploy_http_adapter? && mount_path.present?
+          ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
+            self,
+            path: mount_path,
+            as_prefix: ROLLING_DEPLOY_AUTO_ROUTE_PREFIX
+          )
+        end
+      end
     end
 
     # Check license status on Rails startup and log appropriately

--- a/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "rolling-deploy auto routes", type: :request do
+  let(:config) { ReactOnRailsPro.configuration }
+  let(:default_path) { ReactOnRailsPro::Configuration::DEFAULT_ROLLING_DEPLOY_MOUNT_PATH }
+  let(:token) { "a" * 32 }
+  let(:auto_route_prefix) { ReactOnRailsPro::Engine.const_get(:ROLLING_DEPLOY_AUTO_ROUTE_PREFIX, false) }
+
+  around do |example|
+    original_adapter = config.rolling_deploy_adapter
+    original_mount_path = config.rolling_deploy_mount_path
+    original_token = config.rolling_deploy_token
+
+    example.run
+  ensure
+    config.rolling_deploy_adapter = original_adapter
+    config.rolling_deploy_mount_path = original_mount_path
+    config.rolling_deploy_token = original_token
+    Rails.application.reload_routes!
+  end
+
+  def configure_rolling_deploy_routes(adapter:, mount_path:)
+    config.rolling_deploy_adapter = adapter
+    config.rolling_deploy_mount_path = mount_path
+    config.rolling_deploy_token = token
+    Rails.application.reload_routes!
+  end
+
+  def route_for(path)
+    Rails.application.routes.recognize_path(path, method: :get)
+  end
+
+  def route_set_with_auto_mount
+    path = default_path
+    prefix = auto_route_prefix
+
+    ActionDispatch::Routing::RouteSet.new.tap do |routes|
+      routes.prepend do
+        ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
+          self,
+          path: path,
+          as_prefix: prefix
+        )
+      end
+    end
+  end
+
+  it "auto-mounts the bundles controller when the built-in HTTP adapter is configured" do
+    configure_rolling_deploy_routes(
+      adapter: ReactOnRailsPro::RollingDeployAdapters::Http,
+      mount_path: default_path
+    )
+    allow(ReactOnRailsPro::RendererCacheHelpers).to receive(:bundle_sources).and_return([])
+
+    get "#{default_path}/manifest", headers: { "Authorization" => "Bearer #{token}" }
+
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)).to include("hashes" => [])
+  end
+
+  it "keeps the auto-mounted routes after Rails reloads routes" do
+    configure_rolling_deploy_routes(
+      adapter: ReactOnRailsPro::RollingDeployAdapters::Http,
+      mount_path: default_path
+    )
+
+    expect { Rails.application.reload_routes! }.not_to raise_error
+    expect(route_for("#{default_path}/manifest")).to include(
+      controller: "react_on_rails_pro/rolling_deploy/bundles",
+      action: "manifest"
+    )
+  end
+
+  it "does not collide with an existing manual mount that uses the default helper prefix" do
+    routes = route_set_with_auto_mount
+    path = default_path
+
+    expect do
+      routes.draw do
+        ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(self, path: path)
+      end
+    end.not_to raise_error
+    expect(routes.named_routes.helper_names).to include(
+      "#{auto_route_prefix}_manifest_path",
+      "react_on_rails_pro_rolling_deploy_manifest_path"
+    )
+  end
+
+  it "keeps the auto-mounted routes ahead of application catch-all routes" do
+    routes = route_set_with_auto_mount
+    routes.draw do
+      get "*all", to: "pages#index", as: :catch_all
+    end
+
+    expect(routes.recognize_path("#{default_path}/manifest", method: :get)).to include(
+      controller: "react_on_rails_pro/rolling_deploy/bundles",
+      action: "manifest"
+    )
+  end
+
+  it "mounts at the configured custom path" do
+    configure_rolling_deploy_routes(
+      adapter: ReactOnRailsPro::RollingDeployAdapters::Http,
+      mount_path: "/internal/rolling-deploy"
+    )
+
+    expect(route_for("/internal/rolling-deploy/manifest")).to include(
+      controller: "react_on_rails_pro/rolling_deploy/bundles",
+      action: "manifest"
+    )
+    expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
+  end
+
+  it "does not mount the routes when the rolling-deploy adapter is nil" do
+    configure_rolling_deploy_routes(adapter: nil, mount_path: default_path)
+
+    expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
+  end
+
+  it "does not mount the routes for non-HTTP custom adapters" do
+    custom_adapter = Module.new do
+      def self.previous_bundle_hashes = []
+      def self.fetch(_hash) = nil
+      def self.upload(_bundle:, _assets: []) = nil
+    end
+
+    configure_rolling_deploy_routes(adapter: custom_adapter, mount_path: default_path)
+
+    expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
+  end
+
+  [nil, ""].each do |mount_path|
+    it "treats #{mount_path.inspect} mount path as an auto-mount opt-out" do
+      configure_rolling_deploy_routes(
+        adapter: ReactOnRailsPro::RollingDeployAdapters::Http,
+        mount_path: mount_path
+      )
+
+      expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
   let(:config) { ReactOnRailsPro.configuration }
   let(:default_path) { ReactOnRailsPro::Configuration::DEFAULT_ROLLING_DEPLOY_MOUNT_PATH }
   let(:token) { "a" * 32 }
-  let(:auto_route_prefix) { ReactOnRailsPro::Engine.const_get(:ROLLING_DEPLOY_AUTO_ROUTE_PREFIX, false) }
 
   around do |example|
     original_adapter = config.rolling_deploy_adapter
@@ -21,10 +20,10 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
     Rails.application.reload_routes!
   end
 
-  def configure_rolling_deploy_routes(adapter:, mount_path:)
+  def configure_rolling_deploy_routes(adapter:, mount_path:, rolling_deploy_token: token)
     config.rolling_deploy_adapter = adapter
     config.rolling_deploy_mount_path = mount_path
-    config.rolling_deploy_token = token
+    config.rolling_deploy_token = rolling_deploy_token
     Rails.application.reload_routes!
   end
 
@@ -34,14 +33,13 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
 
   def route_set_with_auto_mount
     path = default_path
-    prefix = auto_route_prefix
 
     ActionDispatch::Routing::RouteSet.new.tap do |routes|
       routes.prepend do
         ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
           self,
           path: path,
-          as_prefix: prefix
+          as_prefix: "react_on_rails_pro_auto_rolling_deploy"
         )
       end
     end
@@ -83,7 +81,7 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
       end
     end.not_to raise_error
     expect(routes.named_routes.helper_names).to include(
-      "#{auto_route_prefix}_manifest_path",
+      "react_on_rails_pro_auto_rolling_deploy_manifest_path",
       "react_on_rails_pro_rolling_deploy_manifest_path"
     )
   end
@@ -113,8 +111,23 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
     expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
   end
 
+  it "does not route bundle requests with invalid hash segments" do
+    configure_rolling_deploy_routes(
+      adapter: ReactOnRailsPro::RollingDeployAdapters::Http,
+      mount_path: default_path
+    )
+
+    expect(route_for("#{default_path}/bundles/valid_hash-123.js")).to include(
+      controller: "react_on_rails_pro/rolling_deploy/bundles",
+      action: "show",
+      hash: "valid_hash-123.js"
+    )
+    expect { route_for("#{default_path}/bundles/valid!trailing") }
+      .to raise_error(ActionController::RoutingError)
+  end
+
   it "does not mount the routes when the rolling-deploy adapter is nil" do
-    configure_rolling_deploy_routes(adapter: nil, mount_path: default_path)
+    configure_rolling_deploy_routes(adapter: nil, mount_path: default_path, rolling_deploy_token: nil)
 
     expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
   end
@@ -126,7 +139,11 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
       def self.upload(_bundle:, _assets: []) = nil
     end
 
-    configure_rolling_deploy_routes(adapter: custom_adapter, mount_path: default_path)
+    configure_rolling_deploy_routes(
+      adapter: custom_adapter,
+      mount_path: default_path,
+      rolling_deploy_token: nil
+    )
 
     expect { route_for("#{default_path}/manifest") }.to raise_error(ActionController::RoutingError)
   end

--- a/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
         ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
           self,
           path: path,
+          # Must match ReactOnRailsPro::Engine::ROLLING_DEPLOY_AUTO_ROUTE_PREFIX.
           as_prefix: "react_on_rails_pro_auto_rolling_deploy"
         )
       end

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
@@ -20,6 +20,11 @@ describe ReactOnRailsPro::RollingDeploy::BundlesController do
   describe ".draw_routes" do
     let(:mapper) { instance_spy(ActionDispatch::Routing::Mapper) }
 
+    it "keeps the route hash pattern derived from the safe hash pattern without anchors" do
+      expect(described_class::ROUTE_HASH_PATTERN.source)
+        .to eq(described_class::SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
+    end
+
     it "uses the default route helper prefix" do
       described_class.draw_routes(mapper, path: "/rolling")
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
@@ -25,6 +25,7 @@ describe ReactOnRailsPro::RollingDeploy::BundlesController do
     end
 
     it "keeps the route hash pattern derived from the safe hash pattern without anchors" do
+      expect(described_class::SAFE_HASH_PATTERN.source).to start_with("\\A").and end_with("\\z")
       expect(described_class::ROUTE_HASH_PATTERN.source)
         .to eq(described_class::SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
     end

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
@@ -20,9 +20,30 @@ describe ReactOnRailsPro::RollingDeploy::BundlesController do
   describe ".draw_routes" do
     let(:mapper) { instance_spy(ActionDispatch::Routing::Mapper) }
 
+    def route_hash_pattern_matches_segment?(hash)
+      Regexp.new("\\A(?:#{described_class::ROUTE_HASH_PATTERN.source})\\z").match?(hash)
+    end
+
     it "keeps the route hash pattern derived from the safe hash pattern without anchors" do
       expect(described_class::ROUTE_HASH_PATTERN.source)
         .to eq(described_class::SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
+    end
+
+    {
+      "abc123" => true,
+      "_hash" => true,
+      "hash-with.dots" => true,
+      "valid_hash-123.js" => true,
+      "" => false,
+      ".starts_with_dot" => false,
+      "-starts-with-dash" => false,
+      "has!bang" => false,
+      "../traversal" => false,
+      "slash/path" => false
+    }.each do |hash, expected|
+      it "#{expected ? 'accepts' : 'rejects'} hash segment #{hash.inspect}" do
+        expect(route_hash_pattern_matches_segment?(hash)).to eq(expected)
+      end
     end
 
     it "uses the default route helper prefix" do


### PR DESCRIPTION
Fixes #3476

Summary:
- Auto-mounts rolling deploy bundle routes for the built-in HTTP adapter when the adapter mount path is configured.
- Uses an internal helper prefix and prepended routes so existing manual mounts and catch-all routes remain safe.
- Documents the default auto-mounted workflow and manual mount escape hatch.

Verification:
- bundle exec rspec spec/rolling_deploy_auto_routes_spec.rb (in react_on_rails_pro/spec/dummy)
- bundle exec rspec spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb (in react_on_rails_pro)
- bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false react_on_rails_pro/lib/react_on_rails_pro/engine.rb react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
- git diff --check
- autoreview --mode local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy-time HTTP routing and upgrade behavior for Pro rolling deploy; security still relies on existing bearer-token and hash allowlist on the controller, with added coverage but no change to auth semantics.
> 
> **Overview**
> **React on Rails Pro** now **auto-mounts** the HTTP rolling-deploy bundle endpoints when `config.rolling_deploy_adapter` is the built-in `Http` adapter, using `config.rolling_deploy_mount_path` (default `/react_on_rails_pro/rolling_deploy`). Apps no longer need a default `draw_routes` entry in `config/routes.rb`; set the mount path to `nil` or `""` to opt out and keep manual routing.
> 
> The Pro engine **prepends** these routes and registers them under an internal named-route prefix so they win over catch-all routes and do not clash with existing manual mounts at the same path (upgrade-safe). Docs and changelog describe the default flow, custom paths, and secondary manual mounts with a distinct `as_prefix:`.
> 
> `BundlesController` route constraints now use a **non-anchored** `ROUTE_HASH_PATTERN` derived from `SAFE_HASH_PATTERN`, matching how Rails applies segment constraints, with controller-level validation unchanged. New request and unit specs cover auto-mount, opt-out, custom paths, invalid hash segments, and route ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ccf97368f4687e519be38ad946e2c29851b96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP rolling-deploy endpoints now automatically mount when the HTTP adapter is configured.
  * Added configuration option to customize the mount path.
  * Added ability to opt-out of auto-mounting via configuration.

* **Documentation**
  * Updated rolling-deploy adapter documentation with auto-mounting details and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->