### PR TITLE
fix(benchmarks): seed Pro dummy DB so /posts_page stops 500ing (#3602)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -391,9 +391,13 @@ jobs:
         # The Pro Rails suite serves DB-backed routes (e.g. /posts_page). Without
         # a migrated + seeded database those routes 500 on every request (the
         # `posts` table does not exist), so the benchmark must create and seed it
-        # before the server starts. `db:prepare` creates the database, loads the
-        # schema, and runs db/seeds.rb (which is deterministic and faker-free so
-        # it works under RAILS_ENV=production).
+        # before the server starts. On a fresh CI runner `db:prepare` creates the
+        # database, loads the schema, and — because the database is newly created —
+        # runs db/seeds.rb (deterministic and faker-free so it works under
+        # RAILS_ENV=production). Note: `db:prepare` only seeds on first creation, so
+        # the row-count check below fails the job loudly if seeding was skipped (an
+        # empty table would otherwise serve a 200 "No posts found" payload that the
+        # benchmark scores as healthy).
         if: matrix.server_kind == 'rails' && matrix.pro_env == 'true'
         working-directory: ${{ matrix.app_directory }}
         env:
@@ -403,7 +407,7 @@ jobs:
           set -e
           echo "🌱 Preparing and seeding ${{ matrix.suite_name }} benchmark database..."
           bundle exec rails db:prepare
-          echo "✅ Database prepared and seeded"
+          bundle exec rails runner 'count = Post.count; abort("Benchmark DB has 0 posts after db:prepare; seeds did not run") if count.zero?; puts "✅ Database seeded (#{count} posts)"'
 
       - name: Start Pro node renderer
         if: matrix.server_kind == 'node-renderer'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -400,19 +400,22 @@ jobs:
         # benchmark scores as healthy).
         if: matrix.server_kind == 'rails' && matrix.pro_env == 'true'
         working-directory: ${{ matrix.app_directory }}
-        # Route the matrix value through env so the shell treats it as data, not
-        # code (GitHub Actions injection hardening), matching the "Execute
-        # benchmark suite" step below — even though it comes from our own
-        # generate_matrix.rb.
+        # Pass the matrix value via env (treated as data, not interpolated into
+        # the shell), matching the "Execute benchmark suite" step below.
         env:
           RAILS_ENV: production
           NODE_ENV: production
           SUITE_NAME: ${{ matrix.suite_name }}
         run: |
-          set -e
+          set -euo pipefail
           echo "🌱 Preparing and seeding $SUITE_NAME benchmark database..."
           bundle exec rails db:prepare
-          bundle exec rails runner 'count = Post.count; abort("Benchmark DB has 0 posts after db:prepare; seeds did not run") if count.zero?; puts "✅ Database seeded (#{count} posts)"'
+          # Guard every table `/posts_page` reads (posts, plus the users and
+          # comments it joins), not just posts: a partial seed would otherwise
+          # let the route 500 (or render an empty page) while the job stayed
+          # green. `set -o pipefail` keeps this abort fatal even if the command
+          # is ever piped.
+          bundle exec rails runner 'counts = { posts: Post.count, users: User.count, comments: Comment.count }; empty = counts.select { |_, c| c.zero? }.keys; abort("Benchmark DB seeding incomplete after db:prepare (empty: #{empty.join(", ")}); seeds did not run") if empty.any?; puts "✅ Database seeded (#{counts.map { |k, v| "#{v} #{k}" }.join(", ")})"'
 
       - name: Start Pro node renderer
         if: matrix.server_kind == 'node-renderer'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -387,6 +387,24 @@ jobs:
 
           echo "✅ Production assets built successfully"
 
+      - name: Prepare and seed benchmark database
+        # The Pro Rails suite serves DB-backed routes (e.g. /posts_page). Without
+        # a migrated + seeded database those routes 500 on every request (the
+        # `posts` table does not exist), so the benchmark must create and seed it
+        # before the server starts. `db:prepare` creates the database, loads the
+        # schema, and runs db/seeds.rb (which is deterministic and faker-free so
+        # it works under RAILS_ENV=production).
+        if: matrix.server_kind == 'rails' && matrix.pro_env == 'true'
+        working-directory: ${{ matrix.app_directory }}
+        env:
+          RAILS_ENV: production
+          NODE_ENV: production
+        run: |
+          set -e
+          echo "🌱 Preparing and seeding ${{ matrix.suite_name }} benchmark database..."
+          bundle exec rails db:prepare
+          echo "✅ Database prepared and seeded"
+
       - name: Start Pro node renderer
         if: matrix.server_kind == 'node-renderer'
         working-directory: ${{ matrix.app_directory }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -400,12 +400,17 @@ jobs:
         # benchmark scores as healthy).
         if: matrix.server_kind == 'rails' && matrix.pro_env == 'true'
         working-directory: ${{ matrix.app_directory }}
+        # Route the matrix value through env so the shell treats it as data, not
+        # code (GitHub Actions injection hardening), matching the "Execute
+        # benchmark suite" step below — even though it comes from our own
+        # generate_matrix.rb.
         env:
           RAILS_ENV: production
           NODE_ENV: production
+          SUITE_NAME: ${{ matrix.suite_name }}
         run: |
           set -e
-          echo "🌱 Preparing and seeding ${{ matrix.suite_name }} benchmark database..."
+          echo "🌱 Preparing and seeding $SUITE_NAME benchmark database..."
           bundle exec rails db:prepare
           bundle exec rails runner 'count = Post.count; abort("Benchmark DB has 0 posts after db:prepare; seeds did not run") if count.zero?; puts "✅ Database seeded (#{count} posts)"'
 

--- a/react_on_rails_pro/spec/dummy/db/seeds.rb
+++ b/react_on_rails_pro/spec/dummy/db/seeds.rb
@@ -1,48 +1,66 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+# Seed data for the dummy app. The benchmark suite's `/posts_page` route renders
+# these records, and they are handy for local development too.
 #
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+# This file is intentionally deterministic and free of the `faker` gem: it must
+# run under `RAILS_ENV=production` in CI (via `rails db:prepare`), where the
+# development/test-only `faker` gem is not loaded. Deterministic data also keeps
+# benchmark runs reproducible from one CI run to the next.
 
-# Clear existing data
+USER_COUNT = 10
+POSTS_PER_USER = 3..7
+COMMENTS_PER_POST = 2..5
+
+LOREM = %w[
+  lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor
+  incididunt ut labore et dolore magna aliqua enim ad minim veniam quis nostrud
+  exercitation ullamco laboris nisi aliquip ex ea commodo consequat duis aute
+  irure reprehenderit voluptate velit esse cillum fugiat nulla pariatur
+].freeze
+
+lorem_words = lambda do |count, offset|
+  Array.new(count) { |i| LOREM[(offset + i) % LOREM.size] }
+end
+lorem_sentence = ->(word_count, offset) { "#{lorem_words.call(word_count, offset).join(' ').capitalize}." }
+lorem_paragraph = lambda do |sentence_count, offset|
+  Array.new(sentence_count) { |i| lorem_sentence.call(6 + ((offset + i) % 6), offset + (i * 7)) }.join(" ")
+end
+
 puts "Clearing existing data..."
 Comment.delete_all
 Post.delete_all
 User.delete_all
 
-# Create Users
 puts "Creating users..."
-10.times do
-  User.create!(
-    name: Faker::Name.name,
-    email: Faker::Internet.unique.email
-  )
+users = Array.new(USER_COUNT) do |i|
+  User.create!(name: "User #{i + 1}", email: "user-#{i + 1}@example.com")
 end
 
-# Create Posts
 puts "Creating posts..."
-User.all.each do |user|
-  rand(3..7).times do
-    user.posts.create!(
-      title: Faker::Lorem.sentence(word_count: 3),
-      body: Faker::Lorem.paragraphs(number: 3).join("\n\n")
+posts = []
+users.each_with_index do |user, user_index|
+  post_count = POSTS_PER_USER.first + (user_index % POSTS_PER_USER.size)
+  post_count.times do |post_index|
+    seed = (user_index * 11) + post_index
+    posts << user.posts.create!(
+      title: lorem_sentence.call(3, seed),
+      body: Array.new(3) { |p| lorem_paragraph.call(4, seed + p) }.join("\n\n")
     )
   end
 end
 
-# Create Comments
 puts "Creating comments..."
-Post.all.each do |post|
-  rand(2..5).times do
+posts.each_with_index do |post, post_index|
+  comment_count = COMMENTS_PER_POST.first + (post_index % COMMENTS_PER_POST.size)
+  comment_count.times do |comment_index|
+    seed = (post_index * 7) + comment_index
     post.comments.create!(
-      user: User.all.sample,
-      body: Faker::Lorem.paragraph
+      user: users[seed % users.size],
+      body: lorem_paragraph.call(2, seed)
     )
   end
 end
 
-puts "Seed data created successfully!"
+puts "Seed data created successfully! " \
+     "(#{User.count} users, #{Post.count} posts, #{Comment.count} comments)"

--- a/react_on_rails_pro/spec/dummy/db/seeds.rb
+++ b/react_on_rails_pro/spec/dummy/db/seeds.rb
@@ -10,9 +10,8 @@
 
 # Local variables (not top-level constants) so re-running `rails db:seed` in an
 # already-loaded process — seeds.rb is `load`ed, not `require`d — does not emit
-# `warning: already initialized constant`. The per-record counts cycle through
-# these arrays, which stays correct even if a range is later made exclusive or
-# non-unit-step (unlike `range.first + (idx % range.size)`).
+# `warning: already initialized constant`. Per-record counts index into these
+# arrays, so cycling stays correct regardless of each range's bounds or step.
 user_count = 10
 post_counts = (3..7).to_a
 comment_counts = (2..5).to_a

--- a/react_on_rails_pro/spec/dummy/db/seeds.rb
+++ b/react_on_rails_pro/spec/dummy/db/seeds.rb
@@ -8,11 +8,16 @@
 # development/test-only `faker` gem is not loaded. Deterministic data also keeps
 # benchmark runs reproducible from one CI run to the next.
 
-USER_COUNT = 10
-POSTS_PER_USER = 3..7
-COMMENTS_PER_POST = 2..5
+# Local variables (not top-level constants) so re-running `rails db:seed` in an
+# already-loaded process — seeds.rb is `load`ed, not `require`d — does not emit
+# `warning: already initialized constant`. The per-record counts cycle through
+# these arrays, which stays correct even if a range is later made exclusive or
+# non-unit-step (unlike `range.first + (idx % range.size)`).
+user_count = 10
+post_counts = (3..7).to_a
+comment_counts = (2..5).to_a
 
-LOREM = %w[
+lorem = %w[
   lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor
   incididunt ut labore et dolore magna aliqua enim ad minim veniam quis nostrud
   exercitation ullamco laboris nisi aliquip ex ea commodo consequat duis aute
@@ -20,7 +25,7 @@ LOREM = %w[
 ].freeze
 
 lorem_words = lambda do |count, offset|
-  Array.new(count) { |i| LOREM[(offset + i) % LOREM.size] }
+  Array.new(count) { |i| lorem[(offset + i) % lorem.size] }
 end
 lorem_sentence = ->(word_count, offset) { "#{lorem_words.call(word_count, offset).join(' ').capitalize}." }
 lorem_paragraph = lambda do |sentence_count, offset|
@@ -33,14 +38,14 @@ Post.delete_all
 User.delete_all
 
 puts "Creating users..."
-users = Array.new(USER_COUNT) do |i|
+users = Array.new(user_count) do |i|
   User.create!(name: "User #{i + 1}", email: "user-#{i + 1}@example.com")
 end
 
 puts "Creating posts..."
 posts = []
 users.each_with_index do |user, user_index|
-  post_count = POSTS_PER_USER.first + (user_index % POSTS_PER_USER.size)
+  post_count = post_counts[user_index % post_counts.size]
   post_count.times do |post_index|
     seed = (user_index * 11) + post_index
     posts << user.posts.create!(
@@ -52,7 +57,7 @@ end
 
 puts "Creating comments..."
 posts.each_with_index do |post, post_index|
-  comment_count = COMMENTS_PER_POST.first + (post_index % COMMENTS_PER_POST.size)
+  comment_count = comment_counts[post_index % comment_counts.size]
   comment_count.times do |comment_index|
     seed = (post_index * 7) + comment_index
     post.comments.create!(

--- a/react_on_rails_pro/spec/dummy/spec/db/seeds_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/db/seeds_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Unit coverage for `db/seeds.rb`, the layer that actually broke in issue #3602.
+#
+# The Pro benchmark workflow runs `rails db:prepare` under RAILS_ENV=production,
+# where the development/test-only `faker` gem is NOT in the bundle. If seeds.rb
+# reintroduces a `Faker::...` call (or otherwise stops populating the tables),
+# the production CI run leaves `/posts_page` with no data — exactly the #3602
+# failure. These examples reproduce that environment by hiding the `Faker`
+# constant while loading the seed file, so such a regression fails here (on every
+# Pro dummy spec run) instead of silently in the benchmark suite.
+#
+# Unlike posts_page_spec.rb this needs no node renderer — it only touches the DB.
+RSpec.describe "db/seeds.rb" do
+  before do
+    # maintain_test_schema! is disabled in this suite (see posts_page_spec.rb), so
+    # load the schema if the tables the seeds touch are missing.
+    unless %i[users posts comments].all? { |t| ActiveRecord::Base.connection.table_exists?(t) }
+      ActiveRecord::Schema.verbose = false
+      load Rails.root.join("db/schema.rb")
+    end
+  end
+
+  after do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+  end
+
+  # seeds.rb is `load`ed (not `require`d) in production via db:prepare; do the
+  # same here. It clears the tables itself, so each load starts from a clean slate.
+  # Its progress `puts` output is captured to keep spec output quiet.
+  def load_seeds
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    load Rails.root.join("db/seeds.rb")
+  ensure
+    $stdout = original_stdout
+  end
+
+  it "populates users, posts, and comments without the faker gem" do
+    hide_const("Faker")
+
+    expect { load_seeds }.not_to raise_error
+
+    expect(User.count).to be_positive
+    expect(Post.count).to be_positive
+    expect(Comment.count).to be_positive
+  end
+
+  it "produces identical data on every load (deterministic, reproducible benchmarks)" do
+    hide_const("Faker")
+
+    load_seeds
+    first = { users: User.count, posts: Post.count, comments: Comment.count,
+              titles: Post.order(:id).pluck(:title) }
+
+    load_seeds
+    second = { users: User.count, posts: Post.count, comments: Comment.count,
+               titles: Post.order(:id).pluck(:title) }
+
+    expect(second).to eq(first)
+  end
+end

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe "Posts page", :server_rendering do
     # The suite intentionally leaves `maintain_test_schema!` disabled, so make
     # this DB-backed spec self-sufficient: load the schema if it is not present
     # yet. Check every table the examples touch (not just `posts`) so a partial
-    # schema can't slip past the guard. The check is cheap and the load only runs
-    # on the first example.
+    # schema can't slip past the guard.
     unless %i[users posts comments].all? { |t| ActiveRecord::Base.connection.table_exists?(t) }
       ActiveRecord::Schema.verbose = false
       load Rails.root.join("db/schema.rb")

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -23,8 +23,10 @@ RSpec.describe "Posts page", :server_rendering do
   before do
     # The suite intentionally leaves `maintain_test_schema!` disabled, so make
     # this DB-backed spec self-sufficient: load the schema if it is not present
-    # yet. The table check is cheap and the load only runs on the first example.
-    unless ActiveRecord::Base.connection.table_exists?(:posts)
+    # yet. Check every table the examples touch (not just `posts`) so a partial
+    # schema can't slip past the guard. The check is cheap and the load only runs
+    # on the first example.
+    unless %i[users posts comments].all? { |t| ActiveRecord::Base.connection.table_exists?(t) }
       ActiveRecord::Schema.verbose = false
       load Rails.root.join("db/schema.rb")
     end
@@ -51,6 +53,9 @@ RSpec.describe "Posts page", :server_rendering do
 
     expect(response).to have_http_status(:ok)
 
+    # Parse for the heading so we assert "Posts Page" renders specifically in an
+    # <h1> (the page chrome), not just anywhere in the body. The seeded titles
+    # below are plain-text content, so a raw substring match is sufficient there.
     html = Nokogiri::HTML(response.body)
     expect(html.css("h1").map(&:text)).to include("Posts Page")
     expect(response.body).to include("Sentinel Post 1")

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -4,13 +4,18 @@ require "rails_helper"
 
 # Integration coverage for the `/posts_page` benchmark route (issue #3602).
 #
-# `/posts_page` is the only synchronous (non-streaming) benchmark route that
-# reads from the database, so a missing `posts` table surfaces as a hard 500 on
-# every request — which is exactly how it regressed in the Pro benchmark suite.
-# (The streaming RSC posts routes mask the same failure because their HTTP 200
-# status line is sent before the body errors.) These examples render the page
-# with seeded records and assert it returns 200 with the post content, guarding
-# against the route silently breaking again.
+# `/posts_page` renders DB records synchronously (non-streaming), so when the
+# `posts` table was missing in the Pro benchmark suite it surfaced as a hard 500
+# on every request. (The streaming RSC posts routes mask that class of failure
+# because their HTTP 200 status line is flushed before the body errors.)
+#
+# These examples do not reproduce the missing-table case itself — the `before`
+# block loads the schema (see below), so the table is always present here. The
+# missing-table 500 is prevented upstream by seeding the benchmark DB before the
+# server starts (.github/workflows/benchmark.yml). What these examples guard is
+# the layer above that: with the table in place the route must server-render
+# seeded posts and return 200, and an empty table must return 200 "No posts
+# found" rather than 500.
 #
 # Requires the Pro node renderer to be running, like the other server-rendering
 # request specs: the page is rendered with `prerender: true`.

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Integration coverage for the `/posts_page` benchmark route (issue #3602).
+#
+# `/posts_page` is the only synchronous (non-streaming) benchmark route that
+# reads from the database, so a missing `posts` table surfaces as a hard 500 on
+# every request — which is exactly how it regressed in the Pro benchmark suite.
+# (The streaming RSC posts routes mask the same failure because their HTTP 200
+# status line is sent before the body errors.) These examples render the page
+# with seeded records and assert it returns 200 with the post content, guarding
+# against the route silently breaking again.
+#
+# Requires the Pro node renderer to be running, like the other server-rendering
+# request specs: the page is rendered with `prerender: true`.
+RSpec.describe "Posts page", :server_rendering do
+  before do
+    # The suite intentionally leaves `maintain_test_schema!` disabled, so make
+    # this DB-backed spec self-sufficient: load the schema if it is not present
+    # yet. The table check is cheap and the load only runs on the first example.
+    unless ActiveRecord::Base.connection.table_exists?(:posts)
+      ActiveRecord::Schema.verbose = false
+      load Rails.root.join("db/schema.rb")
+    end
+
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+
+    2.times do |i|
+      user = User.create!(name: "User #{i + 1}", email: "user-#{i + 1}@example.com")
+      post = user.posts.create!(title: "Sentinel Post #{i + 1}", body: "Body of sentinel post #{i + 1}.")
+      post.comments.create!(user: user, body: "Comment on sentinel post #{i + 1}.")
+    end
+  end
+
+  after do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+  end
+
+  it "server-renders the seeded posts and returns 200" do
+    get "/posts_page"
+
+    expect(response).to have_http_status(:ok)
+
+    html = Nokogiri::HTML(response.body)
+    expect(html.css("h1").map(&:text)).to include("Posts Page")
+    expect(response.body).to include("Sentinel Post 1")
+    expect(response.body).to include("Sentinel Post 2")
+  end
+
+  it "returns 200 (not 500) when there are no posts to render" do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+
+    get "/posts_page"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("No posts found")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the Pro benchmark's `/posts_page` route, which reported a **100% failure rate (5xx on every request)** while every other route was green (see [#3602](https://github.com/shakacode/react_on_rails/issues/3602) and the [#3586 benchmark comment](https://github.com/shakacode/react_on_rails/pull/3586#issuecomment-4618424415)).

## Root cause

The benchmark workflow builds production assets and starts the server, but **never creates, migrates, or seeds the production database**. So `db/production.sqlite3` has no `posts` table, and the route's first query raises:

```
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such table: posts
```

`/posts_page` is the **only synchronous (non-streaming) benchmark route that reads the database directly**, so it's the only one where the failure surfaces as a 5xx. The streaming RSC posts routes (`rsc_posts_page_over_http`, `rsc_posts_page_over_redis`) hit the same broken DB but return HTTP `200` because the status line is flushed before the body errors — which is why they showed `0%` fail.

Verified locally: with the tables present but empty the route returns `200` ("No posts found"); only a **missing table** produces the 500.

## Changes

1. **`.github/workflows/benchmark.yml`** — add a *Prepare and seed benchmark database* step (`RAILS_ENV=production bundle exec rails db:prepare`) before the server starts, gated to the Pro Rails suite (`server_kind == 'rails' && pro_env == 'true'`). `db:prepare` creates the DB, loads the schema, and runs the seeds on first creation.
2. **`react_on_rails_pro/spec/dummy/db/seeds.rb`** — rewrite to be **deterministic and free of the `faker` gem**. `faker` lives in the `:development, :test` bundler groups and is not loaded under `RAILS_ENV=production`, so the old seeds raised `NameError: uninitialized constant Faker` when run by the benchmark. Deterministic data also keeps benchmark runs reproducible run-to-run.
3. **`react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb`** — new integration test (per the issue's request) that seeds records and asserts `/posts_page` server-renders the posts and returns `200`, plus a case asserting `200` (not `500`) with an empty table. The spec self-loads the schema because the suite intentionally leaves `maintain_test_schema!` disabled.

## Side effect (one-time main re-baseline)

`rsc_posts_page_over_redis` fetches its data via the in-process Rails DB, so with a seeded DB it now renders **real** posts/comments/users instead of erroring out fast. Its timing will shift on the first main-push benchmark after merge (a one-time Bencher re-baseline). `rsc_posts_page_over_http` is unaffected — it fetches from a hard-coded `http://localhost:3000`, which is not the benchmark server (port 3001), so it never fetched real data regardless.

## Testing

- Reproduced the exact 500 (missing-table) and confirmed empty-table returns 200.
- Confirmed `RAILS_ENV=production rails db:prepare` now seeds cleanly (10 users / 50 posts / 173 comments) and the `posts_page` controller assembles posts with nested comments + users.
- New spec parses and runs; locally it exercises schema-load → seed → routing → controller and stops only at SSR (no local `ssr-generated/server-bundle.js`). The CI Pro rspec job builds the bundle and runs the node renderer, so SSR completes there.
- `bundle exec rubocop` clean on the changed Ruby files; `actionlint` clean on the new workflow step.

Fixes #3602

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark CI and dummy-app seeds/tests only; no production app auth or payment paths.
> 
> **Overview**
> Fixes Pro benchmark **100% 5xx on `/posts_page`** by ensuring the production DB exists and is populated before the server starts, and by making seeds safe under `RAILS_ENV=production`.
> 
> **CI (`.github/workflows/benchmark.yml`):** For Pro Rails suites only, runs `rails db:prepare` after asset build and before the server, then aborts if `posts`, `users`, or `comments` counts are zero—so a missing table or skipped seed fails the job instead of looking like a healthy empty page.
> 
> **Seeds (`db/seeds.rb`):** Replaces **Faker**-based random data with deterministic lorem-style content so `db:prepare` works without the dev/test-only `faker` gem and benchmark payloads stay reproducible.
> 
> **Tests:** Adds `db/seeds_spec.rb` (loads seeds with `Faker` hidden; checks counts and determinism) and `posts_page_spec.rb` (SSR returns 200 with seeded posts; empty DB returns 200 with "No posts found", not 500).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e4519bb5a139151bb07db3c4829e22929ab421c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/updated integration tests for the Pro benchmark posts page (populated and empty scenarios).
  * Added a seeds spec to verify deterministic, repeatable seeding and behavior when Faker is unavailable.

* **Chores**
  * CI now prepares and validates the benchmark database for Pro Rails suites before server startup.
  * Replaced nondeterministic seed data with deterministic, CI-friendly seeding and clear success output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Merge decision / follow-up

Minor benchmark cleanup nits are tracked in #3638 so this approved/green reliability fix can merge without restarting CI for readability-only changes.
