### PR TITLE
Improve create-app smoke diagnostics

### DIFF
--- a/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
+++ b/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
@@ -183,8 +183,14 @@ verify_generated_app_runtime() {
 
   app_name="$(basename "$app_dir")"
   echo "Building test bundles for $app_name..."
+  if ! pushd "$app_dir" >/dev/null; then
+    echo "Cannot cd to generated app directory for $app_name: $app_dir" >&2
+    return 1
+  fi
+
   build_status=0
-  build_output="$(cd "$app_dir" && "${PNPM_CMD[@]}" run build:test 2>&1)" || build_status=$?
+  build_output="$("${PNPM_CMD[@]}" run build:test 2>&1)" || build_status=$?
+  popd >/dev/null
   if [ "$build_status" -ne 0 ]; then
     echo "pnpm run build:test failed for $app_name. Output:" >&2
     printf '%s\n' "$build_output" >&2

--- a/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
+++ b/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
@@ -183,10 +183,9 @@ verify_generated_app_runtime() {
 
   app_name="$(basename "$app_dir")"
   echo "Building test bundles for $app_name..."
-  if build_output="$(cd "$app_dir" && "${PNPM_CMD[@]}" run build:test 2>&1)"; then
-    :
-  else
-    build_status=$?
+  build_status=0
+  build_output="$(cd "$app_dir" && "${PNPM_CMD[@]}" run build:test 2>&1)" || build_status=$?
+  if [ "$build_status" -ne 0 ]; then
     echo "pnpm run build:test failed for $app_name. Output:" >&2
     printf '%s\n' "$build_output" >&2
     return "$build_status"

--- a/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
+++ b/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
@@ -177,9 +177,21 @@ verify_rails_route() {
 
 verify_generated_app_runtime() {
   local app_dir="$1"
+  local app_name
+  local build_output
+  local build_status
 
-  echo "Building test bundles for $(basename "$app_dir")..."
-  (cd "$app_dir" && "${PNPM_CMD[@]}" run build:test >/dev/null)
+  app_name="$(basename "$app_dir")"
+  echo "Building test bundles for $app_name..."
+  if build_output="$(cd "$app_dir" && "${PNPM_CMD[@]}" run build:test 2>&1)"; then
+    :
+  else
+    build_status=$?
+    echo "pnpm run build:test failed for $app_name. Output:" >&2
+    printf '%s\n' "$build_output" >&2
+    return "$build_status"
+  fi
+
   verify_rails_route "$app_dir" "/" "OSS vs Pro"
   verify_rails_route "$app_dir" "/hello_world" "Say hello to:"
 }

--- a/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
+++ b/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
@@ -190,7 +190,10 @@ verify_generated_app_runtime() {
 
   build_status=0
   build_output="$("${PNPM_CMD[@]}" run build:test 2>&1)" || build_status=$?
-  popd >/dev/null
+  popd >/dev/null || {
+    echo "popd failed after building test bundles for $app_name" >&2
+    return 1
+  }
   if [ "$build_status" -ne 0 ]; then
     echo "pnpm run build:test failed for $app_name. Output:" >&2
     printf '%s\n' "$build_output" >&2
@@ -199,6 +202,25 @@ verify_generated_app_runtime() {
 
   verify_rails_route "$app_dir" "/" "OSS vs Pro"
   verify_rails_route "$app_dir" "/hello_world" "Say hello to:"
+}
+
+assert_file_absent() {
+  local file_path="$1"
+
+  if test -f "$file_path"; then
+    echo "Expected file to be absent: $file_path" >&2
+    return 1
+  fi
+}
+
+assert_grep_absent() {
+  local pattern="$1"
+  local file_path="$2"
+
+  if grep -q -- "$pattern" "$file_path"; then
+    echo "Expected $file_path not to contain: $pattern" >&2
+    return 1
+  fi
 }
 
 echo "Verifying generated files..."
@@ -216,7 +238,7 @@ grep -q 'DEFAULT_ROUTE = "/"' "$APP_TS_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_TS_DIR/bin/dev"
 grep -q -- '--open-browser-once' "$APP_TS_DIR/bin/dev"
 test -f "$APP_TS_DIR/pnpm-lock.yaml"
-! test -f "$APP_TS_DIR/package-lock.json"
+assert_file_absent "$APP_TS_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_TS_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_TS_DIR/bin/setup"
 expect_git_history "$APP_TS_DIR" \
@@ -229,12 +251,12 @@ grep -q "gem \"react_on_rails\"" "$APP_JS_DIR/Gemfile"
 grep -q "path: \"$RUBY_GEM_DIR\"" "$APP_JS_DIR/Gemfile"
 grep -q 'root to: "home#index"' "$APP_JS_DIR/config/routes.rb"
 grep -q "hello_world" "$APP_JS_DIR/config/routes.rb"
-! grep -q "gem \"react_on_rails_pro\"" "$APP_JS_DIR/Gemfile"
+assert_grep_absent "gem \"react_on_rails_pro\"" "$APP_JS_DIR/Gemfile"
 test -f "$APP_JS_DIR/app/views/home/index.html.erb"
 grep -q 'DEFAULT_ROUTE = "/"' "$APP_JS_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_JS_DIR/bin/dev"
 test -f "$APP_JS_DIR/pnpm-lock.yaml"
-! test -f "$APP_JS_DIR/package-lock.json"
+assert_file_absent "$APP_JS_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_JS_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_JS_DIR/bin/setup"
 expect_git_history "$APP_JS_DIR" \
@@ -253,7 +275,7 @@ grep -q 'DEFAULT_ROUTE = "/"' "$APP_RSPACK_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_RSPACK_DIR/bin/dev"
 grep -q '"@rspack/core"' "$APP_RSPACK_DIR/package.json"
 test -f "$APP_RSPACK_DIR/pnpm-lock.yaml"
-! test -f "$APP_RSPACK_DIR/package-lock.json"
+assert_file_absent "$APP_RSPACK_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_RSPACK_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_RSPACK_DIR/bin/setup"
 expect_git_history "$APP_RSPACK_DIR" \
@@ -278,7 +300,7 @@ test -f "$APP_PRO_DIR/app/javascript/src/HelloWorld/ror_components/HelloWorld.cl
 grep -q 'DEFAULT_ROUTE = "/"' "$APP_PRO_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_PRO_DIR/bin/dev"
 test -f "$APP_PRO_DIR/pnpm-lock.yaml"
-! test -f "$APP_PRO_DIR/package-lock.json"
+assert_file_absent "$APP_PRO_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_PRO_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_PRO_DIR/bin/setup"
 expect_git_history "$APP_PRO_DIR" \
@@ -300,7 +322,7 @@ grep -Eq "stream_react_component\\(['\\\"]HelloServer['\\\"]" "$APP_RSC_JS_DIR/a
 grep -q 'DEFAULT_ROUTE = "/"' "$APP_RSC_JS_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_RSC_JS_DIR/bin/dev"
 test -f "$APP_RSC_JS_DIR/pnpm-lock.yaml"
-! test -f "$APP_RSC_JS_DIR/package-lock.json"
+assert_file_absent "$APP_RSC_JS_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_RSC_JS_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_RSC_JS_DIR/bin/setup"
 expect_git_history "$APP_RSC_JS_DIR" \
@@ -319,7 +341,7 @@ test -f "$APP_RSC_TS_DIR/app/javascript/src/HelloServer/components/HelloServer.t
 grep -q 'DEFAULT_ROUTE = "/"' "$APP_RSC_TS_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_RSC_TS_DIR/bin/dev"
 test -f "$APP_RSC_TS_DIR/pnpm-lock.yaml"
-! test -f "$APP_RSC_TS_DIR/package-lock.json"
+assert_file_absent "$APP_RSC_TS_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_RSC_TS_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_RSC_TS_DIR/bin/setup"
 expect_git_history "$APP_RSC_TS_DIR" \
@@ -342,7 +364,7 @@ grep -q "\"@rspack/core\"" "$APP_RSC_RSPACK_DIR/package.json"
 grep -q 'DEFAULT_ROUTE = "/"' "$APP_RSC_RSPACK_DIR/bin/dev"
 grep -q 'AUTO_OPEN_BROWSER_ONCE = true' "$APP_RSC_RSPACK_DIR/bin/dev"
 test -f "$APP_RSC_RSPACK_DIR/pnpm-lock.yaml"
-! test -f "$APP_RSC_RSPACK_DIR/package-lock.json"
+assert_file_absent "$APP_RSC_RSPACK_DIR/package-lock.json"
 grep -q '"packageManager": "pnpm@' "$APP_RSC_RSPACK_DIR/package.json"
 grep -q 'system!("pnpm install")' "$APP_RSC_RSPACK_DIR/bin/setup"
 expect_git_history "$APP_RSC_RSPACK_DIR" \

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -1222,7 +1222,7 @@ module ReactOnRails
         content = File.read(shakapacker_config_path)
 
         # Already has an active (non-commented) precompile_hook configured? Don't overwrite.
-        return if content.match?(/^\s+precompile_hook:\s*['"][^'"]+['"]/)
+        return if active_precompile_hook_configured?(content)
 
         # Replace the commented placeholder with the actual value
         # Shakapacker 9.x default config has: # precompile_hook: ~

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -1221,7 +1221,7 @@ module ReactOnRails
 
         content = File.read(shakapacker_config_path)
 
-        # Already has an active (non-commented) precompile_hook configured? Don't overwrite.
+        # Don't materialize a placeholder beside an active precompile_hook in the same YAML section.
         return if active_precompile_hook_configured?(content)
 
         # Replace the commented placeholder with the actual value

--- a/react_on_rails/lib/generators/react_on_rails/base_generator.rb
+++ b/react_on_rails/lib/generators/react_on_rails/base_generator.rb
@@ -1221,7 +1221,8 @@ module ReactOnRails
 
         content = File.read(shakapacker_config_path)
 
-        # Don't materialize a placeholder beside an active precompile_hook in the same YAML section.
+        # Don't materialize placeholders when any placeholder section already has
+        # a direct or inherited active precompile_hook.
         return if active_precompile_hook_configured?(content)
 
         # Replace the commented placeholder with the actual value

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -73,17 +73,31 @@ module ReactOnRails
         # with one gsub. If any placeholder section already resolves to a direct
         # or inherited active hook, leave the file unchanged rather than
         # partially materializing generated hooks in other sections.
-        document.sections.any? do |section|
+        active_hook_configured = document.sections.any? do |section|
           next false unless section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
           section_effective_active_precompile_hook?(section, config, document.section_index, document.anchor_index)
         end
+        warn_existing_precompile_hook_placeholder_skip if active_hook_configured
+        active_hook_configured
       rescue ShakapackerYmlErbError
         true
       end
 
       def fail_closed_generated_precompile_hook
         false
+      end
+
+      def warn_existing_precompile_hook_placeholder_skip
+        return unless respond_to?(:say_status, true)
+
+        say_status :warning,
+                   "Existing direct or inherited precompile_hook found in a section with a placeholder.",
+                   :yellow
+        say_status :warning,
+                   "Skipping generated precompile_hook placeholder updates; " \
+                   "configure remaining sections manually if needed.",
+                   :yellow
       end
 
       def shakapacker_yml_document(content)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -169,8 +169,6 @@ module ReactOnRails
 
       def parse_shakapacker_yml(path)
         parse_shakapacker_yml_content(File.read(path))
-      rescue ShakapackerYmlErbError
-        raise
       rescue StandardError
         {}
       end

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -46,7 +46,8 @@ module ReactOnRails
         content = File.read(shakapacker_config_path)
         config = parse_shakapacker_yml_content(content)
         document = shakapacker_yml_document(content)
-        return false if normalize_precompile_hook(effective_precompile_hook(config, environment))
+        active_hook = normalize_precompile_hook(effective_precompile_hook(config, environment))
+        return false if active_hook
         return false if environment_effective_raw_precompile_hook?(document, config, environment)
         return false unless content.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -150,10 +150,17 @@ module ReactOnRails
           match = line.match(RAW_PRECOMPILE_HOOK_VALUE)
           next false unless match
 
-          raw_value = match[1].strip
+          raw_value = unquote_shakapacker_yml_scalar(match[1].strip)
           raw_value.include?("<%") ||
             !raw_value.match?(UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE)
         end
+      end
+
+      def unquote_shakapacker_yml_scalar(value)
+        return value[1...-1] if value.length >= 2 && value.start_with?('"') && value.end_with?('"')
+        return value[1...-1] if value.length >= 2 && value.start_with?("'") && value.end_with?("'")
+
+        value
       end
 
       def shakapacker_yml_section_merge_aliases(section)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -7,13 +7,12 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
-      PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
       RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*([^#]*?)\s*(?:#.*)?$/
       UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE = /\A(?:|~|null|false|true|yes|no|on|off)\z/i
       class ShakapackerYmlErbError < StandardError; end
       ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
-                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :RAW_PRECOMPILE_HOOK_VALUE,
+                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :RAW_PRECOMPILE_HOOK_VALUE,
                        :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE,
                        :ShakapackerYmlErbError, :ShakapackerYmlDocument
 
@@ -183,7 +182,12 @@ module ReactOnRails
       end
 
       def raw_precompile_hook_state(section)
+        child_indent = shakapacker_yml_section_child_indent(section)
+        return nil unless child_indent
+
         precompile_hook_values = section.each_line.filter_map do |line|
+          next unless shakapacker_yml_section_child_line?(line, child_indent)
+
           line.match(RAW_PRECOMPILE_HOOK_VALUE)&.[](1)
         end
         return nil if precompile_hook_values.empty?
@@ -202,12 +206,29 @@ module ReactOnRails
         value
       end
 
+      def shakapacker_yml_section_child_indent(section)
+        section.each_line.drop(1).filter_map do |line|
+          next if line.strip.empty? || line.match?(/^\s*#/)
+
+          indent = line[/\A */].length
+          indent if indent.positive?
+        end.min
+      end
+
+      def shakapacker_yml_section_child_line?(line, child_indent)
+        line[/\A */].length == child_indent
+      end
+
       def shakapacker_yml_section_merge_aliases(section)
         aliases = []
+        child_indent = shakapacker_yml_section_child_indent(section)
+        return aliases unless child_indent
+
         lines = section.each_line.to_a
         lines.each_with_index do |line, index|
           match = line.match(/^(\s+)<<:\s*(.*)$/)
           next unless match
+          next unless match[1].length == child_indent
 
           aliases.concat(match[2].scan(/\*([A-Za-z0-9_-]+)/).flatten)
           aliases.concat(shakapacker_yml_block_merge_aliases(lines[(index + 1)..], match[1].length))

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -8,14 +8,13 @@ module ReactOnRails
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
       PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
-      ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
       RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*([^#]*?)\s*(?:#.*)?$/
       UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE = /\A(?:|~|null|false|true|yes|no|on|off)\z/i
       class ShakapackerYmlErbError < StandardError; end
       ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
-                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK,
-                       :RAW_PRECOMPILE_HOOK_VALUE, :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE,
+                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :RAW_PRECOMPILE_HOOK_VALUE,
+                       :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE,
                        :ShakapackerYmlErbError, :ShakapackerYmlDocument
 
       private
@@ -57,8 +56,9 @@ module ReactOnRails
         )
         config = parse_shakapacker_yml_content(materialized_content)
         normalize_precompile_hook(effective_precompile_hook(config, environment)) == DEFAULT_PRECOMPILE_HOOK_COMMAND
-      # ShakapackerYmlErbError is caught here as StandardError and returns false to skip writes.
-      # active_precompile_hook_configured? returns true for the same error so both callers fail closed.
+      rescue ShakapackerYmlErbError
+        # render_shakapacker_yml_erb already warned; materialization fails closed.
+        fail_closed_generated_precompile_hook
       rescue StandardError
         false
       end
@@ -69,10 +69,10 @@ module ReactOnRails
         config = parse_shakapacker_yml_content(content)
         document = shakapacker_yml_document(content)
 
-        # The generator materializes all placeholders at once, so one direct or
-        # inherited active hook keeps the whole file under Shakapacker control.
-        # As a result, one custom active hook prevents materializing generated
-        # hooks in other sections; this is safer than partial materialization.
+        # configure_precompile_hook_in_shakapacker rewrites every placeholder
+        # with one gsub. If any placeholder section already resolves to a direct
+        # or inherited active hook, leave the file unchanged rather than
+        # partially materializing generated hooks in other sections.
         document.sections.any? do |section|
           next false unless section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
@@ -80,6 +80,10 @@ module ReactOnRails
         end
       rescue ShakapackerYmlErbError
         true
+      end
+
+      def fail_closed_generated_precompile_hook
+        false
       end
 
       def shakapacker_yml_document(content)
@@ -167,17 +171,24 @@ module ReactOnRails
         aliases = []
         lines = section.each_line.to_a
         lines.each_with_index do |line, index|
-          next unless line.match?(/^\s+<<:/)
+          match = line.match(/^(\s+)<<:\s*(.*)$/)
+          next unless match
 
-          aliases.concat(line.scan(/\*([A-Za-z0-9_-]+)/).flatten)
-          aliases.concat(shakapacker_yml_block_merge_aliases(lines[(index + 1)..]))
+          aliases.concat(match[2].scan(/\*([A-Za-z0-9_-]+)/).flatten)
+          aliases.concat(shakapacker_yml_block_merge_aliases(lines[(index + 1)..], match[1].length))
         end
         aliases
       end
 
-      def shakapacker_yml_block_merge_aliases(lines)
-        lines.take_while { |line| line.match?(/^\s+-\s+\*/) }
-             .flat_map { |line| line.scan(/\*([A-Za-z0-9_-]+)/).flatten }
+      def shakapacker_yml_block_merge_aliases(lines, merge_indent)
+        lines.each_with_object([]) do |line, aliases|
+          next if line.strip.empty? || line.match?(/^\s*#/)
+
+          break aliases if line[/\A */].length <= merge_indent
+
+          match = line.match(/^\s*-\s+\*([A-Za-z0-9_-]+)/)
+          aliases << match[1] if match
+        end
       end
 
       def effective_precompile_hook(config, environment)
@@ -217,7 +228,14 @@ module ReactOnRails
 
       def parse_shakapacker_yml(path)
         parse_shakapacker_yml_content(File.read(path))
+      rescue ShakapackerYmlErbError
+        # render_shakapacker_yml_erb already warned; file-level parsing stays tolerant.
+        empty_shakapacker_yml_config
       rescue StandardError
+        {}
+      end
+
+      def empty_shakapacker_yml_config
         {}
       end
 
@@ -243,7 +261,9 @@ module ReactOnRails
         require "erb"
 
         # TOPLEVEL_BINDING matches Rails config ERB evaluation closely enough for
-        # ENV/Rails constants; unavailable app-specific helpers still fail closed.
+        # ENV/Rails constants. The tradeoff is that evaluation uses this
+        # process's top-level scope rather than an app-isolated binding, so
+        # unavailable app helpers or side effects fail closed and skip writes.
         ERB.new(content).result(TOPLEVEL_BINDING)
       rescue ScriptError, StandardError => e
         warn_shakapacker_yml_erb_error(e)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -192,11 +192,24 @@ module ReactOnRails
         end
         return nil if precompile_hook_values.empty?
 
-        raw_value = unquote_shakapacker_yml_scalar(precompile_hook_values.last.strip)
-        return :active if raw_value.include?("<%")
+        raw_precompile_hook_value_state(precompile_hook_values.last.strip)
+      end
+
+      def raw_precompile_hook_value_state(raw_value)
+        unquoted_value = unquote_shakapacker_yml_scalar(raw_value)
+        return :active if unquoted_value.include?("<%")
+        return :inactive if unquoted_value.empty?
+        return :active if quoted_shakapacker_yml_scalar?(raw_value)
         return :active unless raw_value.match?(UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE)
 
         :inactive
+      end
+
+      def quoted_shakapacker_yml_scalar?(value)
+        return true if value.length >= 2 && value.start_with?('"') && value.end_with?('"')
+        return true if value.length >= 2 && value.start_with?("'") && value.end_with?("'")
+
+        false
       end
 
       def unquote_shakapacker_yml_scalar(value)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -39,8 +39,6 @@ module ReactOnRails
         return unless generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment: environment)
 
         DEFAULT_PRECOMPILE_HOOK_COMMAND
-      rescue ShakapackerYmlErbError
-        nil
       end
 
       def generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment:)
@@ -66,6 +64,8 @@ module ReactOnRails
       end
 
       def active_precompile_hook_configured?(content)
+        # Parse rendered ERB for effective hook values, but inspect raw YAML
+        # sections so conditional ERB hook declarations are still detectable.
         config = parse_shakapacker_yml_content(content)
         document = shakapacker_yml_document(content)
 
@@ -119,6 +119,7 @@ module ReactOnRails
       def environment_effective_raw_precompile_hook?(document, config, environment)
         section_name = shakapacker_config_key?(config, environment) ? environment.to_s : "production"
 
+        # `document` carries prebuilt raw section indexes from the caller.
         raw_active_precompile_hook_in_section_tree?(
           section_name, document.section_index, document.anchor_index
         )
@@ -221,9 +222,8 @@ module ReactOnRails
       def render_shakapacker_yml_erb(content)
         require "erb"
 
-        # Use TOPLEVEL_BINDING so simple ENV lookups work. Rails-specific ERB
-        # raises here and is caught as ShakapackerYmlErbError so we fail closed
-        # instead of risking an overwrite of custom hook config.
+        # TOPLEVEL_BINDING matches Rails config ERB evaluation closely enough for
+        # ENV/Rails constants; unavailable app-specific helpers still fail closed.
         ERB.new(content).result(TOPLEVEL_BINDING)
       rescue ScriptError, StandardError => e
         warn_shakapacker_yml_erb_error(e)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -157,7 +157,20 @@ module ReactOnRails
       end
 
       def shakapacker_yml_section_merge_aliases(section)
-        section.each_line.grep(/^\s+<<:/).flat_map { |line| line.scan(/\*([A-Za-z0-9_-]+)/).flatten }
+        aliases = []
+        lines = section.each_line.to_a
+        lines.each_with_index do |line, index|
+          next unless line.match?(/^\s+<<:/)
+
+          aliases.concat(line.scan(/\*([A-Za-z0-9_-]+)/).flatten)
+          aliases.concat(shakapacker_yml_block_merge_aliases(lines[(index + 1)..]))
+        end
+        aliases
+      end
+
+      def shakapacker_yml_block_merge_aliases(lines)
+        lines.take_while { |line| line.match?(/^\s+-\s+\*/) }
+             .flat_map { |line| line.scan(/\*([A-Za-z0-9_-]+)/).flatten }
       end
 
       def effective_precompile_hook(config, environment)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -6,9 +6,10 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
+      PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
       ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
-                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :ERB_PRECOMPILE_HOOK
+                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK
 
       private
 
@@ -111,6 +112,7 @@ module ReactOnRails
         section = section_index[section_name]
         return false unless section
         return true if section.match?(ERB_PRECOMPILE_HOOK)
+        return false if section.match?(PRECOMPILE_HOOK_KEY)
 
         shakapacker_yml_section_merge_aliases(section).any? do |anchor_name|
           inherited_section_name = anchor_index[anchor_name]

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -220,20 +220,21 @@ module ReactOnRails
       end
 
       def shakapacker_yml_section_merge_aliases(section)
-        aliases = []
         child_indent = shakapacker_yml_section_child_indent(section)
-        return aliases unless child_indent
+        return [] unless child_indent
 
         lines = section.each_line.to_a
+        merge_alias_groups = []
         lines.each_with_index do |line, index|
           match = line.match(/^(\s+)<<:\s*(.*)$/)
           next unless match
           next unless match[1].length == child_indent
 
-          aliases.concat(match[2].scan(/\*([A-Za-z0-9_-]+)/).flatten)
+          aliases = match[2].scan(/\*([A-Za-z0-9_-]+)/).flatten
           aliases.concat(shakapacker_yml_block_merge_aliases(lines[(index + 1)..], match[1].length))
+          merge_alias_groups << aliases
         end
-        aliases
+        merge_alias_groups.reverse.flatten
       end
 
       def shakapacker_yml_block_merge_aliases(lines, merge_indent)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -6,7 +6,7 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
-      ACTIVE_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*['"][^'"]+['"]/
+      ACTIVE_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*(?:"[^"]+"|'[^']+'|[^#\s][^#\n]*)/
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :ACTIVE_PRECOMPILE_HOOK
 
@@ -37,7 +37,7 @@ module ReactOnRails
         return false unless shakapacker_supports_precompile_hook?
 
         content = File.read(shakapacker_config_path)
-        return false if content.match?(ACTIVE_PRECOMPILE_HOOK)
+        return false if active_precompile_hook_configured?(content)
         return false unless content.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
         materialized_content = content.gsub(
@@ -50,6 +50,10 @@ module ReactOnRails
         )
       rescue StandardError
         false
+      end
+
+      def active_precompile_hook_configured?(content)
+        content.match?(ACTIVE_PRECOMPILE_HOOK)
       end
 
       def effective_precompile_hook(config, environment)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -9,7 +9,7 @@ module ReactOnRails
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
       PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
       ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
-      ShakapackerYmlErbError = Class.new(StandardError)
+      class ShakapackerYmlErbError < StandardError; end
       ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK,
@@ -68,6 +68,8 @@ module ReactOnRails
 
         # The generator materializes all placeholders at once, so one direct or
         # inherited active hook keeps the whole file under Shakapacker control.
+        # As a result, one custom active hook prevents materializing generated
+        # hooks in other sections; this is safer than partial materialization.
         document.sections.any? do |section|
           next false unless section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
@@ -87,7 +89,8 @@ module ReactOnRails
       end
 
       def shakapacker_yml_sections(content)
-        # Split at top-level YAML keys; standalone top-level comments become harmless one-line sections.
+        # Split at top-level YAML mapping keys. Top-level comments and document
+        # separators become harmless single-line sections with no recognized name.
         content.each_line.slice_before { |line| line.match?(/^\S/) }.map(&:join)
       end
 
@@ -204,6 +207,9 @@ module ReactOnRails
       def render_shakapacker_yml_erb(content)
         require "erb"
 
+        # Use TOPLEVEL_BINDING so simple ENV lookups work. Rails-specific ERB
+        # raises here and is caught as ShakapackerYmlErbError so we fail closed
+        # instead of risking an overwrite of custom hook config.
         ERB.new(content).result(TOPLEVEL_BINDING)
       rescue ScriptError, StandardError => e
         warn_shakapacker_yml_erb_error(e)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -7,13 +7,15 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
-      RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*([^#]*?)\s*(?:#.*)?$/
+      RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*(.*?)\s*$/
+      # YAML boolean scalars, including truthy values, are not valid shell commands.
       UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE = /\A(?:|~|null|false|true|yes|no|on|off)\z/i
+      SHAKAPACKER_YML_QUOTE_CHARACTERS = ['"', "'"].freeze
       class ShakapackerYmlErbError < StandardError; end
       ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :RAW_PRECOMPILE_HOOK_VALUE,
-                       :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE,
+                       :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE, :SHAKAPACKER_YML_QUOTE_CHARACTERS,
                        :ShakapackerYmlErbError, :ShakapackerYmlDocument
 
       private
@@ -56,10 +58,8 @@ module ReactOnRails
         )
         config = parse_shakapacker_yml_content(materialized_content)
         normalize_precompile_hook(effective_precompile_hook(config, environment)) == DEFAULT_PRECOMPILE_HOOK_COMMAND
-      rescue ShakapackerYmlErbError
-        # render_shakapacker_yml_erb already warned; materialization fails closed.
-        fail_closed_generated_precompile_hook
       rescue StandardError
+        # ERB evaluation failures already warned; materialization fails closed.
         false
       end
 
@@ -82,10 +82,6 @@ module ReactOnRails
         active_hook_configured
       rescue ShakapackerYmlErbError
         true
-      end
-
-      def fail_closed_generated_precompile_hook
-        false
       end
 
       def warn_existing_precompile_hook_placeholder_skip
@@ -161,6 +157,8 @@ module ReactOnRails
       def raw_precompile_hook_state_in_section_tree(section_name, section_index, anchor_index, visited = {})
         return nil if visited[section_name]
 
+        # Mutate this path's cycle state; recursive merge branches receive duped
+        # hashes so sibling aliases do not hide one another.
         visited[section_name] = true
         section = section_index[section_name]
         return nil unless section
@@ -188,11 +186,61 @@ module ReactOnRails
         precompile_hook_values = section.each_line.filter_map do |line|
           next unless shakapacker_yml_section_child_line?(line, child_indent)
 
-          line.match(RAW_PRECOMPILE_HOOK_VALUE)&.[](1)
+          raw_precompile_hook_value(line)
         end
         return nil if precompile_hook_values.empty?
 
-        raw_precompile_hook_value_state(precompile_hook_values.last.strip)
+        raw_precompile_hook_value_state(precompile_hook_values.last)
+      end
+
+      def raw_precompile_hook_value(line)
+        raw_value = line.match(RAW_PRECOMPILE_HOOK_VALUE)&.[](1)
+        return nil unless raw_value
+
+        strip_shakapacker_yml_inline_comment(raw_value).strip
+      end
+
+      def strip_shakapacker_yml_inline_comment(value)
+        value.each_char.with_index do |char, index|
+          next unless char == "#"
+          next unless shakapacker_yml_inline_comment_start?(value, index)
+          next if shakapacker_yml_quoted_at?(value, index)
+
+          return value[0...index].rstrip
+        end
+
+        value.rstrip
+      end
+
+      def shakapacker_yml_inline_comment_start?(value, index)
+        index.zero? || value[index - 1].match?(/\s/)
+      end
+
+      def shakapacker_yml_quoted_at?(value, target_index)
+        quote = nil
+        index = 0
+
+        while index < target_index
+          char = value[index]
+          if quote
+            if shakapacker_yml_escaped_quote?(value, index, quote)
+              index += 2
+              next
+            end
+            quote = nil if char == quote
+          elsif SHAKAPACKER_YML_QUOTE_CHARACTERS.include?(char)
+            quote = char
+          end
+
+          index += 1
+        end
+
+        !quote.nil?
+      end
+
+      def shakapacker_yml_escaped_quote?(value, index, quote)
+        (quote == '"' && value[index] == "\\") ||
+          (quote == "'" && value[index] == "'" && value[index + 1] == "'")
       end
 
       def raw_precompile_hook_value_state(raw_value)
@@ -247,6 +295,7 @@ module ReactOnRails
           aliases.concat(shakapacker_yml_block_merge_aliases(lines[(index + 1)..], match[1].length))
           merge_alias_groups << aliases
         end
+        # Later duplicate << keys override earlier ones in the rendered mapping.
         merge_alias_groups.reverse.flatten
       end
 
@@ -331,9 +380,9 @@ module ReactOnRails
         require "erb"
 
         # TOPLEVEL_BINDING matches Rails config ERB evaluation closely enough for
-        # ENV/Rails constants. The tradeoff is that evaluation uses this
-        # process's top-level scope rather than an app-isolated binding, so
-        # unavailable app helpers or side effects fail closed and skip writes.
+        # ENV/Rails constants. ERB can execute side-effectful Ruby here under the
+        # developer-invoked trust model Rails config ERB already uses. Missing app
+        # helpers or runtime failures fail closed and skip writes.
         ERB.new(content).result(TOPLEVEL_BINDING)
       rescue ScriptError, StandardError => e
         warn_shakapacker_yml_erb_error(e)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -61,7 +61,13 @@ module ReactOnRails
       end
 
       def active_precompile_hook_configured?(content)
-        content.match?(ACTIVE_PRECOMPILE_HOOK)
+        shakapacker_yml_sections(content).any? do |section|
+          section.match?(ACTIVE_PRECOMPILE_HOOK) && section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
+        end
+      end
+
+      def shakapacker_yml_sections(content)
+        content.each_line.slice_before { |line| line.match?(/^\S/) }.map(&:join)
       end
 
       def effective_precompile_hook(config, environment)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -9,10 +9,13 @@ module ReactOnRails
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
       PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
       ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
+      RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*([^#]*?)\s*(?:#.*)?$/
+      UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE = /\A(?:|~|null|false|true|yes|no|on|off)\z/i
       class ShakapackerYmlErbError < StandardError; end
       ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK,
+                       :RAW_PRECOMPILE_HOOK_VALUE, :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE,
                        :ShakapackerYmlErbError, :ShakapackerYmlDocument
 
       private
@@ -47,7 +50,7 @@ module ReactOnRails
         config = parse_shakapacker_yml_content(content)
         document = shakapacker_yml_document(content)
         return false if normalize_precompile_hook(effective_precompile_hook(config, environment))
-        return false if environment_effective_raw_erb_precompile_hook?(document, config, environment)
+        return false if environment_effective_raw_precompile_hook?(document, config, environment)
         return false unless content.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
         materialized_content = content.gsub(
@@ -110,13 +113,13 @@ module ReactOnRails
         return false unless section_name
 
         !normalize_precompile_hook(effective_precompile_hook(config, section_name)).nil? ||
-          raw_erb_precompile_hook_in_section_tree?(section_name, section_index, anchor_index)
+          raw_active_precompile_hook_in_section_tree?(section_name, section_index, anchor_index)
       end
 
-      def environment_effective_raw_erb_precompile_hook?(document, config, environment)
+      def environment_effective_raw_precompile_hook?(document, config, environment)
         section_name = shakapacker_config_key?(config, environment) ? environment.to_s : "production"
 
-        raw_erb_precompile_hook_in_section_tree?(
+        raw_active_precompile_hook_in_section_tree?(
           section_name, document.section_index, document.anchor_index
         )
       end
@@ -125,19 +128,30 @@ module ReactOnRails
         section.match(/\A([A-Za-z0-9_-]+):(?:\s|$)/)&.[](1)
       end
 
-      def raw_erb_precompile_hook_in_section_tree?(section_name, section_index, anchor_index, visited = {})
+      def raw_active_precompile_hook_in_section_tree?(section_name, section_index, anchor_index, visited = {})
         return false if visited[section_name]
 
         visited[section_name] = true
         section = section_index[section_name]
         return false unless section
-        return true if section.match?(ERB_PRECOMPILE_HOOK)
+        return true if raw_active_precompile_hook?(section)
         return false if section.match?(PRECOMPILE_HOOK_KEY)
 
         shakapacker_yml_section_merge_aliases(section).any? do |anchor_name|
           inherited_section_name = anchor_index[anchor_name]
           inherited_section_name &&
-            raw_erb_precompile_hook_in_section_tree?(inherited_section_name, section_index, anchor_index, visited)
+            raw_active_precompile_hook_in_section_tree?(inherited_section_name, section_index, anchor_index, visited)
+        end
+      end
+
+      def raw_active_precompile_hook?(section)
+        section.each_line.any? do |line|
+          match = line.match(RAW_PRECOMPILE_HOOK_VALUE)
+          next false unless match
+
+          raw_value = match[1].strip
+          raw_value.include?("<%") ||
+            !raw_value.match?(UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE)
         end
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -6,7 +6,15 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
-      ACTIVE_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*(?:"[^"]+"|'[^']+'|[^#\s][^#\n]*)/
+      # Unquoted YAML null/false scalars parse as nil/false, so they are inactive unless quoted.
+      ACTIVE_PRECOMPILE_HOOK = /
+        ^\s+precompile_hook:\s*
+        (?:
+          "[^"]+"
+          | '[^']+'
+          | (?!(?:~|null|false|no|off)\s*(?:\#|$)) [^#\s][^#\n]*
+        )
+      /ix
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :ACTIVE_PRECOMPILE_HOOK
 

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -196,7 +196,7 @@ module ReactOnRails
       def render_shakapacker_yml_erb(content)
         require "erb"
 
-        ERB.new(content).result
+        ERB.new(content).result(TOPLEVEL_BINDING)
       rescue ScriptError, StandardError => e
         warn_shakapacker_yml_erb_error(e)
         raise ShakapackerYmlErbError, "Could not evaluate ERB in #{SHAKAPACKER_YML_PATH}: #{e.message}"

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -6,13 +6,14 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
-      # Unquoted YAML null/false scalars parse as nil/false, so they are inactive unless quoted.
+      # Unquoted YAML null/boolean scalars parse as nil/false/true, so they are inactive unless quoted.
+      # The /i flag intentionally covers YAML scalar aliases such as Null, TRUE, No, and OFF.
       ACTIVE_PRECOMPILE_HOOK = /
         ^\s+precompile_hook:\s*
         (?:
           "[^"]+"
           | '[^']+'
-          | (?!(?:~|null|false|no|off)\s*(?:\#|$)) [^#\s][^#\n]*
+          | (?!(?:~|null|true|false|yes|no|on|off)\s*(?:\#|$)) [^#\s][^#\n]*
         )
       /ix
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
@@ -61,13 +62,32 @@ module ReactOnRails
       end
 
       def active_precompile_hook_configured?(content)
+        config = parse_shakapacker_yml_content(content)
+
+        # The generator materializes all placeholders at once, so one direct or
+        # inherited active hook keeps the whole file under Shakapacker control.
         shakapacker_yml_sections(content).any? do |section|
-          section.match?(ACTIVE_PRECOMPILE_HOOK) && section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
+          next false unless section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
+
+          section.match?(ACTIVE_PRECOMPILE_HOOK) || section_inherits_active_precompile_hook?(section, config)
         end
       end
 
       def shakapacker_yml_sections(content)
+        # Split at every top-level YAML key so each environment block is evaluated independently.
+        # Standalone top-level comments become harmless one-line sections.
         content.each_line.slice_before { |line| line.match?(/^\S/) }.map(&:join)
+      end
+
+      def section_inherits_active_precompile_hook?(section, config)
+        section_name = shakapacker_yml_section_name(section)
+        return false unless section_name
+
+        !normalize_precompile_hook(effective_precompile_hook(config, section_name)).nil?
+      end
+
+      def shakapacker_yml_section_name(section)
+        section.match(/\A([A-Za-z0-9_-]+):(?:\s|$)/)&.[](1)
       end
 
       def effective_precompile_hook(config, environment)
@@ -100,7 +120,7 @@ module ReactOnRails
       end
 
       def normalize_precompile_hook(hook)
-        return nil if hook.nil? || hook == false || hook.to_s.empty?
+        return nil if hook.nil? || hook == false || hook == true || hook.to_s.empty?
 
         hook.to_s.strip
       end

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -135,7 +135,7 @@ module ReactOnRails
       end
 
       def environment_effective_raw_precompile_hook?(document, config, environment)
-        section_name = shakapacker_config_key?(config, environment) ? environment.to_s : "production"
+        section_name = shakapacker_effective_section_name(document, config, environment)
 
         # `document` carries prebuilt raw section indexes from the caller.
         raw_active_precompile_hook_in_section_tree?(
@@ -143,35 +143,55 @@ module ReactOnRails
         )
       end
 
+      def shakapacker_effective_section_name(document, config, environment)
+        return environment.to_s if shakapacker_config_key?(config, environment)
+        return environment.to_s if document.section_index.key?(environment.to_s)
+
+        "production"
+      end
+
       def shakapacker_yml_section_name(section)
         section.match(/\A([A-Za-z0-9_-]+):(?:\s|$)/)&.[](1)
       end
 
       def raw_active_precompile_hook_in_section_tree?(section_name, section_index, anchor_index, visited = {})
-        return false if visited[section_name]
+        raw_precompile_hook_state_in_section_tree(section_name, section_index, anchor_index, visited) == :active
+      end
+
+      def raw_precompile_hook_state_in_section_tree(section_name, section_index, anchor_index, visited = {})
+        return nil if visited[section_name]
 
         visited[section_name] = true
         section = section_index[section_name]
-        return false unless section
-        return true if raw_active_precompile_hook?(section)
-        return false if section.match?(PRECOMPILE_HOOK_KEY)
+        return nil unless section
 
-        shakapacker_yml_section_merge_aliases(section).any? do |anchor_name|
+        local_state = raw_precompile_hook_state(section)
+        return local_state if local_state
+
+        shakapacker_yml_section_merge_aliases(section).each do |anchor_name|
           inherited_section_name = anchor_index[anchor_name]
-          inherited_section_name &&
-            raw_active_precompile_hook_in_section_tree?(inherited_section_name, section_index, anchor_index, visited)
+          next unless inherited_section_name
+
+          inherited_state = raw_precompile_hook_state_in_section_tree(
+            inherited_section_name, section_index, anchor_index, visited.dup
+          )
+          return inherited_state if inherited_state
         end
+
+        nil
       end
 
-      def raw_active_precompile_hook?(section)
-        section.each_line.any? do |line|
-          match = line.match(RAW_PRECOMPILE_HOOK_VALUE)
-          next false unless match
-
-          raw_value = unquote_shakapacker_yml_scalar(match[1].strip)
-          raw_value.include?("<%") ||
-            !raw_value.match?(UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE)
+      def raw_precompile_hook_state(section)
+        precompile_hook_values = section.each_line.filter_map do |line|
+          line.match(RAW_PRECOMPILE_HOOK_VALUE)&.[](1)
         end
+        return nil if precompile_hook_values.empty?
+
+        raw_value = unquote_shakapacker_yml_scalar(precompile_hook_values.last.strip)
+        return :active if raw_value.include?("<%")
+        return :active unless raw_value.match?(UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE)
+
+        :inactive
       end
 
       def unquote_shakapacker_yml_scalar(value)

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -10,9 +10,10 @@ module ReactOnRails
       PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
       ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
       ShakapackerYmlErbError = Class.new(StandardError)
+      ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK,
-                       :ShakapackerYmlErbError
+                       :ShakapackerYmlErbError, :ShakapackerYmlDocument
 
       private
 
@@ -44,8 +45,9 @@ module ReactOnRails
 
         content = File.read(shakapacker_config_path)
         config = parse_shakapacker_yml_content(content)
+        document = shakapacker_yml_document(content)
         return false if normalize_precompile_hook(effective_precompile_hook(config, environment))
-        return false if environment_effective_raw_erb_precompile_hook?(content, config, environment)
+        return false if environment_effective_raw_erb_precompile_hook?(document, config, environment)
         return false unless content.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
         materialized_content = content.gsub(
@@ -54,25 +56,34 @@ module ReactOnRails
         )
         config = parse_shakapacker_yml_content(materialized_content)
         normalize_precompile_hook(effective_precompile_hook(config, environment)) == DEFAULT_PRECOMPILE_HOOK_COMMAND
+      # ShakapackerYmlErbError is caught here as StandardError and returns false to skip writes.
+      # active_precompile_hook_configured? returns true for the same error so both callers fail closed.
       rescue StandardError
         false
       end
 
       def active_precompile_hook_configured?(content)
         config = parse_shakapacker_yml_content(content)
-        sections = shakapacker_yml_sections(content)
-        section_index = shakapacker_yml_section_index(sections)
-        anchor_index = shakapacker_yml_anchor_index(sections)
+        document = shakapacker_yml_document(content)
 
         # The generator materializes all placeholders at once, so one direct or
         # inherited active hook keeps the whole file under Shakapacker control.
-        sections.any? do |section|
+        document.sections.any? do |section|
           next false unless section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
-          section_effective_active_precompile_hook?(section, config, section_index, anchor_index)
+          section_effective_active_precompile_hook?(section, config, document.section_index, document.anchor_index)
         end
       rescue ShakapackerYmlErbError
         true
+      end
+
+      def shakapacker_yml_document(content)
+        sections = shakapacker_yml_sections(content)
+        ShakapackerYmlDocument.new(
+          sections: sections,
+          section_index: shakapacker_yml_section_index(sections),
+          anchor_index: shakapacker_yml_anchor_index(sections)
+        )
       end
 
       def shakapacker_yml_sections(content)
@@ -99,12 +110,11 @@ module ReactOnRails
           raw_erb_precompile_hook_in_section_tree?(section_name, section_index, anchor_index)
       end
 
-      def environment_effective_raw_erb_precompile_hook?(content, config, environment)
-        sections = shakapacker_yml_sections(content)
+      def environment_effective_raw_erb_precompile_hook?(document, config, environment)
         section_name = shakapacker_config_key?(config, environment) ? environment.to_s : "production"
 
         raw_erb_precompile_hook_in_section_tree?(
-          section_name, shakapacker_yml_section_index(sections), shakapacker_yml_anchor_index(sections)
+          section_name, document.section_index, document.anchor_index
         )
       end
 

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -6,18 +6,9 @@ module ReactOnRails
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
-      # Unquoted YAML null/boolean scalars parse as nil/false/true, so they are inactive unless quoted.
-      # The /i flag intentionally covers YAML scalar aliases such as Null, TRUE, No, and OFF.
-      ACTIVE_PRECOMPILE_HOOK = /
-        ^\s+precompile_hook:\s*
-        (?:
-          "[^"]+"
-          | '[^']+'
-          | (?!(?:~|null|true|false|yes|no|on|off)\s*(?:\#|$)) [^#\s][^#\n]*
-        )
-      /ix
+      ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
-                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :ACTIVE_PRECOMPILE_HOOK
+                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :ERB_PRECOMPILE_HOOK
 
       private
 
@@ -35,7 +26,7 @@ module ReactOnRails
 
         config = parse_shakapacker_yml(shakapacker_config_path)
         hook_command = normalize_precompile_hook(effective_precompile_hook(config, environment))
-        return hook_command if generated_precompile_hook?(hook_command)
+        return hook_command if hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
 
         return unless generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment: environment)
 
@@ -46,7 +37,9 @@ module ReactOnRails
         return false unless shakapacker_supports_precompile_hook?
 
         content = File.read(shakapacker_config_path)
-        return false if active_precompile_hook_configured?(content)
+        config = parse_shakapacker_yml_content(content)
+        return false if normalize_precompile_hook(effective_precompile_hook(config, environment))
+        return false if environment_effective_raw_erb_precompile_hook?(content, config, environment)
         return false unless content.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
         materialized_content = content.gsub(
@@ -54,40 +47,80 @@ module ReactOnRails
           "\\1precompile_hook: '#{DEFAULT_PRECOMPILE_HOOK_COMMAND}'"
         )
         config = parse_shakapacker_yml_content(materialized_content)
-        generated_precompile_hook?(
-          normalize_precompile_hook(effective_precompile_hook(config, environment))
-        )
+        normalize_precompile_hook(effective_precompile_hook(config, environment)) == DEFAULT_PRECOMPILE_HOOK_COMMAND
       rescue StandardError
         false
       end
 
       def active_precompile_hook_configured?(content)
         config = parse_shakapacker_yml_content(content)
+        sections = shakapacker_yml_sections(content)
+        section_index = shakapacker_yml_section_index(sections)
+        anchor_index = shakapacker_yml_anchor_index(sections)
 
         # The generator materializes all placeholders at once, so one direct or
         # inherited active hook keeps the whole file under Shakapacker control.
-        shakapacker_yml_sections(content).any? do |section|
+        sections.any? do |section|
           next false unless section.match?(COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER)
 
-          section.match?(ACTIVE_PRECOMPILE_HOOK) || section_inherits_active_precompile_hook?(section, config)
+          section_effective_active_precompile_hook?(section, config, section_index, anchor_index)
         end
       end
 
       def shakapacker_yml_sections(content)
-        # Split at every top-level YAML key so each environment block is evaluated independently.
-        # Standalone top-level comments become harmless one-line sections.
+        # Split at top-level YAML keys; standalone top-level comments become harmless one-line sections.
         content.each_line.slice_before { |line| line.match?(/^\S/) }.map(&:join)
       end
 
-      def section_inherits_active_precompile_hook?(section, config)
+      def shakapacker_yml_section_index(sections)
+        sections.filter_map { |section| (name = shakapacker_yml_section_name(section)) && [name, section] }.to_h
+      end
+
+      def shakapacker_yml_anchor_index(sections)
+        sections.filter_map do |section|
+          match = section.match(/\A[A-Za-z0-9_-]+:\s*&([A-Za-z0-9_-]+)/)
+          [match[1], shakapacker_yml_section_name(section)] if match
+        end.to_h
+      end
+
+      def section_effective_active_precompile_hook?(section, config, section_index, anchor_index)
         section_name = shakapacker_yml_section_name(section)
         return false unless section_name
 
-        !normalize_precompile_hook(effective_precompile_hook(config, section_name)).nil?
+        !normalize_precompile_hook(effective_precompile_hook(config, section_name)).nil? ||
+          raw_erb_precompile_hook_in_section_tree?(section_name, section_index, anchor_index)
+      end
+
+      def environment_effective_raw_erb_precompile_hook?(content, config, environment)
+        sections = shakapacker_yml_sections(content)
+        section_name = shakapacker_config_key?(config, environment) ? environment.to_s : "production"
+
+        raw_erb_precompile_hook_in_section_tree?(
+          section_name, shakapacker_yml_section_index(sections), shakapacker_yml_anchor_index(sections)
+        )
       end
 
       def shakapacker_yml_section_name(section)
         section.match(/\A([A-Za-z0-9_-]+):(?:\s|$)/)&.[](1)
+      end
+
+      def raw_erb_precompile_hook_in_section_tree?(section_name, section_index, anchor_index, visited = {})
+        return false if visited[section_name]
+
+        visited[section_name] = true
+        section = section_index[section_name]
+        return false unless section
+        return true if section.match?(ERB_PRECOMPILE_HOOK)
+
+        shakapacker_yml_section_merge_aliases(section).any? do |anchor_name|
+          inherited_section_name = anchor_index[anchor_name]
+          inherited_section_name &&
+            raw_erb_precompile_hook_in_section_tree?(inherited_section_name, section_index, anchor_index, visited)
+        end
+      end
+
+      def shakapacker_yml_section_merge_aliases(section)
+        section.each_line.grep(/^\s+<<:/).flat_map { |line| line.scan(/\*([A-Za-z0-9_-]+)/).flatten }
       end
 
       def effective_precompile_hook(config, environment)
@@ -125,10 +158,6 @@ module ReactOnRails
         hook.to_s.strip
       end
 
-      def generated_precompile_hook?(hook_command)
-        hook_command == DEFAULT_PRECOMPILE_HOOK_COMMAND
-      end
-
       def parse_shakapacker_yml(path)
         parse_shakapacker_yml_content(File.read(path))
       rescue StandardError
@@ -138,17 +167,30 @@ module ReactOnRails
       def parse_shakapacker_yml_content(content)
         require "yaml"
 
-        return YAML.safe_load(content, permitted_classes: [Symbol], aliases: true) if yaml_safe_load_supports_aliases?
+        rendered_content = render_shakapacker_yml_erb(content)
+        if yaml_safe_load_supports_aliases?
+          return YAML.safe_load(rendered_content, permitted_classes: [Symbol], aliases: true)
+        end
+        return {} if yaml_content_uses_aliases?(rendered_content)
+
+        YAML.safe_load(rendered_content, permitted_classes: [Symbol])
+      rescue ArgumentError => e
+        parse_shakapacker_yml_after_alias_keyword_error(e, rendered_content || content)
+      rescue ScriptError, StandardError
+        {}
+      end
+
+      def render_shakapacker_yml_erb(content)
+        require "erb"
+
+        ERB.new(content).result
+      end
+
+      def parse_shakapacker_yml_after_alias_keyword_error(error, content)
+        return {} unless yaml_alias_keyword_error?(error)
         return {} if yaml_content_uses_aliases?(content)
 
         YAML.safe_load(content, permitted_classes: [Symbol])
-      rescue ArgumentError => e
-        return {} if yaml_alias_keyword_error?(e) && yaml_content_uses_aliases?(content)
-        return YAML.safe_load(content, permitted_classes: [Symbol]) if yaml_alias_keyword_error?(e)
-
-        {}
-      rescue StandardError
-        {}
       end
 
       def yaml_safe_load_supports_aliases?

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -2,14 +2,17 @@
 
 module ReactOnRails
   module Generators
+    # rubocop:disable Metrics/ModuleLength
     module ShakapackerPrecompileHookHelper
       SHAKAPACKER_YML_PATH = "config/shakapacker.yml"
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
       PRECOMPILE_HOOK_KEY = /^\s+precompile_hook:\s*/
       ERB_PRECOMPILE_HOOK = /^\s+precompile_hook:\s*.*<%/
+      ShakapackerYmlErbError = Class.new(StandardError)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
-                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK
+                       :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :PRECOMPILE_HOOK_KEY, :ERB_PRECOMPILE_HOOK,
+                       :ShakapackerYmlErbError
 
       private
 
@@ -32,6 +35,8 @@ module ReactOnRails
         return unless generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment: environment)
 
         DEFAULT_PRECOMPILE_HOOK_COMMAND
+      rescue ShakapackerYmlErbError
+        nil
       end
 
       def generated_precompile_hook_will_be_configured?(shakapacker_config_path, environment:)
@@ -66,6 +71,8 @@ module ReactOnRails
 
           section_effective_active_precompile_hook?(section, config, section_index, anchor_index)
         end
+      rescue ShakapackerYmlErbError
+        true
       end
 
       def shakapacker_yml_sections(content)
@@ -162,6 +169,8 @@ module ReactOnRails
 
       def parse_shakapacker_yml(path)
         parse_shakapacker_yml_content(File.read(path))
+      rescue ShakapackerYmlErbError
+        raise
       rescue StandardError
         {}
       end
@@ -177,7 +186,9 @@ module ReactOnRails
 
         YAML.safe_load(rendered_content, permitted_classes: [Symbol])
       rescue ArgumentError => e
-        parse_shakapacker_yml_after_alias_keyword_error(e, rendered_content || content)
+        parse_shakapacker_yml_after_alias_keyword_error(e, rendered_content)
+      rescue ShakapackerYmlErbError
+        raise
       rescue ScriptError, StandardError
         {}
       end
@@ -186,6 +197,20 @@ module ReactOnRails
         require "erb"
 
         ERB.new(content).result
+      rescue ScriptError, StandardError => e
+        warn_shakapacker_yml_erb_error(e)
+        raise ShakapackerYmlErbError, "Could not evaluate ERB in #{SHAKAPACKER_YML_PATH}: #{e.message}"
+      end
+
+      def warn_shakapacker_yml_erb_error(error)
+        return unless respond_to?(:say_status, true)
+
+        say_status :warning,
+                   "Could not evaluate ERB in #{SHAKAPACKER_YML_PATH}: #{error.class}: #{error.message}",
+                   :yellow
+        say_status :warning,
+                   "Skipping generated precompile_hook updates so custom Shakapacker config is not overwritten.",
+                   :yellow
       end
 
       def parse_shakapacker_yml_after_alias_keyword_error(error, content)
@@ -238,5 +263,6 @@ module ReactOnRails
         Dir.pwd
       end
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -405,6 +405,36 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
+    it "honors later duplicate merge keys when they disable earlier raw hooks" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
+        default: &default
+          precompile_hook: <%= false %>
+
+        base: &base
+          precompile_hook: false
+
+        test:
+          <<: *default
+          <<: *base
+          # precompile_hook: ~
+      YAML
+    end
+
+    it "honors later duplicate merge keys when they enable earlier inactive hooks" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        base: &base
+          precompile_hook: false
+
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<: *base
+          <<: *default
+          # precompile_hook: ~
+      YAML
+    end
+
     it "ignores nested precompile_hook keys when scanning a section" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
         default:
@@ -651,6 +681,44 @@ RSpec.describe GeneratorHelper, type: :generator do
       expect(
         generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
       ).to be(true)
+    end
+
+    it "materializes when a later duplicate merge key disables an earlier raw hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: <%= false %>
+
+        base: &base
+          precompile_hook: false
+
+        test:
+          <<: *default
+          <<: *base
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
+    end
+
+    it "does not materialize when a later duplicate merge key enables an earlier inactive hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        base: &base
+          precompile_hook: false
+
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<: *base
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
     end
 
     it "materializes when an inactive hook has a trailing comment that contains ERB" do

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -290,6 +290,16 @@ RSpec.describe GeneratorHelper, type: :generator do
       end
     end
 
+    it "treats quoted empty scalars as inactive" do
+      ['""', "''"].each do |inactive_value|
+        expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
+          default:
+            precompile_hook: #{inactive_value}
+            # precompile_hook: ~
+        YAML
+      end
+    end
+
     it "ignores active hooks in sections without a commented placeholder" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
         default:

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -301,6 +301,15 @@ RSpec.describe GeneratorHelper, type: :generator do
       end
     end
 
+    it "preserves hash characters inside quoted raw hook values when YAML parsing falls back" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default:
+          released_at: 2026-06-05
+          precompile_hook: "bin/custom#hook" # trailing comment
+          # precompile_hook: ~
+      YAML
+    end
+
     it "keeps unquoted boolean-like raw scalars inactive when YAML parsing falls back" do
       %w[false true no off].each do |inactive_value|
         expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
@@ -501,6 +510,15 @@ RSpec.describe GeneratorHelper, type: :generator do
           precompile_hook: 'bin/custom-precompile-hook'
           # precompile_hook: ~
       YAML
+    end
+  end
+
+  describe "#raw_precompile_hook_value" do
+    it "strips unquoted comments without truncating quoted hashes" do
+      expect(raw_precompile_hook_value(%(  precompile_hook: "bin/custom#hook" # comment))).to eq(
+        '"bin/custom#hook"'
+      )
+      expect(raw_precompile_hook_value("  precompile_hook: false # <%= old_hook %>")).to eq("false")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -229,6 +229,29 @@ RSpec.describe GeneratorHelper, type: :generator do
     end
   end
 
+  describe "#active_precompile_hook_configured?" do
+    it "treats quoted and unquoted command strings as active" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default:
+          precompile_hook: bin/shakapacker-precompile-hook
+      YAML
+
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default:
+          precompile_hook: 'bin/shakapacker-precompile-hook'
+      YAML
+    end
+
+    it "treats unquoted YAML null and false scalars as inactive" do
+      %w[~ null Null NULL false False FALSE no off].each do |inactive_value|
+        expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
+          default:
+            precompile_hook: #{inactive_value}
+        YAML
+      end
+    end
+  end
+
   describe "#generated_precompile_hook_will_be_configured?" do
     let(:shakapacker_yml_path) { File.join(destination_root, "config/shakapacker.yml") }
 
@@ -256,6 +279,25 @@ RSpec.describe GeneratorHelper, type: :generator do
       expect(
         generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
       ).to be(false)
+    end
+
+    it "materializes the generated hook when unrelated environments use inactive YAML scalars" do
+      %w[~ null false].each do |inactive_value|
+        File.write(shakapacker_yml_path, <<~YAML)
+          default: &default
+            # precompile_hook: ~
+
+          development:
+            precompile_hook: #{inactive_value}
+
+          test:
+            <<: *default
+        YAML
+
+        expect(
+          generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+        ).to be(true), inactive_value
+      end
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -290,6 +290,28 @@ RSpec.describe GeneratorHelper, type: :generator do
       end
     end
 
+    it "treats quoted boolean-like raw scalars as active commands when YAML parsing falls back" do
+      ['"false"', "'false'", '"true"', "'true'", '"no"', "'off'"].each do |quoted_value|
+        expect(active_precompile_hook_configured?(<<~YAML)).to be(true), quoted_value
+          default:
+            released_at: 2026-06-05
+            precompile_hook: #{quoted_value}
+            # precompile_hook: ~
+        YAML
+      end
+    end
+
+    it "keeps unquoted boolean-like raw scalars inactive when YAML parsing falls back" do
+      %w[false true no off].each do |inactive_value|
+        expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
+          default:
+            released_at: 2026-06-05
+            precompile_hook: #{inactive_value}
+            # precompile_hook: ~
+        YAML
+      end
+    end
+
     it "treats quoted empty scalars as inactive" do
       ['""', "''"].each do |inactive_value|
         expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
@@ -785,6 +807,22 @@ RSpec.describe GeneratorHelper, type: :generator do
         default: &default
           released_at: 2026-06-05
           precompile_hook: 'bin/custom-precompile-hook'
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
+    it "does not materialize over an inherited quoted boolean-like raw hook when YAML parsing falls back" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          released_at: 2026-06-05
+          precompile_hook: "false"
 
         test:
           <<: *default

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -405,6 +405,15 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
+    it "ignores nested precompile_hook keys when scanning a section" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
+        default:
+          nested:
+            precompile_hook: <%= false %>
+          # precompile_hook: ~
+      YAML
+    end
+
     it "treats raw ERB precompile hooks as active because they may vary by environment" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
         default:
@@ -652,6 +661,19 @@ RSpec.describe GeneratorHelper, type: :generator do
 
         test:
           <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
+    end
+
+    it "materializes when only a nested map has a raw precompile_hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        test:
+          nested:
+            precompile_hook: <%= false %>
+          # precompile_hook: ~
       YAML
 
       expect(

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -322,6 +322,18 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
+    it "detects inherited active hooks through block merge lists" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<:
+            - *default
+          # precompile_hook: ~
+      YAML
+    end
+
     it "treats raw ERB precompile hooks as active because they may vary by environment" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
         default:
@@ -496,6 +508,22 @@ RSpec.describe GeneratorHelper, type: :generator do
 
         test:
           <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
+    it "does not materialize over a raw ERB hook inherited through a block merge list" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<:
+            - *default
           # precompile_hook: ~
       YAML
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -244,8 +244,12 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
-    it "treats unquoted YAML null and false scalars as inactive" do
-      %w[~ null Null NULL false False FALSE no off].each do |inactive_value|
+    it "treats unquoted YAML null and boolean scalars as inactive" do
+      %w[
+        ~ null Null NULL
+        false False FALSE no No NO off Off OFF
+        true True TRUE yes Yes YES on On ON
+      ].each do |inactive_value|
         expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
           default:
             precompile_hook: #{inactive_value}
@@ -261,6 +265,17 @@ RSpec.describe GeneratorHelper, type: :generator do
 
         development:
           precompile_hook: bin/development-precompile-hook
+      YAML
+    end
+
+    it "detects active hooks inherited by sections with a commented placeholder" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default: &default
+          precompile_hook: bin/custom-precompile-hook
+
+        test:
+          <<: *default
+          # precompile_hook: ~
       YAML
     end
   end
@@ -294,8 +309,23 @@ RSpec.describe GeneratorHelper, type: :generator do
       ).to be(false)
     end
 
+    it "does not materialize the generated hook over an inherited custom hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: bin/custom-precompile-hook
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
     it "materializes the generated hook when unrelated environments use inactive YAML scalars" do
-      %w[~ null false].each do |inactive_value|
+      %w[~ null false true yes on].each do |inactive_value|
         File.write(shakapacker_yml_path, <<~YAML)
           default: &default
             # precompile_hook: ~

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -300,6 +300,14 @@ RSpec.describe GeneratorHelper, type: :generator do
       end
     end
 
+    it "ignores ERB in trailing comments after inactive scalar values" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
+        default:
+          precompile_hook: false # previously used <%= "bin/custom-precompile-hook" %>
+          # precompile_hook: ~
+      YAML
+    end
+
     it "ignores active hooks in sections without a commented placeholder" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
         default:
@@ -339,6 +347,23 @@ RSpec.describe GeneratorHelper, type: :generator do
 
         test:
           <<:
+            - *default
+          # precompile_hook: ~
+      YAML
+    end
+
+    it "detects inherited active hooks through commented block merge lists" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        base: &base
+          compile: true
+
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<:
+            # Keep base first so later aliases can override it.
+            - *base
             - *default
           # precompile_hook: ~
       YAML
@@ -526,6 +551,27 @@ RSpec.describe GeneratorHelper, type: :generator do
       ).to be(false)
     end
 
+    it "does not materialize over a raw ERB hook inherited through a commented block merge list" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        base: &base
+          compile: true
+
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<:
+            # Keep base first so later aliases can override it.
+            - *base
+            - *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
     it "does not materialize over a raw ERB hook inherited through a block merge list" do
       File.write(shakapacker_yml_path, <<~YAML)
         default: &default
@@ -535,6 +581,36 @@ RSpec.describe GeneratorHelper, type: :generator do
           <<:
             - *default
           # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
+    it "materializes when an inactive hook has a trailing comment that contains ERB" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: false # previously used <%= "bin/custom-precompile-hook" %>
+          # precompile_hook: ~
+
+        test:
+          <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
+    end
+
+    it "fails closed when ERB cannot be evaluated while checking generated hook materialization" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: <%= missing_local %>
+          # precompile_hook: ~
+
+        test:
+          <<: *default
       YAML
 
       expect(

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -297,6 +297,18 @@ RSpec.describe GeneratorHelper, type: :generator do
           # precompile_hook: ~
       YAML
     end
+
+    it "does not treat inherited raw ERB hooks as active after a local inactive override" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<: *default
+          precompile_hook: ~
+          # precompile_hook: ~
+      YAML
+    end
   end
 
   describe "#generated_precompile_hook_will_be_configured?" do
@@ -441,6 +453,22 @@ RSpec.describe GeneratorHelper, type: :generator do
       expect(
         generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
       ).to be(false)
+    end
+
+    it "materializes when the target environment locally disables an inherited raw ERB hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<: *default
+          precompile_hook: ~
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -349,6 +349,15 @@ RSpec.describe GeneratorHelper, type: :generator do
           # precompile_hook: ~
       YAML
     end
+
+    it "detects raw active hooks when unrelated YAML values force parser fallback" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default:
+          released_at: 2026-06-05
+          precompile_hook: 'bin/custom-precompile-hook'
+          # precompile_hook: ~
+      YAML
+    end
   end
 
   describe "#generated_precompile_hook_will_be_configured?" do
@@ -484,6 +493,22 @@ RSpec.describe GeneratorHelper, type: :generator do
       File.write(shakapacker_yml_path, <<~YAML)
         default: &default
           precompile_hook: <%= false %>
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
+    it "does not materialize over an inherited raw quoted hook when YAML parsing falls back" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          released_at: 2026-06-05
+          precompile_hook: 'bin/custom-precompile-hook'
 
         test:
           <<: *default

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -227,6 +227,22 @@ RSpec.describe GeneratorHelper, type: :generator do
 
       expect(parse_shakapacker_yml_content(aliased_config)).to eq({})
     end
+
+    it "warns and raises when shakapacker.yml ERB cannot be evaluated" do
+      expect do
+        parse_shakapacker_yml_content(<<~YAML)
+          default:
+            precompile_hook: <%= missing_local %>
+        YAML
+      end.to raise_error(%r{Could not evaluate ERB in config/shakapacker\.yml})
+
+      expect(say_status_calls).to include(
+        a_hash_including(message: a_string_matching(%r{Could not evaluate ERB in config/shakapacker\.yml}))
+      )
+      expect(say_status_calls).to include(
+        a_hash_including(message: a_string_matching(/Skipping generated precompile_hook updates/))
+      )
+    end
   end
 
   describe "#active_precompile_hook_configured?" do
@@ -306,6 +322,14 @@ RSpec.describe GeneratorHelper, type: :generator do
         test:
           <<: *default
           precompile_hook: ~
+          # precompile_hook: ~
+      YAML
+    end
+
+    it "fails closed when ERB cannot be evaluated" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default:
+          precompile_hook: <%= missing_local %>
           # precompile_hook: ~
       YAML
     end

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -352,6 +352,26 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
+    it "warns when an active hook causes placeholder materialization to be skipped" do
+      say_status_calls.clear
+
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default: &default
+          precompile_hook: bin/custom-precompile-hook
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(say_status_calls).to include(
+        a_hash_including(message: a_string_matching(/Existing direct or inherited precompile_hook/))
+      )
+      expect(say_status_calls).to include(
+        a_hash_including(message: a_string_matching(/configure remaining sections manually/))
+      )
+    end
+
     it "detects inherited active hooks through commented block merge lists" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
         base: &base

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -230,15 +230,17 @@ RSpec.describe GeneratorHelper, type: :generator do
   end
 
   describe "#active_precompile_hook_configured?" do
-    it "treats quoted and unquoted command strings as active" do
+    it "treats quoted and unquoted command strings beside a placeholder as active" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
         default:
           precompile_hook: bin/shakapacker-precompile-hook
+          # precompile_hook: ~
       YAML
 
       expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
         default:
           precompile_hook: 'bin/shakapacker-precompile-hook'
+          # precompile_hook: ~
       YAML
     end
 
@@ -247,8 +249,19 @@ RSpec.describe GeneratorHelper, type: :generator do
         expect(active_precompile_hook_configured?(<<~YAML)).to be(false), inactive_value
           default:
             precompile_hook: #{inactive_value}
+            # precompile_hook: ~
         YAML
       end
+    end
+
+    it "ignores active hooks in sections without a commented placeholder" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
+        default:
+          # precompile_hook: ~
+
+        development:
+          precompile_hook: bin/development-precompile-hook
+      YAML
     end
   end
 
@@ -298,6 +311,23 @@ RSpec.describe GeneratorHelper, type: :generator do
           generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
         ).to be(true), inactive_value
       end
+    end
+
+    it "materializes the generated hook when an unrelated environment has an active hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          # precompile_hook: ~
+
+        development:
+          precompile_hook: bin/development-precompile-hook
+
+        test:
+          <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -389,6 +389,22 @@ RSpec.describe GeneratorHelper, type: :generator do
       YAML
     end
 
+    it "honors merge-list precedence when an earlier alias disables a later raw hook" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(false)
+        base: &base
+          precompile_hook: false
+
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<:
+            - *base
+            - *default
+          # precompile_hook: ~
+      YAML
+    end
+
     it "treats raw ERB precompile hooks as active because they may vary by environment" do
       expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
         default:
@@ -608,6 +624,26 @@ RSpec.describe GeneratorHelper, type: :generator do
       ).to be(false)
     end
 
+    it "materializes when an earlier merge-list alias disables a later raw hook" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        base: &base
+          precompile_hook: false
+
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<:
+            - *base
+            - *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
+    end
+
     it "materializes when an inactive hook has a trailing comment that contains ERB" do
       File.write(shakapacker_yml_path, <<~YAML)
         default: &default
@@ -631,6 +667,22 @@ RSpec.describe GeneratorHelper, type: :generator do
 
         test:
           <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
+    it "does not fall back to production raw hooks when parsed YAML is empty and the target section exists" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        production:
+          # precompile_hook: ~
+
+        test:
+          released_at: 2026-06-05
+          precompile_hook: 'bin/custom-test-hook'
+          # precompile_hook: ~
       YAML
 
       expect(

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -278,6 +278,25 @@ RSpec.describe GeneratorHelper, type: :generator do
           # precompile_hook: ~
       YAML
     end
+
+    it "detects inherited active hooks after rendering ERB" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default: &default
+          precompile_hook: <%= "bin/custom-precompile-hook" %>
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+    end
+
+    it "treats raw ERB precompile hooks as active because they may vary by environment" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        default:
+          precompile_hook: <%= false %>
+          # precompile_hook: ~
+      YAML
+    end
   end
 
   describe "#generated_precompile_hook_will_be_configured?" do
@@ -324,6 +343,21 @@ RSpec.describe GeneratorHelper, type: :generator do
       ).to be(false)
     end
 
+    it "does not materialize the generated hook over an inherited custom hook defined through ERB" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: <%= "bin/custom-precompile-hook" %>
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+
     it "materializes the generated hook when unrelated environments use inactive YAML scalars" do
       %w[~ null false true yes on].each do |inactive_value|
         File.write(shakapacker_yml_path, <<~YAML)
@@ -358,6 +392,55 @@ RSpec.describe GeneratorHelper, type: :generator do
       expect(
         generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
       ).to be(true)
+    end
+
+    it "materializes the generated hook when an unrelated environment has an active hook beside a placeholder" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          # precompile_hook: ~
+
+        development:
+          <<: *default
+          precompile_hook: bin/development-precompile-hook
+          # precompile_hook: ~
+
+        test:
+          <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(true)
+    end
+
+    it "does not materialize over an ERB hook that may be active in the target build environment" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: '<%= Rails.env.production? ? "bin/custom-hook" : "" %>'
+          # precompile_hook: ~
+
+        test:
+          <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "production")
+      ).to be(false)
+    end
+
+    it "does not materialize over an inherited raw ERB hook even if it renders inactive during install" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: <%= false %>
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -229,6 +229,36 @@ RSpec.describe GeneratorHelper, type: :generator do
     end
   end
 
+  describe "#generated_precompile_hook_will_be_configured?" do
+    let(:shakapacker_yml_path) { File.join(destination_root, "config/shakapacker.yml") }
+
+    before do
+      FileUtils.mkdir_p(File.dirname(shakapacker_yml_path))
+      allow(ReactOnRails::PackerUtils).to receive(:shakapacker_version_requirement_met?)
+        .with("9.0.0")
+        .and_return(true)
+    end
+
+    after do
+      FileUtils.rm_rf(File.join(destination_root, "config"))
+    end
+
+    it "does not materialize the generated hook when an unquoted active hook already exists" do
+      File.write(shakapacker_yml_path, <<~YAML)
+        default: &default
+          precompile_hook: bin/shakapacker-precompile-hook
+          # precompile_hook: ~
+
+        test:
+          <<: *default
+      YAML
+
+      expect(
+        generated_precompile_hook_will_be_configured?(shakapacker_yml_path, environment: "test")
+      ).to be(false)
+    end
+  end
+
   describe "Pro/RSC flag helpers" do
     it "treats --rsc as implying Pro" do
       allow(self).to receive(:options).and_return({ rsc: true, pro: false })

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -243,6 +243,22 @@ RSpec.describe GeneratorHelper, type: :generator do
         a_hash_including(message: a_string_matching(/Skipping generated precompile_hook updates/))
       )
     end
+
+    it "keeps file-level parsing tolerant when shakapacker.yml ERB cannot be evaluated" do
+      shakapacker_yml_path = File.join(destination_root, "config/shakapacker.yml")
+      FileUtils.mkdir_p(File.dirname(shakapacker_yml_path))
+      File.write(shakapacker_yml_path, <<~YAML)
+        default:
+          javascript_transpiler: <%= missing_local %>
+      YAML
+
+      expect(parse_shakapacker_yml(shakapacker_yml_path)).to eq({})
+      expect(say_status_calls).to include(
+        a_hash_including(message: a_string_matching(%r{Could not evaluate ERB in config/shakapacker\.yml}))
+      )
+    ensure
+      FileUtils.rm_f(shakapacker_yml_path)
+    end
   end
 
   describe "#active_precompile_hook_configured?" do

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -493,6 +493,52 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  context "when Shakapacker was pre-installed with an inactive unquoted precompile_hook value" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          assets_bundler: "webpack"
+          precompile_hook: false
+
+        development:
+          <<: *default
+
+        test:
+          <<: *default
+          compile: true
+          # precompile_hook: ~
+
+        production:
+          <<: *default
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      Dir.chdir(destination_root) do
+        run_generator(["--ignore-warnings", "--skip"])
+      end
+    end
+
+    it "configures the commented generated hook placeholder" do
+      assert_file "config/shakapacker.yml" do |content|
+        expect(content).to match(/^\s+precompile_hook: false$/)
+        expect(content).to include("precompile_hook: 'bin/shakapacker-precompile-hook'")
+      end
+    end
+  end
+
   context "when shakapacker.yml already has a custom precompile_hook" do
     before(:all) do
       prepare_destination

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -539,6 +539,52 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  context "when Shakapacker was pre-installed with an active unquoted precompile_hook value" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          assets_bundler: "webpack"
+          precompile_hook: bin/custom-precompile-hook
+          # precompile_hook: ~
+
+        development:
+          <<: *default
+
+        test:
+          <<: *default
+          compile: true
+
+        production:
+          <<: *default
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      Dir.chdir(destination_root) do
+        run_generator(["--ignore-warnings", "--skip"])
+      end
+    end
+
+    it "leaves the custom hook under Shakapacker control" do
+      assert_file "config/shakapacker.yml" do |content|
+        expect(content).to include("precompile_hook: bin/custom-precompile-hook")
+        expect(content).not_to include("precompile_hook: 'bin/shakapacker-precompile-hook'")
+      end
+    end
+  end
+
   context "when shakapacker.yml already has a custom precompile_hook" do
     before(:all) do
       prepare_destination

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -585,6 +585,58 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  context "when Shakapacker was pre-installed with an inherited custom precompile_hook value" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          assets_bundler: "webpack"
+          precompile_hook: bin/custom-precompile-hook
+
+        development:
+          <<: *default
+
+        test:
+          <<: *default
+          compile: true
+          # precompile_hook: ~
+
+        production:
+          <<: *default
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      Dir.chdir(destination_root) do
+        run_generator(["--ignore-warnings", "--skip"])
+      end
+    end
+
+    it "leaves the inherited custom hook under Shakapacker control" do
+      assert_file "config/shakapacker.yml" do |content|
+        expect(content).to include("precompile_hook: bin/custom-precompile-hook")
+        expect(content).to include("# precompile_hook: ~")
+        expect(content).not_to include("precompile_hook: 'bin/shakapacker-precompile-hook'")
+      end
+
+      assert_file "package.json" do |content|
+        scripts = JSON.parse(content).fetch("scripts")
+        expect(scripts["build:test"]).to eq("RAILS_ENV=test NODE_ENV=test bin/shakapacker")
+      end
+    end
+  end
+
   context "when Shakapacker was pre-installed with an active hook in an unrelated environment" do
     before(:all) do
       prepare_destination

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -585,6 +585,52 @@ describe InstallGenerator, type: :generator do
     end
   end
 
+  context "when Shakapacker was pre-installed with an active hook in an unrelated environment" do
+    before(:all) do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+          source_entry_path: packs
+          public_output_path: packs
+          assets_bundler: "webpack"
+          # precompile_hook: ~
+
+        development:
+          <<: *default
+          precompile_hook: bin/development-precompile-hook
+
+        test:
+          <<: *default
+          compile: true
+
+        production:
+          <<: *default
+      YAML
+      simulate_existing_file("bin/shakapacker", "")
+      simulate_existing_file("bin/shakapacker-dev-server", "")
+      simulate_existing_file("config/webpack/webpack.config.js", <<~JS)
+        const { generateWebpackConfig } = require('shakapacker')
+        const webpackConfig = generateWebpackConfig()
+        module.exports = webpackConfig
+      JS
+
+      Dir.chdir(destination_root) do
+        run_generator(["--ignore-warnings", "--skip"])
+      end
+    end
+
+    it "still configures the generated hook placeholder" do
+      assert_file "config/shakapacker.yml" do |content|
+        expect(content).to include("precompile_hook: bin/development-precompile-hook")
+        expect(content).to include("precompile_hook: 'bin/shakapacker-precompile-hook'")
+      end
+    end
+  end
+
   context "when shakapacker.yml already has a custom precompile_hook" do
     before(:all) do
       prepare_destination


### PR DESCRIPTION
## Summary
- Print captured `pnpm run build:test` output when create-app smoke runtime builds fail, while keeping successful smoke runs quiet.
- Treat unquoted inactive YAML `precompile_hook:` scalars (`~`, `null`, `false`, plus YAML false aliases like `no`/`off`) as not configured; quoted strings and unquoted command paths remain active.
- Scope placeholder suppression to the same top-level YAML section, so an active hook in an unrelated environment does not prevent materializing the generated hook where it is still needed.

Closes #3536.

## Verification
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb`
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb:460 react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb:534 react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb:580 react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb:626`
- `bash -n packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
- `shellcheck --exclude=SC2251 packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
- `pnpm --filter create-react-on-rails-app test`
- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/base_generator.rb react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `git diff --check`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`

## Draft reason
Full `bundle exec rubocop` and `bundle exec rubocop --force-exclusion` still fail on unrelated baseline/generated paths (`react_on_rails/spec/react_on_rails/dummy-for-generators` and `react_on_rails/spike/3313_prism_gemfile_rewriter/*`). The touched Ruby files and pre-push branch RuboCop passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generator behavior for `config/shakapacker.yml` during install (ERB execution and conditional writes), which can affect asset precompile scripts; scope is install/generator paths with extensive new tests.
> 
> **Overview**
> Improves **create-app smoke diagnostics** and makes **Shakapacker `precompile_hook` handling** safer during generator installs.
> 
> The local-gems smoke script now **captures and prints full `pnpm run build:test` output** when runtime builds fail, and uses small **`assert_file_absent` / `assert_grep_absent`** helpers instead of negated shell tests.
> 
> The install generator no longer treats any regex-matched `precompile_hook` line as “already configured.” It **evaluates `shakapacker.yml` (including ERB)**, walks **YAML sections, anchors, and merge inheritance**, and treats **unquoted inactive scalars** (`~`, `null`, `false`, YAML boolean aliases) as unset while **command paths and quoted strings** stay active. **Placeholder materialization is all-or-nothing**: if any section with `# precompile_hook: ~` already has a direct or inherited active hook, the generator **skips rewriting** the file; an active hook in another environment **does not** block materializing where placeholders remain. **Unreadable ERB/YAML fails closed** (warn and skip overwriting custom config).
> 
> Specs cover ERB failure, merge precedence, inherited ERB hooks, and several pre-installed Shakapacker layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616fd83a13d6ecb3ffa39355ec66930cdd43f6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of precompile hook configurations to recognize quoted and unquoted values and avoid overwriting active custom hooks.

* **Improvements**
  * Install process preserves existing active precompile hooks; generator adds hooks only when appropriate.
  * Smoke-test now captures and prints full build output on failures for easier debugging.

* **Tests**
  * Added coverage for precompile hook detection and generator install scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up

- Non-blocking review polish is tracked in #3649.

### Codex follow-up notes
- Placeholder materialization remains all-or-nothing: if any placeholder section has a direct or inherited active hook, the generator leaves `shakapacker.yml` unchanged rather than partially replacing placeholders and overriding inherited hooks.
- Fail closed on Shakapacker YAML/ERB parsing: unreadable or unsafe config should skip writing generated hook config rather than risk overwriting app-specific settings.
- Shakapacker YAML section parsing now uses one parsed section-index object shared by hook-detection helpers so inherited/ERB hook checks stay consistent.

