### PR TITLE
[codex] Harden renderer teardown polish

### DIFF
--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -20,12 +20,12 @@ import type {
   RegisteredComponent,
   RendererFunction,
   RendererTeardown,
-  RendererTeardownResult,
   Root,
 } from 'react-on-rails/types';
 
 import { getRailsContext, resetRailsContext } from 'react-on-rails/context';
 import createReactOutput from 'react-on-rails/createReactOutput';
+import { isRendererTeardownResult } from 'react-on-rails/@internal/rendererTeardown';
 import { isServerRenderHash } from 'react-on-rails/isServerRenderResult';
 import { supportsHydrate, supportsRootApi, unmountComponentAtNode } from 'react-on-rails/reactApis';
 import reactHydrateOrRender from 'react-on-rails/reactHydrateOrRender';
@@ -72,14 +72,6 @@ function invokeRendererTeardown(teardown: RendererTeardown | undefined, domNodeI
       console.error(`Error in renderer teardown for dom node "${domNodeId}":`, error);
     });
   }
-}
-
-function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
-  return (
-    value != null &&
-    typeof value === 'object' &&
-    typeof (value as { teardown?: unknown }).teardown === 'function'
-  );
 }
 
 // Result of attempting renderer delegation. Pro awaits the renderer inside delegateToRenderer, so it

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -77,8 +77,9 @@ const wrapServerComponentRenderer = (
       : componentOrRenderFunction;
 
     // Preserve compatibility with existing 3-arg render functions: they are awaited before domNodeId
-    // validation. Moving that guard earlier is intentionally deferred to #3647. Keep this
-    // teardown-result guard before DOM checks so wrong-shaped render results get the clearer error.
+    // validation. Moving that guard earlier is intentionally deferred to a follow-up so this change
+    // stays focused on teardown-result validation. Keep this teardown-result guard before DOM checks
+    // so wrong-shaped render results get the clearer error.
     if (isRendererTeardownResult(Component)) {
       throw new Error(
         `wrapServerComponentRenderer: render function for server component '${componentName}' ` +

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -76,6 +76,8 @@ const wrapServerComponentRenderer = (
       ? ((await componentOrRenderFunction(props, railsContext, domNodeId)) as ReactComponent)
       : componentOrRenderFunction;
 
+    // Preserve compatibility with existing 3-arg render functions: they are awaited before domNodeId
+    // validation. Moving that guard earlier is intentionally deferred to #3647.
     if (isRendererTeardownResult(Component)) {
       throw new Error(
         `wrapServerComponentRenderer: render function for server component '${componentName}' ` +

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -24,7 +24,12 @@
 import 'react-on-rails-rsc/client.browser';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
-import { ReactComponent, ReactComponentOrRenderFunction, RendererFunction } from 'react-on-rails/types';
+import {
+  ReactComponent,
+  ReactComponentOrRenderFunction,
+  RendererFunction,
+  RendererTeardownResult,
+} from 'react-on-rails/types';
 import isRenderFunction from 'react-on-rails/isRenderFunction';
 import { ensureReactUseAvailable } from 'react-on-rails/reactApis';
 import { createRSCProvider } from '../RSCProvider.tsx';
@@ -32,6 +37,14 @@ import getReactServerComponent from '../getReactServerComponent.client.ts';
 import handleRecoverableError from '../handleRecoverableError.client.ts';
 
 ensureReactUseAvailable();
+
+function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as { teardown?: unknown }).teardown === 'function'
+  );
+}
 
 /**
  * Wraps a client component with the necessary RSC context and handling for client-side operations.
@@ -74,6 +87,13 @@ const wrapServerComponentRenderer = (
     const Component = isRenderFunction(componentOrRenderFunction)
       ? ((await componentOrRenderFunction(props, railsContext, domNodeId)) as ReactComponent)
       : componentOrRenderFunction;
+
+    if (isRendererTeardownResult(Component)) {
+      throw new Error(
+        `wrapServerComponentRenderer: render function for server component '${componentName}' ` +
+          'returned a renderer teardown result; expected a React component.',
+      );
+    }
 
     if (typeof Component !== 'function') {
       throw new Error(`wrapServerComponentRenderer: component '${componentName}' is not a function`);

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -77,7 +77,8 @@ const wrapServerComponentRenderer = (
       : componentOrRenderFunction;
 
     // Preserve compatibility with existing 3-arg render functions: they are awaited before domNodeId
-    // validation. Moving that guard earlier is intentionally deferred to #3647.
+    // validation. Moving that guard earlier is intentionally deferred to #3647. Keep this
+    // teardown-result guard before DOM checks so wrong-shaped render results get the clearer error.
     if (isRendererTeardownResult(Component)) {
       throw new Error(
         `wrapServerComponentRenderer: render function for server component '${componentName}' ` +

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -24,27 +24,15 @@
 import 'react-on-rails-rsc/client.browser';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
-import {
-  ReactComponent,
-  ReactComponentOrRenderFunction,
-  RendererFunction,
-  RendererTeardownResult,
-} from 'react-on-rails/types';
+import { ReactComponent, ReactComponentOrRenderFunction, RendererFunction } from 'react-on-rails/types';
 import isRenderFunction from 'react-on-rails/isRenderFunction';
+import { isRendererTeardownResult } from 'react-on-rails/@internal/rendererTeardown';
 import { ensureReactUseAvailable } from 'react-on-rails/reactApis';
 import { createRSCProvider } from '../RSCProvider.tsx';
 import getReactServerComponent from '../getReactServerComponent.client.ts';
 import handleRecoverableError from '../handleRecoverableError.client.ts';
 
 ensureReactUseAvailable();
-
-function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
-  return (
-    value != null &&
-    typeof value === 'object' &&
-    typeof (value as { teardown?: unknown }).teardown === 'function'
-  );
-}
 
 /**
  * Wraps a client component with the necessary RSC context and handling for client-side operations.

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -77,9 +77,8 @@ const wrapServerComponentRenderer = (
       : componentOrRenderFunction;
 
     // Preserve compatibility with existing 3-arg render functions: they are awaited before domNodeId
-    // validation. Moving that guard earlier is intentionally deferred to a follow-up so this change
-    // stays focused on teardown-result validation. Keep this teardown-result guard before DOM checks
-    // so wrong-shaped render results get the clearer error.
+    // validation; moving that check earlier is a future improvement. Keep this teardown-result guard
+    // before DOM checks so wrong-shaped render results get the clearer error.
     if (isRendererTeardownResult(Component)) {
       throw new Error(
         `wrapServerComponentRenderer: render function for server component '${componentName}' ` +

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -395,6 +395,43 @@ describe('ClientSideRenderer', () => {
     }
   });
 
+  it('logs a non-native thenable teardown rejection without requiring .catch', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const rejection = new Error('thenable teardown boom');
+      const teardown = jest.fn(
+        () =>
+          ({
+            then(_onFulfilled: () => void, onRejected: (error: Error) => void) {
+              onRejected(rejection);
+            },
+          }) as unknown as Promise<void>,
+      );
+      const TestRenderer: RendererFunction = (
+        _props?: Record<string, unknown>,
+        _railsContext?: RailsContext,
+        _domNodeId?: string,
+      ) => ({ teardown });
+      ComponentRegistry.register({ TestComponent: TestRenderer });
+      const componentSpec = setupTestComponentDom('dom-id-teardown-thenable-reject');
+      addRailsContext();
+
+      await renderOrHydrateComponent(componentSpec);
+      unmountAll();
+      expect(teardown).toHaveBeenCalledTimes(1);
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error in renderer teardown for dom node "dom-id-teardown-thenable-reject":',
+        rejection,
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it('rejects with a render error when an async renderer rejects before returning a teardown', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     try {

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -420,9 +420,8 @@ describe('ClientSideRenderer', () => {
       unmountAll();
       expect(teardown).toHaveBeenCalledTimes(1);
 
-      await new Promise((resolve) => {
-        setTimeout(resolve, 0);
-      });
+      await Promise.resolve(); // lets Promise.resolve(nonNativeThenable) settle
+      await Promise.resolve(); // lets the .catch() rejection handler run
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Error in renderer teardown for dom node "dom-id-teardown-thenable-reject":',
         rejection,

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.manifest.test.js
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.manifest.test.js
@@ -40,6 +40,7 @@ const runWebpack = () => {
     },
     resolve: {
       alias: {
+        'react-on-rails/@internal/rendererTeardown$': path.join(reactOnRailsSrcRoot, 'rendererTeardown.ts'),
         'react-on-rails/isRenderFunction$': path.join(reactOnRailsSrcRoot, 'isRenderFunction.ts'),
         'react-on-rails/reactApis$': path.join(reactOnRailsSrcRoot, 'reactApis.cts'),
         'react-on-rails/types$': path.join(reactOnRailsSrcRoot, 'types/index.ts'),

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -110,7 +110,8 @@ describe('wrapServerComponentRenderer/client validation (issue #3647)', () => {
     const renderFunction = (_props, _railsContext, _domNodeId) => ({ teardown: jest.fn() });
     const WrappedComponent = wrapServerComponentRenderer(renderFunction, 'TeardownResultComponent');
 
-    await expect(WrappedComponent({}, railsContext, 'any-dom-id')).rejects.toThrow(
+    // No DOM node needed; the teardown-result guard throws before getElementById is called.
+    await expect(WrappedComponent({}, railsContext, 'nonexistent-dom-id')).rejects.toThrow(
       "wrapServerComponentRenderer: render function for server component 'TeardownResultComponent' " +
         'returned a renderer teardown result; expected a React component.',
     );

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -107,13 +107,10 @@ describe('wrapServerComponentRenderer/client validation (issue #3647)', () => {
 
   it('rejects a render function that resolves to a renderer teardown result', async () => {
     const { wrapServerComponentRenderer } = loadWrappedRendererWithMocks();
-    const domNode = document.createElement('div');
-    domNode.id = 'rsc-root-with-teardown-result';
-    document.body.appendChild(domNode);
     const renderFunction = (_props, _railsContext) => ({ teardown: jest.fn() });
     const WrappedComponent = wrapServerComponentRenderer(renderFunction, 'TeardownResultComponent');
 
-    await expect(WrappedComponent({}, railsContext, domNode.id)).rejects.toThrow(
+    await expect(WrappedComponent({}, railsContext, 'any-dom-id')).rejects.toThrow(
       "wrapServerComponentRenderer: render function for server component 'TeardownResultComponent' " +
         'returned a renderer teardown result; expected a React component.',
     );

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -60,9 +60,6 @@ const loadWrappedRendererWithMocks = () => {
 };
 
 const cleanupWrappedRendererMocks = () => {
-  jest.dontMock('react-dom/client');
-  jest.dontMock('react-on-rails-rsc/client.browser');
-  jest.dontMock('../src/getReactServerComponent.client.ts');
   jest.resetModules();
   document.body.innerHTML = '';
 };

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -60,7 +60,6 @@ const loadWrappedRendererWithMocks = () => {
 };
 
 const cleanupWrappedRendererMocks = () => {
-  jest.resetModules();
   document.body.innerHTML = '';
 };
 

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -107,7 +107,7 @@ describe('wrapServerComponentRenderer/client validation (issue #3647)', () => {
 
   it('rejects a render function that resolves to a renderer teardown result', async () => {
     const { wrapServerComponentRenderer } = loadWrappedRendererWithMocks();
-    const renderFunction = (_props, _railsContext) => ({ teardown: jest.fn() });
+    const renderFunction = (_props, _railsContext, _domNodeId) => ({ teardown: jest.fn() });
     const WrappedComponent = wrapServerComponentRenderer(renderFunction, 'TeardownResultComponent');
 
     await expect(WrappedComponent({}, railsContext, 'any-dom-id')).rejects.toThrow(

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -37,6 +37,92 @@ const createBailoutDigestError = () => {
   return error;
 };
 
+const loadWrappedRendererWithMocks = () => {
+  jest.resetModules();
+
+  const unmount = jest.fn();
+  const render = jest.fn();
+  const hydrateRoot = jest.fn(() => ({ unmount }));
+  const createRoot = jest.fn(() => ({ render, unmount }));
+  const getReactServerComponent = jest.fn(() => jest.fn());
+
+  jest.doMock('react-dom/client', () => ({ createRoot, hydrateRoot }));
+  jest.doMock('react-on-rails-rsc/client.browser', () => ({}));
+  jest.doMock('../src/getReactServerComponent.client.ts', () => ({
+    __esModule: true,
+    default: getReactServerComponent,
+  }));
+
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const wrapServerComponentRenderer = require('../src/wrapServerComponentRenderer/client.tsx').default;
+
+  return { wrapServerComponentRenderer, createRoot, hydrateRoot, render, unmount, getReactServerComponent };
+};
+
+const cleanupWrappedRendererMocks = () => {
+  jest.dontMock('react-dom/client');
+  jest.dontMock('react-on-rails-rsc/client.browser');
+  jest.dontMock('../src/getReactServerComponent.client.ts');
+  jest.resetModules();
+  document.body.innerHTML = '';
+};
+
+describe('wrapServerComponentRenderer/client validation (issue #3647)', () => {
+  const railsContext = { rscPayloadGenerationUrlPath: '/rsc_payload' };
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    cleanupWrappedRendererMocks();
+  });
+
+  it('rejects with an explicit message when domNodeId is missing', async () => {
+    const { wrapServerComponentRenderer } = loadWrappedRendererWithMocks();
+    const WrappedComponent = wrapServerComponentRenderer(() => null, 'MissingDomNodeIdComponent');
+
+    await expect(WrappedComponent({}, railsContext, undefined)).rejects.toThrow(
+      "RSCClientRoot: No domNodeId provided for server component 'MissingDomNodeIdComponent'",
+    );
+  });
+
+  it('rejects with an explicit message when the target DOM node is missing', async () => {
+    const { wrapServerComponentRenderer } = loadWrappedRendererWithMocks();
+    const WrappedComponent = wrapServerComponentRenderer(() => null, 'MissingDomNodeComponent');
+
+    await expect(WrappedComponent({}, railsContext, 'missing-rsc-root')).rejects.toThrow(
+      "RSCClientRoot: No DOM node found for id: missing-rsc-root (server component 'MissingDomNodeComponent')",
+    );
+  });
+
+  it('rejects with an explicit message when railsContext is missing', async () => {
+    const { wrapServerComponentRenderer } = loadWrappedRendererWithMocks();
+    const domNode = document.createElement('div');
+    domNode.id = 'rsc-root-without-context';
+    document.body.appendChild(domNode);
+    const WrappedComponent = wrapServerComponentRenderer(() => null, 'MissingRailsContextComponent');
+
+    await expect(WrappedComponent({}, undefined, domNode.id)).rejects.toThrow(
+      "RSCClientRoot: No railsContext provided for server component 'MissingRailsContextComponent'.",
+    );
+  });
+
+  it('rejects a render function that resolves to a renderer teardown result', async () => {
+    const { wrapServerComponentRenderer } = loadWrappedRendererWithMocks();
+    const domNode = document.createElement('div');
+    domNode.id = 'rsc-root-with-teardown-result';
+    document.body.appendChild(domNode);
+    const renderFunction = (_props, _railsContext) => ({ teardown: jest.fn() });
+    const WrappedComponent = wrapServerComponentRenderer(renderFunction, 'TeardownResultComponent');
+
+    await expect(WrappedComponent({}, railsContext, domNode.id)).rejects.toThrow(
+      "wrapServerComponentRenderer: render function for server component 'TeardownResultComponent' " +
+        'returned a renderer teardown result; expected a React component.',
+    );
+  });
+});
+
 describe('wrapServerComponentRenderer/client recoverable errors', () => {
   let originalReportErrorDescriptor;
 

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -52,6 +52,7 @@
     "./ReactDOMServer": "./lib/ReactDOMServer.cjs",
     "./serverRenderReactComponent": "./lib/serverRenderReactComponent.js",
     "./@internal/sanitizeNonce": "./lib/sanitizeNonce.js",
+    "./@internal/rendererTeardown": "./lib/rendererTeardown.js",
     "./@internal/base/client": "./lib/base/client.js",
     "./@internal/base/full": {
       "react-server": "./lib/base/full.rsc.js",

--- a/packages/react-on-rails/src/ClientRenderer.ts
+++ b/packages/react-on-rails/src/ClientRenderer.ts
@@ -4,7 +4,6 @@ import type {
   RailsContext,
   RendererFunction,
   RendererTeardown,
-  RendererTeardownResult,
   RenderReturnType,
 } from './types/index.ts';
 import ComponentRegistry from './ComponentRegistry.ts';
@@ -15,6 +14,7 @@ import { getRailsContext } from './context.ts';
 import { isServerRenderHash } from './isServerRenderResult.ts';
 import { onPageUnloaded } from './pageLifecycle.ts';
 import { supportsRootApi, unmountComponentAtNode } from './reactApis.cts';
+import { isRendererTeardownResult } from './rendererTeardown.ts';
 
 const REACT_ON_RAILS_STORE_ATTRIBUTE = 'data-js-react-on-rails-store';
 
@@ -38,14 +38,6 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
     value != null &&
     (typeof value === 'object' || typeof value === 'function') &&
     typeof (value as { then?: unknown }).then === 'function'
-  );
-}
-
-function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
-  return (
-    value != null &&
-    typeof value === 'object' &&
-    typeof (value as { teardown?: unknown }).teardown === 'function'
   );
 }
 

--- a/packages/react-on-rails/src/createReactOutput.ts
+++ b/packages/react-on-rails/src/createReactOutput.ts
@@ -1,24 +1,11 @@
 import { createElement, isValidElement, type ReactElement } from 'react';
-import type {
-  CreateParams,
-  ReactComponent,
-  RenderFunction,
-  CreateReactOutputResult,
-  RendererTeardownResult,
-} from './types/index.ts';
+import type { CreateParams, ReactComponent, RenderFunction, CreateReactOutputResult } from './types/index.ts';
 import { isServerRenderHash, isPromise } from './isServerRenderResult.ts';
+import { isRendererTeardownResult } from './rendererTeardown.ts';
 
 const unsupportedManualRendererMessage = (name: string) =>
   `ReactOnRails.render() does not support renderer functions ("${name}"). ` +
   'Use normal React on Rails component rendering so renderer teardowns are captured on navigation.';
-
-function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
-  return (
-    value != null &&
-    typeof value === 'object' &&
-    typeof (value as { teardown?: unknown }).teardown === 'function'
-  );
-}
 
 function createReactElementFromRenderFunctionResult(
   renderFunctionResult: ReactComponent,

--- a/packages/react-on-rails/src/rendererTeardown.ts
+++ b/packages/react-on-rails/src/rendererTeardown.ts
@@ -1,6 +1,6 @@
 import type { RendererTeardownResult } from './types/index.ts';
 
-// eslint-disable-next-line import/prefer-default-export -- internal teardown helper should use a named import.
+// eslint-disable-next-line import/prefer-default-export -- single-export module; named export keeps the type guard's API tied to its predicate name.
 export function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
   return (
     value != null &&

--- a/packages/react-on-rails/src/rendererTeardown.ts
+++ b/packages/react-on-rails/src/rendererTeardown.ts
@@ -1,0 +1,10 @@
+import type { RendererTeardownResult } from './types/index.ts';
+
+// eslint-disable-next-line import/prefer-default-export -- internal teardown helpers should use named imports.
+export function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as { teardown?: unknown }).teardown === 'function'
+  );
+}

--- a/packages/react-on-rails/src/rendererTeardown.ts
+++ b/packages/react-on-rails/src/rendererTeardown.ts
@@ -1,6 +1,6 @@
 import type { RendererTeardownResult } from './types/index.ts';
 
-// eslint-disable-next-line import/prefer-default-export -- internal teardown helpers should use named imports.
+// eslint-disable-next-line import/prefer-default-export -- internal teardown helper should use a named import.
 export function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
   return (
     value != null &&

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -547,7 +547,8 @@ describe('ClientRenderer', () => {
       setupRendererDom('renderer-thenable');
 
       renderComponent('renderer-thenable');
-      // Flush microtasks so Promise.resolve(thenable) adopts the thenable and captures the teardown.
+      // Flush through a macrotask: Promise.resolve(nonNativeThenable) first schedules thenable
+      // assimilation, then the downstream handler captures the teardown.
       await new Promise((resolve) => {
         setTimeout(resolve, 0);
       });

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -369,7 +369,8 @@ describe('ClientRenderer', () => {
     });
 
     it('does not let a stale async renderer overwrite a newer same-id teardown', async () => {
-      // No setupRailsContext(): this test only exercises teardown-race ordering, not component rendering.
+      // No additional setupRailsContext() call needed; the enclosing beforeEach already runs it.
+      // This test exercises teardown-race ordering only, not full component rendering.
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       try {
         const resolvers: Array<(result: { teardown: () => void }) => void> = [];

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -369,6 +369,7 @@ describe('ClientRenderer', () => {
     });
 
     it('does not let a stale async renderer overwrite a newer same-id teardown', async () => {
+      // No setupRailsContext(): this test only exercises teardown-race ordering, not component rendering.
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       try {
         const resolvers: Array<(result: { teardown: () => void }) => void> = [];

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -39,6 +39,30 @@ const runPageUnload = (): void => {
   });
 };
 
+const setupRailsContext = (): void => {
+  const railsContextElement = document.createElement('div');
+  railsContextElement.id = 'js-react-on-rails-context';
+  railsContextElement.textContent = JSON.stringify({
+    railsEnv: 'test',
+    inMailer: false,
+    i18nLocale: 'en',
+    i18nDefaultLocale: 'en',
+    rorVersion: '13.0.0',
+    rorPro: false,
+    href: 'http://localhost:3000',
+    location: 'http://localhost:3000',
+    scheme: 'http',
+    host: 'localhost',
+    port: 3000,
+    pathname: '/',
+    search: null,
+    httpAcceptLanguage: 'en',
+    serverSide: false,
+    componentRegistryTimeout: 0,
+  });
+  document.body.appendChild(railsContextElement);
+};
+
 describe('ClientRenderer', () => {
   beforeEach(() => {
     // Clear registries
@@ -62,28 +86,7 @@ describe('ClientRenderer', () => {
 
   describe('renderComponent', () => {
     it('renders a simple React component', () => {
-      // Setup Rails context
-      const railsContextElement = document.createElement('div');
-      railsContextElement.id = 'js-react-on-rails-context';
-      railsContextElement.textContent = JSON.stringify({
-        railsEnv: 'test',
-        inMailer: false,
-        i18nLocale: 'en',
-        i18nDefaultLocale: 'en',
-        rorVersion: '13.0.0',
-        rorPro: false,
-        href: 'http://localhost:3000',
-        location: 'http://localhost:3000',
-        scheme: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathname: '/',
-        search: null,
-        httpAcceptLanguage: 'en',
-        serverSide: false,
-        componentRegistryTimeout: 0,
-      });
-      document.body.appendChild(railsContextElement);
+      setupRailsContext();
 
       // Register a simple component
       const TestComponent: React.FC<{ message: string }> = ({ message }) =>
@@ -119,28 +122,7 @@ describe('ClientRenderer', () => {
     });
 
     it('handles missing DOM element gracefully', () => {
-      // Setup Rails context
-      const railsContextElement = document.createElement('div');
-      railsContextElement.id = 'js-react-on-rails-context';
-      railsContextElement.textContent = JSON.stringify({
-        railsEnv: 'test',
-        inMailer: false,
-        i18nLocale: 'en',
-        i18nDefaultLocale: 'en',
-        rorVersion: '13.0.0',
-        rorPro: false,
-        href: 'http://localhost:3000',
-        location: 'http://localhost:3000',
-        scheme: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathname: '/',
-        search: null,
-        httpAcceptLanguage: 'en',
-        serverSide: false,
-        componentRegistryTimeout: 0,
-      });
-      document.body.appendChild(railsContextElement);
+      setupRailsContext();
 
       // Test with non-existent DOM ID
       expect(() => renderComponent('non-existent-component')).not.toThrow();
@@ -151,30 +133,6 @@ describe('ClientRenderer', () => {
   // own mount. They may return a teardown wrapper so React on Rails can clean the mount up on
   // page unload (Turbo/Turbolinks navigation) or when the same dom-id node is replaced.
   describe('renderer functions (issue #3209: teardown cleanup)', () => {
-    const setupRailsContext = () => {
-      const railsContextElement = document.createElement('div');
-      railsContextElement.id = 'js-react-on-rails-context';
-      railsContextElement.textContent = JSON.stringify({
-        railsEnv: 'test',
-        inMailer: false,
-        i18nLocale: 'en',
-        i18nDefaultLocale: 'en',
-        rorVersion: '13.0.0',
-        rorPro: false,
-        href: 'http://localhost:3000',
-        location: 'http://localhost:3000',
-        scheme: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathname: '/',
-        search: null,
-        httpAcceptLanguage: 'en',
-        serverSide: false,
-        componentRegistryTimeout: 0,
-      });
-      document.body.appendChild(railsContextElement);
-    };
-
     const setupRendererDom = (domId: string, componentName = 'TestRenderer'): HTMLElement => {
       const componentElement = document.createElement('div');
       componentElement.className = 'js-react-on-rails-component';
@@ -410,6 +368,41 @@ describe('ClientRenderer', () => {
       consoleErrorSpy.mockRestore();
     });
 
+    it('does not let a stale async renderer overwrite a newer same-id teardown', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const resolvers: Array<(result: { teardown: () => void }) => void> = [];
+      const AsyncRenderer: RendererFunction = (_props, _railsContext, _domNodeId) =>
+        new Promise<{ teardown: () => void }>((resolve) => {
+          resolvers.push(resolve);
+        });
+      ComponentRegistry.register({ AsyncRenderer });
+      const node1 = setupRendererDom('renderer-stale-after-newer', 'AsyncRenderer');
+
+      renderComponent('renderer-stale-after-newer');
+
+      node1.remove();
+      const node2 = document.createElement('div');
+      node2.id = 'renderer-stale-after-newer';
+      document.body.appendChild(node2);
+      renderComponent('renderer-stale-after-newer');
+      expect(resolvers).toHaveLength(2);
+
+      const staleTeardown = jest.fn();
+      const currentTeardown = jest.fn();
+      resolvers[1]({ teardown: currentTeardown });
+      await Promise.resolve();
+      resolvers[0]({ teardown: staleTeardown });
+      await Promise.resolve();
+
+      runPageUnload();
+      expect(currentTeardown).toHaveBeenCalledTimes(1);
+      expect(staleTeardown).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('resolved after the page or node was already cleaned up'),
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
     it('drops and logs about an async teardown when unmount races the renderer resolving', async () => {
       // Complements the happy-path async test above: here page unload fires BEFORE the
       // renderer's promise resolves, which is the actual race the core package cannot win (Pro does).
@@ -558,28 +551,7 @@ describe('ClientRenderer', () => {
 
   describe('reactOnRailsComponentLoaded', () => {
     it('is an alias for renderComponent', () => {
-      // Setup minimal Rails context
-      const railsContextElement = document.createElement('div');
-      railsContextElement.id = 'js-react-on-rails-context';
-      railsContextElement.textContent = JSON.stringify({
-        railsEnv: 'test',
-        inMailer: false,
-        i18nLocale: 'en',
-        i18nDefaultLocale: 'en',
-        rorVersion: '13.0.0',
-        rorPro: false,
-        href: 'http://localhost:3000',
-        location: 'http://localhost:3000',
-        scheme: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathname: '/',
-        search: null,
-        httpAcceptLanguage: 'en',
-        serverSide: false,
-        componentRegistryTimeout: 0,
-      });
-      document.body.appendChild(railsContextElement);
+      setupRailsContext();
 
       // Should work the same as renderComponent
       expect(() => reactOnRailsComponentLoaded('test-component')).not.toThrow();
@@ -587,30 +559,6 @@ describe('ClientRenderer', () => {
   });
 
   describe('Issue #2210: Multiple calls to renderComponent', () => {
-    const setupRailsContext = () => {
-      const railsContextElement = document.createElement('div');
-      railsContextElement.id = 'js-react-on-rails-context';
-      railsContextElement.textContent = JSON.stringify({
-        railsEnv: 'test',
-        inMailer: false,
-        i18nLocale: 'en',
-        i18nDefaultLocale: 'en',
-        rorVersion: '13.0.0',
-        rorPro: false,
-        href: 'http://localhost:3000',
-        location: 'http://localhost:3000',
-        scheme: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathname: '/',
-        search: null,
-        httpAcceptLanguage: 'en',
-        serverSide: false,
-        componentRegistryTimeout: 0,
-      });
-      document.body.appendChild(railsContextElement);
-    };
-
     it('skips already-rendered components to prevent hydration errors', () => {
       setupRailsContext();
 
@@ -694,30 +642,6 @@ describe('ClientRenderer', () => {
   });
 
   describe('page unload cleanup (React-root cleanup)', () => {
-    const setupRailsContext = () => {
-      const railsContextElement = document.createElement('div');
-      railsContextElement.id = 'js-react-on-rails-context';
-      railsContextElement.textContent = JSON.stringify({
-        railsEnv: 'test',
-        inMailer: false,
-        i18nLocale: 'en',
-        i18nDefaultLocale: 'en',
-        rorVersion: '13.0.0',
-        rorPro: false,
-        href: 'http://localhost:3000',
-        location: 'http://localhost:3000',
-        scheme: 'http',
-        host: 'localhost',
-        port: 3000,
-        pathname: '/',
-        search: null,
-        httpAcceptLanguage: 'en',
-        serverSide: false,
-        componentRegistryTimeout: 0,
-      });
-      document.body.appendChild(railsContextElement);
-    };
-
     beforeEach(() => {
       // Isolate from roots tracked by earlier tests.
       runPageUnload();

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -385,6 +385,8 @@ describe('ClientRenderer', () => {
         const node2 = document.createElement('div');
         node2.id = 'renderer-stale-after-newer';
         document.body.appendChild(node2);
+        // Keep the original component descriptor in place to simulate a soft navigation replacing
+        // only the mount node for this id.
         renderComponent('renderer-stale-after-newer');
         expect(resolvers).toHaveLength(2);
 

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -392,6 +392,8 @@ describe('ClientRenderer', () => {
 
         const staleTeardown = jest.fn();
         const currentTeardown = jest.fn();
+        // Resolve the newer renderer first so its teardown is attached to the active entry before
+        // the stale renderer settles.
         resolvers[1]({ teardown: currentTeardown });
         await Promise.resolve();
         resolvers[0]({ teardown: staleTeardown });

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -370,37 +370,40 @@ describe('ClientRenderer', () => {
 
     it('does not let a stale async renderer overwrite a newer same-id teardown', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      const resolvers: Array<(result: { teardown: () => void }) => void> = [];
-      const AsyncRenderer: RendererFunction = (_props, _railsContext, _domNodeId) =>
-        new Promise<{ teardown: () => void }>((resolve) => {
-          resolvers.push(resolve);
-        });
-      ComponentRegistry.register({ AsyncRenderer });
-      const node1 = setupRendererDom('renderer-stale-after-newer', 'AsyncRenderer');
+      try {
+        const resolvers: Array<(result: { teardown: () => void }) => void> = [];
+        const AsyncRenderer: RendererFunction = (_props, _railsContext, _domNodeId) =>
+          new Promise<{ teardown: () => void }>((resolve) => {
+            resolvers.push(resolve);
+          });
+        ComponentRegistry.register({ AsyncRenderer });
+        const node1 = setupRendererDom('renderer-stale-after-newer', 'AsyncRenderer');
 
-      renderComponent('renderer-stale-after-newer');
+        renderComponent('renderer-stale-after-newer');
 
-      node1.remove();
-      const node2 = document.createElement('div');
-      node2.id = 'renderer-stale-after-newer';
-      document.body.appendChild(node2);
-      renderComponent('renderer-stale-after-newer');
-      expect(resolvers).toHaveLength(2);
+        node1.remove();
+        const node2 = document.createElement('div');
+        node2.id = 'renderer-stale-after-newer';
+        document.body.appendChild(node2);
+        renderComponent('renderer-stale-after-newer');
+        expect(resolvers).toHaveLength(2);
 
-      const staleTeardown = jest.fn();
-      const currentTeardown = jest.fn();
-      resolvers[1]({ teardown: currentTeardown });
-      await Promise.resolve();
-      resolvers[0]({ teardown: staleTeardown });
-      await Promise.resolve();
+        const staleTeardown = jest.fn();
+        const currentTeardown = jest.fn();
+        resolvers[1]({ teardown: currentTeardown });
+        await Promise.resolve();
+        resolvers[0]({ teardown: staleTeardown });
+        await Promise.resolve();
 
-      runPageUnload();
-      expect(currentTeardown).toHaveBeenCalledTimes(1);
-      expect(staleTeardown).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('resolved after the page or node was already cleaned up'),
-      );
-      consoleErrorSpy.mockRestore();
+        runPageUnload();
+        expect(currentTeardown).toHaveBeenCalledTimes(1);
+        expect(staleTeardown).not.toHaveBeenCalled();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('resolved after the page or node was already cleaned up'),
+        );
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
 
     it('drops and logs about an async teardown when unmount races the renderer resolving', async () => {


### PR DESCRIPTION
Closes #3647

## Summary
- Centralize `isRendererTeardownResult` in `packages/react-on-rails/src/rendererTeardown.ts` and expose it as `react-on-rails/@internal/rendererTeardown`, so OSS and Pro share one teardown-result guard instead of carrying inline copies.
- Keep the Pro `wrapServerComponentRenderer/client` runtime guard so teardown-shaped server-component render results fail with a clear error before the generic component-shape check.
- Harden and clarify the renderer teardown tests around same-id async races, DOM descriptor reuse, and Pro wrapper validation cleanup.
- Keep Pro parity coverage for non-native thenable teardown rejection handling.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check packages/react-on-rails/src/rendererTeardown.ts packages/react-on-rails/src/ClientRenderer.ts packages/react-on-rails/src/createReactOutput.ts packages/react-on-rails-pro/src/ClientSideRenderer.ts packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx packages/react-on-rails/tests/ClientRenderer.test.ts packages/react-on-rails/package.json`
- `pnpm exec eslint --no-warn-ignored packages/react-on-rails/src/rendererTeardown.ts packages/react-on-rails/src/ClientRenderer.ts packages/react-on-rails/src/createReactOutput.ts packages/react-on-rails-pro/src/ClientSideRenderer.ts packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx packages/react-on-rails/tests/ClientRenderer.test.ts`
- `pnpm --filter react-on-rails run type-check`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm --filter react-on-rails exec jest tests/ClientRenderer.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro exec jest tests/ClientSideRenderer.test.ts tests/wrapServerComponentRenderer.client.test.jsx --runInBand`
- `pnpm --filter react-on-rails run build`
- `pnpm --filter react-on-rails-pro run build`
- Follow-up focused reruns after review-comment cleanup: `pnpm exec prettier --check packages/react-on-rails/tests/ClientRenderer.test.ts packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx`, `pnpm exec eslint --no-warn-ignored packages/react-on-rails/tests/ClientRenderer.test.ts packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx`, `pnpm --filter react-on-rails exec jest tests/ClientRenderer.test.ts --runInBand`, `pnpm --filter react-on-rails-pro exec jest tests/wrapServerComponentRenderer.client.test.jsx --runInBand`.

## Design Calls
- Added an internal OSS export instead of documenting three synchronized `isRendererTeardownResult` copies; Pro already consumes OSS internal subpaths, and this keeps the guard shape single-sourced.
- Kept `invokeRendererTeardown` duplicated; that helper still has package-specific runtime/logging context and remains covered by parity tests.
- Kept public `RendererFunction` return typing unchanged pending downstream migration data.
- Left docs and dummy-app renderer conversions out of this PR per scope; this PR stays focused on renderer teardown diagnostics, guard reuse, and targeted tests.
- No changelog entry: this is Pro/OSS renderer hardening plus an invalid-shape diagnostic guard, not a new user-facing feature or documented behavior change.

Labels: none. This is a focused test/diagnostic hardening PR with no CI workflow, dependency, generator, SSR output, or broad Pro/core boundary changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal guard deduplication and stricter runtime validation for invalid server-component render shapes; behavior changes are limited to clearer errors and test-documented teardown edge cases, with no auth or data-path changes.
> 
> **Overview**
> **Centralizes** the `isRendererTeardownResult` type guard in `rendererTeardown.ts` and exposes it as `react-on-rails/@internal/rendererTeardown`, replacing inline copies in OSS (`ClientRenderer`, `createReactOutput`) and Pro (`ClientSideRenderer`, `wrapServerComponentRenderer/client`).
> 
> **Pro RSC wrapper** now rejects server-component render functions that resolve to a teardown object with an explicit error (before DOM/context checks), closing #3647-style misconfiguration diagnostics.
> 
> **Tests** add coverage for non-native thenable teardown rejections (Pro), same-id async teardown races where a stale renderer must not overwrite a newer mount (OSS), and `wrapServerComponentRenderer` validation for missing `domNodeId`, DOM node, `railsContext`, and teardown-shaped returns; webpack manifest test aliases the new internal module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92db44df38c91ceafc87c1b0ff13ca80c090108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime validation that rejects invalid server-rendered results (e.g., teardown objects) with clearer error messages.
  * Improved handling and logging when asynchronous renderer teardown or replacement fails or races.
  * Improved validation and error messages for missing mount target or missing context during server-component mounting.

* **Tests**
  * Expanded tests for server component rendering validation edge cases.
  * Added tests ensuring async renderer teardown/replacement logs correctly for promise/thenable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->