### PR TITLE
fix(pro): preload CSS behind 'use client' RSC boundaries to stop FOUC (#3211)

### DIFF
--- a/.claude/docs/3211-rsc-css-fouc-design.md
+++ b/.claude/docs/3211-rsc-css-fouc-design.md
@@ -71,8 +71,9 @@ chunkGroup.chunks.forEach(function (c) {
 });
 ```
 
-Patched loop keeps JS behavior **byte-identical** (still one `.js` per chunk) and
-additionally collects every `.css` file into a sibling `cssChunks` array:
+Patched loop preserves one-`.js`-per-chunk recording while iterating every entry
+in `c.files`, and additionally collects every `.css` file into a sibling
+`cssChunks` array:
 
 ```js
 chunkGroup.chunks.forEach(function (c) {
@@ -109,11 +110,11 @@ Injection point: `streamRenderRSCComponent` in
 `renderToPipeableStream(await reactRenderingResult, …)`.
 
 New pure helper `resolveCssHrefs(manifest): string[]` walks
-`filePathToModuleMetadata`, collects every entry's `css`, dedupes via `Set`,
-prepends `moduleLoading.prefix`, and returns a **sorted** array (sort = build/test
-stability, not cascade semantics). The client manifest is loaded through a small
-cached accessor added next to the existing loaders in `cache/` so the renderer
-can read it without re-reading the file per request.
+`filePathToModuleMetadata`, collects every entry's `css`, dedupes while
+preserving manifest/chunk order, and prepends `moduleLoading.prefix`. The client
+manifest is loaded through a small cached accessor added next to the existing
+loaders in `cache/` so the renderer can read it without re-reading the file per
+unchanged manifest file signature.
 
 Wrap the user tree:
 
@@ -172,16 +173,16 @@ navigation they decode and React hoists/dedupes/suspends commit identically.
 
 ## Touch points
 
-| File                                                             | Change                                                             |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `package.json` (`pnpm.patchedDependencies`)                      | register the patch                                                 |
-| `patches/react-on-rails-rsc@19.0.4.patch` _(new)_                | collect `.css` into `css[]`                                        |
-| `packages/react-on-rails-pro/src/resolveCssHrefs.ts` _(new)_     | manifest → sorted deduped hrefs                                    |
-| `cache/` client-manifest accessor                                | cached read of client manifest for the renderer                    |
-| `packages/react-on-rails-pro/src/capabilities/proRSC.ts`         | wrap tree with `<link precedence>` before `renderToPipeableStream` |
-| `…/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb` | unpend; assert `css`                                               |
-| `…/spec/dummy/e2e-tests/`                                        | assert `<link precedence>` in `<head>` + computed bg color         |
-| `react_on_rails_rsc` types (consumed)                            | `ImportManifestEntry.css?: string[]` (via patch + local type)      |
+| File                                                             | Change                                                                         |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `package.json` (`pnpm.patchedDependencies`)                      | register the patch                                                             |
+| `patches/react-on-rails-rsc@19.0.4.patch` _(new)_                | collect `.css` into `css[]`                                                    |
+| `packages/react-on-rails-pro/src/resolveCssHrefs.ts` _(new)_     | manifest → ordered deduped hrefs                                               |
+| `cache/` client-manifest accessor                                | cached read of client manifest for the renderer, invalidated by file signature |
+| `packages/react-on-rails-pro/src/capabilities/proRSC.ts`         | wrap tree with `<link precedence>` before `renderToPipeableStream`             |
+| `…/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb` | unpend; assert `css`                                                           |
+| `…/spec/dummy/e2e-tests/`                                        | assert `<link precedence>` in `<head>` + computed bg color                     |
+| `react_on_rails_rsc` types (consumed)                            | `ImportManifestEntry.css?: string[]` (via patch + local type)                  |
 
 ## Migration / compatibility
 

--- a/.claude/docs/3211-rsc-css-fouc-design.md
+++ b/.claude/docs/3211-rsc-css-fouc-design.md
@@ -1,0 +1,200 @@
+# Design: Fix CSS FOUC behind `'use client'` boundaries (issue #3211)
+
+Status: approved 2026-06-03. Single PR (patch + renderer + tests).
+
+## Problem
+
+When a true React Server Component renders a `'use client'` boundary, any CSS
+imported by that boundary (or its descendants) is **not** preloaded. It loads
+only as a side-effect of the JS chunk evaluating — several hundred ms to several
+seconds after first paint — producing a visible flash of unstyled content
+(FOUC). On slow networks the gap is large enough to be jarring.
+
+Two independent gaps cause this, and **both** must be closed:
+
+1. **Manifest gap.** The patched `react-server-dom-webpack-plugin.js` shipped by
+   `react-on-rails-rsc@19.0.4` records only `.js` files for each client
+   reference. The `mini-css-extract-plugin` CSS sibling of the same chunk group
+   is dropped, so nothing downstream even _knows_ the CSS exists.
+2. **Renderer gap.** The Pro RSC renderer never emits any CSS metadata — no
+   `<link rel="stylesheet">`, no `preloadStyle`/`preinitStyle`, no `precedence`.
+   The only path by which CSS reaches the page is the mini-css-extract runtime
+   appending a `<link>` when each JS chunk evaluates — which is exactly the
+   too-late path that causes the flicker.
+
+The bug is invisible in `react_on_rails_pro/spec/dummy` historically because its
+RSC components used inline `style={{…}}`. PR #3527 (merged) added a real CSS
+module behind a `'use client'` boundary (`UseClientCssProbe`) plus a _pending_
+manifest spec that traps gap #1.
+
+## Why the fix is entirely in this repo
+
+The upstream package fix (`shakacode/react_on_rails_rsc#35`) is still open and
+unpublished. There is no fixed release to depend on. So the manifest half ships
+here as a `pnpm patch` against `19.0.4`, mirroring what rsc#35 will eventually
+publish; when a fixed release lands we drop the patch.
+
+## The mechanism we rely on: React 19 `<link precedence>`
+
+All RSC frameworks (Next App Router, Vite RSC/Waku, TanStack Start) converge on
+one React 19 primitive: render `<link rel="stylesheet" href precedence>` into
+the React tree. React 19 then:
+
+- hoists each `<link>` into `<head>`,
+- dedupes by `href`, and
+- **blocks tree commit until the stylesheet's `load` fires**.
+
+That last property is what makes FOUC structurally impossible. Because we emit
+the links _inside the RSC Flight payload_, the same elements re-materialize on
+client navigation (`createFromReadableStream`) and React hoists/dedupes/suspends
+identically — so SSR and CSR are both covered with no CSR-specific code.
+
+## Design
+
+### Part A — Manifest plugin patch (record CSS)
+
+`patches/react-on-rails-rsc@19.0.4.patch`, applied via pnpm
+`patchedDependencies`, rewrites the chunk-collection loop in
+`dist/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js`.
+
+Current (buggy) inner loop records at most the first `.js` per chunk and `break`s
+on the first non-`.js` file, dropping CSS:
+
+```js
+chunkGroup.chunks.forEach(function (c) {
+  for (const file of c.files) {
+    if (!file.endsWith('.js')) break; // drops css
+    if (file.endsWith('.hot-update.js')) break;
+    chunks.push(c.id, file);
+    break; // one js per chunk
+  }
+});
+```
+
+Patched loop keeps JS behavior **byte-identical** (still one `.js` per chunk) and
+additionally collects every `.css` file into a sibling `cssChunks` array:
+
+```js
+chunkGroup.chunks.forEach(function (c) {
+  let jsRecorded = false;
+  for (const file of c.files) {
+    if (file.endsWith('.hot-update.js')) continue;
+    if (!jsRecorded && file.endsWith('.js')) {
+      chunks.push(c.id, file);
+      jsRecorded = true;
+    } else if (file.endsWith('.css')) {
+      cssChunks.push(file);
+    }
+  }
+});
+```
+
+`recordModule` writes `{ id, chunks, css: cssChunks, name: "*" }`. The manifest
+type `ImportManifestEntry` gains an optional `css?: string[]` — backward
+compatible; the Flight client runtime ignores it.
+
+Decisions:
+
+- Keep the existing per-chunkGroup overwrite semantics for both `chunks` and
+  `css` (no chunk-merge change). Minimal, parity with current JS handling. If a
+  test later proves CSS needs cross-chunk-group merge, that is a separate change.
+- `css` filenames are bare emitted names (e.g. `css/2696-bb8356be.css`); the
+  `moduleLoading.prefix` from the manifest is prepended at render time to form a
+  usable href (handles CDN / non-default `publicPath`).
+
+### Part B — Renderer emits `<link rel="stylesheet" precedence>` (SSR)
+
+Injection point: `streamRenderRSCComponent` in
+`packages/react-on-rails-pro/src/capabilities/proRSC.ts`, immediately before
+`renderToPipeableStream(await reactRenderingResult, …)`.
+
+New pure helper `resolveCssHrefs(manifest): string[]` walks
+`filePathToModuleMetadata`, collects every entry's `css`, dedupes via `Set`,
+prepends `moduleLoading.prefix`, and returns a **sorted** array (sort = build/test
+stability, not cascade semantics). The client manifest is loaded through a small
+cached accessor added next to the existing loaders in `cache/` so the renderer
+can read it without re-reading the file per request.
+
+Wrap the user tree:
+
+```jsx
+const tree = await reactRenderingResult;
+const wrapped = React.createElement(
+  React.Fragment,
+  null,
+  ...cssHrefs.map((href) =>
+    React.createElement('link', { key: href, rel: 'stylesheet', href, precedence: 'ror-rsc' }),
+  ),
+  tree,
+);
+renderToPipeableStream(wrapped, { onError });
+```
+
+`precedence` value: `ror-rsc`.
+
+v1 = **eager emission**: emit every client-reference CSS chunk on every RSC
+render, in manifest-traversal order. A few KB for the dummy app. Acceptable when
+CSS Modules are properly scoped. Tree-walked emission (emit only references
+encountered during render, via `prepareDestinationForModule` /
+`preinitStyle`) is the documented future optimization, not v1.
+
+### Part C — CSR (`prerender: false`)
+
+No code change. The `<link>`s live inside the RSC Flight payload; on client
+navigation they decode and React hoists/dedupes/suspends commit identically.
+
+### Part D — Tests
+
+1. **Manifest (Part A).** Flip the merged `rsc_use_client_css_manifest_spec.rb`
+   from `pending` to asserting `metadata.fetch("css")` includes a `.css` href.
+2. **Render (Part B/C).** Reuse the existing `UseClientCssProbe`, already
+   rendered by `RSCPostsPage/Main.jsx` on the live streaming-RSC route
+   `/rsc_posts_page_over_http`. Assert:
+   - `<head>` contains `link[rel="stylesheet"][data-precedence]` whose `href`
+     resolves to the probe's CSS, and
+   - the probe element's computed `background-color` is the styled value
+     (`rgb(212, 250, 236)`) after load.
+
+   This is a deterministic, structural assertion of the anti-FOUC mechanism — no
+   network-timing race.
+
+## Explicitly out of scope (YAGNI)
+
+- No `mini-css-extract` `insert` override (Next's `_N_E_STYLE_LOAD`).
+- No `data-rsc-css-href` markers + post-decode harvest (TanStack pattern).
+- No per-route entry-CSS map (Next's `entryCSSFiles`).
+- No CSR-side `preinitStyle` (deferred perf optimization, not correctness).
+- No throttled "Slow 3G" e2e variant (flaky; the structural assertion above
+  covers the regression deterministically). Optional manual follow-up only.
+- No non-CSS asset types (fonts, images).
+- No separate `RSCFOUCDemo` fixture — the merged `UseClientCssProbe` is the
+  single canonical probe.
+
+## Touch points
+
+| File                                                             | Change                                                             |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `package.json` (`pnpm.patchedDependencies`)                      | register the patch                                                 |
+| `patches/react-on-rails-rsc@19.0.4.patch` _(new)_                | collect `.css` into `css[]`                                        |
+| `packages/react-on-rails-pro/src/resolveCssHrefs.ts` _(new)_     | manifest → sorted deduped hrefs                                    |
+| `cache/` client-manifest accessor                                | cached read of client manifest for the renderer                    |
+| `packages/react-on-rails-pro/src/capabilities/proRSC.ts`         | wrap tree with `<link precedence>` before `renderToPipeableStream` |
+| `…/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb` | unpend; assert `css`                                               |
+| `…/spec/dummy/e2e-tests/`                                        | assert `<link precedence>` in `<head>` + computed bg color         |
+| `react_on_rails_rsc` types (consumed)                            | `ImportManifestEntry.css?: string[]` (via patch + local type)      |
+
+## Migration / compatibility
+
+- Manifest extension is backward compatible (`css` optional, JS chunks
+  unchanged).
+- Apps without `'use client'` boundaries behave identically.
+- React Flight client never reads `css`; only the SSR renderer consumes it.
+
+## Test plan (commands)
+
+- `pnpm install` (applies the patch)
+- `cd react_on_rails_pro/spec/dummy && bundle exec rake react_on_rails:generate_packs`
+- `cd react_on_rails_pro/spec/dummy && pnpm run build:test`
+- `bundle exec rspec spec/requests/rsc_use_client_css_manifest_spec.rb` → green (no pending)
+- Playwright e2e for `/rsc_posts_page_over_http` → link-in-head + bg-color assertions pass
+- `bundle exec rubocop` on changed Ruby; lint changed JS/TS

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -30,10 +30,10 @@ jobs:
           SKIP_FILE=".bundle-size-skip-branch"
           SKIP_BRANCH=$(grep -v '^[[:space:]]*#' "$SKIP_FILE" 2>/dev/null | grep -v '^[[:space:]]*$' | tr -d '[:space:]' || echo "")
           if [ "$SKIP_BRANCH" = "$BRANCH" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Branch '$BRANCH' is set to skip size check"
           else
-            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
   check-bundle-size:
@@ -53,8 +53,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       # 1. Get PR's size-limit config first (base branch may not have it)
       - name: Checkout PR branch for config

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.4
 
       # 1. Get PR's size-limit config first (base branch may not have it)
       - name: Checkout PR branch for config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **[Pro]** **Widened the `react-on-rails-rsc` peer-dependency range to the full React 19 line**: `react-on-rails-pro` now declares `react-on-rails-rsc` as `>= 19.0.2 < 20.0.0` (previously `>= 19.0.2 <= 19.2.3`), so future `react-on-rails-rsc` patch and minor releases on the React 19 line no longer trigger a peer-dependency warning. The `react` / `react-dom` peers stay at `>= 16`: React 18 support is retained, and the React-19-only RSC path is gated through the optional `react-on-rails-rsc` peer rather than by raising the React baseline. Resolves [Issue 3486](https://github.com/shakacode/react_on_rails/issues/3486). [PR 3580](https://github.com/shakacode/react_on_rails/pull/3580) by [justin808](https://github.com/justin808).
 
+#### Fixed
+
+- **[Pro]** **RSC CSS no longer flashes unstyled (FOUC) behind `'use client'` boundaries**: CSS imported by a `'use client'` boundary in a true React Server Component tree is now preloaded instead of loading only as a side effect of the JS chunk evaluating. The RSC client manifest now records each client reference's `.css` siblings (via a `pnpm` patch to `react-on-rails-rsc` until the upstream fix is published), and the Pro RSC renderer emits `<link rel="stylesheet" precedence="ror-rsc">` for them inside the RSC payload so React 19 hoists the stylesheets into `<head>` and blocks paint until they load — on both server render and client-side navigation. Fixes [Issue 3211](https://github.com/shakacode/react_on_rails/issues/3211). [PR 3587](https://github.com/shakacode/react_on_rails/pull/3587) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.1] - 2026-06-02
 
 #### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "publint": "^0.3.4",
     "react": "^19.0.3",
     "react-dom": "^19.0.3",
-    "react-on-rails-rsc": "^19.0.4",
+    "react-on-rails-rsc": "19.0.4",
     "redux": "^4.2.1",
     "size-limit": "^12.0.0",
     "stylelint": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,9 @@
   "homepage": "https://github.com/shakacode/react_on_rails#readme",
   "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
   "pnpm": {
+    "patchedDependencies": {
+      "react-on-rails-rsc@19.0.4": "patches/react-on-rails-rsc@19.0.4.patch"
+    },
     "// for overrides": [
       "Generated via pnpm audit --fix, with manual caps added to prevent major version jumps.",
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -99,6 +99,6 @@
     "mock-fs": "^5.5.0",
     "react": "^19.0.3",
     "react-dom": "^19.0.3",
-    "react-on-rails-rsc": "^19.0.4"
+    "react-on-rails-rsc": "19.0.4"
   }
 }

--- a/packages/react-on-rails-pro/src/cache/manifestLoader.ts
+++ b/packages/react-on-rails-pro/src/cache/manifestLoader.ts
@@ -15,15 +15,42 @@
 import type { BundleManifest } from 'react-on-rails-rsc';
 import { buildClientRenderer } from 'react-on-rails-rsc/client.node';
 import loadJsonFile from '../loadJsonFile.ts';
+import resolveCssHrefs from '../resolveCssHrefs.ts';
 
 let clientManifestFileName: string | undefined;
 let serverClientManifestFileName: string | undefined;
 
 let clientRendererPromise: Promise<ReturnType<typeof buildClientRenderer>> | undefined;
+let rscCssHrefsPromise: Promise<string[]> | undefined;
 
 export function setManifestFileNames(clientManifest: string, serverClientManifest: string): void {
   clientManifestFileName = clientManifest;
   serverClientManifestFileName = serverClientManifest;
+}
+
+/**
+ * Stylesheet hrefs for every `'use client'` module reference in the RSC client
+ * manifest, used to emit `<link rel="stylesheet" precedence>` into the RSC
+ * payload so React hoists them into `<head>` (preventing CSS FOUC, see #3211).
+ * Memoized per process — the manifest is a build-time constant.
+ */
+export function getRscCssHrefs(): Promise<string[]> {
+  if (!rscCssHrefsPromise) {
+    if (!clientManifestFileName) {
+      throw new Error(
+        'Manifest file names not set. Ensure setManifestFileNames() is called before getRscCssHrefs(). ' +
+          'This is done automatically during the first RSC render request.',
+      );
+    }
+    const clientFile = clientManifestFileName;
+    rscCssHrefsPromise = loadJsonFile<BundleManifest>(clientFile)
+      .then((reactClientManifest) => resolveCssHrefs(reactClientManifest))
+      .catch((err: unknown) => {
+        rscCssHrefsPromise = undefined;
+        throw err;
+      });
+  }
+  return rscCssHrefsPromise;
 }
 
 export function getClientManifestFileName(): string | undefined {

--- a/packages/react-on-rails-pro/src/cache/manifestLoader.ts
+++ b/packages/react-on-rails-pro/src/cache/manifestLoader.ts
@@ -14,25 +14,54 @@
 
 import type { BundleManifest } from 'react-on-rails-rsc';
 import { buildClientRenderer } from 'react-on-rails-rsc/client.node';
-import loadJsonFile from '../loadJsonFile.ts';
+import loadJsonFile, { clearLoadedJsonFile, getJsonFileSignature } from '../loadJsonFile.ts';
 import resolveCssHrefs from '../resolveCssHrefs.ts';
 
 let clientManifestFileName: string | undefined;
 let serverClientManifestFileName: string | undefined;
+let manifestCacheKey: string | undefined;
 
 let clientRendererPromise: Promise<ReturnType<typeof buildClientRenderer>> | undefined;
 let rscCssHrefsPromise: Promise<string[]> | undefined;
 
+const buildManifestCacheKey = (clientManifest: string, serverClientManifest: string): string =>
+  `${getJsonFileSignature(clientManifest)}\0${getJsonFileSignature(serverClientManifest)}`;
+
+const clearManifestDerivedCaches = (manifestFiles: Array<string | undefined>): void => {
+  clientRendererPromise = undefined;
+  rscCssHrefsPromise = undefined;
+  for (const manifestFile of manifestFiles) {
+    if (manifestFile) {
+      clearLoadedJsonFile(manifestFile);
+    }
+  }
+};
+
 export function setManifestFileNames(clientManifest: string, serverClientManifest: string): void {
+  const previousClientManifest = clientManifestFileName;
+  const previousServerClientManifest = serverClientManifestFileName;
+  const nextManifestCacheKey = buildManifestCacheKey(clientManifest, serverClientManifest);
+
   clientManifestFileName = clientManifest;
   serverClientManifestFileName = serverClientManifest;
+
+  if (nextManifestCacheKey !== manifestCacheKey) {
+    manifestCacheKey = nextManifestCacheKey;
+    clearManifestDerivedCaches([
+      previousClientManifest,
+      previousServerClientManifest,
+      clientManifest,
+      serverClientManifest,
+    ]);
+  }
 }
 
 /**
  * Stylesheet hrefs for every `'use client'` module reference in the RSC client
  * manifest, used to emit `<link rel="stylesheet" precedence>` into the RSC
  * payload so React hoists them into `<head>` (preventing CSS FOUC, see #3211).
- * Memoized per process — the manifest is a build-time constant.
+ * Memoized per manifest file signature so development rebuilds refresh stylesheet
+ * hrefs while production requests reuse the same loaded manifest.
  */
 export function getRscCssHrefs(): Promise<string[]> {
   if (!rscCssHrefsPromise) {
@@ -55,6 +84,10 @@ export function getRscCssHrefs(): Promise<string[]> {
 
 export function getClientManifestFileName(): string | undefined {
   return clientManifestFileName;
+}
+
+export function getManifestCacheKey(): string | undefined {
+  return manifestCacheKey;
 }
 
 export function getClientRenderer(): Promise<ReturnType<typeof buildClientRenderer>> {

--- a/packages/react-on-rails-pro/src/cache/manifestLoaderServer.ts
+++ b/packages/react-on-rails-pro/src/cache/manifestLoaderServer.ts
@@ -15,12 +15,19 @@
 import type { BundleManifest } from 'react-on-rails-rsc';
 import { buildServerRenderer } from 'react-on-rails-rsc/server.node';
 import loadJsonFile from '../loadJsonFile.ts';
-import { getClientManifestFileName } from './manifestLoader.ts';
+import { getClientManifestFileName, getManifestCacheKey } from './manifestLoader.ts';
 
 let serverRendererPromise: Promise<ReturnType<typeof buildServerRenderer>> | undefined;
+let serverRendererManifestCacheKey: string | undefined;
 
 // eslint-disable-next-line import/prefer-default-export -- named export for consistency with manifestLoader
 export function getServerRenderer(): Promise<ReturnType<typeof buildServerRenderer>> {
+  const currentManifestCacheKey = getManifestCacheKey();
+  if (currentManifestCacheKey !== serverRendererManifestCacheKey) {
+    serverRendererManifestCacheKey = currentManifestCacheKey;
+    serverRendererPromise = undefined;
+  }
+
   if (!serverRendererPromise) {
     const clientManifest = getClientManifestFileName();
     if (!clientManifest) {

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -16,6 +16,8 @@
 
 import { Readable } from 'stream';
 
+import * as React from 'react';
+
 import {
   RSCRenderParams,
   assertRailsContextWithServerStreamingCapabilities,
@@ -31,9 +33,36 @@ import {
   StreamingTrackers,
   transformRenderStreamChunksToResultObject,
 } from '../streamingUtils.ts';
-import { setManifestFileNames } from '../cache/manifestLoader.ts';
+import { setManifestFileNames, getRscCssHrefs } from '../cache/manifestLoader.ts';
 import { getServerRenderer } from '../cache/manifestLoaderServer.ts';
 import { setBuildId } from '../cache/buildIdProvider.ts';
+
+// Precedence group for RSC-emitted stylesheet <link>s. React 19 hoists links
+// that share a precedence into <head> together and blocks tree commit until they
+// load, which is what prevents CSS FOUC on 'use client' boundaries (#3211).
+const RSC_CSS_PRECEDENCE = 'ror-rsc';
+
+/**
+ * Wrap the rendered RSC tree with `<link rel="stylesheet" precedence>` for every
+ * stylesheet imported behind a `'use client'` boundary. Emitting the links
+ * inside the RSC payload means React hoists/dedupes them into `<head>` on both
+ * the initial SSR stream and on client-side navigation (the same payload decodes
+ * identically), so no CSR-specific handling is needed.
+ */
+const wrapWithRscCssLinks = (renderedTree: React.ReactNode, cssHrefs: readonly string[]): React.ReactNode => {
+  if (cssHrefs.length === 0) {
+    return renderedTree;
+  }
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    ...cssHrefs.map((href) =>
+      React.createElement('link', { key: href, rel: 'stylesheet', href, precedence: RSC_CSS_PRECEDENCE }),
+    ),
+    renderedTree,
+  );
+};
 
 const CLIENT_HOOK_NAMES = [
   'useState',
@@ -129,7 +158,8 @@ const streamRenderRSCComponent = (
 
   const initializeAndRender = async () => {
     const { renderToPipeableStream } = await getServerRenderer();
-    const rscStream = renderToPipeableStream(await reactRenderingResult, {
+    const [renderedTree, cssHrefs] = await Promise.all([reactRenderingResult, getRscCssHrefs()]);
+    const rscStream = renderToPipeableStream(wrapWithRscCssLinks(renderedTree, cssHrefs), {
       onError: (err) => {
         const error = convertToError(err);
         reportError(error);

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -54,14 +54,10 @@ const wrapWithRscCssLinks = (renderedTree: React.ReactNode, cssHrefs: readonly s
     return renderedTree;
   }
 
-  return React.createElement(
-    React.Fragment,
-    null,
-    ...cssHrefs.map((href) =>
-      React.createElement('link', { key: href, rel: 'stylesheet', href, precedence: RSC_CSS_PRECEDENCE }),
-    ),
-    renderedTree,
+  const stylesheetLinks = cssHrefs.map((href) =>
+    React.createElement('link', { key: href, rel: 'stylesheet', href, precedence: RSC_CSS_PRECEDENCE }),
   );
+  return React.createElement(React.Fragment, null, stylesheetLinks, renderedTree);
 };
 
 const CLIENT_HOOK_NAMES = [
@@ -124,13 +120,13 @@ const streamRenderRSCComponent = (
   assertRailsContextWithServerStreamingCapabilities(railsContext);
 
   const { reactClientManifestFileName, reactServerClientManifestFileName } = railsContext;
+  const rscPayloadParams = railsContext.serverSideRSCPayloadParameters as
+    | { rscBundleHash?: string }
+    | undefined;
 
   // Initialize manifest loader and BUILD_ID on first render request.
   // These are per-process constants that don't change between requests.
   setManifestFileNames(reactClientManifestFileName, reactServerClientManifestFileName);
-  const rscPayloadParams = railsContext.serverSideRSCPayloadParameters as
-    | { rscBundleHash?: string }
-    | undefined;
   if (rscPayloadParams?.rscBundleHash) {
     setBuildId(rscPayloadParams.rscBundleHash);
   }
@@ -158,7 +154,11 @@ const streamRenderRSCComponent = (
 
   const initializeAndRender = async () => {
     const { renderToPipeableStream } = await getServerRenderer();
-    const [renderedTree, cssHrefs] = await Promise.all([reactRenderingResult, getRscCssHrefs()]);
+    const cssHrefsPromise = getRscCssHrefs().catch((err: unknown) => {
+      console.error('Error loading RSC CSS hrefs', convertToError(err));
+      return [] as string[];
+    });
+    const [renderedTree, cssHrefs] = await Promise.all([reactRenderingResult, cssHrefsPromise]);
     const rscStream = renderToPipeableStream(wrapWithRscCssLinks(renderedTree, cssHrefs), {
       onError: (err) => {
         const error = convertToError(err);

--- a/packages/react-on-rails-pro/src/loadJsonFile.ts
+++ b/packages/react-on-rails-pro/src/loadJsonFile.ts
@@ -12,11 +12,28 @@
  * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
  */
 
+import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
-import * as fs from 'fs/promises';
 
 type LoadedJsonFile = Record<string, unknown>;
 const loadedJsonFiles = new Map<string, LoadedJsonFile>();
+
+const resolveJsonFilePath = (fileName: string): string => path.resolve(__dirname, fileName);
+
+export function getJsonFileSignature(fileName: string): string {
+  const filePath = resolveJsonFilePath(fileName);
+  try {
+    const stats = fs.statSync(filePath);
+    return `${filePath}\0${stats.size}\0${stats.mtimeMs}`;
+  } catch {
+    return `${filePath}\0missing`;
+  }
+}
+
+export function clearLoadedJsonFile(fileName: string): void {
+  loadedJsonFiles.delete(resolveJsonFilePath(fileName));
+}
 
 export default async function loadJsonFile<T extends LoadedJsonFile = LoadedJsonFile>(
   fileName: string,
@@ -24,14 +41,14 @@ export default async function loadJsonFile<T extends LoadedJsonFile = LoadedJson
   // Asset JSON files are uploaded to node renderer.
   // Renderer copies assets to the same place as the server-bundle.js and rsc-bundle.js.
   // Thus, the __dirname of this code is where we can find the manifest file.
-  const filePath = path.resolve(__dirname, fileName);
+  const filePath = resolveJsonFilePath(fileName);
   const loadedJsonFile = loadedJsonFiles.get(filePath);
   if (loadedJsonFile) {
     return loadedJsonFile as T;
   }
 
   try {
-    const file = JSON.parse(await fs.readFile(filePath, 'utf8')) as T;
+    const file = JSON.parse(await fsPromises.readFile(filePath, 'utf8')) as T;
     loadedJsonFiles.set(filePath, file);
     return file;
   } catch (error) {

--- a/packages/react-on-rails-pro/src/resolveCssHrefs.ts
+++ b/packages/react-on-rails-pro/src/resolveCssHrefs.ts
@@ -41,24 +41,26 @@ const joinPrefix = (prefix: string, file: string): string => {
 /**
  * Collect every CSS file recorded for a `'use client'` module reference in the
  * RSC client manifest, prepend the manifest's `moduleLoading.prefix` (so CDN /
- * non-default `publicPath` deployments get fully-qualified hrefs), dedupe, and
- * return a stably sorted list.
- *
- * The sort exists for build/test determinism, not cascade semantics — CSS
- * Modules are expected to be scoped, so emission order does not affect styling.
+ * non-default `publicPath` deployments get fully-qualified hrefs), dedupe while
+ * preserving manifest/chunk order, and return the href list.
  */
 export default function resolveCssHrefs(manifest: RscCssManifest): string[] {
   const prefix = manifest.moduleLoading?.prefix ?? '';
   const metadata = manifest.filePathToModuleMetadata ?? {};
 
-  const hrefs = new Set<string>();
+  const hrefs: string[] = [];
+  const seenHrefs = new Set<string>();
   for (const entry of Object.values(metadata)) {
     for (const file of entry?.css ?? []) {
       if (typeof file === 'string' && file.length > 0) {
-        hrefs.add(joinPrefix(prefix, file));
+        const href = joinPrefix(prefix, file);
+        if (!seenHrefs.has(href)) {
+          seenHrefs.add(href);
+          hrefs.push(href);
+        }
       }
     }
   }
 
-  return Array.from(hrefs).sort();
+  return hrefs;
 }

--- a/packages/react-on-rails-pro/src/resolveCssHrefs.ts
+++ b/packages/react-on-rails-pro/src/resolveCssHrefs.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Shakacode LLC
+ *
+ * This file is NOT licensed under the MIT (open source) license.
+ * It is part of the React on Rails Pro offering and is licensed separately.
+ *
+ * Unauthorized copying, modification, distribution, or use of this file,
+ * via any medium, is strictly prohibited without a valid license agreement
+ * from Shakacode LLC.
+ *
+ * For licensing terms, please see:
+ * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
+ */
+
+/**
+ * Structural view of the RSC client manifest, narrowed to the fields needed to
+ * resolve stylesheet hrefs. The `css` array on each module entry is published by
+ * the patched `react-server-dom-webpack-plugin` (see
+ * `patches/react-on-rails-rsc@19.0.4.patch`); it is absent on unpatched
+ * manifests, which `resolveCssHrefs` treats as "no CSS".
+ */
+type RscCssModuleEntry = {
+  css?: string[];
+  // Manifest entries also carry id/chunks/name/async; we ignore those here. The
+  // index signature keeps the published `BundleManifest` assignable to this view.
+  [key: string]: unknown;
+};
+
+export type RscCssManifest = {
+  moduleLoading?: { prefix?: string | null };
+  filePathToModuleMetadata?: Record<string, RscCssModuleEntry | undefined>;
+};
+
+const joinPrefix = (prefix: string, file: string): string => {
+  if (!prefix) return file;
+  const base = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  const rel = file.startsWith('/') ? file.slice(1) : file;
+  return `${base}/${rel}`;
+};
+
+/**
+ * Collect every CSS file recorded for a `'use client'` module reference in the
+ * RSC client manifest, prepend the manifest's `moduleLoading.prefix` (so CDN /
+ * non-default `publicPath` deployments get fully-qualified hrefs), dedupe, and
+ * return a stably sorted list.
+ *
+ * The sort exists for build/test determinism, not cascade semantics — CSS
+ * Modules are expected to be scoped, so emission order does not affect styling.
+ */
+export default function resolveCssHrefs(manifest: RscCssManifest): string[] {
+  const prefix = manifest.moduleLoading?.prefix ?? '';
+  const metadata = manifest.filePathToModuleMetadata ?? {};
+
+  const hrefs = new Set<string>();
+  for (const entry of Object.values(metadata)) {
+    for (const file of entry?.css ?? []) {
+      if (typeof file === 'string' && file.length > 0) {
+        hrefs.add(joinPrefix(prefix, file));
+      }
+    }
+  }
+
+  return Array.from(hrefs).sort();
+}

--- a/packages/react-on-rails-pro/tests/manifestLoader.test.ts
+++ b/packages/react-on-rails-pro/tests/manifestLoader.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment node
+ */
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { getRscCssHrefs, setManifestFileNames } from '../src/cache/manifestLoader.ts';
+
+const writeManifest = async (filePath: string, cssFile: string) => {
+  await fs.writeFile(
+    filePath,
+    JSON.stringify({
+      moduleLoading: { prefix: '/packs/' },
+      filePathToModuleMetadata: {
+        'file:///app/UseClient.jsx': {
+          id: '1',
+          chunks: [],
+          css: [cssFile],
+          name: '*',
+        },
+      },
+    }),
+  );
+};
+
+describe('manifestLoader', () => {
+  it('invalidates manifest-derived CSS when the client manifest file changes', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ror-manifest-loader-'));
+    const clientManifest = path.join(tempDir, 'react-client-manifest.json');
+    const serverClientManifest = path.join(tempDir, 'react-server-client-manifest.json');
+
+    await writeManifest(clientManifest, 'css/first.css');
+    await writeManifest(serverClientManifest, 'css/first.css');
+    setManifestFileNames(clientManifest, serverClientManifest);
+    await expect(getRscCssHrefs()).resolves.toEqual(['/packs/css/first.css']);
+
+    await writeManifest(clientManifest, 'css/second.css');
+    setManifestFileNames(clientManifest, serverClientManifest);
+
+    await expect(getRscCssHrefs()).resolves.toEqual(['/packs/css/second.css']);
+  });
+});

--- a/packages/react-on-rails-pro/tests/manifestLoaderServerRSC.rsc.test.ts
+++ b/packages/react-on-rails-pro/tests/manifestLoaderServerRSC.rsc.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ */
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { setManifestFileNames } from '../src/cache/manifestLoader.ts';
+import { getServerRenderer } from '../src/cache/manifestLoaderServer.ts';
+
+const writeManifest = async (filePath: string, moduleName = 'initial') => {
+  await fs.writeFile(
+    filePath,
+    JSON.stringify({
+      moduleLoading: { prefix: '/packs/' },
+      filePathToModuleMetadata: {
+        [`file:///app/${moduleName}.jsx`]: {
+          id: moduleName,
+          chunks: [],
+          css: [],
+          name: '*',
+        },
+      },
+    }),
+  );
+};
+
+describe('manifestLoaderServer', () => {
+  it('invalidates the server renderer when the client manifest file changes', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ror-manifest-loader-server-'));
+    const clientManifest = path.join(tempDir, 'react-client-manifest.json');
+    const serverClientManifest = path.join(tempDir, 'react-server-client-manifest.json');
+
+    await writeManifest(clientManifest);
+    await writeManifest(serverClientManifest);
+
+    setManifestFileNames(clientManifest, serverClientManifest);
+    const firstRenderer = await getServerRenderer();
+
+    await writeManifest(clientManifest, 'changed-client-manifest');
+    setManifestFileNames(clientManifest, serverClientManifest);
+    const secondRenderer = await getServerRenderer();
+
+    expect(secondRenderer).not.toBe(firstRenderer);
+  });
+});

--- a/packages/react-on-rails-pro/tests/resolveCssHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/resolveCssHrefs.test.ts
@@ -1,0 +1,78 @@
+import resolveCssHrefs from '../src/resolveCssHrefs.ts';
+
+describe('resolveCssHrefs', () => {
+  it('returns an empty list when no module records CSS', () => {
+    expect(
+      resolveCssHrefs({
+        moduleLoading: { prefix: '/webpack/' },
+        filePathToModuleMetadata: {
+          'file:///app/Button.jsx': { id: '1', chunks: ['1', 'js/1.js'], name: '*' },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it('collects CSS across modules, prefixes, dedupes, and sorts', () => {
+    const hrefs = resolveCssHrefs({
+      moduleLoading: { prefix: '/webpack/test/' },
+      filePathToModuleMetadata: {
+        'file:///app/Layout.jsx': {
+          id: '1',
+          chunks: [],
+          css: ['css/layout.css', 'css/shared.css'],
+          name: '*',
+        },
+        'file:///app/Header.jsx': {
+          id: '2',
+          chunks: [],
+          css: ['css/header.css', 'css/shared.css'],
+          name: '*',
+        },
+      },
+    });
+
+    // shared.css appears in two modules but is emitted once; output is sorted.
+    expect(hrefs).toEqual([
+      '/webpack/test/css/header.css',
+      '/webpack/test/css/layout.css',
+      '/webpack/test/css/shared.css',
+    ]);
+  });
+
+  it('joins prefix and file with exactly one slash regardless of trailing/leading slashes', () => {
+    expect(
+      resolveCssHrefs({
+        moduleLoading: { prefix: 'https://cdn.example.com/assets' },
+        filePathToModuleMetadata: {
+          'file:///app/A.jsx': { css: ['/css/a.css'] },
+          'file:///app/B.jsx': { css: ['css/b.css'] },
+        },
+      }),
+    ).toEqual(['https://cdn.example.com/assets/css/a.css', 'https://cdn.example.com/assets/css/b.css']);
+  });
+
+  it('treats a missing prefix as empty (bare hrefs)', () => {
+    expect(
+      resolveCssHrefs({
+        filePathToModuleMetadata: {
+          'file:///app/A.jsx': { css: ['css/a.css'] },
+        },
+      }),
+    ).toEqual(['css/a.css']);
+  });
+
+  it('ignores empty/blank css entries and unpatched manifests', () => {
+    expect(
+      resolveCssHrefs({
+        moduleLoading: { prefix: '/webpack/' },
+        filePathToModuleMetadata: {
+          'file:///app/A.jsx': { css: [''] },
+          'file:///app/B.jsx': undefined,
+          'file:///app/C.jsx': { id: '3', chunks: [], name: '*' },
+        },
+      }),
+    ).toEqual([]);
+
+    expect(resolveCssHrefs({})).toEqual([]);
+  });
+});

--- a/packages/react-on-rails-pro/tests/resolveCssHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/resolveCssHrefs.test.ts
@@ -12,7 +12,7 @@ describe('resolveCssHrefs', () => {
     ).toEqual([]);
   });
 
-  it('collects CSS across modules, prefixes, dedupes, and sorts', () => {
+  it('collects CSS across modules, prefixes, dedupes, and preserves manifest order', () => {
     const hrefs = resolveCssHrefs({
       moduleLoading: { prefix: '/webpack/test/' },
       filePathToModuleMetadata: {
@@ -31,11 +31,11 @@ describe('resolveCssHrefs', () => {
       },
     });
 
-    // shared.css appears in two modules but is emitted once; output is sorted.
+    // shared.css appears in two modules but is emitted once where it first appears.
     expect(hrefs).toEqual([
-      '/webpack/test/css/header.css',
       '/webpack/test/css/layout.css',
       '/webpack/test/css/shared.css',
+      '/webpack/test/css/header.css',
     ]);
   });
 

--- a/patches/react-on-rails-rsc@19.0.4.patch
+++ b/patches/react-on-rails-rsc@19.0.4.patch
@@ -1,0 +1,37 @@
+diff --git a/dist/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js b/dist/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+index 91a62a8..d13d74c 100644
+--- a/dist/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
++++ b/dist/react-server-dom-webpack/cjs/react-server-dom-webpack-plugin.js
+@@ -201,21 +201,27 @@ class ReactFlightWebpackPlugin {
+                                         (filePathToModuleMetadata[module] = {
+                                             id,
+                                             chunks,
++                                            css: cssChunks,
+                                             name: "*"
+                                         }));
+                         }
+                         const chunks = [];
++                        const cssChunks = [];
+                         chunkGroup.chunks.forEach(function (c) {
++                            let jsRecorded = false;
+                             var _iterator = _createForOfIteratorHelper(c.files), _step;
+                             try {
+                                 for (_iterator.s(); !(_step = _iterator.n()).done;) {
+                                     const file = _step.value;
+-                                    if (!file.endsWith(".js"))
+-                                        break;
+                                     if (file.endsWith(".hot-update.js"))
+-                                        break;
+-                                    chunks.push(c.id, file);
+-                                    break;
++                                        continue;
++                                    if (!jsRecorded && file.endsWith(".js")) {
++                                        chunks.push(c.id, file);
++                                        jsRecorded = true;
++                                    }
++                                    else if (file.endsWith(".css")) {
++                                        cssChunks.push(file);
++                                    }
+                                 }
+                             }
+                             catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,11 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4 <5'
   yaml@>=1.0.0 <1.10.3: '>=1.10.3 <2'
 
+patchedDependencies:
+  react-on-rails-rsc@19.0.4:
+    hash: e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5
+    path: patches/react-on-rails-rsc@19.0.4.patch
+
 importers:
 
   .:
@@ -183,7 +188,7 @@ importers:
         version: 19.2.3(react@19.2.3)
       react-on-rails-rsc:
         specifier: ^19.0.4
-        version: 19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.105.2(@swc/core@1.15.3))
+        version: 19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.105.2(@swc/core@1.15.3))
       redux:
         specifier: ^4.2.1
         version: 4.2.1
@@ -260,7 +265,7 @@ importers:
         version: 19.2.0(react@19.2.0)
       react-on-rails-rsc:
         specifier: ^19.0.4
-        version: 19.0.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(webpack@5.105.2(@swc/core@1.15.3))
+        version: 19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(webpack@5.105.2(@swc/core@1.15.3))
 
   packages/react-on-rails-pro-node-renderer:
     dependencies:
@@ -721,7 +726,7 @@ importers:
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
         specifier: ^19.0.4
-        version: 19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1)
+        version: 19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -16650,7 +16655,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-on-rails-rsc@19.0.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(webpack@5.105.2(@swc/core@1.15.3)):
+  react-on-rails-rsc@19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -16659,7 +16664,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1):
+  react-on-rails-rsc@19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -16668,7 +16673,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.3)(webpack-cli@7.0.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.0.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.105.2(@swc/core@1.15.3)):
+  react-on-rails-rsc@19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
         specifier: ^19.0.3
         version: 19.2.3(react@19.2.3)
       react-on-rails-rsc:
-        specifier: ^19.0.4
+        specifier: 19.0.4
         version: 19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.105.2(@swc/core@1.15.3))
       redux:
         specifier: ^4.2.1
@@ -264,7 +264,7 @@ importers:
         specifier: ^19.0.3
         version: 19.2.0(react@19.2.0)
       react-on-rails-rsc:
-        specifier: ^19.0.4
+        specifier: 19.0.4
         version: 19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(webpack@5.105.2(@swc/core@1.15.3))
 
   packages/react-on-rails-pro-node-renderer:
@@ -725,7 +725,7 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: ^19.0.4
+        specifier: 19.0.4
         version: 19.0.4(patch_hash=e0eae6c987bb9de707491f7cee07c400963613636ca67397b6a730de4754d0c5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts
@@ -19,7 +19,9 @@ test.describe('RSC use-client CSS (#3211 FOUC fix)', () => {
     // No-FOUC guarantee: the renderer hoists the use-client stylesheet into the
     // server-rendered <head> with our precedence group, so the browser will not
     // paint the boundary until the stylesheet has loaded.
-    expect(ssrHtml).toMatch(/<link[^>]*rel="stylesheet"[^>]*data-precedence="ror-rsc"[^>]*>/);
+    expect(ssrHtml).toMatch(
+      /<link(?=[^>]*\brel="stylesheet")(?=[^>]*\bdata-precedence="ror-rsc")(?=[^>]*\bhref="[^"]*\.css")[^>]*>/,
+    );
 
     const probe = page.getByTestId('rsc-css-probe');
     await expect(probe).toBeVisible();

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// Regression test for issue #3211: CSS imported behind a `'use client'` boundary
+// in a true RSC tree must be preloaded via `<link rel="stylesheet" precedence>`
+// emitted from the RSC payload, so React 19 hoists it into the SSR'd <head> and
+// the browser blocks first paint until it loads. Without the fix the stylesheet
+// only loads as a side effect of the JS chunk evaluating, producing a flash of
+// unstyled content (FOUC).
+//
+// `UseClientCssProbe` ('use client', imports a CSS module) is rendered by
+// `RSCPostsPage` on the streaming RSC route below.
+test.describe('RSC use-client CSS (#3211 FOUC fix)', () => {
+  test('preloads the use-client stylesheet (hoisted into SSR <head>) and styles the probe', async ({
+    page,
+  }) => {
+    const response = await page.goto('/rsc_posts_page_over_http', { waitUntil: 'commit' });
+    const ssrHtml = (await response?.text()) ?? '';
+
+    // No-FOUC guarantee: the renderer hoists the use-client stylesheet into the
+    // server-rendered <head> with our precedence group, so the browser will not
+    // paint the boundary until the stylesheet has loaded.
+    expect(ssrHtml).toMatch(/<link[^>]*rel="stylesheet"[^>]*data-precedence="ror-rsc"[^>]*>/);
+
+    const probe = page.getByTestId('rsc-css-probe');
+    await expect(probe).toBeVisible();
+
+    // The precedence-grouped stylesheet resource is present in the live document
+    // (React keeps it as it manages the loaded stylesheet).
+    await expect(page.locator('link[rel="stylesheet"][data-precedence="ror-rsc"]').first()).toBeAttached();
+
+    // End result: the probe paints with the background color from its CSS module
+    // (UseClientCssProbe.module.scss: background-color: rgb(212 250 236)).
+    await expect(probe).toHaveCSS('background-color', 'rgb(212, 250, 236)');
+  });
+});

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -53,7 +53,7 @@
     "react-error-boundary": "^4.1.2",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "^19.0.4",
+    "react-on-rails-rsc": "19.0.4",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",

--- a/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe "RSC use-client CSS manifest regression" do
 
     expect(metadata).to be_present, "Expected #{probe_key_fragment} in #{manifest_path}"
 
-    pending("use-client component CSS is not yet recorded in the RSC client manifest")
+    # The patched react-server-dom-webpack plugin records the CSS sibling chunk of
+    # each 'use client' module so the renderer can preload it (see #3211). Without
+    # the patch this raises KeyError because only JS chunks were tracked.
     expect(metadata.fetch("css")).to include(a_string_matching(/\.css(?:\?|$)/))
   end
 end


### PR DESCRIPTION
Fixes #3211

## Problem

When a true RSC tree renders a `'use client'` boundary, CSS imported by that
boundary (or its descendants) was **not** preloaded. It loaded only as a side
effect of the JS chunk evaluating — hundreds of ms to seconds after first
paint — producing a flash of unstyled content (FOUC). Invisible in the dummy
app historically because its RSC components used inline `style={{…}}`; the first
real app converting a page shell (Layout/Header/Footer) to true RSC hits it
immediately.

Two independent gaps caused this and **both** are fixed here. The upstream
package fix ([react_on_rails_rsc#35](https://github.com/shakacode/react_on_rails_rsc/pull/35))
is still open/unpublished, so the manifest half ships as a `pnpm patch`.

## The fix

### Part A — manifest plugin patch (`patches/react-on-rails-rsc@19.0.4.patch`)

The patched `react-server-dom-webpack-plugin` recorded only `.js` files per
chunk — its inner file loop `break`s on the first non-`.js` file, dropping the
`mini-css-extract` CSS sibling. The patch keeps the JS behavior **byte-identical**
(still one `.js` per chunk) and additionally collects `.css` files into a
sibling `css: string[]` on each client-reference manifest entry. `css` is
optional, so the Flight client runtime ignores it and older readers are
unaffected. Mirrors what rsc#35 will publish — drop the patch on the next fixed
release.

### Part B — renderer emits `<link rel="stylesheet" precedence>`

`proRSC.ts` now wraps the rendered RSC tree with a `<link rel="stylesheet"
precedence="ror-rsc">` for every stylesheet resolved from the manifest
(`resolveCssHrefs`: dedupe, prepend `moduleLoading.prefix` for CDN/`publicPath`,
sort). Emitting the links **inside the RSC payload** means React 19 hoists them
into `<head>` and blocks tree commit until they load — on both the SSR stream
and client-side navigation (same payload decodes identically), so no
CSR-specific code is needed.

> v1 uses eager emission (every client-reference stylesheet per render).
> Tree-walked emission via `preinitStyle` is a documented future optimization,
> not required for correctness.

## Tests

- **`resolveCssHrefs` unit tests** — prefix join (one slash, CDN, missing), dedupe, sort, unpatched/empty manifest.
- **`rsc_use_client_css_manifest_spec.rb`** — the pending spec added in #3527 is unpended; asserts the use-client probe entry now records `css`.
- **`rsc_use_client_css.spec.ts` (e2e)** — on `/rsc_posts_page_over_http`, the use-client stylesheet is hoisted into the SSR'd `<head>` with `data-precedence="ror-rsc"` and the probe paints with its CSS-module background color.

## Verification

End-to-end against the dummy app (node renderer + Rails):

- Manifest: the `UseClientCssProbe` entry now has `"css": ["css/client8-…​.css"]`.
- Rendered page `<head>` contains `<link rel="stylesheet" href="/webpack/test/css/client8-…​.css" data-precedence="ror-rsc"/>`, hoisted by React from the RSC payload.
- Pro JS suite green (164 tests incl. RSC render-path), manifest rspec green, e2e green (chromium + firefox).

Design rationale: `.claude/docs/3211-rsc-css-fouc-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Pro RSC streaming and pins/patches `react-on-rails-rsc` build output; incorrect hrefs or manifest cache bugs could affect styling on all RSC renders, though failures degrade to empty CSS links with logging.
> 
> **Overview**
> Fixes **CSS FOUC** for styles imported behind `'use client'` boundaries in true RSC trees by closing two gaps: the RSC client manifest now records `.css` chunk siblings (via a **`pnpm` patch** on `react-on-rails-rsc@19.0.4` until upstream ships), and the Pro RSC stream wraps the rendered tree with React 19 **`<link rel="stylesheet" precedence="ror-rsc">`** elements resolved from that manifest (`resolveCssHrefs`, cached `getRscCssHrefs`) so styles hoist into `<head>` and block paint on SSR and client navigation.
> 
> Manifest loading now **invalidates** cached CSS hrefs and server renderers when manifest files change (file signature on `loadJsonFile`). The pending dummy **manifest request spec** is enabled; **Playwright** and unit tests cover manifest `css`, href resolution, and SSR head + computed styles. Also adds design doc, changelog entry, pins `react-on-rails-rsc` to `19.0.4`, and minor CI quoting/pnpm version tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e455f8491562f9dcf5aa896696161eb6545434c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS Flash of Unstyled Content (FOUC) for React Server Components with 'use client' boundaries; RSC-imported styles are now preloaded and applied during server render and client navigation.

* **Documentation**
  * Added design doc describing the RSC CSS handling, manifest metadata, runtime stylesheet behavior, and out-of-scope items.

* **Tests**
  * Added E2E and unit tests validating manifest CSS recording, stylesheet injection, and computed styling after load.

* **Chores**
  * Updated changelog and pinned a dev dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->