### PR TITLE
Align Conductor setup with Ruby 3.3 floor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,6 +360,8 @@ Run only RuboCop:
 rake lint:rubocop
 ```
 
+For v17, new Ruby code should use long-form hash syntax instead of shorthand; shorthand cleanup is tracked for v18 in [#3501](https://github.com/shakacode/react_on_rails/issues/3501).
+
 Run only ESLint:
 
 ```sh

--- a/SWITCHING_CI_CONFIGS.md
+++ b/SWITCHING_CI_CONFIGS.md
@@ -122,7 +122,7 @@ bin/ci-switch-config minimum
 
 This will:
 
-1. Create `.tool-versions` with Ruby 3.3.7 and Node 20.18.1
+1. Create `.tool-versions` with the Ruby patch from `MINIMUM_RUBY_VERSION` in `bin/ci-switch-config` and Node 20.18.1
 2. Run `script/convert` to downgrade dependencies:
    - Shakapacker 9.5.0 → 8.2.0
    - React 19.0.0 → 18.0.0

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -47,9 +47,9 @@ run_cmd node --version >/dev/null 2>&1 || { echo "❌ Error: Node.js is not inst
 
 # Check Ruby version
 RUBY_VERSION=$(run_cmd ruby -v | awk '{print $2}')
-MIN_RUBY_VERSION="3.0.0"
+MIN_RUBY_VERSION="3.3.0"
 if [[ $(echo -e "$MIN_RUBY_VERSION\n$RUBY_VERSION" | sort -V | head -n1) != "$MIN_RUBY_VERSION" ]]; then
-    echo "❌ Error: Ruby version $RUBY_VERSION is too old. React on Rails requires Ruby >= 3.0.0"
+    echo "❌ Error: Ruby version $RUBY_VERSION is too old. React on Rails requires Ruby >= $MIN_RUBY_VERSION"
     echo "   Please upgrade Ruby using your version manager or system package manager."
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Update Conductor setup's Ruby prerequisite gate from `3.0.0` to `3.3.0`.
- Point the minimum CI config docs at `MINIMUM_RUBY_VERSION` instead of hardcoding the Ruby patch in prose.
- Document the temporary v17 long-form Ruby hash syntax expectation for contributors.

## Why

This follows up on post-merge review feedback from #3500. The v17 Ruby floor is now 3.3, so Conductor setup should fail early with the same prerequisite instead of allowing Ruby 3.0-3.2 to continue until Bundler/gemspec resolution fails later.

The docs tweaks reduce future drift when the CI minimum patch version changes and make the v17 RuboCop hash-syntax behavior visible to contributors. The shorthand cleanup remains tracked for v18 in #3501.

## Review comment triage

- MUST-FIX: Conductor setup still allowed Ruby 3.0-3.2. Addressed.
- OPTIONAL: `SWITCHING_CI_CONFIGS.md` could drift from `bin/ci-switch-config`. Addressed.
- OPTIONAL: contributor docs should explain the temporary long-form hash syntax rule. Addressed.
- SKIPPED: parser `.b` comment was informational and explicitly said either form is fine.

## Validation

- `zsh -n conductor-setup.sh`
- Ruby gate comparison check: `3.2.9 reject`, `3.3.0 accept`, `3.3.7 accept`, `3.4.0 accept`
- `pnpm exec prettier --check CONTRIBUTING.md SWITCHING_CI_CONFIGS.md`
- `nps format.listDifferent`
- `bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false`
- `git diff --check`
- pre-commit hook
- pre-push hook (`lychee` reported 3 redirects, 0 errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and local setup prerequisite changes only; no runtime gem or application behavior changes.
> 
> **Overview**
> **Conductor setup** now rejects Ruby below **3.3.0** (was 3.0.0), matching the v17 floor so unsupported Rubies fail at the prerequisite check instead of later during Bundler resolution. The error text uses the configured minimum version dynamically.
> 
> **CI switching docs** no longer hardcode Ruby **3.3.7** when describing the minimum config; they point readers to **`MINIMUM_RUBY_VERSION`** in `bin/ci-switch-config` so the documented patch stays in sync with the script.
> 
> **Contributor linting docs** note that for **v17**, new Ruby should use **long-form hash syntax** (shorthand cleanup deferred to v18, issue #3501).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971048c5efe40bc497010aece9102efddb43ce67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added coding standards guidance for Ruby hash syntax in the current version
  * Updated minimum configuration setup instructions with dynamic version reference

* **Chores**
  * Increased minimum Ruby version requirement to 3.3.0 for workspace setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->