### PR TITLE
[INVESTIGATION] Add RSC use-client CSS manifest regression fixture

### DIFF
--- a/react_on_rails_pro/spec/dummy/client/app/components/RSCPostsPage/Main.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/components/RSCPostsPage/Main.jsx
@@ -3,6 +3,7 @@ import { ErrorBoundary } from '../ErrorBoundary';
 import Posts from './Posts';
 import HelloWorld from '../HelloWorldHooksForServerComponents';
 import Spinner from '../Spinner';
+import UseClientCssProbe from './UseClientCssProbe';
 
 const RSCPostsPage = ({ artificialDelay, postsCount, fetchPosts, fetchComments, fetchUser, ...props }) => {
   return (
@@ -10,6 +11,7 @@ const RSCPostsPage = ({ artificialDelay, postsCount, fetchPosts, fetchComments, 
       <div>
         <HelloWorld {...props} />
         <h1 style={{ fontSize: '2rem', fontWeight: 'bold' }}>RSC Posts Page</h1>
+        <UseClientCssProbe />
         <Suspense fallback={<Spinner />}>
           <Posts
             artificialDelay={artificialDelay}

--- a/react_on_rails_pro/spec/dummy/client/app/components/RSCPostsPage/UseClientCssProbe.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/components/RSCPostsPage/UseClientCssProbe.jsx
@@ -1,0 +1,12 @@
+'use client';
+
+import React from 'react';
+import styles from './UseClientCssProbe.module.scss';
+
+const UseClientCssProbe = () => (
+  <div className={styles.probe} data-testid="rsc-css-probe">
+    RSC use-client CSS probe
+  </div>
+);
+
+export default UseClientCssProbe;

--- a/react_on_rails_pro/spec/dummy/client/app/components/RSCPostsPage/UseClientCssProbe.module.scss
+++ b/react_on_rails_pro/spec/dummy/client/app/components/RSCPostsPage/UseClientCssProbe.module.scss
@@ -1,0 +1,9 @@
+.probe {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border: 2px solid rgb(8 96 80);
+  background-color: rgb(212 250 236);
+  color: rgb(12 45 38);
+  font-weight: 700;
+}

--- a/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "RSC use-client CSS manifest regression" do
+  let(:manifest_path) { Rails.root.join("public", "webpack", Rails.env, "react-client-manifest.json") }
+  let(:probe_key_fragment) { "RSCPostsPage/UseClientCssProbe.jsx" }
+
+  it "records CSS assets for use-client components rendered by an RSC page" do
+    pending("react-on-rails-rsc PR #35 or its successor should publish client-reference css metadata")
+
+    expect(File).to exist(manifest_path)
+
+    manifest = JSON.parse(File.read(manifest_path))
+    entries = manifest.fetch("filePathToModuleMetadata", manifest)
+    _entry_key, metadata = entries.find { |key, _value| key.include?(probe_key_fragment) }
+
+    expect(metadata).to be_present, "Expected #{probe_key_fragment} in #{manifest_path}"
+    expect(metadata.fetch("css")).to include(a_string_matching(/\.css(?:\?|$)/))
+  end
+end

--- a/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "RSC use-client CSS manifest regression" do
     _entry_key, metadata = entries.find { |key, _value| key.include?(probe_key_fragment) }
 
     expect(metadata).to be_present, "Expected #{probe_key_fragment} in #{manifest_path}"
+
+    pending("use-client component CSS is not yet recorded in the RSC client manifest")
     expect(metadata.fetch("css")).to include(a_string_matching(/\.css(?:\?|$)/))
   end
 end

--- a/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "RSC use-client CSS manifest regression" do
   let(:probe_key_fragment) { "RSCPostsPage/UseClientCssProbe.jsx" }
 
   it "records CSS assets for use-client components rendered by an RSC page" do
-    pending("react-on-rails-rsc PR #35 or its successor should publish client-reference css metadata")
-
     expect(File).to exist(manifest_path)
 
     manifest = JSON.parse(File.read(manifest_path))


### PR DESCRIPTION
Refs #3211
Related to shakacode/react_on_rails_rsc#35

## Summary
- Adds a small use-client probe component under the Pro dummy RSC posts page that imports a CSS module.
- Adds an investigation request spec documenting the downstream manifest contract: the client manifest entry for that probe should expose css assets.
- Marks the missing CSS metadata assertion as pending so CI can stay green while the production RSC package fix is still outstanding.

## Current expected behavior
- Against current main, the underlying assertion still fails with `KeyError: key not found: "css"`.
- That failure is intentionally captured as a pending spec in this PR.
- Once the RSC package publishes css metadata, this pending spec should become an unexpected pass and force us to remove the pending marker.

## Test plan
- `pnpm install`
- `cd react_on_rails_pro/spec/dummy && bundle exec rake react_on_rails:generate_packs`
- `cd react_on_rails_pro/spec/dummy && pnpm run build:test`
- `cd react_on_rails_pro/spec/dummy && bundle exec rspec spec/requests/rsc_use_client_css_manifest_spec.rb` -> `1 example, 0 failures, 1 pending`
- `bundle exec rubocop react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify CSS asset bundling in React Server Components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->