### PR TITLE
ci(rspack): run OSS dummy integration tests under Rspack (Layer 1 of #3481)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -87,19 +87,33 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
+          # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label).
+          # Legs are built with `jq -nc` so the JSON stays readable/diffable (one leg per line) while
+          # still emitting compact single-line output for $GITHUB_OUTPUT. Refs #3481.
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]] || \
              [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions, plus an
-            # Rspack leg (alongside Webpack) so both bundlers stay green. Refs #3481.
-            echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},{"ruby-version":"3.3","node-version":"20","dependency-level":"minimum","bundler":"webpack"},{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}]}' >> "$GITHUB_OUTPUT"
+            # Rspack leg (alongside Webpack) so both bundlers stay green.
+            matrix="$(jq -nc '{
+              "include": [
+                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest",  "bundler": "webpack" },
+                { "ruby-version": "3.3", "node-version": "20", "dependency-level": "minimum", "bundler": "webpack" },
+                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest",  "bundler": "rspack" }
+              ]
+            }')"
           else
             # PR matrix: test only latest versions for fast feedback, with an Rspack
-            # leg alongside Webpack to guard both bundlers. Refs #3481.
-            echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}]}' >> "$GITHUB_OUTPUT"
+            # leg alongside Webpack to guard both bundlers.
+            matrix="$(jq -nc '{
+              "include": [
+                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest", "bundler": "webpack" },
+                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest", "bundler": "rspack" }
+              ]
+            }')"
           fi
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
 
   build-dummy-app-test-bundles:
     needs: [detect-changes, setup-integration-matrix]
@@ -117,6 +131,9 @@ jobs:
         needs.detect-changes.outputs.run_dummy_tests == 'true'
       )
     strategy:
+      # Keep both bundler legs reporting independently: a failure in one bundler
+      # must not cancel the other (the default fail-fast: true would). Refs #3481.
+      fail-fast: false
       matrix: ${{ fromJson(needs.setup-integration-matrix.outputs.matrix) }}
     runs-on: ubuntu-22.04
     steps:
@@ -178,11 +195,15 @@ jobs:
         # pass this step (the next step's grep matches even on a failed build, since Shakapacker logs
         # "Completed <bundler> build" before it exits non-zero). Fail fast here instead. Refs #3481.
         shell: bash
+        env:
+          # Lifted into env: (rather than inline in the run: line) to match the verify step and avoid
+          # interpolating ${{ }} directly into shell. matrix.bundler is webpack | rspack. Refs #3481.
+          SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }}
         run: |
           set -o pipefail
           rm -rf react_on_rails/spec/dummy/public/webpack/test
           pnpm --filter "react_on_rails" run build:rescript
-          cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" SHAKAPACKER_ASSETS_BUNDLER="${{ matrix.bundler }}" bin/shakapacker 2>&1 | tee "$RUNNER_TEMP/shakapacker-build.log"
+          cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" bin/shakapacker 2>&1 | tee "$RUNNER_TEMP/shakapacker-build.log"
       - name: Verify test bundles were built with ${{ matrix.bundler }}
         # Guard against a silent bundler fallback. Both Shakapacker's bundler-binary selection and its
         # "[Shakapacker] Completed <bundler> build" log line resolve through config.rspack?, which is
@@ -205,7 +226,7 @@ jobs:
           fi
           echo "Confirmed: dummy test bundles built with ${EXPECTED_BUNDLER}."
       - id: get-sha
-        run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Save test bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache/save@v4
         with:
@@ -228,6 +249,9 @@ jobs:
         needs.detect-changes.outputs.run_dummy_tests == 'true'
       )
     strategy:
+      # Keep both bundler legs reporting independently: a failure in one bundler
+      # must not cancel the other (the default fail-fast: true would). Refs #3481.
+      fail-fast: false
       matrix: ${{ fromJson(needs.setup-integration-matrix.outputs.matrix) }}
     runs-on: ubuntu-22.04
     steps:
@@ -267,7 +291,7 @@ jobs:
         if: matrix.dependency-level == 'minimum'
         run: script/convert
       - id: get-sha
-        run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Save test bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache@v4
         with:
@@ -321,6 +345,11 @@ jobs:
         run: |
           echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}" >> "$GITHUB_ENV"
       - name: Main CI
+        # SHAKAPACKER_ASSETS_BUNDLER is intentionally not set here: the specs consume the pre-built
+        # bundles restored from cache above and never re-invoke bin/shakapacker, so the active bundler
+        # is already baked into the compiled assets. If a future spec or setup hook ever does rebuild,
+        # set this step's env to SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }} so the rspack leg
+        # can't silently fall back to webpack (the shakapacker.yml default). Refs #3481.
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -173,19 +173,33 @@ jobs:
       - name: Smoke check generated pack entrypoints
         run: test -s react_on_rails/spec/dummy/client/app/generated/server-bundle-generated.js
       - name: Build test bundles for dummy app
+        # shell: bash gives `bash -eo pipefail`; set -o pipefail is explicit belt-and-suspenders.
+        # Without pipefail the `tee` below masks a nonzero bin/shakapacker exit, letting a broken build
+        # pass this step (the next step's grep matches even on a failed build, since Shakapacker logs
+        # "Completed <bundler> build" before it exits non-zero). Fail fast here instead. Refs #3481.
+        shell: bash
         run: |
+          set -o pipefail
           rm -rf react_on_rails/spec/dummy/public/webpack/test
           pnpm --filter "react_on_rails" run build:rescript
           cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" SHAKAPACKER_ASSETS_BUNDLER="${{ matrix.bundler }}" bin/shakapacker 2>&1 | tee "$RUNNER_TEMP/shakapacker-build.log"
       - name: Verify test bundles were built with ${{ matrix.bundler }}
-        # Guard against a silent bundler fallback. Shakapacker logs
-        # "[Shakapacker] Completed <bundler> build" off the same condition that selects the bundler
-        # binary, so this confirms the rspack leg actually compiled with rspack (and the webpack leg
-        # with webpack) rather than silently using the other bundler and still going green. Refs #3481.
+        # Guard against a silent bundler fallback. Both Shakapacker's bundler-binary selection and its
+        # "[Shakapacker] Completed <bundler> build" log line resolve through config.rspack?, which is
+        # driven by the SHAKAPACKER_ASSETS_BUNDLER env var set in the build step above. Matching the log
+        # therefore confirms the rspack leg actually compiled with rspack (and the webpack leg with
+        # webpack) rather than silently falling back to the other bundler and still going green.
+        # (The build step's set -o pipefail handles the compile-failed case; this guards selection.)
+        # Refs #3481.
         env:
           EXPECTED_BUNDLER: ${{ matrix.bundler }}
         run: |
-          if ! grep -qF "[Shakapacker] Completed ${EXPECTED_BUNDLER} build" "$RUNNER_TEMP/shakapacker-build.log"; then
+          log="$RUNNER_TEMP/shakapacker-build.log"
+          if [ ! -s "$log" ]; then
+            echo "::error::Build log $log is missing or empty - the build step did not produce a log."
+            exit 1
+          fi
+          if ! grep -qF "[Shakapacker] Completed ${EXPECTED_BUNDLER} build" "$log"; then
             echo "::error::Expected a '${EXPECTED_BUNDLER}' build, but Shakapacker did not report completing one. The leg may have silently used a different bundler."
             exit 1
           fi
@@ -195,6 +209,8 @@ jobs:
       - name: Save test bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache/save@v4
         with:
+          # Both bundlers emit into public/webpack in this app (shakapacker.yml public_output_path),
+          # so this path is correct on the rspack leg too despite the "webpack" directory name.
           path: react_on_rails/spec/dummy/public/webpack
           key: dummy-app-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
 
@@ -255,6 +271,8 @@ jobs:
       - name: Save test bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache@v4
         with:
+          # Both bundlers emit into public/webpack in this app (shakapacker.yml public_output_path),
+          # so this path is correct on the rspack leg too despite the "webpack" directory name.
           path: react_on_rails/spec/dummy/public/webpack
           key: dummy-app-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
       - name: Install Node modules with pnpm

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,7 +101,7 @@ jobs:
             echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}]}' >> "$GITHUB_OUTPUT"
           fi
 
-  build-dummy-app-webpack-test-bundles:
+  build-dummy-app-test-bundles:
     needs: [detect-changes, setup-integration-matrix]
     # Skip only if: main push AND non-runtime-only changes
     # Otherwise run if: on main OR workflow_dispatch OR dummy tests needed
@@ -176,17 +176,30 @@ jobs:
         run: |
           rm -rf react_on_rails/spec/dummy/public/webpack/test
           pnpm --filter "react_on_rails" run build:rescript
-          cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" SHAKAPACKER_ASSETS_BUNDLER="${{ matrix.bundler }}" bin/shakapacker
+          cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" SHAKAPACKER_ASSETS_BUNDLER="${{ matrix.bundler }}" bin/shakapacker 2>&1 | tee "$RUNNER_TEMP/shakapacker-build.log"
+      - name: Verify test bundles were built with ${{ matrix.bundler }}
+        # Guard against a silent bundler fallback. Shakapacker logs
+        # "[Shakapacker] Completed <bundler> build" off the same condition that selects the bundler
+        # binary, so this confirms the rspack leg actually compiled with rspack (and the webpack leg
+        # with webpack) rather than silently using the other bundler and still going green. Refs #3481.
+        env:
+          EXPECTED_BUNDLER: ${{ matrix.bundler }}
+        run: |
+          if ! grep -qF "[Shakapacker] Completed ${EXPECTED_BUNDLER} build" "$RUNNER_TEMP/shakapacker-build.log"; then
+            echo "::error::Expected a '${EXPECTED_BUNDLER}' build, but Shakapacker did not report completing one. The leg may have silently used a different bundler."
+            exit 1
+          fi
+          echo "Confirmed: dummy test bundles built with ${EXPECTED_BUNDLER}."
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
-      - name: Save test Webpack bundles to cache (for build number checksum used by RSpec job)
+      - name: Save test bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache/save@v4
         with:
           path: react_on_rails/spec/dummy/public/webpack
-          key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
+          key: dummy-app-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
 
   dummy-app-integration-tests:
-    needs: [detect-changes, setup-integration-matrix, build-dummy-app-webpack-test-bundles]
+    needs: [detect-changes, setup-integration-matrix, build-dummy-app-test-bundles]
     # Run on main, workflow_dispatch, OR when tests needed on PR
     if: |
       !(
@@ -239,11 +252,11 @@ jobs:
         run: script/convert
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
-      - name: Save test Webpack bundles to cache (for build number checksum used by RSpec job)
+      - name: Save test bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache@v4
         with:
           path: react_on_rails/spec/dummy/public/webpack
-          key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
+          key: dummy-app-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
       - name: Install Node modules with pnpm
         # minimum config changes package.json (shakapacker version), so can't use frozen lockfile
         run: pnpm install ${{ matrix.dependency-level == 'latest' && '--frozen-lockfile' || '--no-frozen-lockfile' }}
@@ -288,7 +301,7 @@ jobs:
       - run: cd react_on_rails/spec/dummy && bundle info shakapacker
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
+          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}" >> "$GITHUB_ENV"
       - name: Main CI
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -241,7 +241,7 @@ jobs:
     # every integration leg here is skipped — including the bundler that built fine. Independent
     # build-level signal is still preserved (fail-fast: false runs both build legs); only the
     # integration run is gated. A per-bundler build+integration job split would fully decouple them
-    # and is deferred to a later layer of #3481.
+    # and is tracked in #3593.
     needs: [detect-changes, setup-integration-matrix, build-dummy-app-test-bundles]
     # Run on main, workflow_dispatch, OR when tests needed on PR
     if: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -236,6 +236,12 @@ jobs:
           key: dummy-app-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
 
   dummy-app-integration-tests:
+    # Known Layer-1 tradeoff (#3481): `needs` gates job-to-job, not matrix-leg-to-leg, so if either
+    # bundler's build leg in build-dummy-app-test-bundles fails, that whole job is marked failed and
+    # every integration leg here is skipped — including the bundler that built fine. Independent
+    # build-level signal is still preserved (fail-fast: false runs both build legs); only the
+    # integration run is gated. A per-bundler build+integration job split would fully decouple them
+    # and is deferred to a later layer of #3481.
     needs: [detect-changes, setup-integration-matrix, build-dummy-app-test-bundles]
     # Run on main, workflow_dispatch, OR when tests needed on PR
     if: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -98,9 +98,9 @@ jobs:
             # Rspack leg (alongside Webpack) so both bundlers stay green.
             matrix="$(jq -nc '{
               "include": [
-                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest",  "bundler": "webpack" },
-                { "ruby-version": "3.3", "node-version": "20", "dependency-level": "minimum", "bundler": "webpack" },
-                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest",  "bundler": "rspack" }
+                {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},
+                {"ruby-version":"3.3","node-version":"20","dependency-level":"minimum","bundler":"webpack"},
+                {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}
               ]
             }')"
           else
@@ -108,8 +108,8 @@ jobs:
             # leg alongside Webpack to guard both bundlers.
             matrix="$(jq -nc '{
               "include": [
-                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest", "bundler": "webpack" },
-                { "ruby-version": "4.0", "node-version": "22", "dependency-level": "latest", "bundler": "rspack" }
+                {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},
+                {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}
               ]
             }')"
           fi
@@ -186,6 +186,8 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
       - name: generate file system-based packs
+        env:
+          SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }}
         run: cd react_on_rails/spec/dummy && RAILS_ENV="test" bundle exec rake react_on_rails:generate_packs
       - name: Smoke check generated pack entrypoints
         run: test -s react_on_rails/spec/dummy/client/app/generated/server-bundle-generated.js
@@ -339,6 +341,8 @@ jobs:
       - name: Increase the amount of inotify watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: generate file system-based packs
+        env:
+          SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }}
         run: cd react_on_rails/spec/dummy && RAILS_ENV="test" bundle exec rake react_on_rails:generate_packs
       - name: Git Stuff
         if: matrix.dependency-level == 'minimum'
@@ -351,11 +355,10 @@ jobs:
         run: |
           echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}" >> "$GITHUB_ENV"
       - name: Main CI
-        # SHAKAPACKER_ASSETS_BUNDLER is intentionally not set here: the specs consume the pre-built
-        # bundles restored from cache above and never re-invoke bin/shakapacker, so the active bundler
-        # is already baked into the compiled assets. If a future spec or setup hook ever does rebuild,
-        # set this step's env to SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }} so the rspack leg
-        # can't silently fall back to webpack (the shakapacker.yml default). Refs #3481.
+        # Normal runs consume cached bundles, but EnsureAssetsCompiled can rebuild if assets are stale.
+        # Keep the override here so the rspack leg cannot fall back to webpack on that path. Refs #3481.
+        env:
+          SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }}
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,11 +92,13 @@ jobs:
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]] || \
              [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
-            # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.3","node-version":"20","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
+            # Full matrix: test both latest and minimum supported versions, plus an
+            # Rspack leg (alongside Webpack) so both bundlers stay green. Refs #3481.
+            echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},{"ruby-version":"3.3","node-version":"20","dependency-level":"minimum","bundler":"webpack"},{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}]}' >> "$GITHUB_OUTPUT"
           else
-            # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
+            # PR matrix: test only latest versions for fast feedback, with an Rspack
+            # leg alongside Webpack to guard both bundlers. Refs #3481.
+            echo 'matrix={"include":[{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},{"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build-dummy-app-webpack-test-bundles:
@@ -174,14 +176,14 @@ jobs:
         run: |
           rm -rf react_on_rails/spec/dummy/public/webpack/test
           pnpm --filter "react_on_rails" run build:rescript
-          cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" bin/shakapacker
+          cd react_on_rails/spec/dummy && RAILS_ENV="test" NODE_ENV="test" SHAKAPACKER_ASSETS_BUNDLER="${{ matrix.bundler }}" bin/shakapacker
       - id: get-sha
         run: echo "sha=\"$(git rev-parse HEAD)\"" >> "$GITHUB_OUTPUT"
       - name: Save test Webpack bundles to cache (for build number checksum used by RSpec job)
         uses: actions/cache/save@v4
         with:
           path: react_on_rails/spec/dummy/public/webpack
-          key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
+          key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
 
   dummy-app-integration-tests:
     needs: [detect-changes, setup-integration-matrix, build-dummy-app-webpack-test-bundles]
@@ -241,7 +243,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: react_on_rails/spec/dummy/public/webpack
-          key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
+          key: dummy-app-webpack-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
       - name: Install Node modules with pnpm
         # minimum config changes package.json (shakapacker version), so can't use frozen lockfile
         run: pnpm install ${{ matrix.dependency-level == 'latest' && '--frozen-lockfile' || '--no-frozen-lockfile' }}
@@ -292,20 +294,20 @@ jobs:
       - name: Store test results
         uses: actions/upload-artifact@v4
         with:
-          name: main-rspec-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
+          name: main-rspec-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
           path: ~/rspec
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dummy-app-capybara-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
+          name: dummy-app-capybara-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
           path: react_on_rails/spec/dummy/tmp/capybara
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dummy-app-test-log-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
+          name: dummy-app-test-log-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
           path: react_on_rails/spec/dummy/log/test.log
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dummy-app-pnpm-log-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}
+          name: dummy-app-pnpm-log-${{ github.run_id }}-${{ github.job }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
           path: react_on_rails/spec/dummy/pnpm-debug.log


### PR DESCRIPTION
## Summary

Wires the **CI coverage** for Rspack in the OSS spec dummy app — the piece #3510 deliberately deferred for workflow approval. Adds a `bundler` matrix dimension to `integration-tests.yml` so `react_on_rails/spec/dummy` **builds and runs its full RSpec integration suite under Rspack alongside Webpack**. Webpack stays the default; the new leg sets `SHAKAPACKER_ASSETS_BUNDLER=rspack`, which Shakapacker resolves ahead of the `assets_bundler: webpack` default in `config/shakapacker.yml`.

This is **Layer 1** (breadth: keep both bundlers green) from the issue's manager triage. It builds directly on the Rspack scaffolding (configs + deps) merged in #3510.

## Changes (`.github/workflows/integration-tests.yml`)

- **`setup-integration-matrix`** — pin existing entries to `bundler: webpack` and add **one** rspack leg (ruby 4.0 / node 22 / latest) to both the full-ci and PR matrices. Cost: **+1 job on PRs, +1 on full-ci**.
- **Build job** — thread `SHAKAPACKER_ASSETS_BUNDLER=${{ matrix.bundler }}` into the dummy test-bundle build.
- **Cache keys + artifact names** — add `matrix.bundler` so the webpack and rspack legs (which share ruby 4.0 / latest) don't collide on the bundle cache or upload-artifact names.

### Hardening + naming (follow-up commit)

- **Assert the resolved bundler** — a new _Verify test bundles were built with `<bundler>`_ step captures `bin/shakapacker` output and greps for Shakapacker's `[Shakapacker] Completed <bundler> build` line. That line is emitted from the **same condition that selects the bundler binary**, so the rspack leg now **fails loudly** instead of going green if `SHAKAPACKER_ASSETS_BUNDLER` is ever ignored or silently falls back to webpack. Closes the one silent-failure surface flagged in review.
- **Drop misleading "webpack" names in this workflow** — `build-dummy-app-webpack-test-bundles` → `build-dummy-app-test-bundles`, the _Save test Webpack bundles_ step → _Save test bundles_, and the `dummy-app-webpack-bundle-` cache-key prefix → `dummy-app-bundle-`. These now cover both bundlers. The Pro workflows keep their webpack-specific names (they only build webpack). The cache key is a same-SHA intra-run handoff, so the prefix change has **no cache-miss cost**.
- **`CI_DEPENDENCY_LEVEL`** now includes `matrix.bundler` so the webpack and rspack latest legs are uniquely identified.

No production code changes; CI configuration only.

## Verification

- `actionlint` clean (the workflow CI gate). yamllint is not a CI gate in this repo.
- Local build of `react_on_rails/spec/dummy` test bundles:
  - `SHAKAPACKER_ASSETS_BUNDLER=rspack bin/shakapacker` → Rspack resolves `config/rspack/rspack.config.js`, compiles client + server, emits a valid `manifest.json` + 3.3 MB `server-bundle.js`.
  - `SHAKAPACKER_ASSETS_BUNDLER=webpack bin/shakapacker` → unchanged (webpack 5, valid manifest). The `NODE_ENV` DefinePlugin warning pre-exists on both bundlers.
- **New verify step proven locally on both legs**: the rspack build emits `[Shakapacker] Completed rspack build` (step passes) and contains no webpack marker; the webpack build emits `[Shakapacker] Completed webpack build` (step passes). A leg that silently used the wrong bundler would fail this grep.
- The full browser-based RSpec suite under Rspack is exercised by the new CI leg.

## Deferred follow-ups (not in this PR)

- Pro `spec/dummy` — no Rspack scaffolding yet (out of #3510's scope).
- `execjs-compatible-dummy` — scaffolded in #3510 but not actually built in any CI job today; wiring a build is its own change.
- Production `precompile-check` under Rspack.
- **Layer 2**: the Pro RSC runtime / route-hydration gate — depends on #3488 and the native `RSCRspackPlugin` (RSC + Rspack still experimental).

Refs #3481. Kept open (not `Closes`) since the above remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that add CI coverage and guards; no runtime, auth, or production asset paths are modified.
> 
> **Overview**
> Extends **integration-tests** so the OSS spec dummy app is exercised under **Rspack as well as Webpack** (Layer 1 of #3481), with no application code changes.
> 
> The integration matrix now includes a **`bundler`** dimension (`webpack` | `rspack`): full CI and PR runs each add an rspack leg alongside the existing webpack legs. **`SHAKAPACKER_ASSETS_BUNDLER`** is set on pack generation, `bin/shakapacker` test builds, and the main RSpec run so Shakapacker does not silently default to webpack from `shakapacker.yml`.
> 
> **Build hardening:** the dummy bundle build uses **`pipefail`** and logs output to a file; a new step **greps for** `[Shakapacker] Completed <bundler> build` so a leg fails if the wrong bundler ran. **`fail-fast: false`** on matrix jobs keeps webpack and rspack reporting independently. Cache keys, **`CI_DEPENDENCY_LEVEL`**, and artifact names include **`matrix.bundler`** to avoid collisions; job/step names drop webpack-only wording where both bundlers apply.
> 
> **Note:** if either bundler’s build job fails, integration is still skipped for all legs (documented tradeoff; #3593).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9340fe30577ea340568ee7d9b9e43238618d5b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI matrix to run builds with both webpack and rspack and added explicit Node versions for full and PR runs.
  * Updated CI to capture and verify bundler-specific build logs and to avoid failing fast across matrix legs.
  * Separated build caches and test artifacts per bundler by including bundler in cache keys and artifact names to prevent collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
