### PR TITLE
Guard Pro React root unmount errors

### DIFF
--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -296,8 +296,13 @@ You should return a React.Component always for the client side entry point.`);
     }
 
     if (supportsRootApi) {
-      this.root?.unmount();
-      this.root = undefined;
+      try {
+        this.root?.unmount();
+      } catch (e: unknown) {
+        console.error(`Error calling root.unmount() for dom node "${this.domNodeId}":`, e);
+      } finally {
+        this.root = undefined;
+      }
     } else {
       // Use the stored node first. During same-id replacement, document.getElementById(this.domNodeId)
       // already points at the new node, but the old legacy React tree is attached to this.domNode.

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -575,6 +575,46 @@ describe('ClientSideRenderer', () => {
     expect(rootUnmount).toHaveBeenCalledTimes(1);
   });
 
+  it('logs and continues cleanup when a framework-created React root throws during unmount', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const unmountError = new Error('root unmount boom');
+      const firstRootUnmount = jest.fn(() => {
+        throw unmountError;
+      });
+      const secondRootUnmount = jest.fn();
+      const thirdRootUnmount = jest.fn();
+      mockReactHydrateOrRender
+        .mockReturnValueOnce({ render: jest.fn(), unmount: firstRootUnmount })
+        .mockReturnValueOnce({ render: jest.fn(), unmount: secondRootUnmount })
+        .mockReturnValueOnce({ render: jest.fn(), unmount: thirdRootUnmount });
+      ComponentRegistry.register({
+        TestComponent: ({ greeting }: { greeting: string }) => React.createElement('div', null, greeting),
+      });
+      const firstComponentSpec = setupTestComponentDom('dom-id-root-unmount-throws');
+      const secondComponentSpec = setupTestComponentDom('dom-id-root-unmount-continues');
+      addRailsContext();
+
+      await renderOrHydrateComponent(firstComponentSpec);
+      await renderOrHydrateComponent(secondComponentSpec);
+
+      expect(() => unmountAll()).not.toThrow();
+      expect(firstRootUnmount).toHaveBeenCalledTimes(1);
+      expect(secondRootUnmount).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error calling root.unmount() for dom node "dom-id-root-unmount-throws":',
+        unmountError,
+      );
+
+      await renderOrHydrateComponent(firstComponentSpec);
+
+      expect(mockReactHydrateOrRender).toHaveBeenCalledTimes(3);
+      expect(thirdRootUnmount).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   // Complements the no-teardown renderer test: a renderer that opts out of cleanup still owns its own
   // mount, so unmount() must take the renderer-owned path and NOT unmount a React root (it never
   // created one). With the default mock, a non-renderer mount would set `this.root`; a renderer mount


### PR DESCRIPTION
## Summary

Fixes #3618.

Hardens the Pro `ClientSideRenderer` modern React root teardown path:

- wraps `this.root?.unmount()` in `try/catch`
- logs root unmount failures at error level instead of letting them abort cleanup
- clears `this.root` in `finally`
- adds a targeted regression proving one throwing root unmount does not stop other roots from unmounting or prevent later renders

## Validation

- `script/ci-changes-detector origin/main` -> Pro JS/TS category detected
- `pnpm --filter react-on-rails-pro exec jest tests/ClientSideRenderer.test.ts --runInBand` -> passed, 22 tests
- `pnpm --filter react-on-rails-pro run type-check` -> passed
- `git diff --check` -> clean

## Self-review

- Diff is limited to `packages/react-on-rails-pro/src/ClientSideRenderer.ts` and the targeted Pro client renderer test.
- Legacy teardown behavior is preserved; only the modern React root path is guarded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Pro client teardown error handling; behavior on success is unchanged and aligns with existing guarded teardown paths.
> 
> **Overview**
> Hardens Pro **`ClientSideRenderer`** teardown on the modern React root API path so a failing **`root.unmount()`** no longer aborts bulk cleanup (fixes #3618).
> 
> **`unmount()`** now wraps **`this.root?.unmount()`** in **try/catch/finally**: failures are logged with **`console.error`** (including dom node id), and **`this.root`** is always cleared in **`finally`**. Renderer-owned mounts and the legacy **`unmountComponentAtNode`** path are unchanged.
> 
> A new **`ClientSideRenderer`** test asserts that when one framework root throws on unmount, **`unmountAll()`** still unmounts other roots, logs the error, and a later render on the same dom id still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f56327dc74c5ab71fe3c8bafaec0312dfd6f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error handling during React component unmounting to ensure cleanup always completes, even if an error occurs. Errors are now logged while allowing subsequent cleanup operations to continue, preventing potential state inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->