### PR TITLE
Docs: clarify rails new JavaScript skip flag

### DIFF
--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -58,13 +58,11 @@ Trying out **React on Rails** is super easy, so long as you have the basic prere
 
 Then we need to create a fresh Rails application as follows.
 
-First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app.
+First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app. Use
+`--skip-javascript` so React on Rails can install its Shakapacker JavaScript setup; Rails 5.2-6.x legacy apps also
+use that flag when creating a test app for this flow.
 
 ```bash
-# For Rails 5.2
-rails new test-react-on-rails --skip-webpacker
-
-# For Rails 6.x+
 rails new test-react-on-rails --skip-javascript
 
 cd test-react-on-rails

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -58,11 +58,14 @@ Trying out **React on Rails** is super easy, so long as you have the basic prere
 
 Then we need to create a fresh Rails application as follows.
 
-First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app. Use
-`--skip-javascript` so React on Rails can install its Shakapacker JavaScript setup. Rails 6.x apps use the same
-flag for this flow. Rails 5.2 apps are outside this Rails 7+ tutorial; for Webpacker-era JavaScript setup guidance,
-see the [legacy Webpacker migration shims](../building-features/rails-webpacker-react-integration-options.md#legacy-webpacker--webpack-4-migration-shims)
-and [migrating from react-rails](../migrating/migrating-from-react-rails.md).
+First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app.
+Pass `--skip-javascript` so React on Rails can install Shakapacker for the JavaScript setup.
+
+> [!NOTE]
+> **Rails 5.2 / 6.x users:** Rails 6.x uses the same `--skip-javascript` flag. Rails 5.2 is outside
+> the scope of this Rails 7+ tutorial. For Webpacker-era setup guidance, see the
+> [legacy Webpacker migration shims](../building-features/rails-webpacker-react-integration-options.md#legacy-webpacker--webpack-4-migration-shims)
+> and [migrating from react-rails](../migrating/migrating-from-react-rails.md).
 
 ```bash
 rails new test-react-on-rails --skip-javascript

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -59,9 +59,10 @@ Trying out **React on Rails** is super easy, so long as you have the basic prere
 Then we need to create a fresh Rails application as follows.
 
 First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app. Use
-`--skip-javascript` so React on Rails can install its Shakapacker JavaScript setup. Rails 6.x legacy test apps use
-the same flag for this flow; Rails 5.2 apps are outside this Rails 7+ tutorial and should follow the appropriate
-legacy docs for their JavaScript setup.
+`--skip-javascript` so React on Rails can install its Shakapacker JavaScript setup. Rails 6.x apps use the same
+flag for this flow. Rails 5.2 apps are outside this Rails 7+ tutorial; for Webpacker-era JavaScript setup guidance,
+see the [legacy Webpacker migration shims](../building-features/rails-webpacker-react-integration-options.md#legacy-webpacker--webpack-4-migration-shims)
+and [migrating from react-rails](../migrating/migrating-from-react-rails.md).
 
 ```bash
 rails new test-react-on-rails --skip-javascript

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -59,8 +59,9 @@ Trying out **React on Rails** is super easy, so long as you have the basic prere
 Then we need to create a fresh Rails application as follows.
 
 First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app. Use
-`--skip-javascript` so React on Rails can install its Shakapacker JavaScript setup; Rails 5.2-6.x legacy apps also
-use that flag when creating a test app for this flow.
+`--skip-javascript` so React on Rails can install its Shakapacker JavaScript setup. Rails 6.x legacy test apps use
+the same flag for this flow; Rails 5.2 apps are outside this Rails 7+ tutorial and should follow the appropriate
+legacy docs for their JavaScript setup.
 
 ```bash
 rails new test-react-on-rails --skip-javascript


### PR DESCRIPTION
## Summary

- Follow-up to #3655, which was merged before its active tutorial review threads were fixed.
- Removes the invalid Rails 5.2 `--skip-webpacker` example from the getting-started tutorial.
- Keeps `--skip-javascript` and clarifies that Rails 5.2-6.x legacy test apps should use that flag for this flow while the tutorial itself targets Rails 7.0+.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm exec prettier --check -- docs/oss/getting-started/tutorial.md docs/oss/upgrading/upgrading-react-on-rails.md`
- [x] `script/check-docs-sidebar origin/main HEAD`
- [x] `git diff --check`

Addresses the unresolved #3655 tutorial review threads about the Rails 5.2 / Rails 6 JavaScript skip flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the OSS getting-started tutorial; no runtime or application code affected.
> 
> **Overview**
> **Clarifies the getting-started tutorial’s `rails new` JavaScript setup** after follow-up to #3655: drops the invalid Rails 5.2 `--skip-webpacker` example and the split command blocks, leaving a single `rails new … --skip-javascript` snippet.
> 
> The prose now explains that `--skip-javascript` is required so React on Rails can install Shakapacker, that Rails 6.x uses the same flag for this flow, and that Rails 5.2 is outside the Rails 7+ tutorial—with pointers to legacy Webpacker migration shims and the react-rails migration doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440dc3f69cec4b8ee753bb8aafe99bb394202bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Create a new Ruby on Rails App" tutorial with explicit instructions for running `rails new` with the `--skip-javascript` flag.
  * Added version-specific guidance for Rails 5.2/6.x users clarifying the relevant configuration flag for those versions.
  * Included links to legacy migration resources for users on older Rails versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->