### PR TITLE
fix(pro): make RSC manifest signatures async

### DIFF
--- a/docs/pro/react-server-components/how-react-server-components-work.md
+++ b/docs/pro/react-server-components/how-react-server-components-work.md
@@ -110,6 +110,12 @@ Let's search for the client component `ToggleContainer` that we built before in 
 
 This entry indicates that the `ToggleContainer` client component is included in the `client25` chunk. The `js/client25.js` file contains the client-side code for the `ToggleContainer` component. You can find the `client25` chunk in the `public/webpack/<environment>/js/client25.js` file. Also, the `id` field is the Webpack module ID for the `ToggleContainer` client component. It's used by react runtime to load and hydrate the component in the browser.
 
+### CSS Links for `'use client'` Boundaries
+
+React on Rails Pro reads CSS metadata from the RSC client manifest and emits `<link rel="stylesheet" precedence="ror-rsc">` entries into the RSC payload. React hoists those links into `<head>` and delays committing the corresponding streamed content until the stylesheets are ready, which prevents a flash of unstyled content for client components behind RSC boundaries.
+
+The current resolver works from the manifest alone, so it emits CSS for every `'use client'` module entry in the manifest instead of only the client references encountered by one render. This is intentional for now: CSS modules and component-scoped styles remain safe, but global CSS imported by a client component can apply on an RSC page that did not render that component. If that matters for your app, avoid importing page-specific global CSS from broad client-component entry points until `react-on-rails-rsc` can attach CSS at the rendered client-reference boundary.
+
 If you want to change the file name of the `react-client-manifest.json` file, you can do so by setting the `clientManifestFilename` option in the `react-on-rails-rsc/WebpackPlugin` plugin as follows:
 
 ```js

--- a/packages/react-on-rails-pro/src/cache/manifestLoader.ts
+++ b/packages/react-on-rails-pro/src/cache/manifestLoader.ts
@@ -24,8 +24,16 @@ let manifestCacheKey: string | undefined;
 let clientRendererPromise: Promise<ReturnType<typeof buildClientRenderer>> | undefined;
 let rscCssHrefsPromise: Promise<string[]> | undefined;
 
-const buildManifestCacheKey = (clientManifest: string, serverClientManifest: string): string =>
-  `${getJsonFileSignature(clientManifest)}\0${getJsonFileSignature(serverClientManifest)}`;
+const buildManifestCacheKey = async (
+  clientManifest: string,
+  serverClientManifest: string,
+): Promise<string> => {
+  const [clientManifestSignature, serverClientManifestSignature] = await Promise.all([
+    getJsonFileSignature(clientManifest),
+    getJsonFileSignature(serverClientManifest),
+  ]);
+  return `${clientManifestSignature}\0${serverClientManifestSignature}`;
+};
 
 const clearManifestDerivedCaches = (manifestFiles: Array<string | undefined>): void => {
   clientRendererPromise = undefined;
@@ -37,10 +45,13 @@ const clearManifestDerivedCaches = (manifestFiles: Array<string | undefined>): v
   }
 };
 
-export function setManifestFileNames(clientManifest: string, serverClientManifest: string): void {
+export async function setManifestFileNames(
+  clientManifest: string,
+  serverClientManifest: string,
+): Promise<void> {
   const previousClientManifest = clientManifestFileName;
   const previousServerClientManifest = serverClientManifestFileName;
-  const nextManifestCacheKey = buildManifestCacheKey(clientManifest, serverClientManifest);
+  const nextManifestCacheKey = await buildManifestCacheKey(clientManifest, serverClientManifest);
 
   clientManifestFileName = clientManifest;
   serverClientManifestFileName = serverClientManifest;

--- a/packages/react-on-rails-pro/src/capabilities/proRSC.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proRSC.ts
@@ -57,7 +57,7 @@ const wrapWithRscCssLinks = (renderedTree: React.ReactNode, cssHrefs: readonly s
   const stylesheetLinks = cssHrefs.map((href) =>
     React.createElement('link', { key: href, rel: 'stylesheet', href, precedence: RSC_CSS_PRECEDENCE }),
   );
-  return React.createElement(React.Fragment, null, stylesheetLinks, renderedTree);
+  return React.createElement(React.Fragment, null, ...stylesheetLinks, renderedTree);
 };
 
 const CLIENT_HOOK_NAMES = [
@@ -124,9 +124,8 @@ const streamRenderRSCComponent = (
     | { rscBundleHash?: string }
     | undefined;
 
-  // Initialize manifest loader and BUILD_ID on first render request.
-  // These are per-process constants that don't change between requests.
-  setManifestFileNames(reactClientManifestFileName, reactServerClientManifestFileName);
+  // Initialize manifest loader; in development this also invalidates derived
+  // caches when manifests change on disk.
   if (rscPayloadParams?.rscBundleHash) {
     setBuildId(rscPayloadParams.rscBundleHash);
   }
@@ -153,6 +152,7 @@ const streamRenderRSCComponent = (
   };
 
   const initializeAndRender = async () => {
+    await setManifestFileNames(reactClientManifestFileName, reactServerClientManifestFileName);
     const { renderToPipeableStream } = await getServerRenderer();
     const cssHrefsPromise = getRscCssHrefs().catch((err: unknown) => {
       console.error('Error loading RSC CSS hrefs', convertToError(err));

--- a/packages/react-on-rails-pro/src/loadJsonFile.ts
+++ b/packages/react-on-rails-pro/src/loadJsonFile.ts
@@ -12,7 +12,6 @@
  * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
  */
 
-import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
@@ -21,10 +20,10 @@ const loadedJsonFiles = new Map<string, LoadedJsonFile>();
 
 const resolveJsonFilePath = (fileName: string): string => path.resolve(__dirname, fileName);
 
-export function getJsonFileSignature(fileName: string): string {
+export async function getJsonFileSignature(fileName: string): Promise<string> {
   const filePath = resolveJsonFilePath(fileName);
   try {
-    const stats = fs.statSync(filePath);
+    const stats = await fsPromises.stat(filePath);
     return `${filePath}\0${stats.size}\0${stats.mtimeMs}`;
   } catch {
     return `${filePath}\0missing`;

--- a/packages/react-on-rails-pro/src/resolveCssHrefs.ts
+++ b/packages/react-on-rails-pro/src/resolveCssHrefs.ts
@@ -39,10 +39,14 @@ const joinPrefix = (prefix: string, file: string): string => {
 };
 
 /**
- * Collect every CSS file recorded for a `'use client'` module reference in the
- * RSC client manifest, prepend the manifest's `moduleLoading.prefix` (so CDN /
- * non-default `publicPath` deployments get fully-qualified hrefs), dedupe while
- * preserving manifest/chunk order, and return the href list.
+ * Collect every CSS file recorded for every `'use client'` module reference in
+ * the RSC client manifest. This intentionally returns a manifest-wide list
+ * rather than a per-render list because this resolver receives only the emitted
+ * manifest, not the client references encountered by a specific RSC payload.
+ *
+ * Each href is prefixed with `moduleLoading.prefix` (so CDN / non-default
+ * `publicPath` deployments get fully-qualified hrefs), deduped, and returned in
+ * manifest/chunk order.
  */
 export default function resolveCssHrefs(manifest: RscCssManifest): string[] {
   const prefix = manifest.moduleLoading?.prefix ?? '';

--- a/packages/react-on-rails-pro/tests/manifestLoader.test.ts
+++ b/packages/react-on-rails-pro/tests/manifestLoader.test.ts
@@ -25,6 +25,10 @@ const writeManifest = async (filePath: string, cssFile: string) => {
 };
 
 describe('manifestLoader', () => {
+  afterEach(async () => {
+    await setManifestFileNames('', '');
+  });
+
   it('invalidates manifest-derived CSS when the client manifest file changes', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ror-manifest-loader-'));
     const clientManifest = path.join(tempDir, 'react-client-manifest.json');
@@ -32,11 +36,11 @@ describe('manifestLoader', () => {
 
     await writeManifest(clientManifest, 'css/first.css');
     await writeManifest(serverClientManifest, 'css/first.css');
-    setManifestFileNames(clientManifest, serverClientManifest);
+    await setManifestFileNames(clientManifest, serverClientManifest);
     await expect(getRscCssHrefs()).resolves.toEqual(['/packs/css/first.css']);
 
     await writeManifest(clientManifest, 'css/second.css');
-    setManifestFileNames(clientManifest, serverClientManifest);
+    await setManifestFileNames(clientManifest, serverClientManifest);
 
     await expect(getRscCssHrefs()).resolves.toEqual(['/packs/css/second.css']);
   });

--- a/packages/react-on-rails-pro/tests/manifestLoaderServerRSC.rsc.test.ts
+++ b/packages/react-on-rails-pro/tests/manifestLoaderServerRSC.rsc.test.ts
@@ -26,6 +26,10 @@ const writeManifest = async (filePath: string, moduleName = 'initial') => {
 };
 
 describe('manifestLoaderServer', () => {
+  afterEach(async () => {
+    await setManifestFileNames('', '');
+  });
+
   it('invalidates the server renderer when the client manifest file changes', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ror-manifest-loader-server-'));
     const clientManifest = path.join(tempDir, 'react-client-manifest.json');
@@ -34,11 +38,11 @@ describe('manifestLoaderServer', () => {
     await writeManifest(clientManifest);
     await writeManifest(serverClientManifest);
 
-    setManifestFileNames(clientManifest, serverClientManifest);
+    await setManifestFileNames(clientManifest, serverClientManifest);
     const firstRenderer = await getServerRenderer();
 
     await writeManifest(clientManifest, 'changed-client-manifest');
-    setManifestFileNames(clientManifest, serverClientManifest);
+    await setManifestFileNames(clientManifest, serverClientManifest);
     const secondRenderer = await getServerRenderer();
 
     expect(secondRenderer).not.toBe(firstRenderer);

--- a/packages/react-on-rails-pro/tests/resolveCssHrefs.test.ts
+++ b/packages/react-on-rails-pro/tests/resolveCssHrefs.test.ts
@@ -39,6 +39,28 @@ describe('resolveCssHrefs', () => {
     ]);
   });
 
+  it('includes CSS for every manifest entry because rendered client references are not available here', () => {
+    const hrefs = resolveCssHrefs({
+      moduleLoading: { prefix: '/packs/' },
+      filePathToModuleMetadata: {
+        'file:///app/RenderedClient.jsx': {
+          id: '1',
+          chunks: [],
+          css: ['css/rendered-client.css'],
+          name: '*',
+        },
+        'file:///app/UnrenderedClient.jsx': {
+          id: '2',
+          chunks: [],
+          css: ['css/unrendered-client.css'],
+          name: '*',
+        },
+      },
+    });
+
+    expect(hrefs).toEqual(['/packs/css/rendered-client.css', '/packs/css/unrendered-client.css']);
+  });
+
   it('joins prefix and file with exactly one slash regardless of trailing/leading slashes', () => {
     expect(
       resolveCssHrefs({

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts
@@ -12,9 +12,11 @@ import { test, expect } from '@playwright/test';
 test.describe('RSC use-client CSS (#3211 FOUC fix)', () => {
   test('preloads the use-client stylesheet (hoisted into SSR <head>) and styles the probe', async ({
     page,
+    request,
   }) => {
-    const response = await page.goto('/rsc_posts_page_over_http', { waitUntil: 'commit' });
-    const ssrHtml = (await response?.text()) ?? '';
+    const response = await request.get('/rsc_posts_page_over_http');
+    expect(response.ok()).toBe(true);
+    const ssrHtml = await response.text();
 
     // No-FOUC guarantee: the renderer hoists the use-client stylesheet into the
     // server-rendered <head> with our precedence group, so the browser will not
@@ -22,6 +24,8 @@ test.describe('RSC use-client CSS (#3211 FOUC fix)', () => {
     expect(ssrHtml).toMatch(
       /<link(?=[^>]*\brel="stylesheet")(?=[^>]*\bdata-precedence="ror-rsc")(?=[^>]*\bhref="[^"]*\.css")[^>]*>/,
     );
+
+    await page.goto('/rsc_posts_page_over_http', { waitUntil: 'commit' });
 
     const probe = page.getByTestId('rsc-css-probe');
     await expect(probe).toBeVisible();


### PR DESCRIPTION
## Summary

Follow-up to PR #3587 and issue #3594.

- Moves RSC manifest file signature checks from synchronous `fs.statSync` calls to async `fs.promises.stat`, so manifest cache invalidation no longer does blocking filesystem work on the RSC render path.
- Makes the current RSC CSS limitation explicit and tested: `resolveCssHrefs()` works from the manifest alone, so it intentionally emits CSS for every `'use client'` manifest entry rather than only the client references encountered by one render.
- Includes the small review-adjacent cleanups from #3587: spreading stylesheet link children into the React fragment and resetting manifest loader singleton state in focused tests.

## #3594 Scope

This PR covers #3594 items 2, 3, and 4.

It does not yet close item 1. I checked `react-on-rails-rsc@19.0.5-rc.5`; the published tarball still does not include the upstream PR #35 CSS-manifest plugin changes, so bumping to that RC would not make downstream installs receive the manifest writer fix. That part should wait for a `react-on-rails-rsc` release that actually includes the upstream CSS metadata support, then Pro/generator pins can move to it and the temporary root patch can be removed.

## Test Plan

- `pnpm --filter react-on-rails-pro exec jest tests/manifestLoader.test.ts tests/resolveCssHrefs.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro exec jest tests/resolveCssHrefs.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro run test:rsc`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `cd react_on_rails && bundle exec rubocop`
- `cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion`

Labels: full-ci, benchmark. This touches Pro RSC render/cache behavior and removes blocking I/O from a server-rendering path, so broader CI plus benchmarks are appropriate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Pro RSC streaming render path and manifest cache invalidation; behavior is mostly equivalent but async timing and manifest-wide CSS semantics affect styling and dev hot reload.
> 
> **Overview**
> This PR removes **blocking filesystem work** from the Pro RSC render path by making manifest cache signatures async (`fs.promises.stat` instead of `statSync`) and awaiting `setManifestFileNames()` inside each RSC stream initialization so dev rebuilds still invalidate derived caches correctly.
> 
> It also **documents and locks in** the current RSC CSS behavior: `resolveCssHrefs()` intentionally emits stylesheet links for **every** `'use client'` entry in the client manifest (not only client references used on a given render), with a new unit test and a docs section on FOUC prevention and the global-CSS caveat.
> 
> Smaller follow-ups: stylesheet `<link>` children are spread into the React fragment, manifest-loader tests reset singleton state in `afterEach`, and the Playwright FOUC test fetches SSR HTML via `request.get` before navigating the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fd69337bc50b1869efde3d82eacbdfd53c0dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation section explaining how stylesheets are managed for React Server Components with `'use client'` boundaries, including stylesheet loading behavior and flash-of-unstyled-content prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->