### PR TITLE
Use probe-only route for ShakaPerf FOUC gate

### DIFF
--- a/test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts
+++ b/test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts
@@ -1,6 +1,7 @@
 import { abTest, installRequestBlocking } from 'shaka-shared';
 
 const RSC_CSS_PROBE_SELECTOR = '[data-testid="rsc-css-probe"]';
+const RSC_CSS_PROBE_PATH = '/rsc_posts_page_over_http?posts_count=0';
 const RSC_STYLESHEET_SELECTOR = 'link[rel="stylesheet"][data-precedence="ror-rsc"]';
 // A styled probe must have a real CSS-module background, not the default unstyled page background.
 // If the intended probe style ever matches one of these defaults, change the Pro dummy probe color first.
@@ -58,7 +59,7 @@ async function waitForFirstVisibleProbeState(page: ShakaPerfPage): Promise<First
 abTest(
   'rsc first paint use-client css emits stylesheet before hydration',
   {
-    startingPath: '/rsc_posts_page_over_http',
+    startingPath: RSC_CSS_PROBE_PATH,
     testTypes: ['visreg'],
     options: {
       beforeNavigate: ({ context }) => installRequestBlocking(context, ['.js']),
@@ -104,7 +105,7 @@ abTest(
 abTest(
   'rsc real first-visible probe is styled',
   {
-    startingPath: '/rsc_posts_page_over_http',
+    startingPath: RSC_CSS_PROBE_PATH,
     testTypes: ['visreg'],
     options: {
       viewports: ['desktop'],


### PR DESCRIPTION
Follow-up to #3617 after a late review thread noted that /rsc_posts_page_over_http renders posts by default, including external placeholder images. This points both ShakaPerf FOUC abtests at the existing probe-only route with posts_count=0 so the release gate depends on the CSS probe, not image loading.\n\nVerification:\n- pnpm exec eslint test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts\n- pnpm exec prettier --check test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts\n- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only URL change in ShakaPerf abtests; no production or auth paths affected.
> 
> **Overview**
> Both ShakaPerf RSC FOUC release-gate abtests now load **`/rsc_posts_page_over_http?posts_count=0`** via a shared **`RSC_CSS_PROBE_PATH`** constant instead of the bare posts route.
> 
> That keeps the gate focused on the CSS probe and RSC stylesheet behavior, avoiding default post rendering and external placeholder image loads that could add noise or flakiness to visual regression checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4b362b655180707504d9de67677973596d9c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved A/B test configuration for CSS rendering and first paint performance validation by standardizing the test route path across related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->