### PR TITLE
docs(ci): link latest/minimum coupling comment to tracking issue #3622

### DIFF
--- a/.github/workflows/dummy-app-bundler-tests.yml
+++ b/.github/workflows/dummy-app-bundler-tests.yml
@@ -11,10 +11,10 @@ name: Dummy App Bundler Tests
 # call decouples the bundlers: a failed build here only skips THIS call's integration job; the other
 # bundler's separate call runs independently.
 #
-# Remaining (pre-existing, out of scope for #3593): within one call the build -> integration `needs`
-# still couples that bundler's own dependency-level legs (e.g. webpack latest + minimum) — if either
-# build leg fails, this call's integration job is skipped. Only the webpack/rspack dimension is
-# decoupled here; the latest/minimum coupling predates the bundler split.
+# Remaining (pre-existing, out of scope for #3593; tracked in #3622): within one call the build ->
+# integration `needs` still couples that bundler's own dependency-level legs (e.g. webpack latest +
+# minimum) — if either build leg fails, this call's integration job is skipped. Only the
+# webpack/rspack dimension is decoupled here; the latest/minimum coupling predates the bundler split.
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

Tiny doc-only follow-up to #3613 (which fixed #3593).

The header comment in `dummy-app-bundler-tests.yml` described the remaining (pre-existing) **latest/minimum** dependency-level coupling as "out of scope for #3593" but pointed to no tracking issue — implying #3593 still covered it, which it explicitly does not. Now that the limitation is tracked in **#3622**, point the comment there.

```diff
-# Remaining (pre-existing, out of scope for #3593): within one call the build -> integration `needs`
+# Remaining (pre-existing, out of scope for #3593; tracked in #3622): within one call the build ->
```

Comment-only; no CI behavior change. `actionlint` clean.

## Context

This commit was originally pushed onto the #3613 branch but landed a few seconds after #3613 squash-merged, so it missed the merge. Re-submitting it as its own focused PR.

Refs #3622, #3593, #3613.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in a workflow file; no runtime or CI logic is modified.
> 
> **Overview**
> Updates the header comment in **`dummy-app-bundler-tests.yml`** so the pre-existing **latest/minimum** `needs` coupling is explicitly **tracked in #3622**, not only described as out of scope for #3593. **No workflow steps, inputs, or CI behavior change**—comment-only follow-up to #3613.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c32c7292e0e54cb6d2060101a891485f4ed52c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration documentation to clarify existing dependencies and coupling in the test pipeline. No changes to workflow logic or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->