### PR TITLE
[codex] Tolerate blank RSC stream separators

### DIFF
--- a/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
+++ b/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
@@ -33,6 +33,10 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
   return result;
 }
 
+function isBlankSeparatorLine(header: Uint8Array): boolean {
+  return header.length === 0 || header.every((byte) => byte === 0x0d);
+}
+
 export default class LengthPrefixedStreamParser {
   private buf: Uint8Array = new Uint8Array(0);
 
@@ -52,26 +56,28 @@ export default class LengthPrefixedStreamParser {
         if (idx >= 0) {
           const header = this.buf.subarray(0, idx);
           this.buf = this.buf.subarray(idx + 1);
-          const tabIdx = header.indexOf(0x09); // \t
-          if (tabIdx < 0) {
-            throw new Error(
-              `Malformed length-prefixed header: missing tab separator in: ${JSON.stringify(decoder.decode(header))}`,
-            );
+          if (!isBlankSeparatorLine(header)) {
+            const tabIdx = header.indexOf(0x09); // \t
+            if (tabIdx < 0) {
+              throw new Error(
+                `Malformed length-prefixed header: missing tab separator in: ${JSON.stringify(decoder.decode(header))}`,
+              );
+            }
+            const metaStr = decoder.decode(header.subarray(0, tabIdx));
+            try {
+              this.metadata = JSON.parse(metaStr);
+            } catch {
+              throw new Error(
+                `Malformed length-prefixed header: invalid metadata JSON: ${JSON.stringify(metaStr)}`,
+              );
+            }
+            const lenHex = decoder.decode(header.subarray(tabIdx + 1));
+            if (!/^[0-9a-fA-F]+$/.test(lenHex)) {
+              throw new Error(`Invalid content length hex: ${JSON.stringify(lenHex)}`);
+            }
+            this.contentLen = parseInt(lenHex, 16);
+            this.state = 'content';
           }
-          const metaStr = decoder.decode(header.subarray(0, tabIdx));
-          try {
-            this.metadata = JSON.parse(metaStr);
-          } catch {
-            throw new Error(
-              `Malformed length-prefixed header: invalid metadata JSON: ${JSON.stringify(metaStr)}`,
-            );
-          }
-          const lenHex = decoder.decode(header.subarray(tabIdx + 1));
-          if (!/^[0-9a-fA-F]+$/.test(lenHex)) {
-            throw new Error(`Invalid content length hex: ${JSON.stringify(lenHex)}`);
-          }
-          this.contentLen = parseInt(lenHex, 16);
-          this.state = 'content';
         } else {
           canExtract = false;
         }

--- a/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
+++ b/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
@@ -17,6 +17,8 @@
  *
  * Wire format per chunk:
  *   <metadata JSON>\t<content byte length hex>\n<raw content bytes>
+ * Blank separator lines between records are tolerated, including CR-only
+ * separators from CRLF line endings.
  *
  * Handles buffer boundaries: a single feed() call may contain partial
  * headers, partial content, or multiple complete chunks merged together.
@@ -34,7 +36,7 @@ function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
 }
 
 function isBlankSeparatorLine(header: Uint8Array): boolean {
-  return header.length === 0 || header.every((byte) => byte === 0x0d);
+  return header.length === 0 || header.every((byte) => byte === 0x0d); // 0x0d = CR from \r\n endings
 }
 
 export default class LengthPrefixedStreamParser {

--- a/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
+++ b/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
@@ -105,7 +105,7 @@ export default class LengthPrefixedStreamParser {
   }
 
   flush(): void {
-    if (this.state === 'header' && this.buf.length === 0) return;
+    if (this.state === 'header' && isBlankSeparatorLine(this.buf)) return;
     console.warn(
       `[react_on_rails] Incomplete length-prefixed stream: ${this.buf.length} bytes remaining in state ${this.state}`,
     );

--- a/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
+++ b/packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts
@@ -105,6 +105,8 @@ export default class LengthPrefixedStreamParser {
   }
 
   flush(): void {
+    // A stream can end after the CR half of a CRLF separator; all-CR buffers
+    // are blank separator fragments, not incomplete payload data.
     if (this.state === 'header' && isBlankSeparatorLine(this.buf)) return;
     console.warn(
       `[react_on_rails] Incomplete length-prefixed stream: ${this.buf.length} bytes remaining in state ${this.state}`,

--- a/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
+++ b/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
@@ -1,0 +1,50 @@
+import LengthPrefixedStreamParser from '../src/parseLengthPrefixedStream.ts';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const toRecord = (content: string, metadata: Record<string, unknown> = {}) => {
+  const contentBytes = encoder.encode(content);
+  return `${JSON.stringify(metadata)}\t${contentBytes.length.toString(16)}\n${content}`;
+};
+
+const collectRecords = (...chunks: string[]) => {
+  const parser = new LengthPrefixedStreamParser();
+  const records: Array<{ content: string; metadata: Record<string, unknown> }> = [];
+
+  chunks.forEach((chunk) => {
+    parser.feed(encoder.encode(chunk), (content, metadata) => {
+      records.push({ content: decoder.decode(content), metadata });
+    });
+  });
+
+  return records;
+};
+
+describe('LengthPrefixedStreamParser', () => {
+  it('parses records separated by blank lines', () => {
+    const records = collectRecords(`${toRecord('first', { index: 1 })}\n${toRecord('second', { index: 2 })}`);
+
+    expect(records).toEqual([
+      { content: 'first', metadata: { index: 1 } },
+      { content: 'second', metadata: { index: 2 } },
+    ]);
+  });
+
+  it('parses when a blank separator is split across feed calls', () => {
+    const records = collectRecords(toRecord('first', { index: 1 }), '\n', toRecord('second', { index: 2 }));
+
+    expect(records).toEqual([
+      { content: 'first', metadata: { index: 1 } },
+      { content: 'second', metadata: { index: 2 } },
+    ]);
+  });
+
+  it('still rejects non-empty malformed headers', () => {
+    const parser = new LengthPrefixedStreamParser();
+
+    expect(() => {
+      parser.feed(encoder.encode(`not-json-or-length\n${toRecord('content')}`), () => {});
+    }).toThrow('Malformed length-prefixed header: missing tab separator');
+  });
+});

--- a/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
+++ b/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
@@ -31,6 +31,28 @@ describe('LengthPrefixedStreamParser', () => {
     ]);
   });
 
+  it('parses records separated by CRLF blank lines', () => {
+    const records = collectRecords(
+      `${toRecord('first', { index: 1 })}\r\n${toRecord('second', { index: 2 })}`,
+    );
+
+    expect(records).toEqual([
+      { content: 'first', metadata: { index: 1 } },
+      { content: 'second', metadata: { index: 2 } },
+    ]);
+  });
+
+  it('parses records separated by multiple blank lines', () => {
+    const records = collectRecords(
+      `${toRecord('first', { index: 1 })}\n\n${toRecord('second', { index: 2 })}`,
+    );
+
+    expect(records).toEqual([
+      { content: 'first', metadata: { index: 1 } },
+      { content: 'second', metadata: { index: 2 } },
+    ]);
+  });
+
   it('parses when a blank separator is split across feed calls', () => {
     const records = collectRecords(toRecord('first', { index: 1 }), '\n', toRecord('second', { index: 2 }));
 

--- a/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
+++ b/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
@@ -22,6 +22,12 @@ const collectRecords = (...chunks: string[]) => {
 };
 
 describe('LengthPrefixedStreamParser', () => {
+  it('tolerates leading blank lines before the first record', () => {
+    const records = collectRecords(`\n${toRecord('hello', { index: 0 })}`);
+
+    expect(records).toEqual([{ content: 'hello', metadata: { index: 0 } }]);
+  });
+
   it('parses records separated by blank lines', () => {
     const records = collectRecords(`${toRecord('first', { index: 1 })}\n${toRecord('second', { index: 2 })}`);
 
@@ -68,5 +74,24 @@ describe('LengthPrefixedStreamParser', () => {
     expect(() => {
       parser.feed(encoder.encode(`not-json-or-length\n${toRecord('content')}`), () => {});
     }).toThrow('Malformed length-prefixed header: missing tab separator');
+  });
+
+  it('does not warn when flushing a trailing CR-only separator fragment', () => {
+    const parser = new LengthPrefixedStreamParser();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const records: Array<{ content: string; metadata: Record<string, unknown> }> = [];
+
+    try {
+      parser.feed(encoder.encode(`${toRecord('hello', { index: 0 })}\r`), (content, metadata) => {
+        records.push({ content: decoder.decode(content), metadata });
+      });
+
+      parser.flush();
+
+      expect(records).toEqual([{ content: 'hello', metadata: { index: 0 } }]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
+++ b/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
@@ -68,6 +68,20 @@ describe('LengthPrefixedStreamParser', () => {
     ]);
   });
 
+  it('parses when a CRLF blank separator is split across feed calls', () => {
+    const records = collectRecords(
+      toRecord('first', { index: 1 }),
+      '\r',
+      '\n',
+      toRecord('second', { index: 2 }),
+    );
+
+    expect(records).toEqual([
+      { content: 'first', metadata: { index: 1 } },
+      { content: 'second', metadata: { index: 2 } },
+    ]);
+  });
+
   it('still rejects non-empty malformed headers', () => {
     const parser = new LengthPrefixedStreamParser();
 


### PR DESCRIPTION
## Summary

Fixes #3499.

`LengthPrefixedStreamParser` now tolerates blank separator lines between length-prefixed records. This matches the default Pro RSC payload template behavior described in #3499 without loosening validation for malformed non-empty headers.

The change is limited to `packages/react-on-rails-pro` parser code and focused package tests. It does not modify the protected `react_on_rails_pro/` Rails directory.

## Validation

- `pnpm --filter react-on-rails-pro exec jest tests/parseLengthPrefixedStream.test.ts` passed: 8 tests
- `pnpm --filter react-on-rails-pro run type-check` passed
- `pnpm exec eslint packages/react-on-rails-pro/src/parseLengthPrefixedStream.ts` passed
- `pnpm --filter react-on-rails-pro run test:non-rsc` passed: 10 suites, 102 tests
- `NODE_CONDITIONS=react-server pnpm --filter react-on-rails-pro exec jest tests/serverRenderRSCReactComponent.rsc.test.tsx` passed: 6 tests
- `git diff --check` passed
- `codex review --uncommitted` passed with no findings

## Notes

Commit hooks passed. ESLint reported the new test file is ignored by the repo's current ignore pattern, while the source parser file passed ESLint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped parser change in react-on-rails-pro with focused tests; no Rails or auth changes, and malformed-header behavior is preserved.
> 
> **Overview**
> **`LengthPrefixedStreamParser`** now skips blank separator lines between length-prefixed records instead of treating them as malformed headers. That aligns parsing with Pro RSC payloads that insert extra newlines between chunks (fixes #3499).
> 
> Header handling wraps the existing tab/JSON/hex validation in a check via new **`isBlankSeparatorLine`** (empty line or CR-only from split CRLF). **`flush()`** treats a leftover all-CR buffer in header state as a benign separator so it no longer logs an incomplete-stream warning when the stream ends mid-`\r\n`.
> 
> Malformed **non-empty** headers still throw as before. A dedicated Jest suite covers leading/multiple blank lines, CRLF separators, split **`feed()`** boundaries, and the no-warn **`flush()`** case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa622aab5dc707a7633fef9d98691ea0ba58695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Stream parser now tolerates blank separator lines, including CR-only fragments from CRLF line endings.
  * Added stricter validation for data headers with clearer error messages for missing delimiters, invalid metadata, or malformed content length.
  * Fixed stream flush behavior to silently handle trailing blank separators instead of producing warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->