### PR TITLE
[INVESTIGATION] Add async props error-matrix specs

### DIFF
--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -338,6 +338,7 @@ describe ReactOnRailsPro::Request do
     let(:js_code) { "console.log('incremental rendering');" }
     let(:async_props_block) { proc { |_emitter| } }
     let(:mock_output) { instance_double(Protocol::HTTP::Body::Writable::Output) }
+    let(:output_writes) { [] }
 
     before do
       allow(ReactOnRailsPro::ServerRenderingPool::NodeRenderingPool).to receive_messages(
@@ -345,7 +346,7 @@ describe ReactOnRailsPro::Request do
         rsc_bundle_hash: "rsc_bundle.js"
       )
 
-      allow(mock_output).to receive(:<<)
+      allow(mock_output).to receive(:<<) { |payload| output_writes << payload }
       allow(mock_output).to receive(:close)
 
       bidi_response = mock_response(status: 200, chunks: [to_length_prefixed("chunk")])
@@ -440,6 +441,39 @@ describe ReactOnRailsPro::Request do
 
       stream.each_chunk(&:itself)
 
+      expect(mock_output).to have_received(:close)
+    end
+
+    it "sends an async-props failure update chunk before closing when the async props block raises" do
+      pending(
+        "Known issue #3300: Ruby async-props failures should reach the renderer through an updateChunk"
+      )
+
+      test_async_props_block = proc do |_emitter|
+        raise StandardError, "books async prop failed"
+      end
+
+      stream = described_class.render_code_with_incremental_updates(
+        "/render-incremental",
+        js_code,
+        async_props_block: test_async_props_block
+      )
+
+      expect do
+        stream.each_chunk(&:itself)
+      end.to raise_error(StandardError, "books async prop failed")
+
+      renderer_updates = output_writes.filter_map do |payload|
+        parsed = JSON.parse(payload.chomp)
+        parsed if parsed["bundleTimestamp"] && parsed["updateChunk"]
+      end
+
+      failure_update = renderer_updates.find { |update| update["updateChunk"].include?("books async prop failed") }
+
+      expect(failure_update).not_to be_nil
+      expect(failure_update["bundleTimestamp"]).to eq("rsc_bundle.js")
+      expect(failure_update["updateChunk"]).to include("asyncPropsManager")
+      expect(failure_update["updateChunk"]).to include("StandardError")
       expect(mock_output).to have_received(:close)
     end
   end

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "spec_helper"
+require "timeout"
 require "react_on_rails_pro/stream_request"
 require "react_on_rails_pro/renderer_http_client"
 
@@ -249,6 +250,31 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       stream.each_chunk(&:itself)
 
       expect(task_waited).to be true
+    end
+
+    it "stops async tasks when the downstream consumer aborts after receiving a chunk" do
+      task_stopped = false
+      response = mock_ok_response(to_length_prefixed("chunk"))
+
+      stream = described_class.create do |_send_bundle, tasks|
+        tasks.push(
+          Async::Task.current.async do
+            sleep
+          ensure
+            task_stopped = true
+          end
+        )
+        response
+      end
+      abort_after_first_chunk = proc { |_chunk| raise "client disconnected" }
+
+      expect do
+        Timeout.timeout(5) do
+          stream.each_chunk(&abort_after_first_chunk)
+        end
+      end.to raise_error(RuntimeError, "client disconnected")
+
+      expect(task_stopped).to be true
     end
   end
 


### PR DESCRIPTION
## Summary

Refs #3300.

This is an investigation/test-first PR for the remaining async-props/error-matrix work after the LPP byte-length coverage from #3526.

- Adds a passing regression spec that verifies `StreamRequest` stops child async tasks when the downstream consumer aborts after receiving a chunk.
- Adds a pending expected-failing spec for the known async-props failure gap: when the Ruby `async_props_block` raises, the renderer should receive a normal incremental `updateChunk` carrying the failure before the request closes.
- Keeps the failure expectation aligned with the existing renderer contract (`bundleTimestamp` + `updateChunk`) rather than introducing an ad hoc NDJSON message shape.

## Pending Spec

The async-props failure spec is intentionally pending. It documents the desired behavior and current failure, but this PR does not implement the production fix. Follow-up test-hygiene nits are tracked in #3547.

## Verification

- `cd react_on_rails_pro && bundle check`
- `cd react_on_rails_pro && bundle exec ruby -e 'require "async"; puts Async::VERSION'` -> `2.35.0`
- `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/stream_request_spec.rb spec/react_on_rails_pro/request_spec.rb` -> `60 examples, 0 failures, 1 pending`
- `bundle exec rubocop react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb --cache-root /private/tmp/rubocop_cache --no-server --cache false` -> no offenses
- `git diff --check`

Note: running these Pro specs from the repository root failed earlier because the root bundle does not include the Pro `async` runtime dependency. The Pro bundle does include it, so the focused verification was run from `react_on_rails_pro`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only changes; one example is intentionally pending and documents future behavior without altering runtime code.
> 
> **Overview**
> **Test-first coverage** for async-props / streaming error behavior (refs #3300), with **no production code changes**.
> 
> Adds a **passing regression** in `stream_request_spec`: when a downstream consumer raises after the first chunk (e.g. client disconnect), background `Async::Task` work is stopped via the existing `ensure` cleanup—verified with `Timeout` so the example cannot hang.
> 
> In `request_spec` for `render_code_with_incremental_updates`, **captures NDJSON written to the bidi output** (`output_writes`) so incremental renderer messages can be asserted. Adds a **pending** example that documents the desired contract when the Ruby `async_props_block` raises: propagate the error **and** emit a normal incremental `updateChunk` (with `bundleTimestamp`, `asyncPropsManager`, error details) **before** closing the output—aligned with today’s renderer shape, not a new message type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9832e1930ea98cae547be67e0a51efdf130cd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to verify error handling in asynchronous property updates, ensuring failure information is properly communicated.
  * Added test coverage for async task cleanup when stream consumers disconnect, verifying proper resource disposal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->