### PR TITLE
Suppress regression issues when only /posts_page: Pro regresses

### DIFF
--- a/benchmarks/lib/github.rb
+++ b/benchmarks/lib/github.rb
@@ -12,6 +12,10 @@ module Github
     $stdout.puts "::warning::#{escape_workflow_command_data(message)}"
   end
 
+  def notice(message)
+    $stdout.puts "::notice::#{escape_workflow_command_data(message)}"
+  end
+
   def escape_workflow_command_data(value)
     value.to_s
          # Escape percent first so the percent signs introduced below are not double-encoded.

--- a/benchmarks/lib/regression_report.rb
+++ b/benchmarks/lib/regression_report.rb
@@ -12,4 +12,5 @@ module RegressionReport
   SUITE_NAME = "suite_name"
   SHARD_LABEL = "shard_label"
   SUMMARY = "summary"
+  REGRESSED_BENCHMARKS = "regressed_benchmarks"
 end

--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -35,7 +35,8 @@ BENCHER_URL = "https://bencher.dev/perf/react-on-rails-t8a9ncxo"
 # REMOVE this entry (restoring unconditional filing) once the failure-era samples have
 # rolled out of Bencher's 64-run t-test window for /posts_page: Pro on main — i.e. once
 # the dashboard baseline reflects real timings again. After that a regression for it is
-# genuine and must be reported.
+# genuine and must be reported. Tracking issue + full revert steps:
+# https://github.com/shakacode/react_on_rails/issues/3669
 IGNORED_REGRESSION_BENCHMARKS = ["/posts_page: Pro"].freeze
 
 # Creates (or updates) the single per-commit regression issue and upserts one

--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -316,15 +316,20 @@ rescue StandardError => e
   nil
 end
 
-# True only when every payload reports its regressed benchmarks AND all of them are in
-# IGNORED_REGRESSION_BENCHMARKS. Fails safe toward filing: a payload missing the list
-# (older writer / hand-off that couldn't name them), an empty list, or any non-ignored
-# benchmark returns false, so a real regression is never silently dropped.
-def only_ignored_benchmarks_regressed?(payloads)
-  per_payload = payloads.map { |payload| payload[RegressionReport::REGRESSED_BENCHMARKS] }
-  return false unless per_payload.all? { |names| names.is_a?(Array) && !names.empty? }
+# Returns the regressed benchmarks to suppress only when every payload reports its
+# regressed benchmarks AND all of them are in IGNORED_REGRESSION_BENCHMARKS. Fails
+# safe toward filing: no payloads, a payload missing the list (older writer / hand-off
+# that couldn't name them), an empty list, or any non-ignored benchmark returns nil.
+def suppressed_regressed_benchmarks(payloads)
+  return nil if payloads.empty?
 
-  per_payload.flatten.uniq.all? { |name| IGNORED_REGRESSION_BENCHMARKS.include?(name) }
+  per_payload = payloads.map { |payload| payload[RegressionReport::REGRESSED_BENCHMARKS] }
+  return nil unless per_payload.all? { |names| names.is_a?(Array) && !names.empty? }
+
+  regressed_benchmarks = per_payload.flatten.uniq
+  return nil unless regressed_benchmarks.all? { |name| IGNORED_REGRESSION_BENCHMARKS.include?(name) }
+
+  regressed_benchmarks
 end
 
 def report_regressions(artifacts_dir)
@@ -342,12 +347,13 @@ def report_regressions(artifacts_dir)
   # payloads being readable: an unreadable payload is an unknown regression that could
   # be anything, so fall through and let the normal flow file (and then fail) rather
   # than suppress it.
-  if readable.size == payloads.size && only_ignored_benchmarks_regressed?(readable)
+  suppressed_benchmarks = suppressed_regressed_benchmarks(readable) if readable.size == payloads.size
+  if suppressed_benchmarks
     # Surface as a run-summary notice (not a plain log line) so it is visible that the
     # suppression is active and still needs removing once the baseline recovers.
     Github.notice(
       "Benchmark regression issue suppressed: the only regressed benchmark(s) are " \
-      "temporarily ignored (#{IGNORED_REGRESSION_BENCHMARKS.join(', ')}). Remove " \
+      "temporarily ignored (#{suppressed_benchmarks.join(', ')}). Remove " \
       "IGNORED_REGRESSION_BENCHMARKS in report_regressions.rb once their Bencher baseline recovers."
     )
     return true

--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -20,6 +20,24 @@ require_relative "lib/regression_report"
 
 BENCHER_URL = "https://bencher.dev/perf/react-on-rails-t8a9ncxo"
 
+# TEMPORARY — benchmarks whose regressions must NOT open an issue, by the exact
+# benchmark name Bencher reports (the leading-slash name shown in the summary table,
+# matched against RegressionReport::REGRESSED_BENCHMARKS in each suite's payload).
+#
+# /posts_page: Pro spent weeks hard-500ing on every request (failed_pct = 100), so the
+# route was effectively an instant error and Bencher built its rps/latency baseline
+# from those bogus-fast failure responses. Now that the route is fixed, its real
+# (slower) timings read as large regressions against that fast baseline and would file
+# a spurious regression issue on every main push. We can't surgically delete just this
+# benchmark's history in Bencher (the delete is blocked by a FOREIGN KEY constraint
+# from its reports/alerts), so we suppress its issue here instead.
+#
+# REMOVE this entry (restoring unconditional filing) once the failure-era samples have
+# rolled out of Bencher's 64-run t-test window for /posts_page: Pro on main — i.e. once
+# the dashboard baseline reflects real timings again. After that a regression for it is
+# genuine and must be reported.
+IGNORED_REGRESSION_BENCHMARKS = ["/posts_page: Pro"].freeze
+
 # Creates (or updates) the single per-commit regression issue and upserts one
 # section per suite into a shared comment. Only safe to drive from a single
 # process — see the file header.
@@ -297,6 +315,17 @@ rescue StandardError => e
   nil
 end
 
+# True only when every payload reports its regressed benchmarks AND all of them are in
+# IGNORED_REGRESSION_BENCHMARKS. Fails safe toward filing: a payload missing the list
+# (older writer / hand-off that couldn't name them), an empty list, or any non-ignored
+# benchmark returns false, so a real regression is never silently dropped.
+def only_ignored_benchmarks_regressed?(payloads)
+  per_payload = payloads.map { |payload| payload[RegressionReport::REGRESSED_BENCHMARKS] }
+  return false unless per_payload.all? { |names| names.is_a?(Array) && !names.empty? }
+
+  per_payload.flatten.uniq.all? { |name| IGNORED_REGRESSION_BENCHMARKS.include?(name) }
+end
+
 def report_regressions(artifacts_dir)
   paths = regression_payload_paths(artifacts_dir)
 
@@ -307,6 +336,21 @@ def report_regressions(artifacts_dir)
 
   payloads = paths.map { |path| load_payload(path) }
   readable = payloads.compact
+
+  # Skip filing when every regressed benchmark is temporarily ignored. Gated on all
+  # payloads being readable: an unreadable payload is an unknown regression that could
+  # be anything, so fall through and let the normal flow file (and then fail) rather
+  # than suppress it.
+  if readable.size == payloads.size && only_ignored_benchmarks_regressed?(readable)
+    # Surface as a run-summary notice (not a plain log line) so it is visible that the
+    # suppression is active and still needs removing once the baseline recovers.
+    Github.notice(
+      "Benchmark regression issue suppressed: the only regressed benchmark(s) are " \
+      "temporarily ignored (#{IGNORED_REGRESSION_BENCHMARKS.join(', ')}). Remove " \
+      "IGNORED_REGRESSION_BENCHMARKS in report_regressions.rb once their Bencher baseline recovers."
+    )
+    return true
+  end
 
   # One section per suite: a sharded suite emits one payload per shard, so combine
   # them rather than filing a section per shard. Suites sorted for stable output.

--- a/benchmarks/spec/report_regressions_spec.rb
+++ b/benchmarks/spec/report_regressions_spec.rb
@@ -310,6 +310,23 @@ RSpec.describe "benchmark regression reporting" do
       end
     end
 
+    it "reports only the ignored benchmarks that actually regressed in the suppression notice" do
+      ignored = IGNORED_REGRESSION_BENCHMARKS.first
+      unused_ignored = "/unused_route: Pro"
+      stub_const("IGNORED_REGRESSION_BENCHMARKS", [ignored, unused_ignored].freeze)
+
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-pro", suite: "Pro", regressed: [ignored])
+        expect do
+          expect(report_regressions(dir)).to be(true)
+        end.to output(
+          satisfy do |text|
+            text.include?("temporarily ignored (#{ignored})") && !text.include?(unused_ignored)
+          end
+        ).to_stdout
+      end
+    end
+
     it "still files when a non-ignored benchmark also regressed alongside an ignored one" do
       ignored = IGNORED_REGRESSION_BENCHMARKS.first
       Dir.mktmpdir do |dir|

--- a/benchmarks/spec/report_regressions_spec.rb
+++ b/benchmarks/spec/report_regressions_spec.rb
@@ -243,14 +243,15 @@ RSpec.describe "benchmark regression reporting" do
       end
     end
 
-    def write_payload(dir, artifact:, suite:, shard_label: "1/1", summary: nil)
+    def write_payload(dir, artifact:, suite:, shard_label: "1/1", summary: nil, regressed: nil)
       artifact_dir = File.join(dir, artifact)
       FileUtils.mkdir_p(artifact_dir)
-      File.write(
-        File.join(artifact_dir, RegressionReport::FILENAME),
-        JSON.generate(suite_name: suite, shard_label: shard_label,
-                      summary: summary || "#{suite} #{shard_label} regressed")
-      )
+      payload = { suite_name: suite, shard_label: shard_label,
+                  summary: summary || "#{suite} #{shard_label} regressed" }
+      # Omit the key entirely when regressed is nil so the "older writer" fail-safe path
+      # (payload without REGRESSED_BENCHMARKS) stays covered by the existing examples.
+      payload[RegressionReport::REGRESSED_BENCHMARKS] = regressed unless regressed.nil?
+      File.write(File.join(artifact_dir, RegressionReport::FILENAME), JSON.generate(payload))
     end
 
     it "exits 0 and reports nothing when no payloads are present" do
@@ -293,6 +294,51 @@ RSpec.describe "benchmark regression reporting" do
         output, status = run_script(script, dir, gh_stub: failing_gh)
         expect(status).not_to be_success
         expect(output).to match(/Failed to file regression issue for Core/)
+      end
+    end
+
+    # The temporary /posts_page: Pro suppression (IGNORED_REGRESSION_BENCHMARKS). These
+    # examples (and the constant) should be deleted when that suppression is lifted.
+    it "suppresses the issue when every regressed benchmark is ignored" do
+      ignored = IGNORED_REGRESSION_BENCHMARKS.first
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-pro", suite: "Pro", regressed: [ignored])
+        output, status = run_script(script, dir, gh_stub: fake_gh)
+        expect(status).to be_success
+        expect(output).to match(/temporarily ignored/)
+        expect(output).not_to match(/Filing regression report/)
+      end
+    end
+
+    it "still files when a non-ignored benchmark also regressed alongside an ignored one" do
+      ignored = IGNORED_REGRESSION_BENCHMARKS.first
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-pro", suite: "Pro",
+                           regressed: [ignored, "/some_other_route: Pro"])
+        output, status = run_script(script, dir, gh_stub: fake_gh)
+        expect(status).to be_success
+        expect(output).to match(/Filing regression report for Pro/)
+      end
+    end
+
+    it "still files when another suite regressed even if this suite's regression is ignored" do
+      ignored = IGNORED_REGRESSION_BENCHMARKS.first
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-pro", suite: "Pro", regressed: [ignored])
+        write_payload(dir, artifact: "regression-core", suite: "Core", regressed: ["/hello: Core"])
+        output, status = run_script(script, dir, gh_stub: fake_gh)
+        expect(status).to be_success
+        expect(output).to match(/Filing regression report for Core/)
+        expect(output).to match(/Filing regression report for Pro/)
+      end
+    end
+
+    it "files normally when a payload omits the regressed-benchmarks list (fail-safe)" do
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-pro", suite: "Pro") # no regressed key
+        output, status = run_script(script, dir, gh_stub: fake_gh)
+        expect(status).to be_success
+        expect(output).to match(/Filing regression report for Pro/)
       end
     end
 

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -45,6 +45,43 @@ RSpec.describe "track_benchmarks" do
     end
   end
 
+  describe "#regressed_benchmark_names" do
+    it "returns the deduped benchmark names from active alerts" do
+      report = BencherReport.parse(
+        JSON.generate(
+          "results" => [],
+          "alerts" => [
+            { "benchmark" => { "name" => "/posts_page: Pro" },
+              "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" },
+            { "benchmark" => { "name" => "/posts_page: Pro" },
+              "threshold" => { "measure" => { "slug" => "p50-latency" } }, "status" => "active" },
+            { "benchmark" => { "name" => "/other: Pro" },
+              "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }
+          ]
+        )
+      )
+      expect(regressed_benchmark_names(report)).to contain_exactly("/posts_page: Pro", "/other: Pro")
+    end
+
+    it "is empty when there is no report" do
+      expect(regressed_benchmark_names(nil)).to eq([])
+    end
+
+    it "is empty when there are no active alerts" do
+      expect(regressed_benchmark_names(report_without_alert)).to eq([])
+    end
+
+    it "ignores non-active alerts (dismissed/silenced never count as regressions)" do
+      report = BencherReport.parse(
+        JSON.generate(
+          "results" => [],
+          "alerts" => [{ "benchmark" => { "name" => "/x: Pro" }, "status" => "dismissed" }]
+        )
+      )
+      expect(regressed_benchmark_names(report)).to eq([])
+    end
+  end
+
   describe "#retry_without_start_point_hash?" do
     it "is true when the start-point head version is missing and there is no regression" do
       expect(retry_without_start_point_hash?("Head Version abc123 not found", 1, report_without_alert)).to be(true)

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -279,6 +279,17 @@ def regression?(report)
   report&.regression? || false
 end
 
+# The names of the benchmarks Bencher raised an active alert for, deduped. Read from
+# the same alerts[] as #regression?, so it is exactly the set of rows the summary
+# table flags 🔴. Handed off to report-regressions so it can decide which benchmarks
+# regressed without re-parsing the rendered table. Empty when there is no report or no
+# alert carried a benchmark name.
+def regressed_benchmark_names(report)
+  return [] unless report
+
+  report.alerts.filter_map(&:benchmark).uniq
+end
+
 # A missing start-point baseline (operational, not a regression): retrying without
 # the start-point hash falls back to the latest baseline. The no-regression guard is
 # load-bearing — a real regression must not be silently re-run against a different
@@ -361,7 +372,8 @@ if __FILE__ == $PROGRAM_NAME
           JSON.generate(
             RegressionReport::SUITE_NAME => ENV.fetch("BENCHMARK_SUITE_GROUP", SUITE_NAME),
             RegressionReport::SHARD_LABEL => ENV.fetch("BENCHMARK_SHARD_LABEL", ""),
-            RegressionReport::SUMMARY => handoff_summary
+            RegressionReport::SUMMARY => handoff_summary,
+            RegressionReport::REGRESSED_BENCHMARKS => regressed_benchmark_names(report)
           )
         )
         Github.warning(


### PR DESCRIPTION
### Summary

Temporarily stops the benchmark CI from filing spurious "Performance Regression Detected on main" issues for `/posts_page: Pro`.

For several weeks `/posts_page: Pro` hard-500'd on every request (`failed_pct = 100`), so the route was effectively an instant error and Bencher built its rps/latency baseline from those bogus-fast failure responses. Now that the route is fixed, its real (slower) timings read as large regressions against that fast baseline and would open a new regression issue on **every** main push.

The benchmark's history can't be cleaned up directly in Bencher — deleting the benchmark is blocked by a `FOREIGN KEY constraint failed` from its existing reports/alerts, and archiving doesn't reset the baseline. So this suppresses the issue at the reporting layer instead.

How it works:

- `track_benchmarks.rb` now hands off the set of benchmarks Bencher raised an **active alert** on (`regressed_benchmark_names`, read from the same `alerts[]` that drives `regression?` and the 🔴 summary-table flags) via a new `regressed_benchmarks` key in the `regression.json` payload.
- `report_regressions.rb` skips filing when **every** regressed benchmark across all suite payloads is in the hardcoded `IGNORED_REGRESSION_BENCHMARKS` list (`["/posts_page: Pro"]`), and emits a `::notice::` so the active suppression stays visible in the workflow run summary.

Fails safe toward reporting — a payload missing the list, an empty list, an unreadable payload, or **any** non-ignored benchmark files the issue as before. A regression in another suite/benchmark is never suppressed.

**This is temporary.** The inline comment on `IGNORED_REGRESSION_BENCHMARKS` documents the removal condition: delete the entry (and the tagged spec examples) once the failure-era samples have rolled out of Bencher's 64-run t-test window for `/posts_page: Pro` on main and the dashboard baseline reflects real timings again.

### Pull Request checklist

- [x] Add/update test to cover these changes
- ~[ ] Update documentation~ — n/a (internal benchmark-CI tooling, no user-facing docs)
- ~[ ] Update CHANGELOG file~ — n/a (not a user-visible library change; CHANGELOG guidelines exclude test/tooling changes)

### Other Information

- Scope is `/posts_page: Pro` only, as intended — the `/rsc_posts_page_over_http: Pro` and `/rsc_posts_page_over_redis: Pro` variants still file regressions normally.
- New/updated tests: 4 suppression cases in `benchmarks/spec/report_regressions_spec.rb` (only-ignored suppressed; non-ignored alongside ignored still files; another suite still files; missing-list fail-safe) and 4 `regressed_benchmark_names` cases in `benchmarks/spec/track_benchmarks_spec.rb`.
- Verification: `bundle exec rspec spec/report_regressions_spec.rb spec/track_benchmarks_spec.rb` → 43 examples, 0 failures; `rubocop` on all changed files → no offenses (also passed the lefthook pre-commit autofix/rubocop pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Suppresses filing regression issues when all detected regressions match a configured ignore list, reducing noise for known/temporary cases.
  - Emits a CI-visible notice when filing is suppressed.
  - Regression hand-off payloads now include the list of affected benchmark names.

* **Tests**
  - Added end-to-end and unit tests covering suppression behavior and extraction/deduplication of regressed benchmark names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->