### PR TITLE
Cover streamed RSC posts content

### DIFF
--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -202,6 +202,17 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+    # Redis backs streamed RSC fixtures covered by the request specs.
+    services:
+      redis:
+        image: cimg/redis:6.2.6
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/react_on_rails_pro/spec/dummy/spec/requests/rsc_posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/rsc_posts_page_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Integration coverage for the streaming RSC posts benchmark route (issue #3625).
+#
+# The route can flush HTTP 200 before the body finishes rendering, so this spec
+# asserts user-visible streamed post content rather than status alone.
+# The HTTP variant still fetches from a hard-coded local server URL; this covers
+# the Redis route, which can be exercised in request specs with a Redis service.
+RSpec.describe "RSC posts page", :server_rendering do
+  before do
+    # Match posts_page_spec.rb: maintain_test_schema! is disabled in this suite,
+    # so DB-backed request specs must load the schema when needed.
+    unless %i[users posts comments].all? { |t| ActiveRecord::Base.connection.table_exists?(t) }
+      ActiveRecord::Schema.verbose = false
+      load Rails.root.join("db/schema.rb")
+    end
+
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+
+    2.times do |i|
+      user = User.create!(name: "User #{i + 1}", email: "user-#{i + 1}@example.com")
+      post = user.posts.create!(title: "Sentinel Post #{i + 1}", body: "Body of sentinel post #{i + 1}.")
+      post.comments.create!(user: user, body: "Comment on sentinel post #{i + 1}.")
+    end
+  end
+
+  after do
+    Comment.delete_all
+    Post.delete_all
+    User.delete_all
+  end
+
+  it "streams seeded posts over Redis and returns 200" do
+    get "/rsc_posts_page_over_redis"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("RSC Posts Page")
+    expect(response.body).to include("Sentinel Post 1")
+    expect(response.body).to include("Sentinel Post 2")
+    expect(response.body).not_to include("Error in RSC stream")
+  end
+end


### PR DESCRIPTION
## Summary

- Add Pro dummy request coverage for the Redis-backed streaming RSC posts route.
- Assert the streamed body includes real seeded post content, not just HTTP 200.
- Guard against the body falling back to an RSC stream error payload.

Refs #3625.

## Notes

This covers `/rsc_posts_page_over_redis`, which can be exercised in a request spec with a Redis service. The HTTP variant still fetches from hard-coded `http://localhost:3000` URLs inside the RSC component, so it needs a separate host/benchmark decision before a request spec can assert real post content there.

## Validation

- `gh issue view 3625 --repo shakacode/react_on_rails --json number,title,state,author,body,comments,labels,createdAt,updatedAt`
- `gh search issues --repo shakacode/react_on_rails "streaming RSC posts route coverage broken body"` (no duplicate issues found)
- `bundle exec rubocop react_on_rails_pro/spec/dummy/spec/requests/rsc_posts_page_spec.rb`
- `git diff --check -- react_on_rails_pro/spec/dummy/spec/requests/rsc_posts_page_spec.rb`
- `redis-server --port 6379 --save "" --appendonly no --dir /private/tmp`
- `cd react_on_rails_pro/spec/dummy && bundle exec rspec spec/requests/rsc_posts_page_spec.rb`
- `script/ci-changes-detector origin/main test/3625-streaming-rsc-posts-coverage`

The spec was first run without Redis and failed by returning HTTP 200 with an RSC stream error body, confirming the assertion catches the silent-failure class described in the issue. It passed after starting local Redis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new request specs and CI service configuration; no production runtime behavior is modified.
> 
> **Overview**
> Adds integration test coverage for the Pro dummy **Redis-backed streaming RSC posts** route (`/rsc_posts_page_over_redis`), addressing silent failures where HTTP 200 can return before the stream finishes with real content.
> 
> The new request spec seeds posts in the DB, hits the route, and asserts the response body includes the page title and sentinel post titles while **excluding** `Error in RSC stream`. Pro integration CI’s **Node renderer RSpec** job now runs a **Redis 6.2** service container (with health checks), matching the dependency already used on the Playwright E2E job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe452d7cd93d44a7027427b8f83447afcf782bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added request spec covering the RSC posts page streaming route: verifies successful response, streamed page title and seeded post content are present, and that no streaming error text appears.
* **Chores**
  * Updated integration workflow to provision a Redis service to support streamed request-spec fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->