### PR TITLE
ci: stop benchmarks/tests running on internal-docs & issue-template-only PRs

### DIFF
--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -254,8 +254,13 @@ while IFS= read -r file; do
   # any character including /.
   # shellcheck disable=SC2221,SC2222
   case "$file" in
-    # Documentation files
-    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|.lychee.toml)
+    # Documentation and non-runtime project metadata. None of these affect the
+    # gem/package runtime, tests, or benchmarks, so they must NOT fall through to
+    # the catch-all below, which forces the entire test + benchmark suite to run
+    # (see the #3474 regression and the benchmarks-on-a-docs-PR case in #3597).
+    #   - internal/**              : planning, contributor-info, testimonials, history docs
+    #   - .github/ISSUE_TEMPLATE/** : GitHub issue templates (repo metadata, not CI infra)
+    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|internal/*|internal/**/*|.github/ISSUE_TEMPLATE/*|.github/ISSUE_TEMPLATE/**/*|.lychee.toml)
       # Don't change DOCS_ONLY flag, just continue
       ;;
 

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -194,6 +194,57 @@ test_docs_changes_are_non_runtime_only() {
   assert_contains "$out" '"run_lint": false' "docs output"
 }
 
+# Regression for PR #3597: an internal docs/planning YAML (e.g.
+# internal/contributor-info/demo-fleet.yml) used to fall through to the
+# uncategorized catch-all, forcing the entire test + benchmark suite to run.
+test_internal_non_markdown_docs_are_non_runtime_only() {
+  setup_repo
+  write_file_change "internal/contributor-info/demo-fleet.yml" "fleet: []"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "internal yaml output"
+  assert_contains "$out" '"non_runtime_only": true' "internal yaml output"
+  assert_contains "$out" '"run_lint": false' "internal yaml output"
+  assert_contains "$out" '"run_ruby_tests": false' "internal yaml output"
+  assert_contains "$out" '"benchmarks_changed": false' "internal yaml output"
+}
+
+# Regression for PR #3597: a GitHub issue template (.github/ISSUE_TEMPLATE/*.yml)
+# is repo metadata, not CI infrastructure, and must not trigger any test suite.
+test_issue_template_changes_are_non_runtime_only() {
+  setup_repo
+  write_file_change ".github/ISSUE_TEMPLATE/rc-release-tracking.yml" "name: RC release"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "issue template output"
+  assert_contains "$out" '"non_runtime_only": true' "issue template output"
+  assert_contains "$out" '"run_lint": false' "issue template output"
+  assert_contains "$out" '"run_ruby_tests": false' "issue template output"
+}
+
+# Regression for PR #3597 (the exact file set): mixed internal markdown +
+# internal YAML + an issue-template YAML in one docs-only PR stays non-runtime,
+# so it never triggers the benchmark suite.
+test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only() {
+  setup_repo
+  mkdir -p internal/contributor-info .github/ISSUE_TEMPLATE
+  printf 'design notes\n' > internal/contributor-info/rc-testing-plan.md
+  printf 'fleet: []\n' > internal/contributor-info/demo-fleet.yml
+  printf 'name: RC release\n' > .github/ISSUE_TEMPLATE/rc-release-tracking.yml
+  commit_change "docs-only RC planning PR"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "docs PR output"
+  assert_contains "$out" '"non_runtime_only": true' "docs PR output"
+  assert_contains "$out" '"run_lint": false' "docs PR output"
+  assert_contains "$out" '"run_ruby_tests": false' "docs PR output"
+  assert_contains "$out" '"run_js_tests": false' "docs PR output"
+  assert_contains "$out" '"benchmarks_changed": false' "docs PR output"
+}
+
 test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   setup_repo
   perl -0pi -e 's/class Example/class Example\n    # Explain the fixture./' \
@@ -604,6 +655,9 @@ test_empty_diff_skips_everything() {
 
 run_test test_empty_diff_skips_everything
 run_test test_docs_changes_are_non_runtime_only
+run_test test_internal_non_markdown_docs_are_non_runtime_only
+run_test test_issue_template_changes_are_non_runtime_only
+run_test test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_wrapping_ruby_code_with_block_comment_delimiters_remains_runtime_affecting


### PR DESCRIPTION
## Problem

CI benchmark suites (Core, Pro, Pro Node Renderer) ran on a **docs-only** PR — [#3597](https://github.com/shakacode/react_on_rails/pull/3597), which only adds RC release-gate planning docs and a GitHub issue template.

## Root cause

`script/ci-changes-detector` is the single gate deciding which test workflows **and** benchmark suites run. Any changed file matching no explicit category falls through to the catch-all (`*`), which sets `DOCS_ONLY=false` and "runs everything" for safety — including all benchmark suites.

Two non-`.md` file types had no category:

- `internal/**` — planning, contributor-info, testimonials, and history docs
- `.github/ISSUE_TEMPLATE/**` — GitHub issue templates (repo metadata, not CI infra)

#3597's `internal/contributor-info/demo-fleet.yml` and `.github/ISSUE_TEMPLATE/rc-release-tracking.yml` hit the catch-all, so the full test + benchmark suite ran on a documentation change. The workflow-level `paths-ignore: ['**.md', …]` couldn't help: it only skips when *every* changed file matches, and these `.yml` files don't match `**.md`.

This is the same class of bug as the #3474 regression already covered by the test harness (a file falling through to the catch-all forcing the whole suite).

## Fix

Categorize `internal/**` and `.github/ISSUE_TEMPLATE/**` as documentation/non-runtime in the detector so they no longer force the test + benchmark suite.

## Tests

Added three regression tests to `script/ci-changes-detector-test.bash`:

- internal YAML (`demo-fleet.yml`) → non-runtime
- issue-template YAML → non-runtime
- the exact mixed file set from #3597 (internal `.md` + internal `.yml` + issue-template `.yml`) → `docs_only`, no benchmarks

All 37 detector tests pass locally (`bash script/ci-changes-detector-test.bash`). `shellcheck` is clean on the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to CI path classification and test harness coverage; no application runtime or auth paths change.
> 
> **Overview**
> **`script/ci-changes-detector`** now treats **`internal/**`** and **`.github/ISSUE_TEMPLATE/**`** like other documentation/non-runtime paths, so those files no longer hit the uncategorized catch-all that turns on the full test and benchmark matrix on docs-only PRs.
> 
> Three regression tests in **`script/ci-changes-detector-test.bash`** lock in non-runtime behavior for internal YAML, issue-template YAML, and the mixed file set from #3597 (`docs_only`, no Ruby/JS tests, no benchmarks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8dcec1bb9f5a691153d4a5ed3af94cd72e70639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI pipeline change detection to better categorize documentation and non-runtime project metadata.
  * Internal documentation and GitHub issue template modifications are now properly classified as documentation-only, improving test execution efficiency.
  * Enhanced test coverage for documentation categorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->