### PR TITLE
Apply RSC dependency manager review nits

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -408,6 +408,7 @@ module ReactOnRails
       end
 
       def add_rsc_dependencies
+        # Defaults used by the rescue block if rsc_packages_with_version raises before assigning.
         rsc_packages = RSC_DEPENDENCIES
         used_version_pins = false
         say "Installing React Server Components dependencies..."
@@ -475,8 +476,9 @@ module ReactOnRails
         [
           summary,
           rsc_dependency_pin_failure_details(used_version_pins),
+          "",
           "You can install them manually by running:",
-          "  #{manual_add_packages_command(rsc_packages)}"
+          "    #{manual_add_packages_command(rsc_packages)}"
         ].compact.join("\n")
       end
 
@@ -705,6 +707,8 @@ module ReactOnRails
         return false unless package_name_and_version
 
         _package_name, package_version = package_name_and_version
+        # Covers the only range operators used in this codebase's DEPENDENCIES constants (~ and ^).
+        # Other npm range forms (>, >=, <, <=, *, x, X, hyphen) are intentionally not handled.
         package_version.start_with?("~", "^")
       end
 

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -759,9 +759,16 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
       instance.send(:add_rsc_dependencies)
 
       warning_text = warnings.join("\n")
+      expected_recovery = <<~MSG.strip
+        pin lookup failed
+
+        You can install them manually by running:
+            npm install --save-exact react-on-rails-rsc
+      MSG
+
       expect(warning_text).to include("Error adding React Server Components dependencies: pin lookup failed")
-      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc")
-      expect(warning_text).not_to include("pin lookup failed\n\nYou can install")
+      expect(warning_text).to include(expected_recovery)
+      expect(warning_text).not_to include("Could not install the pinned react-on-rails-rsc")
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #3678.

Carries forward the post-merge cleanup from `68db9bb8` on top of current `origin/main`:

- clarifies the fallback defaults used when RSC dependency pin lookup raises
- keeps the fallback recovery message formatting consistent, including the manual install command indentation
- documents that npm range detection intentionally covers the `~` and `^` operators used by this codebase constants

## Validation

- `script/ci-changes-detector origin/main` -> generator changes detected; RSpec gem tests and generator tests recommended
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb` -> 78 examples, 0 failures
- `RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb` -> 2 files inspected, no offenses
- `git diff --check` -> clean

## Self-review

- Diff is limited to `react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb` and its targeted spec.
- No unrelated generator behavior changes beyond the review-nit cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and user-facing warning formatting only; generator dependency behavior is unchanged aside from whitespace in messages.
> 
> **Overview**
> Small **review-nit cleanup** in the RSC path of `JsDependencyManager`—no new install logic.
> 
> **`add_rsc_dependencies`** now documents why `rsc_packages` is initialized to `RSC_DEPENDENCIES` before pin resolution (so the `rescue` path still has sensible package names if `rsc_packages_with_version` raises).
> 
> **`rsc_dependency_failure_message`** adds a blank line before the manual-install section and indents the suggested `npm install` line (four spaces) so RSC failure/recovery warnings read consistently.
> 
> **`package_uses_semver_range?`** gets an inline note that range detection is limited to `~` and `^`, matching how `DEPENDENCIES` constants are written.
> 
> The generator spec for **pin lookup failure** now asserts the full recovery block (error text, blank line, indented manual command) and confirms the pinned-install warning is **not** shown when version resolution fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbcc597ef710e13a96a97d04350bc7178e776396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential undefined variable behavior in error handling for React Server Components dependency installation.
  * Improved error message formatting when React Server Components dependency resolution fails, making manual installation instructions clearer and easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->