### PR TITLE
Harden async props pending specs

### DIFF
--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -466,6 +466,8 @@ describe ReactOnRailsPro::Request do
       renderer_updates = output_writes.filter_map do |payload|
         parsed = JSON.parse(payload.chomp)
         parsed if parsed["bundleTimestamp"] && parsed["updateChunk"]
+      rescue JSON::ParserError
+        nil
       end
 
       failure_update = renderer_updates.find { |update| update["updateChunk"].include?("books async prop failed") }

--- a/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "spec_helper"
-require "timeout"
+require "async"
 require "react_on_rails_pro/stream_request"
 require "react_on_rails_pro/renderer_http_client"
 
@@ -269,8 +269,10 @@ RSpec.describe ReactOnRailsPro::StreamRequest do
       abort_after_first_chunk = proc { |_chunk| raise "client disconnected" }
 
       expect do
-        Timeout.timeout(5) do
-          stream.each_chunk(&abort_after_first_chunk)
+        Sync do
+          Async::Task.current.with_timeout(5) do
+            stream.each_chunk(&abort_after_first_chunk)
+          end
         end
       end.to raise_error(RuntimeError, "client disconnected")
 


### PR DESCRIPTION
## Summary

Closes #3547.

- Replaces the async stream abort spec's `Timeout.timeout(5)` guard with an Async-native `Async::Task.current.with_timeout(5)` inside an outer `Sync` block, matching the Async task context used by the code under test.
- Ignores unrelated non-JSON writes while filtering pending async-props `output_writes`, so the pending failure contract stays focused on renderer update chunks.

## Verification

- `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/stream_request_spec.rb spec/react_on_rails_pro/request_spec.rb` -> `60 examples, 0 failures, 1 pending`
- `bundle exec rubocop react_on_rails_pro/spec/react_on_rails_pro/stream_request_spec.rb react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb --cache-root /private/tmp/rubocop_cache --no-server --cache false` -> `2 files inspected, no offenses detected`
- `git diff --check` -> clean
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local` -> no accepted/actionable findings

No production behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to RSpec examples; no application or library runtime code is modified.
> 
> **Overview**
> **Test-only** hardening for async streaming and incremental async-props specs—no production behavior changes.
> 
> The stream abort example now runs inside a **`Sync`** block and uses **`Async::Task.current.with_timeout(5)`** instead of **`Timeout.timeout`**, so the timeout guard matches the Async task context used by **`each_chunk`**.
> 
> The pending async-props failure example now **rescues `JSON::ParserError`** when scanning **`output_writes`**, so only valid renderer update chunks (`bundleTimestamp` + `updateChunk`) are considered and unrelated non-JSON writes do not break the assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f04467296e796ea581bae8daa956b5f8ab2afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness for async property failure handling scenarios.
  * Enhanced test reliability for async task cancellation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->