### PR TITLE
fix(benchmark): harden rails routes parser against field-order changes and required globs

### DIFF
--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -15,8 +15,7 @@ NON_BENCHMARK_ROUTES = %w[
 
 def route_has_required_params?(path)
   path_without_optional = path.gsub(/\([^)]*\)/, "")
-  # `:id` dynamic segments and `*splat` globs left outside the optional parens are
-  # required params, so the route can't be benchmarked as a literal URL.
+  # `:id` / `*splat` segments outside the optional parens are required, so the route isn't a literal URL.
   path_without_optional.include?(":") || path_without_optional.match?(/\*[A-Za-z_]/)
 end
 
@@ -108,11 +107,7 @@ def normalize_route_path(route)
 end
 
 def benchmark_route_from_rails_output(route)
-  # Flushes now key off the `--[ Route N ]--` separator, so this runs on every
-  # accumulated block regardless of which fields it captured. Guard the keys a
-  # benchmarkable route needs (controller_action, uri) so an incomplete block —
-  # e.g. one missing a field under a future `rails routes` format change — is
-  # skipped, not turned into a NoMethodError that aborts the whole run.
+  # Guard required keys: separator-triggered flushes run on every block, so incomplete ones skip rather than raise.
   return unless route[:verb] == "GET"
   return unless route[:controller_action] && benchmark_controller_action?(route[:controller_action])
 

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -15,7 +15,9 @@ NON_BENCHMARK_ROUTES = %w[
 
 def route_has_required_params?(path)
   path_without_optional = path.gsub(/\([^)]*\)/, "")
-  path_without_optional.include?(":")
+  # `:id` dynamic segments and `*splat` globs left outside the optional parens are
+  # required params, so the route can't be benchmarked as a literal URL.
+  path_without_optional.include?(":") || path_without_optional.match?(/\*[A-Za-z_]/)
 end
 
 def strip_optional_params(route)
@@ -59,6 +61,12 @@ def benchmark_routes_from_rails_routes_output(routes_output)
     stripped = line.strip
 
     case stripped
+    when /\A-+\[ Route \d+ \]/
+      # The separator is the real block delimiter, so flush the route accumulated
+      # so far here rather than keying off Controller#Action being the last field.
+      route = benchmark_route_from_rails_output(current_route)
+      routes << route if route
+      current_route = {}
     when /\APrefix\s+\|\s*(.*)\z/
       current_route[:prefix] = Regexp.last_match(1)
     when /\AVerb\s+\|\s*(.*)\z/
@@ -67,12 +75,12 @@ def benchmark_routes_from_rails_routes_output(routes_output)
       current_route[:uri] = Regexp.last_match(1)
     when /\AController#Action\s+\|\s*(.*)\z/
       current_route[:controller_action] = Regexp.last_match(1)
-
-      route = benchmark_route_from_rails_output(current_route)
-      routes << route if route
-      current_route = {}
     end
   end
+
+  # Flush the final block: there is no trailing separator after the last route.
+  route = benchmark_route_from_rails_output(current_route)
+  routes << route if route
 
   routes
 end

--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -108,11 +108,16 @@ def normalize_route_path(route)
 end
 
 def benchmark_route_from_rails_output(route)
+  # Flushes now key off the `--[ Route N ]--` separator, so this runs on every
+  # accumulated block regardless of which fields it captured. Guard the keys a
+  # benchmarkable route needs (controller_action, uri) so an incomplete block —
+  # e.g. one missing a field under a future `rails routes` format change — is
+  # skipped, not turned into a NoMethodError that aborts the whole run.
   return unless route[:verb] == "GET"
-  return unless benchmark_controller_action?(route[:controller_action])
+  return unless route[:controller_action] && benchmark_controller_action?(route[:controller_action])
 
   path = route[:uri]
-  return if route_has_required_params?(path)
+  return if path.nil? || route_has_required_params?(path)
   return if path.include?("_for_testing")
 
   normalized = normalize_route_path(strip_optional_params(path))

--- a/benchmarks/spec/benchmark_routes_spec.rb
+++ b/benchmarks/spec/benchmark_routes_spec.rb
@@ -75,8 +75,9 @@ RSpec.describe "benchmark route discovery helpers" do
     it "resets on the route separator so field-order changes don't misclassify routes" do
       # The parser must key off the `--[ Route N ]--` separator (the real block
       # delimiter), not assume Controller#Action is the last field of every block.
-      # Here URI is emitted after Controller#Action; a separator-keyed parser still
-      # captures both routes correctly.
+      # Here URI is emitted after Controller#Action; a Controller#Action-keyed flush
+      # would read the URI before it's set and crash, whereas a separator-keyed
+      # parser captures both routes correctly.
       routes_output = <<~TEXT
         --[ Route 1 ]-------------------------------------------------------------------
         Prefix            | client_side_hello_world
@@ -106,6 +107,31 @@ RSpec.describe "benchmark route discovery helpers" do
 
       expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq([])
     end
+
+    it "skips an incomplete block missing Controller#Action instead of crashing" do
+      # A separator/end-of-block flush runs on every accumulated block, so a GET
+      # block that never emitted a Controller#Action line (e.g. a future
+      # `rails routes` format change) must be skipped rather than raise.
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | mystery
+        Verb              | GET
+        URI               | /mystery(.:format)
+      TEXT
+
+      expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq([])
+    end
+
+    it "skips an incomplete block missing URI instead of crashing" do
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | mystery
+        Verb              | GET
+        Controller#Action | pages#mystery
+      TEXT
+
+      expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq([])
+    end
   end
 
   describe "#route_has_required_params?" do
@@ -123,6 +149,12 @@ RSpec.describe "benchmark route discovery helpers" do
 
     it "ignores an optional glob segment" do
       expect(route_has_required_params?("/react_router(/*all)(.:format)")).to be(false)
+    end
+
+    it "detects a required glob even when an optional glob is also present" do
+      # Optional parens are stripped before glob detection, so an optional glob
+      # must not mask a sibling required one.
+      expect(route_has_required_params?("/a(/*opt)/b/*req(.:format)")).to be(true)
     end
   end
 

--- a/benchmarks/spec/benchmark_routes_spec.rb
+++ b/benchmarks/spec/benchmark_routes_spec.rb
@@ -71,6 +71,59 @@ RSpec.describe "benchmark route discovery helpers" do
 
       expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq(["/server_side_hello_world"])
     end
+
+    it "resets on the route separator so field-order changes don't misclassify routes" do
+      # The parser must key off the `--[ Route N ]--` separator (the real block
+      # delimiter), not assume Controller#Action is the last field of every block.
+      # Here URI is emitted after Controller#Action; a separator-keyed parser still
+      # captures both routes correctly.
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | client_side_hello_world
+        Verb              | GET
+        Controller#Action | pages#client_side_hello_world
+        URI               | /client_side_hello_world(.:format)
+        --[ Route 2 ]-------------------------------------------------------------------
+        Prefix            | server_side_hello_world
+        Verb              | GET
+        Controller#Action | pages#server_side_hello_world
+        URI               | /server_side_hello_world(.:format)
+      TEXT
+
+      expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq(
+        ["/client_side_hello_world", "/server_side_hello_world"]
+      )
+    end
+
+    it "skips routes with a required glob segment" do
+      routes_output = <<~TEXT
+        --[ Route 1 ]-------------------------------------------------------------------
+        Prefix            | legacy_catch_all
+        Verb              | GET
+        URI               | /legacy/*path(.:format)
+        Controller#Action | pages#legacy
+      TEXT
+
+      expect(benchmark_routes_from_rails_routes_output(routes_output)).to eq([])
+    end
+  end
+
+  describe "#route_has_required_params?" do
+    it "treats a dynamic segment as a required param" do
+      expect(route_has_required_params?("/users/:id(.:format)")).to be(true)
+    end
+
+    it "ignores optional segments" do
+      expect(route_has_required_params?("/users(/:id)(.:format)")).to be(false)
+    end
+
+    it "treats a required glob segment as a required param" do
+      expect(route_has_required_params?("/legacy/*path")).to be(true)
+    end
+
+    it "ignores an optional glob segment" do
+      expect(route_has_required_params?("/react_router(/*all)(.:format)")).to be(false)
+    end
   end
 
   describe "#benchmark_routes_for_app" do


### PR DESCRIPTION
## Summary

Two robustness fixes to benchmark route auto-discovery in `benchmarks/lib/benchmark_routes.rb`, both called out in #3544.

### 1. Reset the parser on the route separator, not on `Controller#Action`

`benchmark_routes_from_rails_routes_output` flushed the accumulated route the moment it saw a `Controller#Action` line, which silently assumes that's the last field of every `rails routes --expanded` block. If Rails ever reorders the fields (or emits another field after `Controller#Action`), the previous behavior misclassified the next route — and if a field it depends on (e.g. `URI`) arrives after `Controller#Action`, it crashed on a `nil` path.

The parser now flushes on the `--[ Route N ]--` separator line — the actual block delimiter — and flushes the final block after the loop (there's no trailing separator). The first separator flushes an empty hash, which `benchmark_route_from_rails_output` safely ignores.

### 2. Recognize required glob routes in `route_has_required_params?`

It previously detected required params only via `:` after stripping optional `(...)` parens. A required glob outside the parens (e.g. `/foo/*splat`) slipped through and would be benchmarked as a literal URL. Added a `\*[A-Za-z_]` check. Optional globs like `/react_router(/*all)` remain unaffected (they're stripped first).

## Testing

Added focused specs (all driven test-first):

- `#benchmark_routes_from_rails_routes_output`
  - resets on the separator so a block emitting `URI` after `Controller#Action` is still parsed correctly
  - skips a route with a required glob segment (`/legacy/*path`)
- `#route_has_required_params?` unit coverage for dynamic segments, optional segments, required globs, and optional globs

```
bundle exec rspec benchmarks/spec   # 55 examples, 0 failures
bundle exec rubocop benchmarks/lib/benchmark_routes.rb benchmarks/spec/benchmark_routes_spec.rb   # no offenses
```

No CHANGELOG entry: this is internal benchmark/CI tooling with no user-visible gem behavior change.

Closes #3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal benchmark/CI route discovery with added specs; no user-facing gem or production app behavior.
> 
> **Overview**
> Hardens **benchmark route auto-discovery** when parsing `rails routes --expanded` output so CI benchmarks only hit literal GET URLs.
> 
> The parser now **flushes each route on the `--[ Route N ]--` separator** (and once after the last block) instead of on `Controller#Action`, so reordered fields or a late `URI` line no longer mis-attributes routes or blow up on a nil path. **`benchmark_route_from_rails_output`** skips incomplete blocks (missing `controller_action` or `uri`) instead of raising.
> 
> **`route_has_required_params?`** now treats required `*glob` segments like `:dynamic` params (after stripping optional `(...)` segments), so catch-all routes are not auto-benchmarked as fixed paths.
> 
> Specs cover separator-based parsing, required globs, incomplete blocks, and param/glob edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889e43ccae81b53b23d1ead2a94427642f5e5bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route discovery: splat/glob segments are treated as required, parser now resets on route separators and flushes blocks correctly, and incomplete or partial route entries are safely ignored.
* **Tests**
  * Added specs for parser robustness, field-order resilience, required vs optional parameter detection (including globs), and safe skipping of incomplete route blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->