### PR TITLE
Remove legacy Pro license file warning

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/engine.rb
@@ -5,11 +5,8 @@ require "rails/railtie"
 module ReactOnRailsPro
   class Engine < Rails::Engine
     LICENSE_URL = "https://pro.reactonrails.com/"
-    # TODO: Remove this legacy migration warning path after 16.5.0 stable release (target: 2026-05-31).
-    LEGACY_LICENSE_FILE = "config/react_on_rails_pro_license.key"
     ROLLING_DEPLOY_AUTO_ROUTE_PREFIX = "react_on_rails_pro_auto_rolling_deploy"
     private_constant :LICENSE_URL
-    private_constant :LEGACY_LICENSE_FILE
     private_constant :ROLLING_DEPLOY_AUTO_ROUTE_PREFIX
 
     initializer "react_on_rails_pro.routes" do
@@ -57,10 +54,8 @@ module ReactOnRailsPro
 
         case status
         when :valid
-          log_legacy_file_cleanup_notice if legacy_license_file_present?
           log_valid_license
         when :missing
-          log_legacy_license_migration_notice if legacy_license_file_present?
           log_license_issue("No license found", "Get a license at #{LICENSE_URL}")
         when :expired
           expiration = ReactOnRailsPro::LicenseValidator.license_expiration
@@ -121,27 +116,6 @@ module ReactOnRailsPro
           Rails.logger.warn "#{prefix} #{warning} #{action}"
         else
           Rails.logger.info "#{prefix} No license required for development/test environments."
-        end
-      end
-
-      def legacy_license_file_present?
-        Rails.root.join(LEGACY_LICENSE_FILE).exist?
-      end
-
-      def log_legacy_file_cleanup_notice
-        Rails.logger.info "[React on Rails Pro] Legacy license file at #{LEGACY_LICENSE_FILE} " \
-                          "is no longer read and can be safely deleted."
-      end
-
-      def log_legacy_license_migration_notice
-        message = "[React on Rails Pro] Detected legacy license file at #{LEGACY_LICENSE_FILE}, " \
-                  "but this file is no longer read. " \
-                  "Move your token to REACT_ON_RAILS_PRO_LICENSE."
-
-        if Rails.env.production?
-          Rails.logger.warn message
-        else
-          Rails.logger.info message
         end
       end
     end

--- a/react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe ReactOnRailsPro::Engine do
   let(:test_private_key) { OpenSSL::PKey::RSA.new(2048) }
   let(:test_public_key) { test_private_key.public_key }
   let(:mock_logger) { instance_double(Logger, warn: nil, info: nil) }
-  let(:mock_root) { instance_double(Pathname, join: config_file_path) }
-  let(:config_file_path) { instance_double(Pathname, exist?: false) }
 
   let(:valid_payload) do
     {
@@ -25,7 +23,7 @@ RSpec.describe ReactOnRailsPro::Engine do
     ReactOnRailsPro::LicenseValidator.reset!
     stub_const("ReactOnRailsPro::LicensePublicKey::KEY", test_public_key)
     ENV.delete("REACT_ON_RAILS_PRO_LICENSE")
-    allow(Rails).to receive_messages(logger: mock_logger, root: mock_root)
+    allow(Rails).to receive(:logger).and_return(mock_logger)
   end
 
   after do
@@ -53,20 +51,6 @@ RSpec.describe ReactOnRailsPro::Engine do
         it "includes the production license violation warning" do
           expect(mock_logger).to receive(:warn).with(/violates the license terms/)
           described_class.log_license_status
-        end
-
-        context "when legacy license file exists" do
-          before do
-            allow(config_file_path).to receive(:exist?).and_return(true)
-          end
-
-          it "logs migration warning for env-var setup" do
-            allow(mock_logger).to receive(:warn)
-            described_class.log_license_status
-            expect(mock_logger).to have_received(:warn).with(/legacy license file/)
-            expect(mock_logger).to have_received(:warn).with(/REACT_ON_RAILS_PRO_LICENSE/)
-            expect(mock_logger).to have_received(:warn).with(/No license found/)
-          end
         end
       end
 
@@ -134,19 +118,6 @@ RSpec.describe ReactOnRailsPro::Engine do
           expect(mock_logger).not_to receive(:warn)
           described_class.log_license_status
         end
-
-        context "when legacy license file exists" do
-          before do
-            allow(config_file_path).to receive(:exist?).and_return(true)
-          end
-
-          it "logs cleanup notice and valid license" do
-            allow(mock_logger).to receive(:info)
-            described_class.log_license_status
-            expect(mock_logger).to have_received(:info).with(/can be safely deleted/)
-            expect(mock_logger).to have_received(:info).with(/License validated successfully/)
-          end
-        end
       end
 
       # Dynamically generate tests for plan types that display their name in log messages.
@@ -199,20 +170,6 @@ RSpec.describe ReactOnRailsPro::Engine do
           expect(mock_logger).to receive(:info).with(%r{No license required for development/test environments})
           described_class.log_license_status
         end
-
-        context "when legacy license file exists" do
-          before do
-            allow(config_file_path).to receive(:exist?).and_return(true)
-          end
-
-          it "logs migration info for env-var setup" do
-            allow(mock_logger).to receive(:info)
-            described_class.log_license_status
-            expect(mock_logger).to have_received(:info).with(/legacy license file/)
-            expect(mock_logger).to have_received(:info).with(/REACT_ON_RAILS_PRO_LICENSE/)
-            expect(mock_logger).to have_received(:info).with(/No license found/)
-          end
-        end
       end
 
       context "with expired license" do
@@ -251,19 +208,6 @@ RSpec.describe ReactOnRailsPro::Engine do
         it "logs success info" do
           expect(mock_logger).to receive(:info).with(/License validated successfully/)
           described_class.log_license_status
-        end
-
-        context "when legacy license file exists" do
-          before do
-            allow(config_file_path).to receive(:exist?).and_return(true)
-          end
-
-          it "logs cleanup notice and valid license" do
-            allow(mock_logger).to receive(:info)
-            described_class.log_license_status
-            expect(mock_logger).to have_received(:info).with(/can be safely deleted/)
-            expect(mock_logger).to have_received(:info).with(/License validated successfully/)
-          end
         end
       end
 


### PR DESCRIPTION
## Summary

Fixes #3624.

Removes the elapsed legacy Pro license key-file warning path from `ReactOnRailsPro::Engine`:

- removes `LEGACY_LICENSE_FILE` and the legacy file presence helper
- removes the valid-license cleanup notice and missing-license migration notice
- removes obsolete legacy-file contexts from the targeted engine spec

The file was already no longer read; this drops only the migration warning/notice path after the planned removal date.

## Validation

- `script/ci-changes-detector origin/main` -> passed
- `BUNDLE_GEMFILE=react_on_rails_pro/Gemfile bundle exec rspec react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb` -> 25 examples, 0 failures
- `RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop react_on_rails_pro/lib/react_on_rails_pro/engine.rb react_on_rails_pro/spec/react_on_rails_pro/engine_spec.rb` -> 2 files inspected, no offenses
- `git diff --check` -> clean

## Self-review

- Diff is limited to `react_on_rails_pro/lib/react_on_rails_pro/engine.rb` and its targeted spec.
- Removed legacy helper/call-site references were verified absent after the change.
- Remaining `config/react_on_rails_pro_license.key` mentions are historical docs/changelog/artifact references or unrelated negative assertions, so they were left unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only cleanup with no change to license validation or env-var behavior; specs updated to match.
> 
> **Overview**
> Removes the **legacy Pro license key file** migration path from `ReactOnRailsPro::Engine` startup logging. The constant `LEGACY_LICENSE_FILE` (`config/react_on_rails_pro_license.key`), filesystem checks, and log messages that told users to migrate to `REACT_ON_RAILS_PRO_LICENSE` or delete the old file are gone; **`log_license_status`** now only handles valid, missing, expired, and invalid env-based licenses.
> 
> The engine spec drops **`Rails.root`** / legacy-file stubs and all contexts that asserted those migration or cleanup notices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb519cb8bf317eb371e86ecf752e878ff235b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy license file support from startup initialization and logging.
  * Simplified license status validation to focus on current licensing flows only.
  * Updated test infrastructure to reflect licensing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->