### PR TITLE
Align docs demo naming and version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ These docs are for React on Rails 17. Historical docs and code are available for
 [v14](https://github.com/shakacode/react_on_rails/tree/14.0.0),
 [v13](https://github.com/shakacode/react_on_rails/tree/13.4.0),
 [v12](https://github.com/shakacode/react_on_rails/tree/12.6.0), and
-[v11](https://github.com/shakacode/react_on_rails/tree/11.3.0). Version 15.0.0
-was retracted, so use the v15 links only when maintaining older applications.
+[v11](https://github.com/shakacode/react_on_rails/tree/11.3.0). See the
+[upgrade guide](https://reactonrails.com/docs/upgrading/upgrading-react-on-rails/#v15-retraction-notice)
+before using v15 material.
 
 ## Install in 30 Seconds
 
@@ -114,7 +115,7 @@ Start with the docs here:
 
 ## Requirements
 
-- Ruby on Rails >= 5
+- Ruby on Rails >= 5.2
 - Shakapacker >= 6.0 (autobundling requires >= 7.0; CI tested: 8.2.0 - 10.1.0)
 - Ruby >= 3.3 (CI tested: 3.3 - 4.0)
 - Node.js >= 18

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,5 @@
 # Documentation Guide
 
-> **Current docs:** This documentation is for React on Rails 17. For historical v15 material, see the
-> [React on Rails 15.0.0 docs](https://github.com/shakacode/react_on_rails/tree/15.0.0/docs) and
-> [React on Rails 15.0.0 code](https://github.com/shakacode/react_on_rails/tree/15.0.0). Version 15.0.0 was
-> retracted, so use these links only when maintaining older applications.
-
 React on Rails is one product with two tiers: open source for Rails + React integration, and Pro when you need higher SSR throughput, deeper RSC support, or maintainer-backed help.
 
 ## Choose the path that matches your app
@@ -40,7 +35,7 @@ React on Rails is one product with two tiers: open source for Rails + React inte
 - [API Reference](./oss/api-reference/view-helpers-api.md)
 - [Deployment and troubleshooting](./oss/deployment/README.md)
 - [Configuration](./oss/configuration/README.md)
-- [Changelog](https://github.com/shakacode/react_on_rails/blob/main/CHANGELOG.md)
+- [Changelog](./oss/upgrading/changelog.md)
 
 ## Pro features
 

--- a/docs/oss/core-concepts/how-react-on-rails-works.md
+++ b/docs/oss/core-concepts/how-react-on-rails-works.md
@@ -24,7 +24,7 @@ If you open the HTML source of any web page using React on Rails, you'll see the
 1. A script tag containing the properties of the React component, such as the registered name and any props. A JavaScript function runs after the page loads, using this data to build and initialize your React components.
 1. Additional JavaScript is placed to console-log any messages, such as server rendering errors. Note: these server-side logs can be configured only to be sent to the server logs.
 
-You can see all this on the source for [reactrails.com](https://reactrails.com/)
+You can see all this on the source for [www.reactrails.com](https://www.reactrails.com/)
 
 ## Building the Bundles
 

--- a/docs/oss/core-concepts/performance-benchmarks.md
+++ b/docs/oss/core-concepts/performance-benchmarks.md
@@ -93,9 +93,9 @@ Server components produce HTML that does not need hydration — they have no cli
 > This section links to a public live demo first, then covers a non-production local directional benchmark, then a production case study. For validated,
 > at-scale results, see the [Production Case Study: Popmenu](#popmenu) below.
 
-### Public Marketplace RSC Demo Overview {#public-marketplace-rsc-demo}
+### Marketplace demo {#public-marketplace-rsc-demo}
 
-The [LocalHub marketplace demo](https://rsc.reactonrails.com/) is a public,
+The [Marketplace demo](https://rsc.reactonrails.com/) is a public,
 inspectable React on Rails Pro + RSC demo showing the same page families
 rendered with traditional SSR, client rendering, and React Server Components.
 See the [Live Demo and Evidence](../../pro/react-server-components/index.md#live-demo-and-evidence)

--- a/docs/oss/deployment/heroku-deployment.md
+++ b/docs/oss/deployment/heroku-deployment.md
@@ -1,6 +1,6 @@
 # Heroku Deployment
 
-> **Note:** This guide is based on the working tutorial app at [reactrails.com](https://reactrails.com). While the instructions work, some versions referenced are older. For current Heroku best practices with Rails 7, see [Heroku's Rails 7 Guide](https://devcenter.heroku.com/articles/getting-started-with-rails7).
+> **Note:** This guide is based on the working tutorial app at [www.reactrails.com](https://www.reactrails.com). While the instructions work, some versions referenced are older. For current Heroku best practices with Rails 7, see [Heroku's Rails 7 Guide](https://devcenter.heroku.com/articles/getting-started-with-rails7).
 
 ## Create Your Heroku App
 

--- a/docs/oss/getting-started/examples-and-references.md
+++ b/docs/oss/getting-started/examples-and-references.md
@@ -95,7 +95,7 @@ For detailed proof criteria and migration contribution guidance, see
 - [hn.reactonrails.com](https://hn.reactonrails.com/) — Hacker News reader
   showing React on Rails Pro with React 19 and React Server Components on a
   familiar read-heavy UI.
-- [reactrails.com](https://reactrails.com) — production-style React on Rails app
+- [www.reactrails.com](https://www.reactrails.com) — production-style React on Rails app
   you can click through in your browser without any local setup. Backed by the
   legacy [shakacode/react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial)
   source.
@@ -107,7 +107,7 @@ repos are useful historical references, but they are not the primary starting
 point for new evaluations.
 
 - Legacy full app: [shakacode/react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial) —
-  older production-style app (see Live Demos above for the running site at reactrails.com).
+  older production-style app (see Live Demos above for the running site at www.reactrails.com).
   Still useful as a historical reference, but not the recommended starting point for new projects.
 
 If you are choosing a public reference repo for docs, talks, or adoption work,

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -15,7 +15,7 @@ After finishing this tutorial you will get an application that can do the follow
 You can find it here:
 
 - [Source code for this app in PR, using the --redux option](https://github.com/shakacode/react_on_rails-test-new-redux-generation/pull/17) and [for Heroku](https://github.com/shakacode/react_on_rails-test-new-redux-generation/pull/18).
-- [Live on Heroku](https://reactrails.com/)
+- [Live on Heroku](https://www.reactrails.com/)
 
 By the time you read this, the latest may have changed. Be sure to check the versions here:
 
@@ -49,7 +49,7 @@ By the time you read this, the latest may have changed. Be sure to check the ver
 Trying out **React on Rails** is super easy, so long as you have the basic prerequisites.
 
 - **Ruby:** We support Ruby 3.3+ and recommend using the latest stable Ruby version. Solutions like [rvm](https://rvm.io) or [rbenv](https://github.com/rbenv/rbenv) make it easy to have multiple Ruby versions on your machine.
-- **Rails:** This tutorial targets Rails 7.0+. React on Rails supports Rails 6 and later, but some tutorial steps may differ for Rails 6.
+- **Rails:** React on Rails supports Rails 5.2 and later. This tutorial targets Rails 7.0+ for new apps, so some steps may differ for older existing apps.
 - **Node.js:** We support all [active Node versions](https://github.com/nodejs/release#release-schedule) but recommend using the latest LTS release of Nodejs for the longest support. Older inactive node versions might still work but is not guaranteed. We also recommend using [nvm](https://github.com/nvm-sh/nvm/) to ease using different node versions in different projects.
 - **Node Package manager:** You can use [npm](https://npmjs.com/), Yarn ([Classic](https://classic.yarnpkg.com/) or [Berry](https://yarnpkg.com/)), or [pnpm](https://pnpm.io/).
 - You need to have either [Overmind](https://github.com/DarthSim/overmind) or [Foreman](https://rubygems.org/gems/foreman) as a process manager.
@@ -58,10 +58,10 @@ Trying out **React on Rails** is super easy, so long as you have the basic prere
 
 Then we need to create a fresh Rails application as follows.
 
-First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this tutorial.
+First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app.
 
 ```bash
-# For Rails 6.x
+# For Rails 5.2-6.x
 rails new test-react-on-rails --skip-javascript
 
 # For Rails 7.x
@@ -110,7 +110,7 @@ You will be prompted to approve changes in certain files. Press `enter` to proce
 one by one or enter `a` to replace all configuration files required by the project.
 You can check the diffs before you commit to see what changed.
 
-**Note on Redux:** The basic installer uses React Hooks for state management. However, this tutorial demonstrates Redux integration (as used in the [live example](https://reactrails.com/)). To follow this tutorial with Redux, run:
+**Note on Redux:** The basic installer uses React Hooks for state management. However, this tutorial demonstrates Redux integration (as used in the [live example](https://www.reactrails.com/)). To follow this tutorial with Redux, run:
 
 ```bash
 rails generate react_on_rails:install --redux

--- a/docs/oss/introduction.md
+++ b/docs/oss/introduction.md
@@ -2,11 +2,6 @@
 
 > **Integrate React components seamlessly into your Rails application with server-side rendering, hot reloading, and more.**
 
-> **Current docs:** This documentation is for React on Rails 17. For historical v15 material, see the
-> [React on Rails 15.0.0 docs](https://github.com/shakacode/react_on_rails/tree/15.0.0/docs) and
-> [React on Rails 15.0.0 code](https://github.com/shakacode/react_on_rails/tree/15.0.0). Version 15.0.0 was
-> retracted, so use these links only when maintaining older applications.
-
 > [!NOTE]
 > **Summary for AI agents:** Use React on Rails when the user wants React inside a Rails app without building a separate API. Start with [Quick Start](./getting-started/quick-start.md) for new apps, [Install into an Existing Rails App](./getting-started/installation-into-an-existing-rails-app.md) for retrofits, and [OSS vs Pro](./getting-started/oss-vs-pro.md) when the request mentions React Server Components, streaming SSR, the Node renderer, or caching.
 
@@ -78,7 +73,7 @@ Step-by-step walkthrough building a full app with Redux, routing, and deployment
 
 - **[Spec/Dummy App](https://github.com/shakacode/react_on_rails/tree/main/react_on_rails/spec/dummy)** - Simple example in this repo
 - **[Examples and migration references](./getting-started/examples-and-references.md)** - Maintained starters, migration references, and Pro + RSC demos
-- **[Live demo at reactrails.com](https://reactrails.com)** - Running React on Rails app you can click through without local setup
+- **[Live demo at www.reactrails.com](https://www.reactrails.com)** - Running React on Rails app you can click through without local setup
 
 ## Popular Use Cases
 
@@ -116,7 +111,7 @@ Read the full **[React on Rails Doctrine](./misc/doctrine.md)** for our design p
 
 ## System Requirements
 
-- **Rails 7+** (Rails 5.2+ supported)
+- **Rails 5.2+** (new apps require Rails 7+)
 - **Ruby 3.3+**
 - **Node.js 18+**
 - **Shakapacker 6+** (7+ recommended for React on Rails v17)

--- a/docs/oss/upgrading/upgrading-react-on-rails.md
+++ b/docs/oss/upgrading/upgrading-react-on-rails.md
@@ -9,6 +9,10 @@ If you would like help in migrating between React on Rails versions or help with
 
 We specialize in helping companies to quickly and efficiently upgrade. The older versions use the Rails asset pipeline to package client assets. The current and recommended way is to use Webpack 4+ for asset preparation. You may also need help migrating from the `rails/webpacker`'s Webpack configuration to a better setup ready for Server Side Rendering.
 
+## v15 Retraction Notice
+
+React on Rails v15.0.0 was retracted due to API design issues. When upgrading from v14 or earlier, skip v15 and upgrade directly to v16 or a later supported release. Historical v15 material remains available for maintaining older applications: [React on Rails 15.0.0 docs](https://github.com/shakacode/react_on_rails/tree/15.0.0/docs) and [React on Rails 15.0.0 code](https://github.com/shakacode/react_on_rails/tree/15.0.0).
+
 ## General Upgrade Process
 
 After upgrading to any major version, always run the generator to get the latest defaults:

--- a/docs/pro/react-on-rails-pro.md
+++ b/docs/pro/react-on-rails-pro.md
@@ -53,9 +53,9 @@ The fastest way to understand how the Pro feature set fits together is to inspec
 
 It demonstrates the Node renderer, caching, and SSR-oriented workflows in a real Rails app.
 
-## Explore the Public RSC Demo
+## Explore the Marketplace demo
 
-Use the public LocalHub demo when you want an inspectable React on Rails Pro + RSC marketplace surface. The
+Use the public Marketplace demo when you want an inspectable React on Rails Pro + RSC marketplace surface. The
 [React Server Components index](./react-server-components/index.md#live-demo-and-evidence) keeps the demo, evidence
 dashboard, Lighthouse artifacts, and source repository links in one place.
 

--- a/docs/pro/react-server-components/index.md
+++ b/docs/pro/react-server-components/index.md
@@ -39,11 +39,11 @@ In React on Rails, Rails is the backend: your controller owns database access, a
 
 Teams adopting RSC have reported dramatic wins — BlogHunch's 30% server-cost reduction, Frigade's 62% client-bundle reduction, and Mux's 50,000-line incremental migration — all documented in [Migration Success Stories](./success-stories.md). DoorDash's 65% LCP improvement from an earlier Next.js SSR migration is included as a useful server-rendering baseline.
 
-The public demo below shows how these ideas look in an inspectable React on Rails Pro application.
+The Marketplace demo below shows how these ideas look in an inspectable React on Rails Pro application.
 
 ## Live Demo and Evidence {#live-demo-and-evidence}
 
-The public [LocalHub marketplace demo](https://rsc.reactonrails.com/) shows the
+The public [Marketplace demo](https://rsc.reactonrails.com/) shows the
 same marketplace-style surfaces rendered with traditional SSR, client rendering,
 and React Server Components. Use this canonical link list when you want
 inspectable proof instead of a static claim:


### PR DESCRIPTION
## Summary

- Standardizes the flagship RSC demo references to "Marketplace demo" in the performance, Pro, and RSC docs.
- Canonicalizes legacy `reactrails.com` docs links to `www.reactrails.com` while leaving historical changelog/release-note entries alone.
- Aligns the docs/root README Rails version floor language and moves the v15 retraction notice into the upgrade guide.
- Points the docs guide Changelog entry at the existing docs changelog mirror (`docs/oss/upgrading/changelog.md`, symlinked to the root `CHANGELOG.md`) so local markdown link checks resolve.

Closes #3596.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm start format.listDifferent`
- `bin/lefthook/markdown-link-lint branch --offline`
- `git diff --check origin/main...HEAD`
- `rg -n -P "(?<!www\.)reactrails\.com" README.md docs --glob '!docs/oss/upgrading/release-notes/**'` (no matches)
- `rg -n "LocalHub|Public Marketplace RSC Demo|Rails 7\+\*\* \(Rails 5\.2\+ supported\)|Ruby on Rails >= 5$|React on Rails supports Rails 6 and later|Current docs|retracted, so use|Version 15\.0\.0 was retracted" README.md docs/README.md docs/oss/introduction.md docs/oss/getting-started/tutorial.md docs/oss/core-concepts/performance-benchmarks.md docs/pro/react-on-rails-pro.md docs/pro/react-server-components/index.md` (no matches)
- `git push -u origin jg-codex/3596-docs-consistency` (pre-push branch lint passed; online markdown links: 314 total, 275 OK, 0 errors, 25 excluded, 14 redirects)

Labels: none. Docs-only consistency cleanup should rely on path-based CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or dependency changes; risk is limited to incorrect guidance if any link or version text is wrong.
> 
> **Overview**
> This PR **aligns documentation** so demo names, live URLs, Rails version floors, and v15 guidance read the same across the root README, docs index, OSS guides, and Pro/RSC pages.
> 
> The flagship RSC public demo is consistently called **Marketplace demo** (replacing *LocalHub* / longer headings). Tutorial, Heroku, examples, and “how it works” links now use **`www.reactrails.com`** instead of bare `reactrails.com`.
> 
> **Rails support** wording is tightened: supported floor is **Rails 5.2+**, with new apps still described as **Rails 7+** in the tutorial and introduction. The root README requirements list **>= 5.2** instead of **>= 5**.
> 
> **v15 retraction** copy is **centralized** in the upgrade guide (`#v15-retraction-notice`); the root README links there instead of inline warnings, and duplicate “current docs / retracted” blocks are removed from `docs/README.md` and the OSS introduction.
> 
> The docs guide **Changelog** entry points at the in-repo **`docs/oss/upgrading/changelog.md`** mirror so offline markdown link checks pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca9272e2cda71f0fbad38e438233c5cf21e0d57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Rails version requirement to >= 5.2
  * Added v15 Retraction Notice with upgrade guidance for affected users
  * Clarified tutorial setup instructions for different Rails versions
  * Renamed marketplace demo references for consistency across documentation
  * Updated external documentation links and domain references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Merge decision / follow-up

Non-blocking docs nits from review are tracked in #3635 so this approved docs PR can merge without another CI cycle.
