### PR TITLE
Make benchmark reports smaller and more reliable

### DIFF
--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -309,8 +309,8 @@ non_rsc_tests.each do |test_case|
   rps, p50, p90, status = run_vegeta_benchmark(test_case, non_rsc_bundle)
   add_to_summary(test_case[:name], "non-RSC", rps, p50, p90, status)
 
-  # Add to BMF collector for Bencher output
-  bmf_collector.add(name: "#{test_case[:name]} (non-RSC)", rps: rps, p50: p50, p90: p90, status: status)
+  # Add to BMF collector for Bencher output (p90 stays in the summary table only)
+  bmf_collector.add(name: "#{test_case[:name]} (non-RSC)", rps: rps, p50: p50, status: status)
 end
 
 # Run RSC benchmarks
@@ -324,8 +324,8 @@ rsc_tests.each do |test_case|
   rps, p50, p90, status = run_vegeta_benchmark(test_case, rsc_bundle)
   add_to_summary(test_case[:name], "RSC", rps, p50, p90, status)
 
-  # Add to BMF collector for Bencher output
-  bmf_collector.add(name: "#{test_case[:name]} (RSC)", rps: rps, p50: p50, p90: p90, status: status)
+  # Add to BMF collector for Bencher output (p90 stays in the summary table only)
+  bmf_collector.add(name: "#{test_case[:name]} (RSC)", rps: rps, p50: p50, status: status)
 end
 
 # Display summary

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -217,11 +217,9 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
   vegeta_rps = vegeta_data["throughput"]&.round(2) || "MISSING"
   vegeta_p50 = vegeta_data.dig("latencies", "50th")&./(1_000_000.0)&.round(2) || "MISSING"
   vegeta_p90 = vegeta_data.dig("latencies", "90th")&./(1_000_000.0)&.round(2) || "MISSING"
-  vegeta_p99 = vegeta_data.dig("latencies", "99th")&./(1_000_000.0)&.round(2) || "MISSING"
-  vegeta_max = vegeta_data.dig("latencies", "max")&./(1_000_000.0)&.round(2) || "MISSING"
   vegeta_status = vegeta_data["status_codes"]&.map { |k, v| "#{k}=#{v}" }&.join(",") || "MISSING"
 
-  [vegeta_rps, vegeta_p50, vegeta_p90, vegeta_p99, vegeta_max, vegeta_status]
+  [vegeta_rps, vegeta_p50, vegeta_p90, vegeta_status]
 rescue StandardError => e
   puts "Error: #{e.message}"
   failure_metrics(e)
@@ -298,7 +296,7 @@ bmf_collector = BmfCollector.new(prefix: BMF_PREFIX)
 
 # Initialize summary file
 File.write(SUMMARY_TXT, "")
-add_to_summary("Test", "Bundle", "RPS", "p50(ms)", "p90(ms)", "p99(ms)", "max(ms)", "Status")
+add_to_summary("Test", "Bundle", "RPS", "p50(ms)", "p90(ms)", "Status")
 
 # Run non-RSC benchmarks
 non_rsc_tests.each do |test_case|
@@ -308,11 +306,11 @@ non_rsc_tests.each do |test_case|
   puts "  Request: #{test_case[:request]}"
   print_separator
 
-  rps, p50, p90, p99, max_latency, status = run_vegeta_benchmark(test_case, non_rsc_bundle)
-  add_to_summary(test_case[:name], "non-RSC", rps, p50, p90, p99, max_latency, status)
+  rps, p50, p90, status = run_vegeta_benchmark(test_case, non_rsc_bundle)
+  add_to_summary(test_case[:name], "non-RSC", rps, p50, p90, status)
 
   # Add to BMF collector for Bencher output
-  bmf_collector.add(name: "#{test_case[:name]} (non-RSC)", rps: rps, p50: p50, p90: p90, p99: p99, status: status)
+  bmf_collector.add(name: "#{test_case[:name]} (non-RSC)", rps: rps, p50: p50, p90: p90, status: status)
 end
 
 # Run RSC benchmarks
@@ -323,11 +321,11 @@ rsc_tests.each do |test_case|
   puts "  Request: #{test_case[:request]}"
   print_separator
 
-  rps, p50, p90, p99, max_latency, status = run_vegeta_benchmark(test_case, rsc_bundle)
-  add_to_summary(test_case[:name], "RSC", rps, p50, p90, p99, max_latency, status)
+  rps, p50, p90, status = run_vegeta_benchmark(test_case, rsc_bundle)
+  add_to_summary(test_case[:name], "RSC", rps, p50, p90, status)
 
   # Add to BMF collector for Bencher output
-  bmf_collector.add(name: "#{test_case[:name]} (RSC)", rps: rps, p50: p50, p90: p90, p99: p99, status: status)
+  bmf_collector.add(name: "#{test_case[:name]} (RSC)", rps: rps, p50: p50, p90: p90, status: status)
 end
 
 # Display summary

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -153,8 +153,8 @@ routes.each do |route|
   rps, p50, p90, status = run_k6_benchmark(target, route_name)
   add_to_summary(route, rps, p50, p90, status)
 
-  # Add to BMF collector for Bencher output
-  bmf_collector.add(name: route, rps: rps, p50: p50, p90: p90, status: status)
+  # Add to BMF collector for Bencher output (p90 stays in the summary table only)
+  bmf_collector.add(name: route, rps: rps, p50: p50, status: status)
 end
 
 puts "\nSummary saved to #{SUMMARY_TXT}"

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -94,15 +94,13 @@ def run_k6_benchmark(target, route_name)
   ].join(" ")
 
   k6_command = "k6 run #{k6_env_vars} --summary-export=#{Shellwords.escape(k6_summary_json)} " \
-               "--summary-trend-stats 'med,max,p(90),p(99)' #{k6_script}"
+               "--summary-trend-stats 'med,p(90)' #{k6_script}"
   raise "k6 benchmark failed" unless system("#{k6_command} | tee #{Shellwords.escape(k6_txt)}")
 
   k6_data = parse_json_file(k6_summary_json, "k6")
   k6_rps = k6_data.dig("metrics", "iterations", "rate")&.round(2) || "MISSING"
   k6_p50 = k6_data.dig("metrics", "http_req_duration", "med")&.round(2) || "MISSING"
   k6_p90 = k6_data.dig("metrics", "http_req_duration", "p(90)")&.round(2) || "MISSING"
-  k6_p99 = k6_data.dig("metrics", "http_req_duration", "p(99)")&.round(2) || "MISSING"
-  k6_max = k6_data.dig("metrics", "http_req_duration", "max")&.round(2) || "MISSING"
 
   # Status: extract counts from checks (status_200, status_3xx, status_4xx, status_5xx)
   k6_reqs_total = k6_data.dig("metrics", "http_reqs", "count") || 0
@@ -121,7 +119,7 @@ def run_k6_benchmark(target, route_name)
   k6_status_parts << "other=#{k6_other}" if k6_other.positive?
   k6_status = k6_status_parts.empty? ? "MISSING" : k6_status_parts.join(",")
 
-  [k6_rps, k6_p50, k6_p90, k6_p99, k6_max, k6_status]
+  [k6_rps, k6_p50, k6_p90, k6_status]
 rescue StandardError => e
   puts "Error: #{e.message}"
   failure_metrics(e)
@@ -131,7 +129,7 @@ end
 
 # Initialize summary file
 File.write(SUMMARY_TXT, "")
-add_to_summary("Route", "RPS", "p50(ms)", "p90(ms)", "p99(ms)", "max(ms)", "Status")
+add_to_summary("Route", "RPS", "p50(ms)", "p90(ms)", "Status")
 
 # Run benchmarks for each route
 routes.each do |route|
@@ -152,11 +150,11 @@ routes.each do |route|
   puts "Warm-up complete for #{route}"
 
   route_name = sanitize_route_name(route)
-  rps, p50, p90, p99, max_latency, status = run_k6_benchmark(target, route_name)
-  add_to_summary(route, rps, p50, p90, p99, max_latency, status)
+  rps, p50, p90, status = run_k6_benchmark(target, route_name)
+  add_to_summary(route, rps, p50, p90, status)
 
   # Add to BMF collector for Bencher output
-  bmf_collector.add(name: route, rps: rps, p50: p50, p90: p90, p99: p99, status: status)
+  bmf_collector.add(name: route, rps: rps, p50: p50, p90: p90, status: status)
 end
 
 puts "\nSummary saved to #{SUMMARY_TXT}"

--- a/benchmarks/lib/benchmark_helpers.rb
+++ b/benchmarks/lib/benchmark_helpers.rb
@@ -19,9 +19,9 @@ rescue StandardError => e
   raise "Failed to read #{tool_name} results: #{e.message}"
 end
 
-# Create failure metrics array for summary
+# Create failure metrics array for summary (rps, p50, p90 + status message)
 def failure_metrics(error)
-  ["FAILED", "FAILED", "FAILED", "FAILED", "FAILED", error.message]
+  ["FAILED", "FAILED", "FAILED", error.message]
 end
 
 # Append a line to the summary file

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -2,6 +2,17 @@
 
 require "open3"
 
+# Routes that exist only to demonstrate mistakes / anti-patterns (linked from the
+# dummy apps' sidebar as "Improperly defined…" / "Incorrectly …"). They are meant
+# to error (and hard-500 in the Pro suite), so they are demos, not performance
+# workloads — keep auto-discovery from sweeping them into the suite.
+# Explicitly-requested routes (ROUTES=) are honored regardless.
+NON_BENCHMARK_ROUTES = %w[
+  /react_helmet_broken
+  /context_function_return_jsx
+  /pure_component_wrapped_in_function
+].freeze
+
 def route_has_required_params?(path)
   path_without_optional = path.gsub(/\([^)]*\)/, "")
   path_without_optional.include?(":")
@@ -96,5 +107,8 @@ def benchmark_route_from_rails_output(route)
   return if route_has_required_params?(path)
   return if path.include?("_for_testing")
 
-  normalize_route_path(strip_optional_params(path))
+  normalized = normalize_route_path(strip_optional_params(path))
+  return if NON_BENCHMARK_ROUTES.include?(normalized)
+
+  normalized
 end

--- a/benchmarks/lib/bmf_helpers.rb
+++ b/benchmarks/lib/bmf_helpers.rb
@@ -12,7 +12,7 @@
 #
 # Measures (snake_case for easy CLI usage with --threshold-measure):
 #   - rps: Requests per second (higher is better - use Lower Boundary threshold)
-#   - p50_latency_ms, p90_latency_ms, p99_latency_ms: Latencies (lower is better - Upper Boundary)
+#   - p50_latency_ms, p90_latency_ms: Latencies (lower is better - Upper Boundary)
 #   - failed_pct: Failed request percentage (lower is better - use Upper Boundary)
 
 require "json"
@@ -30,9 +30,8 @@ class BmfCollector
   # @param rps [Numeric, nil] Requests per second
   # @param p50 [Numeric, nil] 50th percentile latency in ms
   # @param p90 [Numeric, nil] 90th percentile latency in ms
-  # @param p99 [Numeric, nil] 99th percentile latency in ms
   # @param status [String, nil] Status string like "200=100,5xx=2"
-  def add(name:, rps:, p50:, p90:, p99:, status:)
+  def add(name:, rps:, p50:, p90:, status:)
     # Skip if RPS is not a valid number (FAILED, MISSING, etc.)
     return unless rps.is_a?(Numeric)
 
@@ -41,7 +40,6 @@ class BmfCollector
       rps: rps,
       p50: p50,
       p90: p90,
-      p99: p99,
       failed_pct: calculate_failed_percentage(status)
     }
   end
@@ -60,7 +58,6 @@ class BmfCollector
       # Units (ms) configured in Bencher measure settings
       add_measure(benchmark_entry, "p50_latency", r[:p50])
       add_measure(benchmark_entry, "p90_latency", r[:p90])
-      add_measure(benchmark_entry, "p99_latency", r[:p99])
 
       # Failure percentage (lower is better) - use Upper Boundary threshold in Bencher
       add_measure(benchmark_entry, "failed_pct", r[:failed_pct])

--- a/benchmarks/lib/bmf_helpers.rb
+++ b/benchmarks/lib/bmf_helpers.rb
@@ -37,7 +37,7 @@ class BmfCollector
     @results << {
       name: "#{@prefix}#{name}#{@suffix}",
       rps: rps,
-      p50: p50,
+      p50: p50.is_a?(Numeric) ? p50 : nil,
       failed_pct: calculate_failed_percentage(status)
     }
   end

--- a/benchmarks/lib/bmf_helpers.rb
+++ b/benchmarks/lib/bmf_helpers.rb
@@ -12,7 +12,7 @@
 #
 # Measures (snake_case for easy CLI usage with --threshold-measure):
 #   - rps: Requests per second (higher is better - use Lower Boundary threshold)
-#   - p50_latency_ms, p90_latency_ms: Latencies (lower is better - Upper Boundary)
+#   - p50_latency: 50th-percentile latency in ms (lower is better - Upper Boundary)
 #   - failed_pct: Failed request percentage (lower is better - use Upper Boundary)
 
 require "json"
@@ -29,9 +29,8 @@ class BmfCollector
   # @param name [String] The benchmark name (e.g., route path or test name)
   # @param rps [Numeric, nil] Requests per second
   # @param p50 [Numeric, nil] 50th percentile latency in ms
-  # @param p90 [Numeric, nil] 90th percentile latency in ms
   # @param status [String, nil] Status string like "200=100,5xx=2"
-  def add(name:, rps:, p50:, p90:, status:)
+  def add(name:, rps:, p50:, status:)
     # Skip if RPS is not a valid number (FAILED, MISSING, etc.)
     return unless rps.is_a?(Numeric)
 
@@ -39,7 +38,6 @@ class BmfCollector
       name: "#{@prefix}#{name}#{@suffix}",
       rps: rps,
       p50: p50,
-      p90: p90,
       failed_pct: calculate_failed_percentage(status)
     }
   end
@@ -54,10 +52,9 @@ class BmfCollector
       # RPS (higher is better) - use Lower Boundary threshold in Bencher
       add_measure(benchmark_entry, "rps", r[:rps])
 
-      # Latencies (lower is better) - use Upper Boundary threshold in Bencher
+      # Latency (lower is better) - use Upper Boundary threshold in Bencher
       # Units (ms) configured in Bencher measure settings
       add_measure(benchmark_entry, "p50_latency", r[:p50])
-      add_measure(benchmark_entry, "p90_latency", r[:p90])
 
       # Failure percentage (lower is better) - use Upper Boundary threshold in Bencher
       add_measure(benchmark_entry, "failed_pct", r[:failed_pct])

--- a/benchmarks/spec/benchmark_routes_spec.rb
+++ b/benchmarks/spec/benchmark_routes_spec.rb
@@ -44,6 +44,33 @@ RSpec.describe "benchmark route discovery helpers" do
         ["/", "/client_side_hello_world", "/react_router"]
       )
     end
+
+    it "skips intentional error/anti-pattern demo routes" do
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | react_helmet_broken
+        Verb              | GET
+        URI               | /react_helmet_broken(.:format)
+        Controller#Action | pages#react_helmet_broken
+        --[ Route 2 ]-------------------------------------------------------------------
+        Prefix            | context_function_return_jsx
+        Verb              | GET
+        URI               | /context_function_return_jsx(.:format)
+        Controller#Action | pages#context_function_return_jsx
+        --[ Route 3 ]-------------------------------------------------------------------
+        Prefix            | pure_component_wrapped_in_function
+        Verb              | GET
+        URI               | /pure_component_wrapped_in_function(.:format)
+        Controller#Action | pages#pure_component_wrapped_in_function
+        --[ Route 4 ]-------------------------------------------------------------------
+        Prefix            | server_side_hello_world
+        Verb              | GET
+        URI               | /server_side_hello_world(.:format)
+        Controller#Action | pages#server_side_hello_world
+      TEXT
+
+      expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq(["/server_side_hello_world"])
+    end
   end
 
   describe "#benchmark_routes_for_app" do
@@ -70,6 +97,14 @@ RSpec.describe "benchmark route discovery helpers" do
 
         expect(benchmark_routes_for_app(app_dir, nil)).to eq(["/client_side_hello_world"])
       end
+    end
+
+    it "honors explicitly requested routes even when they are on the skip-list" do
+      # The NON_BENCHMARK_ROUTES filter applies to auto-discovery only; an explicit
+      # ROUTES= request must still benchmark a skip-listed demo route on demand.
+      expect(
+        benchmark_routes_for_app("unused", "/react_helmet_broken,/context_function_return_jsx")
+      ).to eq(["/react_helmet_broken", "/context_function_return_jsx"])
     end
 
     it "raises when rails routes fails" do

--- a/benchmarks/spec/bmf_collector_spec.rb
+++ b/benchmarks/spec/bmf_collector_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../lib/bmf_helpers"
+
+# BmfCollector produces the JSON Bencher ingests. Its measure names must stay in
+# lockstep with track_benchmarks.rb's THRESHOLDS, so pin the emitted shape: the
+# tracked measures rps, p50_latency, and failed_pct.
+RSpec.describe BmfCollector do
+  describe "#to_bmf" do
+    it "emits exactly rps, p50_latency and failed_pct" do
+      collector = described_class.new
+      collector.add(name: "/route", rps: 100.0, p50: 5.0, status: "200=100")
+
+      entry = collector.to_bmf.fetch("/route")
+      expect(entry.keys).to contain_exactly("rps", "p50_latency", "failed_pct")
+      expect(entry["rps"]).to eq("value" => 100.0)
+      expect(entry["p50_latency"]).to eq("value" => 5.0)
+    end
+
+    it "applies the prefix and suffix to the benchmark name" do
+      collector = described_class.new(prefix: "Pro Node Renderer: ", suffix: ": Pro")
+      collector.add(name: "simple_eval", rps: 1.0, p50: 1.0, status: "200=1")
+
+      expect(collector.to_bmf.keys).to eq(["Pro Node Renderer: simple_eval: Pro"])
+    end
+
+    it "drops rows whose rps is not numeric (FAILED/MISSING)" do
+      collector = described_class.new
+      collector.add(name: "/broken", rps: "FAILED", p50: "FAILED", status: "FAILED")
+
+      expect(collector.to_bmf).to be_empty
+    end
+  end
+
+  describe "failed_pct" do
+    def failed_pct(status)
+      collector = described_class.new
+      collector.add(name: "/x", rps: 1.0, p50: 1.0, status: status)
+      collector.to_bmf.dig("/x", "failed_pct", "value")
+    end
+
+    it "counts 0/4xx/5xx/other as failures and 2xx/3xx as success" do
+      expect(failed_pct("200=98,5xx=2")).to eq(2.0)
+      expect(failed_pct("200=900,302=50,404=40,503=10")).to eq(5.0)
+      expect(failed_pct("0=5,200=95")).to eq(5.0)
+    end
+
+    it "is 0 for an all-success status and for MISSING/FAILED" do
+      expect(failed_pct("200=100")).to eq(0.0)
+      expect(failed_pct("MISSING")).to eq(0.0)
+      expect(failed_pct("FAILED")).to eq(0.0)
+    end
+  end
+end

--- a/benchmarks/spec/bmf_collector_spec.rb
+++ b/benchmarks/spec/bmf_collector_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe BmfCollector do
 
       expect(collector.to_bmf).to be_empty
     end
+
+    it "omits p50_latency when p50 is not numeric" do
+      collector = described_class.new
+      collector.add(name: "/partial", rps: 100.0, p50: "MISSING", status: "200=100")
+
+      entry = collector.to_bmf.fetch("/partial")
+      expect(entry).to include("rps" => { "value" => 100.0 })
+      expect(entry).not_to have_key("p50_latency")
+    end
   end
 
   describe "failed_pct" do

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require "optparse"
 require_relative "spec_helper"
 require_relative "../track_benchmarks"
+require_relative "../lib/bmf_helpers"
 
 # track_benchmarks.rb runs its tracking flow only under `if __FILE__ == $PROGRAM_NAME`,
 # so requiring it just loads the helpers. These pin the stderr/exit-code
@@ -44,6 +46,64 @@ RSpec.describe "track_benchmarks" do
     it "is false on success and for unrelated non-zero failures" do
       expect(retry_without_start_point_hash?("Head Version abc123 not found", 0)).to be(false)
       expect(retry_without_start_point_hash?("some other error", 1)).to be(false)
+    end
+  end
+
+  # The boundary/side mapping is a silent safety control: a flipped side or wrong
+  # value would stop regressions from alerting while CI stays green, so pin it.
+  describe "#threshold_args" do
+    it "puts the boundary on the lower side for higher-is-better measures" do
+      expect(threshold_args("rps", :lower, "0.9995")).to eq(
+        %w[--threshold-measure rps --threshold-test t_test
+           --threshold-max-sample-size 64
+           --threshold-lower-boundary 0.9995 --threshold-upper-boundary _]
+      )
+    end
+
+    it "puts the boundary on the upper side for lower-is-better measures" do
+      expect(threshold_args("p50_latency", :upper, "0.9999")).to eq(
+        %w[--threshold-measure p50_latency --threshold-test t_test
+           --threshold-max-sample-size 64
+           --threshold-lower-boundary _ --threshold-upper-boundary 0.9999]
+      )
+    end
+  end
+
+  describe "#bencher_args" do
+    # Parse only the threshold tail: OptionParser raises InvalidOption on any flag it
+    # doesn't declare, and the leading `bencher run` flags aren't declared here, so
+    # drop everything before the first --threshold-measure.
+    def parse_thresholds(argv)
+      thresholds = []
+      OptionParser.new do |opts|
+        opts.on("--threshold-measure=MEASURE") { |measure| thresholds << { measure: measure } }
+        opts.on("--threshold-lower-boundary=BOUNDARY") { |boundary| thresholds.last[:lower] = boundary }
+        opts.on("--threshold-upper-boundary=BOUNDARY") { |boundary| thresholds.last[:upper] = boundary }
+        opts.on("--threshold-test=TEST")
+        opts.on("--threshold-max-sample-size=SIZE")
+      end.parse(argv.drop_while { |arg| arg != "--threshold-measure" })
+      thresholds
+    end
+
+    it "tracks exactly rps/p50_latency/failed_pct with their tuned boundaries and sides" do
+      expect(parse_thresholds(bencher_args("my-branch", []))).to eq(
+        [
+          { measure: "rps", lower: "0.9995", upper: "_" },
+          { measure: "p50_latency", lower: "_", upper: "0.9999" },
+          { measure: "failed_pct", lower: "_", upper: "0.95" }
+        ]
+      )
+    end
+  end
+
+  # A threshold on a measure that no metric reports is a silent no-op, so the tracked
+  # measures must match exactly what BmfCollector emits.
+  describe "tracked measures" do
+    it "match exactly the measures BmfCollector emits" do
+      collector = BmfCollector.new
+      collector.add(name: "x", rps: 1.0, p50: 1.0, status: "200=1")
+
+      expect(collector.to_bmf.fetch("x").keys).to match_array(THRESHOLDS.map(&:first))
     end
   end
 end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -18,7 +18,6 @@ THRESHOLDS = [
   ["rps", :lower],
   ["p50_latency", :upper],
   ["p90_latency", :upper],
-  ["p99_latency", :upper],
   ["failed_pct", :upper]
 ].freeze
 

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -10,15 +10,24 @@ require_relative "lib/github"
 require_relative "lib/github_cli"
 require_relative "lib/regression_report"
 
-BOUNDARY = "0.95"
 MAX_SAMPLE = "64"
-# Threshold direction: :lower for "regression = drop" measures (rps),
-# :upper for "regression = climb" measures (latency, failure rate).
+# Per-measure t-test boundaries (the confidence level Bencher uses for its
+# prediction interval). Tuned from a sweep of recent main-branch reports so fewer
+# than 1/20 commits raise a false regression across all benchmarks: rps and p50
+# individually need ~0.9995 / ~0.9999 to clear that bar. failed_pct stays at 0.95
+# because healthy runs sit at ~0 with near-zero variance, so its boundary rarely
+# matters.
+# Bencher's t-test threshold is a prediction interval, so each one-sided boundary B
+# gives a per-test false-positive rate of ~(1 - B):
+# https://bencher.dev/docs/explanation/thresholds/
+# Direction: :lower for "regression = drop" measures (rps), :upper for
+# "regression = climb" measures (latency, failure rate).
+# p90/p99/max are intentionally NOT tracked: their tail noise can't meet the 1/20
+# target at any usable boundary. p90 stays in the summary table for visibility only.
 THRESHOLDS = [
-  ["rps", :lower],
-  ["p50_latency", :upper],
-  ["p90_latency", :upper],
-  ["failed_pct", :upper]
+  ["rps", :lower, "0.9995"],
+  ["p50_latency", :upper, "0.9999"],
+  ["failed_pct", :upper, "0.95"]
 ].freeze
 
 # Bencher exits non-zero both for a performance alert (a real regression) and for
@@ -81,8 +90,9 @@ def branch_and_start_point_args
   end
 end
 
-def threshold_args(measure, direction)
-  lower, upper = direction == :lower ? [BOUNDARY, "_"] : ["_", BOUNDARY]
+def threshold_args(measure, direction, boundary)
+  # "_" is Bencher's sentinel for "no boundary on this side".
+  lower, upper = direction == :lower ? [boundary, "_"] : ["_", boundary]
   [
     "--threshold-measure", measure,
     "--threshold-test", "t_test",
@@ -104,7 +114,7 @@ def bencher_args(branch, start_point_args)
     "--err",
     "--quiet",
     "--format", "html",
-    *THRESHOLDS.flat_map { |measure, direction| threshold_args(measure, direction) }
+    *THRESHOLDS.flat_map { |measure, direction, boundary| threshold_args(measure, direction, boundary) }
   ]
 end
 


### PR DESCRIPTION
Supersedes #3550 because that source branch is not maintainer-writable. This branch rebases the same benchmark-report changes onto current `main` and adds the requested BMF p50 normalization fix.

Fixes #3520.

## Summary
- Exclude intentional error-demo routes from benchmark auto-discovery.
- Drop p99/max from benchmark reports and keep p90 in text summaries only.
- Tune tracked Bencher thresholds to rps, p50 latency, and failed percentage.
- Omit `p50_latency` from BMF output when p50 is non-numeric (`"MISSING"`/`"FAILED"`) while preserving valid rps and failed_pct data.

## Test plan
- RED: `bundle exec rspec benchmarks/spec/bmf_collector_spec.rb` failed with `p50_latency` emitted as `{ "value" => "MISSING" }`.
- GREEN: `bundle exec rspec benchmarks/spec/bmf_collector_spec.rb`
- `bundle exec rspec benchmarks/spec`
- `bundle exec rubocop benchmarks/bench-node-renderer.rb benchmarks/bench.rb benchmarks/lib/benchmark_helpers.rb benchmarks/lib/benchmark_routes.rb benchmarks/lib/bmf_helpers.rb benchmarks/spec/benchmark_routes_spec.rb benchmarks/spec/bmf_collector_spec.rb benchmarks/spec/track_benchmarks_spec.rb benchmarks/track_benchmarks.rb`
- `git diff --check`

Note: full `bundle exec rubocop` currently reports pre-existing offenses in `react_on_rails/spike/3313_prism_gemfile_rewriter/*`, outside this PR diff. The changed-file RuboCop also passed in the pre-push hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which routes are load-tested and how CI flags performance regressions; mis-tuned boundaries could hide real regressions or increase false alerts, but scope is benchmarks/CI only.
> 
> **Overview**
> Benchmark CI is tightened so reports stay smaller and Bencher regressions are less noisy.
> 
> **Route discovery** skips three intentional error-demo GET routes (`NON_BENCHMARK_ROUTES`) during auto-discovery; explicit `ROUTES=` still benchmarks them. Specs cover skip-list vs explicit override.
> 
> **Collected metrics**: **p99** and **max** are dropped from k6/Vegeta parsing and tabular summaries. **p90** remains in human-readable summary tables only—it is no longer written to BMF or passed to `BmfCollector.add`. Bencher JSON now tracks **rps**, **p50_latency**, and **failed_pct** only; non-numeric **p50** omits `p50_latency` while keeping valid **rps** / **failed_pct**.
> 
> **Regression thresholds** in `track_benchmarks.rb` use per-measure t-test boundaries (~0.9995 for rps, ~0.9999 for p50, 0.95 for failed_pct) instead of a single 0.95 boundary on p90/p99. New specs lock threshold CLI args to the BMF measure set so silent no-op thresholds cannot drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62889232412c1aecb9ff1057c9eef2c65b7d7111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined benchmark metrics reporting by removing p99 and max latency measurements; output now displays RPS, p50, and p90 latencies only.
  * Enhanced benchmark route discovery with intelligent filtering to exclude non-benchmark routes while allowing explicit route overrides.
  * Improved benchmark data collection to focus on key performance indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->