### PR TITLE
Replace custom MockClient with async-http Mock::Endpoint

### DIFF
--- a/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/helpers/react_on_rails_pro_helper_spec.rb
@@ -612,9 +612,9 @@ describe ReactOnRailsProHelper do
 
       def execute_stream_view_containing_react_components
         queue = Async::Queue.new
-        mock_request_and_response(queue)
 
         Sync do |parent|
+          mock_request_and_response(queue)
           parent.async { stream_view_containing_react_components(template: template_path) }
 
           chunks_to_write = chunks.dup
@@ -684,7 +684,7 @@ describe ReactOnRailsProHelper do
         original_prerender_caching = ReactOnRailsPro.configuration.prerender_caching
         ReactOnRailsPro.configuration.prerender_caching = true
         Rails.cache.clear
-        example.run
+        Sync { example.run }
       ensure
         ReactOnRailsPro.configuration.prerender_caching = original_prerender_caching
         Rails.cache.clear

--- a/react_on_rails_pro/spec/react_on_rails_pro/support/mock_stream_helper.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/support/mock_stream_helper.rb
@@ -112,6 +112,8 @@ module MockStreamHelper
     end
 
     ::Protocol::HTTP::Response[status, {}, body]
+  rescue RuntimeError => e
+    ::Protocol::HTTP::Response[500, {}, [e.message]]
   end
 
   def stub_renderer_client(origin, wrapped_endpoint)

--- a/react_on_rails_pro/spec/react_on_rails_pro/support/mock_stream_helper.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/support/mock_stream_helper.rb
@@ -2,94 +2,9 @@
 
 require "json"
 require "uri"
+require "async/http/mock"
 
 module MockStreamHelper
-  class MockRequest
-    attr_reader :url, :path, :form, :json, :stream
-
-    def initialize(url:, path:, form:, json:, stream:)
-      @url = url
-      @path = path
-      @form = form
-      @json = json
-      @stream = stream
-    end
-
-    def body
-      if form
-        URI.encode_www_form(flat_form)
-      elsif json
-        JSON.generate(json)
-      else
-        ""
-      end
-    end
-
-    private
-
-    def flat_form
-      form.each_with_object([]) do |(key, value), pairs|
-        next pairs << [key, "[file]"] if value.is_a?(Hash) && value.key?(:body)
-
-        if value.is_a?(Array)
-          value.each { |item| pairs << ["#{key}[]", item] }
-        else
-          pairs << [key, value]
-        end
-      end
-    end
-  end
-
-  class MockClient
-    def initialize(origin)
-      @origin = origin
-    end
-
-    def post(path, form: nil, json: nil, stream: false)
-      request = MockRequest.new(url: full_url(path), path:, form:, json:, stream:)
-      build_response(request)
-    end
-
-    def get(path)
-      request = MockRequest.new(url: full_url(path), path:, form: nil, json: nil, stream: false)
-      build_response(request)
-    end
-
-    def post_bidi(_path, headers: [])
-      raise NotImplementedError, "MockClient does not support post_bidi; use a real renderer for incremental tests"
-    end
-
-    def close; end
-
-    private
-
-    def full_url(path)
-      "#{@origin}#{path}"
-    end
-
-    def build_response(request)
-      status, block, request_data = MockStream.next_response(request.url)
-      request_data[:request] = request
-
-      if request.stream
-        return ReactOnRailsPro::RendererHttpClient::Response.new(status:) do |yielder, _status_assigner|
-          # The mock pre-sets status above; pass the request so specs can assert on the captured payload.
-          block.call(->(value) { yielder.call(value) }, request)
-        end
-      end
-
-      chunks = []
-      error = nil
-      begin
-        block.call(->(value) { chunks << value }, request)
-      rescue StandardError => e
-        error = e
-      end
-
-      ReactOnRailsPro::RendererHttpClient::Response.new(status:, body: chunks, error:)
-    end
-  end
-
   module MockStream
     class << self
       def mock_responses
@@ -163,7 +78,48 @@ module MockStreamHelper
 
   def install_renderer_http_client_mock(origin)
     ReactOnRailsPro::Request.instance_variable_set(:@connection, nil)
-    allow(ReactOnRailsPro::Request).to receive(:create_connection).and_return(MockClient.new(origin))
+
+    mock_endpoint = Async::HTTP::Mock::Endpoint.new
+    real_endpoint = Async::HTTP::Endpoint.parse(origin)
+    wrapped_endpoint = mock_endpoint.wrap(real_endpoint)
+
+    start_mock_server(mock_endpoint)
+    stub_renderer_client(origin, wrapped_endpoint)
+  end
+
+  private
+
+  def start_mock_server(mock_endpoint)
+    Async(transient: true) do
+      mock_endpoint.run do |request|
+        handle_mock_request(request)
+      end
+    end
+  end
+
+  def handle_mock_request(request)
+    url = "#{request.scheme}://#{request.authority}#{request.path}"
+    status, block, request_data = MockStream.next_response(url)
+    request_data[:request] = request
+
+    body = Protocol::HTTP::Body::Writable.new
+    Async do
+      block.call(->(value) { body.write(value) })
+    rescue StandardError => e
+      body.close(e)
+    else
+      body.close_write
+    end
+
+    ::Protocol::HTTP::Response[status, {}, body]
+  end
+
+  def stub_renderer_client(origin, wrapped_endpoint)
+    client = ReactOnRailsPro::RendererHttpClient.new(
+      origin:, pool_size: 1, connect_timeout: 5, read_timeout: 5, force_http2: false
+    )
+    allow(client).to receive(:endpoint_for).and_return(wrapped_endpoint)
+    allow(ReactOnRailsPro::Request).to receive(:create_connection).and_return(client)
   end
 end
 


### PR DESCRIPTION
## Summary

Closes #3386.

- Removes `MockClient` (~49 lines) and `MockRequest` (~35 lines) from `mock_stream_helper.rb`, replacing them with `Async::HTTP::Mock::Endpoint` — an in-process HTTP/2 server over Unix socket pairs
- `install_renderer_http_client_mock` now creates a **real** `RendererHttpClient` whose `endpoint_for` is stubbed to route through the mock endpoint, so tests exercise the full async-http protocol stack
- `MockStream` registry (URL pattern matching, count-based depletion, request capture) is preserved unchanged — no test API changes
- Net result: 177 → 133 lines (−44), real HTTP/2 coverage in tests

## Test plan

- [x] All 504 Pro unit tests pass (`bundle exec rspec spec/react_on_rails_pro/`) — 0 failures, 1 pre-existing pending (#3300)
- [x] Rubocop clean on changed file
- [x] Verified no other files reference `MockClient` or `MockRequest`
- [x] Verified both callers of `install_renderer_http_client_mock` (helper_spec lines 346 and 939) run inside `Sync {}` blocks
- [x] Verified both `mock_streaming_response` blocks use `|yielder|` signature only (no `|yielder, request|`)
- [ ] CI: `react_on_rails_pro_helper_spec.rb` integration tests (needs PostgreSQL, unavailable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Upgraded renderer-client test infrastructure to use a realistic async mock HTTP endpoint, exercising streaming responses, full request-URL handling, transient server interactions, and clearer error-path behavior to better mirror real renderer traffic.
  * Adjusted test async timing: streaming mocks and a caching around-hook now run inside the synchronous async context to ensure reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->