### PR TITLE
fix(benchmark): harden target monitoring

### DIFF
--- a/benchmarks/bench-node-renderer.rb
+++ b/benchmarks/bench-node-renderer.rb
@@ -351,6 +351,8 @@ if __FILE__ == $PROGRAM_NAME
 
   # Create output directory
   FileUtils.mkdir_p(OUTDIR)
+  target_monitor = BenchmarkTargetMonitor.from_env(output_dir: OUTDIR)
+  target_monitor.start_measurement!
 
   # Initialize BMF collector for Bencher output
   bmf_collector = BmfCollector.new(prefix: BMF_PREFIX)
@@ -366,15 +368,17 @@ if __FILE__ == $PROGRAM_NAME
   # Display summary
   display_summary(SUMMARY_TXT)
 
-  # Write the Bencher payload only on a fully green run. Guarding the write here
-  # (rather than writing unconditionally before exit) makes the "never upload a
-  # partial-success payload" invariant self-enforcing instead of relying on the
-  # downstream Bencher step having no `if: always()`.
+  # Write the Bencher payload only on a fully green run against a healthy target.
+  # Guarding the write here makes the "never upload partial metrics" invariant
+  # self-enforcing instead of relying on later workflow steps to discard data.
   if failed_tests.empty?
-    # Append to existing Pro results.
-    bmf_collector.write_bmf_json(BENCHMARK_JSON, append: true)
-    # Display sidecar (summary table data) — append to match the BMF.
-    bmf_collector.write_display_json(DISPLAY_JSON, append: true)
+    begin
+      # Append to existing Pro results and display sidecar rows.
+      write_benchmark_payload(bmf_collector, target_monitor: target_monitor, append: true)
+    rescue BenchmarkTargetMonitor::MonitorFailure => e
+      $stdout.puts "::error::#{e.message}"
+      exit 1
+    end
   else
     $stdout.puts "::error::#{failed_tests.length} node renderer benchmark(s) failed: #{failed_tests.join(', ')}"
     exit 1

--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -190,6 +190,8 @@ if __FILE__ == $PROGRAM_NAME
   puts "Server is ready!"
 
   FileUtils.mkdir_p(OUTDIR)
+  target_monitor = BenchmarkTargetMonitor.from_env(output_dir: OUTDIR)
+  target_monitor.start_measurement!
 
   # Initialize BMF collector for Bencher output (suffix used for Core/Pro distinction)
   bmf_collector = BmfCollector.new(suffix: BMF_SUFFIX)
@@ -203,14 +205,16 @@ if __FILE__ == $PROGRAM_NAME
   puts "\nSummary saved to #{SUMMARY_TXT}"
   system("column", "-t", "-s", "\t", SUMMARY_TXT)
 
-  # Write the Bencher payload only on a fully green run. Guarding the write here
-  # (rather than writing unconditionally before exit) makes the "never upload a
-  # partial-success payload" invariant self-enforcing instead of relying on the
-  # downstream Bencher step having no `if: always()`.
+  # Write the Bencher payload only on a fully green run against a healthy target.
+  # Guarding the write here makes the "never upload partial metrics" invariant
+  # self-enforcing instead of relying on later workflow steps to discard data.
   if failed_routes.empty?
-    bmf_collector.write_bmf_json(BENCHMARK_JSON)
-    # Display sidecar (summary table data) — written alongside the BMF.
-    bmf_collector.write_display_json(DISPLAY_JSON)
+    begin
+      write_benchmark_payload(bmf_collector, target_monitor: target_monitor)
+    rescue BenchmarkTargetMonitor::MonitorFailure => e
+      $stdout.puts "::error::#{e.message}"
+      exit 1
+    end
   else
     $stdout.puts "::error::#{failed_routes.length} of #{routes.length} benchmark route(s) failed: " \
                  "#{failed_routes.join(', ')}"

--- a/benchmarks/lib/benchmark_helpers.rb
+++ b/benchmarks/lib/benchmark_helpers.rb
@@ -102,6 +102,7 @@ def display_summary(summary_file)
   system("column", "-t", "-s", "\t", summary_file)
 end
 
+# Requires BENCHMARK_JSON and DISPLAY_JSON constants from benchmark_config.rb.
 def write_benchmark_payload(bmf_collector, target_monitor:, append: false)
   target_monitor.verify_after_measurement!
   bmf_collector.write_bmf_json(BENCHMARK_JSON, append: append)

--- a/benchmarks/lib/benchmark_helpers.rb
+++ b/benchmarks/lib/benchmark_helpers.rb
@@ -4,6 +4,7 @@ require "json"
 require "fileutils"
 require "net/http"
 require "uri"
+require_relative "benchmark_target_monitor"
 
 # Shared utilities for benchmark scripts
 # Note: env_or_default and validation helpers are in benchmark_config.rb
@@ -99,4 +100,10 @@ end
 def display_summary(summary_file)
   puts "\nSummary saved to #{summary_file}"
   system("column", "-t", "-s", "\t", summary_file)
+end
+
+def write_benchmark_payload(bmf_collector, target_monitor:, append: false)
+  target_monitor.verify_after_measurement!
+  bmf_collector.write_bmf_json(BENCHMARK_JSON, append: append)
+  bmf_collector.write_display_json(DISPLAY_JSON, append: append)
 end

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -37,11 +37,15 @@ class BenchmarkTargetMonitor
     @output_dir = output_dir
     @pid_alive = pid_alive || ->(pid) { self.class.pid_alive?(pid) }
     @measurement_started = false
+    @log_windowed = false
   end
 
   def start_measurement!
+    return if @measurement_started
+
     @measurement_started = true
-    preserve_and_blank_target_log if target_log?
+    @log_windowed = target_log?
+    preserve_and_blank_target_log if @log_windowed
   end
 
   def verify_after_measurement!
@@ -66,8 +70,6 @@ class BenchmarkTargetMonitor
   end
 
   def preserve_and_blank_target_log
-    return unless @output_dir
-
     FileUtils.mkdir_p(@output_dir)
     File.binwrite(File.join(@output_dir, STARTUP_LOG_FILENAME), File.binread(@target_log))
     blank_existing_log_bytes
@@ -109,7 +111,7 @@ class BenchmarkTargetMonitor
   end
 
   def verify_unexpected_worker_log!
-    return unless target_log?
+    return unless @log_windowed
 
     matches = unexpected_worker_restart_lines
     return if matches.empty?

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+# Guards benchmark payload writes against target process failures that happen
+# after the benchmark script starts measuring but before Bencher receives data.
+class BenchmarkTargetMonitor
+  class MonitorFailure < StandardError; end
+
+  STARTUP_LOG_FILENAME = "target_startup_before_benchmark.log"
+  UNEXPECTED_WORKER_RESTART = "died UNEXPECTEDLY"
+  BLANK_CHUNK_SIZE = 8 * 1024
+
+  def self.from_env(output_dir:, env: ENV)
+    new(
+      target_pid: env["TARGET_PID"],
+      target_log: env["TARGET_LOG"],
+      output_dir: output_dir
+    )
+  end
+
+  def self.pid_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::EPERM
+    true
+  rescue Errno::ESRCH
+    false
+  end
+
+  def initialize(target_pid: nil, target_log: nil, output_dir: nil, pid_alive: nil)
+    @target_pid = present_string(target_pid)
+    @target_log = present_string(target_log)
+    @output_dir = output_dir
+    @pid_alive = pid_alive || ->(pid) { self.class.pid_alive?(pid) }
+  end
+
+  def start_measurement!
+    preserve_and_blank_target_log if target_log?
+  end
+
+  def verify_after_measurement!
+    verify_target_pid!
+    verify_unexpected_worker_log!
+    true
+  end
+
+  private
+
+  def present_string(value)
+    value = value.to_s
+    value.empty? ? nil : value
+  end
+
+  def target_log?
+    @target_log && File.file?(@target_log)
+  end
+
+  def preserve_and_blank_target_log
+    FileUtils.mkdir_p(@output_dir) if @output_dir
+    File.binwrite(File.join(@output_dir, STARTUP_LOG_FILENAME), File.binread(@target_log)) if @output_dir
+    blank_existing_log_bytes
+  end
+
+  # Truncating a file that a running process already has open can leave sparse NUL
+  # gaps when that process writes again at its old file offset. Overwriting the
+  # startup bytes with newlines keeps the existing workflow grep text-only while
+  # preventing pre-measurement events from matching the post-run scan.
+  def blank_existing_log_bytes
+    remaining = File.size(@target_log)
+    File.open(@target_log, "r+b") do |file|
+      until remaining.zero?
+        chunk_size = [remaining, BLANK_CHUNK_SIZE].min
+        file.write("\n" * chunk_size)
+        remaining -= chunk_size
+      end
+    end
+  end
+
+  def verify_target_pid!
+    return unless @target_pid
+
+    pid = Integer(@target_pid)
+    return if @pid_alive.call(pid)
+
+    raise MonitorFailure, "Benchmark target PID #{pid} exited during the measured benchmark window; " \
+                          "discarding benchmark metrics because the target process did not survive."
+  rescue ArgumentError
+    raise MonitorFailure, "TARGET_PID=#{@target_pid.inspect} is not an integer; discarding benchmark metrics " \
+                          "because target liveness could not be verified."
+  end
+
+  def verify_unexpected_worker_log!
+    return unless target_log?
+
+    matches = unexpected_worker_restart_lines
+    return if matches.empty?
+
+    raise MonitorFailure, "Pro node-renderer worker restarted during the measured benchmark window. " \
+                          "The node-renderer master logged `#{UNEXPECTED_WORKER_RESTART}`, which means " \
+                          "a worker process died and was forked again; discarding benchmark metrics " \
+                          "instead of uploading partial data. Matching log line(s):\n#{matches.join("\n")}"
+  end
+
+  def unexpected_worker_restart_lines
+    File.readlines(@target_log, chomp: true).each_with_index.filter_map do |line, index|
+      next unless line.include?(UNEXPECTED_WORKER_RESTART)
+
+      "#{index + 1}:#{line}"
+    end
+  end
+end

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -9,7 +9,7 @@ class BenchmarkTargetMonitor
 
   STARTUP_LOG_FILENAME = "target_startup_before_benchmark.log"
   UNEXPECTED_WORKER_RESTART = "died UNEXPECTEDLY"
-  BLANK_CHUNK_SIZE = 8 * 1024
+  BLANK_CHUNK_SIZE = 8 * 1024 # balances allocation cost against write-call count
   BLANK_CHUNK = ("\n" * BLANK_CHUNK_SIZE).freeze
 
   def self.from_env(output_dir:, env: ENV)
@@ -61,8 +61,8 @@ class BenchmarkTargetMonitor
   private
 
   def present_string(value)
-    value = value.to_s
-    value.empty? ? nil : value
+    string_value = value.to_s
+    string_value.empty? ? nil : string_value
   end
 
   def target_log?

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -81,6 +81,11 @@ class BenchmarkTargetMonitor
     return unless @target_pid
 
     pid = Integer(@target_pid)
+    unless pid.positive?
+      raise MonitorFailure, "TARGET_PID=#{@target_pid.inspect} is not a positive integer; discarding " \
+                            "benchmark metrics because target liveness could not be verified."
+    end
+
     return if @pid_alive.call(pid)
 
     raise MonitorFailure, "Benchmark target PID #{pid} exited during the measured benchmark window; " \

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -10,6 +10,7 @@ class BenchmarkTargetMonitor
   STARTUP_LOG_FILENAME = "target_startup_before_benchmark.log"
   UNEXPECTED_WORKER_RESTART = "died UNEXPECTEDLY"
   BLANK_CHUNK_SIZE = 8 * 1024
+  BLANK_CHUNK = ("\n" * BLANK_CHUNK_SIZE).freeze
 
   def self.from_env(output_dir:, env: ENV)
     new(
@@ -20,6 +21,8 @@ class BenchmarkTargetMonitor
   end
 
   def self.pid_alive?(pid)
+    # Signal 0 checks process existence without delivering a signal. Zombies can
+    # still answer as alive; CI parents reap quickly enough for this guard.
     Process.kill(0, pid)
     true
   rescue Errno::EPERM
@@ -33,13 +36,19 @@ class BenchmarkTargetMonitor
     @target_log = present_string(target_log)
     @output_dir = output_dir
     @pid_alive = pid_alive || ->(pid) { self.class.pid_alive?(pid) }
+    @measurement_started = false
   end
 
   def start_measurement!
+    @measurement_started = true
     preserve_and_blank_target_log if target_log?
   end
 
   def verify_after_measurement!
+    unless @measurement_started
+      raise MonitorFailure, "start_measurement! was never called; discarding benchmark metrics."
+    end
+
     verify_target_pid!
     verify_unexpected_worker_log!
     true
@@ -53,7 +62,7 @@ class BenchmarkTargetMonitor
   end
 
   def target_log?
-    @target_log && File.file?(@target_log)
+    @target_log && @output_dir && File.file?(@target_log)
   end
 
   def preserve_and_blank_target_log
@@ -70,10 +79,12 @@ class BenchmarkTargetMonitor
   # preventing pre-measurement events from matching the post-run scan.
   def blank_existing_log_bytes
     File.open(@target_log, "r+b") do |file|
+      # Capture size after opening, so bytes appended before the open are blanked.
+      # Bytes appended after this point belong to the measured window.
       remaining = file.size
       until remaining.zero?
         chunk_size = [remaining, BLANK_CHUNK_SIZE].min
-        file.write("\n" * chunk_size)
+        file.write(BLANK_CHUNK.byteslice(0, chunk_size))
         remaining -= chunk_size
       end
     end

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -57,8 +57,10 @@ class BenchmarkTargetMonitor
   end
 
   def preserve_and_blank_target_log
-    FileUtils.mkdir_p(@output_dir) if @output_dir
-    File.binwrite(File.join(@output_dir, STARTUP_LOG_FILENAME), File.binread(@target_log)) if @output_dir
+    return unless @output_dir
+
+    FileUtils.mkdir_p(@output_dir)
+    File.binwrite(File.join(@output_dir, STARTUP_LOG_FILENAME), File.binread(@target_log))
     blank_existing_log_bytes
   end
 
@@ -67,8 +69,8 @@ class BenchmarkTargetMonitor
   # startup bytes with newlines keeps the existing workflow grep text-only while
   # preventing pre-measurement events from matching the post-run scan.
   def blank_existing_log_bytes
-    remaining = File.size(@target_log)
     File.open(@target_log, "r+b") do |file|
+      remaining = file.size
       until remaining.zero?
         chunk_size = [remaining, BLANK_CHUNK_SIZE].min
         file.write("\n" * chunk_size)

--- a/benchmarks/lib/benchmark_target_monitor.rb
+++ b/benchmarks/lib/benchmark_target_monitor.rb
@@ -45,6 +45,10 @@ class BenchmarkTargetMonitor
 
     @measurement_started = true
     @log_windowed = target_log?
+    if @target_log && !@log_windowed
+      warn "BenchmarkTargetMonitor: TARGET_LOG=#{@target_log.inspect} set but log windowing disabled " \
+           "(file does not exist or output_dir is nil); worker-restart checks will be skipped."
+    end
     preserve_and_blank_target_log if @log_windowed
   end
 
@@ -86,7 +90,8 @@ class BenchmarkTargetMonitor
       remaining = file.size
       until remaining.zero?
         chunk_size = [remaining, BLANK_CHUNK_SIZE].min
-        file.write(BLANK_CHUNK.byteslice(0, chunk_size))
+        chunk = chunk_size == BLANK_CHUNK_SIZE ? BLANK_CHUNK : BLANK_CHUNK.byteslice(0, chunk_size)
+        file.write(chunk)
         remaining -= chunk_size
       end
     end
@@ -128,5 +133,8 @@ class BenchmarkTargetMonitor
 
       "#{index + 1}:#{line}"
     end
+  rescue Errno::ENOENT
+    raise MonitorFailure, "Target log #{@target_log.inspect} disappeared before post-measurement scan; " \
+                          "discarding benchmark metrics."
   end
 end

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -163,6 +163,16 @@ RSpec.describe "benchmark target monitoring" do
       expect { monitor.verify_after_measurement! }
         .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /TARGET_PID="0".*positive integer/)
     end
+
+    it "fails when TARGET_PID is not an integer string" do
+      pid_alive = ->(_pid) { raise "pid liveness check should not run" }
+      monitor = described_class.new(target_pid: "abc", pid_alive: pid_alive)
+
+      monitor.start_measurement!
+
+      expect { monitor.verify_after_measurement! }
+        .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /TARGET_PID="abc".*is not an integer/)
+    end
   end
 
   describe "write_benchmark_payload" do

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -30,6 +30,36 @@ RSpec.describe BenchmarkTargetMonitor do
     end
   end
 
+  it "does not blank the live log when startup logs cannot be preserved" do
+    content = "booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n"
+
+    with_log_file(content) do |log_path, _output_dir|
+      monitor = described_class.new(target_log: log_path)
+
+      monitor.start_measurement!
+
+      expect(File.read(log_path)).to eq(content)
+    end
+  end
+
+  it "blanks bytes appended after log preservation but before opening the log for overwrite" do
+    with_log_file("booting\nready\n") do |log_path, output_dir|
+      monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+      late_log_line = "Worker 2 died UNEXPECTEDLY :(, restarting\n"
+
+      allow(File).to receive(:open).and_wrap_original do |original_open, path, mode, *args, &block|
+        original_open.call(path, "ab") { |file| file.write(late_log_line) } if path == log_path && mode == "r+b"
+        original_open.call(path, mode, *args, &block)
+      end
+
+      monitor.start_measurement!
+
+      preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
+      expect(File.read(preserved)).not_to include("died UNEXPECTEDLY")
+      expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
+    end
+  end
+
   it "fails when the node renderer master logs an unexpected worker restart during measurement" do
     with_log_file("startup complete\n") do |log_path, output_dir|
       monitor = described_class.new(target_log: log_path, output_dir: output_dir)

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe "benchmark target monitoring" do
       end
     end
 
+    it "is a no-op when neither TARGET_PID nor TARGET_LOG is provided" do
+      Dir.mktmpdir do |dir|
+        monitor = described_class.from_env(output_dir: dir, env: {})
+
+        expect { monitor.start_measurement! }.not_to raise_error
+        expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
     it "preserves startup logs and blanks the live log before the measured window" do
       with_log_file("booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n") do |log_path, output_dir|
         monitor = described_class.new(target_log: log_path, output_dir: output_dir)
@@ -42,6 +51,23 @@ RSpec.describe "benchmark target monitoring" do
         expect(File.read(preserved)).to include("Worker 1 died UNEXPECTEDLY")
         expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
         expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
+    it "does not re-preserve or blank measured log content when measurement starts twice" do
+      with_log_file("startup complete\n") do |log_path, output_dir|
+        monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+        measured_restart = "Worker 2 died UNEXPECTEDLY :(, restarting\n"
+
+        monitor.start_measurement!
+        File.open(log_path, "a") { |file| file.write(measured_restart) }
+        monitor.start_measurement!
+
+        preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
+        expect(File.read(preserved)).to eq("startup complete\n")
+        expect(File.read(log_path)).to include(measured_restart)
+        expect { monitor.verify_after_measurement! }
+          .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /node-renderer master logged/)
       end
     end
 
@@ -63,6 +89,19 @@ RSpec.describe "benchmark target monitoring" do
         monitor = described_class.new(target_log: File.join(dir, "missing.log"), output_dir: File.join(dir, "out"))
 
         expect { monitor.start_measurement! }.not_to raise_error
+        expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
+    it "does not scan a target log that is created after measurement starts" do
+      Dir.mktmpdir do |dir|
+        log_path = File.join(dir, "target.log")
+        output_dir = File.join(dir, "bench_results")
+        monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+
+        monitor.start_measurement!
+        File.write(log_path, "Worker 1 died UNEXPECTEDLY :(, restarting\n")
+
         expect { monitor.verify_after_measurement! }.not_to raise_error
       end
     end

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe BenchmarkTargetMonitor do
       .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /PID 123.*discarding benchmark metrics/)
   end
 
+  it "fails before liveness checks when the benchmark target PID is non-positive" do
+    pid_alive = ->(_pid) { raise "pid liveness check should not run" }
+    monitor = described_class.new(target_pid: "0", pid_alive: pid_alive)
+
+    expect { monitor.verify_after_measurement! }
+      .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /TARGET_PID="0".*positive integer/)
+  end
+
   describe "#write_benchmark_payload" do
     let(:collector) { instance_double(BmfCollector) }
     let(:monitor) { instance_double(described_class) }

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "spec_helper"
+require_relative "../lib/benchmark_config"
+require_relative "../lib/benchmark_helpers"
+require_relative "../lib/benchmark_target_monitor"
+require_relative "../lib/bmf_helpers"
+
+RSpec.describe BenchmarkTargetMonitor do
+  def with_log_file(content)
+    Dir.mktmpdir do |dir|
+      log_path = File.join(dir, "target.log")
+      output_dir = File.join(dir, "bench_results")
+      File.write(log_path, content)
+      yield log_path, output_dir
+    end
+  end
+
+  it "preserves startup logs and blanks the live log before the measured window" do
+    with_log_file("booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n") do |log_path, output_dir|
+      monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+
+      monitor.start_measurement!
+
+      preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
+      expect(File.read(preserved)).to include("Worker 1 died UNEXPECTEDLY")
+      expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
+      expect { monitor.verify_after_measurement! }.not_to raise_error
+    end
+  end
+
+  it "fails when the node renderer master logs an unexpected worker restart during measurement" do
+    with_log_file("startup complete\n") do |log_path, output_dir|
+      monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+      monitor.start_measurement!
+      File.open(log_path, "a") { |file| file.puts("Worker 2 died UNEXPECTEDLY :(, restarting") }
+
+      expect { monitor.verify_after_measurement! }
+        .to raise_error(
+          BenchmarkTargetMonitor::MonitorFailure,
+          /node-renderer master logged `died UNEXPECTEDLY`.*discarding benchmark metrics/m
+        )
+    end
+  end
+
+  it "fails when the benchmark target PID no longer exists before metrics are written" do
+    monitor = described_class.new(target_pid: "123", pid_alive: ->(_pid) { false })
+
+    monitor.start_measurement!
+
+    expect { monitor.verify_after_measurement! }
+      .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /PID 123.*discarding benchmark metrics/)
+  end
+
+  describe "#write_benchmark_payload" do
+    let(:collector) { instance_double(BmfCollector) }
+    let(:monitor) { instance_double(described_class) }
+
+    it "verifies the target monitor before writing Bencher payload files" do
+      expect(monitor).to receive(:verify_after_measurement!).ordered
+      expect(collector).to receive(:write_bmf_json).with(BENCHMARK_JSON, append: true).ordered
+      expect(collector).to receive(:write_display_json).with(DISPLAY_JSON, append: true).ordered
+
+      write_benchmark_payload(collector, target_monitor: monitor, append: true)
+    end
+
+    it "does not write payload files when target monitoring fails" do
+      expect(monitor).to receive(:verify_after_measurement!)
+        .and_raise(described_class::MonitorFailure, "target failed")
+      expect(collector).not_to receive(:write_bmf_json)
+      expect(collector).not_to receive(:write_display_json)
+
+      expect { write_benchmark_payload(collector, target_monitor: monitor) }
+        .to raise_error(described_class::MonitorFailure, "target failed")
+    end
+  end
+end

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -4,96 +4,131 @@ require "tmpdir"
 require_relative "spec_helper"
 require_relative "../lib/benchmark_config"
 require_relative "../lib/benchmark_helpers"
-require_relative "../lib/benchmark_target_monitor"
 require_relative "../lib/bmf_helpers"
 
-RSpec.describe BenchmarkTargetMonitor do
-  def with_log_file(content)
-    Dir.mktmpdir do |dir|
-      log_path = File.join(dir, "target.log")
-      output_dir = File.join(dir, "bench_results")
-      File.write(log_path, content)
-      yield log_path, output_dir
-    end
-  end
-
-  it "preserves startup logs and blanks the live log before the measured window" do
-    with_log_file("booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n") do |log_path, output_dir|
-      monitor = described_class.new(target_log: log_path, output_dir: output_dir)
-
-      monitor.start_measurement!
-
-      preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
-      expect(File.read(preserved)).to include("Worker 1 died UNEXPECTEDLY")
-      expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
-      expect { monitor.verify_after_measurement! }.not_to raise_error
-    end
-  end
-
-  it "does not blank the live log when startup logs cannot be preserved" do
-    content = "booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n"
-
-    with_log_file(content) do |log_path, _output_dir|
-      monitor = described_class.new(target_log: log_path)
-
-      monitor.start_measurement!
-
-      expect(File.read(log_path)).to eq(content)
-    end
-  end
-
-  it "blanks bytes appended after log preservation but before opening the log for overwrite" do
-    with_log_file("booting\nready\n") do |log_path, output_dir|
-      monitor = described_class.new(target_log: log_path, output_dir: output_dir)
-      late_log_line = "Worker 2 died UNEXPECTEDLY :(, restarting\n"
-
-      allow(File).to receive(:open).and_wrap_original do |original_open, path, mode, *args, &block|
-        original_open.call(path, "ab") { |file| file.write(late_log_line) } if path == log_path && mode == "r+b"
-        original_open.call(path, mode, *args, &block)
+RSpec.describe "benchmark target monitoring" do
+  describe BenchmarkTargetMonitor do
+    def with_log_file(content)
+      Dir.mktmpdir do |dir|
+        log_path = File.join(dir, "target.log")
+        output_dir = File.join(dir, "bench_results")
+        File.write(log_path, content)
+        yield log_path, output_dir
       end
-
-      monitor.start_measurement!
-
-      preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
-      expect(File.read(preserved)).not_to include("died UNEXPECTEDLY")
-      expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
     end
-  end
 
-  it "fails when the node renderer master logs an unexpected worker restart during measurement" do
-    with_log_file("startup complete\n") do |log_path, output_dir|
-      monitor = described_class.new(target_log: log_path, output_dir: output_dir)
-      monitor.start_measurement!
-      File.open(log_path, "a") { |file| file.puts("Worker 2 died UNEXPECTEDLY :(, restarting") }
+    it "builds from TARGET_PID and TARGET_LOG in an injected environment" do
+      with_log_file("startup complete\n") do |log_path, output_dir|
+        monitor = described_class.from_env(
+          output_dir: output_dir,
+          env: { "TARGET_PID" => Process.pid.to_s, "TARGET_LOG" => log_path }
+        )
+
+        monitor.start_measurement!
+
+        preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
+        expect(File.read(preserved)).to eq("startup complete\n")
+        expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
+    it "preserves startup logs and blanks the live log before the measured window" do
+      with_log_file("booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n") do |log_path, output_dir|
+        monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+
+        monitor.start_measurement!
+
+        preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
+        expect(File.read(preserved)).to include("Worker 1 died UNEXPECTEDLY")
+        expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
+        expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
+    it "does not monitor or blank the live log when startup logs cannot be preserved" do
+      content = "booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n"
+
+      with_log_file(content) do |log_path, _output_dir|
+        monitor = described_class.new(target_log: log_path)
+
+        monitor.start_measurement!
+
+        expect(File.read(log_path)).to eq(content)
+        expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
+    it "ignores a target log path that does not exist" do
+      Dir.mktmpdir do |dir|
+        monitor = described_class.new(target_log: File.join(dir, "missing.log"), output_dir: File.join(dir, "out"))
+
+        expect { monitor.start_measurement! }.not_to raise_error
+        expect { monitor.verify_after_measurement! }.not_to raise_error
+      end
+    end
+
+    it "blanks bytes appended after log preservation but before opening the log for overwrite" do
+      with_log_file("booting\nready\n") do |log_path, output_dir|
+        monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+        late_log_line = "Worker 2 died UNEXPECTEDLY :(, restarting\n"
+
+        allow(File).to receive(:open).and_wrap_original do |original_open, path, mode, *args, &block|
+          original_open.call(path, "ab") { |file| file.write(late_log_line) } if path == log_path && mode == "r+b"
+          original_open.call(path, mode, *args, &block)
+        end
+
+        monitor.start_measurement!
+
+        preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
+        expect(File.read(preserved)).not_to include("died UNEXPECTEDLY")
+        expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
+      end
+    end
+
+    it "fails when verification runs before the measured window starts" do
+      monitor = described_class.new
 
       expect { monitor.verify_after_measurement! }
-        .to raise_error(
-          BenchmarkTargetMonitor::MonitorFailure,
-          /node-renderer master logged `died UNEXPECTEDLY`.*discarding benchmark metrics/m
-        )
+        .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /start_measurement! was never called/)
+    end
+
+    it "fails when the node renderer master logs an unexpected worker restart during measurement" do
+      with_log_file("startup complete\n") do |log_path, output_dir|
+        monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+        monitor.start_measurement!
+        File.open(log_path, "a") { |file| file.puts("Worker 2 died UNEXPECTEDLY :(, restarting") }
+
+        expect { monitor.verify_after_measurement! }
+          .to raise_error(
+            BenchmarkTargetMonitor::MonitorFailure,
+            /node-renderer master logged `died UNEXPECTEDLY`.*discarding benchmark metrics/m
+          )
+      end
+    end
+
+    it "fails when the benchmark target PID no longer exists before metrics are written" do
+      monitor = described_class.new(target_pid: "123", pid_alive: ->(_pid) { false })
+
+      monitor.start_measurement!
+
+      expect { monitor.verify_after_measurement! }
+        .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /PID 123.*discarding benchmark metrics/)
+    end
+
+    it "fails before liveness checks when the benchmark target PID is non-positive" do
+      pid_alive = ->(_pid) { raise "pid liveness check should not run" }
+      monitor = described_class.new(target_pid: "0", pid_alive: pid_alive)
+
+      monitor.start_measurement!
+
+      expect { monitor.verify_after_measurement! }
+        .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /TARGET_PID="0".*positive integer/)
     end
   end
 
-  it "fails when the benchmark target PID no longer exists before metrics are written" do
-    monitor = described_class.new(target_pid: "123", pid_alive: ->(_pid) { false })
-
-    monitor.start_measurement!
-
-    expect { monitor.verify_after_measurement! }
-      .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /PID 123.*discarding benchmark metrics/)
-  end
-
-  it "fails before liveness checks when the benchmark target PID is non-positive" do
-    pid_alive = ->(_pid) { raise "pid liveness check should not run" }
-    monitor = described_class.new(target_pid: "0", pid_alive: pid_alive)
-
-    expect { monitor.verify_after_measurement! }
-      .to raise_error(BenchmarkTargetMonitor::MonitorFailure, /TARGET_PID="0".*positive integer/)
-  end
-
-  describe "#write_benchmark_payload" do
+  describe "write_benchmark_payload" do
     let(:collector) { instance_double(BmfCollector) }
-    let(:monitor) { instance_double(described_class) }
+    let(:monitor) { instance_double(BenchmarkTargetMonitor) }
 
     it "verifies the target monitor before writing Bencher payload files" do
       expect(monitor).to receive(:verify_after_measurement!).ordered
@@ -105,12 +140,12 @@ RSpec.describe BenchmarkTargetMonitor do
 
     it "does not write payload files when target monitoring fails" do
       expect(monitor).to receive(:verify_after_measurement!)
-        .and_raise(described_class::MonitorFailure, "target failed")
+        .and_raise(BenchmarkTargetMonitor::MonitorFailure, "target failed")
       expect(collector).not_to receive(:write_bmf_json)
       expect(collector).not_to receive(:write_display_json)
 
       expect { write_benchmark_payload(collector, target_monitor: monitor) }
-        .to raise_error(described_class::MonitorFailure, "target failed")
+        .to raise_error(BenchmarkTargetMonitor::MonitorFailure, "target failed")
     end
   end
 end

--- a/benchmarks/spec/benchmark_target_monitor_spec.rb
+++ b/benchmarks/spec/benchmark_target_monitor_spec.rb
@@ -71,13 +71,14 @@ RSpec.describe "benchmark target monitoring" do
       end
     end
 
-    it "does not monitor or blank the live log when startup logs cannot be preserved" do
+    it "warns and skips live log monitoring when startup logs cannot be preserved" do
       content = "booting\nWorker 1 died UNEXPECTEDLY :(, restarting\nready\n"
 
       with_log_file(content) do |log_path, _output_dir|
         monitor = described_class.new(target_log: log_path)
 
-        monitor.start_measurement!
+        expect { monitor.start_measurement! }
+          .to output(/BenchmarkTargetMonitor: TARGET_LOG=.*worker-restart checks will be skipped/).to_stderr
 
         expect(File.read(log_path)).to eq(content)
         expect { monitor.verify_after_measurement! }.not_to raise_error
@@ -88,7 +89,9 @@ RSpec.describe "benchmark target monitoring" do
       Dir.mktmpdir do |dir|
         monitor = described_class.new(target_log: File.join(dir, "missing.log"), output_dir: File.join(dir, "out"))
 
-        expect { monitor.start_measurement! }.not_to raise_error
+        expect { monitor.start_measurement! }
+          .to output(/BenchmarkTargetMonitor: TARGET_LOG=.*missing\.log.*worker-restart checks will be skipped/)
+          .to_stderr
         expect { monitor.verify_after_measurement! }.not_to raise_error
       end
     end
@@ -99,7 +102,9 @@ RSpec.describe "benchmark target monitoring" do
         output_dir = File.join(dir, "bench_results")
         monitor = described_class.new(target_log: log_path, output_dir: output_dir)
 
-        monitor.start_measurement!
+        expect { monitor.start_measurement! }
+          .to output(/BenchmarkTargetMonitor: TARGET_LOG=.*target\.log.*worker-restart checks will be skipped/)
+          .to_stderr
         File.write(log_path, "Worker 1 died UNEXPECTEDLY :(, restarting\n")
 
         expect { monitor.verify_after_measurement! }.not_to raise_error
@@ -121,6 +126,7 @@ RSpec.describe "benchmark target monitoring" do
         preserved = File.join(output_dir, described_class::STARTUP_LOG_FILENAME)
         expect(File.read(preserved)).not_to include("died UNEXPECTEDLY")
         expect(File.read(log_path)).not_to include("died UNEXPECTEDLY")
+        expect { monitor.verify_after_measurement! }.not_to raise_error
       end
     end
 
@@ -141,6 +147,20 @@ RSpec.describe "benchmark target monitoring" do
           .to raise_error(
             BenchmarkTargetMonitor::MonitorFailure,
             /node-renderer master logged `died UNEXPECTEDLY`.*discarding benchmark metrics/m
+          )
+      end
+    end
+
+    it "fails with a monitor error when the target log disappears before verification" do
+      with_log_file("startup complete\n") do |log_path, output_dir|
+        monitor = described_class.new(target_log: log_path, output_dir: output_dir)
+        monitor.start_measurement!
+        FileUtils.rm_f(log_path)
+
+        expect { monitor.verify_after_measurement! }
+          .to raise_error(
+            BenchmarkTargetMonitor::MonitorFailure,
+            /Target log .* disappeared before post-measurement scan/
           )
       end
     end


### PR DESCRIPTION
Closes #3637

## Summary

- Add a benchmark target monitor that starts at the measured benchmark window and verifies the target before any Bencher payload files are written.
- Preserve the pre-measurement target log to `bench_results/target_startup_before_benchmark.log`, then blank the live log so the existing workflow grep cannot match pre-benchmark `died UNEXPECTEDLY` lines.
- Treat the node-renderer master's `died UNEXPECTEDLY` log line as an explicit Pro worker restart signal and fail before uploading partial metrics.

## Tests

- `bundle exec rspec benchmarks/spec/benchmark_target_monitor_spec.rb`
- `bundle exec rspec benchmarks/spec`
- `bundle exec rubocop benchmarks/bench.rb benchmarks/bench-node-renderer.rb benchmarks/lib/benchmark_helpers.rb benchmarks/lib/benchmark_target_monitor.rb benchmarks/spec/benchmark_target_monitor_spec.rb`
- `bundle exec rubocop` (baseline fails on unrelated `react_on_rails/spike/3313_prism_gemfile_rewriter/*` offenses; changed-file RuboCop and hooks are clean)
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local`
- pre-commit and pre-push hooks reran changed-file RuboCop with no offenses

## Design Calls

- Kept the implementation in benchmark scripts/tests and did not edit CI workflow YAML.
- Used log windowing inside the benchmark scripts so #3579's existing post-run workflow grep now sees only measured-run log content.
- Preserved successful-startup/pre-measure logs as an uploaded benchmark artifact; startup crashes that happen before benchmark scripts run still use the existing workflow log dump because improving that path further would require workflow YAML changes.

Labels: benchmark, ci-tooling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to benchmark scripts and CI env vars already in use; they tighten when metrics are written without touching app runtime or auth.
> 
> **Overview**
> Benchmark runs now **gate Bencher uploads** on target health, not only on green Vegeta/k6 results.
> 
> A new **`BenchmarkTargetMonitor`** starts at the measured window (from `TARGET_PID` / `TARGET_LOG`), copies pre-run logs to `target_startup_before_benchmark.log`, overwrites the live log with newlines so startup `died UNEXPECTEDLY` lines cannot pollute post-run checks, then **verifies** the target PID is still alive and that no unexpected Pro node-renderer worker restart was logged during the run. **`write_benchmark_payload`** runs that verification before writing BMF/display JSON; **`bench.rb`** and **`bench-node-renderer.rb`** call the monitor and exit with a GitHub Actions `::error::` if monitoring fails after an otherwise successful suite.
> 
> Specs cover log windowing, PID validation, failure ordering (no payload write on monitor failure), and integration with the shared helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf53a3672a2d572b7ca9a8ba2a7917f464ee8d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmarks now run a pre/post measurement monitor that preserves startup logs, blanks live logs during measurement, verifies the target process and log integrity, and prevents writing results if the monitor detects failures (emits an error and exits).

* **Tests**
  * Added comprehensive tests for log preservation, verification-before-write ordering, payload-write gating, and multiple failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->