### PR TITLE
Clarify Rails-first async docs examples

### DIFF
--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -198,9 +198,7 @@ One of the biggest advantages of React 19 native metadata over react-helmet is *
 Metadata can be rendered inside async components within Suspense boundaries. When the async component resolves, React streams the metadata to the client and updates `<head>`:
 
 ```jsx
-const UserProfile = async ({ userId }) => {
-  const user = await fetchUser(userId);
-
+const UserProfile = async ({ user }) => {
   return (
     <>
       <title>{`${user.name}'s Profile | My App`}</title>
@@ -211,7 +209,7 @@ const UserProfile = async ({ userId }) => {
   );
 };
 
-const ProfilePage = ({ userId }) => (
+const ProfilePage = ({ user }) => (
   <div>
     {/* Initial metadata shown while loading */}
     <title>Loading Profile... | My App</title>
@@ -219,11 +217,20 @@ const ProfilePage = ({ userId }) => (
 
     <Suspense fallback={<ProfileSkeleton />}>
       {/* Updated metadata streamed when resolved */}
-      <UserProfile userId={userId} />
+      <UserProfile user={user} />
     </Suspense>
   </div>
 );
 ```
+
+```erb
+<%# Rails view - controller prepares @user and passes it as props %>
+<%= stream_react_component("ProfilePage",
+                           props: { user: @user.as_json(only: %i[name bio]) },
+                           prerender: true) %>
+```
+
+> **React on Rails note:** Keep authorization, database access, and cache-aware data loading in Rails. Pass the prepared data as props, or use streamed async props for Pro RSC flows, rather than fetching from inside the React component. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 The initial `<title>` ("Loading Profile...") appears immediately. When `UserProfile` resolves, React replaces it with the user-specific title.
 
@@ -235,32 +242,42 @@ Native metadata works in React Server Components too. Since RSC components run e
 // NativeMetadataRSCApp.jsx (no 'use client' directive — this is a Server Component)
 import React, { Suspense } from 'react';
 
-const AsyncContent = async ({ slug }) => {
-  const article = await fetchArticle(slug);
-
+const AsyncContent = async ({ article }) => {
   return (
     <>
       <title>{article.title}</title>
       <meta name="description" content={article.excerpt} />
       <meta property="og:title" content={article.title} />
-      <meta property="og:image" content={article.coverImage} />
+      <meta property="og:image" content={article.cover_image} />
       <article>{article.body}</article>
     </>
   );
 };
 
-const ArticlePage = ({ slug }) => (
+const ArticlePage = ({ article }) => (
   <div>
     <title>Loading...</title>
-    <link rel="canonical" href={`https://example.com/articles/${slug}`} />
+    <link rel="canonical" href={article.canonical_url} />
     <Suspense fallback={<ArticleSkeleton />}>
-      <AsyncContent slug={slug} />
+      <AsyncContent article={article} />
     </Suspense>
   </div>
 );
 
 export default ArticlePage;
 ```
+
+```erb
+<%# Rails view - controller prepares @article and passes it as props %>
+<%= stream_react_component("ArticlePage",
+                           props: { article: @article.as_json(
+                             only: %i[title excerpt cover_image body],
+                             methods: %i[canonical_url]
+                           ) },
+                           prerender: true) %>
+```
+
+> **React on Rails note:** RSC server components still run as part of a Rails-rendered request. Prefer Rails-prepared props for app data so Rails authorization, tenancy, caching, and instrumentation stay in one place. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 ## Hybrid Approach: Rails-Side + React-Side Metadata
 

--- a/docs/oss/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
+++ b/docs/oss/core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md
@@ -928,7 +928,7 @@ See [When to use `.client` / `.server` variants with RSC](#when-to-use-client--s
 
 - Migrate to a single file — delete the `.client.jsx` file, since server components do not run on the client side at all
 - Adjust the `.server.jsx` variant (or rename it to drop the `.server` suffix) to properly use RSC capabilities: async data fetching, streaming with Suspense, direct access to server-only resources
-- If the component uses a render function pattern (`export default (props, railsContext) => { ... }`), convert it to a plain React component (`export default function Component(props) { ... }`) or an async component (`export default async function Component(props) { ... }`)
+- If the component uses a render function pattern (`export default (props, railsContext) => { ... }`), convert it to a plain React component (`export default function Component(props) { ... }`) or an async component (`export default async function Component(props) { ... }`). Keep Rails-owned data loading in the controller and pass prepared data as props; see [RSC data fetching](../migrating/rsc-data-fetching.md).
 - Remove the `'use client'` directive if present — server components must not have it
 
 **Related**: [GitHub issue #2509](https://github.com/shakacode/react_on_rails/issues/2509), [How to use different files for client and server rendering](../building-features/how-to-use-different-files-for-client-and-server-rendering.md)

--- a/docs/oss/core-concepts/execjs-limitations.md
+++ b/docs/oss/core-concepts/execjs-limitations.md
@@ -51,6 +51,8 @@ async function UserProfile({ userId }) {
 }
 ```
 
+> **React on Rails note:** Even on the React on Rails Pro Node renderer, fetching application data from the component bypasses the Rails controller path where authorization, caching, tenancy, and instrumentation usually live. Prefer Rails-prepared props, or Pro streamed async props, for request-specific data.
+
 **Workaround:** Pass all required data as props from Rails rather than fetching it client-side during rendering:
 
 ```ruby

--- a/docs/oss/core-concepts/render-functions.md
+++ b/docs/oss/core-concepts/render-functions.md
@@ -145,6 +145,8 @@ const MyComponent = (props, _railsContext) => {
 
 This and other promise options below are only available in React on Rails Pro with the Node renderer.
 
+> **React on Rails note:** Async render functions should still receive application data from Rails props whenever possible. Keep authorization, database access, and cache-aware loading in Rails, then pass the prepared data through `react_component`, `react_component_hash`, or Pro streamed async props. See [RSC data fetching](../migrating/rsc-data-fetching.md) for the same Rails-first data boundary applied to RSC.
+
 ```jsx
 const MyComponent = async (props, _railsContext) => {
   const data = await fetchData();


### PR DESCRIPTION
## Summary
- Replace in-component async fetch examples in the native metadata docs with Rails-prepared props examples.
- Add Rails-first callouts for ExecJS async limitations, async render functions, and auto-bundling RSC migration guidance.
- Link the related docs back to the RSC data-fetching guide for consistent framing.

Fixes #3470

## Test plan
- PATH=/Users/justin/codex/react_on_rails/node_modules/.bin:$PATH node /Users/justin/codex/react_on_rails/node_modules/nps/dist/bin/nps.js format.listDifferent
- git diff --check
- bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false
- pre-commit hook: trailing-newlines, offline markdown-links, prettier
- pre-push hook: branch-lint, online markdown-links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> This PR **reframes async and SSR documentation** around a Rails-first data boundary: load and authorize data in controllers, pass prepared props (or Pro streamed async props), instead of fetching inside React.
> 
> In **`react-19-native-metadata.md`**, streaming metadata examples no longer use `fetchUser` / `fetchArticle` inside async components. They take **`user` / `article` props**, add matching **`stream_react_component` ERB** with `@user` / `@article.as_json`, and include **React on Rails notes** pointing to [RSC data fetching](../migrating/rsc-data-fetching.md).
> 
> **ExecJS**, **render-functions**, and **auto-bundling RSC migration** sections each gain a short callout that even when async SSR works (Pro Node), app data should still come from Rails props—not component-level fetches that bypass auth, caching, and tenancy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b15fcb71665689f232e17ff95f34665f7c73b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React 19 native metadata examples to demonstrate passing pre-fetched data as props to async components.
  * Added clarifications emphasizing keeping data fetching and authorization within the Rails layer.
  * Enhanced guidance for async components and render functions to use Rails-prepared props.
  * Improved troubleshooting documentation for component variants and data-loading patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->