### PR TITLE
Polish renderer teardown follow-ups

### DIFF
--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -77,8 +77,9 @@ const wrapServerComponentRenderer = (
       : componentOrRenderFunction;
 
     // Preserve compatibility with existing 3-arg render functions: they are awaited before domNodeId
-    // validation; moving that check earlier is a future improvement. Keep this teardown-result guard
-    // before DOM checks so wrong-shaped render results get the clearer error.
+    // and DOM-node validation. TODO: move those DOM validation checks earlier only with tests proving
+    // existing renderers cannot depend on this ordering. Keep this teardown-result guard before DOM
+    // checks so wrong-shaped render results get the clearer error.
     if (isRendererTeardownResult(Component)) {
       throw new Error(
         `wrapServerComponentRenderer: render function for server component '${componentName}' ` +

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -407,12 +407,12 @@ describe('ClientSideRenderer', () => {
             },
           }) as unknown as Promise<void>,
       );
-      const TestRenderer: RendererFunction = (
+      const TestComponent: RendererFunction = (
         _props?: Record<string, unknown>,
         _railsContext?: RailsContext,
         _domNodeId?: string,
       ) => ({ teardown });
-      ComponentRegistry.register({ TestComponent: TestRenderer });
+      ComponentRegistry.register({ TestComponent });
       const componentSpec = setupTestComponentDom('dom-id-teardown-thenable-reject');
       addRailsContext();
 
@@ -420,8 +420,9 @@ describe('ClientSideRenderer', () => {
       unmountAll();
       expect(teardown).toHaveBeenCalledTimes(1);
 
-      await Promise.resolve(); // lets Promise.resolve(nonNativeThenable) settle
-      await Promise.resolve(); // lets the .catch() rejection handler run
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Error in renderer teardown for dom node "dom-id-teardown-thenable-reject":',
         rejection,

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.client.test.jsx
@@ -59,19 +59,11 @@ const loadWrappedRendererWithMocks = () => {
   return { wrapServerComponentRenderer, createRoot, hydrateRoot, render, unmount, getReactServerComponent };
 };
 
-const cleanupWrappedRendererMocks = () => {
-  document.body.innerHTML = '';
-};
-
 describe('wrapServerComponentRenderer/client validation (issue #3647)', () => {
   const railsContext = { rscPayloadGenerationUrlPath: '/rsc_payload' };
 
   beforeEach(() => {
     document.body.innerHTML = '';
-  });
-
-  afterEach(() => {
-    cleanupWrappedRendererMocks();
   });
 
   it('rejects with an explicit message when domNodeId is missing', async () => {
@@ -109,7 +101,8 @@ describe('wrapServerComponentRenderer/client validation (issue #3647)', () => {
     const renderFunction = (_props, _railsContext, _domNodeId) => ({ teardown: jest.fn() });
     const WrappedComponent = wrapServerComponentRenderer(renderFunction, 'TeardownResultComponent');
 
-    // No DOM node needed; the teardown-result guard throws before getElementById is called.
+    // Current compatibility ordering invokes 3-arg render functions and checks their return shape
+    // before DOM lookup/validation, so no DOM node is needed for this guard.
     await expect(WrappedComponent({}, railsContext, 'nonexistent-dom-id')).rejects.toThrow(
       "wrapServerComponentRenderer: render function for server component 'TeardownResultComponent' " +
         'returned a renderer teardown result; expected a React component.',

--- a/packages/react-on-rails/src/rendererTeardown.ts
+++ b/packages/react-on-rails/src/rendererTeardown.ts
@@ -1,5 +1,7 @@
 import type { RendererTeardownResult } from './types/index.ts';
 
+// Shared type guard for RendererTeardownResult, extracted so OSS and Pro can import it without
+// duplicating the predicate or coupling Pro to ClientRenderer internals.
 // eslint-disable-next-line import/prefer-default-export -- single-export module; named export keeps the type guard's API tied to its predicate name.
 export function isRendererTeardownResult(value: unknown): value is RendererTeardownResult {
   return (

--- a/packages/react-on-rails/tests/ClientRenderer.test.ts
+++ b/packages/react-on-rails/tests/ClientRenderer.test.ts
@@ -369,8 +369,8 @@ describe('ClientRenderer', () => {
     });
 
     it('does not let a stale async renderer overwrite a newer same-id teardown', async () => {
-      // No additional setupRailsContext() call needed; the enclosing beforeEach already runs it.
-      // This test exercises teardown-race ordering only, not full component rendering.
+      // setupRailsContext() is provided by the enclosing beforeEach; this test focuses on
+      // teardown-race ordering rather than rendered output correctness, so no extra setup is needed.
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
       try {
         const resolvers: Array<(result: { teardown: () => void }) => void> = [];


### PR DESCRIPTION
## Summary

- Clarify the Pro server-component renderer compatibility comment around DOM validation ordering.
- Remove redundant wrapper-test cleanup and tighten teardown-race comments.
- Make the Pro non-native thenable teardown rejection test flush via a timer tick, matching the OSS pattern.

Closes #3675.

## Validation

- `gh issue view 3675 --json number,title,body,state,author,comments,url`
- Duplicate search: `gh pr list --state all --search "3675 renderer teardown polish" --json number,title,state,url,headRefName`
- `pnpm --filter react-on-rails exec jest tests/ClientRenderer.test.ts --runInBand`
- `pnpm --filter react-on-rails-pro exec jest tests/ClientSideRenderer.test.ts tests/wrapServerComponentRenderer.client.test.jsx --runInBand`
- `pnpm --filter react-on-rails type-check`
- `pnpm --filter react-on-rails-pro type-check`
- `git diff --check`
- `script/ci-changes-detector origin/main fix/3675-renderer-teardown-polish`
- `codex review --uncommitted`: no actionable defects
- Pre-commit hook: trailing-newlines, Prettier, ESLint passed (test files emitted ignored-file warnings only).
- Pre-push hook: no Ruby/Markdown files to lint/check.

## Labels

Labels: none. This is a small comment/test polish follow-up with no runtime behavior reordering.
