### PR TITLE
fix(benchmark): fail benchmark scripts on k6/Vegeta failures instead of shipping fabricated metrics

### DIFF
--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -153,7 +153,9 @@ end
 
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
-# Run Vegeta benchmark for a single test case
+# Run Vegeta benchmark for a single test case. Returns [rps, p50, p90, status]
+# on success and RAISES on any Vegeta/parse failure so the suite can record the
+# failure and exit non-zero instead of shipping fabricated metrics to Bencher.
 def run_vegeta_benchmark(test_case, bundle_timestamp)
   name = test_case[:name]
   request = test_case[:request]
@@ -220,116 +222,127 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
   vegeta_status = vegeta_data["status_codes"]&.map { |k, v| "#{k}=#{v}" }&.join(",") || "MISSING"
 
   [vegeta_rps, vegeta_p50, vegeta_p90, vegeta_status]
-rescue StandardError => e
-  puts "Error: #{e.message}"
-  failure_metrics(e)
 end
 
 # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
+# Run a batch of test cases against a bundle, collecting per-test failures
+# instead of aborting on the first. A failed test is recorded as FAILED in the
+# human-readable summary but is NOT added to the BMF collector, so fabricated
+# metrics never ship to Bencher. Returns the labels of tests that failed (caller
+# exits non-zero when any failed). `runner` is injected so the failure-collection
+# control flow can be unit-tested without a live node renderer or Vegeta.
+def run_vegeta_suite(test_cases, bundle, label, bmf_collector, runner: method(:run_vegeta_benchmark))
+  failed = []
+
+  test_cases.each do |test_case|
+    print_separator
+    puts "Benchmarking (#{label}): #{test_case[:name]}"
+    puts "  Bundle: #{bundle}"
+    puts "  Request: #{test_case[:request]}"
+    print_separator
+
+    test_label = "#{test_case[:name]} (#{label})"
+    begin
+      rps, p50, p90, status = runner.call(test_case, bundle)
+      add_to_summary(test_case[:name], label, rps, p50, p90, status)
+      # Add to BMF collector for Bencher output (p90 stays in the summary table only)
+      bmf_collector.add(name: test_label, rps: rps, p50: p50, status: status)
+    rescue StandardError => e
+      warn "::error::Vegeta benchmark failed for #{test_label}: #{e.message}"
+      failed << test_label
+      add_to_summary(test_case[:name], label, *failure_metrics(e))
+    end
+  end
+
+  failed
+end
+
 # Main execution
 
-validate_benchmark_config!
+if __FILE__ == $PROGRAM_NAME
+  validate_benchmark_config!
 
-# Check required tools
-check_required_tools(%w[vegeta curl column tee])
+  # Check required tools
+  check_required_tools(%w[vegeta curl column tee])
 
-# Wait for node renderer to be ready
-# Note: Node renderer only speaks HTTP/2, but we can still check with a simple GET
-# that will fail - we just check it doesn't refuse connection
-puts "\nWaiting for node renderer at #{BASE_URL}..."
-base_uri = URI.parse("http://#{BASE_URL}")
-start_time = Time.now
-timeout_sec = 60
-loop do
-  # Try a simple TCP connection to check if server is up
-  Socket.tcp(base_uri.host, base_uri.port, connect_timeout: 5, &:close)
-  puts "  Node renderer is accepting connections"
-  break
-rescue StandardError => e
-  elapsed = Time.now - start_time
-  puts "  Attempt at #{elapsed.round(2)}s: #{e.message}"
-  raise "Node renderer at #{BASE_URL} not responding within #{timeout_sec}s" if elapsed > timeout_sec
+  # Wait for node renderer to be ready
+  # Note: Node renderer only speaks HTTP/2, but we can still check with a simple GET
+  # that will fail - we just check it doesn't refuse connection
+  puts "\nWaiting for node renderer at #{BASE_URL}..."
+  base_uri = URI.parse("http://#{BASE_URL}")
+  start_time = Time.now
+  timeout_sec = 60
+  loop do
+    # Try a simple TCP connection to check if server is up
+    Socket.tcp(base_uri.host, base_uri.port, connect_timeout: 5, &:close)
+    puts "  Node renderer is accepting connections"
+    break
+  rescue StandardError => e
+    elapsed = Time.now - start_time
+    puts "  Attempt at #{elapsed.round(2)}s: #{e.message}"
+    raise "Node renderer at #{BASE_URL} not responding within #{timeout_sec}s" if elapsed > timeout_sec
 
-  sleep 1
+    sleep 1
+  end
+
+  # Find and categorize bundles
+  puts "\nDiscovering and categorizing bundles..."
+  all_bundles = find_all_production_bundles
+  puts "Found #{all_bundles.length} production bundle(s)"
+  rsc_bundle, non_rsc_bundle = categorize_bundles(all_bundles)
+
+  rsc_tests = TEST_CASES.select { |tc| tc[:rsc] }
+  non_rsc_tests = TEST_CASES.reject { |tc| tc[:rsc] }
+
+  if rsc_tests.any? && rsc_bundle.nil?
+    skipped = rsc_tests.map { |tc| tc[:name] }.join(", ")
+    puts "Warning: RSC tests requested but no RSC bundle found, skipping: #{skipped}"
+    rsc_tests = []
+  end
+
+  if non_rsc_tests.any? && non_rsc_bundle.nil?
+    skipped = non_rsc_tests.map { |tc| tc[:name] }.join(", ")
+    puts "Warning: Non-RSC tests requested but no non-RSC bundle found, skipping: #{skipped}"
+    non_rsc_tests = []
+  end
+
+  # Print parameters
+  print_params(
+    "BASE_URL" => BASE_URL,
+    "RSC_BUNDLE" => rsc_bundle || "none",
+    "NON_RSC_BUNDLE" => non_rsc_bundle || "none",
+    "RATE" => RATE,
+    "DURATION" => DURATION,
+    "REQUEST_TIMEOUT" => REQUEST_TIMEOUT,
+    "CONNECTIONS" => CONNECTIONS,
+    "MAX_CONNECTIONS" => MAX_CONNECTIONS,
+    "RSC_TESTS" => rsc_tests.map { |tc| tc[:name] }.join(", ").then { |s| s.empty? ? "none" : s },
+    "NON_RSC_TESTS" => non_rsc_tests.map { |tc| tc[:name] }.join(", ").then { |s| s.empty? ? "none" : s }
+  )
+
+  # Create output directory
+  FileUtils.mkdir_p(OUTDIR)
+
+  # Initialize BMF collector for Bencher output
+  bmf_collector = BmfCollector.new(prefix: BMF_PREFIX)
+
+  # Initialize summary file
+  File.write(SUMMARY_TXT, "")
+  add_to_summary("Test", "Bundle", "RPS", "p50(ms)", "p90(ms)", "Status")
+
+  failed_tests = []
+  failed_tests.concat(run_vegeta_suite(non_rsc_tests, non_rsc_bundle, "non-RSC", bmf_collector))
+  failed_tests.concat(run_vegeta_suite(rsc_tests, rsc_bundle, "RSC", bmf_collector))
+
+  # Display summary
+  display_summary(SUMMARY_TXT)
+
+  # Write BMF JSON for Bencher (append to existing Pro results)
+  bmf_collector.write_bmf_json(BENCHMARK_JSON, append: true)
+
+  unless failed_tests.empty?
+    warn "::error::#{failed_tests.length} node renderer benchmark(s) failed: #{failed_tests.join(', ')}"
+    exit 1
+  end
 end
-
-# Find and categorize bundles
-puts "\nDiscovering and categorizing bundles..."
-all_bundles = find_all_production_bundles
-puts "Found #{all_bundles.length} production bundle(s)"
-rsc_bundle, non_rsc_bundle = categorize_bundles(all_bundles)
-
-rsc_tests = TEST_CASES.select { |tc| tc[:rsc] }
-non_rsc_tests = TEST_CASES.reject { |tc| tc[:rsc] }
-
-if rsc_tests.any? && rsc_bundle.nil?
-  puts "Warning: RSC tests requested but no RSC bundle found, skipping: #{rsc_tests.map { |tc| tc[:name] }.join(', ')}"
-  rsc_tests = []
-end
-
-if non_rsc_tests.any? && non_rsc_bundle.nil?
-  skipped = non_rsc_tests.map { |tc| tc[:name] }.join(", ")
-  puts "Warning: Non-RSC tests requested but no non-RSC bundle found, skipping: #{skipped}"
-  non_rsc_tests = []
-end
-
-# Print parameters
-print_params(
-  "BASE_URL" => BASE_URL,
-  "RSC_BUNDLE" => rsc_bundle || "none",
-  "NON_RSC_BUNDLE" => non_rsc_bundle || "none",
-  "RATE" => RATE,
-  "DURATION" => DURATION,
-  "REQUEST_TIMEOUT" => REQUEST_TIMEOUT,
-  "CONNECTIONS" => CONNECTIONS,
-  "MAX_CONNECTIONS" => MAX_CONNECTIONS,
-  "RSC_TESTS" => rsc_tests.map { |tc| tc[:name] }.join(", ").then { |s| s.empty? ? "none" : s },
-  "NON_RSC_TESTS" => non_rsc_tests.map { |tc| tc[:name] }.join(", ").then { |s| s.empty? ? "none" : s }
-)
-
-# Create output directory
-FileUtils.mkdir_p(OUTDIR)
-
-# Initialize BMF collector for Bencher output
-bmf_collector = BmfCollector.new(prefix: BMF_PREFIX)
-
-# Initialize summary file
-File.write(SUMMARY_TXT, "")
-add_to_summary("Test", "Bundle", "RPS", "p50(ms)", "p90(ms)", "Status")
-
-# Run non-RSC benchmarks
-non_rsc_tests.each do |test_case|
-  print_separator
-  puts "Benchmarking (non-RSC): #{test_case[:name]}"
-  puts "  Bundle: #{non_rsc_bundle}"
-  puts "  Request: #{test_case[:request]}"
-  print_separator
-
-  rps, p50, p90, status = run_vegeta_benchmark(test_case, non_rsc_bundle)
-  add_to_summary(test_case[:name], "non-RSC", rps, p50, p90, status)
-
-  # Add to BMF collector for Bencher output (p90 stays in the summary table only)
-  bmf_collector.add(name: "#{test_case[:name]} (non-RSC)", rps: rps, p50: p50, status: status)
-end
-
-# Run RSC benchmarks
-rsc_tests.each do |test_case|
-  print_separator
-  puts "Benchmarking (RSC): #{test_case[:name]}"
-  puts "  Bundle: #{rsc_bundle}"
-  puts "  Request: #{test_case[:request]}"
-  print_separator
-
-  rps, p50, p90, status = run_vegeta_benchmark(test_case, rsc_bundle)
-  add_to_summary(test_case[:name], "RSC", rps, p50, p90, status)
-
-  # Add to BMF collector for Bencher output (p90 stays in the summary table only)
-  bmf_collector.add(name: "#{test_case[:name]} (RSC)", rps: rps, p50: p50, status: status)
-end
-
-# Display summary
-display_summary(SUMMARY_TXT)
-
-# Write BMF JSON for Bencher (append to existing Pro results)
-bmf_collector.write_bmf_json(BENCHMARK_JSON, append: true)

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -253,7 +253,9 @@ def run_vegeta_suite(test_cases, bundle, label, bmf_collector, runner: method(:r
       # Add to BMF collector for Bencher output (p90 stays in the summary table only)
       bmf_collector.add(name: test_label, rps: rps, p50: p50, status: status)
     rescue StandardError => e
-      warn "::error::Vegeta benchmark failed for #{test_label}: #{e.message}"
+      # ::error:: must go to stdout — GitHub Actions only parses workflow commands
+      # from stdout, not stderr, so writing here is what renders the UI annotation.
+      $stdout.puts "::error::Vegeta benchmark failed for #{test_label}: #{e.message}"
       failed << test_label
       add_to_summary(test_case[:name], label, *failure_metrics(e))
     end
@@ -311,6 +313,16 @@ if __FILE__ == $PROGRAM_NAME
     non_rsc_tests = []
   end
 
+  # Fail fast if bundle discovery/categorization left nothing to benchmark.
+  # Otherwise failed_tests stays empty and the script exits 0 after producing
+  # only an empty summary — turning a broken discovery run into a false green,
+  # exactly the silent-success class this script is meant to prevent. Mirrors
+  # bench.rb's `raise "No routes to benchmark"` guard.
+  if rsc_tests.empty? && non_rsc_tests.empty?
+    raise "No benchmarkable test cases found for the discovered bundles " \
+          "(RSC bundle: #{rsc_bundle || 'none'}, non-RSC bundle: #{non_rsc_bundle || 'none'})"
+  end
+
   # Print parameters
   print_params(
     "BASE_URL" => BASE_URL,
@@ -342,11 +354,15 @@ if __FILE__ == $PROGRAM_NAME
   # Display summary
   display_summary(SUMMARY_TXT)
 
-  # Write BMF JSON for Bencher (append to existing Pro results)
-  bmf_collector.write_bmf_json(BENCHMARK_JSON, append: true)
-
-  unless failed_tests.empty?
-    warn "::error::#{failed_tests.length} node renderer benchmark(s) failed: #{failed_tests.join(', ')}"
+  # Write the Bencher payload only on a fully green run. Guarding the write here
+  # (rather than writing unconditionally before exit) makes the "never upload a
+  # partial-success payload" invariant self-enforcing instead of relying on the
+  # downstream Bencher step having no `if: always()`.
+  if failed_tests.empty?
+    # Append to existing Pro results.
+    bmf_collector.write_bmf_json(BENCHMARK_JSON, append: true)
+  else
+    $stdout.puts "::error::#{failed_tests.length} node renderer benchmark(s) failed: #{failed_tests.join(', ')}"
     exit 1
   end
 end

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -205,8 +205,12 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
 
   raise "Vegeta attack failed for #{name}" unless system(vegeta_cmd)
 
-  # Generate text report (display and save)
-  raise "Vegeta text report failed" unless system("vegeta report #{vegeta_bin} | tee #{vegeta_txt}")
+  # Generate text report (display and save). Run through bash with pipefail so a
+  # non-zero `vegeta report` exit is not masked by tee's (always-zero) status;
+  # the default /bin/sh on Linux CI is dash, which has no `set -o pipefail`.
+  unless system("bash", "-c", "set -o pipefail; vegeta report #{vegeta_bin} | tee #{vegeta_txt}")
+    raise "Vegeta text report failed"
+  end
 
   # Generate JSON report
   raise "Vegeta JSON report failed" unless system("vegeta report -type=json #{vegeta_bin} > #{vegeta_json}")
@@ -264,7 +268,7 @@ if __FILE__ == $PROGRAM_NAME
   validate_benchmark_config!
 
   # Check required tools
-  check_required_tools(%w[vegeta curl column tee])
+  check_required_tools(%w[vegeta curl column tee bash])
 
   # Wait for node renderer to be ready
   # Note: Node renderer only speaks HTTP/2, but we can still check with a simple GET

--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -6,6 +6,7 @@
 
 require "English"
 require "open3"
+require "shellwords"
 require "socket"
 require_relative "lib/benchmark_config"
 require_relative "lib/benchmark_helpers"
@@ -192,15 +193,18 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
     end
 
   # Run Vegeta attack with h2c
+  # All paths are Shellwords.escape'd for parity with the k6 command in bench.rb,
+  # so an OUTDIR (or test name) containing spaces/special chars can't break the
+  # shell command.
   vegeta_cmd = [
     "vegeta", "attack",
-    "-targets=#{targets_file}",
+    "-targets=#{Shellwords.escape(targets_file)}",
     *vegeta_args,
     "-duration=#{DURATION}",
     "-timeout=#{REQUEST_TIMEOUT}",
     "-h2c", # HTTP/2 Cleartext (required for node renderer)
     "-max-body=0",
-    "> #{vegeta_bin}"
+    "> #{Shellwords.escape(vegeta_bin)}"
   ].join(" ")
 
   raise "Vegeta attack failed for #{name}" unless system(vegeta_cmd)
@@ -208,12 +212,16 @@ def run_vegeta_benchmark(test_case, bundle_timestamp)
   # Generate text report (display and save). Run through bash with pipefail so a
   # non-zero `vegeta report` exit is not masked by tee's (always-zero) status;
   # the default /bin/sh on Linux CI is dash, which has no `set -o pipefail`.
-  unless system("bash", "-c", "set -o pipefail; vegeta report #{vegeta_bin} | tee #{vegeta_txt}")
+  unless system("bash", "-c",
+                "set -o pipefail; vegeta report #{Shellwords.escape(vegeta_bin)} | " \
+                "tee #{Shellwords.escape(vegeta_txt)}")
     raise "Vegeta text report failed"
   end
 
   # Generate JSON report
-  raise "Vegeta JSON report failed" unless system("vegeta report -type=json #{vegeta_bin} > #{vegeta_json}")
+  unless system("vegeta report -type=json #{Shellwords.escape(vegeta_bin)} > #{Shellwords.escape(vegeta_json)}")
+    raise "Vegeta JSON report failed"
+  end
 
   # Delete the large binary file to save disk space
   FileUtils.rm_f(vegeta_bin)
@@ -255,7 +263,9 @@ def run_vegeta_suite(test_cases, bundle, label, bmf_collector, runner: method(:r
     rescue StandardError => e
       # ::error:: must go to stdout — GitHub Actions only parses workflow commands
       # from stdout, not stderr, so writing here is what renders the UI annotation.
-      $stdout.puts "::error::Vegeta benchmark failed for #{test_label}: #{e.message}"
+      # Newlines are collapsed so a multiline message can't truncate the
+      # annotation (Actions treats a newline as the command terminator).
+      $stdout.puts "::error::Vegeta benchmark failed for #{test_label}: #{e.message.to_s.tr("\n", ' ')}"
       failed << test_label
       add_to_summary(test_case[:name], label, *failure_metrics(e))
     end

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -29,53 +29,11 @@ def shard_benchmark_routes(routes, shard_index, total_shards)
   end
 end
 
-all_routes = benchmark_routes_for_app(APP_DIR, ROUTES)
-
-raise "No routes to benchmark" if all_routes.empty?
-
-validate_positive_integer(BENCHMARK_TOTAL_SHARDS, "BENCHMARK_TOTAL_SHARDS")
-raise "BENCHMARK_SHARD_INDEX must be between 0 and #{BENCHMARK_TOTAL_SHARDS - 1} (got: #{BENCHMARK_SHARD_INDEX})" unless
-  BENCHMARK_SHARD_INDEX.between?(0, BENCHMARK_TOTAL_SHARDS - 1)
-
-routes = shard_benchmark_routes(all_routes, BENCHMARK_SHARD_INDEX, BENCHMARK_TOTAL_SHARDS)
-raise "No routes assigned to shard #{BENCHMARK_SHARD_INDEX + 1}/#{BENCHMARK_TOTAL_SHARDS}" if routes.empty?
-
-validate_benchmark_config!
-
-# Check required tools are installed
-check_required_tools(%w[k6 column tee])
-
-puts <<~PARAMS
-  Benchmark parameters:
-    - APP_DIR: #{APP_DIR}
-    - ROUTES: #{ROUTES || 'auto-detect from Rails'}
-    - BASE_URL: #{BASE_URL}
-    - BENCHMARK_SHARD_INDEX: #{BENCHMARK_SHARD_INDEX}
-    - BENCHMARK_TOTAL_SHARDS: #{BENCHMARK_TOTAL_SHARDS}
-    - ROUTES_IN_SHARD: #{routes.length}/#{all_routes.length}
-    - RATE: #{RATE}
-    - DURATION: #{DURATION}
-    - REQUEST_TIMEOUT: #{REQUEST_TIMEOUT}
-    - CONNECTIONS: #{CONNECTIONS}
-    - MAX_CONNECTIONS: #{MAX_CONNECTIONS}
-    - WEB_CONCURRENCY: #{ENV['WEB_CONCURRENCY'] || 'unset'}
-    - RAILS_MAX_THREADS: #{ENV['RAILS_MAX_THREADS'] || 'unset'}
-    - RAILS_MIN_THREADS: #{ENV['RAILS_MIN_THREADS'] || 'unset'}
-PARAMS
-
-# Wait for the server to be ready
-test_uri = URI.parse("http://#{BASE_URL}#{routes.first}")
-wait_for_server(test_uri)
-puts "Server is ready!"
-
-FileUtils.mkdir_p(OUTDIR)
-
-# Initialize BMF collector for Bencher output (suffix used for Core/Pro distinction)
-bmf_collector = BmfCollector.new(suffix: BMF_SUFFIX)
-
 # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-# Benchmark a single route with k6
+# Benchmark a single route with k6. Returns [rps, p50, p90, status] on success
+# and RAISES on any k6/parse failure so the suite can record the failure and
+# exit non-zero instead of shipping fabricated metrics to Bencher.
 def run_k6_benchmark(target, route_name)
   puts "\n===> k6: #{route_name}"
 
@@ -120,19 +78,14 @@ def run_k6_benchmark(target, route_name)
   k6_status = k6_status_parts.empty? ? "MISSING" : k6_status_parts.join(",")
 
   [k6_rps, k6_p50, k6_p90, k6_status]
-rescue StandardError => e
-  puts "Error: #{e.message}"
-  failure_metrics(e)
 end
 
 # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-# Initialize summary file
-File.write(SUMMARY_TXT, "")
-add_to_summary("Route", "RPS", "p50(ms)", "p90(ms)", "Status")
-
-# Run benchmarks for each route
-routes.each do |route|
+# Benchmark a single route end-to-end (warm-up + k6). Returns
+# [rps, p50, p90, status] on success and RAISES on failure (delegated to
+# run_k6_benchmark) so the suite can record it.
+def benchmark_route(route)
   separator = "=" * 80
   puts "\n#{separator}"
   puts "Benchmarking route: #{route}"
@@ -149,15 +102,93 @@ routes.each do |route|
   end
   puts "Warm-up complete for #{route}"
 
-  route_name = sanitize_route_name(route)
-  rps, p50, p90, status = run_k6_benchmark(target, route_name)
-  add_to_summary(route, rps, p50, p90, status)
-
-  # Add to BMF collector for Bencher output (p90 stays in the summary table only)
-  bmf_collector.add(name: route, rps: rps, p50: p50, status: status)
+  run_k6_benchmark(target, sanitize_route_name(route))
 end
 
-puts "\nSummary saved to #{SUMMARY_TXT}"
-system("column", "-t", "-s", "\t", SUMMARY_TXT)
+# Run every route, collecting per-route failures instead of aborting the whole
+# suite on the first one. A failed route is recorded as FAILED in the
+# human-readable summary but is NOT added to the BMF collector, so fabricated
+# metrics never ship to Bencher. Returns the routes that failed (caller exits
+# non-zero when any failed). `runner` is injected so the failure-collection
+# control flow can be unit-tested without a live server or k6.
+def run_benchmark_suite(routes, bmf_collector, runner: method(:benchmark_route))
+  failed_routes = []
 
-bmf_collector.write_bmf_json(BENCHMARK_JSON)
+  routes.each do |route|
+    rps, p50, p90, status = runner.call(route)
+    add_to_summary(route, rps, p50, p90, status)
+    # Add to BMF collector for Bencher output (p90 stays in the summary table only)
+    bmf_collector.add(name: route, rps: rps, p50: p50, status: status)
+  rescue StandardError => e
+    warn "::error::k6 benchmark failed for route #{route}: #{e.message}"
+    failed_routes << route
+    add_to_summary(route, *failure_metrics(e))
+  end
+
+  failed_routes
+end
+
+if __FILE__ == $PROGRAM_NAME
+  all_routes = benchmark_routes_for_app(APP_DIR, ROUTES)
+
+  raise "No routes to benchmark" if all_routes.empty?
+
+  validate_positive_integer(BENCHMARK_TOTAL_SHARDS, "BENCHMARK_TOTAL_SHARDS")
+  unless BENCHMARK_SHARD_INDEX.between?(0, BENCHMARK_TOTAL_SHARDS - 1)
+    raise "BENCHMARK_SHARD_INDEX must be between 0 and #{BENCHMARK_TOTAL_SHARDS - 1} " \
+          "(got: #{BENCHMARK_SHARD_INDEX})"
+  end
+
+  routes = shard_benchmark_routes(all_routes, BENCHMARK_SHARD_INDEX, BENCHMARK_TOTAL_SHARDS)
+  raise "No routes assigned to shard #{BENCHMARK_SHARD_INDEX + 1}/#{BENCHMARK_TOTAL_SHARDS}" if routes.empty?
+
+  validate_benchmark_config!
+
+  # Check required tools are installed
+  check_required_tools(%w[k6 column tee])
+
+  puts <<~PARAMS
+    Benchmark parameters:
+      - APP_DIR: #{APP_DIR}
+      - ROUTES: #{ROUTES || 'auto-detect from Rails'}
+      - BASE_URL: #{BASE_URL}
+      - BENCHMARK_SHARD_INDEX: #{BENCHMARK_SHARD_INDEX}
+      - BENCHMARK_TOTAL_SHARDS: #{BENCHMARK_TOTAL_SHARDS}
+      - ROUTES_IN_SHARD: #{routes.length}/#{all_routes.length}
+      - RATE: #{RATE}
+      - DURATION: #{DURATION}
+      - REQUEST_TIMEOUT: #{REQUEST_TIMEOUT}
+      - CONNECTIONS: #{CONNECTIONS}
+      - MAX_CONNECTIONS: #{MAX_CONNECTIONS}
+      - WEB_CONCURRENCY: #{ENV['WEB_CONCURRENCY'] || 'unset'}
+      - RAILS_MAX_THREADS: #{ENV['RAILS_MAX_THREADS'] || 'unset'}
+      - RAILS_MIN_THREADS: #{ENV['RAILS_MIN_THREADS'] || 'unset'}
+  PARAMS
+
+  # Wait for the server to be ready
+  test_uri = URI.parse("http://#{BASE_URL}#{routes.first}")
+  wait_for_server(test_uri)
+  puts "Server is ready!"
+
+  FileUtils.mkdir_p(OUTDIR)
+
+  # Initialize BMF collector for Bencher output (suffix used for Core/Pro distinction)
+  bmf_collector = BmfCollector.new(suffix: BMF_SUFFIX)
+
+  # Initialize summary file
+  File.write(SUMMARY_TXT, "")
+  add_to_summary("Route", "RPS", "p50(ms)", "p90(ms)", "Status")
+
+  failed_routes = run_benchmark_suite(routes, bmf_collector)
+
+  puts "\nSummary saved to #{SUMMARY_TXT}"
+  system("column", "-t", "-s", "\t", SUMMARY_TXT)
+
+  bmf_collector.write_bmf_json(BENCHMARK_JSON)
+
+  unless failed_routes.empty?
+    warn "::error::#{failed_routes.length} of #{routes.length} benchmark route(s) failed: " \
+         "#{failed_routes.join(', ')}"
+    exit 1
+  end
+end

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -41,6 +41,12 @@ def run_k6_benchmark(target, route_name)
   k6_summary_json = "#{OUTDIR}/#{route_name}_k6_summary.json"
   k6_txt = "#{OUTDIR}/#{route_name}_k6.txt"
 
+  # Drop any summary file left by a previous run for this route. k6 only writes
+  # the export on a clean finish, so without this a crashed/killed k6 could
+  # leave a stale file that parses into fabricated metrics even though this run
+  # failed (the pipefail guard below catches the non-zero exit).
+  FileUtils.rm_f(k6_summary_json)
+
   # Build k6 command with environment variables
   k6_env_vars = [
     "-e TARGET_URL=#{Shellwords.escape(target)}",
@@ -52,8 +58,14 @@ def run_k6_benchmark(target, route_name)
   ].join(" ")
 
   k6_command = "k6 run #{k6_env_vars} --summary-export=#{Shellwords.escape(k6_summary_json)} " \
-               "--summary-trend-stats 'med,p(90)' #{k6_script}"
-  raise "k6 benchmark failed" unless system("#{k6_command} | tee #{Shellwords.escape(k6_txt)}")
+               "--summary-trend-stats 'med,p(90)' #{Shellwords.escape(k6_script)}"
+  # Run through bash with pipefail so a non-zero k6 exit is not masked by tee's
+  # (always-zero) exit status. The default /bin/sh on Linux CI is dash, which
+  # has no `set -o pipefail`, so invoke bash explicitly. Without this a k6
+  # failure would slip past the rescue and ship fabricated metrics to Bencher.
+  unless system("bash", "-c", "set -o pipefail; #{k6_command} | tee #{Shellwords.escape(k6_txt)}")
+    raise "k6 benchmark failed"
+  end
 
   k6_data = parse_json_file(k6_summary_json, "k6")
   k6_rps = k6_data.dig("metrics", "iterations", "rate")&.round(2) || "MISSING"
@@ -145,7 +157,7 @@ if __FILE__ == $PROGRAM_NAME
   validate_benchmark_config!
 
   # Check required tools are installed
-  check_required_tools(%w[k6 column tee])
+  check_required_tools(%w[k6 column tee bash])
 
   puts <<~PARAMS
     Benchmark parameters:

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -134,7 +134,10 @@ def run_benchmark_suite(routes, bmf_collector, runner: method(:benchmark_route))
   rescue StandardError => e
     # ::error:: must go to stdout — GitHub Actions only parses workflow commands
     # from stdout, not stderr, so writing here is what renders the UI annotation.
-    $stdout.puts "::error::k6 benchmark failed for route #{route}: #{e.message}"
+    # The rescue also covers warm-up failures (not just k6), so the label is
+    # neutral, and newlines are collapsed so a multiline message can't truncate
+    # the annotation (Actions treats a newline as the command terminator).
+    $stdout.puts "::error::Benchmark failed for route #{route}: #{e.message.to_s.tr("\n", ' ')}"
     failed_routes << route
     add_to_summary(route, *failure_metrics(e))
   end

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -132,7 +132,9 @@ def run_benchmark_suite(routes, bmf_collector, runner: method(:benchmark_route))
     # Add to BMF collector for Bencher output (p90 stays in the summary table only)
     bmf_collector.add(name: route, rps: rps, p50: p50, status: status)
   rescue StandardError => e
-    warn "::error::k6 benchmark failed for route #{route}: #{e.message}"
+    # ::error:: must go to stdout — GitHub Actions only parses workflow commands
+    # from stdout, not stderr, so writing here is what renders the UI annotation.
+    $stdout.puts "::error::k6 benchmark failed for route #{route}: #{e.message}"
     failed_routes << route
     add_to_summary(route, *failure_metrics(e))
   end
@@ -196,11 +198,15 @@ if __FILE__ == $PROGRAM_NAME
   puts "\nSummary saved to #{SUMMARY_TXT}"
   system("column", "-t", "-s", "\t", SUMMARY_TXT)
 
-  bmf_collector.write_bmf_json(BENCHMARK_JSON)
-
-  unless failed_routes.empty?
-    warn "::error::#{failed_routes.length} of #{routes.length} benchmark route(s) failed: " \
-         "#{failed_routes.join(', ')}"
+  # Write the Bencher payload only on a fully green run. Guarding the write here
+  # (rather than writing unconditionally before exit) makes the "never upload a
+  # partial-success payload" invariant self-enforcing instead of relying on the
+  # downstream Bencher step having no `if: always()`.
+  if failed_routes.empty?
+    bmf_collector.write_bmf_json(BENCHMARK_JSON)
+  else
+    $stdout.puts "::error::#{failed_routes.length} of #{routes.length} benchmark route(s) failed: " \
+                 "#{failed_routes.join(', ')}"
     exit 1
   end
 end

--- a/benchmarks/lib/benchmark_helpers.rb
+++ b/benchmarks/lib/benchmark_helpers.rb
@@ -19,9 +19,13 @@ rescue StandardError => e
   raise "Failed to read #{tool_name} results: #{e.message}"
 end
 
-# Create failure metrics array for summary (rps, p50, p90 + status message)
+# Create failure metrics array for summary (rps, p50, p90 + status message).
+# The status message is truncated so a long exception (e.g. a JSON parse error)
+# cannot misalign the `column -t` summary table.
 def failure_metrics(error)
-  ["FAILED", "FAILED", "FAILED", error.message]
+  message = error.message.to_s.tr("\n", " ")
+  message = "#{message[0, 77]}..." if message.length > 80
+  ["FAILED", "FAILED", "FAILED", message]
 end
 
 # Append a line to the summary file

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -47,8 +47,10 @@ RSpec.describe "bench-node-renderer" do
     end
 
     it "continues past a failing test and returns every test that failed" do
+      # simple_eval is first in test_cases, so failing it proves the suite keeps
+      # going and still records react_ssr (which runs after the failure).
       runner = lambda do |test_case, _bundle|
-        raise "Vegeta attack failed for #{test_case[:name]}" if test_case[:name] == "react_ssr"
+        raise "Vegeta attack failed for #{test_case[:name]}" if test_case[:name] == "simple_eval"
 
         [100.0, 1.0, 2.0, "200=10"]
       end
@@ -56,11 +58,11 @@ RSpec.describe "bench-node-renderer" do
       failed = nil
       # ::error:: annotations go to stdout so GitHub Actions renders them.
       expect { failed = run_vegeta_suite(test_cases, "bundleX", "RSC", collector, runner: runner) }
-        .to output(/::error::.*react_ssr/).to_stdout
+        .to output(/::error::.*simple_eval/).to_stdout
 
-      expect(failed).to eq(["react_ssr (RSC)"])
-      # The test after the failure still ran (no early abort).
-      expect(collector.added.map { |m| m[:name] }).to eq(["simple_eval (RSC)"])
+      expect(failed).to eq(["simple_eval (RSC)"])
+      # The test after the failure (react_ssr) still ran and was recorded — no early abort.
+      expect(collector.added.map { |m| m[:name] }).to eq(["react_ssr (RSC)"])
     end
 
     it "keeps fabricated metrics out of the Bencher payload for failed tests" do

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -54,8 +54,9 @@ RSpec.describe "bench-node-renderer" do
       end
 
       failed = nil
+      # ::error:: annotations go to stdout so GitHub Actions renders them.
       expect { failed = run_vegeta_suite(test_cases, "bundleX", "RSC", collector, runner: runner) }
-        .to output(/::error::.*react_ssr/).to_stderr
+        .to output(/::error::.*react_ssr/).to_stdout
 
       expect(failed).to eq(["react_ssr (RSC)"])
       # The test after the failure still ran (no early abort).
@@ -66,8 +67,10 @@ RSpec.describe "bench-node-renderer" do
       runner = ->(_test_case, _bundle) { raise "Vegeta attack failed" }
 
       failed = nil
+      # Pin both tests' ::error:: annotations (in order) on stdout rather than
+      # accepting any output, so a dropped or reformatted annotation is caught.
       expect { failed = run_vegeta_suite(test_cases, "bundleX", "non-RSC", collector, runner: runner) }
-        .to output.to_stderr
+        .to output(/::error::.*simple_eval.*::error::.*react_ssr/m).to_stdout
 
       expect(failed).to eq(["simple_eval (non-RSC)", "react_ssr (non-RSC)"])
       expect(collector.added).to be_empty

--- a/benchmarks/spec/bench_node_renderer_spec.rb
+++ b/benchmarks/spec/bench_node_renderer_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../bench-node-renderer"
+
+# bench-node-renderer.rb runs its benchmark flow only under
+# `if __FILE__ == $PROGRAM_NAME`, so requiring it just loads the helpers. These
+# pin the per-test Vegeta failure handling: a single failure must NOT abort the
+# remaining tests, must NOT ship fabricated metrics to Bencher (via the BMF
+# collector), and must be surfaced so the suite can exit non-zero instead of
+# reporting a green run on fabricated data (#3459).
+RSpec.describe "bench-node-renderer" do
+  describe "#run_vegeta_suite" do
+    # Minimal stand-in for BmfCollector that records exactly what would ship to
+    # Bencher, so the specs can assert failed tests never reach the payload.
+    let(:collector) do
+      Class.new do
+        attr_reader :added
+
+        def initialize
+          @added = []
+        end
+
+        def add(name:, rps:, p50:, status:)
+          @added << { name: name, rps: rps, p50: p50, status: status }
+        end
+      end.new
+    end
+
+    let(:test_cases) do
+      [{ name: "simple_eval", request: "2+2" }, { name: "react_ssr", request: "render(...)" }]
+    end
+
+    before do
+      # The human-readable summary file is a side effect covered by the workflow's
+      # validate step; keep these specs focused on failure collection + payload.
+      allow(self).to receive(:add_to_summary)
+    end
+
+    it "returns no failures and records every test when all succeed" do
+      runner = ->(_test_case, _bundle) { [100.0, 1.0, 2.0, "200=10"] }
+
+      failed = run_vegeta_suite(test_cases, "bundleX", "non-RSC", collector, runner: runner)
+
+      expect(failed).to be_empty
+      expect(collector.added.map { |m| m[:name] }).to eq(["simple_eval (non-RSC)", "react_ssr (non-RSC)"])
+    end
+
+    it "continues past a failing test and returns every test that failed" do
+      runner = lambda do |test_case, _bundle|
+        raise "Vegeta attack failed for #{test_case[:name]}" if test_case[:name] == "react_ssr"
+
+        [100.0, 1.0, 2.0, "200=10"]
+      end
+
+      failed = nil
+      expect { failed = run_vegeta_suite(test_cases, "bundleX", "RSC", collector, runner: runner) }
+        .to output(/::error::.*react_ssr/).to_stderr
+
+      expect(failed).to eq(["react_ssr (RSC)"])
+      # The test after the failure still ran (no early abort).
+      expect(collector.added.map { |m| m[:name] }).to eq(["simple_eval (RSC)"])
+    end
+
+    it "keeps fabricated metrics out of the Bencher payload for failed tests" do
+      runner = ->(_test_case, _bundle) { raise "Vegeta attack failed" }
+
+      failed = nil
+      expect { failed = run_vegeta_suite(test_cases, "bundleX", "non-RSC", collector, runner: runner) }
+        .to output.to_stderr
+
+      expect(failed).to eq(["simple_eval (non-RSC)", "react_ssr (non-RSC)"])
+      expect(collector.added).to be_empty
+    end
+  end
+end

--- a/benchmarks/spec/bench_spec.rb
+++ b/benchmarks/spec/bench_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe "bench" do
     before do
       # The human-readable summary file is a side effect covered by the workflow's
       # validate step; keep these specs focused on failure collection + payload.
+      #
+      # add_to_summary is a top-level `def`, which Ruby defines as a private
+      # method on Object. run_benchmark_suite calls it with an implicit receiver,
+      # so `self` resolves to this RSpec example instance — the same object the
+      # before/it blocks run on — and this stub intercepts the call.
       allow(self).to receive(:add_to_summary)
     end
 
@@ -56,17 +61,46 @@ RSpec.describe "bench" do
       expect(failed).to eq(["/bad"])
       # The routes after the failure still ran (no early abort).
       expect(collector.added.map { |m| m[:name] }).to eq(%w[/a /c])
+      # The failed route is recorded in the summary with FAILED placeholders and
+      # the error message — never numeric (fabricated) metrics.
+      expect(self).to have_received(:add_to_summary)
+        .with("/bad", "FAILED", "FAILED", "FAILED", "k6 benchmark failed")
     end
 
     it "keeps fabricated metrics out of the Bencher payload for failed routes" do
       runner = ->(_route) { raise "k6 benchmark failed" }
 
       failed = nil
+      # Pin both routes' ::error:: annotations (in order) rather than accepting
+      # any stderr output, so a dropped or reformatted annotation is caught.
       expect { failed = run_benchmark_suite(%w[/x /y], collector, runner: runner) }
-        .to output.to_stderr
+        .to output(%r{::error::.*/x.*::error::.*/y}m).to_stderr
 
       expect(failed).to eq(%w[/x /y])
       expect(collector.added).to be_empty
+    end
+  end
+
+  describe "#run_k6_benchmark" do
+    # Regression for #3459: the k6 summary command is piped through `tee`, whose
+    # always-zero exit status would otherwise mask a non-zero k6 exit. The
+    # pipeline must run under pipefail (via bash) and any stale summary file from
+    # a prior run must be removed first, so a k6 failure can never be parsed into
+    # fabricated Bencher metrics.
+    it "removes stale summaries, runs under pipefail, and raises without parsing on failure" do
+      allow(FileUtils).to receive(:rm_f)
+      # Model a failing k6 pipeline: with pipefail the bash invocation returns
+      # non-zero even though tee succeeds.
+      allow(self).to receive(:system).and_return(false)
+      allow(self).to receive(:parse_json_file)
+
+      expect { run_k6_benchmark("http://localhost:3001/x", "x") }
+        .to raise_error(/k6 benchmark failed/)
+
+      expect(FileUtils).to have_received(:rm_f).with(/_k6_summary\.json\z/)
+      expect(self).to have_received(:system)
+        .with("bash", "-c", a_string_matching(/\Aset -o pipefail; k6 run .* \| tee /))
+      expect(self).not_to have_received(:parse_json_file)
     end
   end
 end

--- a/benchmarks/spec/bench_spec.rb
+++ b/benchmarks/spec/bench_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../bench"
+
+# bench.rb runs its benchmark flow only under `if __FILE__ == $PROGRAM_NAME`, so
+# requiring it just loads the helpers. These pin the per-route k6 failure
+# handling: a single k6/parse failure must NOT abort the remaining routes, must
+# NOT ship fabricated metrics to Bencher (via the BMF collector), and must be
+# surfaced so the suite can exit non-zero instead of reporting a green run on
+# fabricated data (#3459).
+RSpec.describe "bench" do
+  describe "#run_benchmark_suite" do
+    # Minimal stand-in for BmfCollector that records exactly what would ship to
+    # Bencher, so the specs can assert failed routes never reach the payload.
+    let(:collector) do
+      Class.new do
+        attr_reader :added
+
+        def initialize
+          @added = []
+        end
+
+        def add(name:, rps:, p50:, status:)
+          @added << { name: name, rps: rps, p50: p50, status: status }
+        end
+      end.new
+    end
+
+    before do
+      # The human-readable summary file is a side effect covered by the workflow's
+      # validate step; keep these specs focused on failure collection + payload.
+      allow(self).to receive(:add_to_summary)
+    end
+
+    it "returns no failures and records every route when all succeed" do
+      runner = ->(_route) { [100.0, 1.0, 2.0, "200=10"] }
+
+      failed = run_benchmark_suite(%w[/a /b], collector, runner: runner)
+
+      expect(failed).to be_empty
+      expect(collector.added.map { |m| m[:name] }).to eq(%w[/a /b])
+    end
+
+    it "continues past a failing route and returns every route that failed" do
+      runner = lambda do |route|
+        raise "k6 benchmark failed" if route == "/bad"
+
+        [100.0, 1.0, 2.0, "200=10"]
+      end
+
+      failed = nil
+      expect { failed = run_benchmark_suite(%w[/a /bad /c], collector, runner: runner) }
+        .to output(%r{::error::.*/bad}).to_stderr
+
+      expect(failed).to eq(["/bad"])
+      # The routes after the failure still ran (no early abort).
+      expect(collector.added.map { |m| m[:name] }).to eq(%w[/a /c])
+    end
+
+    it "keeps fabricated metrics out of the Bencher payload for failed routes" do
+      runner = ->(_route) { raise "k6 benchmark failed" }
+
+      failed = nil
+      expect { failed = run_benchmark_suite(%w[/x /y], collector, runner: runner) }
+        .to output.to_stderr
+
+      expect(failed).to eq(%w[/x /y])
+      expect(collector.added).to be_empty
+    end
+  end
+end

--- a/benchmarks/spec/bench_spec.rb
+++ b/benchmarks/spec/bench_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe "bench" do
       end
 
       failed = nil
+      # ::error:: annotations go to stdout so GitHub Actions renders them.
       expect { failed = run_benchmark_suite(%w[/a /bad /c], collector, runner: runner) }
-        .to output(%r{::error::.*/bad}).to_stderr
+        .to output(%r{::error::.*/bad}).to_stdout
 
       expect(failed).to eq(["/bad"])
       # The routes after the failure still ran (no early abort).
@@ -72,9 +73,10 @@ RSpec.describe "bench" do
 
       failed = nil
       # Pin both routes' ::error:: annotations (in order) rather than accepting
-      # any stderr output, so a dropped or reformatted annotation is caught.
+      # any stdout, so a dropped or reformatted annotation is caught. They go to
+      # stdout so GitHub Actions renders them.
       expect { failed = run_benchmark_suite(%w[/x /y], collector, runner: runner) }
-        .to output(%r{::error::.*/x.*::error::.*/y}m).to_stderr
+        .to output(%r{::error::.*/x.*::error::.*/y}m).to_stdout
 
       expect(failed).to eq(%w[/x /y])
       expect(collector.added).to be_empty


### PR DESCRIPTION
## What

Make the benchmark scripts **fail loudly** when a route/test benchmark fails, instead of silently fabricating metrics and reporting a green run. Covers both benchmark scripts:

- `benchmarks/bench.rb` — k6 (Core + Pro Rails suites)
- `benchmarks/bench-node-renderer.rb` — Vegeta (Pro Node Renderer suite)

This is the top reliability blocker from the manager triage on #3459 ("do not swallow k6 failures") — extended to the node-renderer suite, which had the identical bug.

## The bug

Both `run_k6_benchmark` and `run_vegeta_benchmark` wrapped their entire body in `rescue StandardError => e` and returned `failure_metrics(e)` on any failure. So a dead/restarting target, an explicit `raise "... failed"`, or a JSON parse error all turned into a row of fabricated `FAILED` values — and the loop simply continued.

Consequences:
- the scripts exited **0** even when every benchmark invocation died;
- the workflow's `if ! $BENCH_CMD ...` guard could never fail the job;
- the BMF JSON shipped to Bencher contained fabricated values **treated as real measurements**.

## The fix (issue's recommended option **b**: collect failures, exit non-zero at end)

For each script:
- `run_k6_benchmark` / `run_vegeta_benchmark` now **raise** on failure rather than swallowing it.
- New `run_benchmark_suite` / `run_vegeta_suite` run every route/test, record each failure, keep failed entries **out of the BMF collector** (no fabricated metrics reach Bencher), and still write `FAILED` into the human-readable summary table.
- After the suite, emit a `::error::` annotation and `exit 1` when anything failed.

Why `exit 1` is sufficient to stop bad data: the **"Execute benchmark suite"** step guards on the exit code, and the downstream **"Track benchmarks with Bencher"** step has **no `if: always()`** — so a non-zero exit fails the job and skips the Bencher upload entirely.

## Testability

Both scripts now guard their procedural flow under `if __FILE__ == $PROGRAM_NAME` (matching `track_benchmarks.rb`), so the helpers are loadable in isolation. Added `benchmarks/spec/bench_spec.rb` and `benchmarks/spec/bench_node_renderer_spec.rb` covering the failure-collection control flow via an injected runner:
- all routes/tests succeed → no failures, every one recorded
- one fails → suite continues past it, returns the failed entry, emits `::error::`
- failed entries never reach the BMF (Bencher) payload

This also advances the "expand benchmark spec coverage" task in #3459.

## Testing

- `bundle exec rspec benchmarks/spec` → 55 examples, 0 failures
- `bundle exec rubocop benchmarks/bench.rb benchmarks/bench-node-renderer.rb benchmarks/spec/*` → clean
- `ruby -c` on both scripts → Syntax OK
- CI: all 4 live benchmark suites (Core, Pro x2 shards, Pro Node Renderer) exercise these scripts end-to-end.

## Scope

Part of #3459 (a multi-task follow-up collector). Companion PR #3579 monitors backgrounded server/renderer crashes. Remaining for follow-up: split `track_benchmarks.rb` into modules; broaden parser/spec coverage. Not closing #3459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Benchmarks now run suites across all routes/tests, continue after per-item failures, aggregate a human-readable summary, and exit non‑zero if any item failed; exported payloads are written only on fully green runs.

* **Bug Fixes**
  * Prevents masking of runner/report failures by piping and removes stale per-item report files before runs.
  * Failed runs no longer produce fabricated numeric metrics; failure messages are sanitized/truncated for safe display; per-item failures emit error annotations.

* **Tests**
  * New specs cover full‑suite success, partial failures (with error annotations), and that failures do not add metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI reliability and Bencher data integrity for all benchmark workflows; logic is well-tested but mis-detection could still fail good runs or block uploads.
> 
> **Overview**
> Stops benchmark CI from exiting **0** and uploading **Bencher** metrics when **k6** or **Vegeta** runs fail. Per-route/test runners now **raise** on tool/parse errors instead of returning fabricated `FAILED` values that still reached the BMF collector.
> 
> **`bench.rb`** and **`bench-node-renderer.rb`** add **`run_benchmark_suite`** / **`run_vegeta_suite`**: run all items, emit **`::error::`** on stdout for Actions, skip failed rows in the BMF payload, **`exit 1`** if anything failed, and write BMF JSON **only** on a fully green run. **k6**/**Vegeta** pipelines use **bash `pipefail`** (and **k6** drops stale summary JSON) so **`tee`** cannot hide failures; paths are **`Shellwords`**-escaped; the node script guards empty benchmarkable tests like **`bench.rb`**’s no-routes check. Main flow is behind **`if __FILE__ == $PROGRAM_NAME`** for testability.
> 
> **`failure_metrics`** truncates/sanitizes error text for the summary table. New **`bench_spec`** / **`bench_node_renderer_spec`** cover suite continuation, annotations, and no fabricated Bencher data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f377b3131a338d7fac1a958f50cc1e9d9147a2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->