### PR TITLE
refactor: harden ShakapackerConfigHelpers module (#3626)

### DIFF
--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -810,8 +810,9 @@ module ReactOnRails
 
           # The babel `react-refresh/babel` plugin is gated on WEBPACK_SERVE in the
           # generated babel.config.js for both webpack and rspack apps, so that
-          # qualifier intentionally stays bundler-agnostic. Only the bundler plugin
-          # line below (react_refresh_bundler_config_hint) is bundler-specific.
+          # qualifier intentionally stays bundler-agnostic. The bundler-specific
+          # parts are the plugin_check heading (via react_refresh_bundler_plugin_description)
+          # and the config-hint line below (react_refresh_bundler_config_hint).
           <<~REFRESH
             #{Rainbow('⚛️  React Refresh Issues:').yellow.bold}
             #{Rainbow('If you see "$RefreshSig$ is not defined" errors:').white}

--- a/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
+++ b/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
@@ -13,18 +13,21 @@ module ReactOnRails
   # Doctor and SystemChecker `include` this module so the helpers become private
   # instance methods. Dev::ServerManager `extend`s it because its commands live
   # on `class << self`; extend preserves the private visibility, so the helpers
-  # become private singleton methods there. Every helper depends only on other
-  # helpers in this module plus ENV/File, so it behaves identically either way.
+  # become private singleton methods there. The helpers call each other plus
+  # standard-library/Rails globals (ENV, File, Dir, YAML, ERB, Rails) and the
+  # SystemChecker::SUPPORTED_ASSETS_BUNDLERS constant — none of which resolve
+  # through `self` — so they behave identically whether included or extended.
   module ShakapackerConfigHelpers
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
 
     private
 
-    # Reads and parses config/shakapacker.yml. Symbol values are permitted so
-    # this matches Shakapacker's own loader and ReactOnRails::Dev::ServerMode;
-    # ScriptError is rescued alongside StandardError because ERB/YAML can raise
-    # SyntaxError (a ScriptError, not a StandardError). Returns nil on any
-    # failure or when the document is not a mapping.
+    # Reads and parses config/shakapacker.yml. Symbol values are permitted so a
+    # `key: :value` entry parses instead of raising, matching how
+    # ReactOnRails::Dev::ServerMode loads the same file; ScriptError is rescued
+    # alongside StandardError because ERB/YAML can raise SyntaxError (a
+    # ScriptError, not a StandardError). Returns nil on any failure or when the
+    # document is not a mapping.
     def parsed_shakapacker_config
       config_path = shakapacker_config_path
       return nil unless File.exist?(config_path)
@@ -57,10 +60,13 @@ module ReactOnRails
       config = parsed_shakapacker_config
       return nil unless config.is_a?(Hash)
 
+      # No rescue here on purpose: parsed_shakapacker_config already returns nil
+      # on any config-file failure, and the section lookups below only do Hash
+      # access plus string normalization. A raise past this point is a
+      # programming error (e.g. a missing require for SUPPORTED_ASSETS_BUNDLERS)
+      # and should surface loudly rather than silently degrade to "webpack".
       rails_env = ENV["RAILS_ENV"] || ENV["RACK_ENV"] || "development"
       bundler_from_shakapacker_section(config, rails_env) || bundler_from_shakapacker_section(config, "default")
-    rescue StandardError, ScriptError
-      nil
     end
 
     def bundler_from_shakapacker_section(config, section_name)
@@ -130,3 +136,12 @@ module ReactOnRails
     end
   end
 end
+
+# Required at the bottom, after the module is defined, on purpose. SystemChecker
+# `include`s this module at class-body evaluation time, so requiring it from the
+# top of this file would trigger that include before ShakapackerConfigHelpers
+# exists whenever this file is loaded first — raising NameError. By the time the
+# require runs here the module is fully defined, and normalize_assets_bundler
+# only needs SUPPORTED_ASSETS_BUNDLERS lazily at call time, so deferring keeps
+# the module self-contained under either load order.
+require_relative "system_checker"

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -106,6 +106,29 @@ RSpec.describe ReactOnRails::Doctor do
     end
   end
 
+  describe "#parsed_shakapacker_config" do
+    it "reads and parses config/shakapacker.yml at most once per Doctor instance" do
+      # Exercises the memoizing super override (doctor.rb): several checks consult
+      # the config through different public helpers, but a single diagnosis must
+      # read and parse the file only once. Stubbing File (not the method itself)
+      # keeps both the memoization and the super dispatch in the path under test.
+      config_path = "/tmp/myapp/config/shakapacker.yml"
+      allow(doctor).to receive(:shakapacker_config_path).and_return(config_path)
+      allow(File).to receive(:exist?).with(config_path).and_return(true)
+      allow(File).to receive(:read).with(config_path).and_return("default:\n  assets_bundler: rspack\n")
+
+      first = doctor.send(:parsed_shakapacker_config)
+      doctor.send(:active_assets_bundler)
+      doctor.send(:development_hmr_enabled?)
+      second = doctor.send(:parsed_shakapacker_config)
+
+      aggregate_failures do
+        expect(first).to be(second)
+        expect(File).to have_received(:read).with(config_path).once
+      end
+    end
+  end
+
   describe "#development_dev_server_config" do
     it "defaults to HMR when development dev_server override omits mode keys" do
       allow(doctor).to receive(:parsed_shakapacker_config).and_return(

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ReactOnRails::Doctor do
   describe "#parsed_shakapacker_config" do
     it "reads and parses config/shakapacker.yml at most once per Doctor instance" do
       # Exercises the memoizing super override (doctor.rb): several checks consult
-      # the config through different public helpers, but a single diagnosis must
+      # the config through different (private) helpers, but a single diagnosis must
       # read and parse the file only once. Stubbing File (not the method itself)
       # keeps both the memoization and the super dispatch in the path under test.
       config_path = "/tmp/myapp/config/shakapacker.yml"

--- a/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
@@ -921,6 +921,23 @@ RSpec.describe ReactOnRails::SystemChecker do
         expect(checker.send(:configured_assets_bundler)).to eq("webpack")
       end
 
+      it "resolves symbol-valued YAML scalars (permitted_classes: [Symbol])" do
+        # Locks in the ShakapackerConfigHelpers consolidation: SystemChecker's
+        # parser previously omitted permitted_classes:[Symbol], so a `key: :value`
+        # entry raised → nil → wrong defaults. The shared helper permits Symbol,
+        # so `assets_bundler: :rspack` / `javascript_transpiler: :babel` parse.
+        allow(File).to receive(:read).with(default_shakapacker_config_path).and_return(<<~YAML)
+          default:
+            assets_bundler: :rspack
+            javascript_transpiler: :babel
+        YAML
+
+        aggregate_failures do
+          expect(checker.send(:configured_assets_bundler)).to eq("rspack")
+          expect(checker.send(:detected_javascript_transpiler)).to eq("babel")
+        end
+      end
+
       it "prefers the current Rails environment over the default config" do
         allow(File).to receive(:read).with(default_shakapacker_config_path).and_return(<<~YAML)
           default:

--- a/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
@@ -7,6 +7,29 @@ RSpec.describe ReactOnRails::SystemChecker do
   let(:rails_root) { Pathname.new("/tmp/myapp") }
   let(:default_shakapacker_config_path) { rails_root.join("config/shakapacker.yml").to_s }
 
+  describe "ShakapackerConfigHelpers self-contained require" do
+    # normalize_assets_bundler references SystemChecker::SUPPORTED_ASSETS_BUNDLERS
+    # lazily, and shakapacker_config_helpers.rb requires system_checker at the
+    # BOTTOM of the file so the constant resolves even when a consumer loads the
+    # helpers first. Every in-suite spec loads system_checker first, so this guard
+    # boots a fresh Ruby that requires ONLY the helpers file. It goes red if that
+    # require is removed (uninitialized SystemChecker) or moved to the top (which
+    # NameErrors on SystemChecker's class-body `include ShakapackerConfigHelpers`).
+    it "resolves SUPPORTED_ASSETS_BUNDLERS when the helpers file is loaded first" do
+      helpers_path = File.expand_path("../../../lib/react_on_rails/shakapacker_config_helpers", __dir__)
+      script = <<~RUBY
+        require #{helpers_path.inspect}
+        klass = Class.new { include ReactOnRails::ShakapackerConfigHelpers }
+        puts klass.new.send(:normalize_assets_bundler, "rspack")
+      RUBY
+
+      stdout, stderr, status = Open3.capture3(RbConfig.ruby, "-e", script)
+
+      expect(status).to be_success, "Loading shakapacker_config_helpers standalone failed:\n#{stderr}"
+      expect(stdout.strip).to eq("rspack")
+    end
+  end
+
   describe "#initialize" do
     it "initializes with empty messages" do
       expect(checker.messages).to eq([])

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1634,6 +1634,25 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "omits the bundler config-hint bullet on the webpack non-HMR path" do
+      # Symmetric to the rspack live-reload case above: rspack_react_refresh_config_hint
+      # returns "" for webpack, so the non-HMR troubleshooting block must not emit a
+      # config/webpack/development.js bullet (that hint only belongs on the HMR path).
+      allow(described_class).to receive_messages(
+        configured_assets_bundler: "webpack",
+        default_dev_server_mode: :live_reload,
+        development_dev_server_config: { "hmr" => false, "live_reload" => true }
+      )
+
+      output = capture_stdout { described_class.show_help }
+
+      aggregate_failures do
+        expect(output).to match(/React Refresh requires HMR; current default mode is not HMR/)
+        expect(output).not_to match(%r{config/webpack/development.js})
+        expect(output).not_to match(/ReactRefreshWebpackPlugin/)
+      end
+    end
+
     it "uses generic React Refresh guidance for future bundlers" do
       allow(described_class).to receive_messages(
         configured_assets_bundler: "future",


### PR DESCRIPTION
## Summary

Hardening follow-up to #3619, which extracted `ReactOnRails::ShakapackerConfigHelpers` (consumed by `Doctor`, `SystemChecker`, and `Dev::ServerManager`). Addresses every item on #3626. **No user-facing behavior change** — this tightens the module's self-containment and pins the consolidation contract with tests.

## Item 1 — make the helpers module self-contained

- **`require_relative "system_checker"`** so `SUPPORTED_ASSETS_BUNDLERS` always resolves, even for a future consumer that loads this file before `system_checker`. **Placed at the bottom of the file**, not the top: a top-of-file require triggers `SystemChecker`'s `include ShakapackerConfigHelpers` *before* the module is defined whenever this file loads first, raising `NameError`. I verified this empirically — top placement breaks on a helpers-first load; bottom placement is safe under both load orders. (The issue suggested "add the require"; the bottom placement is the circular-safe way to do it.)
- **Dropped the redundant `rescue StandardError, ScriptError`** in `configured_assets_bundler`. `parsed_shakapacker_config` already swallows config-file failures, and the remaining body only does Hash access + string normalization — so a raise there is a programming error (e.g. the missing-require `NameError` above) that should surface loudly rather than silently degrade to `"webpack"`.
- **Fixed the module doc comment** — the helpers also depend on `YAML`/`ERB`/`Rails`/`Dir` and `SUPPORTED_ASSETS_BUNDLERS`; what actually justifies the include-vs-extend equivalence is that none of them resolve through `self`.
- **Qualified the `parsed_shakapacker_config` loader comment** — dropped the unverifiable "matches Shakapacker's own loader" claim, kept the verified `ServerMode` reference.

## Item 2 — pin the widened parser behavior

`system_checker_spec`: a symbol-valued YAML fixture (`assets_bundler: :rspack`, `javascript_transpiler: :babel`) now asserts both resolve. This locks in the `permitted_classes: [Symbol]` widening the refactor introduced (the old `SystemChecker` parser raised on symbol scalars → `nil` → wrong defaults).

## Item 3 — minor test gaps

- `server_manager_spec`: webpack **non-HMR** path omits the bundler config-hint bullet (symmetric to the existing rspack assertion).
- `doctor_spec`: `Doctor` memoizes `parsed_shakapacker_config` — reads/parses the file at most once across checks via the `super` override (stubs `File`, not the method, so memoization + `super` dispatch stay in the path under test). Verified this test fails if the override is removed.

## Item 4 — comment nuance

`server_manager`: note that the `plugin_check` heading (via `react_refresh_bundler_plugin_description`) is also bundler-specific, not just the config-hint line.

## Testing

- 574 consumer specs pass (`system_checker_spec`, `doctor_spec`, `server_manager_spec`) — 3 new.
- `rubocop` clean on all changed files.
- Verified the module loads self-contained under both require orders, and that the new memoization spec catches a regression.

Closes #3626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal diagnostics/CLI helper and test-only changes; bundler mis-detection from swallowed errors is less likely, with no documented public API change.
> 
> **Overview**
> Follow-up hardening for **`ShakapackerConfigHelpers`** with **no intended user-facing behavior change** — mostly load-order safety, fail-loud config resolution, docs, and regression tests.
> 
> **Module self-containment:** `shakapacker_config_helpers.rb` now **`require_relative "system_checker"` at the bottom** so `SystemChecker::SUPPORTED_ASSETS_BUNDLERS` resolves when the helpers file loads first, without a top-level require that would `NameError` during `SystemChecker`'s `include`. **`configured_assets_bundler` drops its broad `rescue`** so programming errors (e.g. missing constant) surface instead of silently falling back to webpack. Comments clarify include vs extend, YAML `Symbol` parsing vs `ServerMode`, and intentional lack of rescue after parse.
> 
> **`bin/dev` help:** A comment in **`help_hmr_react_refresh_troubleshooting`** notes the **plugin-check heading** is bundler-specific via `react_refresh_bundler_plugin_description`, not only the config-hint line.
> 
> **Tests:** **`doctor_spec`** asserts **`parsed_shakapacker_config` is memoized** (one file read per diagnosis). **`system_checker_spec`** adds a **helpers-first load** subprocess guard and a **symbol YAML** fixture for `assets_bundler` / `javascript_transpiler`. **`server_manager_spec`** asserts **webpack non-HMR** help omits the webpack config-hint bullet (symmetric to rspack).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485ea9cefea5ea4510f589faf199c6b650946c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundler configuration resolution now surfaces errors instead of silently suppressing them, improving troubleshooting.

* **Documentation**
  * Clarified troubleshooting/help output to distinguish bundler-agnostic qualifier text from bundler-specific troubleshooting and config hints.

* **Tests**
  * Added tests for configuration memoization, YAML symbol parsing, and HMR/React Refresh troubleshooting guidance across bundlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Merge decision / follow-up

Non-blocking helper hardening nits are tracked in #3636. The circular-safe bottom require remains intentional for this PR; extracting the shared constant can happen separately.
