### PR TITLE
Improve create-app smoke diagnostics

### DIFF
--- a/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
+++ b/packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh
@@ -183,7 +183,11 @@ verify_generated_app_runtime() {
 
   app_name="$(basename "$app_dir")"
   echo "Building test bundles for $app_name..."
-  if ! pushd "$app_dir" >/dev/null; then
+  if [[ ! -d "$app_dir" ]]; then
+    echo "Generated app directory is missing for $app_name: $app_dir" >&2
+    return 1
+  fi
+  if ! pushd "$app_dir" >/dev/null 2>&1; then
     echo "Cannot cd to generated app directory for $app_name: $app_dir" >&2
     return 1
   fi

--- a/packages/create-react-on-rails-app/tests/smoke-test-local-gems.test.ts
+++ b/packages/create-react-on-rails-app/tests/smoke-test-local-gems.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const smokeScriptPath = path.resolve(__dirname, '../scripts/smoke-test-local-gems.sh');
+
+function extractBashFunction(source: string, functionName: string): string {
+  const startMarker = `${functionName}() {`;
+  const startIndex = source.indexOf(startMarker);
+  if (startIndex === -1) {
+    throw new Error(`Could not find ${functionName} in ${smokeScriptPath}`);
+  }
+
+  const functionLines: string[] = [];
+  let braceDepth = 0;
+  for (const line of source.slice(startIndex).split('\n')) {
+    functionLines.push(line);
+    for (const char of line) {
+      if (char === '{') braceDepth += 1;
+      if (char === '}') braceDepth -= 1;
+    }
+
+    if (braceDepth === 0) return functionLines.join('\n');
+  }
+
+  throw new Error(`Could not parse ${functionName} in ${smokeScriptPath}`);
+}
+
+describe('smoke-test-local-gems.sh', () => {
+  const smokeScript = fs.readFileSync(smokeScriptPath, 'utf8');
+
+  it('reports a missing generated app directory without leaking pushd output', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ror-smoke-test-'));
+    const missingAppDir = path.join(tempRoot, 'missing-app');
+    const harness = [
+      'set -Eeuo pipefail',
+      'PNPM_CMD=(false)',
+      extractBashFunction(smokeScript, 'verify_generated_app_runtime'),
+      'verify_generated_app_runtime "$1"',
+    ].join('\n');
+
+    try {
+      const result = spawnSync('bash', ['-c', harness, 'smoke-harness', missingAppDir], {
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Building test bundles for missing-app...');
+      expect(result.stderr).toContain(`Generated app directory is missing for missing-app: ${missingAppDir}`);
+      expect(result.stderr).not.toContain('pushd:');
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -8,8 +8,8 @@ module ReactOnRails
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
       RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*(.*?)\s*$/
-      TOP_LEVEL_SECTION_HEADER = /\A(?:<%.*?%>\s*)*([A-Za-z0-9_-]+):(?:\s|$)/
-      TOP_LEVEL_SECTION_ANCHOR = /\A(?:<%.*?%>\s*)*[A-Za-z0-9_-]+:\s*&([A-Za-z0-9_-]+)/
+      TOP_LEVEL_SECTION_HEADER = /\A([A-Za-z0-9_-]+):(?:\s|$)/
+      TOP_LEVEL_SECTION_ANCHOR = /\A[A-Za-z0-9_-]+:\s*&([A-Za-z0-9_-]+)/
       # YAML boolean scalars, including truthy values, are not valid shell commands.
       UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE = /\A(?:|~|null|false|true|yes|no|on|off)\z/i
       SHAKAPACKER_YML_QUOTE_CHARACTERS = ['"', "'"].freeze
@@ -121,8 +121,8 @@ module ReactOnRails
 
       def shakapacker_yml_anchor_index(sections)
         sections.filter_map do |section|
-          match = section.match(TOP_LEVEL_SECTION_ANCHOR)
-          [match[1], shakapacker_yml_section_name(section)] if match
+          anchor_name = shakapacker_yml_section_anchor(section)
+          [anchor_name, shakapacker_yml_section_name(section)] if anchor_name
         end.to_h
       end
 
@@ -151,7 +151,24 @@ module ReactOnRails
       end
 
       def shakapacker_yml_section_name(section)
-        section.match(TOP_LEVEL_SECTION_HEADER)&.[](1)
+        shakapacker_yml_section_header_source(section).match(TOP_LEVEL_SECTION_HEADER)&.[](1)
+      end
+
+      def shakapacker_yml_section_anchor(section)
+        shakapacker_yml_section_header_source(section).match(TOP_LEVEL_SECTION_ANCHOR)&.[](1)
+      end
+
+      def shakapacker_yml_section_header_source(section)
+        line = section.each_line.first.to_s.lstrip
+
+        while line.start_with?("<%")
+          erb_end = line.index("%>")
+          break unless erb_end
+
+          line = line[(erb_end + 2)..].to_s.lstrip
+        end
+
+        line
       end
 
       def raw_active_precompile_hook_in_section_tree?(section_name, section_index, anchor_index, visited = {})

--- a/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
+++ b/react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb
@@ -8,6 +8,8 @@ module ReactOnRails
       DEFAULT_PRECOMPILE_HOOK_COMMAND = "bin/shakapacker-precompile-hook"
       COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER = /^(\s*)#\s*precompile_hook:\s*~\s*$/
       RAW_PRECOMPILE_HOOK_VALUE = /^\s+precompile_hook:\s*(.*?)\s*$/
+      TOP_LEVEL_SECTION_HEADER = /\A(?:<%.*?%>\s*)*([A-Za-z0-9_-]+):(?:\s|$)/
+      TOP_LEVEL_SECTION_ANCHOR = /\A(?:<%.*?%>\s*)*[A-Za-z0-9_-]+:\s*&([A-Za-z0-9_-]+)/
       # YAML boolean scalars, including truthy values, are not valid shell commands.
       UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE = /\A(?:|~|null|false|true|yes|no|on|off)\z/i
       SHAKAPACKER_YML_QUOTE_CHARACTERS = ['"', "'"].freeze
@@ -15,6 +17,7 @@ module ReactOnRails
       ShakapackerYmlDocument = Struct.new(:sections, :section_index, :anchor_index, keyword_init: true)
       private_constant :SHAKAPACKER_YML_PATH, :DEFAULT_PRECOMPILE_HOOK_COMMAND,
                        :COMMENTED_PRECOMPILE_HOOK_PLACEHOLDER, :RAW_PRECOMPILE_HOOK_VALUE,
+                       :TOP_LEVEL_SECTION_HEADER, :TOP_LEVEL_SECTION_ANCHOR,
                        :UNQUOTED_INACTIVE_PRECOMPILE_HOOK_VALUE, :SHAKAPACKER_YML_QUOTE_CHARACTERS,
                        :ShakapackerYmlErbError, :ShakapackerYmlDocument
 
@@ -106,8 +109,9 @@ module ReactOnRails
       end
 
       def shakapacker_yml_sections(content)
-        # Split at top-level YAML mapping keys. Top-level comments and document
-        # separators become harmless single-line sections with no recognized name.
+        # Split at top-level YAML mapping keys and standalone ERB wrapper lines.
+        # Top-level comments and document separators become harmless single-line
+        # sections with no recognized name.
         content.each_line.slice_before { |line| line.match?(/^\S/) }.map(&:join)
       end
 
@@ -117,7 +121,7 @@ module ReactOnRails
 
       def shakapacker_yml_anchor_index(sections)
         sections.filter_map do |section|
-          match = section.match(/\A[A-Za-z0-9_-]+:\s*&([A-Za-z0-9_-]+)/)
+          match = section.match(TOP_LEVEL_SECTION_ANCHOR)
           [match[1], shakapacker_yml_section_name(section)] if match
         end.to_h
       end
@@ -147,7 +151,7 @@ module ReactOnRails
       end
 
       def shakapacker_yml_section_name(section)
-        section.match(/\A([A-Za-z0-9_-]+):(?:\s|$)/)&.[](1)
+        section.match(TOP_LEVEL_SECTION_HEADER)&.[](1)
       end
 
       def raw_active_precompile_hook_in_section_tree?(section_name, section_index, anchor_index, visited = {})

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -521,6 +521,18 @@ RSpec.describe GeneratorHelper, type: :generator do
         <% end %>
       YAML
     end
+
+    it "detects raw active hooks inherited from anchored sections opened by repeated same-line ERB tags" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        <% if true %><% if true %>default: &default
+          precompile_hook: <%= false %>
+        <% end %><% end %>
+
+        test:
+          <<: *default
+          # precompile_hook: ~
+      YAML
+    end
   end
 
   describe "#raw_precompile_hook_value" do

--- a/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb
@@ -512,6 +512,15 @@ RSpec.describe GeneratorHelper, type: :generator do
           # precompile_hook: ~
       YAML
     end
+
+    it "detects raw active hooks in sections opened by same-line ERB control tags" do
+      expect(active_precompile_hook_configured?(<<~YAML)).to be(true)
+        <% if true %>test:
+          precompile_hook: <%= false %>
+          # precompile_hook: ~
+        <% end %>
+      YAML
+    end
   end
 
   describe "#raw_precompile_hook_value" do


### PR DESCRIPTION
## Summary

- Report a missing generated app directory before `pushd` so create-app smoke diagnostics distinguish scaffold failure from build failure.
- Add a focused Jest harness for the missing-directory diagnostic.
- Harden Shakapacker YAML raw-section detection for same-line ERB control tags wrapping top-level sections.

Closes #3649.

## Validation

- `gh issue view 3649 --repo shakacode/react_on_rails --json number,title,state,author,body,comments,labels,createdAt,updatedAt`
- `gh search issues --repo shakacode/react_on_rails "smoke-test-local-gems generated app directory missing pushd"` (no duplicate issues found)
- `pnpm --filter create-react-on-rails-app test`
- `bash -n packages/create-react-on-rails-app/scripts/smoke-test-local-gems.sh`
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb`
- `bundle exec rubocop react_on_rails/lib/generators/react_on_rails/shakapacker_precompile_hook_helper.rb react_on_rails/spec/react_on_rails/generators/generator_helper_spec.rb`
- `pnpm exec prettier --check packages/create-react-on-rails-app/tests/smoke-test-local-gems.test.ts`
- `git diff --cached --check`
- `script/ci-changes-detector origin/main fix/3649-create-app-smoke-diagnostics`

Note: full `bundle exec rubocop` was attempted and still fails on unrelated generated/spike files outside this PR's diff (`react_on_rails/spec/react_on_rails/dummy-for-generators/*` and `react_on_rails/spike/3313_prism_gemfile_rewriter/*`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to smoke-test messaging and generator-side YAML/ERB parsing for precompile hooks; no runtime auth or data paths.
> 
> **Overview**
> Improves **create-app smoke diagnostics** and **Shakapacker YAML section parsing** when ERB wraps top-level keys.
> 
> In `verify_generated_app_runtime`, a **missing generated app directory** is detected before `pushd`, with a dedicated stderr message so failures read as scaffold problems rather than noisy `pushd` errors. A **Jest harness** exercises that path and asserts `pushd:` does not appear on stderr.
> 
> In `ShakapackerPrecompileHookHelper`, section **names and YAML anchors** are resolved from a header line that **strips leading same-line `<% ... %>` tags** (e.g. `<% if true %>test:`), so raw `precompile_hook` detection and inheritance still work when sections are opened by ERB control tags. Specs cover same-line ERB sections and anchored defaults behind repeated ERB tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b9eaf8699837b88b2a700ec38fede7a011a532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering app-generation verification and YAML/ERB-wrapped configuration detection.

* **Bug Fixes**
  * Cleaner error handling and quieter failure output when a generated app is missing.

* **Improvements**
  * Better handling of YAML sections prefixed by ERB to more reliably detect configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->