### PR TITLE
Tighten benchmark summary annotations

### DIFF
--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -32,7 +32,8 @@ class BenchmarkTable
   # "(tracked measures)" qualifies the 🔴/🟢 significance flags, not the baseline: only
   # tracked measures (rps, p50) are flagged significant, but ANY measure with a baseline
   # (including the untracked p90) shows a ▲/▼ delta and an "(n)" baseline.
-  LEGEND = "#{UP}/#{DOWN} change vs baseline · #{REGRESSION} significant regression · " \
+  LEGEND = "#{UP}/#{DOWN} non-zero change vs baseline · 0.0% exact/near-zero match · " \
+           "#{REGRESSION} significant regression · " \
            "#{IMPROVEMENT} significant improvement (tracked measures) · (n) = baseline".freeze
 
   EMPTY = "_No benchmark results._"

--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -108,13 +108,14 @@ class BenchmarkTable
   end
 
   # "▲2.3%" / "▼1.4%" for a plain change; "🔴 8.4%" / "🟢 5.0%" for a significant one (the
-  # emoji gets a trailing space so it renders clear of the percent). Rounded-to-zero
-  # changes display as plain "0.0%" so equality/tiny noise never gets a misleading arrow.
+  # emoji gets a trailing space so it renders clear of the percent). Non-significant
+  # rounded-to-zero changes display as plain "0.0%" so equality/tiny noise never gets a
+  # misleading arrow, while significant verdicts keep their marker.
   # The percent is the absolute change vs baseline; direction is conveyed by the arrow,
   # or by the emoji plus the column's known better-direction.
   def delta(verdict, value, baseline)
     percent = ((value - baseline) / baseline * 100).abs.round(1)
-    return "#{percent}%" if percent.zero?
+    return "#{percent}%" if percent.zero? && verdict.nil?
 
     case verdict
     when :regression then "#{REGRESSION} #{percent}%"

--- a/benchmarks/lib/benchmark_table.rb
+++ b/benchmarks/lib/benchmark_table.rb
@@ -94,13 +94,13 @@ class BenchmarkTable
 
   # value + ▲/▼ delta + (baseline), with the arrow swapped for 🔴/🟢 and the value bolded
   # when the measure crossed its boundary. No baseline (new benchmark / boundary-less p90)
-  # or an exact match → just the value.
+  # or zero baseline (no meaningful percent) → just the value.
   def metric_cell(name, col, value)
     text = format_number(value).to_s
     baseline = @report.boundary(name, col[:measure])&.baseline
     # No baseline (new benchmark / boundary-less p90), a zero baseline (no meaningful
-    # percent, and it would divide by zero), or an exact match → just the value.
-    return text if baseline.nil? || baseline.zero? || value == baseline
+    # percent, and it would divide by zero) → just the value.
+    return text if baseline.nil? || baseline.zero?
 
     verdict = col[:direction] ? @report.significance(name, col[:measure], col[:direction]) : nil
     value_text = verdict ? "**#{text}**" : text
@@ -108,11 +108,14 @@ class BenchmarkTable
   end
 
   # "▲2.3%" / "▼1.4%" for a plain change; "🔴 8.4%" / "🟢 5.0%" for a significant one (the
-  # emoji gets a trailing space so it renders clear of the percent). The percent is the
-  # absolute change vs baseline; direction is conveyed by the arrow, or by the emoji plus
-  # the column's known better-direction.
+  # emoji gets a trailing space so it renders clear of the percent). Rounded-to-zero
+  # changes display as plain "0.0%" so equality/tiny noise never gets a misleading arrow.
+  # The percent is the absolute change vs baseline; direction is conveyed by the arrow,
+  # or by the emoji plus the column's known better-direction.
   def delta(verdict, value, baseline)
     percent = ((value - baseline) / baseline * 100).abs.round(1)
+    return "#{percent}%" if percent.zero?
+
     case verdict
     when :regression then "#{REGRESSION} #{percent}%"
     when :improvement then "#{IMPROVEMENT} #{percent}%"

--- a/benchmarks/lib/github.rb
+++ b/benchmarks/lib/github.rb
@@ -7,4 +7,8 @@ module Github
   def run_url
     "#{ENV.fetch('GITHUB_SERVER_URL')}/#{ENV.fetch('GITHUB_REPOSITORY')}/actions/runs/#{ENV.fetch('GITHUB_RUN_ID')}"
   end
+
+  def warning(message)
+    $stdout.puts "::warning::#{message}"
+  end
 end

--- a/benchmarks/lib/github.rb
+++ b/benchmarks/lib/github.rb
@@ -14,6 +14,7 @@ module Github
 
   def escape_workflow_command_data(value)
     value.to_s
+         # Escape percent first so the percent signs introduced below are not double-encoded.
          .gsub("%", "%25")
          .gsub("\r", "%0D")
          .gsub("\n", "%0A")

--- a/benchmarks/lib/github.rb
+++ b/benchmarks/lib/github.rb
@@ -9,6 +9,13 @@ module Github
   end
 
   def warning(message)
-    $stdout.puts "::warning::#{message}"
+    $stdout.puts "::warning::#{escape_workflow_command_data(message)}"
+  end
+
+  def escape_workflow_command_data(value)
+    value.to_s
+         .gsub("%", "%25")
+         .gsub("\r", "%0D")
+         .gsub("\n", "%0A")
   end
 end

--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -225,8 +225,10 @@ class RegressionIssueReporter
     # so a parse miss is a warning, not an error.
     number = stdout[%r{/issues/(\d+)}, 1]
     unless number
-      warn "::warning::Created the issue but could not parse its number from gh output " \
-           "(#{stdout.strip.inspect}); its comment section may be missing"
+      Github.warning(
+        "Created the issue but could not parse its number from gh output " \
+        "(#{stdout.strip.inspect}); its comment section may be missing"
+      )
     end
     number
   end

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -133,14 +133,26 @@ RSpec.describe BenchmarkTable do
     expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
   end
 
-  it "shows only the value when the metric exactly equals its baseline (skips a 0.0% delta)" do
+  it "shows an explicit 0.0% delta when the metric exactly equals its baseline" do
     report = fake_report(baselines: { ["/foo", "rps"] => 100.0 })
     markdown = render(
       rows: [row(name: "/foo", rps: 100.0, p50: 5.0, p90: 6.0, status: "200=100")],
       report: report
     )
 
-    expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
+    expect(markdown).to include("| /foo | 100.0 0.0% (100.0) | 5.0 | 6.0 | 200=100 |")
+  end
+
+  it "shows 0.0% without an arrow when the rounded delta is zero" do
+    report = fake_report(baselines: { ["/foo", "rps"] => 100.0 })
+    markdown = render(
+      rows: [row(name: "/foo", rps: 100.00001, p50: 5.0, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    expect(markdown).to include("| /foo | 100.0 0.0% (100.0) | 5.0 | 6.0 | 200=100 |")
+    expect(markdown).not_to include("▲0.0%")
+    expect(markdown).not_to include("▼0.0%")
   end
 
   it "links the benchmark name to its perf URL when the report provides one" do

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -155,6 +155,23 @@ RSpec.describe BenchmarkTable do
     expect(markdown).not_to include("▼0.0%")
   end
 
+  it "preserves significance markers when a significant delta rounds to zero" do
+    report = fake_report(
+      verdicts: { ["/foo", "rps"] => :regression, ["/foo", "p50_latency"] => :improvement },
+      baselines: { ["/foo", "rps"] => 100.0, ["/foo", "p50_latency"] => 5.0 }
+    )
+    markdown = render(
+      rows: [row(name: "/foo", rps: 99.999, p50: 4.999, p90: 6.0, status: "200=100")],
+      report: report
+    )
+
+    expect(markdown).to include(
+      "| /foo | **100.0** 🔴 0.0% (100.0) | **5.0** 🟢 0.0% (5.0) | 6.0 | 200=100 |"
+    )
+    expect(markdown).not_to include("▲0.0%")
+    expect(markdown).not_to include("▼0.0%")
+  end
+
   it "links the benchmark name to its perf URL when the report provides one" do
     report = fake_report(urls: { "/foo" => "https://bencher.dev/perf/p?benchmarks=BM" })
     markdown = render(

--- a/benchmarks/spec/benchmark_table_spec.rb
+++ b/benchmarks/spec/benchmark_table_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe BenchmarkTable do
     expect(markdown).to include("| --- | --- | --- | --- | --- |")
     expect(markdown).to include("| /foo | 100.0 | 5.0 | 6.0 | 200=100 |")
     expect(markdown).not_to include("Fail%")
-    expect(markdown).to include("▲/▼ change vs baseline")
+    expect(markdown).to include("▲/▼ non-zero change vs baseline")
+    expect(markdown).to include("0.0% exact/near-zero match")
     expect(markdown).to include("🔴 significant regression")
     expect(markdown).to include("🟢 significant improvement")
   end

--- a/benchmarks/spec/report_regressions_spec.rb
+++ b/benchmarks/spec/report_regressions_spec.rb
@@ -192,6 +192,20 @@ RSpec.describe "benchmark regression reporting" do
         expect(calls).not_to include("comment list")
       end
     end
+
+    context "when issue creation succeeds but gh output does not include an issue URL" do
+      before do
+        capture_responses["issue list"] = ""
+        capture_responses["issue create"] = "Created issue without a parseable URL\n"
+      end
+
+      it "emits the parse warning to stdout so GitHub Actions annotates it" do
+        expect { expect(report).to eq("") }
+          .to output(/::warning::Created the issue but could not parse its number/).to_stdout
+          .and output("").to_stderr
+        expect(calls).not_to include("comment list")
+      end
+    end
   end
 
   # These drive the script end-to-end as a subprocess with a fake `gh` on PATH (no

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -88,6 +88,26 @@ RSpec.describe "track_benchmarks" do
     end
   end
 
+  describe "GitHub warning annotations" do
+    it "writes warning workflow commands to stdout, not stderr" do
+      expect { Github.warning("benchmark annotation") }
+        .to output("::warning::benchmark annotation\n").to_stdout
+        .and output("").to_stderr
+    end
+
+    it "emits display sidecar warnings to stdout so GitHub Actions annotates them" do
+      allow(File).to receive(:exist?).with(DISPLAY_JSON).and_return(true)
+      allow(File).to receive(:read).with(DISPLAY_JSON).and_return(JSON.generate({ "not" => "an array" }))
+
+      rows = nil
+      warning_pattern = /::warning::#{Regexp.escape(DISPLAY_JSON)} is not a JSON array/o
+      expect { rows = display_rows }
+        .to output(warning_pattern).to_stdout
+
+      expect(rows).to eq([])
+    end
+  end
+
   # On a main regression the rendered table feeds the report-regressions hand-off. If
   # the display sidecar was missing/corrupt the table is empty, and an empty-bodied
   # issue is useless — the hand-off must substitute a run-URL pointer instead.

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe "track_benchmarks" do
         .and output("").to_stderr
     end
 
+    it "escapes workflow command data so multiline messages stay in one annotation" do
+      expect { Github.warning("first line\n100% reproducible\r\nsecond line") }
+        .to output("::warning::first line%0A100%25 reproducible%0D%0Asecond line\n").to_stdout
+    end
+
     it "emits display sidecar warnings to stdout so GitHub Actions annotates them" do
       allow(File).to receive(:exist?).with(DISPLAY_JSON).and_return(true)
       allow(File).to receive(:read).with(DISPLAY_JSON).and_return(JSON.generate({ "not" => "an array" }))

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -146,9 +146,11 @@ def run_bencher(branch, start_point_args)
     # context, EVERY name renders unlinked (likely a report-shape drift). Surface it as a
     # ::warning:: — not a failure — so it is noticed without breaking the job over a link.
     if report.perf_links_unavailable?
-      $stdout.puts "::warning::Bencher report listed benchmarks but no perf-link context " \
-                   "(project/branch/testbed uuid); benchmark names will render unlinked. Re-verify the " \
-                   "report shape against benchmarks/spec/bencher_perf_url_spec.rb before bumping the CLI pin."
+      Github.warning(
+        "Bencher report listed benchmarks but no perf-link context " \
+        "(project/branch/testbed uuid); benchmark names will render unlinked. Re-verify the " \
+        "report shape against benchmarks/spec/bencher_perf_url_spec.rb before bumping the CLI pin."
+      )
     end
   end
   [stderr, status.exitstatus, report]
@@ -194,7 +196,7 @@ def delete_stale_report_comments(before:)
   end
   return if failed.zero?
 
-  warn "::warning::Failed to delete #{failed} stale #{SUITE_NAME} Bencher report comment(s); they may remain visible."
+  Github.warning("Failed to delete #{failed} stale #{SUITE_NAME} Bencher report comment(s); they may remain visible.")
 end
 
 def replace_pr_comments(markdown)
@@ -217,7 +219,7 @@ def replace_pr_comments(markdown)
   if posted
     delete_stale_report_comments(before: cutoff_ts)
   else
-    warn "::warning::Failed to post #{SUITE_NAME} benchmark report comment; keeping prior comments in place."
+    Github.warning("Failed to post #{SUITE_NAME} benchmark report comment; keeping prior comments in place.")
   end
 end
 
@@ -230,13 +232,13 @@ def display_rows
     # Mirror the write side (BmfCollector#write_display_json warns on a non-array
     # sidecar). Without this the table would silently disappear on a contract break,
     # and a main regression hand-off could store an empty summary with no diagnostic.
-    warn "::warning::#{DISPLAY_JSON} is not a JSON array (got #{parsed.class}); skipping the summary table"
+    Github.warning("#{DISPLAY_JSON} is not a JSON array (got #{parsed.class}); skipping the summary table")
     return []
   end
 
   parsed
 rescue JSON::ParserError => e
-  warn "::warning::Could not parse #{DISPLAY_JSON} (#{e.message}); skipping the summary table"
+  Github.warning("Could not parse #{DISPLAY_JSON} (#{e.message}); skipping the summary table")
   []
 end
 
@@ -311,7 +313,7 @@ if __FILE__ == $PROGRAM_NAME
       retry_args.slice!(hash_arg_index, 2)
     end
     puts "Start-point hash not found in Bencher; retrying without --start-point-hash"
-    puts "::warning::Start-point hash not found in Bencher; falling back to latest baseline for comparison"
+    Github.warning("Start-point hash not found in Bencher; falling back to latest baseline for comparison")
     # The retry's stderr is unused: regression classification reads the JSON report,
     # and this path only triggers when the first run had no regression.
     _retry_stderr, bencher_exit_code, report = run_bencher(branch, retry_args)
@@ -328,8 +330,10 @@ if __FILE__ == $PROGRAM_NAME
     # make an auth/API/network failure look like a normal un-highlighted summary, while
     # the job still exits 0. Keep the prior comment intact and surface the failure
     # instead. (post_report_to_summary above is per-run and clobbers nothing.)
-    warn "::warning::Bencher produced no report for #{SUITE_NAME} (operational failure); " \
-         "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
+    Github.warning(
+      "Bencher produced no report for #{SUITE_NAME} (operational failure); " \
+      "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
+    )
   elsif pr_event && regression?(report) && report_markdown.empty?
     # A real regression but no table to render (display sidecar missing/empty). Don't
     # leave the stale PR comment looking unchanged — post the run-URL fallback (which
@@ -357,9 +361,11 @@ if __FILE__ == $PROGRAM_NAME
             RegressionReport::SUMMARY => handoff_summary
           )
         )
-        warn "::warning::Bencher flagged a #{SUITE_NAME} regression on main (exit #{bencher_exit_code}). " \
-             "The report-regressions job will file the issue. " \
-             "See the Bencher dashboard and the workflow run: #{Github.run_url}"
+        Github.warning(
+          "Bencher flagged a #{SUITE_NAME} regression on main (exit #{bencher_exit_code}). " \
+          "The report-regressions job will file the issue. " \
+          "See the Bencher dashboard and the workflow run: #{Github.run_url}"
+        )
       rescue StandardError => e # rubocop:disable Metrics/BlockNesting
         # The suite still fails (exit 1 below), so the regression is surfaced; but the
         # hand-off payload is gone, so report-regressions can't auto-file the issue.

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -196,7 +196,10 @@ def delete_stale_report_comments(before:)
   end
   return if failed.zero?
 
-  Github.warning("Failed to delete #{failed} stale #{SUITE_NAME} Bencher report comment(s); they may remain visible.")
+  Github.warning(
+    "Failed to delete #{failed} stale #{SUITE_NAME} Bencher report comment(s); " \
+    "they may remain visible."
+  )
 end
 
 def replace_pr_comments(markdown)


### PR DESCRIPTION
## Summary

- Show exact or rounded-to-zero benchmark deltas as explicit `0.0% (baseline)` cells without a misleading arrow.
- Route benchmark `::warning::` annotations through a shared `Github.warning` helper that writes to stdout, and update the benchmark tracking/regression scripts to use it.
- Keep the existing bracket escaping and current-value precision behavior covered by benchmark table specs.

Closes #3645

## Tests

- `bundle exec rspec benchmarks/spec/benchmark_table_spec.rb benchmarks/spec/track_benchmarks_spec.rb benchmarks/spec/report_regressions_spec.rb`
- `bundle exec rspec benchmarks/spec`
- `bundle exec rubocop benchmarks/lib/benchmark_table.rb benchmarks/lib/github.rb benchmarks/track_benchmarks.rb benchmarks/report_regressions.rb benchmarks/spec/benchmark_table_spec.rb benchmarks/spec/track_benchmarks_spec.rb benchmarks/spec/report_regressions_spec.rb`
- `bundle exec rubocop` from `react_on_rails/`
- `git diff --check`
- `git diff HEAD --check`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`

## Deferred / Design Calls

- No `.github/workflows/` files were changed. The warning-output audit was handled in benchmark Ruby scripts, so there are no workflow edits to defer.
- Changelog not updated because this only changes benchmark CI summary/logging behavior.

Labels: none — this is benchmark reporting display/logging only and does not affect measured app runtime paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect benchmark CI markdown and logging only; no application runtime, auth, or data paths are touched.
> 
> **Overview**
> Benchmark summary tables now **always show baseline deltas** when a baseline exists, including exact matches as **`0.0% (baseline)`** instead of hiding the delta. **Near-zero** rounded changes render as plain **`0.0%`** without ▲/▼ arrows; **🔴/🟢** significance markers still appear when a verdict exists even if the percent rounds to zero. The table **legend** documents non-zero vs exact/near-zero behavior.
> 
> Benchmark CI scripts route **`::warning::`** output through a shared **`Github.warning`** helper that writes to **stdout** with **percent/newline escaping** so GitHub Actions picks up annotations reliably. **`track_benchmarks.rb`** and **`report_regressions.rb`** adopt this helper for perf-link, display JSON, PR comment, and regression-issue parse warnings.
> 
> Specs cover the new delta rendering edge cases and stdout warning contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81421d587c1684e93577b620d2d9bac5e24d3ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Delta metrics now render explicit "0.0%" and omit directional arrows when rounded change is zero; legend updated to note exact/near-zero matches.
  * CI warnings are emitted as properly escaped GitHub workflow annotations (::warning::) for reliable diagnostics.
  * Improved warning output when regression issue creation yields unparseable results.

* **Tests**
  * Expanded coverage for benchmark rendering, zero-delta behavior, and GitHub warning annotation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->