### PR TITLE
fix(ci): stop detect-invalid-commands workflow from failing on every PR comment (red main check)

### DIFF
--- a/.github/workflows/detect-invalid-ci-commands.yml
+++ b/.github/workflows/detect-invalid-ci-commands.yml
@@ -59,7 +59,10 @@ jobs:
             }
 
             return { shouldRespond: false };
-          result-encoding: string
+          # Default result-encoding (json) JSON.stringifies the returned object so
+          # the downstream `fromJSON(...)` condition and `JSON.parse` can read it.
+          # `result-encoding: string` would coerce the object to "[object Object]",
+          # which breaks `fromJSON` and fails the job on every triggering comment.
 
       - name: Post helpful comment
         if: steps.check_command.outputs.result != '' && fromJSON(steps.check_command.outputs.result).shouldRespond == true


### PR DESCRIPTION
## Problem

`main` shows a red **`detect-invalid-commands`** check. The failure is **not** a regression from any main commit — it's a latent bug in the `Detect Invalid CI Commands` workflow that has existed since the workflow was first added (#2037).

Because this is an `issue_comment`-triggered workflow, GitHub runs it against `main` and attaches the resulting check run to `main`'s HEAD commit. So a comment-handler bug makes `main` itself look red.

### Root cause

The `Check for similar commands` step (`actions/github-script`) returns a JS object:

```js
return { shouldRespond: false };
```

but had `result-encoding: string`, which coerces the object to the literal text `"[object Object]"`.

The downstream `Post helpful comment` step then reads that value two ways, both of which choke on `"[object Object]"`:

```yaml
if: steps.check_command.outputs.result != '' && fromJSON(steps.check_command.outputs.result).shouldRespond == true
```
```js
const result = JSON.parse(process.env.CHECK_RESULT);
```

The job log shows exactly this:

```
##[error]The template is not valid. Newtonsoft.Json.JsonReaderException:
Unexpected character encountered while parsing value: o. Path '', line 1, position 1.
```

(`o` is the second character of `[object Object]`.) The `if:` expression itself throws while evaluating `fromJSON(...)`, so the step — and the whole job — fails on **every** triggering PR comment. The "helpful comment" has never actually posted.

### Reproduction

```
$ node -e 'const r={shouldRespond:false};
  console.log(String(r));            // "[object Object]"  (result-encoding: string)
  console.log(JSON.stringify(r));    // {"shouldRespond":false}  (default json)
  JSON.parse(String(r));'            // SyntaxError: "[object Object]" is not valid JSON
```

## Fix

Drop `result-encoding: string`. The default `json` encoding `JSON.stringify`s the returned object, producing valid JSON that both `fromJSON(...)` (in the `if:`) and `JSON.parse(...)` (in the script) can read.

One-line change plus an explanatory comment so this doesn't regress.

## Verification

- Reproduced the `[object Object]` → invalid-JSON failure locally and confirmed the `json` encoding produces parseable output.
- `actionlint` passes on the workflow file; YAML parses.
- The workflow's logic only triggers on `issue_comment`, so it can't be exercised by this PR's own CI — but the encoding change is the minimal fix for the observed error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no application, auth, or data-path impact.
> 
> **Overview**
> Fixes the **Detect Invalid CI Commands** workflow so it no longer fails on every qualifying PR comment.
> 
> The `Check for similar commands` `github-script` step **removes** `result-encoding: string` and relies on the default **json** encoding so the returned `{ shouldRespond, invalidCommands? }` object is **JSON-stringified** in `steps.check_command.outputs.result`. That value is consumed by the next step’s `fromJSON(...)` in the `if:` and by `JSON.parse` in the script—both were breaking when the output was the literal `"[object Object]"`.
> 
> Inline comments document why `string` encoding must not be reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88664668f70e36746fd73367951943fac7f07862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve command validation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->