### PR TITLE
Fix Pro dummy integration test gating

### DIFF
--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -48,6 +48,7 @@ jobs:
       non_runtime_only: ${{ steps.detect.outputs.non_runtime_only }}
       run_pro_lint: ${{ steps.detect.outputs.run_pro_lint }}
       run_pro_tests: ${{ steps.detect.outputs.run_pro_tests }}
+      run_pro_dummy_tests: ${{ steps.detect.outputs.run_pro_dummy_tests }}
       has_full_ci_label: ${{ steps.check-label.outputs.result }}
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +67,7 @@ jobs:
             {
               echo "run_pro_lint=true"
               echo "run_pro_tests=true"
+              echo "run_pro_dummy_tests=true"
               echo "docs_only=false"
               echo "non_runtime_only=false"
             } >> "$GITHUB_OUTPUT"
@@ -93,7 +95,8 @@ jobs:
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.run_pro_tests == 'true' ||
+        needs.detect-changes.outputs.run_pro_dummy_tests == 'true'
       )
     runs-on: ubuntu-22.04
     env:
@@ -193,7 +196,8 @@ jobs:
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.run_pro_tests == 'true' ||
+        needs.detect-changes.outputs.run_pro_dummy_tests == 'true'
       )
     runs-on: ubuntu-22.04
     env:
@@ -369,7 +373,8 @@ jobs:
       ) && (
         github.ref == 'refs/heads/main' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.run_pro_tests == 'true' ||
+        needs.detect-changes.outputs.run_pro_dummy_tests == 'true'
       )
     runs-on: ubuntu-22.04
     env:

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -96,6 +96,7 @@ setup_repo() {
   mkdir -p react_on_rails/spec/react_on_rails
   mkdir -p react_on_rails/app/helpers
   mkdir -p react_on_rails_pro/app/controllers/react_on_rails_pro/rolling_deploy
+  mkdir -p react_on_rails_pro/spec/dummy/spec/requests
   mkdir -p benchmarks/lib
   cat > docs/guide.md <<'DOC'
 # Guide
@@ -155,6 +156,13 @@ module ReactOnRailsPro
         "ok"
       end
     end
+  end
+end
+RUBY
+  cat > react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb <<'RUBY'
+RSpec.describe "posts page" do
+  it "renders" do
+    expect(true).to be(true)
   end
 end
 RUBY
@@ -454,6 +462,17 @@ test_pro_app_source_change_runs_pro_tests_only() {
   assert_contains "$out" '"run_js_tests": false' "pro app source output"
 }
 
+test_pro_dummy_only_change_runs_pro_dummy_tests_without_pro_unit_tests() {
+  setup_repo
+  perl -0pi -e 's/renders/renders seeded data/' react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+  commit_change "pro dummy spec"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_pro_dummy_tests": true' "pro dummy output"
+  assert_contains "$out" '"run_pro_tests": false' "pro dummy output"
+}
+
 test_pro_node_renderer_comment_only_change_runs_pro_lint_only() {
   setup_repo
   perl -0pi -e 's/export function/\/\/ Explains the Pro node renderer fixture.\nexport function/' \
@@ -674,6 +693,7 @@ run_test test_core_app_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_core_app_source_change_remains_runtime_affecting
 run_test test_pro_app_comment_only_change_runs_pro_lint_only
 run_test test_pro_app_source_change_runs_pro_tests_only
+run_test test_pro_dummy_only_change_runs_pro_dummy_tests_without_pro_unit_tests
 run_test test_pro_node_renderer_comment_only_change_runs_pro_lint_only
 run_test test_mixed_comment_and_code_change_remains_runtime_affecting
 run_test test_ruby_magic_comment_remains_runtime_affecting


### PR DESCRIPTION
## Summary

- expose the existing `run_pro_dummy_tests` detector output from `pro-integration-tests.yml`
- run the Pro dummy app bundle build, RSpec integration job, and Playwright job when Pro-dummy-only changes are detected
- add a detector harness regression for Pro dummy-only changes so `run_pro_dummy_tests` stays true while Pro unit tests remain false

Closes #3633.

## Validation

- `rg -q 'run_pro_dummy_tests' .github/workflows/pro-integration-tests.yml` (failed before the workflow change, passes after)
- `bash script/ci-changes-detector-test.bash` (38 run, 0 failed)
- `actionlint .github/workflows/pro-integration-tests.yml`
- `script/ci-changes-detector origin/main` (workflow change recommends broad CI)
- `git diff --check`
- `bash -n script/ci-changes-detector-test.bash`
- `pnpm exec prettier --check .github/workflows/pro-integration-tests.yml`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- `bundle exec rubocop` was attempted; it fails on pre-existing `react_on_rails/spike/3313_prism_gemfile_rewriter/*` offenses unrelated to this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure and testing configurations to improve build reliability and test coverage detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->