### PR TITLE
refactor: consolidate Shakapacker bundler/config diagnostics helpers

### DIFF
--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -13,6 +13,7 @@ require "time"
 require "uri"
 require "yaml"
 require_relative "../packer_utils"
+require_relative "../shakapacker_config_helpers"
 require_relative "../system_checker"
 require_relative "database_checker"
 require_relative "server_mode"
@@ -21,6 +22,10 @@ require_relative "service_checker"
 module ReactOnRails
   module Dev
     class ServerManager
+      # Commands live on `class << self`, so extend (rather than include) the
+      # shared shakapacker-config helpers to expose them as singleton methods.
+      extend ReactOnRails::ShakapackerConfigHelpers
+
       HELP_FLAGS = ["-h", "--help"].freeze
       TEST_WATCH_MODES = %w[auto full client-only].freeze
       OPEN_BROWSER_WAIT_TIMEOUT = 60
@@ -472,53 +477,6 @@ module ReactOnRails
           development_private == test_private
         end
 
-        def parsed_shakapacker_config
-          config_path = shakapacker_config_path
-          return nil unless File.exist?(config_path)
-
-          YAML.safe_load(ERB.new(File.read(config_path)).result, aliases: true, permitted_classes: [Symbol])
-        rescue StandardError, ScriptError
-          nil
-        end
-
-        def configured_assets_bundler
-          config = parsed_shakapacker_config
-          return nil unless config.is_a?(Hash)
-
-          rails_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
-          bundler_from_shakapacker_section(config, rails_env) || bundler_from_shakapacker_section(config, "default")
-        rescue StandardError, ScriptError
-          nil
-        end
-
-        def active_assets_bundler
-          configured_assets_bundler || "webpack"
-        end
-
-        def assets_bundler_label
-          active_assets_bundler.capitalize
-        end
-
-        def dev_server_label
-          active_assets_bundler == "webpack" ? "webpack-dev-server" : "#{assets_bundler_label} dev server"
-        end
-
-        def development_reload_mode_label
-          development_hmr_enabled? ? "HMR" : "Live reload"
-        end
-
-        def development_reload_feature_label
-          development_hmr_enabled? ? "Hot Module Replacement (HMR)" : "Live reload"
-        end
-
-        def development_mode_title
-          development_hmr_enabled? ? "HMR Development mode (default)" : "Live reload development mode (default)"
-        end
-
-        def hmr_procfile_description
-          "#{development_reload_mode_label} development with #{dev_server_label}"
-        end
-
         def default_procfile_description(default_mode)
           bundler_aware_dev_server_text(ServerMode.text(default_mode, :procfile_description))
         end
@@ -570,74 +528,6 @@ module ReactOnRails
           else
             "#{assets_bundler_label} compilation failed"
           end
-        end
-
-        def bundler_from_shakapacker_section(config, section_name)
-          section = config[section_name] || config[section_name.to_sym]
-          return nil unless section.is_a?(Hash)
-
-          normalize_assets_bundler(section["assets_bundler"] || section[:assets_bundler])
-        end
-
-        def normalize_assets_bundler(value)
-          normalized = value.to_s.strip.downcase
-          ReactOnRails::SystemChecker::SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
-        end
-
-        def development_hmr_enabled?
-          dev_server = development_dev_server_config
-          return hmr_config_value?(dev_server["hmr"]) if dev_server.key?("hmr")
-
-          return false if truthy_config_value?(dev_server["live_reload"])
-
-          # Default to HMR when neither hmr nor live_reload is configured, preserving historical behavior.
-          true
-        end
-
-        def hmr_config_value?(value)
-          value.to_s.strip.casecmp?("only") || truthy_config_value?(value)
-        end
-
-        def development_dev_server_config
-          config = parsed_shakapacker_config
-          return {} unless config.is_a?(Hash)
-
-          development_config = shakapacker_section(config, "default").merge(shakapacker_section(config, "development"))
-          dev_server_config_for(development_config)
-        end
-
-        def shakapacker_section(config, section_name)
-          section = config[section_name] || config[section_name.to_sym]
-          section.is_a?(Hash) ? section : {}
-        end
-
-        def dev_server_config_for(section)
-          dev_server = section["dev_server"] || section[:dev_server]
-          return {} unless dev_server.is_a?(Hash)
-
-          dev_server.transform_keys(&:to_s)
-        end
-
-        def truthy_config_value?(value)
-          value == true || value.to_s == "true"
-        end
-
-        # Resolves SHAKAPACKER_CONFIG the same way ReactOnRails::Engine does, so this CLI
-        # sees the same config file as Rails boot even when invoked from a directory other
-        # than the Rails root. Falls back to Dir.pwd when Rails isn't loaded (bin/dev does
-        # not require Rails directly).
-        def shakapacker_config_path
-          env_config_path = ENV.fetch("SHAKAPACKER_CONFIG", nil)
-          base = shakapacker_config_base_dir
-          return File.expand_path("config/shakapacker.yml", base) if env_config_path.to_s.empty?
-
-          File.expand_path(env_config_path, base)
-        end
-
-        def shakapacker_config_base_dir
-          return Rails.root.to_s if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
-
-          Dir.pwd
         end
 
         # rubocop:disable Metrics/AbcSize
@@ -893,13 +783,18 @@ module ReactOnRails
         def help_react_refresh_troubleshooting(default_mode)
           return help_hmr_react_refresh_troubleshooting if default_mode == :hmr
 
-          <<~REFRESH
+          troubleshooting = <<~REFRESH
             #{Rainbow('⚛️  React Refresh:').yellow.bold}
             #{Rainbow('React Refresh requires HMR; current default mode is not HMR.').white}
             #{Rainbow('•').yellow} #{Rainbow(ServerMode.text(default_mode, :refresh_guidance)).white}
             #{Rainbow('•').yellow} #{Rainbow(ServerMode.text(default_mode, :refresh_note)).white}
-            #{rspack_react_refresh_config_hint}
           REFRESH
+
+          # Append the rspack/other-bundler config-hint bullet only when present so it
+          # lines up with the bullets above; webpack returns "" and we skip it rather
+          # than emitting a trailing blank line.
+          hint = rspack_react_refresh_config_hint
+          hint.empty? ? troubleshooting : "#{troubleshooting}#{hint}\n"
         end
 
         def rspack_react_refresh_config_hint
@@ -913,6 +808,10 @@ module ReactOnRails
         def help_hmr_react_refresh_troubleshooting
           plugin_check = "Check that both babel plugin and #{react_refresh_bundler_plugin_description} are configured:"
 
+          # The babel `react-refresh/babel` plugin is gated on WEBPACK_SERVE in the
+          # generated babel.config.js for both webpack and rspack apps, so that
+          # qualifier intentionally stays bundler-agnostic. Only the bundler plugin
+          # line below (react_refresh_bundler_config_hint) is bundler-specific.
           <<~REFRESH
             #{Rainbow('⚛️  React Refresh Issues:').yellow.bold}
             #{Rainbow('If you see "$RefreshSig$ is not defined" errors:').white}

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -7,6 +7,7 @@ require "timeout"
 require "yaml"
 require_relative "utils"
 require_relative "config_path_resolver"
+require_relative "shakapacker_config_helpers"
 require_relative "dev/server_mode"
 require_relative "version_syntax_converter"
 require_relative "version_synchronizer"
@@ -47,6 +48,7 @@ module ReactOnRails
   # rubocop:disable Metrics/ClassLength, Metrics/AbcSize
   class Doctor
     include ConfigPathResolver
+    include ShakapackerConfigHelpers
 
     MESSAGE_COLORS = {
       error: :red,
@@ -58,7 +60,6 @@ module ReactOnRails
     RSPEC_HELPER_FILES = ["spec/rails_helper.rb", "spec/spec_helper.rb"].freeze
     MINITEST_HELPER_FILE = "test/test_helper.rb"
     DEFAULT_BUILD_TEST_COMMAND = 'config.build_test_command = "RAILS_ENV=test bin/shakapacker"'
-    DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
     SERVER_BUNDLE_SOURCE_EXTENSIONS = %w[.js .jsx .ts .tsx .mjs .cjs].freeze
     CUSTOM_LAUNCHER_INDICATOR_FILES = %w[dev].freeze
     RAILS_SERVER_COMMAND_REGEX = %r{\b(?:(?:bin/)?rails\s+(?:server|s)|puma|unicorn|rackup|passenger\s+start)\b}
@@ -341,7 +342,7 @@ module ReactOnRails
 
     def procfile_descriptions
       {
-        hmr: "#{development_reload_mode_label} development with #{dev_server_procfile_label}",
+        hmr: "#{development_reload_mode_label} development with #{dev_server_label}",
         static: "Static development with #{static_watch_label}"
       }
     end
@@ -353,7 +354,7 @@ module ReactOnRails
     def bundler_aware_dev_server_text(text)
       return text if active_assets_bundler == "webpack"
 
-      text.gsub("webpack-dev-server", dev_server_procfile_label)
+      text.gsub("webpack-dev-server", dev_server_label)
     end
 
     def check_bin_dev_script
@@ -549,99 +550,21 @@ module ReactOnRails
       puts
     end
 
-    def dev_server_label
-      active_assets_bundler == "webpack" ? "webpack-dev-server" : "#{assets_bundler_label} dev server"
-    end
-
-    def active_assets_bundler
-      configured_assets_bundler || "webpack"
-    end
-
-    def assets_bundler_label
-      active_assets_bundler.capitalize
-    end
-
-    def dev_server_procfile_label
-      dev_server_label
-    end
-
     def static_watch_label
       active_assets_bundler == "webpack" ? "webpack --watch" : "#{active_assets_bundler} watch"
     end
-
-    def development_reload_mode_label
-      development_hmr_enabled? ? "HMR" : "Live reload"
-    end
-
-    def configured_assets_bundler
-      config = parsed_shakapacker_config
-      return nil unless config.is_a?(Hash)
-
-      rails_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
-      bundler_from_shakapacker_section(config, rails_env) || bundler_from_shakapacker_section(config, "default")
-    rescue StandardError, ScriptError
-      nil
-    end
-
-    def parsed_shakapacker_config
-      config_path = shakapacker_config_path
-      return nil unless File.exist?(config_path)
-
-      parse_shakapacker_config(File.read(config_path))
-    rescue StandardError, ScriptError
-      nil
-    end
-
-    def bundler_from_shakapacker_section(config, section_name)
-      section = config[section_name] || config[section_name.to_sym]
-      return nil unless section.is_a?(Hash)
-
-      normalize_assets_bundler(section["assets_bundler"] || section[:assets_bundler])
-    end
-
-    def normalize_assets_bundler(value)
-      normalized = value.to_s.strip.downcase
-      ReactOnRails::SystemChecker::SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
-    end
-
-    def development_hmr_enabled?
-      dev_server = development_dev_server_config
-      return hmr_config_value?(dev_server["hmr"]) if dev_server.key?("hmr")
-
-      return false if truthy_config_value?(dev_server["live_reload"])
-
-      # Default to HMR when neither hmr nor live_reload is configured, preserving historical behavior.
-      true
-    end
-
-    def hmr_config_value?(value)
-      value.to_s.strip.casecmp?("only") || truthy_config_value?(value)
-    end
-
-    def development_dev_server_config
-      config = parsed_shakapacker_config
-      return {} unless config.is_a?(Hash)
-
-      development_config = shakapacker_section(config, "default").merge(shakapacker_section(config, "development"))
-      dev_server_config_for(development_config)
-    end
-
-    def shakapacker_section(config, section_name)
-      section = config[section_name] || config[section_name.to_sym]
-      section.is_a?(Hash) ? section : {}
-    end
-
-    def dev_server_config_for(section)
-      dev_server = section["dev_server"] || section[:dev_server]
-      return {} unless dev_server.is_a?(Hash)
-
-      dev_server.transform_keys(&:to_s)
-    end
-
-    def truthy_config_value?(value)
-      value == true || value.to_s == "true"
-    end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+    # Memoized per Doctor instance (a fresh Doctor runs per `doctor` invocation),
+    # so a single diagnosis reads and parses config/shakapacker.yml at most once
+    # even though several checks consult it. The base implementation lives in
+    # ShakapackerConfigHelpers. ServerManager intentionally does not memoize its
+    # copy because its helpers live on `class << self` and would leak across specs.
+    def parsed_shakapacker_config
+      return @parsed_shakapacker_config if defined?(@parsed_shakapacker_config)
+
+      @parsed_shakapacker_config = super
+    end
 
     def print_test_workflow_next_steps
       case @test_output_path_strategy
@@ -2069,20 +1992,6 @@ module ReactOnRails
     # than the Rails root. Without this, a relative SHAKAPACKER_CONFIG would fail to resolve and
     # dev-server mode detection would silently fall back to HMR labels. Falls back to Dir.pwd when
     # Rails isn't booted (e.g. in unit specs).
-    def shakapacker_config_path
-      env_config_path = ENV.fetch("SHAKAPACKER_CONFIG", nil)
-      base = shakapacker_config_base_dir
-      return File.expand_path(DEFAULT_SHAKAPACKER_CONFIG_PATH, base) if env_config_path.to_s.empty?
-
-      File.expand_path(env_config_path, base)
-    end
-
-    def shakapacker_config_base_dir
-      return Rails.root.to_s if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
-
-      Dir.pwd
-    end
-
     def default_dev_server_mode
       @default_dev_server_mode ||= Dev::ServerMode.detect(shakapacker_config_path)
     end

--- a/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
+++ b/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "erb"
+require "yaml"
+
+module ReactOnRails
+  # Shared helpers for reading config/shakapacker.yml and deriving the active
+  # assets bundler (webpack vs rspack), its display labels, and the development
+  # dev-server reload mode. Extracted so the diagnostics/CLI entry points
+  # (Doctor, SystemChecker, and Dev::ServerManager) parse the file the same way
+  # and present consistent bundler wording.
+  #
+  # Doctor and SystemChecker `include` this module so the helpers become private
+  # instance methods. Dev::ServerManager `extend`s it because its commands live
+  # on `class << self`; extend preserves the private visibility, so the helpers
+  # become private singleton methods there. Every helper depends only on other
+  # helpers in this module plus ENV/File, so it behaves identically either way.
+  module ShakapackerConfigHelpers
+    DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
+
+    private
+
+    # Reads and parses config/shakapacker.yml. Symbol values are permitted so
+    # this matches Shakapacker's own loader and ReactOnRails::Dev::ServerMode;
+    # ScriptError is rescued alongside StandardError because ERB/YAML can raise
+    # SyntaxError (a ScriptError, not a StandardError). Returns nil on any
+    # failure or when the document is not a mapping.
+    def parsed_shakapacker_config
+      config_path = shakapacker_config_path
+      return nil unless File.exist?(config_path)
+
+      parsed = YAML.safe_load(ERB.new(File.read(config_path)).result, aliases: true, permitted_classes: [Symbol])
+      parsed.is_a?(Hash) ? parsed : nil
+    rescue StandardError, ScriptError
+      nil
+    end
+
+    # Resolves SHAKAPACKER_CONFIG the same way ReactOnRails::Engine does, so CLI
+    # callers see the same config file as Rails boot even when invoked from a
+    # directory other than the Rails root. Falls back to Dir.pwd when Rails
+    # isn't loaded (bin/dev does not require Rails directly).
+    def shakapacker_config_path
+      env_config_path = ENV.fetch("SHAKAPACKER_CONFIG", nil)
+      base = shakapacker_config_base_dir
+      return File.expand_path(DEFAULT_SHAKAPACKER_CONFIG_PATH, base) if env_config_path.to_s.empty?
+
+      File.expand_path(env_config_path, base)
+    end
+
+    def shakapacker_config_base_dir
+      return Rails.root.to_s if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
+
+      Dir.pwd
+    end
+
+    def configured_assets_bundler
+      config = parsed_shakapacker_config
+      return nil unless config.is_a?(Hash)
+
+      rails_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
+      bundler_from_shakapacker_section(config, rails_env) || bundler_from_shakapacker_section(config, "default")
+    rescue StandardError, ScriptError
+      nil
+    end
+
+    def bundler_from_shakapacker_section(config, section_name)
+      section = config[section_name] || config[section_name.to_sym]
+      return nil unless section.is_a?(Hash)
+
+      normalize_assets_bundler(section["assets_bundler"] || section[:assets_bundler])
+    end
+
+    def normalize_assets_bundler(value)
+      normalized = value.to_s.strip.downcase
+      ReactOnRails::SystemChecker::SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
+    end
+
+    def active_assets_bundler
+      configured_assets_bundler || "webpack"
+    end
+
+    def assets_bundler_label
+      active_assets_bundler.capitalize
+    end
+
+    def dev_server_label
+      active_assets_bundler == "webpack" ? "webpack-dev-server" : "#{assets_bundler_label} dev server"
+    end
+
+    def development_reload_mode_label
+      development_hmr_enabled? ? "HMR" : "Live reload"
+    end
+
+    def development_hmr_enabled?
+      dev_server = development_dev_server_config
+      return hmr_config_value?(dev_server["hmr"]) if dev_server.key?("hmr")
+
+      return false if truthy_config_value?(dev_server["live_reload"])
+
+      # Default to HMR when neither hmr nor live_reload is configured, preserving historical behavior.
+      true
+    end
+
+    def hmr_config_value?(value)
+      value.to_s.strip.casecmp?("only") || truthy_config_value?(value)
+    end
+
+    def development_dev_server_config
+      config = parsed_shakapacker_config
+      return {} unless config.is_a?(Hash)
+
+      development_config = shakapacker_section(config, "default").merge(shakapacker_section(config, "development"))
+      dev_server_config_for(development_config)
+    end
+
+    def shakapacker_section(config, section_name)
+      section = config[section_name] || config[section_name.to_sym]
+      section.is_a?(Hash) ? section : {}
+    end
+
+    def dev_server_config_for(section)
+      dev_server = section["dev_server"] || section[:dev_server]
+      return {} unless dev_server.is_a?(Hash)
+
+      dev_server.transform_keys(&:to_s)
+    end
+
+    def truthy_config_value?(value)
+      value == true || value.to_s == "true"
+    end
+  end
+end

--- a/react_on_rails/lib/react_on_rails/system_checker.rb
+++ b/react_on_rails/lib/react_on_rails/system_checker.rb
@@ -4,6 +4,7 @@ require "erb"
 require "open3"
 require "yaml"
 require_relative "config_path_resolver"
+require_relative "shakapacker_config_helpers"
 
 module ReactOnRails
   # SystemChecker provides validation methods for React on Rails setup
@@ -11,6 +12,7 @@ module ReactOnRails
   # rubocop:disable Metrics/ClassLength
   class SystemChecker
     include ConfigPathResolver
+    include ShakapackerConfigHelpers
 
     attr_reader :messages
 
@@ -625,28 +627,6 @@ module ReactOnRails
       @inferred_bundler_notice_shown = true
     end
 
-    def configured_assets_bundler
-      config = parsed_shakapacker_config
-      return nil unless config.is_a?(Hash)
-
-      rails_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
-      bundler_from_shakapacker_section(config, rails_env) || bundler_from_shakapacker_section(config, "default")
-    rescue StandardError, ScriptError
-      nil
-    end
-
-    def bundler_from_shakapacker_section(config, section_name)
-      section = config[section_name] || config[section_name.to_sym]
-      return nil unless section.is_a?(Hash)
-
-      normalize_assets_bundler(section["assets_bundler"] || section[:assets_bundler])
-    end
-
-    def normalize_assets_bundler(value)
-      normalized = value.to_s.strip.downcase
-      SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
-    end
-
     def required_react_dependencies
       deps = {
         "react" => "React library",
@@ -679,31 +659,6 @@ module ReactOnRails
       default_config = config["default"] || {}
       transpiler = env_config["javascript_transpiler"] || default_config["javascript_transpiler"]
       normalize_transpiler_value(transpiler)
-    end
-
-    def parsed_shakapacker_config
-      shakapacker_config_path = shakapacker_config_path()
-      return nil unless File.exist?(shakapacker_config_path)
-
-      raw_content = File.read(shakapacker_config_path)
-      rendered_content = ERB.new(raw_content).result
-      parsed = YAML.safe_load(rendered_content, aliases: true)
-      parsed.is_a?(Hash) ? parsed : nil
-    rescue StandardError, ScriptError
-      nil
-    end
-
-    def shakapacker_config_path
-      env_config_path = ENV.fetch("SHAKAPACKER_CONFIG", nil)
-      return File.expand_path("config/shakapacker.yml", shakapacker_config_base_dir) if env_config_path.to_s.empty?
-
-      File.expand_path(env_config_path, shakapacker_config_base_dir)
-    end
-
-    def shakapacker_config_base_dir
-      return Rails.root.to_s if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
-
-      Dir.pwd
     end
 
     def normalize_transpiler_value(transpiler)
@@ -877,10 +832,6 @@ module ReactOnRails
       rescue StandardError
         # Handle other file/access errors
       end
-    end
-
-    def active_assets_bundler
-      configured_assets_bundler || "webpack"
     end
   end
   # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
## Summary

Follow-up cleanup from #3508 (issue #3538). `Doctor`, `SystemChecker`, and `Dev::ServerManager` each carried near-identical copies of the `shakapacker.yml` parsing, assets-bundler detection, bundler labels, and dev-server reload-mode helpers. This consolidates them into one mixin and clears the remaining review nits.

## Changes (mapped to the #3538 checklist)

- **Extract shared helpers** — new `ReactOnRails::ShakapackerConfigHelpers`, `include`d by `Doctor`/`SystemChecker` and `extend`ed onto `Dev::ServerManager` (its commands live on `class << self`). Mirrors the existing untyped `ConfigPathResolver` mixin precedent.
- **Unify `YAML.safe_load` options** — `SystemChecker` now permits `Symbol` values and rescues `ScriptError`, matching the other parsers and `ServerMode`.
- **Memoize parsed config** — `parsed_shakapacker_config` is memoized per `Doctor` instance (a fresh `Doctor` runs per invocation), so one diagnosis reads/parses the file once. `ServerManager` intentionally does **not** memoize — its `class << self` state would leak across specs, the same reason `default_dev_server_mode` isn't memoized.
- **Remove the `dev_server_procfile_label` alias** — it was a pure wrapper for `dev_server_label`.
- **Remove unused `ServerManager` helpers** — `development_reload_feature_label`, `development_mode_title`, and `hmr_procfile_description` were defined but never called.
- **Non-HMR React Refresh help indentation** — the rspack config-hint bullet now lines up with the bullets above; webpack omits the bullet instead of leaving a trailing blank line.
- **Babel qualifier decision** — documented that the `react-refresh/babel` `WEBPACK_SERVE` qualifier is intentionally bundler-agnostic (the generated `babel.config.js` gates it on `WEBPACK_SERVE` for both webpack and rspack); only the bundler plugin line is bundler-specific.

Net **−109 lines** across the three diagnostics files.

## Testing

- `bundle exec rspec` for `system_checker_spec`, `doctor_spec`, `server_manager_spec` → **571 examples, 0 failures**
- `bundle exec rubocop` on all four files → **no offenses**
- `bundle exec rake rbs:validate` → **passes**. The RBS-declared `ServerManager` API is unchanged (all 28 declared methods still present with the same signatures), so runtime RBS type checking is unaffected. The moved private helpers were never in the RBS, and the new mixin follows the existing untyped `ConfigPathResolver` convention (no `.rbs`, not in the Steepfile; Steep remains disabled in CI).

No CHANGELOG entry, per the repo's changelog guidelines (refactors are excluded).

Closes #3538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with no public API changes; behavior should match prior diagnostics/CLI wording aside from intentional YAML/parser alignment and help formatting fixes.
> 
> **Overview**
> Introduces **`ReactOnRails::ShakapackerConfigHelpers`** so **`Doctor`**, **`SystemChecker`**, and **`Dev::ServerManager`** share one implementation for reading **`config/shakapacker.yml`**, resolving **`SHAKAPACKER_CONFIG`**, detecting **webpack vs rspack**, and labeling dev-server / HMR vs live reload.
> 
> **`Doctor`** and **`SystemChecker`** **`include`** the mixin; **`ServerManager`** **`extend`**s it so helpers stay on **`class << self`**. Duplicate private methods are removed from all three (~109 net lines). **`SystemChecker`** now uses the same **`YAML.safe_load`** options (**`Symbol`**, **`ScriptError`**) as the other parsers. **`Doctor`** memoizes **`parsed_shakapacker_config`** per run; **`ServerManager`** does not, to avoid class-level state leaking in specs.
> 
> Smaller cleanups: drop unused **`dev_server_procfile_label`** and dead **`ServerManager`** label helpers; fix non-HMR React Refresh help so rspack hints align with bullets (no extra blank line for webpack); document that the **`react-refresh/babel`** **`WEBPACK_SERVE`** note stays bundler-agnostic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5454f8adb86a4ca17dda8667875308362717a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Consolidated shakapacker configuration utilities into a dedicated helper module for improved code organization and maintainability across multiple internal classes.

* **Bug Fixes**
  * Fixed React Refresh troubleshooting help text formatting to eliminate unnecessary blank lines in certain bundler configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->