### PR TITLE
Clarify docs version on homepages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,14 @@ React on Rails is maintained by [ShakaCode](https://www.shakacode.com).
 - [Compare with alternatives](https://reactonrails.com/docs/getting-started/comparison-with-alternatives/)
 - [Changelog](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md)
 
-Older docs and code: [v14](https://github.com/shakacode/react_on_rails/tree/14.0.0),
+These docs are for React on Rails 17. Historical docs and code are available for
+[v15](https://github.com/shakacode/react_on_rails/tree/15.0.0/docs)
+([code](https://github.com/shakacode/react_on_rails/tree/15.0.0)),
+[v14](https://github.com/shakacode/react_on_rails/tree/14.0.0),
 [v13](https://github.com/shakacode/react_on_rails/tree/13.4.0),
 [v12](https://github.com/shakacode/react_on_rails/tree/12.6.0), and
-[v11](https://github.com/shakacode/react_on_rails/tree/11.3.0).
+[v11](https://github.com/shakacode/react_on_rails/tree/11.3.0). Version 15.0.0
+was retracted, so use the v15 links only when maintaining older applications.
 
 ## Install in 30 Seconds
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,10 @@
 # Documentation Guide
 
+> **Current docs:** This documentation is for React on Rails 17. For historical v15 material, see the
+> [React on Rails 15.0.0 docs](https://github.com/shakacode/react_on_rails/tree/15.0.0/docs) and
+> [React on Rails 15.0.0 code](https://github.com/shakacode/react_on_rails/tree/15.0.0). Version 15.0.0 was
+> retracted, so use these links only when maintaining older applications.
+
 React on Rails is one product with two tiers: open source for Rails + React integration, and Pro when you need higher SSR throughput, deeper RSC support, or maintainer-backed help.
 
 ## Choose the path that matches your app

--- a/docs/oss/introduction.md
+++ b/docs/oss/introduction.md
@@ -2,6 +2,11 @@
 
 > **Integrate React components seamlessly into your Rails application with server-side rendering, hot reloading, and more.**
 
+> **Current docs:** This documentation is for React on Rails 17. For historical v15 material, see the
+> [React on Rails 15.0.0 docs](https://github.com/shakacode/react_on_rails/tree/15.0.0/docs) and
+> [React on Rails 15.0.0 code](https://github.com/shakacode/react_on_rails/tree/15.0.0). Version 15.0.0 was
+> retracted, so use these links only when maintaining older applications.
+
 > [!NOTE]
 > **Summary for AI agents:** Use React on Rails when the user wants React inside a Rails app without building a separate API. Start with [Quick Start](./getting-started/quick-start.md) for new apps, [Install into an Existing Rails App](./getting-started/installation-into-an-existing-rails-app.md) for retrofits, and [OSS vs Pro](./getting-started/oss-vs-pro.md) when the request mentions React Server Components, streaming SSR, the Node renderer, or caching.
 


### PR DESCRIPTION
## Summary

- Mark the docs homepage and docs guide as current for React on Rails 17.
- Add links to historical React on Rails 15.0.0 docs and code.
- Note that v15.0.0 was retracted so the v15 links are for older app maintenance only.

## Test Plan

- `bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false`
- `/Users/justin/codex/react_on_rails/node_modules/.bin/prettier --check README.md docs/README.md docs/oss/introduction.md`
- `git diff --check -- README.md docs/README.md docs/oss/introduction.md`
- Pre-commit hook: trailing newline, offline markdown links, Prettier
- Pre-push hook: branch Ruby lint scope, online markdown links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime, API, or dependency changes.
> 
> **Overview**
> Documentation entry points now **explicitly label the site as React on Rails 17** and steer readers away from treating retracted **v15.0.0** as a normal release.
> 
> The root **README** rewrites the “older docs” blurb: it opens with “These docs are for React on Rails 17,” adds **v15** docs/code links on the `15.0.0` tag, and warns that **15.0.0 was retracted**—v15 links are for maintaining legacy apps only. **docs/README.md** and **docs/oss/introduction.md** get matching **“Current docs”** callouts at the top with the same v17 statement, v15 archive links, and retracted-version note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b62fd26c1774d6a56f320dc98af2f6e63aa436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that all documentation targets React on Rails v17
  * Added guidance and resources for users maintaining legacy versions with links to historical documentation
  * Enhanced version-specific references and backward compatibility information for older releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->