### PR TITLE
docs: fix broken external links failing markdown-link-check

### DIFF
--- a/docs/oss/building-features/node-renderer/debugging.md
+++ b/docs/oss/building-features/node-renderer/debugging.md
@@ -101,7 +101,7 @@ See the [Memory Leaks guide](../../../pro/js-memory-leaks.md) for common pattern
 ## Debugging Jest tests
 
 1. See [the Jest documentation](https://jestjs.io/docs/troubleshooting) for overall guidance.
-2. For RubyMine, see [the RubyMine documentation](https://www.jetbrains.com/help/ruby/running-unit-tests-on-jest.html) for the current information. The original [Testing With Jest in WebStorm](https://blog.jetbrains.com/webstorm/2018/10/testing-with-jest-in-webstorm/) post can be useful as well.
+2. For JetBrains IDEs, see [the RubyMine documentation](https://www.jetbrains.com/help/ruby/running-unit-tests-on-jest.html) for current instructions.
 
 ## Debugging the Ruby gem
 

--- a/docs/oss/building-features/node-renderer/error-reporting-and-tracing.md
+++ b/docs/oss/building-features/node-renderer/error-reporting-and-tracing.md
@@ -81,7 +81,7 @@ addNotifier((msg) => {
   - `executor` should wrap an async function in the service's unit of work.
   - Since the only units of work we currently track are rendering requests, the options to start them are specified in `startSsrRequestOptions`.
 
-To track requests as [sessions](https://docs.bugsnag.com/platforms/javascript/capturing-sessions/#startsession) in BugSnag 8.x+,
+To track requests as sessions in BugSnag 8.x+,
 the above example becomes
 
 ```js


### PR DESCRIPTION
## Summary

Fixes the failing **markdown-link-check** CI job (`.github/workflows/check-markdown-links.yml`, lychee), which broke on two dead external links in the Node Renderer docs:

1. **`docs/oss/building-features/node-renderer/debugging.md`** — the WebStorm 2018 blog post (`blog.jetbrains.com/webstorm/2018/10/testing-with-jest-in-webstorm/`) now returns **403**. Removed the stale link; the sentence already points at the current RubyMine docs.
2. **`docs/oss/building-features/node-renderer/error-reporting-and-tracing.md`** — the Bugsnag sessions anchor (`docs.bugsnag.com/platforms/javascript/capturing-sessions/#startsession`) now returns **404**. Removed the inline link; the surrounding prose and the `startSession()`/`pauseSession()` code example already explain the concept.

This is documentation link rot only — no application logic changed.

## Verification

```
lychee --config .lychee.toml docs/.../debugging.md docs/.../error-reporting-and-tracing.md
🔍 19 Total ✅ 19 OK 🚫 0 Errors
```

Pre-commit hooks (lychee offline, trailing-newlines, prettier) also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link rot fixes; no runtime, auth, or application code changes.
> 
> **Overview**
> Fixes **markdown-link-check** failures in Node Renderer docs by removing two dead external links while keeping the same guidance.
> 
> In `debugging.md`, the Jest section no longer links to a **403** WebStorm 2018 blog post; it now points readers only at current **JetBrains/RubyMine** Jest instructions (wording updated from “RubyMine” to “JetBrains IDEs”).
> 
> In `error-reporting-and-tracing.md`, the inline link to Bugsnag’s removed **#startsession** anchor is dropped; the sentence still describes session tracking for BugSnag 8.x+, and the existing `startSession()` / `pauseSession()` example is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96614513d2158c002beeabd83bb78cae996c85ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated debugging guidance with current instructions for JetBrains IDEs.
  * Clarified BugSnag 8.x+ tracing documentation regarding session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->