### PR TITLE
Convert Claude commands to agent skills

### DIFF
--- a/.agents/skills/address-review/SKILL.md
+++ b/.agents/skills/address-review/SKILL.md
@@ -1,5 +1,7 @@
 ---
-description: Fetch GitHub PR review comments, triage them, post summary checkpoints, and resolve addressed threads
+name: address-review
+description: Fetch GitHub PR review comments, triage them into must-fix/discuss/optional/skipped, and guide fixing or replying to selected feedback. Use when addressing PR review comments or review threads.
+argument-hint: '[autopilot] <pr-number-or-url> [check all reviews]'
 ---
 
 Fetch review comments from a GitHub PR in this repository, triage them, and create a todo list only for items worth addressing.
@@ -8,7 +10,7 @@ Fetch review comments from a GitHub PR in this repository, triage them, and crea
 
 ## Step 1: Parse User Input
 
-The user's input is: $ARGUMENTS
+Use the skill invocation arguments as the review request. If the skill was invoked without arguments but the user's message contains a PR number or PR URL, use that message as the review request. If neither source contains a PR reference, ask the user for a PR number or URL before continuing.
 
 First, detect whether the request includes the standalone token `autopilot` (case-insensitive) before or after the PR reference.
 
@@ -672,7 +674,7 @@ Or pick items by number: "1,2", "all must-fix", "all optional", "1,3-5"
 - For actions other than `a`, always post a new PR summary comment with the `<!-- address-review-summary -->` marker after completing an action so future runs know where to resume
 - After triage, always offer rationale replies for selected `SKIPPED`/declined items; `f` requires explicit confirmation before skipped-item replies/resolution, while `f+i` and `m` include skipped-item handling in the chosen action flow
 - Always request push confirmation from the user before running `git push`
-- If this command conflicts with broader agent defaults, this file wins only for `/address-review` workflow behavior; do not override repository safety boundaries
+- If this skill conflicts with broader agent defaults, this file wins only for `/address-review` workflow behavior; do not override repository safety boundaries
 - Resolve the review thread after replying when the concern is actually addressed and a thread ID is available
 - Default to real issues only. Do not spend a review cycle on optional polish unless the user explicitly asks for it
 - Triage comments before creating todos. Only `MUST-FIX` items should become todos by default

--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -19,7 +19,7 @@ clean" loop on top.
   it, such as `/code-review` or `/code-review ultra`. Treat these as environment-specific, not
   repo-local commands.
 - For PR-comment triage (reacting to review comments already on a GitHub PR), use
-  `/address-review` in Claude Code or `.agents/workflows/address-review.md` outside Claude Code.
+  `.agents/skills/address-review/SKILL.md`; Claude Code exposes it as `/address-review`.
 
 Use when:
 

--- a/.agents/skills/run-ci/SKILL.md
+++ b/.agents/skills/run-ci/SKILL.md
@@ -1,10 +1,20 @@
+---
+name: run-ci
+description: Analyze current branch changes with the repo CI detector and run user-selected local CI jobs. Use when the user asks to run, reproduce, or choose local CI checks.
+argument-hint: '[base-ref]'
+---
+
 # Run CI Command
 
 Analyze the current branch changes and run appropriate CI checks locally.
 
+## Argument Handling
+
+This skill accepts an optional base-ref argument. If provided, use it instead of `origin/main` for both `script/ci-changes-detector` and `bin/ci-local`; otherwise default to `origin/main`.
+
 ## Instructions
 
-1. First, run `script/ci-changes-detector origin/main` to analyze what changed
+1. First, run `script/ci-changes-detector origin/main` to analyze what changed, substituting the optional base-ref argument when supplied
 2. Show the user what the detector recommends
 3. Ask the user if they want to:
    - Run the recommended CI jobs (`bin/ci-local`)

--- a/.agents/skills/stress-test/SKILL.md
+++ b/.agents/skills/stress-test/SKILL.md
@@ -1,10 +1,16 @@
+---
+name: stress-test
+description: Orchestrate a destructive demo-workspace QA stress test for React on Rails leakage, memory, performance, security, and framework edge cases. Use only when the user explicitly asks to run stress testing.
+argument-hint: '[commit|PR|--from <sha>] [--tier quick|standard|deep|exhaustive] [options]'
+---
+
 # React on Rails Stress Test
 
 You are the orchestrator of a **no-mercy QA stress test** of the React on Rails framework. Your sub-agents are senior software engineers, offensive-security researchers, and pentesters. They do not write polite code reviews — they actually build demos, exercise the framework in extreme, stupid, and adversarial ways, and break it until it leaks.
 
-This command is destructive **inside the demo workspace only**. The framework source must never be modified.
+This stress test is destructive **inside the demo workspace only**. The framework source must never be modified.
 
-Arguments: $ARGUMENTS
+Use the skill invocation arguments as the stress-test scope and options. If no arguments are supplied, follow the empty-argument behavior in the table below.
 
 ---
 

--- a/.agents/skills/update-changelog/SKILL.md
+++ b/.agents/skills/update-changelog/SKILL.md
@@ -1,10 +1,16 @@
+---
+name: update-changelog
+description: Analyze merged PRs and update CHANGELOG.md, optionally stamping release, rc, beta, or explicit version headers. Use before releases or when changelog entries are missing.
+argument-hint: '[release|rc|beta|version]'
+---
+
 # Update Changelog
 
 You are helping to add an entry to the CHANGELOG.md file for the React on Rails project.
 
 ## Arguments
 
-This command accepts an optional argument: `$ARGUMENTS`
+This skill accepts an optional mode argument from the invocation text:
 
 - **No argument** (`/update-changelog`): Add entries to `[Unreleased]` without stamping a version header. Use this during development.
 - **`release`** (`/update-changelog release`): Add entries and stamp a version header. Auto-compute the next version based on changes (breaking -> major, added features -> minor, fixes -> patch). Then `rake release` (with no args) will pick up this version automatically.
@@ -14,7 +20,7 @@ This command accepts an optional argument: `$ARGUMENTS`
 
 ## When to Use This
 
-This command serves three use cases at different points in the release lifecycle:
+This skill serves three use cases at different points in the release lifecycle:
 
 **During development** -- Add entries to `[Unreleased]` as PRs merge:
 
@@ -25,13 +31,13 @@ This command serves three use cases at different points in the release lifecycle
 
 - Run `/update-changelog release` (or `rc`, `beta`, or an explicit version like `16.5.0.rc.10`) to add entries AND stamp the version header
 - The version is auto-computed from changes (breaking -> major, features -> minor, fixes -> patch) — skipped when an explicit version is provided
-- The command automatically commits, pushes, and opens a PR — review and merge it
+- The skill automatically commits, pushes, and opens a PR — review and merge it
 - Then run `rake release` (no args needed -- it reads the version from CHANGELOG.md)
 - The release task automatically creates a GitHub release from the changelog section
 
 **After a release you forgot to update the changelog for** -- Catch-up mode:
 
-- The command can retroactively find commits between tags and add missing entries
+- The skill can retroactively find commits between tags and add missing entries
 - Ask the user whether to stamp a version header or add to `[Unreleased]`
 
 ### Why changelog comes BEFORE the release

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: verify
+description: Run a local verification loop for the current branch before creating or updating a PR, selecting checks from AGENTS.md and changed files. Use when asked to verify, test, or prepare PR changes.
+---
+
 # Verify Command
 
 Run a local verification loop for the current branch before creating or updating a PR.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -124,7 +124,7 @@ Use the `+ci-*` PR comment commands from the CI command workflow for full-CI dec
 
 ## Review Comment Handling
 
-For Claude Code, use `/address-review`. For Codex or other assistants, use `.agents/workflows/address-review.md`. The default stance is:
+Use `.agents/skills/address-review/SKILL.md` when skills are available; Claude Code exposes the same workflow as `/address-review`. For assistants without skill support, use `.agents/workflows/address-review.md`. The default stance is:
 
 - `MUST-FIX`: fix in the PR.
 - `DISCUSS`: ask the user or make a narrow, evidence-backed decision.

--- a/.claude/docs/changelog-guidelines.md
+++ b/.claude/docs/changelog-guidelines.md
@@ -15,10 +15,10 @@ All entries live in a single chronological flow within each release. Pro entries
 - **Update CHANGELOG.md for user-visible changes only** (features, bug fixes, breaking changes, deprecations, performance improvements)
 - **Do NOT add entries for**: linting, formatting, refactoring, tests, or documentation fixes
 - **Format**: `[PR 1818](https://github.com/shakacode/react_on_rails/pull/1818) by [username](https://github.com/username)` (no hash in PR number)
-- **Use `/update-changelog` command** for guided changelog updates with automatic formatting
+- **Use `/update-changelog` skill** for guided changelog updates with automatic formatting
 - **Before a release**: Run `/update-changelog release` (or `rc`/`beta`) to stamp a version header; then `rake release` reads it automatically and creates the GitHub release
 - **Version management**: `bundle exec rake "update_changelog[release]"` (or `rc`/`beta`/explicit version) for header-only updates
 - **Security support window**: For minor and major releases, update `SECURITY.md` "Current support window" rows and cutoff dates to match the new release line
 - **After releasing without changelog**: Run `bundle exec rake "sync_github_release[VERSION]"` to create the GitHub release from CHANGELOG.md
 - **Examples**: Run `grep -A 3 "^#### " CHANGELOG.md | head -30` to see real formatting examples
-- **Prerelease curation**: See `.claude/commands/update-changelog.md` for prerelease-to-stable consolidation process
+- **Prerelease curation**: See `.agents/skills/update-changelog/SKILL.md` for prerelease-to-stable consolidation process

--- a/.claude/prompts/address-review.md
+++ b/.claude/prompts/address-review.md
@@ -4,10 +4,11 @@ The canonical reusable prompt is [.agents/workflows/address-review.md](../../.ag
 
 Use that shared workflow when pasting an address-review prompt into Codex CLI, ChatGPT, or another coding assistant. This file intentionally stays as a short compatibility pointer so it cannot drift from the canonical `MUST-FIX` / `DISCUSS` / `OPTIONAL` / `SKIPPED` policy, `autopilot` initiation mode, `a` apply action, and deferred-work tracking rules.
 
-For Claude Code slash-command usage, use [.claude/commands/address-review.md](../commands/address-review.md).
+For Claude Code slash-command usage, use [.agents/skills/address-review/SKILL.md](../../.agents/skills/address-review/SKILL.md). The `.claude/skills` symlink exposes it as `/address-review`.
 
 When copying these workflows into another repository:
 
 - Copy `.agents/workflows/address-review.md` as the reusable prompt.
-- Copy `.claude/commands/address-review.md` only when the target repo uses Claude Code.
+- Copy `.agents/skills/address-review/SKILL.md` when the target repo uses agent skills or Claude Code.
+- Add `.claude/skills -> ../.agents/skills` when the target repo uses Claude Code.
 - Copy this file only if the target repo keeps a `.claude/prompts/` alias, and keep it as a pointer rather than duplicating the full workflow.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,11 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 ## Reusable Workflows
 
 - `AGENTS.md`: canonical entry point for agent instructions and workflow discovery
-- `.claude/commands/`: Claude Code slash commands
-- `.claude/skills/`: Claude Code skills
+- `.agents/skills/`: agent skills; `.claude/skills` is a symlink here so Claude Code exposes the same workflows as slash commands
 - `.agents/workflows/`: shared prompt templates and reusable workflows for Codex, GPT, and other non-Claude tools
 - `internal/contributor-info/agent-workflow-adoption.md`: guide for copying these agent workflows into other repositories
 - When the user assigns an issue, PR, review-fix pass, or merge queue to an agent, follow `.agents/workflows/pr-processing.md`
-- When the user asks to address PR review comments outside Claude slash commands, follow `.agents/workflows/address-review.md`
+- When the user asks to address PR review comments, use `.agents/skills/address-review/SKILL.md`; `.agents/workflows/address-review.md` remains a copy/paste prompt for assistants without skill support
 
 ## Canonical Agent Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -565,9 +565,9 @@ Recommended CI jobs:
   ✓ JS unit tests
 ```
 
-#### `/run-ci` - Claude Code Command
+#### `/run-ci` - Claude Code Skill
 
-If using Claude Code, run `/run-ci` for interactive CI execution that:
+If using Claude Code, run the `/run-ci` skill for interactive CI execution that:
 
 1. Analyzes your changes
 2. Shows recommended CI jobs

--- a/internal/contributor-info/agent-workflow-adoption.md
+++ b/internal/contributor-info/agent-workflow-adoption.md
@@ -16,11 +16,12 @@ The goal is not to copy React on Rails blindly. The goal is to copy the reusable
 
 Copy these when the target repo uses Claude Code:
 
-- [.claude/commands/address-review.md](../../.claude/commands/address-review.md) - Claude slash command implementation.
+- [.agents/skills/address-review/SKILL.md](../../.agents/skills/address-review/SKILL.md) - shared address-review skill exposed to Claude Code as `/address-review`.
 - [.claude/prompts/address-review.md](../../.claude/prompts/address-review.md) - optional compatibility pointer to the canonical reusable prompt; copy it only if the target repo keeps Claude prompt aliases.
-- [.claude/skills/autoreview/SKILL.md](../../.claude/skills/autoreview/SKILL.md) - independent review skill used before commits, pushes, PRs, or merge readiness.
+- [.agents/skills/autoreview/SKILL.md](../../.agents/skills/autoreview/SKILL.md) - independent review skill used before commits, pushes, PRs, or merge readiness.
+- `.claude/skills -> ../.agents/skills` - symlink that lets Claude Code load the shared agent skills.
 
-Keep the Claude command and `.agents/workflows/address-review.md` behavior aligned. If the target repo also copies a reusable prompt file, make it point at the canonical shared workflow instead of carrying a second full workflow copy. Tool syntax can differ; policy should not.
+Keep the shared skill and `.agents/workflows/address-review.md` behavior aligned. If the target repo also copies a reusable prompt file, make it point at the canonical shared workflow instead of carrying a second full workflow copy. Tool syntax can differ; policy should not.
 
 ### Optional CI command workflow
 
@@ -109,7 +110,7 @@ When changing policy:
 
 1. Update `AGENTS.md`.
 2. Update `.agents/workflows/pr-processing.md` and `.agents/workflows/address-review.md`.
-3. Update Claude command or prompt files if they exist.
+3. Update Claude skill or prompt files if they exist.
 4. Run Markdown formatting and link checks.
 5. Do one dry-run triage or PR-processing pass before declaring the copied workflow ready.
 
@@ -120,7 +121,7 @@ When changing policy:
 
 - add canonical agent instructions in `AGENTS.md`
 - add reusable PR processing and address-review workflows under `.agents/workflows/`
-- add Claude command/prompt support for the same review flow
+- add Claude skill/prompt support for the same review flow
 - document local validation and full-CI escalation rules for this repository
 
 ## Validation

--- a/internal/contributor-info/ci-optimization.md
+++ b/internal/contributor-info/ci-optimization.md
@@ -137,9 +137,9 @@ Recommended CI jobs:
   ✓ Dummy app integration tests
 ```
 
-### `/run-ci` Claude Command
+### `/run-ci` Claude Skill
 
-Claude Code command for interactive CI execution:
+Claude Code skill for interactive CI execution:
 
 ```
 /run-ci
@@ -255,5 +255,5 @@ Potential further optimizations:
 
 - `script/ci-changes-detector` - Change detection script
 - `bin/ci-local` - Local CI runner
-- `.claude/commands/run-ci.md` - Claude command
+- `.agents/skills/run-ci/SKILL.md` - shared CI skill exposed to Claude Code as `/run-ci`
 - `.github/workflows/*.yml` - All CI workflows


### PR DESCRIPTION
## Summary

- Move Claude command prompts into `.agents/skills/*/SKILL.md` with skill frontmatter and argument-handling prose.
- Move the existing `autoreview` skill into `.agents/skills` and add `.claude/skills -> ../.agents/skills` for Claude Code compatibility.
- Update agent workflow docs and contributor references to treat `.agents/skills` as canonical.

Closes #3695.

## Validation

- `gh issue view 3695 --repo shakacode/react_on_rails --json number,title,body,state,labels,comments,url`
- Duplicate search:
  - `gh issue list --repo shakacode/react_on_rails --state all --search '"claude commands" "agents skills"' --json number,title,state,url`
  - `gh issue list --repo shakacode/react_on_rails --state all --search '"Convert all" ".claude/commands"' --json number,title,state,url`
  - `gh pr list --repo shakacode/react_on_rails --state all --search '"claude commands" "agents skills"' --json number,title,state,url,headRefName`
- `ruby -ryaml -e '...'` skill frontmatter validation: `validated 6 skill frontmatters`
- `ruby -e '...'` expected skill/workflow/symlink path validation: `validated expected skill, workflow, and symlink paths`
- `pnpm install`
- `pnpm start format.listDifferent`
- `bundle exec rubocop` from `react_on_rails/`: `217 files inspected, no offenses detected`
- `git diff --check origin/main...HEAD`
- `lychee --config .lychee.toml --max-cache-age 0s docs/ *.md react_on_rails_pro/*.md`: `2526 Total`, `0 Errors`
- `script/ci-changes-detector origin/main`: categorized this docs/workflow migration as uncategorized and recommended broad CI; local validation used the narrower docs/skill checks above.
- Pre-commit hook: changed-file markdown links, trailing newlines, and Prettier passed.
- Pre-push hook: no Ruby files to lint; online changed-file markdown links passed with `45 Total`, `0 Errors`.

## Labels

Labels: none. This is a docs/workflow skill-layout migration with no runtime, package, CI workflow, dependency, generator, SSR, or Pro behavior changes.

## Caveats

- `rake autofix` was attempted for formatting but failed because the task runs `pnpm run prettier` inside `react_on_rails/`, where no `prettier` script exists. I used the workspace Prettier executable on the affected markdown files, then reran the full Prettier check successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent workflow layout only; no runtime, gem, npm, CI workflow, or application code changes.
> 
> **Overview**
> **Canonical agent workflows now live under `.agents/skills/*/SKILL.md`**, with YAML frontmatter (`name`, `description`, `argument-hint`) so skill-aware tools can discover and invoke them. Prompts that used `$ARGUMENTS` now describe how to read skill invocation arguments (and fallbacks like PR numbers in the user message for `address-review`).
> 
> **Claude Code compatibility** is preserved via **`.claude/skills` → `../.agents/skills`**, so slash commands such as `/address-review` and `/run-ci` still resolve to the shared skill files. `autoreview` is aligned with the same layout, and cross-references (e.g. in `autoreview` and `pr-processing`) point at `.agents/skills/address-review/SKILL.md` instead of Claude-only command paths.
> 
> **Repo docs** (`AGENTS.md`, `CONTRIBUTING.md`, contributor adoption guide, CI optimization notes, changelog guidelines, `.claude/prompts/address-review.md`) are updated to treat **`.agents/skills` as canonical** and **`.agents/workflows`** as the copy/paste path for assistants without skill support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6fd665d3d2fe2c2beccdfc0d532da9af48ae3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced agent skill documentation with improved metadata and clearer usage instructions for `/address-review`, `/run-ci`, `/stress-test`, `/update-changelog`, and `/verify`.
  * Reorganized skill references throughout documentation to reflect new centralized skill locations.
  * Updated contributor guides to use skill-based workflows in place of command-based approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->