### PR TITLE
docs(pro): add streaming SSR contrast and progressive-stage diagrams

### DIFF
--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -350,11 +350,11 @@ For example, with our `MyStreamingComponent`, the sequence is:
 
 To render more of the page progressively, add an async prop and a `<Suspense>` boundary for each slow section — emit each one from the block as Rails resolves it, and every boundary streams in independently. This keeps the whole page in a single component tree (shared layout, context, and props) rather than splitting it across multiple `stream_react_component` calls.
 
-From the browser's perspective, the page fills in stage by stage — interactive from the first paint, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
+Extending the example with a second slow section (`users`), the page fills in stage by stage from the browser's perspective — visible from the first paint and interactive as each part hydrates, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
 
 ```mermaid
 flowchart LR
-    A["Stage 1 · shell (~50 ms)<br/>──────────<br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>page already interactive"] --> B["Stage 2 · users arrive<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
+    A["Stage 1 · shell (~50 ms)<br/>──────────<br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>visible now · interactive as JS loads"] --> B["Stage 2 · users fill in<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
     B --> C["Stage 3 · complete<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts ✓"]
 ```
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -13,6 +13,24 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 - **Suspense integration** — React's `<Suspense>` boundaries define which parts can stream independently
 - **Selective Hydration** — Components become interactive as soon as their JavaScript loads, even while other parts are still streaming
 
+With traditional SSR the first paint waits for the slowest query; with streaming the shell paints first and each slow section streams in afterward:
+
+```mermaid
+flowchart LR
+    subgraph TRAD["Traditional SSR — paint waits for all data"]
+        direction LR
+        t0([Request]) --> t1["Fetch users<br/>~800 ms"] --> t2["Fetch posts<br/>~600 ms"] --> t3["Render HTML<br/>~200 ms"] --> t4(["First paint<br/>~1600 ms"])
+    end
+    subgraph STREAM["Streaming SSR + async props — paint first, data streams in"]
+        direction LR
+        s0([Request]) --> s1["Render shell<br/>~50 ms"] --> s2(["First paint<br/>~50 ms"])
+        s2 -. stream as ready .-> s3["Users fill in"]
+        s2 -. stream as ready .-> s4["Posts fill in"]
+    end
+```
+
+_Timings are illustrative, not benchmarks — the point is **when** the first paint happens: at the end of the chain for traditional SSR, but right after the shell for streaming._
+
 ## How It Works
 
 1. Rails starts the response immediately, sending the HTML shell (layout, static content, loading placeholders)
@@ -331,6 +349,14 @@ For example, with our `MyStreamingComponent`, the sequence is:
 ```
 
 To render more of the page progressively, add an async prop and a `<Suspense>` boundary for each slow section — emit each one from the block as Rails resolves it, and every boundary streams in independently. This keeps the whole page in a single component tree (shared layout, context, and props) rather than splitting it across multiple `stream_react_component` calls.
+
+From the browser's perspective, the page fills in stage by stage — interactive from the first paint, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
+
+```mermaid
+flowchart LR
+    A["Stage 1 · shell (~50 ms)<br/>──────────<br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>page already interactive"] --> B["Stage 2 · users arrive<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
+    B --> C["Stage 3 · complete<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts ✓"]
+```
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -19,7 +19,11 @@ With traditional SSR the first paint waits for the slowest query; with streaming
 flowchart LR
     subgraph TRAD["Traditional SSR — paint waits for all data"]
         direction LR
-        t0([Request]) --> t1["Fetch users<br/>~800 ms"] --> t2["Fetch posts<br/>~600 ms"] --> t3["Render HTML<br/>~200 ms"] --> t4(["First paint<br/>~1600 ms"])
+        t0([Request]) --> t1["Fetch users<br/>~800 ms"]
+        t0 --> t2["Fetch posts<br/>~600 ms"]
+        t1 --> t3["Render HTML<br/>~200 ms"]
+        t2 --> t3
+        t3 --> t4(["First paint<br/>~1000 ms"])
     end
     subgraph STREAM["Streaming SSR + async props — paint first, data streams in"]
         direction LR
@@ -29,7 +33,7 @@ flowchart LR
     end
 ```
 
-_Timings are illustrative, not benchmarks — the point is **when** the first paint happens: at the end of the chain for traditional SSR, but right after the shell for streaming._
+_Timings are illustrative, not benchmarks — the point is **when** the first paint happens: only after all data is ready for traditional SSR, but right after the shell for streaming._
 
 ## How It Works
 
@@ -354,8 +358,8 @@ Extending the example with a second slow section (`users`), the page fills in st
 
 ```mermaid
 flowchart LR
-    A["Stage 1 · shell (~50 ms)<br/>──────────<br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>visible now · interactive as JS loads"] --> B["Stage 2 · users fill in<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
-    B --> C["Stage 3 · complete<br/>──────────<br/>Header ✓<br/>Users ✓<br/>Posts ✓"]
+    A["Stage 1 · shell (~50 ms)<br/><br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>visible now · interactive as JS loads"] --> B["Stage 2 · users fill in<br/><br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
+    B --> C["Stage 3 · complete<br/><br/>Header ✓<br/>Users ✓<br/>Posts ✓"]
 ```
 
 ## Compression Middleware Compatibility


### PR DESCRIPTION
## What

Adds two mermaid diagrams to the canonical Streaming SSR overview (`docs/pro/streaming-ssr.md`):

1. **Why Streaming SSR?** — a traditional-vs-streaming contrast that makes the core point visual: with traditional SSR the first paint lands at the *end* of the request chain (after every query), while with streaming + async props it lands right after the shell. (Timings are illustrative, not benchmarks.)
2. **What Happens During Streaming** — a client-perceived progression showing the page fill in stage by stage as each `<Suspense>` boundary swaps its fallback for real content.

## Why

These distill the genuinely-additive _visual_ ideas from the stalled #2265 ("Add Async Props documentation with animated SVG diagrams") into the doc that's already the maintained source of truth — which already uses mermaid. The rest of #2265 is superseded: its async-props feature code already merged (via #2032 / #2049 / #2076 / #2297 / etc.), and its prose duplicates the current `docs/pro/streaming-ssr.md` + `docs/pro/async-props-database-queries.md`.

## Scope / risk

- **Docs-only.** No code; no sidebar changes (`pro/streaming-ssr` is already in `docs/sidebars.ts`).
- `streaming-ssr.md` already uses mermaid sequence diagrams; these flowcharts render the same way on GitHub and in the Docusaurus build.
- Prettier passes; no new links (lychee unaffected).

## Verify

The two new mermaid blocks render in the GitHub "Files changed" view and the Docusaurus build.

Related to #2265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to an existing Pro guide; no application code or behavior changes.
> 
> **Overview**
> **Docs-only** update to `docs/pro/streaming-ssr.md` adds two **mermaid flowcharts** and short lead-in copy so streaming SSR is easier to skim visually.
> 
> Under **Why Streaming SSR?**, a side-by-side **traditional vs streaming** timeline shows first paint blocked on all fetches versus shell-first paint with users/posts filling in later, plus a note that timings are illustrative.
> 
> Under **What Happens During Streaming**, a **three-stage** flow (shell → users → posts) shows how the page looks as each `<Suspense>` boundary resolves when a second slow async prop is added.
> 
> No runtime, config, or sidebar changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cf04ebfaf983a1afbc8ad5f2718c201285c42a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two visual flow diagrams to explain streaming SSR and perceived load timing: a timeline comparing traditional SSR vs. streaming SSR, and a stage-by-stage browser rendering flow that shows the shell rendering first and progressive filling of content as asynchronous data arrives. These visuals clarify rendering order, perceived load improvements, and help authors and readers better reason about streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->