### PR TITLE
Preserve localhost renderer host with base port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **Shakapacker config warnings now report resolved relative paths**: When `SHAKAPACKER_CONFIG` is set to a relative missing path, the Rails boot warning now includes the Rails-root-resolved path that React on Rails actually checked. Fixes [Issue 3436](https://github.com/shakacode/react_on_rails/issues/3436). [PR 3441](https://github.com/shakacode/react_on_rails/pull/3441) by [justin808](https://github.com/justin808).
+- **Base-port renderer URLs preserve localhost-equivalent hosts**: `bin/dev` base-port mode now keeps localhost-equivalent renderer hosts and schemes, such as `127.0.0.1` and `https://localhost`, when deriving `REACT_RENDERER_URL`; remote or invalid hosts still fall back to `http://localhost`. Fixes [Issue 3466](https://github.com/shakacode/react_on_rails/issues/3466). [PR 3506](https://github.com/shakacode/react_on_rails/pull/3506) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.0] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Fixed
 
 - **Shakapacker config warnings now report resolved relative paths**: When `SHAKAPACKER_CONFIG` is set to a relative missing path, the Rails boot warning now includes the Rails-root-resolved path that React on Rails actually checked. Fixes [Issue 3436](https://github.com/shakacode/react_on_rails/issues/3436). [PR 3441](https://github.com/shakacode/react_on_rails/pull/3441) by [justin808](https://github.com/justin808).
-- **Base-port renderer URLs preserve localhost-equivalent hosts**: `bin/dev` base-port mode now keeps localhost-equivalent renderer hosts and schemes, such as `127.0.0.1` and `https://localhost`, when deriving `REACT_RENDERER_URL`; remote or invalid hosts still fall back to `http://localhost`. Fixes [Issue 3466](https://github.com/shakacode/react_on_rails/issues/3466). [PR 3506](https://github.com/shakacode/react_on_rails/pull/3506) by [justin808](https://github.com/justin808).
+- **Base-port renderer URLs preserve localhost-equivalent hosts**: `bin/dev` base-port mode now keeps localhost-equivalent renderer hosts and schemes, such as `127.0.0.1` and `https://localhost`, when deriving `REACT_RENDERER_URL`; remote or invalid hosts still fall back to `http://localhost:<port>`. Fixes [Issue 3466](https://github.com/shakacode/react_on_rails/issues/3466). [PR 3506](https://github.com/shakacode/react_on_rails/pull/3506) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.0] - 2026-05-30
 

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -1148,8 +1148,9 @@ module ReactOnRails
         #
         # Base-port mode is specifically for local, all-in-one dev setups (one
         # machine running Rails + webpack + node renderer together — typically
-        # worktrees or coding-agent sandboxes). The derived renderer URL is
-        # therefore hard-coded to http://localhost:<port>. If you run the node
+        # worktrees or coding-agent sandboxes). The derived renderer URL keeps
+        # an explicit localhost-equivalent scheme/host when present, and
+        # otherwise falls back to http://localhost:<port>. If you run the node
         # renderer on a separate host/container (e.g. Docker `renderer:3800`),
         # do not use base-port mode — set REACT_RENDERER_URL explicitly and
         # rely on the explicit-ports path instead. warn_if_renderer_url_will_be_overridden
@@ -1172,7 +1173,7 @@ module ReactOnRails
           ENV["SHAKAPACKER_DEV_SERVER_PORT"] = selected[:webpack].to_s
           return unless pro_renderer_active?
 
-          derived_url = "http://localhost:#{selected[:renderer]}"
+          derived_url = base_port_renderer_url(selected[:renderer])
           warn_if_renderer_url_will_be_overridden("REACT_RENDERER_URL", derived_url)
           warn_if_port_will_be_overridden("RENDERER_PORT", selected[:renderer])
           ENV["RENDERER_PORT"] = selected[:renderer].to_s
@@ -1188,6 +1189,22 @@ module ReactOnRails
 
           warn_if_renderer_url_will_be_overridden("RENDERER_URL", derived_url)
           ENV["RENDERER_URL"] = derived_url
+        end
+
+        def base_port_renderer_url(renderer_port)
+          local_base_port_renderer_url(ENV.fetch("REACT_RENDERER_URL", nil), renderer_port) ||
+            "http://localhost:#{renderer_port}"
+        end
+
+        def local_base_port_renderer_url(url, renderer_port)
+          return if url.nil? || url.strip.empty?
+
+          parsed = URI.parse(url)
+          return unless parsed.scheme && localhost_hostname?(parsed.hostname)
+
+          URI::Generic.build(scheme: parsed.scheme, host: parsed.hostname, port: renderer_port).to_s
+        rescue URI::Error
+          nil
         end
 
         # Heuristic for "this app has a Pro node renderer to point at": either

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -1202,7 +1202,7 @@ module ReactOnRails
           parsed = URI.parse(url)
           return unless parsed.scheme && localhost_hostname?(parsed.hostname)
 
-          URI::Generic.build(scheme: parsed.scheme, host: parsed.hostname, port: renderer_port).to_s
+          URI::Generic.build(scheme: parsed.scheme, host: parsed.host, port: renderer_port).to_s
         rescue URI::Error
           nil
         end

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -1192,7 +1192,9 @@ module ReactOnRails
         end
 
         def base_port_renderer_url(renderer_port)
-          local_base_port_renderer_url(ENV.fetch("REACT_RENDERER_URL", nil), renderer_port) ||
+          renderer_url = ENV.fetch("REACT_RENDERER_URL", nil).presence || ENV.fetch("RENDERER_URL", nil)
+
+          local_base_port_renderer_url(renderer_url, renderer_port) ||
             "http://localhost:#{renderer_port}"
         end
 

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -511,14 +511,25 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
       it "preserves an explicit IPv4 localhost REACT_RENDERER_URL host in base-port mode" do
         ENV["REACT_RENDERER_URL"] = "http://127.0.0.1:3800"
-        described_class.start(:development)
+        expect { described_class.start(:development) }
+          .to output(%r{Overriding REACT_RENDERER_URL="http://127.0.0.1:3800" with http://127.0.0.1:5002})
+          .to_stderr
         expect(ENV.fetch("REACT_RENDERER_URL", nil)).to eq("http://127.0.0.1:5002")
+      end
+
+      it "preserves an explicit IPv6 localhost REACT_RENDERER_URL host in base-port mode" do
+        ENV["REACT_RENDERER_URL"] = "http://[::1]:3800"
+        expect { described_class.start(:development) }
+          .to output(%r{Overriding REACT_RENDERER_URL="http://\[::1\]:3800" with http://\[::1\]:5002})
+          .to_stderr
+        expect(ENV.fetch("REACT_RENDERER_URL", nil)).to eq("http://[::1]:5002")
       end
 
       it "warns before overriding an HTTPS localhost REACT_RENDERER_URL on a different port" do
         ENV["REACT_RENDERER_URL"] = "https://localhost:3800"
         expect { described_class.start(:development) }
           .to output(%r{Overriding REACT_RENDERER_URL="https://localhost:3800"}).to_stderr
+        expect(ENV.fetch("REACT_RENDERER_URL", nil)).to eq("https://localhost:5002")
       end
 
       it "does not warn when REACT_RENDERER_URL already equals the derived URL" do

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -544,6 +544,13 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(ENV.fetch("RENDERER_URL", nil)).to eq("http://localhost:5002")
       end
 
+      it "preserves a legacy localhost-equivalent RENDERER_URL host when REACT_RENDERER_URL is unset" do
+        ENV["RENDERER_URL"] = "http://127.0.0.1:3800"
+        described_class.start(:development)
+        expect(ENV.fetch("REACT_RENDERER_URL", nil)).to eq("http://127.0.0.1:5002")
+        expect(ENV.fetch("RENDERER_URL", nil)).to eq("http://127.0.0.1:5002")
+      end
+
       it "warns before overriding a legacy RENDERER_URL on a different port" do
         ENV["RENDERER_URL"] = "http://localhost:3800"
         expect { described_class.start(:development) }

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -497,10 +497,22 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
           .to output(%r{Overriding REACT_RENDERER_URL="http://renderer.internal:3800"}).to_stderr
       end
 
+      it "rewrites a remote REACT_RENDERER_URL to the standard localhost derived URL" do
+        ENV["REACT_RENDERER_URL"] = "http://renderer.internal:3800"
+        described_class.start(:development)
+        expect(ENV.fetch("REACT_RENDERER_URL", nil)).to eq("http://localhost:5002")
+      end
+
       it "warns before overriding a localhost REACT_RENDERER_URL on a different port" do
         ENV["REACT_RENDERER_URL"] = "http://localhost:3800"
         expect { described_class.start(:development) }
           .to output(%r{Overriding REACT_RENDERER_URL="http://localhost:3800" with http://localhost:5002}).to_stderr
+      end
+
+      it "preserves an explicit IPv4 localhost REACT_RENDERER_URL host in base-port mode" do
+        ENV["REACT_RENDERER_URL"] = "http://127.0.0.1:3800"
+        described_class.start(:development)
+        expect(ENV.fetch("REACT_RENDERER_URL", nil)).to eq("http://127.0.0.1:5002")
       end
 
       it "warns before overriding an HTTPS localhost REACT_RENDERER_URL on a different port" do


### PR DESCRIPTION
Fixes #3466

Summary:
- Keeps localhost-equivalent renderer host and scheme when deriving BASE_PORT renderer URLs.
- Falls back to localhost for remote or invalid renderer hosts.
- Adds focused ServerManager specs for the base-port cases.

Verification:
- bundle exec rspec react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb --example 'when configuring ports with a base port active'
- bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false react_on_rails/lib/react_on_rails/dev/server_manager.rb react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
- git diff --check
- autoreview --mode local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to local dev env derivation in ServerManager; no production SSR or auth paths changed, with behavior covered by new specs.
> 
> **Overview**
> **Base-port `bin/dev` no longer forces `http://localhost` for every derived renderer URL.** When `REACT_RENDERER_URL` or legacy `RENDERER_URL` is already set to a localhost-equivalent host (`localhost`, `127.0.0.1`, `[::1]`) with a valid scheme, base-port mode now **rewrites only the port** and keeps the original scheme and host (e.g. `https://localhost:3800` → `https://localhost:5002`, `http://127.0.0.1:3800` → `http://127.0.0.1:5002`).
> 
> Remote or invalid URLs still normalize to **`http://localhost:<derived_port>`**, matching the previous behavior for non-local setups. Comments and **CHANGELOG** document the fix for issue #3466; **ServerManager** specs cover remote fallback, IPv4/IPv6 localhost, HTTPS localhost, and legacy `RENDERER_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3820c6ef600a54f6aeee0cd445773c9e832176ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `bin/dev` base-port mode to preserve localhost-equivalent renderer URL hosts and schemes (e.g., 127.0.0.1, https://localhost). Falls back to http://localhost:<port> for remote or invalid hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->