### PR TITLE
Docs: use async props pattern in metadata and render-function examples

### DIFF
--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -195,10 +195,14 @@ One of the biggest advantages of React 19 native metadata over react-helmet is *
 
 ### Async Components with Dynamic Metadata
 
-Metadata can be rendered inside async components within Suspense boundaries. When the async component resolves, React streams the metadata to the client and updates `<head>`:
+Metadata can be rendered inside async components within Suspense boundaries. When the async component resolves, React streams the metadata to the client and updates `<head>`.
+
+Use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) to stream slow data from Rails while showing a loading shell immediately. The parent component calls `getReactOnRailsAsyncProp` to obtain a Promise for each slow prop, passes it to an async child that `await`s it, and wraps that child in `<Suspense>`:
 
 ```jsx
-const UserProfile = async ({ user }) => {
+const UserProfile = async ({ userPromise }) => {
+  const user = await userPromise;
+
   return (
     <>
       <title>{`${user.name}'s Profile | My App`}</title>
@@ -209,75 +213,87 @@ const UserProfile = async ({ user }) => {
   );
 };
 
-const ProfilePage = ({ user }) => (
-  <div>
-    {/* Initial metadata shown while loading */}
-    <title>Loading Profile... | My App</title>
-    <meta property="og:site_name" content="My App" />
+const ProfilePage = ({ getReactOnRailsAsyncProp }) => {
+  const userPromise = getReactOnRailsAsyncProp('user');
 
-    <Suspense fallback={<ProfileSkeleton />}>
-      {/* Updated metadata streamed when resolved */}
-      <UserProfile user={user} />
-    </Suspense>
-  </div>
-);
+  return (
+    <div>
+      {/* Initial metadata shown while loading */}
+      <title>Loading Profile... | My App</title>
+      <meta property="og:site_name" content="My App" />
+
+      <Suspense fallback={<ProfileSkeleton />}>
+        {/* Updated metadata streamed when resolved */}
+        <UserProfile userPromise={userPromise} />
+      </Suspense>
+    </div>
+  );
+};
 ```
 
 ```erb
-<%# Rails view - controller prepares @user and passes it as props %>
-<%= stream_react_component("ProfilePage",
-                           props: { user: @user.as_json(only: %i[name bio]) },
-                           prerender: true) %>
+<%# Rails view — controller prepares @user; the emit block streams it as an async prop %>
+<%= stream_react_component_with_async_props("ProfilePage",
+                                            props: {}) do |emit|
+  emit.call("user", @user.as_json(only: %i[name bio]))
+end %>
 ```
 
-> **React on Rails note:** Keep authorization, database access, and cache-aware data loading in Rails. Pass the prepared data as props, or use streamed async props for Pro RSC flows, rather than fetching from inside the React component. See [RSC data fetching](../migrating/rsc-data-fetching.md).
+> **React on Rails note:** Keep authorization, database access, and cache-aware data loading in Rails. The `emit` block is ordinary Rails code — it runs inside the controller's request context with full access to authorization, caching, and tenancy. The React component never fetches data itself; it awaits the Promise that `getReactOnRailsAsyncProp` returns. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
-The initial `<title>` ("Loading Profile...") appears immediately. When `UserProfile` resolves, React replaces it with the user-specific title.
+The initial `<title>` ("Loading Profile...") appears immediately. When Rails emits the `user` prop via `emit.call`, the Promise resolves, `UserProfile` renders, and React replaces the title with the user-specific one.
 
 ### React Server Components (RSC) with Native Metadata
 
-Native metadata works in React Server Components too. Since RSC components run exclusively on the server, metadata tags are always server-rendered — ideal for SEO:
+Native metadata works in React Server Components too. Since RSC components run exclusively on the server, metadata tags are always server-rendered — ideal for SEO. Use async props so that slow article data streams in while the shell renders immediately:
 
 ```jsx
 // NativeMetadataRSCApp.jsx (no 'use client' directive — this is a Server Component)
 import React, { Suspense } from 'react';
 
-const AsyncContent = async ({ article }) => {
+const AsyncContent = async ({ articlePromise }) => {
+  const article = await articlePromise;
+
   return (
     <>
       <title>{article.title}</title>
       <meta name="description" content={article.excerpt} />
       <meta property="og:title" content={article.title} />
       <meta property="og:image" content={article.cover_image} />
+      <link rel="canonical" href={article.canonical_url} />
       <article>{article.body}</article>
     </>
   );
 };
 
-const ArticlePage = ({ article }) => (
-  <div>
-    <title>Loading...</title>
-    <link rel="canonical" href={article.canonical_url} />
-    <Suspense fallback={<ArticleSkeleton />}>
-      <AsyncContent article={article} />
-    </Suspense>
-  </div>
-);
+const ArticlePage = ({ getReactOnRailsAsyncProp }) => {
+  const articlePromise = getReactOnRailsAsyncProp('article');
+
+  return (
+    <div>
+      <title>Loading...</title>
+      <Suspense fallback={<ArticleSkeleton />}>
+        <AsyncContent articlePromise={articlePromise} />
+      </Suspense>
+    </div>
+  );
+};
 
 export default ArticlePage;
 ```
 
 ```erb
-<%# Rails view - controller prepares @article and passes it as props %>
-<%= stream_react_component("ArticlePage",
-                           props: { article: @article.as_json(
-                             only: %i[title excerpt cover_image body],
-                             methods: %i[canonical_url]
-                           ) },
-                           prerender: true) %>
+<%# Rails view — controller prepares @article; the emit block streams it as an async prop %>
+<%= stream_react_component_with_async_props("ArticlePage",
+                                            props: {}) do |emit|
+  emit.call("article", @article.as_json(
+    only: %i[title excerpt cover_image body],
+    methods: %i[canonical_url]
+  ))
+end %>
 ```
 
-> **React on Rails note:** RSC server components still run as part of a Rails-rendered request. Prefer Rails-prepared props for app data so Rails authorization, tenancy, caching, and instrumentation stay in one place. See [RSC data fetching](../migrating/rsc-data-fetching.md).
+> **React on Rails note:** RSC server components still run as part of a Rails-rendered request. The `emit` block keeps authorization, tenancy, caching, and instrumentation in Rails — the React component only awaits the Promise from `getReactOnRailsAsyncProp`. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 ## Hybrid Approach: Rails-Side + React-Side Metadata
 

--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -201,7 +201,12 @@ Use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow
 
 > **React on Rails Pro setup:** The controller must `include ReactOnRailsPro::Stream`, render the view via `stream_view_containing_react_components`, and set `config.enable_rsc_support = true` in `config/initializers/react_on_rails.rb`.
 
+> **Server Component boundary:** Async function components such as `UserProfile` must run in a Server Component tree. Keep this file free of a `'use client'` directive. If resolved data needs to cross into a Client Component, await it in the server component first and pass only serializable props.
+
 ```jsx
+import React, { Suspense } from 'react';
+
+// ProfilePage.jsx (no 'use client' directive; this is a Server Component tree)
 const UserProfile = async ({ userPromise, siteName }) => {
   const user = await userPromise;
 

--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -220,6 +220,8 @@ const UserProfile = async ({ userPromise, siteName }) => {
   );
 };
 
+const ProfileSkeleton = () => <p>Loading profile...</p>;
+
 const ProfilePage = ({ getReactOnRailsAsyncProp, siteName }) => {
   const userPromise = getReactOnRailsAsyncProp('user');
 
@@ -236,6 +238,8 @@ const ProfilePage = ({ getReactOnRailsAsyncProp, siteName }) => {
     </div>
   );
 };
+
+export default ProfilePage;
 ```
 
 > **Production note:** Wrap each `<Suspense>` in an `<ErrorBoundary>` so a rejected async-prop stream degrades to fallback UI instead of crashing the whole page. See the [error-handling pattern](../../pro/react-server-components/inside-client-components.md#error-handling) for a reusable boundary.

--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -200,12 +200,12 @@ Metadata can be rendered inside async components within Suspense boundaries. Whe
 Use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) to stream slow data from Rails while showing a loading shell immediately. The parent component calls `getReactOnRailsAsyncProp` to obtain a Promise for each slow prop, passes it to an async child that `await`s it, and wraps that child in `<Suspense>`:
 
 ```jsx
-const UserProfile = async ({ userPromise }) => {
+const UserProfile = async ({ userPromise, siteName }) => {
   const user = await userPromise;
 
   return (
     <>
-      <title>{`${user.name}'s Profile | My App`}</title>
+      <title>{`${user.name}'s Profile | ${siteName}`}</title>
       <meta name="description" content={`Profile page for ${user.name}`} />
       <h1>{user.name}</h1>
       <p>{user.bio}</p>
@@ -213,18 +213,18 @@ const UserProfile = async ({ userPromise }) => {
   );
 };
 
-const ProfilePage = ({ getReactOnRailsAsyncProp }) => {
+const ProfilePage = ({ getReactOnRailsAsyncProp, siteName }) => {
   const userPromise = getReactOnRailsAsyncProp('user');
 
   return (
     <div>
       {/* Initial metadata shown while loading */}
-      <title>Loading Profile... | My App</title>
-      <meta property="og:site_name" content="My App" />
+      <title>{`Loading Profile... | ${siteName}`}</title>
+      <meta property="og:site_name" content={siteName} />
 
       <Suspense fallback={<ProfileSkeleton />}>
         {/* Updated metadata streamed when resolved */}
-        <UserProfile userPromise={userPromise} />
+        <UserProfile userPromise={userPromise} siteName={siteName} />
       </Suspense>
     </div>
   );
@@ -232,20 +232,22 @@ const ProfilePage = ({ getReactOnRailsAsyncProp }) => {
 ```
 
 ```erb
-<%# Rails view — controller prepares @user; the emit block streams it as an async prop %>
+<%# Rails view — controller authorizes @user and captures request-scoped values first %>
+<% site_name = Current.account.name %>
+
 <%= stream_react_component_with_async_props("ProfilePage",
-                                            props: {}) do |emit|
+                                            props: { siteName: site_name }) do |emit|
   emit.call("user", @user.as_json(only: %i[name bio]))
 end %>
 ```
 
-> **React on Rails note:** Keep authorization, database access, and cache-aware data loading in Rails. The `emit` block is ordinary Rails code — it runs inside the controller's request context with full access to authorization, caching, and tenancy. The React component never fetches data itself; it awaits the Promise that `getReactOnRailsAsyncProp` returns. See [RSC data fetching](../migrating/rsc-data-fetching.md).
+> **React on Rails note:** Keep authorization, database access, and cache-aware data loading in Rails. When auth, tenancy, or request state lives in `CurrentAttributes`, capture the needed serializable values before entering async-props work, pass them as regular props or IDs, and resolve scoped records server-side before calling `emit.call`. The React component never fetches data itself; it awaits the Promise that `getReactOnRailsAsyncProp` returns. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 The initial `<title>` ("Loading Profile...") appears immediately. When Rails emits the `user` prop via `emit.call`, the Promise resolves, `UserProfile` renders, and React replaces the title with the user-specific one.
 
 ### React Server Components (RSC) with Native Metadata
 
-Native metadata works in React Server Components too. Since RSC components run exclusively on the server, metadata tags are always server-rendered — ideal for SEO. Use async props so that slow article data streams in while the shell renders immediately:
+Native metadata works in React Server Components too. Since RSC components run exclusively on the server, metadata tags are always server-rendered. Keep canonical URLs and any SEO-critical tags that Rails already knows in the first-wave shell, then use async props so that slower article content and metadata can stream in while the shell renders immediately:
 
 ```jsx
 // NativeMetadataRSCApp.jsx (no 'use client' directive — this is a Server Component)
@@ -260,18 +262,18 @@ const AsyncContent = async ({ articlePromise }) => {
       <meta name="description" content={article.excerpt} />
       <meta property="og:title" content={article.title} />
       <meta property="og:image" content={article.cover_image} />
-      <link rel="canonical" href={article.canonical_url} />
       <article>{article.body}</article>
     </>
   );
 };
 
-const ArticlePage = ({ getReactOnRailsAsyncProp }) => {
+const ArticlePage = ({ getReactOnRailsAsyncProp, canonicalUrl }) => {
   const articlePromise = getReactOnRailsAsyncProp('article');
 
   return (
     <div>
       <title>Loading...</title>
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
       <Suspense fallback={<ArticleSkeleton />}>
         <AsyncContent articlePromise={articlePromise} />
       </Suspense>
@@ -283,17 +285,18 @@ export default ArticlePage;
 ```
 
 ```erb
-<%# Rails view — controller prepares @article; the emit block streams it as an async prop %>
+<%# Rails view — controller authorizes @article and prepares first-wave SEO props %>
+<% canonical_url = @article.canonical_url %>
+
 <%= stream_react_component_with_async_props("ArticlePage",
-                                            props: {}) do |emit|
+                                            props: { canonicalUrl: canonical_url }) do |emit|
   emit.call("article", @article.as_json(
-    only: %i[title excerpt cover_image body],
-    methods: %i[canonical_url]
+    only: %i[title excerpt cover_image body]
   ))
 end %>
 ```
 
-> **React on Rails note:** RSC server components still run as part of a Rails-rendered request. The `emit` block keeps authorization, tenancy, caching, and instrumentation in Rails — the React component only awaits the Promise from `getReactOnRailsAsyncProp`. See [RSC data fetching](../migrating/rsc-data-fetching.md).
+> **React on Rails note:** RSC server components still run as part of a Rails-rendered request. Pass canonical URLs, tenant IDs, viewer IDs, and other first-wave context as explicit serializable props, or resolve the scoped records in Rails before streaming them through `emit.call`. The React component only awaits the Promise from `getReactOnRailsAsyncProp`. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 ## Hybrid Approach: Rails-Side + React-Side Metadata
 

--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -199,7 +199,7 @@ Metadata can be rendered inside async components within Suspense boundaries. Whe
 
 Use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) to stream slow data from Rails while showing a loading shell immediately. These APIs are available in React on Rails Pro: the parent component calls `getReactOnRailsAsyncProp` to obtain a Promise for each slow prop, passes it to an async child that `await`s it, and wraps that child in `<Suspense>`:
 
-> **React on Rails Pro setup:** The controller must `include ReactOnRailsPro::Stream`, render the view via `stream_view_containing_react_components`, and set `config.enable_rsc_support = true` in `config/initializers/react_on_rails.rb`.
+> **React on Rails Pro setup:** This async-props helper is Pro-only. The controller must `include ReactOnRailsPro::Stream` and render the view via `stream_view_containing_react_components` (see [Streaming SSR](../../pro/streaming-ssr.md#4-render-the-view-using-the-stream_view_containing_react_components-helper)), and RSC must be enabled with `config.enable_rsc_support = true` in `config/initializers/react_on_rails_pro.rb` (see [React on Rails Pro configuration](../configuration/configuration-pro.md)).
 
 > **Server Component boundary:** Async function components such as `UserProfile` must run in a Server Component tree. Keep this file free of a `'use client'` directive. If resolved data needs to cross into a Client Component, await it in the server component first and pass only serializable props.
 
@@ -242,7 +242,7 @@ const ProfilePage = ({ getReactOnRailsAsyncProp, siteName }) => {
 export default ProfilePage;
 ```
 
-> **Production note:** Wrap each `<Suspense>` in an `<ErrorBoundary>` so a rejected async-prop stream degrades to fallback UI instead of crashing the whole page. See the [error-handling pattern](../../pro/react-server-components/inside-client-components.md#error-handling) for a reusable boundary.
+> **Production note:** Error Boundaries help with client-side RSC payload fetches, refetches, and render-time failures after the initial stream. They do **not** catch errors thrown during the initial Server Component HTML stream; handle Rails/server-side failures before or inside `emit.call` with Rails-side rescue, logging, and serializable fallback values. See [Error Boundary limitations](../migrating/rsc-troubleshooting.md#error-boundary-limitations) and the [client-side retry pattern](../../pro/react-server-components/inside-client-components.md#error-handling).
 
 ```erb
 <%# Rails view — controller authorizes @user and captures request-scoped values first %>

--- a/docs/oss/building-features/react-19-native-metadata.md
+++ b/docs/oss/building-features/react-19-native-metadata.md
@@ -197,7 +197,9 @@ One of the biggest advantages of React 19 native metadata over react-helmet is *
 
 Metadata can be rendered inside async components within Suspense boundaries. When the async component resolves, React streams the metadata to the client and updates `<head>`.
 
-Use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) to stream slow data from Rails while showing a loading shell immediately. The parent component calls `getReactOnRailsAsyncProp` to obtain a Promise for each slow prop, passes it to an async child that `await`s it, and wraps that child in `<Suspense>`:
+Use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) to stream slow data from Rails while showing a loading shell immediately. These APIs are available in React on Rails Pro: the parent component calls `getReactOnRailsAsyncProp` to obtain a Promise for each slow prop, passes it to an async child that `await`s it, and wraps that child in `<Suspense>`:
+
+> **React on Rails Pro setup:** The controller must `include ReactOnRailsPro::Stream`, render the view via `stream_view_containing_react_components`, and set `config.enable_rsc_support = true` in `config/initializers/react_on_rails.rb`.
 
 ```jsx
 const UserProfile = async ({ userPromise, siteName }) => {
@@ -231,6 +233,8 @@ const ProfilePage = ({ getReactOnRailsAsyncProp, siteName }) => {
 };
 ```
 
+> **Production note:** Wrap each `<Suspense>` in an `<ErrorBoundary>` so a rejected async-prop stream degrades to fallback UI instead of crashing the whole page. See the [error-handling pattern](../../pro/react-server-components/inside-client-components.md#error-handling) for a reusable boundary.
+
 ```erb
 <%# Rails view — controller authorizes @user and captures request-scoped values first %>
 <% site_name = Current.account.name %>
@@ -247,7 +251,7 @@ The initial `<title>` ("Loading Profile...") appears immediately. When Rails emi
 
 ### React Server Components (RSC) with Native Metadata
 
-Native metadata works in React Server Components too. Since RSC components run exclusively on the server, metadata tags are always server-rendered. Keep canonical URLs and any SEO-critical tags that Rails already knows in the first-wave shell, then use async props so that slower article content and metadata can stream in while the shell renders immediately:
+Native metadata works in React Server Components too. Since RSC components run exclusively on the server, metadata tags are always server-rendered. Keep canonical URLs and any SEO-critical tags that Rails already knows in the first-wave shell, then use React on Rails Pro async props so that slower article content and metadata can stream in while the shell renders immediately:
 
 ```jsx
 // NativeMetadataRSCApp.jsx (no 'use client' directive — this is a Server Component)

--- a/docs/oss/core-concepts/render-functions.md
+++ b/docs/oss/core-concepts/render-functions.md
@@ -145,7 +145,7 @@ const MyComponent = (props, _railsContext) => {
 
 This and other promise options below are only available in React on Rails Pro with the Node renderer.
 
-> **React on Rails note:** Async render functions should still receive application data from Rails as regular props. For compatible streaming RSC flows, use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) (`getReactOnRailsAsyncProp`) with `stream_react_component_with_async_props`. Keep authorization, database access, and cache-aware loading in Rails rather than fetching inside the render function. See [RSC data fetching](../migrating/rsc-data-fetching.md).
+> **React on Rails note:** Async render functions should still receive application data from Rails as regular props. For streaming slow props behind Suspense boundaries, React on Rails Pro async props inject `getReactOnRailsAsyncProp` when the Rails view uses `stream_react_component_with_async_props`. That streaming setup requires the controller to `include ReactOnRailsPro::Stream`, render via `stream_view_containing_react_components`, and set `config.enable_rsc_support = true`. Keep authorization, database access, and cache-aware loading in Rails rather than fetching inside the render function. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
@@ -415,8 +415,8 @@ ReactOnRails.register({ AsyncObjectComponent });
                                       props: {
                                         data: {
                                           name: @user.name,
-                                          title: @page_title,
-                                          description: @page_description
+                                          title: "#{@user.name}'s Profile",
+                                          description: @user.bio
                                         }
                                       }) %>
 

--- a/docs/oss/core-concepts/render-functions.md
+++ b/docs/oss/core-concepts/render-functions.md
@@ -147,6 +147,8 @@ This and other promise options below are only available in React on Rails Pro wi
 
 > **React on Rails note:** Async render functions should still receive application data from Rails as regular props. For streaming slow props behind Suspense boundaries, React on Rails Pro async props inject `getReactOnRailsAsyncProp` when the Rails view uses `stream_react_component_with_async_props`. That streaming setup requires the controller to `include ReactOnRailsPro::Stream`, render via `stream_view_containing_react_components`, and set `config.enable_rsc_support = true`. Keep authorization, database access, and cache-aware loading in Rails rather than fetching inside the render function. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
+The `async` keyword is intentional in these examples: it makes the render function return a Promise so the Pro Node renderer can await the resolved string, hash, or component return value. The data is still prepared by Rails and read from props.
+
 ```jsx
 const MyComponent = async (props, _railsContext) => {
   const data = props.data;

--- a/docs/oss/core-concepts/render-functions.md
+++ b/docs/oss/core-concepts/render-functions.md
@@ -145,11 +145,11 @@ const MyComponent = (props, _railsContext) => {
 
 This and other promise options below are only available in React on Rails Pro with the Node renderer.
 
-> **React on Rails note:** Async render functions should still receive application data from Rails props whenever possible. Keep authorization, database access, and cache-aware loading in Rails, then pass the prepared data through `react_component`, `react_component_hash`, or Pro streamed async props. See [RSC data fetching](../migrating/rsc-data-fetching.md) for the same Rails-first data boundary applied to RSC.
+> **React on Rails note:** Async render functions should still receive application data from Rails — either as regular props or via [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) (`getReactOnRailsAsyncProp`). Keep authorization, database access, and cache-aware loading in Rails rather than fetching inside the render function. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
-  const data = await fetchData();
+  const data = await props.getReactOnRailsAsyncProp('data');
   return `<div>Hello ${data.name}</div>`;
 };
 ```
@@ -165,7 +165,7 @@ const MyComponent = async (props, _railsContext) => {
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
-  const data = await fetchData();
+  const data = await props.getReactOnRailsAsyncProp('data');
   return {
     componentHtml: `<div>Hello ${data.name}</div>`,
     title: `<title>${data.title}</title>`,
@@ -178,7 +178,7 @@ const MyComponent = async (props, _railsContext) => {
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
-  const data = await fetchData();
+  const data = await props.getReactOnRailsAsyncProp('data');
   return () => <div>Hello {data.name}</div>;
 };
 ```
@@ -382,7 +382,7 @@ ReactOnRails.register({ HelmetComponent });
 
 ```jsx
 const AsyncStringComponent = async (props) => {
-  const data = await fetchData();
+  const data = await props.getReactOnRailsAsyncProp('data');
   return `<div>Hello ${data.name}</div>`;
 };
 AsyncStringComponent.renderFunction = true;
@@ -391,14 +391,14 @@ ReactOnRails.register({ AsyncStringComponent });
 
 ```erb
 <%# Ruby %>
-<%= react_component("AsyncStringComponent", props: { dataUrl: "/api/data" }) %>
+<%= react_component("AsyncStringComponent", props: { name: @user.name }) %>
 ```
 
 ### Return Type 6: Promise of server-side hash
 
 ```jsx
 const AsyncObjectComponent = async (props) => {
-  const data = await fetchData();
+  const data = await props.getReactOnRailsAsyncProp('data');
   return {
     componentHtml: `<div>Hello ${data.name}</div>`,
     title: `<title>${data.title}</title>`,
@@ -411,7 +411,7 @@ ReactOnRails.register({ AsyncObjectComponent });
 
 ```erb
 <%# Ruby - MUST use react_component_hash %>
-<% helmet_data = react_component_hash("AsyncObjectComponent", props: { dataUrl: "/api/data" }) %>
+<% helmet_data = react_component_hash("AsyncObjectComponent", props: { name: @user.name }) %>
 
 <% content_for :head do %>
   <%= helmet_data["title"] %>
@@ -427,7 +427,7 @@ ReactOnRails.register({ AsyncObjectComponent });
 
 ```jsx
 const AsyncReactComponent = async (props) => {
-  const data = await fetchData();
+  const data = await props.getReactOnRailsAsyncProp('data');
   return () => <div>Hello {data.name}</div>;
 };
 AsyncReactComponent.renderFunction = true;
@@ -436,7 +436,7 @@ ReactOnRails.register({ AsyncReactComponent });
 
 ```erb
 <%# Ruby %>
-<%= react_component("AsyncReactComponent", props: { dataUrl: "/api/data" }) %>
+<%= react_component("AsyncReactComponent", props: { name: @user.name }) %>
 ```
 
 ### Return Type 8: Redirect Object (Legacy)

--- a/docs/oss/core-concepts/render-functions.md
+++ b/docs/oss/core-concepts/render-functions.md
@@ -145,11 +145,11 @@ const MyComponent = (props, _railsContext) => {
 
 This and other promise options below are only available in React on Rails Pro with the Node renderer.
 
-> **React on Rails note:** Async render functions should still receive application data from Rails — either as regular props or via [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) (`getReactOnRailsAsyncProp`). Keep authorization, database access, and cache-aware loading in Rails rather than fetching inside the render function. See [RSC data fetching](../migrating/rsc-data-fetching.md).
+> **React on Rails note:** Async render functions should still receive application data from Rails as regular props. For compatible streaming RSC flows, use [async props](../migrating/rsc-data-fetching.md#async-props-stream-each-slow-prop-independently) (`getReactOnRailsAsyncProp`) with `stream_react_component_with_async_props`. Keep authorization, database access, and cache-aware loading in Rails rather than fetching inside the render function. See [RSC data fetching](../migrating/rsc-data-fetching.md).
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
-  const data = await props.getReactOnRailsAsyncProp('data');
+  const data = props.data;
   return `<div>Hello ${data.name}</div>`;
 };
 ```
@@ -165,7 +165,7 @@ const MyComponent = async (props, _railsContext) => {
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
-  const data = await props.getReactOnRailsAsyncProp('data');
+  const data = props.data;
   return {
     componentHtml: `<div>Hello ${data.name}</div>`,
     title: `<title>${data.title}</title>`,
@@ -178,7 +178,7 @@ const MyComponent = async (props, _railsContext) => {
 
 ```jsx
 const MyComponent = async (props, _railsContext) => {
-  const data = await props.getReactOnRailsAsyncProp('data');
+  const data = props.data;
   return () => <div>Hello {data.name}</div>;
 };
 ```
@@ -382,7 +382,7 @@ ReactOnRails.register({ HelmetComponent });
 
 ```jsx
 const AsyncStringComponent = async (props) => {
-  const data = await props.getReactOnRailsAsyncProp('data');
+  const data = props.data;
   return `<div>Hello ${data.name}</div>`;
 };
 AsyncStringComponent.renderFunction = true;
@@ -391,14 +391,14 @@ ReactOnRails.register({ AsyncStringComponent });
 
 ```erb
 <%# Ruby %>
-<%= react_component("AsyncStringComponent", props: { name: @user.name }) %>
+<%= react_component("AsyncStringComponent", props: { data: { name: @user.name } }) %>
 ```
 
 ### Return Type 6: Promise of server-side hash
 
 ```jsx
 const AsyncObjectComponent = async (props) => {
-  const data = await props.getReactOnRailsAsyncProp('data');
+  const data = props.data;
   return {
     componentHtml: `<div>Hello ${data.name}</div>`,
     title: `<title>${data.title}</title>`,
@@ -411,7 +411,14 @@ ReactOnRails.register({ AsyncObjectComponent });
 
 ```erb
 <%# Ruby - MUST use react_component_hash %>
-<% helmet_data = react_component_hash("AsyncObjectComponent", props: { name: @user.name }) %>
+<% helmet_data = react_component_hash("AsyncObjectComponent",
+                                      props: {
+                                        data: {
+                                          name: @user.name,
+                                          title: @page_title,
+                                          description: @page_description
+                                        }
+                                      }) %>
 
 <% content_for :head do %>
   <%= helmet_data["title"] %>
@@ -427,7 +434,7 @@ ReactOnRails.register({ AsyncObjectComponent });
 
 ```jsx
 const AsyncReactComponent = async (props) => {
-  const data = await props.getReactOnRailsAsyncProp('data');
+  const data = props.data;
   return () => <div>Hello {data.name}</div>;
 };
 AsyncReactComponent.renderFunction = true;
@@ -436,7 +443,7 @@ ReactOnRails.register({ AsyncReactComponent });
 
 ```erb
 <%# Ruby %>
-<%= react_component("AsyncReactComponent", props: { name: @user.name }) %>
+<%= react_component("AsyncReactComponent", props: { data: { name: @user.name } }) %>
 ```
 
 ### Return Type 8: Redirect Object (Legacy)


### PR DESCRIPTION
## Summary
- Rewrites the two streaming metadata examples in `react-19-native-metadata.md` to use the async props API (`getReactOnRailsAsyncProp` / `stream_react_component_with_async_props`) instead of passing sync props to `async` components that never `await` anything
- Updates the `render-functions.md` async examples to consume Rails-prepared regular props, and points async-props usage to compatible `stream_react_component_with_async_props` RSC flows
- Replaces `dataUrl: "/api/data"` ERB props with Rails-prepared data props

## Motivation

PR #3525 fixed the issue of in-component data fetching (e.g. `await fetchUser(userId)`) but introduced a new problem: components marked `async` with no `await`, wrapped in `Suspense` that never triggers. The streaming narrative ("When `UserProfile` resolves, React replaces it…") became factually wrong since everything rendered synchronously.

The correct React on Rails pattern for async data in components is **async props** — `stream_react_component_with_async_props` emits props from Rails as they become available, and the React component awaits Promises from `getReactOnRailsAsyncProp`. This keeps data loading in Rails while giving `async`/`Suspense` real work to do. Render-function return-shape examples keep using regular Rails props because `react_component` / `react_component_hash` do not inject `getReactOnRailsAsyncProp`; async props belong with `stream_react_component_with_async_props`.

Fixes #3470

## Test plan
- [x] `pnpm exec prettier --check -- docs/oss/building-features/react-19-native-metadata.md docs/oss/core-concepts/render-functions.md`
- [x] `lychee --offline --include-fragments=full --exclude '^https?://.*' docs/oss/building-features/react-19-native-metadata.md docs/oss/core-concepts/render-functions.md`
- [x] `script/check-docs-sidebar origin/main`
- [x] Review metadata examples against the canonical async props pattern in `docs/oss/migrating/rsc-data-fetching.md`
- [x] Review render-function examples for helper compatibility: regular Rails props for `react_component` / `react_component_hash`, async props only with `stream_react_component_with_async_props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked async component examples to use promise-based async props for dynamic metadata and streaming.
  * Show initial metadata rendering (first wave) followed by streamed updates to title, meta, and headings after promises resolve.
  * Updated server-side examples to provide data/async props rather than fetching inside render functions.
  * Added guidance to wrap each streamed boundary in an ErrorBoundary for production.
  * Clarified server-side capture, resolution, and emission of streamed async props.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

