### PR TITLE
Add async-http RSC disconnect regression smoke

### DIFF
--- a/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb
@@ -365,6 +365,86 @@ RSpec.describe ReactOnRailsPro::RendererHttpClient do
       expect(response.body).to eq("rendered")
       expect(response_body.closed).to be(true)
     end
+
+    it "closes an aborted streaming response body before the next pooled stream" do
+      client_disconnected = Class.new(StandardError)
+
+      stub_const(
+        "FakePooledBody",
+        Class.new do
+          attr_reader :closed
+
+          def initialize(chunks, on_close)
+            @chunks = chunks
+            @on_close = on_close
+            @closed = false
+          end
+
+          def each(&block)
+            @chunks.each(&block)
+          end
+
+          def close
+            return if @closed
+
+            @closed = true
+            @on_close.call
+          end
+        end
+      )
+      stub_const(
+        "FakePooledStreamingClient",
+        Class.new do
+          attr_reader :bodies, :requests
+
+          def initialize
+            @bodies = []
+            @requests = []
+            @slot_busy = false
+          end
+
+          def post(_path, headers:, body:)
+            raise ReactOnRailsPro::RendererHttpClient::ConnectionError, "pooled stream still busy" if @slot_busy
+
+            @requests << [headers, body]
+            @slot_busy = true
+            response_body = FakePooledBody.new(["rendered"], -> { @slot_busy = false })
+            @bodies << response_body
+            Struct.new(:status, :body).new(200, response_body)
+          end
+        end
+      )
+
+      async_client = FakePooledStreamingClient.new
+      client = described_class.new(origin: "http://localhost:3800", pool_size: 1, connect_timeout: 1, read_timeout: 1)
+      allow(client).to receive(:with_client).and_yield(async_client)
+
+      first_response = client.post("/render", json: { renderingRequest: "render()" }, stream: true)
+      aborted_chunks = []
+
+      expect do
+        first_response.each do |chunk|
+          aborted_chunks << chunk
+          raise client_disconnected, "client disconnected" if aborted_chunks.size == 1
+        end
+      end.to raise_error(client_disconnected, "client disconnected")
+      expect(aborted_chunks).to eq(["rendered"])
+      expect(async_client.bodies.first.closed).to be(true)
+
+      second_response = client.post("/render", json: { renderingRequest: "render()" }, stream: true)
+      chunks = []
+      second_response.each { |chunk| chunks << chunk }
+
+      expect(chunks).to eq(["rendered"])
+      expect(async_client.requests.map { |headers, body| [headers["content-type"], body] }).to eq(
+        [
+          ["application/json", { renderingRequest: "render()" }.to_json],
+          ["application/json", { renderingRequest: "render()" }.to_json]
+        ]
+      )
+      expect(async_client.bodies.size).to eq(2)
+      expect(async_client.bodies.last.closed).to be(true)
+    end
   end
 
   describe "#get" do


### PR DESCRIPTION
## Summary

- Adds a regression smoke for the current `async-http` renderer client path.
- Simulates a one-slot pooled streaming transport where an aborted stream keeps the slot busy unless the response body is closed.
- Verifies an aborted streaming response closes its body and a later streaming render can complete on the same pooled client.

Closes #3295 as fixed/superseded by the async-http transport from #3320, with regression coverage for the disconnect behavior that originally poisoned the HTTPX pool.

## Verification

- `BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rspec react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb` — 39 examples, 0 failures.
- `BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rspec react_on_rails_pro/spec/react_on_rails_pro/renderer_http_client_spec.rb react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb` — 69 examples, 0 failures.
- `BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rspec react_on_rails_pro/spec/react_on_rails_pro/stream_integration_spec.rb` — 11 examples, 0 failures.
- `git diff --check`
- `BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false` — 447 files inspected, no offenses.
- Pre-commit hook passed for trailing newlines, autofix, and RuboCop on the changed Ruby file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in the renderer HTTP client spec; no runtime or configuration behavior is modified.
> 
> **Overview**
> Adds a **regression example** in `renderer_http_client_spec` for RSC-style client disconnects on the async-http renderer path.
> 
> The example stubs a **single-slot pooled** streaming client: if an in-flight stream is not torn down, the slot stays busy and the next `post(..., stream: true)` would fail. It simulates disconnect by raising after the first chunk during `Response#each`, then asserts the aborted body was **closed** and a **second** streaming render completes on the same pooled client with both requests encoded as JSON.
> 
> No production code changes—this locks in behavior that prevents the old HTTPX pool “poisoning” scenario referenced in #3295.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3277cf3c45a5d64b079f5feaa4637f72931550d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for streaming response cleanup and resource reuse behavior, ensuring proper handling when streaming requests are interrupted and confirming pool slots are correctly released for subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->