### PR TITLE
Fix Pro ComponentRegistry value typing

### DIFF
--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -18,6 +18,7 @@ import type { ReactElement } from 'react';
 import type {
   RailsContext,
   RegisteredComponent,
+  RegisteredComponentValue,
   RendererFunction,
   RendererTeardown,
   Root,
@@ -79,9 +80,10 @@ function invokeRendererTeardown(teardown: RendererTeardown | undefined, domNodeI
 // carries the raw (possibly still-pending) RendererResult because it cannot await; the two
 // intentionally differ and are not meant to be unified.
 type DelegationResult = { delegated: false } | { delegated: true; teardown?: RendererTeardown };
+type RegisteredComponentEntry = RegisteredComponent<RegisteredComponentValue>;
 
 async function delegateToRenderer(
-  componentObj: RegisteredComponent,
+  componentObj: RegisteredComponentEntry,
   props: Record<string, unknown>,
   railsContext: RailsContext,
   domNodeId: string,
@@ -103,6 +105,10 @@ async function delegateToRenderer(
     // `as RendererFunction` is a runtime-invariant assertion guarded by `isRenderer` (not a
     // structural narrowing). The object wrapper picks out only explicit teardown returns without
     // confusing legacy bare function returns for cleanup.
+    if (typeof component !== 'function') {
+      throw new Error(`Registered renderer "${name}" must be a function.`);
+    }
+
     const result = await (component as RendererFunction)(props, railsContext, domNodeId);
     return {
       delegated: true,

--- a/packages/react-on-rails-pro/src/ComponentRegistry.ts
+++ b/packages/react-on-rails-pro/src/ComponentRegistry.ts
@@ -12,15 +12,13 @@
  * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
  */
 
-import {
-  type ReactComponentOrRenderFunction,
-  type RegisteredComponent,
-  type RegisteredComponentValue,
-} from 'react-on-rails/types';
+import { type RegisteredComponent, type RegisteredComponentValue } from 'react-on-rails/types';
 import isRenderFunction from 'react-on-rails/isRenderFunction';
 import CallbackRegistry from './CallbackRegistry.ts';
 
-const componentRegistry = new CallbackRegistry<RegisteredComponent>('component');
+type RegisteredComponentEntry = RegisteredComponent<RegisteredComponentValue>;
+
+const componentRegistry = new CallbackRegistry<RegisteredComponentEntry>('component');
 
 /**
  * @param components { component1: component1, component2: component2, etc. }
@@ -48,7 +46,7 @@ export function register(components: Record<string, RegisteredComponentValue>): 
 
     componentRegistry.set(name, {
       name,
-      component: component as ReactComponentOrRenderFunction,
+      component,
       renderFunction,
       isRenderer,
     });
@@ -59,9 +57,9 @@ export function register(components: Record<string, RegisteredComponentValue>): 
  * @param name
  * @returns { name, component, isRenderFunction, isRenderer }
  */
-export const get = (name: string): RegisteredComponent => componentRegistry.get(name);
+export const get = (name: string): RegisteredComponentEntry => componentRegistry.get(name);
 
-export const getOrWaitForComponent = (name: string): Promise<RegisteredComponent> =>
+export const getOrWaitForComponent = (name: string): Promise<RegisteredComponentEntry> =>
   componentRegistry.getOrWaitForItem(name);
 
 /**
@@ -70,7 +68,7 @@ export const getOrWaitForComponent = (name: string): Promise<RegisteredComponent
  * { name, component, renderFunction, isRenderer}
  * @public
  */
-export const components = (): Map<string, RegisteredComponent> => componentRegistry.getAll();
+export const components = (): Map<string, RegisteredComponentEntry> => componentRegistry.getAll();
 
 /** @internal Exported only for tests */
 export function clear(): void {

--- a/packages/react-on-rails-pro/src/capabilities/proMethods.ts
+++ b/packages/react-on-rails-pro/src/capabilities/proMethods.ts
@@ -14,7 +14,12 @@
  * https://github.com/shakacode/react_on_rails/blob/master/REACT-ON-RAILS-PRO-LICENSE.md
  */
 
-import type { RegisteredComponent, Store, StoreGenerator } from 'react-on-rails/types';
+import type {
+  RegisteredComponent,
+  RegisteredComponentValue,
+  Store,
+  StoreGenerator,
+} from 'react-on-rails/types';
 import * as ProComponentRegistry from '../ComponentRegistry.ts';
 import * as ProStoreRegistry from '../StoreRegistry.ts';
 import { hydrateStore } from '../ClientSideRenderer.ts';
@@ -25,7 +30,7 @@ import { hydrateStore } from '../ClientSideRenderer.ts';
  */
 export function createProMethodCapability() {
   return {
-    getOrWaitForComponent(name: string): Promise<RegisteredComponent> {
+    getOrWaitForComponent(name: string): Promise<RegisteredComponent<RegisteredComponentValue>> {
       return ProComponentRegistry.getOrWaitForComponent(name);
     },
 

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -183,6 +183,28 @@ describe('ClientSideRenderer', () => {
     expect(reactElement.type).toBe(TestComponent);
   });
 
+  it('rejects non-callable renderer entries before invoking them', async () => {
+    const componentSpec = setupTestComponentDom('dom-id-non-callable-renderer');
+    addRailsContext();
+    const getOrWaitForComponentSpy = jest.spyOn(ComponentRegistry, 'getOrWaitForComponent');
+    getOrWaitForComponentSpy.mockResolvedValueOnce({
+      name: 'TestComponent',
+      component: { metadata: 'server_render_js payload' },
+      renderFunction: true,
+      isRenderer: true,
+    });
+
+    try {
+      await expect(renderOrHydrateComponent(componentSpec)).rejects.toThrow(
+        'ReactOnRails encountered an error while rendering component: TestComponent',
+      );
+      expect(console.error).toHaveBeenCalledWith('Registered renderer "TestComponent" must be a function.');
+      expect(mockReactHydrateOrRender).not.toHaveBeenCalled();
+    } finally {
+      getOrWaitForComponentSpy.mockRestore();
+    }
+  });
+
   it('passes the bailout-aware recoverable handler for hydrated default-provider roots', async () => {
     const TestComponent = ({ greeting }: { greeting: string }) => React.createElement('div', null, greeting);
     const defaultProviderFactory = jest.fn(({ reactElement }: DefaultRSCProviderFactoryArgs) => reactElement);

--- a/packages/react-on-rails-pro/tests/ComponentRegistry.test.ts
+++ b/packages/react-on-rails-pro/tests/ComponentRegistry.test.ts
@@ -1,0 +1,42 @@
+import type { RegisteredComponentValue } from 'react-on-rails/types';
+import * as ComponentRegistry from '../src/ComponentRegistry.ts';
+
+type Assert<T extends true> = T;
+
+type GetComponentValue = ReturnType<typeof ComponentRegistry.get>['component'];
+type GetOrWaitComponentValue = Awaited<
+  ReturnType<typeof ComponentRegistry.getOrWaitForComponent>
+>['component'];
+type ComponentsMapValue =
+  ReturnType<typeof ComponentRegistry.components> extends Map<string, { component: infer ComponentValue }>
+    ? ComponentValue
+    : never;
+
+type _GetReturnsRegisteredComponentValue = Assert<
+  RegisteredComponentValue extends GetComponentValue ? true : false
+>;
+type _GetOrWaitReturnsRegisteredComponentValue = Assert<
+  RegisteredComponentValue extends GetOrWaitComponentValue ? true : false
+>;
+type _ComponentsReturnsRegisteredComponentValue = Assert<
+  RegisteredComponentValue extends ComponentsMapValue ? true : false
+>;
+
+describe('ComponentRegistry', () => {
+  afterEach(() => {
+    ComponentRegistry.clear();
+  });
+
+  it('registers and retrieves plain object modules without treating them as render functions', () => {
+    const plainObjectModule = { metadata: 'server_render_js payload' };
+
+    ComponentRegistry.register({ PlainObjectModule: plainObjectModule });
+
+    expect(ComponentRegistry.get('PlainObjectModule')).toEqual({
+      name: 'PlainObjectModule',
+      component: plainObjectModule,
+      renderFunction: false,
+      isRenderer: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3677.

- Widen Pro `ComponentRegistry` entries to `RegisteredComponent<RegisteredComponentValue>` so plain object registrations stay represented without casts.
- Align the Pro `getOrWaitForComponent` capability type with the widened registry entry.
- Add a defensive Pro client renderer guard before invoking renderer entries that are not callable.
- Add Pro regression coverage for plain object registry entries and the non-callable renderer guard.

## Validation

- `pnpm install`
- Red checks before implementation:
  - `pnpm --filter react-on-rails-pro exec jest tests/ComponentRegistry.test.ts --runInBand` failed with the expected `RegisteredComponentValue` type assertions.
  - `pnpm --filter react-on-rails-pro exec jest tests/ClientSideRenderer.test.ts --runInBand` failed because the old Pro registry type rejected a plain-object component entry.
- `pnpm --filter react-on-rails-pro run test:non-rsc` (178 tests passed)
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `git diff --check origin/main...HEAD`
- `script/ci-changes-detector origin/main jg-codex/3677-component-registry-typing`

## Caveat

`pnpm --filter react-on-rails-pro exec jest tests/streamServerRenderedReactComponent.test.jsx --runInBand` still fails on current `origin/main` in two existing `notifySSREnd() called multiple times` warning-expectation tests. This PR does not edit the streaming test file or streaming source path.

Labels: none. This is a focused Pro TypeScript/runtime guard change; the detector recommends the Pro JS/TS-related jobs listed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused Pro TypeScript alignment and a defensive runtime check in client rendering; no auth or data-path changes.
> 
> **Overview**
> Aligns **Pro** component registry typing with the OSS `RegisteredComponent<RegisteredComponentValue>` model so plain object registrations (e.g. `server_render_js` payloads) are stored and returned **without** casting to `ReactComponentOrRenderFunction`.
> 
> `ComponentRegistry` and `getOrWaitForComponent` in **proMethods** now expose that widened entry type end-to-end. **ClientSideRenderer** adds a guard in `delegateToRenderer`: if an entry is marked as a renderer but `component` is not a function, it throws before invocation instead of calling a non-callable value.
> 
> New tests cover compile-time assertions on registry return types, plain-object registration behavior, and the non-callable renderer rejection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf1ce629436f430f54b607cb6f3a5fe970e5db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by adding runtime validation to ensure registered renderers are properly configured as callable functions, with clearer error messages for misconfiguration.

* **Tests**
  * Expanded test coverage to verify renderer validation behavior and component registry type safety across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->