### PR TITLE
Cover length-prefixed byte parsing edges

### DIFF
--- a/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
+++ b/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
@@ -98,7 +98,7 @@ describe('LengthPrefixedStreamParser', () => {
   it('uses byte lengths for multibyte content split across feed calls', () => {
     const content = 'Hello \u{1f604} world';
     const frame = encoder.encode(toRecord(content, { index: 1 }));
-    const contentStart = frame.length - encoder.encode(content).length;
+    const contentStart = frame.indexOf(0x0a) + 1;
     const splitInsideEmoji = contentStart + encoder.encode('Hello ').length + 1;
 
     const records = collectByteRecords(frame.subarray(0, splitInsideEmoji), frame.subarray(splitInsideEmoji));

--- a/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
+++ b/packages/react-on-rails-pro/tests/parseLengthPrefixedStream.test.ts
@@ -21,6 +21,19 @@ const collectRecords = (...chunks: string[]) => {
   return records;
 };
 
+const collectByteRecords = (...chunks: Uint8Array[]) => {
+  const parser = new LengthPrefixedStreamParser();
+  const records: Array<{ content: string; metadata: Record<string, unknown> }> = [];
+
+  chunks.forEach((chunk) => {
+    parser.feed(chunk, (content, metadata) => {
+      records.push({ content: decoder.decode(content), metadata });
+    });
+  });
+
+  return records;
+};
+
 describe('LengthPrefixedStreamParser', () => {
   it('tolerates leading blank lines before the first record', () => {
     const records = collectRecords(`\n${toRecord('hello', { index: 0 })}`);
@@ -75,6 +88,33 @@ describe('LengthPrefixedStreamParser', () => {
       '\n',
       toRecord('second', { index: 2 }),
     );
+
+    expect(records).toEqual([
+      { content: 'first', metadata: { index: 1 } },
+      { content: 'second', metadata: { index: 2 } },
+    ]);
+  });
+
+  it('uses byte lengths for multibyte content split across feed calls', () => {
+    const content = 'Hello \u{1f604} world';
+    const frame = encoder.encode(toRecord(content, { index: 1 }));
+    const contentStart = frame.length - encoder.encode(content).length;
+    const splitInsideEmoji = contentStart + encoder.encode('Hello ').length + 1;
+
+    const records = collectByteRecords(frame.subarray(0, splitInsideEmoji), frame.subarray(splitInsideEmoji));
+
+    expect(records).toEqual([{ content, metadata: { index: 1 } }]);
+  });
+
+  it('preserves content that looks like length-prefixed headers', () => {
+    const content = 'first line\n{"payloadType":"string"}\t00000005\nhello\nlast line';
+    const records = collectRecords(toRecord(content, { index: 1 }));
+
+    expect(records).toEqual([{ content, metadata: { index: 1 } }]);
+  });
+
+  it('parses adjacent records without requiring separator lines', () => {
+    const records = collectRecords(`${toRecord('first', { index: 1 })}${toRecord('second', { index: 2 })}`);
 
     expect(records).toEqual([
       { content: 'first', metadata: { index: 1 } },

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -110,6 +110,33 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
         expect(yielded.first["html"]).to eq("<div>Split</div>")
       end
 
+      it "uses byte lengths for multibyte content split across HTTP chunks" do
+        payload = "Hello \u{1F604} world"
+        full = to_length_prefixed(payload)
+        content_start = full.bytesize - payload.bytesize
+        split_inside_emoji = content_start + "Hello ".bytesize + 1
+        chunk1 = full.byteslice(0, split_inside_emoji)
+        chunk2 = full.byteslice(split_inside_emoji, full.bytesize - split_inside_emoji)
+        response = mock_ok_response(chunk1, chunk2)
+
+        yielded = []
+        request.send(:process_response_chunks, response) { |chunk| yielded << chunk }
+
+        expect(yielded.size).to eq(1)
+        expect(yielded.first["html"]).to eq(payload)
+      end
+
+      it "preserves content that looks like LPP headers" do
+        payload = "first line\n{\"payloadType\":\"string\"}\t00000005\nhello\nlast line"
+        response = mock_ok_response(to_length_prefixed(payload))
+
+        yielded = []
+        request.send(:process_response_chunks, response) { |chunk| yielded << chunk }
+
+        expect(yielded.size).to eq(1)
+        expect(yielded.first["html"]).to eq(payload)
+      end
+
       it "dispatches payloadType 'object' as parsed JSON" do
         json_content = '{"serverHtml":"<div/>","clientProps":{}}'
         metadata = {

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       it "uses byte lengths for multibyte content split across HTTP chunks" do
         payload = "Hello \u{1F604} world"
         full = to_length_prefixed(payload)
-        content_start = full.bytesize - payload.bytesize
+        content_start = full.byteindex("\n") + 1
         split_inside_emoji = content_start + "Hello ".bytesize + 1
         chunk1 = full.byteslice(0, split_inside_emoji)
         chunk2 = full.byteslice(split_inside_emoji, full.bytesize - split_inside_emoji)


### PR DESCRIPTION
Refs #3300

## Summary
- Adds JS parser coverage for multibyte content split inside a character, adjacent records, and content that looks like length-prefixed headers.
- Adds Ruby StreamRequest coverage for the same byte-length and header-looking payload cases.
- Keeps this as test-only progress on async props and length-prefixed protocol confidence.

## Test plan
- pnpm install --frozen-lockfile
- pnpm --filter react-on-rails-pro exec jest tests/parseLengthPrefixedStream.test.ts --runInBand
- BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rspec react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
- pnpm --filter react-on-rails-pro run type-check
- pnpm start format.listDifferent
- git diff --check
- BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false
- BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or protocol changes—only new automated tests for existing stream parsing behavior.
> 
> **Overview**
> **Test-only** expansion of length-prefixed protocol (LPP) parsing coverage on the JS `LengthPrefixedStreamParser` and Ruby `StreamRequest` paths.
> 
> New cases assert **byte-accurate** framing when UTF-8 payloads (e.g. emoji) are split mid-character across chunks or HTTP reads, that **payloads resembling LPP headers** are not mis-parsed as records, and (JS only) that **back-to-back records** work without blank-line separators. A `collectByteRecords` helper feeds raw `Uint8Array` slices to exercise byte-boundary splits in Jest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4c6d4087d0cd6ed2f8ea2c7c11af8240567f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/expanded tests to validate stream parsing: correct reconstruction of multibyte payloads across chunk boundaries, preservation of payloads that resemble protocol headers, and parsing of adjacent records without separators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->