### PR TITLE
fix(types): narrow server-component render-function inputs

### DIFF
--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/client.tsx
@@ -24,7 +24,7 @@
 import 'react-on-rails-rsc/client.browser';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
-import { ReactComponent, ReactComponentOrRenderFunction, RendererFunction } from 'react-on-rails/types';
+import type { ReactComponent, ReactComponentRenderFunction, RendererFunction } from 'react-on-rails/types';
 import isRenderFunction from 'react-on-rails/isRenderFunction';
 import { isRendererTeardownResult } from 'react-on-rails/@internal/rendererTeardown';
 import { ensureReactUseAvailable } from 'react-on-rails/reactApis';
@@ -33,6 +33,8 @@ import getReactServerComponent from '../getReactServerComponent.client.ts';
 import handleRecoverableError from '../handleRecoverableError.client.ts';
 
 ensureReactUseAvailable();
+
+type ServerComponentRendererInput = ReactComponent | ReactComponentRenderFunction;
 
 /**
  * Wraps a client component with the necessary RSC context and handling for client-side operations.
@@ -54,7 +56,7 @@ ensureReactUseAvailable();
  * ```
  */
 const wrapServerComponentRenderer = (
-  componentOrRenderFunction: ReactComponentOrRenderFunction,
+  componentOrRenderFunction: ServerComponentRendererInput,
   componentName: string = 'Unknown',
 ) => {
   if (typeof componentOrRenderFunction !== 'function') {
@@ -68,12 +70,10 @@ const wrapServerComponentRenderer = (
   // mount leak this fix closes. Keep all three parameters declared.
   const wrapper: RendererFunction = async (props, railsContext, domNodeId) => {
     // A registerServerComponent render function is expected to resolve to the component to mount,
-    // not a renderer teardown. RendererFunction still accepts legacy render-function return shapes
-    // because older 3-arg renderers sometimes returned a component just to satisfy the old public
-    // type; this wrapper narrows to the expected component shape, and the guard below rejects
-    // anything else at runtime.
+    // not a renderer teardown. The wrapper input type encodes that invariant for TypeScript callers,
+    // and the guard below keeps the runtime error clear for JavaScript callers.
     const Component = isRenderFunction(componentOrRenderFunction)
-      ? ((await componentOrRenderFunction(props, railsContext, domNodeId)) as ReactComponent)
+      ? await componentOrRenderFunction(props, railsContext, domNodeId)
       : componentOrRenderFunction;
 
     // Preserve compatibility with existing 3-arg render functions: they are awaited before domNodeId

--- a/packages/react-on-rails-pro/src/wrapServerComponentRenderer/server.tsx
+++ b/packages/react-on-rails-pro/src/wrapServerComponentRenderer/server.tsx
@@ -16,13 +16,15 @@ import * as React from 'react';
 import type {
   RailsContext,
   ReactComponent,
+  ReactComponentRenderFunction,
   RenderFunction,
-  ReactComponentOrRenderFunction,
 } from 'react-on-rails/types';
 import isRenderFunction from 'react-on-rails/isRenderFunction';
 import { assertRailsContextWithServerStreamingCapabilities } from 'react-on-rails/types';
 import getReactServerComponent from '../getReactServerComponent.server.ts';
 import { createRSCProvider } from '../RSCProvider.tsx';
+
+type ServerComponentRendererInput = ReactComponent | ReactComponentRenderFunction;
 
 /**
  * Wraps a client component with the necessary RSC context and handling for server-side operations.
@@ -44,7 +46,7 @@ import { createRSCProvider } from '../RSCProvider.tsx';
  * ```
  */
 const wrapServerComponentRenderer = (
-  componentOrRenderFunction: ReactComponentOrRenderFunction,
+  componentOrRenderFunction: ServerComponentRendererInput,
   componentName: string = 'Unknown',
 ) => {
   if (typeof componentOrRenderFunction !== 'function') {
@@ -75,12 +77,11 @@ const wrapServerComponentRenderer = (
       );
     }
 
-    // The 2-argument server render-function form is expected to resolve to the component to mount.
-    // RenderFunction can also yield an HTML/server-render result, so this narrows to the expected
-    // component shape and the `typeof Component !== 'function'` guard below rejects anything else at
-    // runtime.
+    // The server-component render-function form is expected to resolve to the component to mount.
+    // The wrapper input type encodes that invariant for TypeScript callers, and the
+    // `typeof Component !== 'function'` guard below keeps the runtime error clear for JavaScript callers.
     const Component = isRenderFunction(componentOrRenderFunction)
-      ? ((await componentOrRenderFunction(props, railsContext)) as ReactComponent)
+      ? await componentOrRenderFunction(props, railsContext)
       : componentOrRenderFunction;
 
     if (typeof Component !== 'function') {

--- a/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.types.test.ts
+++ b/packages/react-on-rails-pro/tests/wrapServerComponentRenderer.types.test.ts
@@ -1,0 +1,32 @@
+import type { ReactComponent, RendererFunction } from 'react-on-rails/types';
+import type wrapServerComponentRenderer from '../src/wrapServerComponentRenderer/client.tsx';
+
+type WrapServerComponentRenderer = typeof wrapServerComponentRenderer;
+
+declare const component: ReactComponent;
+declare const typedPropsRenderFunction: (
+  props: { id: string } | undefined,
+  railsContext: unknown,
+) => ReactComponent;
+declare const componentRenderFunction: (
+  props?: Record<string, unknown>,
+  railsContext?: unknown,
+  domNodeId?: string,
+) => ReactComponent;
+declare const rendererReturningTeardown: RendererFunction;
+declare const typedWrapServerComponentRenderer: WrapServerComponentRenderer;
+
+if (false) {
+  typedWrapServerComponentRenderer(component, 'Component');
+  typedWrapServerComponentRenderer(typedPropsRenderFunction, 'TypedPropsRenderFunction');
+  typedWrapServerComponentRenderer(componentRenderFunction, 'ComponentRenderFunction');
+
+  // @ts-expect-error registerServerComponent render functions must resolve to React components, not renderer teardowns.
+  typedWrapServerComponentRenderer(rendererReturningTeardown, 'RendererTeardown');
+}
+
+describe('wrapServerComponentRenderer types', () => {
+  it('compiles type assertions for server-component render-function inputs', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/react-on-rails/src/types/index.ts
+++ b/packages/react-on-rails/src/types/index.ts
@@ -147,6 +147,8 @@ type RenderFunctionAsyncResult = Promise<
 
 type RenderFunctionResult = RenderFunctionSyncResult | RenderFunctionAsyncResult;
 
+type ReactComponentRenderFunctionResult = ReactComponent | Promise<ReactComponent>;
+
 /**
  * Optional cleanup callback that a renderer function (the 3-argument form
  * `(props, railsContext, domNodeId) => …`) may return inside a {@link RendererTeardownResult}.
@@ -214,6 +216,20 @@ interface RendererFunction extends RenderFunctionMarker {
   (props?: Record<string, unknown>, railsContext?: RailsContext, domNodeId?: string): RendererFunctionResult;
 }
 
+/**
+ * A render function variant for APIs that require a React component result, such as
+ * Pro server-component wrappers. Unlike {@link RenderFunction}, this does not allow
+ * server-render hashes/HTML, and unlike {@link RendererFunction}, this does not allow
+ * renderer teardown results.
+ *
+ * Runtime render-function detection still follows the regular React on Rails
+ * convention: declare at least two parameters, or set `renderFunction = true`
+ * on one-argument functions.
+ */
+interface ReactComponentRenderFunction<Props = any> extends RenderFunctionMarker {
+  (props?: Props, railsContext?: RailsContext, domNodeId?: string): ReactComponentRenderFunctionResult;
+}
+
 type StreamableComponentResult = ReactElement | Promise<ReactElement | string>;
 
 type AsyncPropsManager = {
@@ -273,6 +289,7 @@ export type {
   ReactComponentOrRenderFunction,
   RegisteredComponentValue,
   ReactComponent,
+  ReactComponentRenderFunction,
   AuthenticityHeaders,
   RenderFunction,
   RendererTeardown,
@@ -288,6 +305,7 @@ export type {
   CreateReactOutputAsyncResult,
   RenderFunctionSyncResult,
   RenderFunctionAsyncResult,
+  ReactComponentRenderFunctionResult,
   StreamableComponentResult,
   PipeableOrReadableStream,
 };

--- a/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ServerComponentRouter.server.tsx
+++ b/react_on_rails_pro/spec/dummy/client/app/ror-auto-load-components/ServerComponentRouter.server.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { StaticRouter } from 'react-router-dom/server.js';
-import { RailsContext, ReactComponentOrRenderFunction } from 'react-on-rails-pro';
+import { RailsContext, ReactComponentRenderFunction } from 'react-on-rails-pro';
 import wrapServerComponentRenderer from 'react-on-rails-pro/wrapServerComponentRenderer/server';
 import App from '../components/ServerComponentRouter';
 
@@ -16,4 +16,4 @@ function ServerComponentRouter(props: object, railsContext: RailsContext) {
   );
 }
 
-export default wrapServerComponentRenderer(ServerComponentRouter as ReactComponentOrRenderFunction);
+export default wrapServerComponentRenderer(ServerComponentRouter as ReactComponentRenderFunction<object>);


### PR DESCRIPTION
## Summary

Fixes #3589.

- Add `ReactComponentRenderFunction` as the component-returning render-function type for APIs that require a React component result.
- Narrow the Pro `wrapServerComponentRenderer` client/server inputs to component-returning render functions and remove the load-bearing `as ReactComponent` casts.
- Keep the existing runtime guards for JavaScript callers and wrong-shaped results.
- Update the Pro dummy server-component registration cast and add a type assertion that renderer teardown functions are rejected at compile time.

## Validation

- `pnpm --filter react-on-rails run type-check`
- `pnpm --filter react-on-rails-pro run type-check`
- `pnpm --filter react-on-rails-pro exec jest tests/wrapServerComponentRenderer.types.test.ts --runInBand`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `git diff --check origin/main...HEAD`
- `script/ci-changes-detector origin/main fix/3589-renderer-function-types`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --no-web-search`

Labels: none. This is a focused TypeScript type-surface tightening with existing runtime guards preserved; path-based CI should cover the touched package areas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined TypeScript type definitions for the server component renderer to provide stricter compile-time type validation.
  * Replaced generic input type with a more specific union type for better type safety during component rendering.

* **Tests**
  * Added TypeScript type-checking tests for server component renderer to ensure type compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->