### PR TITLE
Run generated pack hook before create-app bundle builds

### DIFF
--- a/internal/contributor-info/create-react-on-rails-app-smoke-testing.md
+++ b/internal/contributor-info/create-react-on-rails-app-smoke-testing.md
@@ -21,6 +21,7 @@ The script:
 2. Generates TypeScript, JavaScript, and Rspack OSS apps using local `react_on_rails`
 3. Generates Pro and RSC apps using local `react_on_rails` + local `react_on_rails_pro`
 4. Verifies key outputs (`Gemfile` path gems, routes, demo files, package manager normalization, and git history)
+5. Builds test bundles and renders the generated OSS `/` and `/hello_world` routes
 
 It prints the temp directory path so you can inspect generated apps.
 
@@ -33,7 +34,7 @@ to verify Pro or RSC output:
 CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
 ```
 
-The OSS scope does not require `react_on_rails_pro`. It generates and verifies:
+The OSS scope does not require `react_on_rails_pro`. It generates, builds test bundles, and verifies:
 
 1. TypeScript + Webpack
 2. JavaScript + Webpack

--- a/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
+++ b/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
@@ -144,6 +144,46 @@ expect_git_history() {
   fi
 }
 
+verify_rails_route() {
+  local app_dir="$1"
+  local route_path="$2"
+  local expected_text="$3"
+
+  echo "Verifying $(basename "$app_dir") renders $route_path..."
+  (
+    cd "$app_dir"
+    SMOKE_ROUTE_PATH="$route_path" SMOKE_EXPECTED_TEXT="$expected_text" \
+      RAILS_ENV=test NODE_ENV=test bin/rails runner '
+        path = ENV.fetch("SMOKE_ROUTE_PATH")
+        expected_text = ENV.fetch("SMOKE_EXPECTED_TEXT")
+        session = ActionDispatch::Integration::Session.new(Rails.application)
+        session.host!("localhost")
+        session.get(path)
+
+        unless session.response.status == 200
+          warn "Expected #{path} to render 200, got #{session.response.status}"
+          warn session.response.body[0, 1000]
+          exit 1
+        end
+
+        unless session.response.body.include?(expected_text)
+          warn "Expected #{path} response to include #{expected_text.inspect}"
+          warn session.response.body[0, 1000]
+          exit 1
+        end
+      '
+  )
+}
+
+verify_generated_app_runtime() {
+  local app_dir="$1"
+
+  echo "Building test bundles for $(basename "$app_dir")..."
+  (cd "$app_dir" && "${PNPM_CMD[@]}" run build:test >/dev/null)
+  verify_rails_route "$app_dir" "/" "OSS vs Pro"
+  verify_rails_route "$app_dir" "/hello_world" "Say hello to:"
+}
+
 echo "Verifying generated files..."
 grep -q "gem \"react_on_rails\"" "$APP_TS_DIR/Gemfile"
 grep -q "path: \"$RUBY_GEM_DIR\"" "$APP_TS_DIR/Gemfile"
@@ -204,6 +244,10 @@ expect_git_history "$APP_RSPACK_DIR" \
   "Add react_on_rails gem" \
   "Install React on Rails with TypeScript and Rspack" \
   "Normalize the generated app for pnpm"
+
+verify_generated_app_runtime "$APP_TS_DIR"
+verify_generated_app_runtime "$APP_JS_DIR"
+verify_generated_app_runtime "$APP_RSPACK_DIR"
 
 if [[ "$SMOKE_SCOPE" == "full" ]]; then
 grep -q "gem \"react_on_rails\"" "$APP_PRO_DIR/Gemfile"

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -113,8 +113,11 @@ module ReactOnRails
         %w[webpack.config.js]).freeze
       DOCS_REFERENCE_MESSAGE = "// The source code including full typescript support is available at:"
       TEMPLATE_RENDER_FAILED = Object.new.freeze # unique sentinel compared by identity via .equal?
+      SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
+      DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       private_constant :MANAGED_WEBPACK_FILE_TEMPLATES, :REMOVABLE_WEBPACK_FILES, :TemplateRenderContext,
-                       :DOCS_REFERENCE_MESSAGE, :TEMPLATE_RENDER_FAILED
+                       :DOCS_REFERENCE_MESSAGE, :TEMPLATE_RENDER_FAILED, :SHAKAPACKER_YML_PATH,
+                       :DEFAULT_PRECOMPILE_HOOK_COMMAND
 
       def add_root_route
         return unless options.new_app?
@@ -330,6 +333,93 @@ module ReactOnRails
       # (both generators are independently CLI-invocable); keep the two in sync.
       def rspack_bundler_default
         fresh_install_rspack_default
+      end
+
+      def generated_build_test_command
+        shakapacker_build_command(env: "RAILS_ENV=test NODE_ENV=test", environment: "test")
+      end
+
+      def shakapacker_build_command(env:, environment:)
+        hook_command = shakapacker_precompile_hook_command(environment: environment)
+        shakapacker_command = "#{env} bin/shakapacker"
+        return shakapacker_command unless hook_command
+
+        "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
+      end
+
+      def shakapacker_precompile_hook_command(environment:)
+        shakapacker_config_path = File.join(destination_root, SHAKAPACKER_YML_PATH)
+        return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
+        return DEFAULT_PRECOMPILE_HOOK_COMMAND if generated_precompile_hook_will_be_configured?(shakapacker_config_path)
+
+        config = parse_shakapacker_yml(shakapacker_config_path)
+        hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
+
+        generated_precompile_hook?(hook_command) ? hook_command : nil
+      end
+
+      def generated_precompile_hook_will_be_configured?(shakapacker_config_path)
+        return false unless ReactOnRails::PackerUtils.shakapacker_version_requirement_met?("9.0.0")
+
+        content = File.read(shakapacker_config_path)
+        return false if content.match?(/^\s+precompile_hook:\s*['"][^'"]+['"]/)
+
+        content.match?(/^(\s*)#\s*precompile_hook:\s*~\s*$/)
+      rescue StandardError
+        false
+      end
+
+      def effective_precompile_hook(config, environment)
+        environment_section = shakapacker_config_section(config, environment)
+        unless shakapacker_config_key?(config, environment)
+          environment_section = shakapacker_config_section(config, "production")
+        end
+
+        shakapacker_config_value(environment_section, "precompile_hook")
+      end
+
+      def shakapacker_config_section(config, section)
+        return {} unless config.respond_to?(:fetch)
+
+        section_config = config.fetch(section, config.fetch(section.to_sym, {}))
+        section_config.respond_to?(:key?) ? section_config : {}
+      end
+
+      def shakapacker_config_key?(section, key)
+        return false unless section.respond_to?(:key?)
+
+        section.key?(key) || section.key?(key.to_sym)
+      end
+
+      def shakapacker_config_value(section, key)
+        return section[key] if section.key?(key)
+        return section[key.to_sym] if section.key?(key.to_sym)
+
+        nil
+      end
+
+      def normalize_precompile_hook(hook)
+        return nil if hook.nil? || hook == false || hook.to_s.empty?
+
+        hook.to_s.strip
+      end
+
+      def generated_precompile_hook?(hook_command)
+        hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
+      end
+
+      def parse_shakapacker_yml(path)
+        require "yaml"
+
+        YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
+      rescue ArgumentError
+        begin
+          YAML.safe_load_file(path, permitted_classes: [Symbol])
+        rescue ArgumentError
+          YAML.safe_load(File.read(path), permitted_classes: [Symbol]) # rubocop:disable Style/YAMLFileRead
+        end
+      rescue StandardError
+        {}
       end
 
       def generate_new_app_home_page?

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -6,11 +6,13 @@ require "erb"
 require_relative "generator_messages"
 require_relative "generator_helper"
 require_relative "js_dependency_manager"
+require_relative "shakapacker_precompile_hook_helper"
 module ReactOnRails
   module Generators
     class BaseGenerator < Rails::Generators::Base
       include GeneratorHelper
       include JsDependencyManager
+      include ShakapackerPrecompileHookHelper
 
       Rails::Generators.hide_namespace(namespace)
       source_root(File.expand_path("templates", __dir__))
@@ -113,11 +115,8 @@ module ReactOnRails
         %w[webpack.config.js]).freeze
       DOCS_REFERENCE_MESSAGE = "// The source code including full typescript support is available at:"
       TEMPLATE_RENDER_FAILED = Object.new.freeze # unique sentinel compared by identity via .equal?
-      SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
-      DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       private_constant :MANAGED_WEBPACK_FILE_TEMPLATES, :REMOVABLE_WEBPACK_FILES, :TemplateRenderContext,
-                       :DOCS_REFERENCE_MESSAGE, :TEMPLATE_RENDER_FAILED, :SHAKAPACKER_YML_PATH,
-                       :DEFAULT_PRECOMPILE_HOOK_COMMAND
+                       :DOCS_REFERENCE_MESSAGE, :TEMPLATE_RENDER_FAILED
 
       def add_root_route
         return unless options.new_app?
@@ -337,89 +336,6 @@ module ReactOnRails
 
       def generated_build_test_command
         shakapacker_build_command(env: "RAILS_ENV=test NODE_ENV=test", environment: "test")
-      end
-
-      def shakapacker_build_command(env:, environment:)
-        hook_command = shakapacker_precompile_hook_command(environment: environment)
-        shakapacker_command = "#{env} bin/shakapacker"
-        return shakapacker_command unless hook_command
-
-        "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
-      end
-
-      def shakapacker_precompile_hook_command(environment:)
-        shakapacker_config_path = File.join(destination_root, SHAKAPACKER_YML_PATH)
-        return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
-        return DEFAULT_PRECOMPILE_HOOK_COMMAND if generated_precompile_hook_will_be_configured?(shakapacker_config_path)
-
-        config = parse_shakapacker_yml(shakapacker_config_path)
-        hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
-
-        generated_precompile_hook?(hook_command) ? hook_command : nil
-      end
-
-      def generated_precompile_hook_will_be_configured?(shakapacker_config_path)
-        return false unless ReactOnRails::PackerUtils.shakapacker_version_requirement_met?("9.0.0")
-
-        content = File.read(shakapacker_config_path)
-        return false if content.match?(/^\s+precompile_hook:\s*['"][^'"]+['"]/)
-
-        content.match?(/^(\s*)#\s*precompile_hook:\s*~\s*$/)
-      rescue StandardError
-        false
-      end
-
-      def effective_precompile_hook(config, environment)
-        environment_section = shakapacker_config_section(config, environment)
-        unless shakapacker_config_key?(config, environment)
-          environment_section = shakapacker_config_section(config, "production")
-        end
-
-        shakapacker_config_value(environment_section, "precompile_hook")
-      end
-
-      def shakapacker_config_section(config, section)
-        return {} unless config.respond_to?(:fetch)
-
-        section_config = config.fetch(section, config.fetch(section.to_sym, {}))
-        section_config.respond_to?(:key?) ? section_config : {}
-      end
-
-      def shakapacker_config_key?(section, key)
-        return false unless section.respond_to?(:key?)
-
-        section.key?(key) || section.key?(key.to_sym)
-      end
-
-      def shakapacker_config_value(section, key)
-        return section[key] if section.key?(key)
-        return section[key.to_sym] if section.key?(key.to_sym)
-
-        nil
-      end
-
-      def normalize_precompile_hook(hook)
-        return nil if hook.nil? || hook == false || hook.to_s.empty?
-
-        hook.to_s.strip
-      end
-
-      def generated_precompile_hook?(hook_command)
-        hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
-      end
-
-      def parse_shakapacker_yml(path)
-        require "yaml"
-
-        YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
-      rescue ArgumentError
-        begin
-          YAML.safe_load_file(path, permitted_classes: [Symbol])
-        rescue ArgumentError
-          YAML.safe_load(File.read(path), permitted_classes: [Symbol]) # rubocop:disable Style/YAMLFileRead
-        end
-      rescue StandardError
-        {}
       end
 
       def generate_new_app_home_page?

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -339,21 +339,22 @@ module GeneratorHelper
   end
 
   def parse_shakapacker_yml(path)
+    parse_shakapacker_yml_content(File.read(path))
+  rescue StandardError
+    {}
+  end
+
+  def parse_shakapacker_yml_content(content)
     require "yaml"
-    # Use safe_load_file for security (defense-in-depth, even though this is user's own config)
-    # permitted_classes: [Symbol] allows symbol keys which shakapacker.yml may use
-    # aliases: true allows YAML anchors (&default, *default) commonly used in Rails configs
-    YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
+
+    YAML.safe_load(content, permitted_classes: [Symbol], aliases: true)
   rescue ArgumentError
-    # Older Psych versions don't support all parameters - try without aliases
     begin
-      YAML.safe_load_file(path, permitted_classes: [Symbol])
-    rescue ArgumentError
-      # Very old Psych - fall back to safe_load with File.read
-      YAML.safe_load(File.read(path), permitted_classes: [Symbol]) # rubocop:disable Style/YAMLFileRead
+      YAML.safe_load(content, permitted_classes: [Symbol])
+    rescue StandardError
+      {}
     end
   rescue StandardError
-    # If we can't parse the file, return empty config
     {}
   end
 

--- a/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_helper.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "json"
+require_relative "shakapacker_precompile_hook_helper"
 
 # rubocop:disable Metrics/ModuleLength
 module GeneratorHelper
+  include ReactOnRails::Generators::ShakapackerPrecompileHookHelper
+
   def package_json
     # Lazy load package_json gem only when actually needed for dependency management
 
@@ -336,26 +339,6 @@ module GeneratorHelper
 
     # Fresh install: SWC is recommended default for Shakapacker 9.3.0+
     shakapacker_version_9_3_or_higher?
-  end
-
-  def parse_shakapacker_yml(path)
-    parse_shakapacker_yml_content(File.read(path))
-  rescue StandardError
-    {}
-  end
-
-  def parse_shakapacker_yml_content(content)
-    require "yaml"
-
-    YAML.safe_load(content, permitted_classes: [Symbol], aliases: true)
-  rescue ArgumentError
-    begin
-      YAML.safe_load(content, permitted_classes: [Symbol])
-    rescue StandardError
-      {}
-    end
-  rescue StandardError
-    {}
   end
 
   # Check if Shakapacker 9.3.0 or higher is available

--- a/react_on_rails/lib/generators/react_on_rails/generator_messages/ci_section.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_messages/ci_section.rb
@@ -4,6 +4,9 @@ require "rainbow"
 
 module GeneratorMessages
   module CiSection
+    DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
+    private_constant :DEFAULT_PRECOMPILE_HOOK_COMMAND
+
     private
 
     def build_ci_section(app_root: Dir.pwd, ci_workflow_generated: false)
@@ -25,6 +28,11 @@ module GeneratorMessages
                         else
                           ""
                         end
+      manual_build_command = shakapacker_build_command(
+        env: "RAILS_ENV=test NODE_ENV=test",
+        app_root: app_root,
+        environment: "test"
+      )
 
       <<~CI
 
@@ -35,8 +43,80 @@ module GeneratorMessages
         #{ci_status}
 
         To build bundles manually before tests:
-        #{Rainbow('RAILS_ENV=test NODE_ENV=test bin/shakapacker').cyan}#{build_test_hint}
+        #{Rainbow(manual_build_command).cyan}#{build_test_hint}
       CI
+    end
+
+    def shakapacker_build_command(env:, app_root:, environment:)
+      hook_command = shakapacker_precompile_hook_command(app_root: app_root, environment: environment)
+      shakapacker_command = "#{env} bin/shakapacker"
+      return shakapacker_command unless hook_command
+
+      "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
+    end
+
+    def shakapacker_precompile_hook_command(app_root:, environment:)
+      shakapacker_config_path = File.join(app_root, "config/shakapacker.yml")
+      return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
+
+      config = parse_shakapacker_yml(shakapacker_config_path)
+      hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
+
+      # Custom hooks stay inside Shakapacker so direct commands don't double-run on older supported versions.
+      generated_precompile_hook?(hook_command) ? hook_command : nil
+    end
+
+    def effective_precompile_hook(config, environment)
+      environment_section = shakapacker_config_section(config, environment)
+      unless shakapacker_config_key?(config, environment)
+        environment_section = shakapacker_config_section(config, "production")
+      end
+
+      shakapacker_config_value(environment_section, "precompile_hook")
+    end
+
+    def shakapacker_config_section(config, section)
+      return {} unless config.respond_to?(:fetch)
+
+      section_config = config.fetch(section, config.fetch(section.to_sym, {}))
+      section_config.respond_to?(:key?) ? section_config : {}
+    end
+
+    def shakapacker_config_key?(section, key)
+      return false unless section.respond_to?(:key?)
+
+      section.key?(key) || section.key?(key.to_sym)
+    end
+
+    def shakapacker_config_value(section, key)
+      return section[key] if section.key?(key)
+      return section[key.to_sym] if section.key?(key.to_sym)
+
+      nil
+    end
+
+    def normalize_precompile_hook(hook)
+      return nil if hook.nil? || hook == false || hook.to_s.empty?
+
+      hook.to_s.strip
+    end
+
+    def generated_precompile_hook?(hook_command)
+      hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
+    end
+
+    def parse_shakapacker_yml(path)
+      require "yaml"
+
+      YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
+    rescue ArgumentError
+      begin
+        YAML.safe_load_file(path, permitted_classes: [Symbol])
+      rescue ArgumentError
+        YAML.safe_load(File.read(path), permitted_classes: [Symbol]) # rubocop:disable Style/YAMLFileRead
+      end
+    rescue StandardError
+      {}
     end
   end
 end

--- a/react_on_rails/lib/generators/react_on_rails/generator_messages/ci_section.rb
+++ b/react_on_rails/lib/generators/react_on_rails/generator_messages/ci_section.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require "rainbow"
+require_relative "../shakapacker_precompile_hook_helper"
 
 module GeneratorMessages
   module CiSection
-    DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
-    private_constant :DEFAULT_PRECOMPILE_HOOK_COMMAND
+    include ReactOnRails::Generators::ShakapackerPrecompileHookHelper
 
     private
 
@@ -45,78 +45,6 @@ module GeneratorMessages
         To build bundles manually before tests:
         #{Rainbow(manual_build_command).cyan}#{build_test_hint}
       CI
-    end
-
-    def shakapacker_build_command(env:, app_root:, environment:)
-      hook_command = shakapacker_precompile_hook_command(app_root: app_root, environment: environment)
-      shakapacker_command = "#{env} bin/shakapacker"
-      return shakapacker_command unless hook_command
-
-      "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
-    end
-
-    def shakapacker_precompile_hook_command(app_root:, environment:)
-      shakapacker_config_path = File.join(app_root, "config/shakapacker.yml")
-      return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
-
-      config = parse_shakapacker_yml(shakapacker_config_path)
-      hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
-
-      # Custom hooks stay inside Shakapacker so direct commands don't double-run on older supported versions.
-      generated_precompile_hook?(hook_command) ? hook_command : nil
-    end
-
-    def effective_precompile_hook(config, environment)
-      environment_section = shakapacker_config_section(config, environment)
-      unless shakapacker_config_key?(config, environment)
-        environment_section = shakapacker_config_section(config, "production")
-      end
-
-      shakapacker_config_value(environment_section, "precompile_hook")
-    end
-
-    def shakapacker_config_section(config, section)
-      return {} unless config.respond_to?(:fetch)
-
-      section_config = config.fetch(section, config.fetch(section.to_sym, {}))
-      section_config.respond_to?(:key?) ? section_config : {}
-    end
-
-    def shakapacker_config_key?(section, key)
-      return false unless section.respond_to?(:key?)
-
-      section.key?(key) || section.key?(key.to_sym)
-    end
-
-    def shakapacker_config_value(section, key)
-      return section[key] if section.key?(key)
-      return section[key.to_sym] if section.key?(key.to_sym)
-
-      nil
-    end
-
-    def normalize_precompile_hook(hook)
-      return nil if hook.nil? || hook == false || hook.to_s.empty?
-
-      hook.to_s.strip
-    end
-
-    def generated_precompile_hook?(hook_command)
-      hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
-    end
-
-    def parse_shakapacker_yml(path)
-      require "yaml"
-
-      YAML.safe_load_file(path, permitted_classes: [Symbol], aliases: true)
-    rescue ArgumentError
-      begin
-        YAML.safe_load_file(path, permitted_classes: [Symbol])
-      rescue ArgumentError
-        YAML.safe_load(File.read(path), permitted_classes: [Symbol]) # rubocop:disable Style/YAMLFileRead
-      end
-    rescue StandardError
-      {}
     end
   end
 end

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -157,6 +157,8 @@ module ReactOnRails
       # renovate: datasource=github-releases depName=pnpm/pnpm extractVersion=^v(?<version>.+)$ allowedVersions=<11
       CI_PNPM_FALLBACK_VERSION = "10.33.4"
       private_constant :CI_PNPM_FALLBACK_VERSION
+      DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
+      private_constant :DEFAULT_PRECOMPILE_HOOK_COMMAND
 
       # Main generator entry point
       #
@@ -315,18 +317,19 @@ module ReactOnRails
                  { package_manager: package_manager, has_lockfile: has_lockfile,
                    pnpm_version_declared: pnpm_version_declared,
                    pnpm_fallback_version: CI_PNPM_FALLBACK_VERSION,
-                   has_active_record: has_active_record, has_rspec: has_rspec })
+                   has_active_record: has_active_record, has_rspec: has_rspec,
+                   precompile_hook_command: shakapacker_precompile_hook_command(environment: "test") })
         @ci_workflow_generated = true
       end
 
-      # NODE_ENV=production ensures Shakapacker emits a minified production bundle;
-      # without it the default is "development" which produces an unminified dev bundle
-      # and is almost never what `npm run build` is expected to do.
-      DEFAULT_PACKAGE_JSON_SCRIPTS = {
-        "build" => "NODE_ENV=production bin/shakapacker",
-        "build:test" => "RAILS_ENV=test NODE_ENV=test bin/shakapacker"
-      }.freeze
-      private_constant :DEFAULT_PACKAGE_JSON_SCRIPTS
+      # RAILS_ENV=production runs the hook with production Rails config, while
+      # NODE_ENV=production makes Shakapacker emit a minified production bundle.
+      def default_package_json_scripts
+        {
+          "build" => shakapacker_build_command(env: "RAILS_ENV=production NODE_ENV=production"),
+          "build:test" => shakapacker_build_command(env: "RAILS_ENV=test NODE_ENV=test", environment: "test")
+        }
+      end
 
       def add_package_json_scripts
         return if options[:pretend]
@@ -336,7 +339,7 @@ module ReactOnRails
 
         original_text = File.read(package_json_path)
         existing_scripts = JSON.parse(original_text)["scripts"] || {}
-        scripts_to_add = DEFAULT_PACKAGE_JSON_SCRIPTS.reject { |key, _| existing_scripts.key?(key) }
+        scripts_to_add = default_package_json_scripts.reject { |key, _| existing_scripts.key?(key) }
 
         if scripts_to_add.empty?
           say_status :skip, "build scripts already present in package.json", :yellow
@@ -350,6 +353,64 @@ module ReactOnRails
         GeneratorMessages.add_warning("⚠️  Could not parse package.json to add scripts: #{e.message}")
       rescue Errno::EACCES, Errno::ENOENT => e
         GeneratorMessages.add_warning("⚠️  Failed to add build scripts to package.json: #{e.message}")
+      end
+
+      def shakapacker_build_command(env:, environment: "production")
+        hook_command = shakapacker_precompile_hook_command(environment: environment)
+        shakapacker_command = "#{env} bin/shakapacker"
+        return shakapacker_command unless hook_command
+
+        "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
+      end
+
+      def shakapacker_precompile_hook_command(environment:)
+        shakapacker_config_path = File.join(destination_root, SHAKAPACKER_YML_PATH)
+        return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
+
+        config = parse_shakapacker_yml(shakapacker_config_path)
+        hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
+
+        # Custom hooks stay inside Shakapacker so direct commands don't double-run on older supported versions.
+        generated_precompile_hook?(hook_command) ? hook_command : nil
+      end
+
+      def effective_precompile_hook(config, environment)
+        environment_section = shakapacker_config_section(config, environment)
+        unless shakapacker_config_key?(config, environment)
+          environment_section = shakapacker_config_section(config, "production")
+        end
+
+        shakapacker_config_value(environment_section, "precompile_hook")
+      end
+
+      def shakapacker_config_section(config, section)
+        return {} unless config.respond_to?(:fetch)
+
+        section_config = config.fetch(section, config.fetch(section.to_sym, {}))
+        section_config.respond_to?(:key?) ? section_config : {}
+      end
+
+      def shakapacker_config_key?(section, key)
+        return false unless section.respond_to?(:key?)
+
+        section.key?(key) || section.key?(key.to_sym)
+      end
+
+      def shakapacker_config_value(section, key)
+        return section[key] if section.key?(key)
+        return section[key.to_sym] if section.key?(key.to_sym)
+
+        nil
+      end
+
+      def normalize_precompile_hook(hook)
+        return nil if hook.nil? || hook == false || hook.to_s.empty?
+
+        hook.to_s.strip
+      end
+
+      def generated_precompile_hook?(hook_command)
+        hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
       end
 
       # Inserts new entries into the existing "scripts" object without rewriting the rest of

--- a/react_on_rails/lib/generators/react_on_rails/install_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/install_generator.rb
@@ -9,6 +9,7 @@ require_relative "generator_messages"
 require_relative "js_dependency_manager"
 require_relative "pro_setup"
 require_relative "rsc_setup"
+require_relative "shakapacker_precompile_hook_helper"
 # Load-path require: git_utils lives under react_on_rails/lib, not relative to this generator directory.
 require "react_on_rails/git_utils"
 
@@ -23,6 +24,7 @@ module ReactOnRails
       include JsDependencyManager
       include ProSetup
       include RscSetup
+      include ShakapackerPrecompileHookHelper
 
       # fetch USAGE file for details generator description
       source_root(File.expand_path(__dir__))
@@ -98,7 +100,6 @@ module ReactOnRails
 
       # Removed: --skip-shakapacker-install (Shakapacker is now a required dependency)
 
-      SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       HELLO_WORLD_ROUTE = "hello_world"
       HELLO_SERVER_ROUTE = "hello_server"
       # Matches the stock `bin/dev` written by Rails 8.x. Rails 7.1 commonly
@@ -157,8 +158,6 @@ module ReactOnRails
       # renovate: datasource=github-releases depName=pnpm/pnpm extractVersion=^v(?<version>.+)$ allowedVersions=<11
       CI_PNPM_FALLBACK_VERSION = "10.33.4"
       private_constant :CI_PNPM_FALLBACK_VERSION
-      DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
-      private_constant :DEFAULT_PRECOMPILE_HOOK_COMMAND
 
       # Main generator entry point
       #
@@ -353,64 +352,6 @@ module ReactOnRails
         GeneratorMessages.add_warning("⚠️  Could not parse package.json to add scripts: #{e.message}")
       rescue Errno::EACCES, Errno::ENOENT => e
         GeneratorMessages.add_warning("⚠️  Failed to add build scripts to package.json: #{e.message}")
-      end
-
-      def shakapacker_build_command(env:, environment: "production")
-        hook_command = shakapacker_precompile_hook_command(environment: environment)
-        shakapacker_command = "#{env} bin/shakapacker"
-        return shakapacker_command unless hook_command
-
-        "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
-      end
-
-      def shakapacker_precompile_hook_command(environment:)
-        shakapacker_config_path = File.join(destination_root, SHAKAPACKER_YML_PATH)
-        return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
-
-        config = parse_shakapacker_yml(shakapacker_config_path)
-        hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
-
-        # Custom hooks stay inside Shakapacker so direct commands don't double-run on older supported versions.
-        generated_precompile_hook?(hook_command) ? hook_command : nil
-      end
-
-      def effective_precompile_hook(config, environment)
-        environment_section = shakapacker_config_section(config, environment)
-        unless shakapacker_config_key?(config, environment)
-          environment_section = shakapacker_config_section(config, "production")
-        end
-
-        shakapacker_config_value(environment_section, "precompile_hook")
-      end
-
-      def shakapacker_config_section(config, section)
-        return {} unless config.respond_to?(:fetch)
-
-        section_config = config.fetch(section, config.fetch(section.to_sym, {}))
-        section_config.respond_to?(:key?) ? section_config : {}
-      end
-
-      def shakapacker_config_key?(section, key)
-        return false unless section.respond_to?(:key?)
-
-        section.key?(key) || section.key?(key.to_sym)
-      end
-
-      def shakapacker_config_value(section, key)
-        return section[key] if section.key?(key)
-        return section[key.to_sym] if section.key?(key.to_sym)
-
-        nil
-      end
-
-      def normalize_precompile_hook(hook)
-        return nil if hook.nil? || hook == false || hook.to_s.empty?
-
-        hook.to_s.strip
-      end
-
-      def generated_precompile_hook?(hook_command)
-        hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
       end
 
       # Inserts new entries into the existing "scripts" object without rewriting the rest of

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module ReactOnRails
+  module Generators
+    module ShakapackerPrecompileHookHelper
+      SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
+      DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
+      COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
+      ACTIVE_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*['"][^'"]+['"]/
+      private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
+                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :ACTIVE_PRECOMPILE_HOOK
+
+      private
+
+      def shakapacker_build_command(env:, environment: "production", app_root: shakapacker_hook_app_root)
+        hook_command = shakapacker_precompile_hook_command(app_root: app_root, environment: environment)
+        shakapacker_command = "#{env} bin/shakapacker"
+        return shakapacker_command unless hook_command
+
+        "#{env} #{hook_command} && SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true #{shakapacker_command}"
+      end
+
+      def shakapacker_precompile_hook_command(environment:, app_root: shakapacker_hook_app_root)
+        shakapacker_config_path = File.join(app_root, SHAKAPACKER_YML_PATH)
+        return DEFAULT_PRECOMPILE_HOOK_COMMAND unless File.exist?(shakapacker_config_path)
+
+        config = parse_shakapacker_yml(shakapacker_config_path)
+        hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
+        return hook_command if generated_precompile_hook?(hook_command)
+
+        return unless generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment: environment)
+
+        DEFAULT_PRECOMPILE_HOOK_COMMAND
+      end
+
+      def generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment:)
+        return false unless shakapacker_supports_precompile_hook?
+
+        content = File.read(shakapacker_config_path)
+        return false if content.match?(ACTIVE_PRECOMPILE_HOOK)
+        return false unless content.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
+
+        materialized_content = content.gsub(
+          COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER,
+          "\\1precompile_hook: '#{DEFAULT_PRECOMPILE_HOOK_COMMAND}'"
+        )
+        config = parse_shakapacker_yml_content(materialized_content)
+        generated_precompile_hook?(
+          normalize_precompile_hook(effective_precompile_hook(config, environment))
+        )
+      rescue StandardError
+        false
+      end
+
+      def effective_precompile_hook(config, environment)
+        environment_section = shakapacker_config_section(config, environment)
+        unless shakapacker_config_key?(config, environment)
+          environment_section = shakapacker_config_section(config, "production")
+        end
+
+        shakapacker_config_value(environment_section, "precompile_hook")
+      end
+
+      def shakapacker_config_section(config, section)
+        return {} unless config.respond_to?(:fetch)
+
+        section_config = config.fetch(section, config.fetch(section.to_sym, {}))
+        section_config.respond_to?(:key?) ? section_config : {}
+      end
+
+      def shakapacker_config_key?(section, key)
+        return false unless section.respond_to?(:key?)
+
+        section.key?(key) || section.key?(key.to_sym)
+      end
+
+      def shakapacker_config_value(section, key)
+        return section[key] if section.key?(key)
+        return section[key.to_sym] if section.key?(key.to_sym)
+
+        nil
+      end
+
+      def normalize_precompile_hook(hook)
+        return nil if hook.nil? || hook == false || hook.to_s.empty?
+
+        hook.to_s.strip
+      end
+
+      def generated_precompile_hook?(hook_command)
+        hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
+      end
+
+      def parse_shakapacker_yml(path)
+        parse_shakapacker_yml_content(File.read(path))
+      rescue StandardError
+        {}
+      end
+
+      def parse_shakapacker_yml_content(content)
+        require "yaml"
+
+        YAML.safe_load(content, permitted_classes: [Symbol], aliases: true)
+      rescue ArgumentError
+        begin
+          YAML.safe_load(content, permitted_classes: [Symbol])
+        rescue StandardError
+          {}
+        end
+      rescue StandardError
+        {}
+      end
+
+      def shakapacker_supports_precompile_hook?
+        return true unless defined?(ReactOnRails::PackerUtils)
+
+        ReactOnRails::PackerUtils.shakapacker_version_requirement_met?("9.0.0")
+      rescue StandardError
+        false
+      end
+
+      def shakapacker_hook_app_root
+        return destination_root if respond_to?(:destination_root)
+
+        Dir.pwd
+      end
+    end
+  end
+end

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -100,15 +100,46 @@ module ReactOnRails
       def parse_shakapacker_yml_content(content)
         require "yaml"
 
-        YAML.safe_load(content, permitted_classes: [Symbol], aliases: true)
-      rescue ArgumentError
-        begin
-          YAML.safe_load(content, permitted_classes: [Symbol])
-        rescue StandardError
-          {}
-        end
+        return YAML.safe_load(content, permitted_classes: [Symbol], aliases: true) if yaml_safe_load_supports_aliases?
+        return {} if yaml_content_uses_aliases?(content)
+
+        YAML.safe_load(content, permitted_classes: [Symbol])
+      rescue ArgumentError => e
+        return {} if yaml_alias_keyword_error?(e) && yaml_content_uses_aliases?(content)
+        return YAML.safe_load(content, permitted_classes: [Symbol]) if yaml_alias_keyword_error?(e)
+
+        {}
       rescue StandardError
         {}
+      end
+
+      def yaml_safe_load_supports_aliases?
+        YAML.method(:safe_load).parameters.any? do |type, name|
+          type == :keyrest || (type == :key && name == :aliases)
+        end
+      rescue StandardError
+        false
+      end
+
+      def yaml_alias_keyword_error?(error)
+        error.message.include?("aliases")
+      end
+
+      def yaml_content_uses_aliases?(content)
+        require "psych"
+
+        yaml_node_uses_aliases?(Psych.parse_stream(content))
+      rescue StandardError
+        true
+      end
+
+      def yaml_node_uses_aliases?(node)
+        return false unless node
+        return true if node.respond_to?(:anchor) && node.anchor
+        return true if defined?(Psych::Nodes::Alias) && node.is_a?(Psych::Nodes::Alias)
+        return false unless node.respond_to?(:children)
+
+        node.children.any? { |child| yaml_node_uses_aliases?(child) }
       end
 
       def shakapacker_supports_precompile_hook?

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/.github/workflows/ci.yml.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/.github/workflows/ci.yml.tt
@@ -75,7 +75,13 @@ jobs:
 <%- end -%>
       - name: Build JavaScript bundles
         # Shakapacker default. ViteRuby users: replace with `bin/vite build --mode test`.
-        run: bin/shakapacker
+        run: |
+<%- if config[:precompile_hook_command] -%>
+          <%= config[:precompile_hook_command] %>
+          SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true bin/shakapacker
+<%- else -%>
+          bin/shakapacker
+<%- end -%>
         env:
           RAILS_ENV: test
           NODE_ENV: test

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/initializers/react_on_rails.rb.tt
@@ -49,7 +49,7 @@ ReactOnRails.configure do |config|
   # RSpec apps should also add to spec/rails_helper.rb (inside RSpec.configure):
   #   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
   #
-  config.build_test_command = "RAILS_ENV=test bin/shakapacker"
+  config.build_test_command = "<%= generated_build_test_command %>"
 
   config.auto_load_bundle = true
   config.components_subdirectory = "ror_components"

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -203,6 +203,31 @@ RSpec.describe GeneratorHelper, type: :generator do
     end
   end
 
+  describe "#parse_shakapacker_yml_content" do
+    let(:aliased_config) do
+      <<~YAML
+        default: &default
+          precompile_hook: bin/shakapacker-precompile-hook
+
+        test:
+          <<: *default
+      YAML
+    end
+
+    it "fails closed instead of parsing aliased configs without alias support" do
+      allow(YAML).to receive(:safe_load) do |_content, aliases: false, **_kwargs|
+        raise ArgumentError, "unknown keyword: :aliases" if aliases
+
+        {
+          "default" => { "precompile_hook" => "bin/shakapacker-precompile-hook" },
+          "test" => { "precompile_hook" => "bin/shakapacker-precompile-hook" }
+        }
+      end
+
+      expect(parse_shakapacker_yml_content(aliased_config)).to eq({})
+    end
+  end
+
   describe "Pro/RSC flag helpers" do
     it "treats --rsc as implying Pro" do
       allow(self).to receive(:options).and_return({ rsc: true, pro: false })

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe GeneratorHelper, type: :generator do
     end
 
     it "fails closed instead of parsing aliased configs without alias support" do
+      allow(self).to receive(:yaml_safe_load_supports_aliases?).and_return(true)
       allow(YAML).to receive(:safe_load) do |_content, aliases: false, **_kwargs|
         raise ArgumentError, "unknown keyword: :aliases" if aliases
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
@@ -169,6 +169,46 @@ describe GeneratorMessages do
     end
   end
 
+  it "does not assume a commented generated hook placeholder applies to test when test does not merge defaults" do
+    Dir.mktmpdir do |app_root|
+      FileUtils.mkdir_p(File.join(app_root, "config"))
+      File.write(File.join(app_root, "config/shakapacker.yml"), <<~YAML)
+        default: &default
+          # precompile_hook: ~
+
+        test:
+          compile: true
+      YAML
+
+      message = described_class.send(:build_ci_section, app_root: app_root, ci_workflow_generated: true)
+
+      expect(message).to include("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      expect(message).not_to include("bin/shakapacker-precompile-hook")
+      expect(message).not_to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
+    end
+  end
+
+  it "uses the generated hook placeholder in the manual CI build command when test merges defaults" do
+    Dir.mktmpdir do |app_root|
+      FileUtils.mkdir_p(File.join(app_root, "config"))
+      File.write(File.join(app_root, "config/shakapacker.yml"), <<~YAML)
+        default: &default
+          # precompile_hook: ~
+
+        test:
+          <<: *default
+          compile: true
+      YAML
+
+      message = described_class.send(:build_ci_section, app_root: app_root, ci_workflow_generated: true)
+
+      expect(message).to include(
+        "RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook && " \
+        "SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true RAILS_ENV=test NODE_ENV=test bin/shakapacker"
+      )
+    end
+  end
+
   describe ".detect_package_manager" do
     include_context "with clean REACT_ON_RAILS_PACKAGE_MANAGER env"
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
@@ -110,6 +110,65 @@ describe GeneratorMessages do
     end
   end
 
+  it "uses the generated Shakapacker precompile hook in the manual CI build command" do
+    Dir.mktmpdir do |app_root|
+      FileUtils.mkdir_p(File.join(app_root, "config"))
+      File.write(File.join(app_root, "config/shakapacker.yml"), <<~YAML)
+        default: &default
+          precompile_hook: 'bin/shakapacker-precompile-hook'
+
+        test:
+          <<: *default
+      YAML
+
+      message = described_class.send(:build_ci_section, app_root: app_root, ci_workflow_generated: true)
+
+      expect(message).to include(
+        "RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook && " \
+        "SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true RAILS_ENV=test NODE_ENV=test bin/shakapacker"
+      )
+    end
+  end
+
+  it "leaves custom Shakapacker precompile hooks under Shakapacker control" do
+    Dir.mktmpdir do |app_root|
+      FileUtils.mkdir_p(File.join(app_root, "config"))
+      File.write(File.join(app_root, "config/shakapacker.yml"), <<~YAML)
+        default: &default
+          precompile_hook: 'bundle exec rake react_on_rails:locale'
+
+        test:
+          <<: *default
+          precompile_hook: 'bundle exec rake react_on_rails:test_locale'
+      YAML
+
+      message = described_class.send(:build_ci_section, app_root: app_root, ci_workflow_generated: true)
+
+      expect(message).to include("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      expect(message).not_to include("react_on_rails:test_locale")
+      expect(message).not_to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
+    end
+  end
+
+  it "does not inherit default precompile_hook when the Shakapacker environment does not merge it" do
+    Dir.mktmpdir do |app_root|
+      FileUtils.mkdir_p(File.join(app_root, "config"))
+      File.write(File.join(app_root, "config/shakapacker.yml"), <<~YAML)
+        default: &default
+          precompile_hook: 'bin/shakapacker-precompile-hook'
+
+        test:
+          compile: true
+      YAML
+
+      message = described_class.send(:build_ci_section, app_root: app_root, ci_workflow_generated: true)
+
+      expect(message).to include("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      expect(message).not_to include("bin/shakapacker-precompile-hook")
+      expect(message).not_to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
+    end
+  end
+
   describe ".detect_package_manager" do
     include_context "with clean REACT_ON_RAILS_PACKAGE_MANAGER env"
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -95,7 +95,10 @@ describe InstallGenerator, type: :generator do
 
     it "enables build_test_command by default" do
       assert_file "config/initializers/react_on_rails.rb" do |content|
-        expect(content).to include('config.build_test_command = "RAILS_ENV=test bin/shakapacker"')
+        expect(content).to include(
+          'config.build_test_command = "RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook && ' \
+          'SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true RAILS_ENV=test NODE_ENV=test bin/shakapacker"'
+        )
       end
     end
 
@@ -486,6 +489,118 @@ describe InstallGenerator, type: :generator do
         # Other settings should be preserved
         expect(content).to include("source_path: app/javascript")
         expect(content).to include("assets_bundler: \"webpack\"")
+      end
+    end
+  end
+
+  context "when shakapacker.yml already has a custom precompile_hook" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          assets_bundler: "webpack"
+          precompile_hook: 'bundle exec rake react_on_rails:locale'
+
+        development:
+          <<: *default
+
+        test:
+          <<: *default
+          compile: true
+          precompile_hook: 'bundle exec rake react_on_rails:test_locale'
+
+        production:
+          <<: *default
+          precompile_hook: 'bundle exec rake react_on_rails:build_locale'
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      base_generator = ReactOnRails::Generators::BaseGenerator.new([], {}, destination_root: destination_root)
+      generator = described_class.new([], {}, destination_root: destination_root)
+      Dir.chdir(destination_root) do
+        base_generator.send(:copy_base_files)
+        generator.send(:add_package_json_scripts)
+        generator.send(:add_ci_workflow)
+      end
+    end
+
+    it "leaves custom hooks under Shakapacker control" do
+      assert_file "config/shakapacker.yml" do |content|
+        expect(content).to include("precompile_hook: 'bundle exec rake react_on_rails:locale'")
+      end
+
+      assert_file "package.json" do |content|
+        scripts = JSON.parse(content).fetch("scripts")
+        expect(scripts["build"]).to eq("RAILS_ENV=production NODE_ENV=production bin/shakapacker")
+        expect(scripts["build:test"]).to eq("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      end
+
+      assert_file "config/initializers/react_on_rails.rb" do |content|
+        expect(content).to include('config.build_test_command = "RAILS_ENV=test NODE_ENV=test bin/shakapacker"')
+        expect(content).not_to include("bin/shakapacker-precompile-hook")
+      end
+
+      assert_file ".github/workflows/ci.yml" do |content|
+        expect(content).to include("bin/shakapacker")
+        expect(content).not_to include("react_on_rails:test_locale")
+        expect(content).not_to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
+      end
+    end
+  end
+
+  context "when shakapacker.yml has a default hook that the test environment does not merge" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          precompile_hook: 'bin/shakapacker-precompile-hook'
+
+        test:
+          compile: true
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      generator = described_class.new([], {}, destination_root: destination_root)
+      Dir.chdir(destination_root) do
+        generator.send(:add_package_json_scripts)
+        generator.send(:add_ci_workflow)
+      end
+    end
+
+    it "does not run the default hook for test builds" do
+      assert_file "package.json" do |content|
+        scripts = JSON.parse(content).fetch("scripts")
+        expect(scripts["build:test"]).to eq("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      end
+
+      assert_file ".github/workflows/ci.yml" do |content|
+        expect(content).to include("bin/shakapacker")
+        expect(content).not_to include("bin/shakapacker-precompile-hook")
+        expect(content).not_to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -605,6 +605,106 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  context "when shakapacker.yml has a commented generated hook placeholder and test does not merge defaults" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          # precompile_hook: ~
+
+        test:
+          compile: true
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      base_generator = ReactOnRails::Generators::BaseGenerator.new([], {}, destination_root: destination_root)
+      generator = described_class.new([], {}, destination_root: destination_root)
+      Dir.chdir(destination_root) do
+        base_generator.send(:copy_base_files)
+        generator.send(:add_package_json_scripts)
+        generator.send(:add_ci_workflow)
+      end
+    end
+
+    it "does not add the generated hook to test build commands before the environment inherits it" do
+      assert_file "config/initializers/react_on_rails.rb" do |content|
+        expect(content).to include('config.build_test_command = "RAILS_ENV=test NODE_ENV=test bin/shakapacker"')
+        expect(content).not_to include("bin/shakapacker-precompile-hook")
+      end
+
+      assert_file "package.json" do |content|
+        scripts = JSON.parse(content).fetch("scripts")
+        expect(scripts["build:test"]).to eq("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      end
+
+      assert_file ".github/workflows/ci.yml" do |content|
+        expect(content).to include("bin/shakapacker")
+        expect(content).not_to include("bin/shakapacker-precompile-hook")
+        expect(content).not_to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
+      end
+    end
+  end
+
+  context "when shakapacker.yml has a commented generated hook placeholder and test merges defaults" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          # precompile_hook: ~
+
+        test:
+          <<: *default
+          compile: true
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      generator = described_class.new([], {}, destination_root: destination_root)
+      Dir.chdir(destination_root) do
+        generator.send(:add_package_json_scripts)
+        generator.send(:add_ci_workflow)
+      end
+    end
+
+    it "uses the generated hook for scripts and CI before shakapacker.yml is rewritten" do
+      assert_file "package.json" do |content|
+        scripts = JSON.parse(content).fetch("scripts")
+        expect(scripts["build:test"]).to eq(
+          "RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook && " \
+          "SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true RAILS_ENV=test NODE_ENV=test bin/shakapacker"
+        )
+      end
+
+      assert_file ".github/workflows/ci.yml" do |content|
+        expect(content).to include("bin/shakapacker-precompile-hook")
+        expect(content).to include("SHAKAPACKER_SKIP_PRECOMPILE_HOOK")
+      end
+    end
+  end
+
   context "when shakapacker.yml already has private_output_path key without a value" do
     before(:all) do
       prepare_destination

--- a/react_on_rails/spec/react_on_rails/support/shared_examples/scaffold_ci_examples.rb
+++ b/react_on_rails/spec/react_on_rails/support/shared_examples/scaffold_ci_examples.rb
@@ -34,9 +34,11 @@ shared_examples "scaffold_ci_and_scripts" do
     end
   end
 
-  it "CI workflow uses bin/shakapacker for bundle build" do
+  it "CI workflow runs the auto-bundle hook before building JS bundles" do
     assert_file ".github/workflows/ci.yml" do |content|
-      expect(content).to include("bin/shakapacker")
+      expect(content).to match(
+        %r{bin/shakapacker-precompile-hook\s*\n\s*SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true bin/shakapacker}
+      )
       expect(content).to include("RAILS_ENV: test")
       expect(content).to include("NODE_ENV: test")
     end
@@ -55,9 +57,15 @@ shared_examples "scaffold_ci_and_scripts" do
       scripts = package_json["scripts"] || {}
       expect(scripts).to include("build")
       expect(scripts).to include("build:test")
-      expect(scripts["build"]).to include("bin/shakapacker")
+      expect(scripts["build"]).to eq(
+        "RAILS_ENV=production NODE_ENV=production bin/shakapacker-precompile-hook && " \
+        "SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true RAILS_ENV=production NODE_ENV=production bin/shakapacker"
+      )
+      expect(scripts["build:test"]).to eq(
+        "RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook && " \
+        "SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true RAILS_ENV=test NODE_ENV=test bin/shakapacker"
+      )
       expect(scripts["build:test"]).to include("RAILS_ENV=test")
-      expect(scripts["build:test"]).to include("bin/shakapacker")
     end
   end
 end


### PR DESCRIPTION
## Summary
- run the generated Shakapacker precompile hook before generated `build`, `build:test`, scaffolded CI, and generated `build_test_command` bundle builds
- keep custom Shakapacker hooks under Shakapacker control so direct/custom hooks do not double-run, while matching Shakapacker environment and production fallback semantics
- extend create-react-on-rails-app OSS smoke to build test bundles and render `/` and `/hello_world` for Webpack TS, Webpack JS, and Rspack TS generated apps
- update contributor smoke-testing docs

## Test plan
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb -e "enables build_test_command by default" -e "without args CI workflow runs the auto-bundle hook before building JS bundles" -e "without args adds build scripts to package.json" -e "with --rsc CI workflow runs the auto-bundle hook before building JS bundles" -e "with --rsc adds build scripts to package.json" -e "leaves custom hooks under Shakapacker control" -e "does not run the default hook for test builds"`
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb`
- `bundle exec rubocop --cache-root /private/tmp/rubocop_cache --no-server --cache false react_on_rails/lib/generators/react_on_rails/base_generator.rb react_on_rails/lib/generators/react_on_rails/install_generator.rb react_on_rails/lib/generators/react_on_rails/generator_messages/ci_section.rb react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb react_on_rails/spec/react_on_rails/support/shared_examples/scaffold_ci_examples.rb`
- `bash -n packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
- `git diff --check`
- `pnpm start format.listDifferent`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`
- `KEEP_WORKDIR=1 CREATE_ROR_SMOKE_SCOPE=oss packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default build, CI, and test-compile commands for newly generated apps; behavior is environment-sensitive but custom hooks are preserved and coverage is broad.
> 
> **Overview**
> Generated apps now run **`bin/shakapacker-precompile-hook`** before **`bin/shakapacker`** for **`build`**, **`build:test`**, scaffolded **GitHub Actions** bundle steps, and **`config.build_test_command`**, with **`SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true`** so the hook is not executed twice. A shared **`ShakapackerPrecompileHookHelper`** decides when to prepend that command from **`config/shakapacker.yml`** (including commented placeholders and per-environment **`test`** semantics); **custom** **`precompile_hook`** values are left to Shakapacker alone.
> 
> The **create-react-on-rails-app** OSS smoke script now runs **`pnpm run build:test`** and checks that **`/`** and **`/hello_world`** return **200** with expected copy. Contributor smoke-testing docs describe that runtime step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e3e37397e34c4ea6f5eab096981c4ccec0276a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smoke tests now build test bundles and verify generated app routes at runtime (including / and /hello_world).
  * Generators now produce test build commands that include any configured precompile-hook handling.

* **Bug Fixes**
  * CI workflows and generated build scripts run the configured precompile hook before bundling to prevent double/missing precompile steps.

* **Tests**
  * Expanded test coverage for precompile-hook behavior across environments and CI/package script generation.

* **Documentation**
  * Contributor smoke-testing docs updated to reflect the new build-and-verify flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->