### PR TITLE
docs(agents): drop "Ask First" gate on modifying the Pro package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,6 @@ For small, focused PRs (roughly 5 files changed or fewer and one clear purpose):
 - Destructive git operations: `reset --hard` on a branch with work, branch deletion, or force-push that drops/squashes commits, republishes a conflicted rebase, or runs when the remote has commits you don't have locally. (Force-push after a clean rebase — no conflicts, all commits preserved — is OK without asking.)
 - Changes to CI workflows (`.github/workflows/`)
 - Changes to build configuration (`package.json` scripts, webpack config)
-- Modifying the Pro package (`react_on_rails_pro/`)
 
 ### Never
 


### PR DESCRIPTION
### Summary

Removes the `Modifying the Pro package (react_on_rails_pro/)` item from the **Ask First** boundary list in `AGENTS.md`. That gate dated from before the monorepo consolidation matured (added 2026-02-07); `react_on_rails_pro/` is now a first-class part of the monorepo, modified in nearly every feature PR, and has its own contributor guide (`react_on_rails_pro/CLAUDE.md`). The ask-first gate added friction without protecting anything — the Pro licensing/privacy boundary is documented separately in `docs/DIRECTORY_LICENSING.md` and `docs/LICENSING_FAQ.md`, and concerns exposing Pro code rather than editing it.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (docs/policy-only change)
- [x] Update documentation
- ~[ ] Update CHANGELOG file~ (AGENTS.md policy: no CHANGELOG entry for doc/policy changes)

### Other Information

The remaining "Ask First" gates (CI workflows, build configuration) are intentionally kept. Two further candidates surfaced during review and were left for a separate decision: the tension between those gates and the "commit and push without asking" default, and reconciling "use at most one inline AI reviewer" with the newly added autoreview second-model skill (#3496).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy change with no runtime, CI, or security behavior impact.
> 
> **Overview**
> Updates agent policy in **`AGENTS.md`** so editing **`react_on_rails_pro/`** is no longer listed under **Ask First**.
> 
> The **Ask First** section still applies to destructive git operations, **`.github/workflows/`** changes, and build configuration (**`package.json`** scripts, webpack config). Pro licensing/exposure boundaries remain documented elsewhere (e.g. **`docs/DIRECTORY_LICENSING.md`**, **`docs/LICENSING_FAQ.md`**), not via this approval gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7049610de3fb1ea00c0b3cf2821d38801331a442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines for the Pro package.

*Note: This change primarily affects internal development processes with no direct impact on end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->