### PR TITLE
Require PR numbers in squash merge titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,8 @@ restores/saves the gem cache, and supports non-frozen installs via `frozen: 'fal
 
 **Commit messages**: Explain why, not what. One logical change per commit.
 
+**Squash merges**: When completing a GitHub squash merge, include the PR number in the squash commit title using the format `<PR title> (#<PR number>)`, for example `Docs: clarify rails new JavaScript skip flag (#3666)`. For CLI merges, pass `--subject "<PR title> (#<PR number>)"` to `gh pr merge --squash` and verify the title before confirming the merge.
+
 **PR creation**: Use `gh pr create` with a clear title, summary, and test plan.
 
 ## Review Workflow


### PR DESCRIPTION
## Summary

- Add canonical `AGENTS.md` guidance requiring GitHub squash merge commit titles to include the PR number.
- Document the `gh pr merge --squash --subject "<PR title> (#<PR number>)"` CLI pattern so agent-driven merges do not rely on GitHub defaults.

## Testing

- `pnpm exec prettier --check AGENTS.md`
- Pre-commit hook: trailing newline check, offline Markdown link check, Prettier
- Pre-push hook: branch Ruby lint check, online Markdown link check

Labels: none — docs-only agent instruction update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only agent workflow guidance in `AGENTS.md`; no application, CI, or runtime behavior changes.
> 
> **Overview**
> Adds a **Squash merges** rule to the canonical `AGENTS.md` **Git Workflow** section (between commit-message and PR-creation guidance).
> 
> Squash merge commit titles must follow `<PR title> (#<PR number>)`, with a concrete example. Agent-driven CLI merges should use `gh pr merge --squash` with `--subject "<PR title> (#<PR number>)"` and confirm the title before merging, instead of relying on GitHub’s default squash title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 089c943f4b93d5f4ee0f3b558906a8e4d6ebb023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with explicit instructions for formatting commit titles and PR numbers during GitHub squash merges, including CLI merge command guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->