### PR TITLE
fix(pro): polish rolling-deploy auto-route prefix + hash constraint (#3548)

### DIFF
--- a/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
+++ b/react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy/bundles_controller.rb
@@ -63,8 +63,10 @@ module ReactOnRailsPro
       # matcher applies segment constraints to the full segment. Derived from
       # SAFE_HASH_PATTERN by stripping the \A/\z anchors; the controller still
       # performs the anchored defense-in-depth validation before any filesystem
-      # lookup.
-      ROUTE_HASH_PATTERN = Regexp.new(SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
+      # lookup. Carries SAFE_HASH_PATTERN.options forward so any future flags
+      # (e.g. case-insensitivity) stay in sync between the two patterns.
+      ROUTE_HASH_PATTERN = Regexp.new(SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"),
+                                      SAFE_HASH_PATTERN.options)
 
       class << self
         # Helper for manual route mounts. The Pro engine uses these same route

--- a/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
   let(:config) { ReactOnRailsPro.configuration }
   let(:default_path) { ReactOnRailsPro::Configuration::DEFAULT_ROLLING_DEPLOY_MOUNT_PATH }
   let(:token) { "a" * 32 }
+  # Engine keeps this prefix private; read it through const_get so the spec
+  # stays pinned to the real value instead of a copy that can silently drift.
+  let(:auto_route_prefix) { ReactOnRailsPro::Engine.const_get(:ROLLING_DEPLOY_AUTO_ROUTE_PREFIX) }
 
   around do |example|
     original_adapter = config.rolling_deploy_adapter
@@ -33,14 +36,14 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
 
   def route_set_with_auto_mount
     path = default_path
+    as_prefix = auto_route_prefix
 
     ActionDispatch::Routing::RouteSet.new.tap do |routes|
       routes.prepend do
         ReactOnRailsPro::RollingDeploy::BundlesController.draw_routes(
           self,
           path: path,
-          # Must match ReactOnRailsPro::Engine::ROLLING_DEPLOY_AUTO_ROUTE_PREFIX.
-          as_prefix: "react_on_rails_pro_auto_rolling_deploy"
+          as_prefix: as_prefix
         )
       end
     end
@@ -82,7 +85,7 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
       end
     end.not_to raise_error
     expect(routes.named_routes.helper_names).to include(
-      "react_on_rails_pro_auto_rolling_deploy_manifest_path",
+      "#{auto_route_prefix}_manifest_path",
       "react_on_rails_pro_rolling_deploy_manifest_path"
     )
   end

--- a/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe "rolling-deploy auto routes", type: :request do
     end
   end
 
+  it "pins the engine's auto-route prefix to its published value" do
+    # The other examples read the prefix through const_get, so the routes they
+    # mount and the helper names they assert move together — a rename of the
+    # constant would leave them green. This literal pin is the one place that
+    # catches such a rename, since the generated helper names are a contract
+    # for consumers' route specs and manual-mount docs.
+    expect(auto_route_prefix).to eq("react_on_rails_pro_auto_rolling_deploy")
+  end
+
   it "auto-mounts the bundles controller when the built-in HTTP adapter is configured" do
     configure_rolling_deploy_routes(
       adapter: ReactOnRailsPro::RollingDeployAdapters::Http,

--- a/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb
@@ -30,6 +30,14 @@ describe ReactOnRailsPro::RollingDeploy::BundlesController do
         .to eq(described_class::SAFE_HASH_PATTERN.source.delete_prefix("\\A").delete_suffix("\\z"))
     end
 
+    it "carries the safe hash pattern's regexp options forward so the two stay in sync" do
+      # Enforces the guarantee in ROUTE_HASH_PATTERN's comment: a future flag
+      # added to SAFE_HASH_PATTERN (e.g. case-insensitivity) must reach the
+      # route constraint too. Currently both are 0; this fails if they diverge.
+      expect(described_class::ROUTE_HASH_PATTERN.options)
+        .to eq(described_class::SAFE_HASH_PATTERN.options)
+    end
+
     {
       "abc123" => true,
       "_hash" => true,


### PR DESCRIPTION
## Summary

Addresses the two optional review nits raised in #3548 (follow-up from #3504, "Auto-mount Pro rolling deploy bundle routes"). Both are polish-only — no user-visible behavior change.

1. **Auto-route spec references the engine constant instead of a hardcoded literal.** `react_on_rails_pro/spec/dummy/spec/rolling_deploy_auto_routes_spec.rb` now reads `ReactOnRailsPro::Engine::ROLLING_DEPLOY_AUTO_ROUTE_PREFIX` via `const_get` (the constant is `private_constant`, so `const_get` is required) and uses it both for the manual reproduction of the engine auto-mount and for the helper-name assertion. The spec now stays pinned to the real prefix instead of a copy that could silently drift.

2. **`ROUTE_HASH_PATTERN` preserves `SAFE_HASH_PATTERN.options`.** `BundlesController` derives the route constraint from `SAFE_HASH_PATTERN` by stripping the `\A`/`\z` anchors; it now passes `SAFE_HASH_PATTERN.options` to `Regexp.new` so any future flags (e.g. case-insensitivity) stay in sync between the anchored defense-in-depth validation and the route constraint. Today the pattern carries no flags, so the derived regexp is byte-identical.

## Testing

- `bundle exec rspec spec/react_on_rails_pro/rolling_deploy/bundles_controller_spec.rb` → 31 examples, 0 failures
- `cd spec/dummy && bundle exec rspec spec/rolling_deploy_auto_routes_spec.rb` → 10 examples, 0 failures
- `bundle exec rubocop --ignore-parent-exclusion` on both changed files → no offenses

No CHANGELOG entry per the project's guidelines (test/refactor changes with no user-visible behavior change).

Closes #3548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and internal regexp derivation only; no user-visible behavior change with current patterns.
> 
> **Overview**
> **Rolling-deploy route hash constraint:** `BundlesController` now builds `ROUTE_HASH_PATTERN` with `SAFE_HASH_PATTERN.options` (not just the stripped source), so any future regexp flags on the safe pattern also apply to the Rails `:hash` segment constraint. Behavior is unchanged today because both patterns use default options.
> 
> **Specs:** Auto-route examples read `ReactOnRailsPro::Engine::ROLLING_DEPLOY_AUTO_ROUTE_PREFIX` via `const_get` instead of a duplicated string, with one example that still pins the published literal so renames are caught. A controller spec asserts the route and safe hash patterns keep matching **options**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33a1b9fc2e6e69bd8313316801264b9ff1bf4de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured rolling-deploy route pattern preserves regex options so route matching and internal validation remain consistent (prevents mismatches when flags like case-sensitivity are added).

* **Tests**
  * Updated specs to derive the rolling-deploy route prefix dynamically and added a regression test asserting regex-option consistency, improving test reliability and future-proofing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->