### PR TITLE
Decouple Shakapacker config helpers from SystemChecker

### DIFF
--- a/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
+++ b/react_on_rails/lib/react_on_rails/shakapacker_config_helpers.rb
@@ -14,11 +14,12 @@ module ReactOnRails
   # instance methods. Dev::ServerManager `extend`s it because its commands live
   # on `class << self`; extend preserves the private visibility, so the helpers
   # become private singleton methods there. The helpers call each other plus
-  # standard-library/Rails globals (ENV, File, Dir, YAML, ERB, Rails) and the
-  # SystemChecker::SUPPORTED_ASSETS_BUNDLERS constant — none of which resolve
-  # through `self` — so they behave identically whether included or extended.
+  # standard-library/Rails globals (ENV, File, Dir, YAML, ERB, Rails) and module
+  # constants — none of which resolve through `self` — so they behave
+  # identically whether included or extended.
   module ShakapackerConfigHelpers
     DEFAULT_SHAKAPACKER_CONFIG_PATH = "config/shakapacker.yml"
+    SUPPORTED_ASSETS_BUNDLERS = %w[webpack rspack].freeze
 
     private
 
@@ -78,7 +79,7 @@ module ReactOnRails
 
     def normalize_assets_bundler(value)
       normalized = value.to_s.strip.downcase
-      ReactOnRails::SystemChecker::SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
+      SUPPORTED_ASSETS_BUNDLERS.include?(normalized) ? normalized : nil
     end
 
     def active_assets_bundler
@@ -136,12 +137,3 @@ module ReactOnRails
     end
   end
 end
-
-# Required at the bottom, after the module is defined, on purpose. SystemChecker
-# `include`s this module at class-body evaluation time, so requiring it from the
-# top of this file would trigger that include before ShakapackerConfigHelpers
-# exists whenever this file is loaded first — raising NameError. By the time the
-# require runs here the module is fully defined, and normalize_assets_bundler
-# only needs SUPPORTED_ASSETS_BUNDLERS lazily at call time, so deferring keeps
-# the module self-contained under either load order.
-require_relative "system_checker"

--- a/react_on_rails/lib/react_on_rails/system_checker.rb
+++ b/react_on_rails/lib/react_on_rails/system_checker.rb
@@ -16,7 +16,7 @@ module ReactOnRails
 
     attr_reader :messages
 
-    SUPPORTED_ASSETS_BUNDLERS = %w[webpack rspack].freeze
+    SUPPORTED_ASSETS_BUNDLERS = ShakapackerConfigHelpers::SUPPORTED_ASSETS_BUNDLERS
     PackageManagerDetection = Struct.new(:manager, :lockfile_scan_blocked, keyword_init: true)
 
     def initialize

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -108,10 +108,10 @@ RSpec.describe ReactOnRails::Doctor do
 
   describe "#parsed_shakapacker_config" do
     it "reads and parses config/shakapacker.yml at most once per Doctor instance" do
-      # Exercises the memoizing super override (doctor.rb): several checks consult
-      # the config through different (private) helpers, but a single diagnosis must
-      # read and parse the file only once. Stubbing File (not the method itself)
-      # keeps both the memoization and the super dispatch in the path under test.
+      # Exercises Doctor's memoizing super override: several checks consult the
+      # config through different private helpers, but one diagnosis must read and
+      # parse config/shakapacker.yml only once. Stubbing File keeps both the
+      # memoization and the shared helper implementation in the path under test.
       config_path = "/tmp/myapp/config/shakapacker.yml"
       allow(doctor).to receive(:shakapacker_config_path).and_return(config_path)
       allow(File).to receive(:exist?).with(config_path).and_return(true)
@@ -124,6 +124,39 @@ RSpec.describe ReactOnRails::Doctor do
 
       aggregate_failures do
         expect(first).to be(second)
+        expect(File).to have_received(:read).with(config_path).once
+      end
+    end
+
+    it "memoizes nil when config/shakapacker.yml is missing" do
+      config_path = "/tmp/myapp/config/shakapacker.yml"
+      allow(doctor).to receive(:shakapacker_config_path).and_return(config_path)
+      allow(File).to receive(:exist?).with(config_path).and_return(false)
+
+      first = doctor.send(:parsed_shakapacker_config)
+      doctor.send(:active_assets_bundler)
+      second = doctor.send(:parsed_shakapacker_config)
+
+      aggregate_failures do
+        expect(first).to be_nil
+        expect(second).to be_nil
+        expect(File).to have_received(:exist?).with(config_path).once
+      end
+    end
+
+    it "memoizes nil when config/shakapacker.yml cannot be read" do
+      config_path = "/tmp/myapp/config/shakapacker.yml"
+      allow(doctor).to receive(:shakapacker_config_path).and_return(config_path)
+      allow(File).to receive(:exist?).with(config_path).and_return(true)
+      allow(File).to receive(:read).with(config_path).and_raise(Errno::EACCES)
+
+      first = doctor.send(:parsed_shakapacker_config)
+      doctor.send(:active_assets_bundler)
+      second = doctor.send(:parsed_shakapacker_config)
+
+      aggregate_failures do
+        expect(first).to be_nil
+        expect(second).to be_nil
         expect(File).to have_received(:read).with(config_path).once
       end
     end

--- a/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "open3"
+
 require_relative "../../react_on_rails/spec_helper"
 require_relative "../../../lib/react_on_rails/system_checker"
 RSpec.describe ReactOnRails::SystemChecker do
@@ -8,22 +10,22 @@ RSpec.describe ReactOnRails::SystemChecker do
   let(:default_shakapacker_config_path) { rails_root.join("config/shakapacker.yml").to_s }
 
   describe "ShakapackerConfigHelpers self-contained require" do
-    # normalize_assets_bundler references SystemChecker::SUPPORTED_ASSETS_BUNDLERS
-    # lazily, and shakapacker_config_helpers.rb requires system_checker at the
-    # BOTTOM of the file so the constant resolves even when a consumer loads the
-    # helpers first. Every in-suite spec loads system_checker first, so this guard
-    # boots a fresh Ruby that requires ONLY the helpers file. It goes red if that
-    # require is removed (uninitialized SystemChecker) or moved to the top (which
-    # NameErrors on SystemChecker's class-body `include ShakapackerConfigHelpers`).
-    it "resolves SUPPORTED_ASSETS_BUNDLERS when the helpers file is loaded first" do
-      helpers_path = File.expand_path("../../../lib/react_on_rails/shakapacker_config_helpers", __dir__)
+    # Every in-suite spec loads system_checker first, so this guard boots a fresh
+    # Ruby with only lib/ on its load path and requires the helpers file directly.
+    # It goes red if the helper regains a SystemChecker load-order dependency.
+    it "normalizes supported bundlers without loading SystemChecker" do
+      lib_path = File.expand_path("../../../lib", __dir__)
       script = <<~RUBY
-        require #{helpers_path.inspect}
+        require "react_on_rails/shakapacker_config_helpers"
+        if defined?(ReactOnRails::SystemChecker)
+          warn "SystemChecker should not be loaded by ShakapackerConfigHelpers"
+          exit 1
+        end
         klass = Class.new { include ReactOnRails::ShakapackerConfigHelpers }
         puts klass.new.send(:normalize_assets_bundler, "rspack")
       RUBY
 
-      stdout, stderr, status = Open3.capture3(RbConfig.ruby, "-e", script)
+      stdout, stderr, status = Open3.capture3(RbConfig.ruby, "-I", lib_path, "-e", script)
 
       expect(status).to be_success, "Loading shakapacker_config_helpers standalone failed:\n#{stderr}"
       expect(stdout.strip).to eq("rspack")


### PR DESCRIPTION
## Summary

- Move the supported Shakapacker assets-bundler list into `ShakapackerConfigHelpers` so the helper no longer requires `SystemChecker` to normalize bundlers.
- Keep `ReactOnRails::SystemChecker::SUPPORTED_ASSETS_BUNDLERS` as a compatibility alias for existing callers.
- Add explicit `require "open3"` to the standalone helper-load spec and make that subprocess use `-I lib`.
- Add Doctor coverage proving missing and unreadable `config/shakapacker.yml` results are memoized as `nil`.

## Design Calls

- The shared helper remains non-memoized. `Doctor#parsed_shakapacker_config` already defines the per-run cache and uses `defined?(@parsed_shakapacker_config)`, so it is the contract that caches misses. `Dev::ServerManager` stays non-memoized to avoid leaking singleton state across calls/specs.
- No changelog entry: this is internal hardening and test coverage, not a user-visible change.

## Tests

- `bundle exec rspec react_on_rails/spec/lib/react_on_rails/system_checker_spec.rb react_on_rails/spec/lib/react_on_rails/doctor_spec.rb`
- `(cd react_on_rails && bundle exec rubocop)`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`

Labels: none. Focused internal Ruby hardening with direct specs and lint coverage; no CI-expansion label recommended.

Closes #3636

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal Ruby load-order and constant placement only; behavior is preserved via a SystemChecker alias and subprocess specs guard regressions.
> 
> **Overview**
> Moves **`SUPPORTED_ASSETS_BUNDLERS`** into `ShakapackerConfigHelpers` and uses it in `normalize_assets_bundler`, removing the bottom **`require_relative "system_checker"`** that existed only to resolve that constant under alternate load orders.
> 
> `SystemChecker::SUPPORTED_ASSETS_BUNDLERS` becomes an alias of the helper constant so existing callers stay compatible.
> 
> Specs are tightened: the standalone-load guard now requires only `lib/` and asserts **`SystemChecker` is not loaded**; **`Doctor#parsed_shakapacker_config`** gains cases that memoize **`nil`** when `config/shakapacker.yml` is missing or unreadable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e672d9b7dab0db7e91bb1d63bb2cb2ed618b510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized supported assets bundlers configuration definition for improved code organization and maintainability.

* **Tests**
  * Enhanced test coverage for memoization behavior and load-order dependencies in configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->