### PR TITLE
ci(benchmarks): richer summary table — baseline deltas, perf links, p90 baseline, drop Fail% (#3601)

### DIFF
--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -258,8 +258,9 @@ def run_vegeta_suite(test_cases, bundle, label, bmf_collector, runner: method(:r
     begin
       rps, p50, p90, status = runner.call(test_case, bundle)
       add_to_summary(test_case[:name], label, rps, p50, p90, status)
-      # Add to BMF collector for Bencher output. p90 is retained for the display
-      # sidecar (the summary table) only — it is never sent to Bencher as a measure.
+      # Add to BMF collector for Bencher output. p90 is sent to Bencher boundary-less
+      # (recorded for a summary-table baseline but never thresholded) and also kept in the
+      # display sidecar so the summary table can show it; see BmfCollector.
       bmf_collector.add(name: test_label, rps: rps, p50: p50, p90: p90, status: status)
     rescue StandardError => e
       # ::error:: must go to stdout — GitHub Actions only parses workflow commands

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -129,8 +129,9 @@ def run_benchmark_suite(routes, bmf_collector, runner: method(:benchmark_route))
   routes.each do |route|
     rps, p50, p90, status = runner.call(route)
     add_to_summary(route, rps, p50, p90, status)
-    # Add to BMF collector for Bencher output. p90 is retained for the display
-    # sidecar (the summary table) only — it is never sent to Bencher as a measure.
+    # Add to BMF collector for Bencher output. p90 is sent to Bencher boundary-less
+    # (recorded for a summary-table baseline but never thresholded) and also kept in the
+    # display sidecar so the summary table can show it; see BmfCollector.
     bmf_collector.add(name: route, rps: rps, p50: p50, p90: p90, status: status)
   rescue StandardError => e
     # ::error:: must go to stdout — GitHub Actions only parses workflow commands

--- a/benchmarks/lib/bencher_perf_url.rb
+++ b/benchmarks/lib/bencher_perf_url.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# Builds the public Bencher perf-plot URL for a single benchmark from a parsed
+# `bencher run --format json` report (issue #3601 item 2). Matches the query shape
+# Bencher's own PR-comment code emits (lib/bencher_comment perf_url + JsonPerfQuery:
+# branches/heads/testbeds/benchmarks/measures comma-lists, then a trailing report=).
+#
+# Every field here is informational — it only decides whether a benchmark name links
+# out — so extraction is lenient: a missing piece yields nil and an unlinked name, never
+# an error. Kept separate from BencherReport's strict regression/boundary parsing.
+class BencherPerfUrl
+  # Public Bencher host; the path is /perf/<project-slug> (public links). Matches the host
+  # report_regressions.rb uses.
+  BASE = "https://bencher.dev"
+
+  def initialize(raw)
+    @raw = raw.is_a?(Hash) ? raw : {}
+    @context = extract_context
+    @targets = index_targets
+  end
+
+  # The perf URL for one benchmark (all its measures), or nil when any required id is
+  # missing (then the caller renders the name unlinked).
+  def for_benchmark(benchmark_name)
+    target = @targets[benchmark_name]
+    return nil if target.nil?
+
+    measure_uuids = target[:measure_uuids].uniq
+    return nil unless ready?(target, measure_uuids)
+
+    "#{BASE}/perf/#{@context[:project_slug]}?#{query(target, measure_uuids)}"
+  end
+
+  private
+
+  def ready?(target, measure_uuids)
+    @context[:project_slug] && @context[:branch_uuid] && @context[:testbed_uuid] &&
+      target[:benchmark_uuid] && !measure_uuids.empty?
+  end
+
+  # Param order mirrors Bencher's JsonPerfQuery (branches, heads, testbeds, benchmarks,
+  # measures) plus the trailing report= it appends. Values are UUIDs / a slug / comma-
+  # joined UUID lists — all URL-safe — so no escaping is needed; Bencher percent-encodes
+  # the list comma to %2C, but a literal comma decodes identically (its parser splits on
+  # ",") and keeps the URL readable.
+  def query(target, measure_uuids)
+    params = [["branches", @context[:branch_uuid]]]
+    params << ["heads", @context[:head_uuid]] if @context[:head_uuid]
+    params << ["testbeds", @context[:testbed_uuid]]
+    params << ["benchmarks", target[:benchmark_uuid]]
+    params << ["measures", measure_uuids.join(",")]
+    params << ["report", @context[:report_uuid]] if @context[:report_uuid]
+    params.map { |key, value| "#{key}=#{value}" }.join("&")
+  end
+
+  # Top-level ids shared by every benchmark's perf link. Read leniently (nil if absent).
+  def extract_context
+    {
+      project_slug: dig_str(@raw, "project", "slug"),
+      report_uuid: dig_str(@raw, "uuid"),
+      branch_uuid: dig_str(@raw, "branch", "uuid"),
+      head_uuid: dig_str(@raw, "branch", "head", "uuid"),
+      testbed_uuid: dig_str(@raw, "testbed", "uuid")
+    }
+  end
+
+  # Per-benchmark perf inputs (the benchmark UUID + its measure UUIDs), read leniently.
+  # Walks the same results array as BencherReport but never raises: a malformed shape just
+  # yields fewer/no targets and unlinked names.
+  def index_targets
+    targets = {}
+    results = @raw["results"]
+    return targets unless results.is_a?(Array)
+
+    results.each do |iteration|
+      next unless iteration.is_a?(Array)
+
+      iteration.each { |result| collect_target(targets, result) }
+    end
+    targets
+  end
+
+  def collect_target(targets, result)
+    name = dig_str(result, "benchmark", "name") if result.is_a?(Hash)
+    return if name.nil?
+
+    target = targets[name] ||= { benchmark_uuid: dig_str(result, "benchmark", "uuid"), measure_uuids: [] }
+    measures = result["measures"]
+    return unless measures.is_a?(Array)
+
+    measures.each do |measure_entry|
+      uuid = dig_str(measure_entry, "measure", "uuid")
+      target[:measure_uuids] << uuid if uuid
+    end
+  end
+
+  # Lenient nested String fetch: nil for any missing / non-Hash / non-String node.
+  def dig_str(hash, *path)
+    node = path.reduce(hash) { |acc, key| acc.is_a?(Hash) ? acc[key] : nil }
+    node.is_a?(String) ? node : nil
+  end
+end

--- a/benchmarks/lib/bencher_perf_url.rb
+++ b/benchmarks/lib/bencher_perf_url.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 # Builds the public Bencher perf-plot URL for a single benchmark from a parsed
-# `bencher run --format json` report (issue #3601 item 2). Matches the query shape
-# Bencher's own PR-comment code emits (lib/bencher_comment perf_url + JsonPerfQuery:
-# branches/heads/testbeds/benchmarks/measures comma-lists, then a trailing report=).
+# `bencher run --format json` report (issue #3601 item 2). The query mirrors the
+# comma-separated lists Bencher's perf view expects — branches/heads/testbeds/benchmarks/
+# measures, then a trailing report= — as of the CLI v0.6.2 pin in bencher_report.rb. That
+# shape is an external, undocumented contract, so re-verify a real perf link still resolves
+# when bumping the pin (the param order is pinned in-repo by bencher_report_spec.rb).
 #
 # Every field here is informational — it only decides whether a benchmark name links
 # out — so extraction is lenient: a missing piece yields nil and an unlinked name, never
@@ -31,18 +33,29 @@ class BencherPerfUrl
     "#{BASE}/perf/#{@context[:project_slug]}?#{query(target, measure_uuids)}"
   end
 
+  # True when the report-wide ids every perf link needs (project slug + branch & testbed
+  # uuids) are all present. They are shared by every benchmark, so if any is missing EVERY
+  # link degrades to an unlinked name — the all-or-nothing signal BencherReport warns on.
+  def context_ready?
+    [@context[:project_slug], @context[:branch_uuid], @context[:testbed_uuid]].all?
+  end
+
+  # True when the report listed at least one (named) benchmark.
+  def any_benchmarks?
+    @targets.any?
+  end
+
   private
 
   def ready?(target, measure_uuids)
-    @context[:project_slug] && @context[:branch_uuid] && @context[:testbed_uuid] &&
-      target[:benchmark_uuid] && !measure_uuids.empty?
+    context_ready? && target[:benchmark_uuid] && !measure_uuids.empty?
   end
 
-  # Param order mirrors Bencher's JsonPerfQuery (branches, heads, testbeds, benchmarks,
-  # measures) plus the trailing report= it appends. Values are UUIDs / a slug / comma-
-  # joined UUID lists — all URL-safe — so no escaping is needed; Bencher percent-encodes
-  # the list comma to %2C, but a literal comma decodes identically (its parser splits on
-  # ",") and keeps the URL readable.
+  # Param order matches the comma-separated lists Bencher's perf view expects (branches,
+  # heads, testbeds, benchmarks, measures) plus a trailing report=. Values are UUIDs / a
+  # slug / comma-joined UUID lists — all RFC 3986 query-safe characters — so no escaping is
+  # needed; the list comma is left literal (a valid query sub-delimiter) for readability
+  # rather than percent-encoded to %2C.
   def query(target, measure_uuids)
     params = [["branches", @context[:branch_uuid]]]
     params << ["heads", @context[:head_uuid]] if @context[:head_uuid]

--- a/benchmarks/lib/bencher_report.rb
+++ b/benchmarks/lib/bencher_report.rb
@@ -113,6 +113,15 @@ class BencherReport
     @perf_urls.for_benchmark(benchmark_name)
   end
 
+  # True when the report lists benchmarks but is missing the shared perf-link context
+  # (project slug / branch / testbed uuid), so EVERY benchmark name degrades to an unlinked
+  # plain name. A single benchmark missing its own uuid stays silent (a per-row cosmetic
+  # miss); losing the shared context instead is a likely report-contract drift, so the
+  # caller surfaces it as a ::warning:: — never a FormatError (the links are cosmetic).
+  def perf_links_unavailable?
+    @perf_urls.any_benchmarks? && !@perf_urls.context_ready?
+  end
+
   private
 
   def index_boundaries(raw)

--- a/benchmarks/lib/bencher_report.rb
+++ b/benchmarks/lib/bencher_report.rb
@@ -2,6 +2,8 @@
 
 require "json"
 
+require_relative "bencher_perf_url"
+
 # Parses the report emitted by `bencher run --format json` (Bencher CLI v0.6.2;
 # shape verified stable through current main). Exposes what benchmark reporting
 # needs: active regression alerts, and per benchmark+measure t-test prediction
@@ -83,6 +85,10 @@ class BencherReport
 
     @boundaries = index_boundaries(raw)
     @alerts = parse_alerts(raw)
+    # Per-benchmark perf links are informational (they only decide whether a name links
+    # out), so they live in a separate, fully-lenient builder — a missing field yields an
+    # unlinked name, never a FormatError that would fail the job over a cosmetic link.
+    @perf_urls = BencherPerfUrl.new(raw)
   end
 
   attr_reader :alerts
@@ -99,6 +105,12 @@ class BencherReport
   # :regression | :improvement | nil for benchmark+measure given its direction.
   def significance(benchmark_name, measure_key, direction)
     boundary(benchmark_name, measure_key)&.significance(direction)
+  end
+
+  # The Bencher perf-plot URL for one benchmark (all its measures), or nil when the
+  # report is missing any required id (then the caller renders the name unlinked).
+  def perf_url(benchmark_name)
+    @perf_urls.for_benchmark(benchmark_name)
   end
 
   private

--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -96,7 +96,7 @@ class BenchmarkTable
   # when the measure crossed its boundary. No baseline (new benchmark / boundary-less p90)
   # or an exact match → just the value.
   def metric_cell(name, col, value)
-    text = render_value(value)
+    text = format_number(value).to_s
     baseline = @report.boundary(name, col[:measure])&.baseline
     # No baseline (new benchmark / boundary-less p90), a zero baseline (no meaningful
     # percent, and it would divide by zero), or an exact match → just the value.

--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -29,8 +29,11 @@ class BenchmarkTable
     { header: "Status", field: "status" }
   ].freeze
 
+  # "(tracked measures)" qualifies the 🔴/🟢 significance flags, not the baseline: only
+  # tracked measures (rps, p50) are flagged significant, but ANY measure with a baseline
+  # (including the untracked p90) shows a ▲/▼ delta and an "(n)" baseline.
   LEGEND = "#{UP}/#{DOWN} change vs baseline · #{REGRESSION} significant regression · " \
-           "#{IMPROVEMENT} significant improvement · (n) = baseline (tracked measures only)".freeze
+           "#{IMPROVEMENT} significant improvement (tracked measures) · (n) = baseline".freeze
 
   EMPTY = "_No benchmark results._"
 
@@ -79,8 +82,9 @@ class BenchmarkTable
   end
 
   # The benchmark name, linked to its Bencher perf plot when the report exposes a URL.
-  # The link text is still escaped; benchmark names are controlled CI output (route paths,
-  # test names) with no [] so they can't break the link syntax.
+  # The link text is render_value-escaped, which now includes [] (see render_value), so a
+  # name with a bracket can't prematurely close the [text](url) link — defense in depth on
+  # top of names being controlled CI output (route paths, test names).
   def name_cell(row)
     name = row["name"]
     text = render_value(name)
@@ -94,8 +98,8 @@ class BenchmarkTable
   def metric_cell(name, col, value)
     text = render_value(value)
     baseline = @report.boundary(name, col[:measure])&.baseline
-    # No baseline (new benchmark / boundary-less p90), an exact match, or a zero baseline
-    # (no meaningful percent, and it would divide by zero) → just the value.
+    # No baseline (new benchmark / boundary-less p90), a zero baseline (no meaningful
+    # percent, and it would divide by zero), or an exact match → just the value.
     return text if baseline.nil? || baseline.zero? || value == baseline
 
     verdict = col[:direction] ? @report.significance(name, col[:measure], col[:direction]) : nil
@@ -126,10 +130,11 @@ class BenchmarkTable
     # Escape the Markdown metacharacters that affect inline rendering in a table cell,
     # in a single pass (which avoids double-escaping): the pipe (breaks the column
     # structure), the backslash (the escape char itself — also satisfies static
-    # analysis), and *, _, ` (emphasis/code spans — a route or test name with
-    # underscores/asterisks/backticks would otherwise render as Markdown). Cell values
-    # are controlled CI output (route paths, test names, status strings like
+    # analysis), *, _, ` (emphasis/code spans — a route or test name with
+    # underscores/asterisks/backticks would otherwise render as Markdown), and [] (so a
+    # bracket can't close the [text](url) link wrapping the name — see name_cell). Cell
+    # values are controlled CI output (route paths, test names, status strings like
     # "200=900,5xx=10"), so this is rendering robustness, not untrusted-input sanitizing.
-    value.to_s.gsub(/[\\`*_|]/) { |char| "\\#{char}" }
+    value.to_s.gsub(/[\\`*_|\[\]]/) { |char| "\\#{char}" }
   end
 end

--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -1,31 +1,36 @@
 # frozen_string_literal: true
 
-# Renders a benchmark suite's results as a Markdown section: a pipe table whose
-# tracked-measure cells (RPS, p50) are bolded and tagged 🔴 (regression) / 🟢
-# (improvement) when the value crossed its t-test prediction interval in either
-# direction, driven by a BencherReport. Non-tracked columns (p90, Status) are
-# shown but never highlighted. Pure string building — no I/O.
+# Renders a benchmark suite's results as a Markdown section: a pipe table whose tracked
+# metric cells (RPS, p50, p90) show the value, a ▲/▼ delta vs the Bencher baseline, and
+# the baseline in parentheses. A value that crossed its t-test prediction interval is
+# bolded with the arrow replaced by 🔴 (regression) / 🟢 (improvement), driven by a
+# BencherReport. The benchmark name links to that benchmark's perf plot when the report
+# exposes one. Pure string building — no I/O.
 class BenchmarkTable
   REGRESSION = "🔴"
   IMPROVEMENT = "🟢"
+  UP = "▲"
+  DOWN = "▼"
 
-  # Display-order columns. A :measure + :direction makes the column highlightable
-  # and MUST match the tracked measure/side in track_benchmarks.rb THRESHOLDS
-  # (rps: higher-is-better/:lower; p50_latency and failed_pct: lower-is-better/:upper).
-  # Every THRESHOLDS measure has a highlightable column here (pinned both directions by
-  # track_benchmarks_spec.rb) so an alert on any tracked measure is visible in the
-  # table. Columns without :measure (p90, Status) are shown but never highlighted.
+  # Display-order columns. A :measure makes the cell carry a baseline delta; a :measure
+  # WITH a :direction also makes it highlightable and MUST match the tracked measure/side
+  # in track_benchmarks.rb THRESHOLDS (rps: higher-is-better/:lower; p50_latency:
+  # lower-is-better/:upper). Every THRESHOLDS-tracked-AND-displayed measure has a
+  # highlightable column here (pinned by track_benchmarks_spec.rb) so an alert on a
+  # displayed measure is visible. p90_latency has a baseline column but no :direction:
+  # it is sent to Bencher boundary-less (no threshold), so it shows a delta if a baseline
+  # exists but is never flagged significant. failed_pct stays tracked in THRESHOLDS for
+  # alerting but is intentionally NOT a column (redundant with Status — issue #3601 item 4).
   COLUMNS = [
     { header: "Benchmark", field: "name" },
     { header: "RPS", field: "rps", measure: "rps", direction: :lower },
     { header: "p50(ms)", field: "p50", measure: "p50_latency", direction: :upper },
-    { header: "p90(ms)", field: "p90" },
-    { header: "Fail%", field: "failed_pct", measure: "failed_pct", direction: :upper },
+    { header: "p90(ms)", field: "p90", measure: "p90_latency" },
     { header: "Status", field: "status" }
   ].freeze
 
-  LEGEND = "#{REGRESSION} significant regression · #{IMPROVEMENT} significant " \
-           "improvement (vs baseline; tracked measures only)".freeze
+  LEGEND = "#{UP}/#{DOWN} change vs baseline · #{REGRESSION} significant regression · " \
+           "#{IMPROVEMENT} significant improvement · (n) = baseline (tracked measures only)".freeze
 
   EMPTY = "_No benchmark results._"
 
@@ -63,17 +68,56 @@ class BenchmarkTable
   end
 
   def cell(row, col)
-    value = row[col[:field]]
-    text = render_value(value)
-    # Only tracked, numeric cells can be highlighted: a non-tracked column has no
-    # :measure, and a missing/failed value (nil) has nothing meaningful to flag.
-    return text unless col[:measure] && @report && value.is_a?(Numeric)
+    return name_cell(row) if col[:field] == "name"
 
-    case @report.significance(row["name"], col[:measure], col[:direction])
-    when :regression then "**#{text}** #{REGRESSION}"
-    when :improvement then "**#{text}** #{IMPROVEMENT}"
-    else text
+    value = row[col[:field]]
+    # Only tracked, numeric cells get a delta: a non-tracked column has no :measure, and a
+    # missing/failed value (nil or a "FAILED"/"MISSING" token) has no baseline to compare.
+    return render_value(value) unless col[:measure] && @report && value.is_a?(Numeric)
+
+    metric_cell(row["name"], col, value)
+  end
+
+  # The benchmark name, linked to its Bencher perf plot when the report exposes a URL.
+  # The link text is still escaped; benchmark names are controlled CI output (route paths,
+  # test names) with no [] so they can't break the link syntax.
+  def name_cell(row)
+    name = row["name"]
+    text = render_value(name)
+    url = @report&.perf_url(name)
+    url ? "[#{text}](#{url})" : text
+  end
+
+  # value + ▲/▼ delta + (baseline), with the arrow swapped for 🔴/🟢 and the value bolded
+  # when the measure crossed its boundary. No baseline (new benchmark / boundary-less p90)
+  # or an exact match → just the value.
+  def metric_cell(name, col, value)
+    text = render_value(value)
+    baseline = @report.boundary(name, col[:measure])&.baseline
+    # No baseline (new benchmark / boundary-less p90), an exact match, or a zero baseline
+    # (no meaningful percent, and it would divide by zero) → just the value.
+    return text if baseline.nil? || baseline.zero? || value == baseline
+
+    verdict = col[:direction] ? @report.significance(name, col[:measure], col[:direction]) : nil
+    value_text = verdict ? "**#{text}**" : text
+    "#{value_text} #{delta(verdict, value, baseline)} (#{format_number(baseline)})"
+  end
+
+  # "▲2.3%" / "▼1.4%" for a plain change; "🔴 8.4%" / "🟢 5.0%" for a significant one (the
+  # emoji gets a trailing space so it renders clear of the percent). The percent is the
+  # absolute change vs baseline; direction is conveyed by the arrow, or by the emoji plus
+  # the column's known better-direction.
+  def delta(verdict, value, baseline)
+    percent = ((value - baseline) / baseline * 100).abs.round(1)
+    case verdict
+    when :regression then "#{REGRESSION} #{percent}%"
+    when :improvement then "#{IMPROVEMENT} #{percent}%"
+    else "#{value > baseline ? UP : DOWN}#{percent}%"
     end
+  end
+
+  def format_number(number)
+    number.round(2)
   end
 
   def render_value(value)

--- a/benchmarks/lib/bmf_helpers.rb
+++ b/benchmarks/lib/bmf_helpers.rb
@@ -13,6 +13,8 @@
 # Measures (snake_case for easy CLI usage with --threshold-measure):
 #   - rps: Requests per second (higher is better - use Lower Boundary threshold)
 #   - p50_latency: 50th-percentile latency in ms (lower is better - Upper Boundary)
+#   - p90_latency: 90th-percentile latency in ms (sent boundary-less: recorded for a
+#       summary-table baseline but NOT in THRESHOLDS, so never alerted on)
 #   - failed_pct: Failed request percentage (lower is better - use Upper Boundary)
 
 require "json"
@@ -30,8 +32,8 @@ class BmfCollector
   # @param rps [Numeric, nil] Requests per second
   # @param p50 [Numeric, nil] 50th percentile latency in ms
   # @param status [String, nil] Status string like "200=100,5xx=2"
-  # @param p90 [Numeric, nil] 90th percentile latency in ms (summary-only; not sent
-  #   to Bencher, but retained for the display sidecar so the table can show it)
+  # @param p90 [Numeric, nil] 90th percentile latency in ms (sent to Bencher
+  #   boundary-less via to_bmf, and retained for the display sidecar so the table shows it)
   def add(name:, rps:, p50:, status:, p90: nil)
     # Keep every row, including failures (rps "FAILED"/"MISSING"): the display sidecar
     # must still show a failed route/test rather than dropping it silently. The
@@ -63,6 +65,12 @@ class BmfCollector
       # Latency (lower is better) - use Upper Boundary threshold in Bencher
       # Units (ms) configured in Bencher measure settings
       add_measure(benchmark_entry, "p50_latency", r[:p50])
+
+      # p90 latency (lower is better) - sent boundary-less: it is uploaded so Bencher
+      # records its history and can supply a baseline for the summary table, but it is NOT
+      # listed in track_benchmarks.rb THRESHOLDS, so it is never alerted on (its tail noise
+      # can't meet the false-positive target at any usable boundary).
+      add_measure(benchmark_entry, "p90_latency", r[:p90])
 
       # Failure percentage (lower is better) - use Upper Boundary threshold in Bencher
       add_measure(benchmark_entry, "failed_pct", r[:failed_pct])
@@ -107,16 +115,12 @@ class BmfCollector
   # so a failed route/test stays visible in the summary even though it never reaches
   # Bencher (#to_bmf filters those out). rps may therefore be a non-numeric token like
   # "FAILED"/"MISSING"; BenchmarkTable renders it as text and never highlights a
-  # non-numeric cell. p90 and the raw status string are summary-only (absent from to_bmf).
-  # failed_pct is a tracked measure, so it is carried here (as a number) to give the
-  # table a highlightable Fail% column; a failed row (non-numeric rps) has no real
-  # failure rate, so it is left nil ("—").
+  # non-numeric cell. The raw status string is summary-only (Bencher never sees it).
+  # failed_pct is intentionally NOT carried: the Fail% column was dropped (redundant with
+  # Status — issue #3601 item 4), so nothing reads it (it is still a tracked BMF measure).
   def display_rows
     @results.map do |r|
-      {
-        "name" => r[:name], "rps" => r[:rps], "p50" => r[:p50], "p90" => r[:p90],
-        "failed_pct" => (r[:rps].is_a?(Numeric) ? r[:failed_pct] : nil), "status" => r[:status]
-      }
+      { "name" => r[:name], "rps" => r[:rps], "p50" => r[:p50], "p90" => r[:p90], "status" => r[:status] }
     end
   end
 

--- a/benchmarks/spec/bencher_perf_url_spec.rb
+++ b/benchmarks/spec/bencher_perf_url_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../lib/bencher_perf_url"
+
+# BencherPerfUrl builds a benchmark's Bencher perf-plot URL from a parsed
+# `bencher run --format json` report. Its entire contract is leniency: these fields are
+# informational (they only decide whether a name hyperlinks), and the Bencher JSON shape is
+# not a stability contract — so ANY missing/mis-typed piece must yield nil (an unlinked
+# name), never raise and fail the benchmark job. These specs pin that never-raise promise
+# directly; it is otherwise exercised only transitively through BencherReport#perf_url, so a
+# future "tidy" of the guards could silently turn a cosmetic miss into an exception.
+RSpec.describe BencherPerfUrl do
+  # A well-formed report: top-level context + one benchmark with measures.
+  def raw_with(results:, **overrides)
+    {
+      "uuid" => "R",
+      "project" => { "slug" => "P" },
+      "branch" => { "uuid" => "B", "head" => { "uuid" => "H" } },
+      "testbed" => { "uuid" => "T" },
+      "results" => results
+    }.merge(overrides)
+  end
+
+  def bench(name: "/foo", uuid: "BM", measure_uuids: %w[M1 M2])
+    measures = measure_uuids.map { |muuid| { "measure" => { "uuid" => muuid } } }
+    { "benchmark" => { "name" => name, "uuid" => uuid }, "measures" => measures }
+  end
+
+  describe "#for_benchmark" do
+    it "builds the URL from the report-wide context and the per-benchmark ids" do
+      url = described_class.new(raw_with(results: [[bench]])).for_benchmark("/foo")
+      expect(url).to eq(
+        "https://bencher.dev/perf/P?branches=B&heads=H&testbeds=T&benchmarks=BM&measures=M1,M2&report=R"
+      )
+    end
+
+    it "collapses duplicate measure uuids (.uniq) to a single list entry" do
+      raw = raw_with(results: [[bench(measure_uuids: %w[M1 M1 M2])]])
+      expect(described_class.new(raw).for_benchmark("/foo")).to include("measures=M1,M2&")
+    end
+  end
+
+  # The leniency contract: each malformed shape must yield nil WITHOUT raising, so a cosmetic
+  # link miss never escalates to a thrown exception during report rendering.
+  describe "never raises on a malformed report (returns nil → unlinked name)" do
+    it "when constructed with a non-Hash raw" do
+      expect { described_class.new("not a hash") }.not_to raise_error
+      expect(described_class.new(nil).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when results is not an array" do
+      raw = raw_with(results: { "not" => "an array" })
+      expect(described_class.new(raw).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when an iteration entry is not an array" do
+      expect(described_class.new(raw_with(results: ["not an array"])).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when a result element is not a hash" do
+      expect(described_class.new(raw_with(results: [["not a hash"]])).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when a benchmark's measures is not an array" do
+      result = { "benchmark" => { "name" => "/foo", "uuid" => "BM" }, "measures" => "nope" }
+      expect(described_class.new(raw_with(results: [[result]])).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when a measure entry is not a hash" do
+      result = { "benchmark" => { "name" => "/foo", "uuid" => "BM" }, "measures" => ["nope"] }
+      expect(described_class.new(raw_with(results: [[result]])).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when every measure uuid is a non-string (number/null), so none is usable" do
+      measures = [{ "measure" => { "uuid" => 123 } }, { "measure" => { "uuid" => nil } }]
+      result = { "benchmark" => { "name" => "/foo", "uuid" => "BM" }, "measures" => measures }
+      # No usable measure uuid → not ready → nil (rather than "measures=123" or a raise).
+      expect(described_class.new(raw_with(results: [[result]])).for_benchmark("/foo")).to be_nil
+    end
+
+    it "when a required context id (testbed) is a non-string" do
+      raw = raw_with(results: [[bench]], "testbed" => { "uuid" => 42 })
+      expect(described_class.new(raw).for_benchmark("/foo")).to be_nil
+    end
+  end
+
+  # The report-wide context (project slug + branch & testbed uuids) is shared by every
+  # benchmark's link: when it is usable the report can link them all, but if any id is
+  # missing EVERY link degrades to an unlinked name. #context_ready? + #any_benchmarks? let
+  # BencherReport surface that all-or-nothing drift as a ::warning:: (issue #3601 item 2
+  # follow-up) without failing the job over a cosmetic link.
+  describe "#context_ready? / #any_benchmarks?" do
+    it "is ready and has benchmarks for a well-formed report" do
+      perf = described_class.new(raw_with(results: [[bench]]))
+      expect(perf.context_ready?).to be(true)
+      expect(perf.any_benchmarks?).to be(true)
+    end
+
+    it "is not ready when a shared context id is missing, even though benchmarks exist" do
+      raw = raw_with(results: [[bench]])
+      raw["testbed"] = {}
+      perf = described_class.new(raw)
+      expect(perf.context_ready?).to be(false)
+      expect(perf.any_benchmarks?).to be(true)
+    end
+
+    it "has no benchmarks when results is empty" do
+      expect(described_class.new(raw_with(results: [])).any_benchmarks?).to be(false)
+    end
+  end
+end

--- a/benchmarks/spec/bencher_report_spec.rb
+++ b/benchmarks/spec/bencher_report_spec.rb
@@ -260,6 +260,33 @@ RSpec.describe BencherReport do
     end
   end
 
+  # All perf links share one report-wide context (project/branch/testbed uuid). Losing it
+  # silently unlinks EVERY benchmark name — a likely report-shape drift the caller surfaces
+  # as a ::warning:: (never a FormatError, since links are cosmetic). The strict parse does
+  # not read these fields, so a report can parse cleanly yet still have unusable perf links.
+  describe "#perf_links_unavailable?" do
+    def result_for(name)
+      { "benchmark" => { "name" => name, "uuid" => "BM" },
+        "measures" => [{ "measure" => { "slug" => "rps", "name" => "rps", "uuid" => "M1" },
+                         "metric" => { "value" => 1.0 } }] }
+    end
+
+    it "is true when the report lists benchmarks but the shared perf context is absent" do
+      raw = { "results" => [[result_for("/foo")]], "alerts" => [] }
+      expect(described_class.new(raw).perf_links_unavailable?).to be(true)
+    end
+
+    it "is false when the shared perf context is present" do
+      raw = { "project" => { "slug" => "P" }, "branch" => { "uuid" => "B" }, "testbed" => { "uuid" => "T" },
+              "results" => [[result_for("/foo")]], "alerts" => [] }
+      expect(described_class.new(raw).perf_links_unavailable?).to be(false)
+    end
+
+    it "is false when the report lists no benchmarks (nothing to link)" do
+      expect(described_class.new("results" => [], "alerts" => []).perf_links_unavailable?).to be(false)
+    end
+  end
+
   describe "defensive parsing" do
     it "raises FormatError on invalid JSON" do
       expect { described_class.parse("{not json") }.to raise_error(BencherReport::FormatError, /not valid JSON/)

--- a/benchmarks/spec/bencher_report_spec.rb
+++ b/benchmarks/spec/bencher_report_spec.rb
@@ -190,6 +190,76 @@ RSpec.describe BencherReport do
     end
   end
 
+  # Per-benchmark Bencher perf-plot URL (issue #3601 item 2). Built from the report's
+  # branch/head/testbed UUIDs (top-level), the per-benchmark UUID and its measure UUIDs,
+  # and the report UUID — matching the query shape Bencher's own PR-comment code emits
+  # (lib/bencher_comment perf_url + JsonPerfQuery: branches/heads/testbeds/benchmarks/
+  # measures comma-lists, then report=). These fields are NOT part of the documented
+  # contract, so extraction is lenient: any missing piece yields nil and the caller
+  # renders the benchmark name unlinked rather than failing the job.
+  describe "#perf_url" do
+    def bench(name:, uuid:, measure_uuids:)
+      measures = measure_uuids.each_with_index.map do |muuid, i|
+        { "measure" => { "slug" => "m#{i}", "name" => "m#{i}", "uuid" => muuid }, "metric" => { "value" => 1.0 } }
+      end
+      { "benchmark" => { "name" => name, "uuid" => uuid }, "measures" => measures }
+    end
+
+    def report_with(results:, **ctx)
+      head_uuid = ctx.fetch(:head_uuid, "H")
+      branch = { "uuid" => ctx.fetch(:branch_uuid, "B") }
+      branch["head"] = { "uuid" => head_uuid } if head_uuid
+      raw = {
+        "uuid" => ctx.fetch(:report_uuid, "R"),
+        "project" => { "slug" => ctx.fetch(:project_slug, "P") },
+        "branch" => branch,
+        "testbed" => { "uuid" => ctx.fetch(:testbed_uuid, "T") },
+        "results" => results, "alerts" => []
+      }
+      described_class.new(raw)
+    end
+
+    it "builds a per-benchmark perf URL from branch/head/testbed/benchmark/measures/report" do
+      report = report_with(results: [[bench(name: "/foo: Core", uuid: "BM", measure_uuids: %w[M1 M2])]])
+      expect(report.perf_url("/foo: Core")).to eq(
+        "https://bencher.dev/perf/P?branches=B&heads=H&testbeds=T&benchmarks=BM&measures=M1,M2&report=R"
+      )
+    end
+
+    it "returns nil for an unknown benchmark" do
+      report = report_with(results: [[bench(name: "/foo", uuid: "BM", measure_uuids: %w[M1])]])
+      expect(report.perf_url("/missing")).to be_nil
+    end
+
+    it "returns nil when a required id (testbed) is absent, so the name renders unlinked" do
+      raw = { "uuid" => "R", "project" => { "slug" => "P" },
+              "branch" => { "uuid" => "B", "head" => { "uuid" => "H" } },
+              "results" => [[bench(name: "/foo", uuid: "BM", measure_uuids: %w[M1])]], "alerts" => [] }
+      expect(described_class.new(raw).perf_url("/foo")).to be_nil
+    end
+
+    it "returns nil when the benchmark has no measure uuids" do
+      report = report_with(results: [[bench(name: "/foo", uuid: "BM", measure_uuids: [])]])
+      expect(report.perf_url("/foo")).to be_nil
+    end
+
+    it "omits the optional head param when the branch head uuid is absent" do
+      report = report_with(results: [[bench(name: "/foo", uuid: "BM", measure_uuids: %w[M1])]], head_uuid: nil)
+      expect(report.perf_url("/foo")).to eq(
+        "https://bencher.dev/perf/P?branches=B&testbeds=T&benchmarks=BM&measures=M1&report=R"
+      )
+    end
+
+    it "omits the optional report param when the report uuid is absent" do
+      raw = { "project" => { "slug" => "P" },
+              "branch" => { "uuid" => "B", "head" => { "uuid" => "H" } }, "testbed" => { "uuid" => "T" },
+              "results" => [[bench(name: "/foo", uuid: "BM", measure_uuids: %w[M1])]], "alerts" => [] }
+      expect(described_class.new(raw).perf_url("/foo")).to eq(
+        "https://bencher.dev/perf/P?branches=B&heads=H&testbeds=T&benchmarks=BM&measures=M1"
+      )
+    end
+  end
+
   describe "defensive parsing" do
     it "raises FormatError on invalid JSON" do
       expect { described_class.parse("{not json") }.to raise_error(BencherReport::FormatError, /not valid JSON/)

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -4,109 +4,177 @@ require_relative "spec_helper"
 require_relative "../lib/benchmark_table"
 require_relative "../lib/bencher_report"
 
-# BenchmarkTable renders a suite's display rows as a Markdown pipe table, bolding
-# and tagging tracked-measure cells (RPS, p50) that crossed their t-test boundary
-# while leaving non-tracked columns (p90, Status) plain. The significance verdict
-# comes from an injected report, so the renderer is tested in isolation against a
-# verified BencherReport double whose verdicts are looked up by (name, measure).
+# BenchmarkTable renders a suite's display rows as a Markdown pipe table. Each tracked
+# metric cell (RPS, p50, p90) shows the value, a ▲/▼ delta vs the Bencher baseline, and
+# the baseline in parentheses; a value that crossed its t-test boundary is bolded with
+# the arrow replaced by 🔴 (regression) / 🟢 (improvement). The benchmark name links to
+# that benchmark's Bencher perf plot. All significance/baseline/url facts come from an
+# injected report, so the renderer is tested in isolation against a verified
+# BencherReport double looked up by (name, measure).
 RSpec.describe BenchmarkTable do
-  # A BencherReport stand-in returning the verdict registered for a (name, measure)
-  # pair, else nil. Verified against the real interface so it can't drift.
-  def fake_report(verdicts = {})
+  # A BencherReport stand-in. `verdicts` maps [name, measure] => :regression/:improvement;
+  # `baselines` maps [name, measure] => Float (returned via a real Boundary so #baseline
+  # behaves exactly like production); `urls` maps name => perf URL. Verified against the
+  # real interface so it can't drift.
+  def fake_report(verdicts: {}, baselines: {}, urls: {})
     instance_double(BencherReport).tap do |report|
       allow(report).to receive(:significance) { |name, measure, _direction| verdicts[[name, measure]] }
+      allow(report).to receive(:boundary) do |name, measure|
+        base = baselines[[name, measure]]
+        base && BencherReport::Boundary.new(value: nil, baseline: base, lower_limit: nil, upper_limit: nil)
+      end
+      allow(report).to receive(:perf_url) { |name| urls[name] }
     end
   end
 
-  def row(name:, rps:, p50:, p90:, status:, failed_pct: nil)
-    { "name" => name, "rps" => rps, "p50" => p50, "p90" => p90, "failed_pct" => failed_pct, "status" => status }
+  def row(name:, rps:, p50:, p90:, status:)
+    { "name" => name, "rps" => rps, "p50" => p50, "p90" => p90, "status" => status }
   end
 
   def render(rows:, report:)
     described_class.new(title: "Core Benchmark Summary", rows: rows, report: report).to_markdown
   end
 
-  it "renders a header, divider, the title, one row per input, and a legend" do
+  it "renders title, header (no Fail% column), divider, one row per input, and a legend" do
     markdown = render(
       rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
       report: fake_report
     )
 
     expect(markdown).to include("### Core Benchmark Summary")
-    expect(markdown).to include("| Benchmark | RPS | p50(ms) | p90(ms) | Fail% | Status |")
-    expect(markdown).to include("| --- | --- | --- | --- | --- | --- |")
-    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | — | 200=100 |")
+    expect(markdown).to include("| Benchmark | RPS | p50(ms) | p90(ms) | Status |")
+    expect(markdown).to include("| --- | --- | --- | --- | --- |")
+    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
+    expect(markdown).not_to include("Fail%")
+    expect(markdown).to include("▲/▼ change vs baseline")
     expect(markdown).to include("🔴 significant regression")
     expect(markdown).to include("🟢 significant improvement")
   end
 
-  it "bolds + tags a regressed RPS cell and an improved p50 cell" do
+  it "shows a ▲/▼ delta and the baseline for a non-significant change" do
+    report = fake_report(baselines: { ["/foo", "rps"] => 97.75, ["/foo", "p50_latency"] => 5.07 })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    # rps rose 2.3% above baseline (▲), p50 fell 1.4% below baseline (▼).
+    expect(markdown).to include("| /foo | 100.0 ▲2.3% (97.75) | 5.0 ▼1.4% (5.07) | 6.0 | 200=100 |")
+  end
+
+  it "bolds + tags a regressed RPS cell and an improved p50 cell, replacing the arrow with the emoji" do
     report = fake_report(
-      ["/foo", "rps"] => :regression,
-      ["/foo", "p50_latency"] => :improvement
+      verdicts: { ["/foo", "rps"] => :regression, ["/foo", "p50_latency"] => :improvement },
+      baselines: { ["/foo", "rps"] => 100.0, ["/foo", "p50_latency"] => 5.0 }
     )
     markdown = render(
       rows: [row(name: "/foo", rps: 80.0, p50: 4.0, p90: 6.0, status: "200=100")],
       report: report
     )
 
-    expect(markdown).to include("| /foo | **80.0** 🔴 | **4.0** 🟢 | 6.0 | — | 200=100 |")
+    expect(markdown).to include("| /foo | **80.0** 🔴 20.0% (100.0) | **4.0** 🟢 20.0% (5.0) | 6.0 | 200=100 |")
   end
 
-  it "bolds + tags a regressed failed_pct cell in the Fail% column" do
-    report = fake_report(["/foo", "failed_pct"] => :regression)
-    markdown = render(
-      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, failed_pct: 2.0, status: "200=980,5xx=20")],
-      report: report
+  it "shows a p90 delta when a baseline exists but never marks it significant (p90 is untracked)" do
+    # Even if the report somehow returned a verdict for p90, the p90 column has no
+    # direction, so the renderer must not consult significance for it — only the baseline.
+    report = fake_report(
+      verdicts: { ["/foo", "p90_latency"] => :regression },
+      baselines: { ["/foo", "p90_latency"] => 5.0 }
     )
-
-    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | **2.0** 🔴 | 200=980,5xx=20 |")
-  end
-
-  it "never highlights non-tracked columns (p90, Status) and leaves untouched rows plain" do
-    # Even if the report had verdicts for these, the renderer must not consult it
-    # for p90/Status — they are not in COLUMNS as highlightable.
-    report = fake_report(["/foo", "p90"] => :regression, ["/foo", "status"] => :regression)
     markdown = render(
       rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
       report: report
     )
 
-    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | — | 200=100 |")
+    expect(markdown).to include("6.0 ▲20.0% (5.0)")
     expect(markdown).not_to include("**6.0**")
+    expect(markdown).not_to include("🔴 20.0% (5.0)")
   end
 
-  it "renders nil numeric cells as an em dash and never highlights them" do
-    report = fake_report(["/p", "p50_latency"] => :regression)
+  it "shows only the value (no delta) when the report has no baseline for a measure" do
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: fake_report
+    )
+
+    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
+  end
+
+  it "shows only the value (no delta) when the baseline is zero, avoiding a divide-by-zero" do
+    report = fake_report(baselines: { ["/foo", "rps"] => 0.0 })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
+  end
+
+  it "shows only the value when the metric exactly equals its baseline (skips a 0.0% delta)" do
+    report = fake_report(baselines: { ["/foo", "rps"] => 100.0 })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
+  end
+
+  it "links the benchmark name to its perf URL when the report provides one" do
+    report = fake_report(urls: { "/foo" => "https://bencher.dev/perf/p?benchmarks=BM" })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    expect(markdown).to include("| [/foo](https://bencher.dev/perf/p?benchmarks=BM) | 100.0 |")
+  end
+
+  it "leaves the benchmark name unlinked when the report has no perf URL for it" do
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: fake_report
+    )
+
+    expect(markdown).to include("| /foo | 100.0 |")
+    expect(markdown).not_to include("](")
+  end
+
+  it "renders a non-numeric rps token (FAILED/MISSING) as plain text without a delta" do
+    report = fake_report(
+      verdicts: { ["/broken", "rps"] => :regression },
+      baselines: { ["/broken", "rps"] => 100.0 }
+    )
+    markdown = render(
+      rows: [row(name: "/broken", rps: "FAILED", p50: nil, p90: nil, status: "Connection refused")],
+      report: report
+    )
+
+    expect(markdown).to include("| /broken | FAILED | — | — | Connection refused |")
+    expect(markdown).not_to include("**FAILED**")
+  end
+
+  it "renders nil numeric cells as an em dash and never adds a delta to them" do
+    report = fake_report(baselines: { ["/p", "p50_latency"] => 5.0 })
     markdown = render(
       rows: [row(name: "/p", rps: 100.0, p50: nil, p90: nil, status: "200=100")],
       report: report
     )
 
-    expect(markdown).to include("| /p | 100.0 | — | — | — | 200=100 |")
+    expect(markdown).to include("| /p | 100.0 | — | — | 200=100 |")
   end
 
-  it "escapes pipe characters in values" do
+  it "renders without a report (no links, no deltas) when report is nil" do
     markdown = render(
-      rows: [row(name: "/a|b", rps: 1.0, p50: 2.0, p90: 3.0, status: "200=1")],
-      report: fake_report
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: nil
     )
 
-    expect(markdown).to include('/a\|b')
+    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
   end
 
-  it "escapes backslashes (so the escape char can't combine with following text)" do
-    markdown = render(
-      rows: [row(name: "/a\\b", rps: 1.0, p50: 2.0, p90: 3.0, status: "x\\|y")],
-      report: fake_report
-    )
-
-    # "/a\b" -> "/a\\b"; "x\|y" -> "x\\\|y" (backslash escaped, then the pipe escaped).
-    expect(markdown).to include('/a\\\\b')
-    expect(markdown).to include('x\\\\\\|y')
-  end
-
-  it "escapes emphasis/code metacharacters (_ * `) so names don't render as Markdown" do
+  it "escapes emphasis/code metacharacters (_ * `) in names and status" do
     markdown = render(
       rows: [row(name: "a_b_c", rps: 1.0, p50: 2.0, p90: 3.0, status: "`x` *y*")],
       report: fake_report
@@ -116,24 +184,14 @@ RSpec.describe BenchmarkTable do
     expect(markdown).to include('\`x\` \*y\*')
   end
 
-  it "renders a non-numeric rps token (FAILED/MISSING) as plain text without highlighting" do
-    report = fake_report(["/broken", "rps"] => :regression)
+  it "escapes pipe and backslash characters in values" do
     markdown = render(
-      rows: [row(name: "/broken", rps: "FAILED", p50: nil, p90: nil, status: "Connection refused")],
-      report: report
+      rows: [row(name: "/a|b", rps: 1.0, p50: 2.0, p90: 3.0, status: "x\\|y")],
+      report: fake_report
     )
 
-    expect(markdown).to include("| /broken | FAILED | — | — | — | Connection refused |")
-    expect(markdown).not_to include("**FAILED**")
-  end
-
-  it "renders without a report (no highlighting) when report is nil" do
-    markdown = render(
-      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
-      report: nil
-    )
-
-    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | — | 200=100 |")
+    expect(markdown).to include('/a\|b')
+    expect(markdown).to include('x\\\\\\|y')
   end
 
   it "shows a placeholder instead of an empty table when there are no rows" do

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe BenchmarkTable do
     expect(markdown).to include("100.0 ▲2.3% (97.76)")
   end
 
+  it "rounds displayed metric values to the same precision as baselines" do
+    report = fake_report(baselines: { ["/foo", "rps"] => 97.756 })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.126, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    expect(markdown).to include("100.13 ▲2.4% (97.76)")
+  end
+
   it "bolds + tags a regressed RPS cell and an improved p50 cell, replacing the arrow with the emoji" do
     report = fake_report(
       verdicts: { ["/foo", "rps"] => :regression, ["/foo", "p50_latency"] => :improvement },
@@ -144,14 +154,14 @@ RSpec.describe BenchmarkTable do
   end
 
   it "escapes brackets in a linked name so they can't prematurely close the link" do
-    report = fake_report(urls: { "a]b" => "https://bencher.dev/perf/p?benchmarks=BM" })
+    report = fake_report(urls: { "a[b]c" => "https://bencher.dev/perf/p?benchmarks=BM" })
     markdown = render(
-      rows: [row(name: "a]b", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      rows: [row(name: "a[b]c", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
       report: report
     )
 
-    # The "]" is backslash-escaped inside the link text, so the link wraps the whole name.
-    expect(markdown).to include('| [a\]b](https://bencher.dev/perf/p?benchmarks=BM) | 100.0 |')
+    # Brackets are backslash-escaped inside the link text, so the link wraps the whole name.
+    expect(markdown).to include('| [a\[b\]c](https://bencher.dev/perf/p?benchmarks=BM) | 100.0 |')
   end
 
   it "leaves the benchmark name unlinked when the report has no perf URL for it" do

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe BenchmarkTable do
     expect(markdown).to include("| /foo | 100.0 ▲2.3% (97.75) | 5.0 ▼1.4% (5.07) | 6.0 | 200=100 |")
   end
 
+  it "rounds the displayed baseline to two decimals" do
+    # A high-precision Bencher baseline must not leak its full precision into the cell.
+    report = fake_report(baselines: { ["/foo", "rps"] => 97.756 })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    # baseline 97.756 -> (97.76); proves format_number's round(2) actually rounds.
+    expect(markdown).to include("100.0 ▲2.3% (97.76)")
+  end
+
   it "bolds + tags a regressed RPS cell and an improved p50 cell, replacing the arrow with the emoji" do
     report = fake_report(
       verdicts: { ["/foo", "rps"] => :regression, ["/foo", "p50_latency"] => :improvement },
@@ -129,6 +141,17 @@ RSpec.describe BenchmarkTable do
     )
 
     expect(markdown).to include("| [/foo](https://bencher.dev/perf/p?benchmarks=BM) | 100.0 |")
+  end
+
+  it "escapes brackets in a linked name so they can't prematurely close the link" do
+    report = fake_report(urls: { "a]b" => "https://bencher.dev/perf/p?benchmarks=BM" })
+    markdown = render(
+      rows: [row(name: "a]b", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    # The "]" is backslash-escaped inside the link text, so the link wraps the whole name.
+    expect(markdown).to include('| [a\]b](https://bencher.dev/perf/p?benchmarks=BM) | 100.0 |')
   end
 
   it "leaves the benchmark name unlinked when the report has no perf URL for it" do

--- a/benchmarks/spec/bmf_collector_spec.rb
+++ b/benchmarks/spec/bmf_collector_spec.rb
@@ -4,12 +4,13 @@ require_relative "spec_helper"
 require_relative "../lib/bmf_helpers"
 require "tmpdir"
 
-# BmfCollector produces the JSON Bencher ingests. Its measure names must stay in
-# lockstep with track_benchmarks.rb's THRESHOLDS, so pin the emitted shape: the
-# tracked measures rps, p50_latency, and failed_pct.
+# BmfCollector produces the JSON Bencher ingests. The thresholded measures (rps,
+# p50_latency, failed_pct) must stay in lockstep with track_benchmarks.rb's THRESHOLDS.
+# p90_latency is also emitted but sent boundary-less (no threshold) so Bencher records its
+# history and can supply a baseline for the summary table — it is never alerted on.
 RSpec.describe BmfCollector do
   describe "#to_bmf" do
-    it "emits exactly rps, p50_latency and failed_pct" do
+    it "emits rps, p50_latency and failed_pct (and p90_latency only when p90 is supplied)" do
       collector = described_class.new
       collector.add(name: "/route", rps: 100.0, p50: 5.0, status: "200=100")
 
@@ -17,6 +18,22 @@ RSpec.describe BmfCollector do
       expect(entry.keys).to contain_exactly("rps", "p50_latency", "failed_pct")
       expect(entry["rps"]).to eq("value" => 100.0)
       expect(entry["p50_latency"]).to eq("value" => 5.0)
+    end
+
+    it "emits p90_latency (boundary-less) when p90 is supplied" do
+      collector = described_class.new
+      collector.add(name: "/route", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")
+
+      entry = collector.to_bmf.fetch("/route")
+      expect(entry.keys).to contain_exactly("rps", "p50_latency", "p90_latency", "failed_pct")
+      expect(entry["p90_latency"]).to eq("value" => 6.0)
+    end
+
+    it "omits p90_latency when p90 is not numeric" do
+      collector = described_class.new
+      collector.add(name: "/partial", rps: 100.0, p50: 5.0, p90: "MISSING", status: "200=100")
+
+      expect(collector.to_bmf.fetch("/partial")).not_to have_key("p90_latency")
     end
 
     it "applies the prefix and suffix to the benchmark name" do
@@ -63,10 +80,11 @@ RSpec.describe BmfCollector do
     end
   end
 
-  # The display sidecar carries the columns the Markdown summary table needs but
-  # that Bencher never sees: p90 and the human Status string. It is keyed by the
-  # same canonical name the BMF uses, so track_benchmarks.rb joins it with the
-  # Bencher report exactly (no name reconstruction).
+  # The display sidecar carries the summary-table columns keyed by the same canonical
+  # name the BMF uses, so track_benchmarks.rb joins it with the Bencher report exactly (no
+  # name reconstruction). It still carries the raw Status string (Bencher never sees it)
+  # and keeps failed rows visible even though to_bmf drops them. failed_pct is no longer
+  # carried — the Fail% column was dropped (issue #3601 item 4), so nothing reads it.
   describe "display sidecar" do
     describe "#display_rows" do
       it "includes p90 and the raw status, keyed by the canonical (prefixed/suffixed) name" do
@@ -75,7 +93,7 @@ RSpec.describe BmfCollector do
 
         expect(collector.display_rows).to eq(
           [{ "name" => "Pro Node Renderer: simple_eval: Pro", "rps" => 100.0,
-             "p50" => 5.0, "p90" => 6.0, "failed_pct" => 0.0, "status" => "200=100" }]
+             "p50" => 5.0, "p90" => 6.0, "status" => "200=100" }]
         )
       end
 
@@ -85,10 +103,8 @@ RSpec.describe BmfCollector do
         collector.add(name: "/broken", rps: "FAILED", p50: "FAILED", p90: "FAILED", status: "Connection refused")
 
         expect(collector.display_rows).to eq(
-          [{ "name" => "/partial", "rps" => 100.0, "p50" => nil, "p90" => nil,
-             "failed_pct" => 0.0, "status" => "200=100" },
-           { "name" => "/broken", "rps" => "FAILED", "p50" => nil, "p90" => nil,
-             "failed_pct" => nil, "status" => "Connection refused" }]
+          [{ "name" => "/partial", "rps" => 100.0, "p50" => nil, "p90" => nil, "status" => "200=100" },
+           { "name" => "/broken", "rps" => "FAILED", "p50" => nil, "p90" => nil, "status" => "Connection refused" }]
         )
       end
 
@@ -110,8 +126,7 @@ RSpec.describe BmfCollector do
 
           expect(collector.write_display_json(path)).to be(true)
           expect(JSON.parse(File.read(path))).to eq(
-            [{ "name" => "/foo", "rps" => 1.0, "p50" => 2.0, "p90" => 3.0,
-               "failed_pct" => 0.0, "status" => "200=1" }]
+            [{ "name" => "/foo", "rps" => 1.0, "p50" => 2.0, "p90" => 3.0, "status" => "200=1" }]
           )
         end
       end
@@ -156,13 +171,14 @@ RSpec.describe BmfCollector do
     end
   end
 
-  # p90 is summary-only: it must never become a tracked Bencher measure.
-  describe "p90 stays out of the BMF output" do
-    it "is not added to to_bmf even when supplied" do
+  # p90 is sent to Bencher boundary-less: in the BMF (so a baseline can accrue) but never
+  # in THRESHOLDS, so it is recorded yet never alerted on (issue #3601 item 3).
+  describe "p90 reaches the BMF but is never thresholded" do
+    it "is added to to_bmf as p90_latency when supplied" do
       collector = described_class.new
       collector.add(name: "/foo", rps: 1.0, p50: 2.0, p90: 3.0, status: "200=1")
 
-      expect(collector.to_bmf.fetch("/foo").keys).to contain_exactly("rps", "p50_latency", "failed_pct")
+      expect(collector.to_bmf.fetch("/foo").keys).to contain_exactly("rps", "p50_latency", "p90_latency", "failed_pct")
     end
   end
 end

--- a/benchmarks/spec/fixtures/bencher_report_sample.json
+++ b/benchmarks/spec/fixtures/bencher_report_sample.json
@@ -1,21 +1,30 @@
 {
+  "uuid": "report-uuid",
+  "project": { "slug": "react-on-rails-t8a9ncxo" },
+  "branch": { "uuid": "branch-uuid", "head": { "uuid": "head-uuid" } },
+  "testbed": { "uuid": "testbed-uuid" },
   "results": [
     [
       {
-        "benchmark": { "name": "/heavy: Core" },
+        "benchmark": { "name": "/heavy: Core", "uuid": "bench-uuid" },
         "measures": [
           {
-            "measure": { "slug": "rps", "name": "rps" },
+            "measure": { "slug": "rps", "name": "rps", "uuid": "rps-uuid" },
             "metric": { "value": 80.0 },
             "boundary": { "baseline": 100.0, "lower_limit": 90.0, "upper_limit": null }
           },
           {
-            "measure": { "slug": "p50-latency", "name": "p50_latency" },
+            "measure": { "slug": "p50-latency", "name": "p50_latency", "uuid": "p50-uuid" },
             "metric": { "value": 3.5 },
             "boundary": { "baseline": 5.0, "lower_limit": null, "upper_limit": 6.0 }
           },
           {
-            "measure": { "slug": "failed-pct", "name": "failed_pct" },
+            "measure": { "slug": "p90-latency", "name": "p90_latency", "uuid": "p90-uuid" },
+            "metric": { "value": 7.2 },
+            "boundary": { "baseline": 6.0, "lower_limit": null, "upper_limit": null }
+          },
+          {
+            "measure": { "slug": "failed-pct", "name": "failed_pct", "uuid": "failed-uuid" },
             "metric": { "value": 1.1 },
             "boundary": { "baseline": 0.2, "lower_limit": null, "upper_limit": 1.0 }
           }

--- a/benchmarks/spec/report_table_integration_spec.rb
+++ b/benchmarks/spec/report_table_integration_spec.rb
@@ -22,8 +22,14 @@ RSpec.describe "BencherReport + BenchmarkTable integration" do
   # Display rows as the bench scripts would emit them (BmfCollector#display_rows),
   # keyed by the same canonical name the fixture's report uses.
   let(:rows) do
-    [{ "name" => "/heavy: Core", "rps" => 80.0, "p50" => 3.5, "p90" => 7.2,
-       "failed_pct" => 1.1, "status" => "200=900,5xx=10" }]
+    [{ "name" => "/heavy: Core", "rps" => 80.0, "p50" => 3.5, "p90" => 7.2, "status" => "200=900,5xx=10" }]
+  end
+
+  # The per-benchmark perf URL built from the fixture's UUIDs (branches/heads/testbeds/
+  # benchmarks/measures in document order, then report=) — exercises the real link seam.
+  let(:perf_url) do
+    "https://bencher.dev/perf/react-on-rails-t8a9ncxo?branches=branch-uuid&heads=head-uuid" \
+      "&testbeds=testbed-uuid&benchmarks=bench-uuid&measures=rps-uuid,p50-uuid,p90-uuid,failed-uuid&report=report-uuid"
   end
 
   it "classifies the fixture as a regression and exposes the active alert" do
@@ -40,9 +46,19 @@ RSpec.describe "BencherReport + BenchmarkTable integration" do
     expect(report.significance("/heavy: Core", "failed_pct", :upper)).to eq(:regression)
   end
 
-  it "renders the regressed RPS/failed_pct cells and improved p50 cell, leaving p90/Status plain" do
+  it "exposes a per-benchmark perf URL built from the report's UUIDs" do
+    expect(report.perf_url("/heavy: Core")).to eq(perf_url)
+  end
+
+  it "links the name, bolds/tags the regressed RPS and improved p50 with deltas, and shows a plain p90 delta" do
     markdown = BenchmarkTable.new(title: "Core Benchmark Summary", rows: rows, report: report).to_markdown
 
-    expect(markdown).to include("| /heavy: Core | **80.0** 🔴 | **3.5** 🟢 | 7.2 | **1.1** 🔴 | 200=900,5xx=10 |")
+    # No Fail% column (dropped); p90 shows a ▲ delta vs its boundary-less baseline but is
+    # never bolded/tagged; the name links to the perf plot.
+    expect(markdown).to include(
+      "| [/heavy: Core](#{perf_url}) | **80.0** 🔴 20.0% (100.0) | **3.5** 🟢 30.0% (5.0) | " \
+      "7.2 ▲20.0% (6.0) | 200=900,5xx=10 |"
+    )
+    expect(markdown).not_to include("Fail%")
   end
 end

--- a/benchmarks/spec/report_table_integration_spec.rb
+++ b/benchmarks/spec/report_table_integration_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe "BencherReport + BenchmarkTable integration" do
   # benchmarks/measures in document order, then report=) — exercises the real link seam.
   let(:perf_url) do
     "https://bencher.dev/perf/react-on-rails-t8a9ncxo?branches=branch-uuid&heads=head-uuid" \
-      "&testbeds=testbed-uuid&benchmarks=bench-uuid&measures=rps-uuid,p50-uuid,p90-uuid,failed-uuid&report=report-uuid"
+      "&testbeds=testbed-uuid&benchmarks=bench-uuid" \
+      "&measures=rps-uuid,p50-uuid,p90-uuid,failed-uuid&report=report-uuid"
   end
 
   it "classifies the fixture as a regression and exposes the active alert" do

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -66,6 +66,28 @@ RSpec.describe "track_benchmarks" do
     end
   end
 
+  describe "#run_bencher" do
+    it "emits the perf-link context warning to stdout so GitHub Actions annotates it" do
+      status = instance_double(Process::Status, exitstatus: 0)
+      report_json = JSON.generate(
+        "results" => [[{
+          "benchmark" => { "name" => "/foo", "uuid" => "bench-uuid" },
+          "measures" => [{
+            "measure" => { "slug" => "rps", "name" => "rps", "uuid" => "rps-uuid" },
+            "metric" => { "value" => 1.0 }
+          }]
+        }]],
+        "alerts" => []
+      )
+
+      allow(Open3).to receive(:capture3).and_return([report_json, "", status])
+      allow(File).to receive(:write).with(REPORT_JSON, report_json)
+
+      expect { run_bencher("branch", []) }
+        .to output(/::warning::Bencher report listed benchmarks but no perf-link context/).to_stdout
+    end
+  end
+
   # On a main regression the rendered table feeds the report-regressions hand-off. If
   # the display sidecar was missing/corrupt the table is empty, and an empty-bodied
   # issue is useless — the hand-off must substitute a run-URL pointer instead.

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -135,41 +135,75 @@ RSpec.describe "track_benchmarks" do
     end
   end
 
-  # A threshold on a measure that no metric reports is a silent no-op, so the tracked
-  # measures must match exactly what BmfCollector emits.
+  # A threshold on a measure that no metric reports is a silent no-op, so every tracked
+  # measure must be among what BmfCollector emits. The reverse is NOT exact equality:
+  # BmfCollector also emits p90_latency boundary-less (recorded for a summary baseline but
+  # deliberately absent from THRESHOLDS, so never alerted on).
   describe "tracked measures" do
-    it "match exactly the measures BmfCollector emits" do
+    let(:emitted) do
       collector = BmfCollector.new
-      collector.add(name: "x", rps: 1.0, p50: 1.0, status: "200=1")
+      collector.add(name: "x", rps: 1.0, p50: 1.0, p90: 1.0, status: "200=1")
+      collector.to_bmf.fetch("x").keys
+    end
 
-      expect(collector.to_bmf.fetch("x").keys).to match_array(THRESHOLDS.map(&:first))
+    it "are all emitted by BmfCollector (so no threshold is a silent no-op)" do
+      expect(emitted).to include(*THRESHOLDS.map(&:first))
+    end
+
+    it "exclude p90_latency, which BmfCollector emits boundary-less (recorded but never alerted)" do
+      expect(emitted).to include("p90_latency")
+      expect(THRESHOLDS.map(&:first)).not_to include("p90_latency")
     end
   end
 
   # The summary table's highlightable columns must stay in lockstep with the tracked
   # measures/sides Bencher is configured with, or a column would either be silently
-  # un-highlightable or highlighted with the wrong direction.
+  # un-highlightable or highlighted with the wrong direction. A column is "highlightable"
+  # when it has a :direction; a column with a :measure but no :direction (p90_latency)
+  # only shows a baseline delta and is never tagged.
   describe "summary table highlight columns" do
+    # Tracked measures intentionally NOT shown as a table column: failed_pct is redundant
+    # with the Status column (issue #3601 item 4) but stays in THRESHOLDS as an alerting
+    # safety net. A measure listed here fires the build on a regression but renders only
+    # via Status, not a highlighted cell — a deliberate trade, pinned so re-adding a column
+    # (or dropping the threshold) is a conscious change.
+    display_suppressed = %w[failed_pct].freeze
+
     it "use measures and directions that exist in THRESHOLDS" do
       thresholds = THRESHOLDS.to_h { |measure, direction, _boundary| [measure, direction] }
 
-      BenchmarkTable::COLUMNS.select { |col| col[:measure] }.each do |col|
+      BenchmarkTable::COLUMNS.select { |col| col[:direction] }.each do |col|
         expect(thresholds).to include(col[:measure])
         expect(col[:direction]).to eq(thresholds[col[:measure]])
       end
     end
 
-    # The reverse direction: every tracked measure must have a highlightable column,
-    # or an alert on that measure (e.g. failed_pct) would fire but render as an
-    # un-highlighted cell — invisible in the PR comment and the regression hand-off.
-    it "expose every tracked THRESHOLDS measure as a highlightable column" do
-      highlightable = BenchmarkTable::COLUMNS.select { |col| col[:measure] }
+    # The reverse direction: every tracked measure must have a highlightable column —
+    # except the deliberately display-suppressed ones — or an alert on it would fire but
+    # render as an un-highlighted cell, invisible in the PR comment and regression hand-off.
+    it "expose every tracked THRESHOLDS measure as a highlightable column, except suppressed ones" do
+      highlightable = BenchmarkTable::COLUMNS.select { |col| col[:direction] }
                                              .to_h { |col| [col[:measure], col[:direction]] }
 
       THRESHOLDS.each do |measure, direction, _boundary|
-        expect(highlightable).to include(measure)
-        expect(highlightable[measure]).to eq(direction)
+        if display_suppressed.include?(measure)
+          expect(highlightable).not_to include(measure)
+        else
+          expect(highlightable).to include(measure)
+          expect(highlightable[measure]).to eq(direction)
+        end
       end
+    end
+
+    # p90_latency is a baseline-only column: it carries a :measure (so the table can show a
+    # delta if Bencher supplies a baseline) but no :direction, and it must NOT be in
+    # THRESHOLDS — it is sent boundary-less so it is recorded yet never alerted on.
+    it "treat p90_latency as a baseline-only column, not a tracked threshold" do
+      p90 = BenchmarkTable::COLUMNS.find { |col| col[:measure] == "p90_latency" }
+
+      expect(p90).not_to be_nil
+      expect(p90[:direction]).to be_nil
+      expect(THRESHOLDS.map(&:first)).not_to include("p90_latency")
     end
   end
 end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -142,6 +142,14 @@ def run_bencher(branch, start_point_args)
            "benchmarks/spec/bencher_report_spec.rb before bumping the CLI pin. #{e.message}"
       exit 1
     end
+    # Cosmetic-but-diagnostic: if the report lists benchmarks but no shared perf-link
+    # context, EVERY name renders unlinked (likely a report-shape drift). Surface it as a
+    # ::warning:: — not a failure — so it is noticed without breaking the job over a link.
+    if report.perf_links_unavailable?
+      warn "::warning::Bencher report listed benchmarks but no perf-link context " \
+           "(project/branch/testbed uuid); benchmark names will render unlinked. Re-verify the " \
+           "report shape against benchmarks/spec/bencher_perf_url_spec.rb before bumping the CLI pin."
+    end
   end
   [stderr, status.exitstatus, report]
 end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -146,9 +146,9 @@ def run_bencher(branch, start_point_args)
     # context, EVERY name renders unlinked (likely a report-shape drift). Surface it as a
     # ::warning:: — not a failure — so it is noticed without breaking the job over a link.
     if report.perf_links_unavailable?
-      warn "::warning::Bencher report listed benchmarks but no perf-link context " \
-           "(project/branch/testbed uuid); benchmark names will render unlinked. Re-verify the " \
-           "report shape against benchmarks/spec/bencher_perf_url_spec.rb before bumping the CLI pin."
+      $stdout.puts "::warning::Bencher report listed benchmarks but no perf-link context " \
+                   "(project/branch/testbed uuid); benchmark names will render unlinked. Re-verify the " \
+                   "report shape against benchmarks/spec/bencher_perf_url_spec.rb before bumping the CLI pin."
     end
   end
   [stderr, status.exitstatus, report]


### PR DESCRIPTION
## Summary

Implements all four improvements in #3601, building on #3586's JSON-driven benchmark reporting.

**Before**

```
| Benchmark | RPS | p50(ms) | p90(ms) | Fail% | Status |
| --- | --- | --- | --- | --- | --- |
| Pro Node Renderer: simple_eval (non-RSC) | 2895.81 | 3.13 | 3.99 | 0.0 | 200=86878 |
```

**After**

```
| Benchmark | RPS | p50(ms) | p90(ms) | Status |
| --- | --- | --- | --- | --- |
| [Pro Node Renderer: simple_eval (non-RSC)](perf_url) | 2895.81 ▲2.3% (2830.0) | 3.13 ▼1.3% (3.17) | 3.99 | 200=86878 |
| [Pro Node Renderer: react_ssr (non-RSC)](perf_url) | **2472.91** 🔴 8.4% (2700.0) | 3.65 ▲1.0% (3.61) | 4.70 | 200=74197 |
```

### What changed (the four issue items)

1. **Baseline + delta per tracked column.** Each numeric metric cell (RPS, p50, p90) shows a ▲/▼ change vs the Bencher baseline plus the baseline in parentheses. A value that crossed its t-test boundary is **bolded** with the arrow replaced by 🔴 (regression) / 🟢 (improvement). Percent uses Bencher's own formula `((value − baseline) / baseline) × 100`. No baseline (new benchmark), an exact match, or a zero baseline → value alone.

2. **Per-benchmark perf links.** The benchmark **name** links to that benchmark's Bencher perf plot. A new, fully-lenient `BencherPerfUrl` builds the URL from the report's branch/head/testbed/benchmark/measure UUIDs — matching the query shape Bencher's own `lib/bencher_comment` emits (`branches`/`heads`/`testbeds`/`benchmarks`/`measures` comma-lists + `report=`). Any missing field → unlinked name, never a job failure.

3. **p90 baseline.** `p90_latency` is now sent to Bencher **boundary-less** (in the BMF but _not_ in `THRESHOLDS`): Bencher records its history and can supply a baseline, but it is never alerted on (its tail noise can't meet the false-positive target). If Bencher returns no baseline, p90 just shows the value.

4. **Dropped the Fail% column** (redundant with Status, which already shows request counts). `failed_pct` **stays in `THRESHOLDS`** as an alerting safety net — a failure-rate spike still fails the build — but is no longer a displayed column. The lockstep spec now pins it as _tracked-but-display-suppressed_.

### Design

Drove the design choices interactively: inline baseline (no column doubling), one perf link per benchmark name (vs per-metric cell), send p90 boundary-less, and keep the `failed_pct` alert. `BencherReport` delegates URL building to the new `BencherPerfUrl` so report parsing and link construction stay separate, single-purpose units.

Review follow-up keeps the exact-match / zero-baseline value-only rule instead of rendering a redundant `0.0%` delta. That is a deliberate table contract, not an alerting-path behavior.

## Testing

- `bundle exec rspec benchmarks/spec` → **149 examples, 0 failures** (new `perf_url` / URL-build specs, rewritten renderer specs for the new layout, BMF p90 specs, updated lockstep + integration specs; fixture extended with UUIDs and a boundary-less p90 measure).
- `bundle exec rubocop benchmarks` → clean (27 files; RuboCop AST deprecation warnings only).

**CI-only verification:** the exact perf-URL rendering and whether Bencher supplies a p90 baseline can only be confirmed on this PR's first benchmark run. The defensive `nil`→unlinked fallback and value-only p90 path keep the table correct either way — worst case is no link / no p90 delta, never a broken table or a failed job.

Closes #3601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI reporting and BMF shape only; regression thresholds unchanged except adding non-alerting p90_latency; cosmetic perf links degrade safely with warnings.
> 
> **Overview**
> Implements **#3601**: the CI benchmark summary table is richer and easier to navigate without changing regression detection semantics for the measures that still threshold.
> 
> **Summary table (`BenchmarkTable`)** drops the **Fail%** column (Status already carries request breakdown). **RPS**, **p50**, and **p90** cells now show the value plus **▲/▼** percent change and **(baseline)** when Bencher supplies a baseline; tracked measures (**rps**, **p50**) still **bold** and swap the arrow for **🔴/🟢** when significance crosses the t-test interval. **p90** can show a delta but is never flagged significant. Benchmark **names** become markdown links to Bencher perf plots when URL building succeeds.
> 
> **Data path:** `BmfCollector` now uploads **`p90_latency`** in the BMF **without** a `THRESHOLDS` entry (history/baseline only). Display sidecar rows no longer include **`failed_pct`**; **`failed_pct`** remains thresholded for build failures. New **`BencherPerfUrl`** (lenient) builds perf URLs; **`BencherReport`** exposes **`perf_url`** / **`perf_links_unavailable?`**. **`track_benchmarks`** prints a **`::warning::`** when benchmarks exist but shared perf-link context is missing.
> 
> Specs, fixtures, and integration tests pin URL shape, table layout, and THRESHOLDS/display lockstep (including **failed_pct** as tracked-but-not-displayed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa26bc27533e25dc306acec6004c41150035d146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-benchmark clickable perf-plot links added to benchmark results when report context is available.

* **Updates**
  * Redesigned benchmark summary table: columns now show Benchmark, RPS, p50(ms), p90(ms), and Status with visual delta indicators and bolding for significant changes.
  * p90 is shown as a baseline-only metric (displayed but not significance-tracked).
  * Removed failed percentage from displayed results.
  * Emit a warning when perf-link context is unavailable so names render unlinked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
