### PR TITLE
Clean up renderer dummy teardown follow-ups

### DIFF
--- a/react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx
@@ -23,10 +23,8 @@ import { wrapElementInStrictMode } from '../../app/strictModeSupport';
  *
  */
 export default (props, railsContext, domNodeId) => {
-  const { prerender } = props;
+  const { prerender, ...componentProps } = props;
   const render = prerender ? ReactDOM.hydrate : ReactDOM.render;
-  // eslint-disable-next-line no-param-reassign
-  delete props.prerender;
 
   const domNode = document.getElementById(domNodeId);
   if (!domNode) {
@@ -37,7 +35,7 @@ export default (props, railsContext, domNodeId) => {
   }
 
   const combinedReducer = combineReducers(reducers);
-  const combinedProps = composeInitialState(props, railsContext);
+  const combinedProps = composeInitialState(componentProps, railsContext);
 
   // This is where we'll put in the middleware for the async function. Placeholder.
   // store will have helloWorldData as a top level property

--- a/react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx
+++ b/react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx
@@ -19,8 +19,6 @@ import { wrapElementInStrictMode } from '../../app/strictModeSupport';
 export default (props, _railsContext, domNodeId) => {
   const { prerender } = props;
   const render = prerender ? ReactDOM.hydrate : ReactDOM.render;
-  // eslint-disable-next-line no-param-reassign
-  delete props.prerender;
 
   const domNode = document.getElementById(domNodeId);
   if (!domNode) {

--- a/react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx
+++ b/react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx
@@ -11,6 +11,8 @@ const App = (props, railsContext, domNodeId) =>
   // loadableReady resolves once the split chunks are present, then we hydrate. Returning the promise
   // (which resolves to a teardown wrapper) lets React on Rails unmount this root on Turbo/Turbolinks
   // navigation or same-id node replacement instead of leaking it. The callback form would discard it.
+  // Keep this Pro dummy dependency at @loadable/component >= 5.12.0; package.json requests ^5.16.3
+  // and the lockfile resolves 5.16.7, both of which support the Promise-returning loadableReady API.
   loadableReady().then(() => {
     const el = document.getElementById(domNodeId);
     // Navigation may remove the node before chunks resolve; no root was mounted,


### PR DESCRIPTION
## Summary

- Document the Pro dummy app's `@loadable/component` Promise-returning `loadableReady()` version assumption.
- Stop mutating `props.prerender` in the legacy React 16 dummy Redux startup path.

Closes #3689.

## Validation

- `gh issue view 3689 --repo shakacode/react_on_rails --json number,title,state,author,body,comments,labels,createdAt,updatedAt`
- `gh search issues --repo shakacode/react_on_rails "delete props.prerender"` (only #3689 found)
- `pnpm exec prettier --check react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx`
- `pnpm exec eslint react_on_rails/spec/dummy/client/app-react16/startup/ReduxApp.client.jsx react_on_rails/spec/dummy/client/app-react16/startup/ReduxSharedStoreApp.client.jsx react_on_rails_pro/spec/dummy/client/app/loadable/loadable-client.imports-loadable.jsx`
- `git diff --cached --check`
- `script/ci-changes-detector origin/main fix/3689-dummy-renderer-props-cleanup`

Note: `bundle exec rubocop` was run per repo policy but failed on unrelated existing/generated files outside this PR's diff, including `react_on_rails/spec/react_on_rails/dummy-for-generators/*` and `react_on_rails/spike/3313_prism_gemfile_rewriter/*`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/dummy client startup changes only; no production auth, data, or core library behavior.
> 
> **Overview**
> Follow-up cleanup for dummy renderer teardown (#3689).
> 
> **ReduxApp.client.jsx** no longer mutates incoming `props` by deleting `prerender`. It destructures `prerender` into `componentProps` and passes only `componentProps` into `composeInitialState`, avoiding param reassignment and eslint suppressions.
> 
> **ReduxSharedStoreApp.client.jsx** drops the same `delete props.prerender` pattern (it only needed `prerender` for hydrate vs render).
> 
> **loadable-client.imports-loadable.jsx** adds a comment documenting the Pro dummy’s `@loadable/component` version floor (≥5.12.0) for the Promise-returning `loadableReady()` API used for teardown on navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60afe44c67427875a57e93ec7f903585981e01fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal prop handling to prevent unintended mutations in Redux startup functions.
  * Updated documentation comments for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->