### PR TITLE
fix(pro): resolve React version support range — keep React 18, widen react-on-rails-rsc peer to < 20.0.0 (#3486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Changed
+
+- **[Pro]** **Widened the `react-on-rails-rsc` peer-dependency range to the full React 19 line**: `react-on-rails-pro` now declares `react-on-rails-rsc` as `>= 19.0.2 < 20.0.0` (previously `>= 19.0.2 <= 19.2.3`), so future `react-on-rails-rsc` patch and minor releases on the React 19 line no longer trigger a peer-dependency warning. The `react` / `react-dom` peers stay at `>= 16`: React 18 support is retained, and the React-19-only RSC path is gated through the optional `react-on-rails-rsc` peer rather than by raising the React baseline. Resolves [Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486). [PR 3580](https://github.com/shakacode/react_on_rails/pull/3580) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.1] - 2026-06-02
 
 #### Breaking Changes

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -8,9 +8,32 @@ apps.
 
 This is a planning document. It does not change package versions, build configuration, or Pro package code.
 
-**Status**: Draft | **Created**: 2026-04-30 | **Last updated**: 2026-05-09 | **Tracks**:
+**Status**: Draft | **Created**: 2026-04-30 | **Last updated**: 2026-06-03 | **Tracks**:
 [Issue 2182](https://github.com/shakacode/react_on_rails/issues/2182) and
 [Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255)
+
+## Decision Record — React Version Support Range ([Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486))
+
+Resolved 2026-06-03 by @justin808. This closes the two package-range questions split out of
+[Issue 3255](https://github.com/shakacode/react_on_rails/issues/3255) and tracked in
+[Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486).
+
+1. **Minimum supported React version — keep React 18 (and 16/17) support.** The OSS `react-on-rails` and Pro
+   `react-on-rails-pro` `react` / `react-dom` peer ranges stay at `>= 16`. React on Rails v17 is a Ruby-baseline release
+   (Ruby 3.3+ required), not a React-baseline release, and v17 actively ships features for React 16/17 consumers (the
+   `react-on-rails/webpackHelpers` `reactDomClientWarning` export). The React 19 baseline that RSC requires is expressed
+   where it belongs — at the RSC boundary, through the **optional** `react-on-rails-rsc` peer dependency — so non-RSC
+   SSR/streaming users are not forced off React 18. The `packages/react-on-rails/src/ReactDOMServer.cts` React 16/17 shim
+   therefore stays; its removal remains gated on a future, explicitly-signed-off baseline bump.
+
+2. **`react-on-rails-rsc` peer ceiling — widen to `>= 19.0.2 < 20.0.0`.** The previous `<= 19.2.3` upper bound was a
+   precautionary verified-patch ceiling, not a recorded API incompatibility. No specific API risk was found, so per the
+   issue default the ceiling widens to the full React 19 line. This stops the peer from rejecting a future `19.2.4` patch
+   or `19.3.x` minor release of `react-on-rails-rsc`.
+
+The `react` / `react-dom` peers (`>= 16`) and the `react-on-rails-rsc` peer (`>= 19.0.2 < 20.0.0`) are intentionally
+**not** identical: the RSC peer is optional and only constrains the React-19-only RSC path. This is the resolved, recorded
+outcome for the Open Questions at the end of this document.
 
 ## Current Repository Signal
 
@@ -24,19 +47,18 @@ and `app>react-dom`; verification should
 confirm whether that workspace stays on React 18 during this work. That means the first implementation step is
 verification, not necessarily a broad package-range change.
 
-Note: `packages/react-on-rails-pro/package.json` already sets the `react-on-rails-rsc` peer dependency ceiling to
-`>= 19.0.2 <= 19.2.3` (space means AND; both comparators must be satisfied). These 19.x version numbers apply to the
+Note: `packages/react-on-rails-pro/package.json` now sets the `react-on-rails-rsc` peer dependency ceiling to
+`>= 19.0.2 < 20.0.0` (resolved by the [Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486) decision
+recorded above; widened from the earlier precautionary `<= 19.2.3` ceiling). These 19.x version numbers apply to the
 `react-on-rails-rsc` package, not to React itself: `react-on-rails-rsc`'s major and minor numbers track the React
-release line it targets, so a constraint such as `<= 19.2.3` here is a constraint on the RSC integration package, not on
-the React peer dependency. The `<= 19.2.3` upper bound is a precautionary
-verified-patch ceiling from the current planning pass, not a recorded React API incompatibility. Verification should decide
-whether this ceiling should be widened alongside any React 19.2.x range update. Because a hard upper bound would reject a
-future `19.2.4` patch or `19.3.x` minor release, the decision must either widen the stable React 19 range to
-`>= 19.0.2 < 20.0.0` or document the specific API risk that requires a tight pin. Pre-release React versions should remain
-outside the recommended range unless the verification record explicitly tests them. If verification finds no specific API
-risk, the default outcome is to widen the range to `>= 19.0.2 < 20.0.0`. The same decision must also audit the Pro package
-`react` and `react-dom` peer dependency ranges, currently `>= 16`, so all three peer ranges stay aligned with the minimum
-React version decision. **Owner**: @justin808 | **Target**: before any package-range change is merged (see Open Questions).
+release line it targets, so this range constrains the RSC integration package, not the React peer dependency. The earlier
+`<= 19.2.3` upper bound was a precautionary verified-patch ceiling from the planning pass, not a recorded React API
+incompatibility; verification found no specific API risk, so the ceiling was widened to the full React 19 line per the
+issue default. A future `19.2.4` patch or `19.3.x` minor release of `react-on-rails-rsc` is now accepted. Pre-release
+React versions should remain outside the recommended range unless the verification record explicitly tests them. The Pro
+package `react` and `react-dom` peer dependency ranges stay at `>= 16`: React 18 support is retained, and the React 19
+baseline that RSC requires is expressed through the optional `react-on-rails-rsc` peer rather than by tightening the
+`react` / `react-dom` peers. **Owner**: @justin808 | **Status**: resolved 2026-06-03 (see Decision Record above).
 
 ## React 19.2.x Verification Checklist
 
@@ -62,7 +84,7 @@ Use a dedicated branch for the actual version verification work:
       `pnpm --filter react-on-rails-pro list --depth=0 react-on-rails-rsc` output in the verification record, such as a
       comment on Issue 3255, so the tested React 19.2.x patch version is auditable. Also verify that the resolved
       `react-on-rails-rsc` version satisfies both the root `^19.0.4` range and the
-      `packages/react-on-rails-pro/package.json` peer dependency ceiling `>= 19.0.2 <= 19.2.3`; a mismatch means the ceiling
+      `packages/react-on-rails-pro/package.json` peer dependency ceiling `>= 19.0.2 < 20.0.0`; a mismatch means the ceiling
       must be widened before workspace installs stay consistent across OSS and Pro.
 - [ ] Run package checks. Type checking catches breaking API changes — `@types/react` shifts such as removal of the
       implicit `children` prop from `React.FC` and a stricter `useRef` return type, plus `react-dom/server` changes such
@@ -239,9 +261,10 @@ checklist items there so each assignment is auditable in the issue tracker. If n
   do Rails `ActionController::Live` and Node Renderer streaming paths affect those metrics differently?
   **Owner**: @justin808 | **Secondary reviewer**: React on Rails maintainer with Pro access | **Target**: after the
   SSR-vs-RSC strategy decision, before benchmark implementation
-- Should the minimum supported React version retain React 18.x compatibility or move to React 19.x only?
-  **Owner**: @justin808 | **Target**: before any package-range change is merged
-- Should the `react-on-rails-pro` peer dependency ceiling for `react-on-rails-rsc` stay at `<= 19.2.3` or widen with the
-  React 19.2.x verification work? If it stays tight, what specific API risk justifies rejecting future React 19.x patch
-  or minor releases? Default to widening to `< 20.0.0` when verification finds no specific API risk.
-  **Owner**: @justin808 | **Target**: before any package-range change is merged
+- ~~Should the minimum supported React version retain React 18.x compatibility or move to React 19.x only?~~
+  **Owner**: @justin808 | **Resolved** 2026-06-03 ([Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486)):
+  retain React 18.x (peers stay `>= 16`). See the Decision Record at the top of this document.
+- ~~Should the `react-on-rails-pro` peer dependency ceiling for `react-on-rails-rsc` stay at `<= 19.2.3` or widen with the
+  React 19.2.x verification work?~~
+  **Owner**: @justin808 | **Resolved** 2026-06-03 ([Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486)):
+  widened to `>= 19.0.2 < 20.0.0` (no specific API risk found). See the Decision Record at the top of this document.

--- a/internal/planning/react-19-partial-prerendering-plan.md
+++ b/internal/planning/react-19-partial-prerendering-plan.md
@@ -6,7 +6,9 @@ Track the work needed for [Issue 2182](https://github.com/shakacode/react_on_rai
 support and decide how React on Rails should expose any partial pre-rendering workflow that becomes practical for Rails
 apps.
 
-This is a planning document. It does not change package versions, build configuration, or Pro package code.
+This is a planning document for [Issue 2182](https://github.com/shakacode/react_on_rails/issues/2182). The one package
+change it has driven — the `react-on-rails-rsc` peer-ceiling widening — is captured in the Decision Record below; beyond
+that it does not change build configuration or Pro package code.
 
 **Status**: Draft | **Created**: 2026-04-30 | **Last updated**: 2026-06-03 | **Tracks**:
 [Issue 2182](https://github.com/shakacode/react_on_rails/issues/2182) and

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -72,7 +72,7 @@
   "peerDependencies": {
     "react": ">= 16",
     "react-dom": ">= 16",
-    "react-on-rails-rsc": ">= 19.0.2 <= 19.2.3",
+    "react-on-rails-rsc": ">= 19.0.2 < 20.0.0",
     "@tanstack/react-router": ">=1.139.0 <2.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

Resolves the two release-critical **package-range decisions** split out of #3255 and tracked in #3486. Package ranges are part of the public contract, so this needed explicit sign-off — signed off by @justin808 (2026-06-03).

### Decision 1 — Minimum supported React version: **keep React 18 (and 16/17)**

- OSS `react-on-rails` and Pro `react-on-rails-pro` `react` / `react-dom` peers stay at `>= 16` (no change).
- Rationale: v17 is a **Ruby**-baseline release (Ruby 3.3+), not a React-baseline one, and v17 actively ships features _for React 16/17 consumers_ (the `react-on-rails/webpackHelpers` `reactDomClientWarning` export). The React 19 baseline that RSC requires is expressed where it belongs — at the RSC boundary, through the **optional** `react-on-rails-rsc` peer — so non-RSC SSR/streaming users are not forced off React 18.
- The `packages/react-on-rails/src/ReactDOMServer.cts` React 16/17 shim therefore stays; removal remains gated on a future, explicitly-signed-off baseline bump.

### Decision 2 — `react-on-rails-rsc` peer ceiling: **widen to `>= 19.0.2 < 20.0.0`**

- Pro `react-on-rails-rsc` peer changes from `>= 19.0.2 <= 19.2.3` → `>= 19.0.2 < 20.0.0`.
- The old `<= 19.2.3` upper bound was a precautionary verified-patch ceiling, **not** a recorded API incompatibility. No specific API risk was found, so per the issue default the ceiling widens to the full React 19 line. Future `19.2.4` patch / `19.3.x` minor releases of `react-on-rails-rsc` are now accepted without a peer warning.

The `react`/`react-dom` peers (`>= 16`) and the `react-on-rails-rsc` peer (`>= 19.0.2 < 20.0.0`) are intentionally **not** identical — the RSC peer is optional and only constrains the React-19-only RSC path.

## Changes

- `packages/react-on-rails-pro/package.json` — widen the `react-on-rails-rsc` peer ceiling (the only contract change).
- `internal/planning/react-19-partial-prerendering-plan.md` — add a **Decision Record**, update the now-stale inline ceiling references, and mark the two Open Questions resolved (satisfies the acceptance criterion to record the decision and link it from the planning doc).
- `CHANGELOG.md` — Pro entry under `[Unreleased]`.

## Verification

- `react-on-rails-pro` dev dependency `react-on-rails-rsc@^19.0.4` satisfies the new range.
- `package.json` validates as JSON; `npx prettier --check` passes on all changed files; lefthook pre-commit (markdown-links, trailing-newlines, prettier) passed.
- No Ruby/JS source changed (JSON + Markdown only) — no rubocop/rspec/eslint surface. No test asserts the peer-range string.

## Acceptance criteria (from #3486)

- [x] Explicit, documented decision on the minimum supported React version before any package-range change merges.
- [x] Explicit decision on the peer-dependency ceiling (widen to `< 20.0.0`).
- [x] Decision recorded and linked from `internal/planning/react-19-partial-prerendering-plan.md`; verification record posted on the issue.

Fixes #3486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change (peer range string plus changelog/planning docs); no application or library runtime code paths modified.
> 
> **Overview**
> Resolves **#3486** by documenting two package-contract decisions and applying the only runtime contract change: **`react-on-rails-pro`** now peers on **`react-on-rails-rsc`** as **`>= 19.0.2 < 20.0.0`** (was **`<= 19.2.3`**), so future React 19-line RSC package releases do not trigger install warnings. **`react` / `react-dom`** peers stay **`>= 16`**; React 19 for RSC remains gated by the optional **`react-on-rails-rsc`** peer.
> 
> **`CHANGELOG.md`** adds an **[Unreleased]** Pro note. **`internal/planning/react-19-partial-prerendering-plan.md`** gains a **Decision Record**, updates ceiling wording, and marks the related open questions resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1d967a1ec6a93c3c01d6dd7b0ee64c4f21f5919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Widened the Pro package peer-dependency for react-on-rails-rsc to support the full React 19 line (>= 19.0.2 and < 20.0.0), preventing peer-dependency warnings for future React 19 releases.

* **Documentation**
  * Updated changelog and planning/decision documentation to reflect the revised React 19 support range and related verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->