### PR TITLE
Prompt once for RubyGems OTP during release, reused for both gems

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -66,12 +66,43 @@ def unbundled_sh_in_dir_for_release(dir, *shell_commands)
   end
 end
 
-def prompt_for_otp(service_name)
-  print "\n🔑 Enter OTP code for #{service_name}: "
+def prompt_for_otp(service_name, allow_blank: false, hint: nil)
+  print "\n🔑 Enter OTP code for #{service_name}#{hint ? " (#{hint})" : ''}: "
   $stdout.flush
   otp = $stdin.gets&.strip
-  abort "\n❌ No OTP provided. Aborting." if otp.nil? || otp.empty?
+  if otp.nil? || otp.empty?
+    return nil if allow_blank
+
+    abort "\n❌ No OTP provided. Aborting."
+  end
   normalize_otp_code(otp, service_name: service_name)
+end
+
+# Resolve the RubyGems OTP to reuse for BOTH gem pushes (react_on_rails and
+# react_on_rails_pro). When the operator does not supply RUBYGEMS_OTP, prompt
+# once here and capture the code so it can be forwarded to both pushes via
+# GEM_HOST_OTP_CODE. Without this up-front prompt, `gem push` prompts separately
+# for each gem — the code typed into that subprocess is never captured by this
+# script, so the operator ends up entering an OTP twice. RubyGems accepts the
+# same TOTP for both pushes within its validity window; if it expires between
+# gems, publish_gem_with_retry prompts for a fresh code.
+def resolve_rubygems_otp_for_publish(provided_otp)
+  normalized = normalize_otp_code(provided_otp, service_name: "RubyGems")
+  if normalized
+    puts "Using provided RubyGems OTP for gem publications..."
+    return normalized
+  end
+
+  unless $stdin.tty?
+    puts "\nNOTE: You will be prompted for RubyGems OTP code if needed."
+    puts "TIP: Set RUBYGEMS_OTP environment variable to provide OTP upfront."
+    return nil
+  end
+
+  # Pressing Enter without a code falls back to legacy per-gem prompting handled
+  # by `gem push` itself (e.g. accounts without RubyGems 2FA enabled).
+  puts "\nThe same RubyGems OTP is reused for both gems (react_on_rails and react_on_rails_pro)."
+  prompt_for_otp("RubyGems", allow_blank: true, hint: "press Enter to be prompted per gem")
 end
 
 def normalize_otp_code(otp, service_name:)
@@ -1441,13 +1472,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
       puts "Publishing PUBLIC Ruby gems..."
       puts "=" * 80
 
-      current_rubygems_otp = rubygems_otp
-      if current_rubygems_otp
-        puts "Using provided RubyGems OTP for gem publications..."
-      else
-        puts "\nNOTE: You will be prompted for RubyGems OTP code if needed."
-        puts "TIP: Set RUBYGEMS_OTP environment variable to provide OTP upfront."
-      end
+      current_rubygems_otp = resolve_rubygems_otp_for_publish(rubygems_otp)
 
       current_rubygems_otp = publish_gem_with_retry(
         release_paths_hash[:gem_root],

--- a/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_rake_helpers_spec.rb
@@ -99,6 +99,65 @@ RSpec.describe "release.rake helper methods" do
     end
   end
 
+  describe "#prompt_for_otp" do
+    it "normalizes a submitted OTP" do
+      allow($stdin).to receive(:gets).and_return(" 123456 \n")
+      expect { expect(prompt_for_otp("RubyGems")).to eq("123456") }.to output(/Enter OTP code for RubyGems/).to_stdout
+    end
+
+    it "aborts when no OTP is entered and blanks are not allowed" do
+      allow($stdin).to receive(:gets).and_return("\n")
+      expect { prompt_for_otp("RubyGems") }.to raise_error(SystemExit, /No OTP provided/)
+    end
+
+    it "returns nil when blank input is allowed instead of aborting" do
+      allow($stdin).to receive(:gets).and_return("\n")
+      expect(prompt_for_otp("RubyGems", allow_blank: true)).to be_nil
+    end
+
+    it "includes the hint in the prompt when provided" do
+      allow($stdin).to receive(:gets).and_return("123456\n")
+      expect { prompt_for_otp("RubyGems", hint: "press Enter to skip") }
+        .to output(/Enter OTP code for RubyGems \(press Enter to skip\)/).to_stdout
+    end
+  end
+
+  describe "#resolve_rubygems_otp_for_publish" do
+    it "returns the provided OTP without prompting" do
+      expect(self).not_to receive(:prompt_for_otp)
+      expect { expect(resolve_rubygems_otp_for_publish("123456")).to eq("123456") }
+        .to output(/Using provided RubyGems OTP/).to_stdout
+    end
+
+    it "prompts once for the OTP when none is provided and stdin is a TTY" do
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow(self).to receive(:prompt_for_otp)
+        .with("RubyGems", allow_blank: true, hint: "press Enter to be prompted per gem")
+        .and_return("654321")
+
+      expect { expect(resolve_rubygems_otp_for_publish(nil)).to eq("654321") }
+        .to output(/reused for both gems/).to_stdout
+    end
+
+    it "returns nil without prompting when stdin is not a TTY" do
+      allow($stdin).to receive(:tty?).and_return(false)
+      expect(self).not_to receive(:prompt_for_otp)
+
+      expect { expect(resolve_rubygems_otp_for_publish(nil)).to be_nil }
+        .to output(/Set RUBYGEMS_OTP environment variable/).to_stdout
+    end
+
+    it "returns nil when the operator submits a blank OTP (legacy per-gem prompting)" do
+      allow($stdin).to receive(:tty?).and_return(true)
+      allow(self).to receive(:prompt_for_otp)
+        .with("RubyGems", allow_blank: true, hint: "press Enter to be prompted per gem")
+        .and_return(nil)
+
+      expect { expect(resolve_rubygems_otp_for_publish(nil)).to be_nil }
+        .to output(/reused for both gems/).to_stdout
+    end
+  end
+
   describe "#expected_bump_type_from_changelog_section" do
     it "returns major for breaking changes" do
       section = <<~MARKDOWN


### PR DESCRIPTION
## Problem

During `rake release`, the operator is prompted to enter a RubyGems OTP **twice** — once for `react_on_rails` and again for `react_on_rails_pro`.

The release task already *intends* to reuse a single OTP across both gems: it threads `current_rubygems_otp` from the first `publish_gem_with_retry` call into the second and forwards it via the `GEM_HOST_OTP_CODE` env var. But that reuse only worked when the code already existed as a string inside the script — i.e. when `RUBYGEMS_OTP` was set up front, or after a retry.

In the normal interactive flow (no `RUBYGEMS_OTP`), `gem release` ran with no OTP env var, so the underlying `gem push` did its **own** interactive prompt. The code typed into that subprocess was never captured by the rake script, so there was nothing to forward to the second gem — hence a second prompt.

## Fix

Add `resolve_rubygems_otp_for_publish`, which prompts **once** up front when no OTP is supplied (and stdin is a TTY), captures the code, and forwards it to both gem pushes via `GEM_HOST_OTP_CODE`.

- RubyGems accepts the same TOTP for both pushes within its ~30s validity window.
- If the code expires between gems, the existing retry path in `publish_gem_with_retry` prompts for a fresh code — so no regression there.
- Pressing **Enter** at the prompt (blank) falls back to the prior per-gem behavior, preserving releases for accounts without RubyGems 2FA.
- Non-TTY runs (and `RUBYGEMS_OTP=…`) are unchanged.

`prompt_for_otp` gains `allow_blank:` and `hint:` keyword options to support the optional up-front prompt without aborting on empty input. Existing callers keep the prior abort-on-empty behavior via the defaults.

This makes the documented behavior in `internal/contributor-info/releasing.md` ("Once for publishing `react_on_rails` to RubyGems (reused for `react_on_rails_pro` if valid)") actually true in the interactive path.

## Testing

- New specs for `#prompt_for_otp` (normalize, abort-on-blank, `allow_blank`, `hint`) and `#resolve_rubygems_otp_for_publish` (provided OTP, TTY prompt-once, non-TTY skip, blank fallback).
- `bundle exec rspec spec/react_on_rails/release_rake_helpers_spec.rb` → 83 examples, 0 failures.
- `bundle exec rubocop` on both changed files → no offenses.

## Note

The npm side (`publish_npm_with_retry`) has the same latent issue — if `NPM_OTP` is unset and the first publish prompts interactively, the code isn't captured for the remaining 3 packages. I kept this PR focused on RubyGems as asked; happy to do the npm equivalent as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only release rake helpers and operator UX; no runtime app or auth logic, with new RSpec coverage.
> 
> **Overview**
> Interactive **`rake release`** now collects a **single RubyGems OTP** up front (when `RUBYGEMS_OTP` is unset and stdin is a TTY) and reuses it for both **`react_on_rails`** and **`react_on_rails_pro`** via `GEM_HOST_OTP_CODE`, instead of each `gem push` prompting separately in a subprocess the rake task cannot forward.
> 
> Adds **`resolve_rubygems_otp_for_publish`** and extends **`prompt_for_otp`** with optional **`allow_blank`** and **`hint`** (blank Enter keeps the old per-gem prompts; non-TTY / env-provided OTP behavior unchanged). Specs cover the new helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283f461c430e394975e1da82ef0dd3c7f3482c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced RubyGems OTP management during release publishing—operators can now provide an OTP once and reuse it across multiple gem pushes instead of being prompted repeatedly for each push.
  * Added flexible OTP prompting with optional blank entry support for streamlined workflows.

* **Tests**
  * Added comprehensive test coverage for OTP prompting and resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->