### PR TITLE
Warn on dynamic RSC webpack plugin options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **Generator defaults to Rspack for fresh installs**: `rails generate react_on_rails:install` and `create-react-on-rails-app` now default to the Rspack bundler on fresh installs (significantly faster builds via SWC), instead of Webpack. Pass `--no-rspack` (or its alias `--webpack`) to use Webpack. This only affects fresh installs — existing apps that already declare an `assets_bundler` in `config/shakapacker.yml` are left unchanged, an explicit `--rspack`/`--no-rspack`/`--webpack` always wins, and the default falls back to Webpack on Shakapacker versions below 9.0 (where Rspack is unsupported). [PR 3484](https://github.com/shakacode/react_on_rails/pull/3484) by [justin808](https://github.com/justin808).
 
+#### Improved
+
+- **RSC setup verification warns on dynamic plugin options**: `react_on_rails:install --rsc` now warns when `new RSCWebpackPlugin(...)` uses computed options that cannot be statically verified, avoiding misleading missing-`clientReferences` reports for dynamic config. Fixes [Issue 3412](https://github.com/shakacode/react_on_rails/issues/3412). [PR 3505](https://github.com/shakacode/react_on_rails/pull/3505) by [justin808](https://github.com/justin808).
+
 #### Fixed
 
 - **Shakapacker config warnings now report resolved relative paths**: When `SHAKAPACKER_CONFIG` is set to a relative missing path, the Rails boot warning now includes the Rails-root-resolved path that React on Rails actually checked. Fixes [Issue 3436](https://github.com/shakacode/react_on_rails/issues/3436). [PR 3441](https://github.com/shakacode/react_on_rails/pull/3441) by [justin808](https://github.com/justin808).

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup.rb
@@ -538,7 +538,7 @@ module ReactOnRails
         content = File.read(path)
         missing = []
         if content.include?("RSCWebpackPlugin")
-          warn_dynamic_rsc_plugin_options_for_config(content, "serverWebpackConfig.js")
+          warn_non_object_literal_rsc_plugin_options_for_config(content)
           unless rsc_plugin_client_references_configured?(content, is_server: true)
             missing << "generated scoped clientReferences in serverWebpackConfig.js"
           end
@@ -556,7 +556,7 @@ module ReactOnRails
         content = File.read(path)
         missing = []
         if content.include?("RSCWebpackPlugin")
-          warn_dynamic_rsc_plugin_options_for_config(content, "clientWebpackConfig.js")
+          warn_non_object_literal_rsc_plugin_options_for_config(content)
           unless rsc_plugin_client_references_configured?(content, is_server: false)
             missing << "generated scoped clientReferences in clientWebpackConfig.js"
           end
@@ -574,21 +574,20 @@ module ReactOnRails
         content.include?("rscWebpackConfig") ? [] : ["rscWebpackConfig in ServerClientOrBoth.js"]
       end
 
-      def warn_dynamic_rsc_plugin_options_for_config(content, config_filename)
-        return unless dynamic_rsc_plugin_options_invocation_count(content).positive?
+      def warn_non_object_literal_rsc_plugin_options_for_config(content)
+        return unless non_object_literal_rsc_plugin_invocation_count(content).positive?
 
-        warn_dynamic_rsc_plugin_options_once(config_filename)
+        warn_non_object_literal_rsc_plugin_options_once
       end
 
-      def warn_dynamic_rsc_plugin_options_once(config_filename)
-        @dynamic_rsc_plugin_options_warned ||= false
-        return if @dynamic_rsc_plugin_options_warned
+      def warn_non_object_literal_rsc_plugin_options_once
+        return if @non_object_literal_rsc_plugin_options_warned
 
-        @dynamic_rsc_plugin_options_warned = true
+        @non_object_literal_rsc_plugin_options_warned = true
         GeneratorMessages.add_warning(
-          "RSCWebpackPlugin in #{config_filename} uses dynamic or computed options, so the generator " \
-          "cannot verify whether scoped clientReferences are configured. Please verify this webpack " \
-          "config manually."
+          "RSCWebpackPlugin calls use non-object-literal options in one or more webpack configs, " \
+          "so the generator cannot verify whether scoped clientReferences are configured. " \
+          "Please verify your webpack configs manually."
         )
       end
     end

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup.rb
@@ -538,6 +538,7 @@ module ReactOnRails
         content = File.read(path)
         missing = []
         if content.include?("RSCWebpackPlugin")
+          warn_dynamic_rsc_plugin_options_for_config(content, "serverWebpackConfig.js")
           unless rsc_plugin_client_references_configured?(content, is_server: true)
             missing << "generated scoped clientReferences in serverWebpackConfig.js"
           end
@@ -555,6 +556,7 @@ module ReactOnRails
         content = File.read(path)
         missing = []
         if content.include?("RSCWebpackPlugin")
+          warn_dynamic_rsc_plugin_options_for_config(content, "clientWebpackConfig.js")
           unless rsc_plugin_client_references_configured?(content, is_server: false)
             missing << "generated scoped clientReferences in clientWebpackConfig.js"
           end
@@ -570,6 +572,24 @@ module ReactOnRails
 
         content = File.read(File.join(destination_root, scob_path))
         content.include?("rscWebpackConfig") ? [] : ["rscWebpackConfig in ServerClientOrBoth.js"]
+      end
+
+      def warn_dynamic_rsc_plugin_options_for_config(content, config_filename)
+        return unless dynamic_rsc_plugin_options_invocation_count(content).positive?
+
+        warn_dynamic_rsc_plugin_options_once(config_filename)
+      end
+
+      def warn_dynamic_rsc_plugin_options_once(config_filename)
+        @dynamic_rsc_plugin_options_warned ||= false
+        return if @dynamic_rsc_plugin_options_warned
+
+        @dynamic_rsc_plugin_options_warned = true
+        GeneratorMessages.add_warning(
+          "RSCWebpackPlugin in #{config_filename} uses dynamic or computed options, so the generator " \
+          "cannot verify whether scoped clientReferences are configured. Please verify this webpack " \
+          "config manually."
+        )
       end
     end
   end

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
@@ -6,6 +6,7 @@ module ReactOnRails
       module ClientReferences # rubocop:disable Metrics/ModuleLength
         JS_STRING_DELIMITERS = ["'", '"', "`"].freeze
         JS_COMMENT_STATES = %i[line_comment block_comment].freeze
+        JS_COMMENT_START_CHARS = ["/", "*"].freeze
         # Known limitation: this list only covers single-character regex preceders. Multi-character
         # JavaScript keywords that legally precede a regex literal (`return`, `typeof`, `void`,
         # `delete`, `throw`, `case`, `in`, `instanceof`) are not represented. A regex like `/\{/`
@@ -243,9 +244,9 @@ module ReactOnRails
           # No parseable `isServer: <bool>` section means this file's plugin call sits outside
           # what the generator's scanner can match (e.g. options are computed at runtime, or the
           # plugin is invoked without an options object). Verification callers intentionally
-          # under-report here: warning about "missing scoped clientReferences" when there's no
-          # section to inspect would only surface noise for dynamic invocations like
-          # `RSCWebpackPlugin(buildOptions())`, where the user has nothing actionable to do.
+          # keep these out of the missing-pattern list because there is no literal section to
+          # classify as broken. They warn separately for dynamic invocations so users can verify
+          # those configs manually.
           return true if sections.empty?
 
           sections.all? do |section|
@@ -256,6 +257,27 @@ module ReactOnRails
               rsc_plugin_body_has_top_level_key?(body, "clientReferences")
             end
           end
+        end
+
+        def dynamic_rsc_plugin_options_invocation_count(content)
+          count = 0
+          search_from = 0
+
+          while (match = content.match(RSC_PLUGIN_INVOCATION_REGEX, search_from))
+            call_start = match.begin(0)
+            after_open_paren = match.end(0)
+            unless js_code_position?(content, call_start)
+              search_from = after_open_paren
+              next
+            end
+
+            options_start = first_js_token_index(content, after_open_paren)
+            options_start_char = options_start ? content[options_start] : nil
+            count += 1 if options_start_char && options_start_char != "{" && options_start_char != ")"
+            search_from = after_open_paren
+          end
+
+          count
         end
 
         def rsc_plugin_defines_client_references?(content, is_server:)
@@ -411,11 +433,10 @@ module ReactOnRails
           false
         end
 
-        # Skips whitespace, JS line/block comments, and leading string literals so callers see the
-        # next structural character. Without comment skipping, configurations like
-        # `new RSCWebpackPlugin( /* opts */ {` would land on `/` and be rejected as "no plugin
-        # options" even though the options object is present.
-        def first_significant_js_index(content, start_index)
+        # Skips whitespace and JS line/block comments, preserving strings as the next token.
+        # Dynamic-option verification uses this so `new RSCWebpackPlugin("opts")` warns instead
+        # of having the string skipped as incidental syntax.
+        def first_js_token_index(content, start_index)
           index = start_index
           state = nil
           escaped = false
@@ -423,16 +444,52 @@ module ReactOnRails
           while index < content.length
             char = content[index]
             next_char = content[index + 1]
-            prev_state = state
-            state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
-            # Exiting a block comment leaves `char` as `*` and `index` pointing at the closing
-            # `/`; advance past it so the next iteration evaluates the first character after `*/`.
-            if state || prev_state == :block_comment
+
+            if state
+              state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
               index += 1
               next
             end
 
-            return index unless char.match?(/\s/) || JS_STRING_DELIMITERS.include?(prev_state)
+            return index unless char.match?(/\s/) || (char == "/" && JS_COMMENT_START_CHARS.include?(next_char))
+
+            state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
+
+            index += 1
+          end
+
+          nil
+        end
+
+        # Skips whitespace, JS line/block comments, and leading string literals so callers see the
+        # next structural character. Without comment skipping, configurations like
+        # `new RSCWebpackPlugin( /* opts */ {` would land on `/` and be rejected as "no plugin
+        # options" even though the options object is present.
+        def first_significant_js_index(content, start_index)
+          index = first_js_token_index(content, start_index)
+
+          while index && JS_STRING_DELIMITERS.include?(content[index])
+            string_end = js_string_end_index(content, index)
+            return nil unless string_end
+
+            index = first_js_token_index(content, string_end + 1)
+          end
+
+          index
+        end
+
+        def js_string_end_index(content, string_start_index)
+          state = nil
+          escaped = false
+          index = string_start_index
+
+          while index < content.length
+            char = content[index]
+            next_char = content[index + 1]
+            previous_state = state
+            state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
+
+            return index if previous_state && state.nil?
 
             index += 1
           end

--- a/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
+++ b/react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb
@@ -6,7 +6,8 @@ module ReactOnRails
       module ClientReferences # rubocop:disable Metrics/ModuleLength
         JS_STRING_DELIMITERS = ["'", '"', "`"].freeze
         JS_COMMENT_STATES = %i[line_comment block_comment].freeze
-        JS_COMMENT_START_CHARS = ["/", "*"].freeze
+        # Characters that complete `//` or `/*` after a leading `/`.
+        JS_COMMENT_SECOND_CHARS = ["/", "*"].freeze
         # Known limitation: this list only covers single-character regex preceders. Multi-character
         # JavaScript keywords that legally precede a regex literal (`return`, `typeof`, `void`,
         # `delete`, `throw`, `case`, `in`, `instanceof`) are not represented. A regex like `/\{/`
@@ -259,7 +260,10 @@ module ReactOnRails
           end
         end
 
-        def dynamic_rsc_plugin_options_invocation_count(content)
+        # Counts active `new RSCWebpackPlugin(...)` calls whose first argument is present but
+        # not an object literal. This includes computed options plus static string/template
+        # literals; all are outside the verifier's parseable `{...}` contract.
+        def non_object_literal_rsc_plugin_invocation_count(content)
           count = 0
           search_from = 0
 
@@ -434,8 +438,8 @@ module ReactOnRails
         end
 
         # Skips whitespace and JS line/block comments, preserving strings as the next token.
-        # Dynamic-option verification uses this so `new RSCWebpackPlugin("opts")` warns instead
-        # of having the string skipped as incidental syntax.
+        # Non-object-literal option verification uses this so `new RSCWebpackPlugin("opts")`
+        # warns instead of having the string skipped as incidental syntax.
         def first_js_token_index(content, start_index)
           index = start_index
           state = nil
@@ -451,7 +455,7 @@ module ReactOnRails
               next
             end
 
-            return index unless char.match?(/\s/) || (char == "/" && JS_COMMENT_START_CHARS.include?(next_char))
+            return index unless char.match?(/\s/) || (char == "/" && JS_COMMENT_SECOND_CHARS.include?(next_char))
 
             state, escaped, index = advance_js_scan_state(state, escaped, char, next_char, index)
 
@@ -478,6 +482,9 @@ module ReactOnRails
           index
         end
 
+        # Scans from a string-opening delimiter at `string_start_index` and returns the index
+        # of the matching closing delimiter, not one past it. Returns nil for unterminated
+        # strings. Callers must ensure `content[string_start_index]` is in JS_STRING_DELIMITERS.
         def js_string_end_index(content, string_start_index)
           state = nil
           escaped = false

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -1691,6 +1691,79 @@ describe RscGenerator, type: :generator do
       expect(generator.send(:rsc_plugin_client_references_configured?, content, is_server: false)).to be(true)
     end
 
+    it "counts active dynamic plugin options without counting comments or literal options" do
+      content = <<~JS
+        const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+        // clientConfig.plugins.push(new RSCWebpackPlugin(buildCommentedOptions()));
+        clientConfig.plugins.push(new RSCWebpackPlugin({ isServer: false }));
+        clientConfig.plugins.push(new RSCWebpackPlugin(buildOptions()));
+        clientConfig.plugins.push(new RSCWebpackPlugin("literalOptions"));
+        clientConfig.plugins.push(new RSCWebpackPlugin(`templateOptions`));
+      JS
+
+      expect(generator.send(:dynamic_rsc_plugin_options_invocation_count, content)).to eq(3)
+    end
+
+    it "warns during verification when client plugin options are dynamic but keeps them out of missing patterns" do
+      config_path = "config/webpack/clientWebpackConfig.js"
+      simulate_existing_file(
+        config_path,
+        <<~JS
+          const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+          clientConfig.plugins.push(new RSCWebpackPlugin(buildOptions()));
+        JS
+      )
+
+      expect(generator.send(:check_rsc_client_config)).to eq([])
+
+      messages = GeneratorMessages.messages.join("\n")
+      expect(messages).to include("uses dynamic or computed options")
+      expect(messages).to include("cannot verify whether scoped clientReferences are configured")
+      expect(messages).not_to include("generated scoped clientReferences in clientWebpackConfig.js")
+    end
+
+    it "warns only once when verification sees dynamic plugin options in both webpack configs" do
+      simulate_existing_file(
+        "config/webpack/serverWebpackConfig.js",
+        <<~JS
+          const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+          const rscBundle = false;
+          serverWebpackConfig.plugins.push(new RSCWebpackPlugin(serverPluginOptions()));
+        JS
+      )
+      simulate_existing_file(
+        "config/webpack/clientWebpackConfig.js",
+        <<~JS
+          const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+          clientConfig.plugins.push(new RSCWebpackPlugin(clientPluginOptions()));
+        JS
+      )
+
+      generator.send(:check_rsc_server_config)
+      generator.send(:check_rsc_client_config)
+
+      dynamic_warnings = GeneratorMessages.messages.grep(/uses dynamic or computed options/)
+      expect(dynamic_warnings.length).to eq(1)
+    end
+
+    it "does not warn during verification for literal options or commented-out dynamic plugin calls" do
+      simulate_existing_file(
+        "config/webpack/clientWebpackConfig.js",
+        <<~JS
+          const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
+          // clientConfig.plugins.push(new RSCWebpackPlugin(buildOptions()));
+          clientConfig.plugins.push(new RSCWebpackPlugin({
+            isServer: false,
+            clientReferences,
+          }));
+        JS
+      )
+
+      generator.send(:check_rsc_client_config)
+
+      expect(GeneratorMessages.messages.join("\n")).not_to include("uses dynamic or computed options")
+    end
+
     it "treats shorthand clientReferences as a top-level configured option" do
       body = <<~JS
         isServer: false,

--- a/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
@@ -1691,20 +1691,21 @@ describe RscGenerator, type: :generator do
       expect(generator.send(:rsc_plugin_client_references_configured?, content, is_server: false)).to be(true)
     end
 
-    it "counts active dynamic plugin options without counting comments or literal options" do
+    it "counts active non-object-literal plugin options without counting comments or object options" do
       content = <<~JS
         const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
         // clientConfig.plugins.push(new RSCWebpackPlugin(buildCommentedOptions()));
         clientConfig.plugins.push(new RSCWebpackPlugin({ isServer: false }));
+        clientConfig.plugins.push(new RSCWebpackPlugin());
         clientConfig.plugins.push(new RSCWebpackPlugin(buildOptions()));
         clientConfig.plugins.push(new RSCWebpackPlugin("literalOptions"));
         clientConfig.plugins.push(new RSCWebpackPlugin(`templateOptions`));
       JS
 
-      expect(generator.send(:dynamic_rsc_plugin_options_invocation_count, content)).to eq(3)
+      expect(generator.send(:non_object_literal_rsc_plugin_invocation_count, content)).to eq(3)
     end
 
-    it "warns during verification when client plugin options are dynamic but keeps them out of missing patterns" do
+    it "warns during verification when client plugin options are not object literals" do
       config_path = "config/webpack/clientWebpackConfig.js"
       simulate_existing_file(
         config_path,
@@ -1717,12 +1718,12 @@ describe RscGenerator, type: :generator do
       expect(generator.send(:check_rsc_client_config)).to eq([])
 
       messages = GeneratorMessages.messages.join("\n")
-      expect(messages).to include("uses dynamic or computed options")
+      expect(messages).to include("use non-object-literal options")
       expect(messages).to include("cannot verify whether scoped clientReferences are configured")
       expect(messages).not_to include("generated scoped clientReferences in clientWebpackConfig.js")
     end
 
-    it "warns only once when verification sees dynamic plugin options in both webpack configs" do
+    it "warns only once without naming only the first config when both webpack configs use non-object options" do
       simulate_existing_file(
         "config/webpack/serverWebpackConfig.js",
         <<~JS
@@ -1742,11 +1743,14 @@ describe RscGenerator, type: :generator do
       generator.send(:check_rsc_server_config)
       generator.send(:check_rsc_client_config)
 
-      dynamic_warnings = GeneratorMessages.messages.grep(/uses dynamic or computed options/)
-      expect(dynamic_warnings.length).to eq(1)
+      non_object_warnings = GeneratorMessages.messages.grep(/use non-object-literal options/)
+      expect(non_object_warnings.length).to eq(1)
+      expect(non_object_warnings.first).to include("one or more webpack configs")
+      expect(non_object_warnings.first).not_to include("serverWebpackConfig.js")
+      expect(non_object_warnings.first).not_to include("clientWebpackConfig.js")
     end
 
-    it "does not warn during verification for literal options or commented-out dynamic plugin calls" do
+    it "does not warn during verification for object options or commented-out non-object plugin calls" do
       simulate_existing_file(
         "config/webpack/clientWebpackConfig.js",
         <<~JS
@@ -1761,7 +1765,7 @@ describe RscGenerator, type: :generator do
 
       generator.send(:check_rsc_client_config)
 
-      expect(GeneratorMessages.messages.join("\n")).not_to include("uses dynamic or computed options")
+      expect(GeneratorMessages.messages.join("\n")).not_to include("use non-object-literal options")
     end
 
     it "treats shorthand clientReferences as a top-level configured option" do


### PR DESCRIPTION
Fixes #3412

Summary:
- Warns once when RSCWebpackPlugin options are dynamic and cannot be statically verified.
- Keeps dynamic invocations out of the missing clientReferences pattern list.
- Covers comments, strings, templates, literals, and dynamic first arguments in generator specs.

Verification:
- bundle exec rspec react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb:1694 react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb:1707 react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb:1725 react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb:1749 react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb:2099
- bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false react_on_rails/lib/generators/react_on_rails/rsc_setup.rb react_on_rails/lib/generators/react_on_rails/rsc_setup/client_references.rb react_on_rails/spec/react_on_rails/generators/rsc_generator_spec.rb
- git diff --check
- autoreview --mode local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to install-time generator verification and JS parsing helpers; no runtime rendering or webpack build behavior is modified.
> 
> **Overview**
> **RSC install verification** now detects `new RSCWebpackPlugin(...)` calls whose first argument is not an object literal (e.g. `buildOptions()`, string/template literals) and emits a **single** generator warning that scoped `clientReferences` cannot be checked automatically, instead of listing missing generated patterns.
> 
> Server and client webpack config checks invoke this path when the plugin is present. **JS scanning** in `client_references.rb` gains `first_js_token_index` / `js_string_end_index` and refactors `first_significant_js_index` so comment/string skipping correctly classifies non-literal plugin arguments; commented-out dynamic calls and normal `{ ... }` options stay silent.
> 
> CHANGELOG documents the improvement for `react_on_rails:install --rsc` (fixes #3412).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35bf36712bc33c92e6f9374c028839bb49c7a7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved**
  * The RSC setup command now detects and warns when RSCWebpackPlugin uses non-literal options, preventing misleading messages about missing client references configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->