### PR TITLE
fix(benchmark): detect backgrounded server/renderer crashes during readiness and benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -135,9 +135,11 @@ jobs:
             RUN_PRO_NODE_RENDERER_BENCHMARKS=true
           fi
 
-          echo "run_core_benchmarks=$RUN_CORE_BENCHMARKS" >> "$GITHUB_OUTPUT"
-          echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS" >> "$GITHUB_OUTPUT"
-          echo "run_pro_node_renderer_benchmarks=$RUN_PRO_NODE_RENDERER_BENCHMARKS" >> "$GITHUB_OUTPUT"
+          {
+            echo "run_core_benchmarks=$RUN_CORE_BENCHMARKS"
+            echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS"
+            echo "run_pro_node_renderer_benchmarks=$RUN_PRO_NODE_RENDERER_BENCHMARKS"
+          } >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Set benchmark matrices
         id: benchmark-matrices
@@ -395,7 +397,9 @@ jobs:
           bundle exec rake react_on_rails_pro:pre_seed_renderer_cache MODE=symlink
 
           echo "🚀 Starting ${{ matrix.suite_name }} node renderer..."
-          node renderer/node-renderer.js &
+          renderer_log="${RUNNER_TEMP:-$PWD}/node-renderer.log"
+          echo "TARGET_LOG=$renderer_log" >> "$GITHUB_ENV"
+          node renderer/node-renderer.js > "$renderer_log" 2>&1 &
           renderer_pid=$!
           # Persist the PID so "Execute benchmark suite" can confirm the renderer
           # survived the run; a backgrounded child under `set -e` does not
@@ -409,6 +413,7 @@ jobs:
             # of looping until the timeout (or racing a dead/restarting target).
             if ! kill -0 "$renderer_pid" 2>/dev/null; then
               echo "::error::Node renderer (PID $renderer_pid) exited during startup"
+              cat "$renderer_log" || true
               exit 1
             fi
             if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close"; then
@@ -420,6 +425,7 @@ jobs:
           done
 
           echo "::error::Node renderer failed to start within 30 seconds"
+          cat "$renderer_log" || true
           exit 1
 
       - name: Start Rails production server
@@ -489,6 +495,13 @@ jobs:
           if ! kill -0 "$TARGET_PID" 2>/dev/null; then
             echo "::error::Benchmark target (PID $TARGET_PID) died during the benchmark run; metrics are unreliable"
             exit 1
+          fi
+          if [ -n "${TARGET_LOG:-}" ] && [ -f "$TARGET_LOG" ]; then
+            if grep -q "died UNEXPECTEDLY" "$TARGET_LOG"; then
+              echo "::error::Benchmark target logged an unexpected worker restart; metrics are unreliable"
+              grep -n "died UNEXPECTEDLY" "$TARGET_LOG" || true
+              exit 1
+            fi
           fi
 
           echo "✅ Benchmark suite completed successfully"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -396,19 +396,30 @@ jobs:
 
           echo "🚀 Starting ${{ matrix.suite_name }} node renderer..."
           node renderer/node-renderer.js &
-          echo "Node renderer started in background"
+          renderer_pid=$!
+          # Persist the PID so "Execute benchmark suite" can confirm the renderer
+          # survived the run; a backgrounded child under `set -e` does not
+          # propagate its failure to the step.
+          echo "TARGET_PID=$renderer_pid" >> "$GITHUB_ENV"
+          echo "Node renderer started in background (PID $renderer_pid)"
 
           echo "⏳ Waiting for node renderer to be ready..."
           for i in {1..30}; do
+            # Fail fast if the renderer bound the port and then crashed, instead
+            # of looping until the timeout (or racing a dead/restarting target).
+            if ! kill -0 "$renderer_pid" 2>/dev/null; then
+              echo "::error::Node renderer (PID $renderer_pid) exited during startup"
+              exit 1
+            fi
             if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close"; then
-              echo "✅ Node renderer is ready and listening"
+              echo "✅ Node renderer is ready and listening (PID $renderer_pid)"
               exit 0
             fi
             echo "  Attempt $i/30: Node renderer not ready yet..."
             sleep 1
           done
 
-          echo "❌ ERROR: Node renderer failed to start within 30 seconds"
+          echo "::error::Node renderer failed to start within 30 seconds"
           exit 1
 
       - name: Start Rails production server
@@ -418,19 +429,30 @@ jobs:
           set -e
           echo "🚀 Starting ${{ matrix.suite_name }} production server..."
           $SERVER_CMD &
-          echo "Server started in background"
+          server_pid=$!
+          # Persist the PID so "Execute benchmark suite" can confirm the server
+          # survived the run; a backgrounded child under `set -e` does not
+          # propagate its failure to the step.
+          echo "TARGET_PID=$server_pid" >> "$GITHUB_ENV"
+          echo "Server started in background (PID $server_pid)"
 
           echo "⏳ Waiting for server to be ready..."
           for i in {1..30}; do
+            # Fail fast if the server bound the port and then crashed, instead of
+            # looping until the timeout (or racing a dead/restarting target).
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "::error::Server (PID $server_pid) exited during startup"
+              exit 1
+            fi
             if curl -fsS http://localhost:3001 > /dev/null; then
-              echo "✅ Server is ready and responding"
+              echo "✅ Server is ready and responding (PID $server_pid)"
               exit 0
             fi
             echo "  Attempt $i/30: Server not ready yet..."
             sleep 1
           done
 
-          echo "❌ ERROR: Server failed to start within 30 seconds"
+          echo "::error::Server failed to start within 30 seconds"
           exit 1
 
       - name: Execute benchmark suite
@@ -453,6 +475,19 @@ jobs:
             fi
           elif ! $BENCH_CMD "$BENCHMARK_SCRIPT"; then
             echo "❌ ERROR: Benchmark execution failed"
+            exit 1
+          fi
+
+          # The benchmark target was backgrounded in a prior step, so `set -e`
+          # never saw it crash. Confirm it survived the whole run: a mid-run
+          # death means the metrics were measured against a dead/restarting
+          # target and must not ship to Bencher, so fail the job.
+          if [ -z "$TARGET_PID" ]; then
+            echo "::error::TARGET_PID is unset; cannot verify the benchmark target stayed alive"
+            exit 1
+          fi
+          if ! kill -0 "$TARGET_PID" 2>/dev/null; then
+            echo "::error::Benchmark target (PID $TARGET_PID) died during the benchmark run; metrics are unreliable"
             exit 1
           fi
 


### PR DESCRIPTION
## What

Monitor the backgrounded server / node-renderer processes in `benchmark.yml` so a crash is detected instead of silently benchmarking a dead target and shipping garbage metrics to Bencher. This is the second reliability blocker from the manager triage on #3459 ("monitor backgrounded server/renderer processes").

## The bug

The production server (`$SERVER_CMD &`, core/pro suites) and the Pro node renderer (`node renderer/node-renderer.js &`) are backgrounded under `set -e`, which **does not propagate a backgrounded child's failure**. Two failure modes slipped through:

1. **Readiness race / wasted wait** — the TCP/curl readiness loop could race a process that binds the port and then crashes, or spin until the full 30s timeout against a process that already exited.
2. **Mid-run crash** — if the target died *during* the benchmark, the run still produced metrics (measured against a dead/restarting target) that shipped to Bencher as if real.

## The fix

For both the "Start Rails production server" and "Start Pro node renderer" steps:

- **Capture the PID** with `$!` and persist it via `$GITHUB_ENV` (`TARGET_PID`) so a later step can check it. (Each matrix child runs exactly one of these steps — `server_kind` is `rails` xor `node-renderer` — so one var is sufficient.)
- **In the readiness loop**, `kill -0` the PID first and **fail fast** with an `::error::` annotation if it died during startup, instead of looping to the timeout.
- **After the benchmark runs** (in "Execute benchmark suite"), `kill -0 "$TARGET_PID"` again; if the target died mid-run, emit `::error::` and `exit 1`.

Why `exit 1` stops bad data: the downstream **"Track benchmarks with Bencher"** step has **no `if: always()`**, so failing the job skips the Bencher upload entirely (same mechanism as #3575).

The two start steps' existing 30s-timeout failures now also emit `::error::` annotations, consistent with the new death-detection paths.

## Process-tree notes (why `kill -0 $!` is meaningful)

- **node renderer**: `node ... &` → `$!` is the node PID directly — precise crash detection.
- **rails (core/pro)**: `bin/prod` runs the server as its last, non-`exec`'d command, so `bin/prod`'s liveness tracks the server's — a full crash is detected.

## Testing

- `ruby -ryaml` parse → OK
- `actionlint` → clean on the changed steps (only a pre-existing SC2129 style nit elsewhere)
- Local simulation of the `$!` / `kill -0` logic across all three scenarios (alive through readiness+post-run; dies at startup → readiness fails fast; dies mid-run → post-run check catches it).
- This PR is labeled `benchmark` / `benchmark-pro` / `benchmark-pro-node-renderer` so CI runs all three suites and exercises every start step end-to-end.

## Scope

Part of #3459 (multi-task follow-up collector); intentionally focused on one reliability blocker. Companion to #3575 (don't swallow k6 failures). Not closing #3459.

> Note: while here I found `benchmarks/bench-node-renderer.rb` has the **same swallow-and-continue bug** that #3575 fixes in `bench.rb` (Vegeta failures → `failure_metrics`, script exits 0). Worth a follow-up so the node-renderer suite can't ship fabricated metrics either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow reliability only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> The benchmark workflow now treats backgrounded Rails and node-renderer targets as first-class processes instead of fire-and-forget jobs under `set -e`.
> 
> **Startup:** Each start step records `$!` as `TARGET_PID` (and `TARGET_LOG` for the node renderer). Readiness loops call `kill -0` so an exit during startup fails immediately with `::error::` (and dumps the renderer log on failure) instead of waiting the full 30s against a dead process.
> 
> **After benchmarks:** "Execute benchmark suite" verifies `TARGET_PID` is set, confirms the process is still alive, and for the renderer scans the log for `died UNEXPECTEDLY`. Any failure exits before Bencher upload, so unreliable metrics are not published.
> 
> A small cleanup groups multiple `GITHUB_OUTPUT` echoes in "Set benchmark outputs" into one block, matching the matrix step style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a628f3a3faa9b0ba7b76830f8d3e59f974939f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved benchmark workflow monitoring to ensure target processes remain alive for the full run; jobs now fail if a process exits early.
  * Added log inspection to detect unexpected worker restarts and prevent publishing unreliable metrics.
  * Adjusted benchmark run-flag output handling to ensure consistent emission of run_* flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Merge decision / follow-up

Worker-specific node-renderer monitoring and log-window hardening are tracked in #3637. This PR still blocks bad benchmark uploads when the monitored target dies, so those refinements are deferred.
