### PR TITLE
Pass CSP nonce to streamed RSC rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **Shakapacker config warnings now report resolved relative paths**: When `SHAKAPACKER_CONFIG` is set to a relative missing path, the Rails boot warning now includes the Rails-root-resolved path that React on Rails actually checked. Fixes [Issue 3436](https://github.com/shakacode/react_on_rails/issues/3436). [PR 3441](https://github.com/shakacode/react_on_rails/pull/3441) by [justin808](https://github.com/justin808).
 - **Base-port renderer URLs preserve localhost-equivalent hosts**: `bin/dev` base-port mode now keeps localhost-equivalent renderer hosts and schemes, such as `127.0.0.1` and `https://localhost`, when deriving `REACT_RENDERER_URL`; remote or invalid hosts still fall back to `http://localhost:<port>`. Fixes [Issue 3466](https://github.com/shakacode/react_on_rails/issues/3466). [PR 3506](https://github.com/shakacode/react_on_rails/pull/3506) by [justin808](https://github.com/justin808).
+- **[Pro]** **Streamed RSC rendering now propagates CSP nonces**: React on Rails Pro now passes the Rails CSP nonce to React's streamed RSC renderer options so streamed script output can satisfy strict content security policies. Fixes [Issue 3491](https://github.com/shakacode/react_on_rails/issues/3491). [PR 3507](https://github.com/shakacode/react_on_rails/pull/3507) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.0] - 2026-05-30
 

--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -14,6 +14,7 @@
 
 import { Readable } from 'stream';
 
+import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import { renderToPipeableStream } from 'react-on-rails/ReactDOMServer';
 import { convertToError } from 'react-on-rails/serverRenderUtils';
 import {
@@ -97,7 +98,7 @@ const streamRenderReactComponent = (
           streamingTrackers.postSSRHookTracker.notifySSREnd();
         },
         identifierPrefix: domNodeId,
-        nonce: railsContext.cspNonce,
+        nonce: sanitizeNonce(railsContext.cspNonce),
       });
     })
     .catch((e: unknown) => {

--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -97,6 +97,7 @@ const streamRenderReactComponent = (
           streamingTrackers.postSSRHookTracker.notifySSREnd();
         },
         identifierPrefix: domNodeId,
+        nonce: railsContext.cspNonce,
       });
     })
     .catch((e: unknown) => {

--- a/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
@@ -4,7 +4,6 @@
 
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import { renderToPipeableStream } from 'react-on-rails/ReactDOMServer';
 import streamServerRenderedReactComponent from '../src/streamServerRenderedReactComponent.ts';
 import * as ComponentRegistry from '../src/ComponentRegistry.ts';
@@ -175,7 +174,7 @@ describe('streamServerRenderedReactComponent', () => {
       expect.anything(),
       expect.objectContaining({
         identifierPrefix: 'myDomId',
-        nonce: sanitizeNonce(testingRailsContext.cspNonce),
+        nonce: 'stream-csp-nonce',
       }),
     );
   });

--- a/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
@@ -4,6 +4,7 @@
 
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import { renderToPipeableStream } from 'react-on-rails/ReactDOMServer';
 import streamServerRenderedReactComponent from '../src/streamServerRenderedReactComponent.ts';
 import * as ComponentRegistry from '../src/ComponentRegistry.ts';
@@ -95,6 +96,7 @@ describe('streamServerRenderedReactComponent', () => {
     throwJsErrors = false,
     throwAsyncError = false,
     componentType = 'reactComponent',
+    railsContext = testingRailsContext,
   } = {}) => {
     switch (componentType) {
       case 'reactComponent':
@@ -135,7 +137,7 @@ describe('streamServerRenderedReactComponent', () => {
       trace: false,
       props: { throwSyncError, throwAsyncError },
       throwJsErrors,
-      railsContext: testingRailsContext,
+      railsContext,
     });
 
     const chunks = [];
@@ -173,7 +175,24 @@ describe('streamServerRenderedReactComponent', () => {
       expect.anything(),
       expect.objectContaining({
         identifierPrefix: 'myDomId',
-        nonce: testingRailsContext.cspNonce,
+        nonce: sanitizeNonce(testingRailsContext.cspNonce),
+      }),
+    );
+  });
+
+  it("omits React's streaming bootstrap nonce option when Rails CSP nonce is absent", async () => {
+    const { renderResult } = setupStreamTest({
+      railsContext: { ...testingRailsContext, cspNonce: undefined },
+    });
+    await new Promise((resolve) => {
+      renderResult.once('end', resolve);
+    });
+
+    expect(renderToPipeableStream).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        identifierPrefix: 'myDomId',
+        nonce: undefined,
       }),
     );
   });

--- a/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
+++ b/packages/react-on-rails-pro/tests/streamServerRenderedReactComponent.test.jsx
@@ -4,10 +4,20 @@
 
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import { renderToPipeableStream } from 'react-on-rails/ReactDOMServer';
 import streamServerRenderedReactComponent from '../src/streamServerRenderedReactComponent.ts';
 import * as ComponentRegistry from '../src/ComponentRegistry.ts';
 import ReactOnRails from '../src/ReactOnRails.node.ts';
 import LengthPrefixedStreamParser from '../src/parseLengthPrefixedStream.ts';
+
+jest.mock('react-on-rails/ReactDOMServer', () => {
+  const actual = jest.requireActual('react-on-rails/ReactDOMServer');
+
+  return {
+    ...actual,
+    renderToPipeableStream: jest.fn(actual.renderToPipeableStream),
+  };
+});
 
 const AsyncContent = async ({ throwAsyncError }) => {
   await new Promise((resolve) => {
@@ -48,6 +58,7 @@ describe('streamServerRenderedReactComponent', () => {
     serverSideRSCPayloadParameters: {},
     reactClientManifestFileName: 'clientManifest.json',
     reactServerClientManifestFileName: 'serverClientManifest.json',
+    cspNonce: 'stream-csp-nonce',
     componentSpecificMetadata: {
       renderRequestId: '123',
     },
@@ -55,6 +66,7 @@ describe('streamServerRenderedReactComponent', () => {
 
   beforeEach(() => {
     ComponentRegistry.components().clear();
+    renderToPipeableStream.mockClear();
   });
 
   // Parses a length-prefixed stream chunk: metadata\tcontent_len\ncontent
@@ -149,6 +161,21 @@ describe('streamServerRenderedReactComponent', () => {
     expect(chunks[1].consoleReplayScript).toBe('');
     expect(chunks[1].hasErrors).toBe(false);
     expect(chunks[1].isShellReady).toBe(true);
+  });
+
+  it("passes Rails' CSP nonce to React's streaming bootstrap options", async () => {
+    const { renderResult } = setupStreamTest();
+    await new Promise((resolve) => {
+      renderResult.once('end', resolve);
+    });
+
+    expect(renderToPipeableStream).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        identifierPrefix: 'myDomId',
+        nonce: testingRailsContext.cspNonce,
+      }),
+    );
   });
 
   it('emits an error if there is an error in the shell and throwJsErrors is true', async () => {


### PR DESCRIPTION
Fixes #3491

Summary:
- Passes the Rails CSP nonce through to React's streamed RSC renderer options.
- Adds a focused package test that asserts the nonce reaches renderToPipeableStream.

Verification:
- pnpm --dir packages/react-on-rails-pro exec jest tests/streamServerRenderedReactComponent.test.jsx --runInBand
- pnpm run type-check
- pnpm run lint
- git diff --check
- autoreview --mode local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted Pro streaming change reusing existing `sanitizeNonce`; covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> **Pro streamed RSC** now forwards the Rails **CSP nonce** into React’s `renderToPipeableStream` bootstrap options (via `sanitizeNonce`), so inline scripts emitted during streaming can satisfy strict CSP—aligned with how nonce is already handled for injected RSC payload scripts.
> 
> Tests mock `renderToPipeableStream` and assert the nonce is set when `railsContext.cspNonce` is present and omitted when it is absent. **CHANGELOG** documents the fix for issue #3491.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2bbd90bd2edcc6c5d1626bcd8639165acfce6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rails CSP nonces are now propagated to streamed React Server Components, enabling strict Content Security Policy compliance for rendered scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->