### PR TITLE
Keep generator CI fixtures out of gem root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage/
 
 react_on_rails/spec/examples.txt
 react_on_rails/spec/react_on_rails/dummy-for-generators/
+react_on_rails/.github/
 react_on_rails_pro/spec/examples.txt
 react_on_rails_pro/spec/react_on_rails_pro/dummy-for-generators/
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -11,6 +11,14 @@ describe InstallGenerator, type: :generator do
     ReactOnRails::Generators::BaseGenerator.new([], options, destination_root: destination_root)
   end
 
+  def install_generator_fixture(options = {})
+    described_class.new([], options, destination_root: destination_root)
+  end
+
+  def gem_root_ci_workflow_path
+    File.expand_path("../../../.github/workflows/ci.yml", __dir__)
+  end
+
   def render_stock_webpack_template(template_path, options = {})
     base_generator_fixture(options).send(:rendered_template_for_cleanup, template_path)
   end
@@ -74,6 +82,21 @@ describe InstallGenerator, type: :generator do
         expect(rendered).to include("RSCRspackPlugin")
         expect(rendered).to include("react-on-rails-rsc/RspackPlugin")
       end
+    end
+  end
+
+  describe "manual generator fixtures" do
+    it "keep CI workflow generation inside the generator spec destination" do
+      prepare_destination
+      simulate_existing_rails_files(package_json: true)
+      simulate_npm_files(package_json: true)
+
+      Dir.chdir(File.expand_path("../../..", __dir__)) do
+        install_generator_fixture(force: true).send(:add_ci_workflow)
+      end
+
+      assert_file ".github/workflows/ci.yml"
+      expect(File).not_to exist(gem_root_ci_workflow_path)
     end
   end
 
@@ -2003,10 +2026,9 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when Procfile.dev already contains node-renderer" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { described_class.new([], { pro: true }, destination_root: "/fake/path") }
 
     before do
-      allow(install_generator).to receive(:destination_root).and_return("/fake/path")
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev").and_return(true)
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev-static-assets").and_return(false)
@@ -2022,10 +2044,9 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when Procfile.dev exists without node-renderer" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { described_class.new([], { pro: true }, destination_root: "/fake/path") }
 
     before do
-      allow(install_generator).to receive(:destination_root).and_return("/fake/path")
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev").and_return(true)
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev-static-assets").and_return(false)
@@ -2041,10 +2062,9 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when Procfile.dev contains an unrelated renderer process" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { described_class.new([], { pro: true }, destination_root: "/fake/path") }
 
     before do
-      allow(install_generator).to receive(:destination_root).and_return("/fake/path")
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev").and_return(true)
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev-static-assets").and_return(false)
@@ -2060,10 +2080,9 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when Procfile.dev has a node-renderer entry that is missing RENDERER_PORT" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { described_class.new([], { pro: true }, destination_root: "/fake/path") }
 
     before do
-      allow(install_generator).to receive(:destination_root).and_return("/fake/path")
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev").and_return(true)
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev-static-assets").and_return(false)
@@ -2739,10 +2758,9 @@ describe InstallGenerator, type: :generator do
   # CI template renders, defeating the "no lockfile" scenario.
 
   context "when Procfile.dev already contains RSC watcher" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { described_class.new([], { rsc: true }, destination_root: "/fake/path") }
 
     before do
-      allow(install_generator).to receive(:destination_root).and_return("/fake/path")
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with("/fake/path/Procfile.dev").and_return(true)
       procfile_content = "rails: bundle exec rails s\nrsc-bundle: RSC_BUNDLE_ONLY=true bin/shakapacker\n"
@@ -2794,7 +2812,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "run_generators adds post-install messaging for redux installs" do
-      install_generator = described_class.new([], { redux: true })
+      install_generator = install_generator_fixture(redux: true)
       allow(install_generator).to receive(:installation_prerequisites_met?).and_return(true)
       allow(install_generator).to receive(:invoke_generators)
       allow(install_generator).to receive(:add_bin_scripts)
@@ -2805,7 +2823,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "shows incomplete-installation guidance when shakapacker setup fails" do
-      install_generator = described_class.new
+      install_generator = install_generator_fixture
       install_generator.instance_variable_set(:@shakapacker_setup_incomplete, true)
 
       install_generator.send(:add_post_install_message)
@@ -2822,7 +2840,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "incomplete-installation guidance uses detected package manager install command" do
-      install_generator = described_class.new
+      install_generator = install_generator_fixture
       install_generator.instance_variable_set(:@shakapacker_setup_incomplete, true)
       allow(GeneratorMessages).to receive(:detect_package_manager).and_return("pnpm")
 
@@ -2833,7 +2851,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "incomplete-installation guidance preserves original install flags" do
-      install_generator = described_class.new([], { redux: true, typescript: true, rspack: true, rsc: true })
+      install_generator = install_generator_fixture(redux: true, typescript: true, rspack: true, rsc: true)
       install_generator.instance_variable_set(:@shakapacker_setup_incomplete, true)
 
       install_generator.send(:add_post_install_message)
@@ -2846,7 +2864,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "post-install message disables landing-page hints when root route is unavailable" do
-      install_generator = described_class.new([], { new_app: true })
+      install_generator = install_generator_fixture(new_app: true)
       allow(install_generator).to receive_messages(
         shakapacker_setup_incomplete?: false,
         new_app_root_route_available?: false,
@@ -2868,10 +2886,16 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "recovery_install_command keeps meaningful flags only" do
-      install_generator = described_class.new(
-        [],
-        { redux: true, typescript: true, rspack: true, rsc: true, pro: true, ignore_warnings: true,
-          force: true, skip: true, pretend: true }
+      install_generator = install_generator_fixture(
+        redux: true,
+        typescript: true,
+        rspack: true,
+        rsc: true,
+        pro: true,
+        ignore_warnings: true,
+        force: true,
+        skip: true,
+        pretend: true
       )
 
       command = install_generator.send(:recovery_install_command)
@@ -2885,7 +2909,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "recovery_install_command includes --pro when requested without --rsc" do
-      install_generator = described_class.new([], { pro: true })
+      install_generator = install_generator_fixture(pro: true)
 
       command = install_generator.send(:recovery_install_command)
 
@@ -2893,7 +2917,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "recovery_install_command normalizes the --webpack alias to --no-rspack" do
-      install_generator = described_class.new([], { webpack: true })
+      install_generator = install_generator_fixture(webpack: true)
 
       command = install_generator.send(:recovery_install_command)
 
@@ -2901,7 +2925,7 @@ describe InstallGenerator, type: :generator do
     end
 
     specify "shakapacker install error preserves original install flags" do
-      install_generator = described_class.new([], { redux: true, typescript: true, ignore_warnings: true })
+      install_generator = install_generator_fixture(redux: true, typescript: true, ignore_warnings: true)
 
       install_generator.send(:handle_shakapacker_install_error)
       output_text = GeneratorMessages.output.join("\n")
@@ -2913,7 +2937,7 @@ describe InstallGenerator, type: :generator do
     specify "shakapacker gemfile error preserves original install flags" do
       # ignore_warnings: true is required so handle_shakapacker_gemfile_error logs
       # the error instead of raising Thor::Error, which lets this example inspect output.
-      install_generator = described_class.new([], { rspack: true, pro: true, ignore_warnings: true })
+      install_generator = install_generator_fixture(rspack: true, pro: true, ignore_warnings: true)
 
       install_generator.send(:handle_shakapacker_gemfile_error)
       output_text = GeneratorMessages.output.join("\n")
@@ -2938,8 +2962,8 @@ describe InstallGenerator, type: :generator do
   end
 
   describe "--pretend mode behavior" do
-    let(:install_generator) { described_class.new([], { pretend: true }) }
-    let(:typescript_install_generator) { described_class.new([], { pretend: true, typescript: true }) }
+    let(:install_generator) { install_generator_fixture(pretend: true) }
+    let(:typescript_install_generator) { install_generator_fixture(pretend: true, typescript: true) }
 
     it "skips automatic shakapacker installation commands" do
       allow(install_generator).to receive(:shakapacker_configured?).and_return(false)
@@ -3016,7 +3040,7 @@ describe InstallGenerator, type: :generator do
     end
 
     it "forwards pretend mode to redux, pro, and rsc generators" do
-      redux_pro_rsc_install_generator = described_class.new([], { pretend: true, redux: true, pro: true, rsc: true })
+      redux_pro_rsc_install_generator = install_generator_fixture(pretend: true, redux: true, pro: true, rsc: true)
 
       allow(redux_pro_rsc_install_generator).to receive(:ensure_shakapacker_installed)
       allow(redux_pro_rsc_install_generator).to receive(:setup_react_dependencies)
@@ -3036,7 +3060,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when detecting node availability" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "missing_node? returns false when node is on PATH" do
       allow(ReactOnRails::Utils).to receive(:command_available?).with("node").and_return(true)
@@ -3057,7 +3081,7 @@ describe InstallGenerator, type: :generator do
   # finalize_shakapacker_setup — the runtime path that fires during a real
   # `rails g react_on_rails:install` when Shakapacker wasn't pre-configured.
   describe "ensure_shakapacker_installed detection path" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     before do
       allow(install_generator).to receive(:print_shakapacker_setup_banner)
@@ -3144,7 +3168,7 @@ describe InstallGenerator, type: :generator do
   end
 
   describe "#shakapacker_configured?" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     before do
       allow(File).to receive(:exist?).and_call_original
@@ -3492,7 +3516,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when --rspack option is provided" do
-      let(:install_generator) { described_class.new([], { rspack: true }) }
+      let(:install_generator) { install_generator_fixture(rspack: true) }
 
       it "returns true" do
         expect(install_generator.send(:using_rspack?)).to be true
@@ -3500,7 +3524,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when --no-rspack is passed" do
-      let(:install_generator) { described_class.new([], { rspack: false }) }
+      let(:install_generator) { install_generator_fixture(rspack: false) }
 
       # --rspack declares no default, so options.key?(:rspack) is true only when the flag
       # is explicitly passed. --no-rspack sets it to false, selecting Webpack.
@@ -3510,7 +3534,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when --webpack is passed (alias for --no-rspack)" do
-      let(:install_generator) { described_class.new([], { webpack: true }) }
+      let(:install_generator) { install_generator_fixture(webpack: true) }
 
       it "returns false" do
         expect(install_generator.send(:using_rspack?)).to be false
@@ -3518,7 +3542,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when --no-webpack is passed" do
-      let(:install_generator) { described_class.new([], { webpack: false }) }
+      let(:install_generator) { install_generator_fixture(webpack: false) }
 
       it "returns true" do
         expect(install_generator.send(:using_rspack?)).to be true
@@ -3526,7 +3550,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when --rspack and --webpack contradict each other" do
-      let(:install_generator) { described_class.new([], { rspack: true, webpack: true }) }
+      let(:install_generator) { install_generator_fixture(rspack: true, webpack: true) }
 
       it "raises a Thor::Error" do
         expect { install_generator.send(:using_rspack?) }
@@ -3535,7 +3559,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when --no-rspack and --webpack agree (both Webpack)" do
-      let(:install_generator) { described_class.new([], { rspack: false, webpack: true }) }
+      let(:install_generator) { install_generator_fixture(rspack: false, webpack: true) }
 
       it "returns false without raising" do
         expect(install_generator.send(:using_rspack?)).to be false
@@ -3543,7 +3567,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "when no bundler flag is passed (fresh install)" do
-      let(:install_generator) { described_class.new }
+      let(:install_generator) { install_generator_fixture }
 
       # With no flag and no existing bundler choice, the default resolves to Rspack when
       # Shakapacker supports it (Rspack landed in 9.0).
@@ -3568,7 +3592,7 @@ describe InstallGenerator, type: :generator do
 
   describe "#destination_config_path" do
     context "with --rspack" do
-      let(:install_generator) { described_class.new([], { rspack: true }) }
+      let(:install_generator) { install_generator_fixture(rspack: true) }
 
       it "remaps config/webpack/ to config/rspack/" do
         expect(install_generator.send(:destination_config_path, "config/webpack/serverWebpackConfig.js"))
@@ -3582,7 +3606,7 @@ describe InstallGenerator, type: :generator do
     end
 
     context "with --no-rspack" do
-      let(:install_generator) { described_class.new([], { rspack: false }) }
+      let(:install_generator) { install_generator_fixture(rspack: false) }
 
       it "returns path unchanged" do
         expect(install_generator.send(:destination_config_path, "config/webpack/serverWebpackConfig.js"))
@@ -3597,7 +3621,7 @@ describe InstallGenerator, type: :generator do
   describe "bundler environment isolation" do
     # Pin to Webpack (--no-rspack) so shakapacker:install runs with an empty env hash here;
     # the SHAKAPACKER_ASSETS_BUNDLER=rspack env is covered by the dedicated example below.
-    let(:install_generator) { described_class.new([], { rspack: false }) }
+    let(:install_generator) { install_generator_fixture(rspack: false) }
 
     it "clears BUNDLE_GEMFILE when running bundle add" do
       allow(install_generator).to receive(:shakapacker_in_gemfile?).and_return(false)
@@ -3622,7 +3646,7 @@ describe InstallGenerator, type: :generator do
     end
 
     it "passes SHAKAPACKER_ASSETS_BUNDLER=rspack to shakapacker:install when --rspack is set" do
-      rspack_generator = described_class.new([], { rspack: true })
+      rspack_generator = install_generator_fixture(rspack: true)
       allow(Bundler).to receive(:with_unbundled_env).and_yield
       allow(rspack_generator).to receive(:system).with("bundle install").and_return(true)
       allow(rspack_generator).to receive(:system)
@@ -3692,7 +3716,7 @@ describe InstallGenerator, type: :generator do
   # Pro/RSC prerequisite validation tests
 
   context "when using --pro flag without Pro gem installed" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
     # Pin to a stable version so this test exercises the pessimistic (~>) branch
     # of pro_gem_version_requirement regardless of whether the live VERSION is a
     # prerelease (the prerelease branch is covered by a separate context below).
@@ -3722,7 +3746,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --rsc flag without Pro gem installed" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
     let(:fake_pid) { 12_345 }
 
     before do
@@ -3744,7 +3768,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --rsc flag with a prerelease ReactOnRails version" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
     let(:fake_pid) { 12_345 }
 
     before do
@@ -3772,7 +3796,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when auto-installing Pro gem succeeds" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
     let(:fake_pid) { 12_345 }
 
     before do
@@ -3802,7 +3826,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when auto-install times out" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
     let(:fake_pid) { 12_345 }
 
     before do
@@ -3820,7 +3844,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when auto-install raises an error" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
 
     before do
       allow(Gem).to receive(:loaded_specs).and_return({})
@@ -3834,7 +3858,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --pro flag with Pro gem in Gem.loaded_specs" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
 
     specify "missing_pro_gem? returns false" do
       allow(Gem).to receive(:loaded_specs).and_return({ "react_on_rails_pro" => double })
@@ -3844,7 +3868,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --pro flag with Pro gem in Gemfile.lock" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
 
     specify "missing_pro_gem? returns false" do
       allow(Gem).to receive(:loaded_specs).and_return({})
@@ -3855,7 +3879,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when not using --pro or --rsc flags" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "missing_pro_gem? returns false without checking gem" do
       expect(install_generator.send(:missing_pro_gem?)).to be false
@@ -3863,7 +3887,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when the selected JavaScript package manager is unavailable" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     before do
       allow(GeneratorMessages).to receive(:detect_package_manager_with_source).and_return(["pnpm", :package_json])
@@ -3888,7 +3912,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when the detection source picks the missing package manager" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     before do
       allow(GeneratorMessages).to receive(:package_manager_executable_available?) { |command| command == "npm" }
@@ -3942,7 +3966,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when no JavaScript package manager is available at all" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     before do
       allow(GeneratorMessages).to receive_messages(
@@ -3962,7 +3986,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when no JavaScript package manager is available but the user had configured one" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     before do
       allow(GeneratorMessages).to receive_messages(
@@ -3983,7 +4007,7 @@ describe InstallGenerator, type: :generator do
   describe "#warn_if_unsupported_env_package_manager" do
     include_context "with clean REACT_ON_RAILS_PACKAGE_MANAGER env"
 
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "warns when REACT_ON_RAILS_PACKAGE_MANAGER is set to an unsupported value" do
       ENV["REACT_ON_RAILS_PACKAGE_MANAGER"] = "rush"
@@ -4021,7 +4045,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when force-checking Pro gem without pro-related flags" do
-    let(:install_generator) { described_class.new([], { pro: false, rsc: false }) }
+    let(:install_generator) { install_generator_fixture(pro: false, rsc: false) }
     let(:fake_pid) { 12_345 }
 
     before do
@@ -4043,7 +4067,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when --pro flag used on a dirty worktree without pro gem" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
 
     before do
       allow(ReactOnRails::GitUtils).to receive(:warn_if_uncommitted_changes).and_return(true)
@@ -4063,7 +4087,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when --rsc flag used on a dirty worktree without pro gem" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
 
     before do
       allow(ReactOnRails::GitUtils).to receive(:warn_if_uncommitted_changes).and_return(true)
@@ -4083,7 +4107,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when --pro flag used on a dirty worktree with pro gem installed" do
-    let(:install_generator) { described_class.new([], { pro: true }) }
+    let(:install_generator) { install_generator_fixture(pro: true) }
 
     before do
       allow(ReactOnRails::GitUtils).to receive(:warn_if_uncommitted_changes).and_return(true)
@@ -4101,7 +4125,7 @@ describe InstallGenerator, type: :generator do
   # React version detection tests
 
   context "when package.json has standard React version" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "detect_react_version extracts version" do
       allow(install_generator).to receive(:package_json).and_return({ "dependencies" => { "react" => "19.0.3" } })
@@ -4111,7 +4135,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when package.json has React version with caret prefix" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "detect_react_version extracts version without prefix" do
       allow(install_generator).to receive(:package_json).and_return({ "dependencies" => { "react" => "^19.0.3" } })
@@ -4121,7 +4145,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when package.json has React as workspace protocol" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "detect_react_version returns nil" do
       allow(install_generator).to receive(:package_json).and_return({ "dependencies" => { "react" => "workspace:*" } })
@@ -4131,7 +4155,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when package.json is not available" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "detect_react_version returns nil" do
       allow(install_generator).to receive(:package_json).and_return(nil)
@@ -4143,7 +4167,7 @@ describe InstallGenerator, type: :generator do
   # RSC React version warning tests
 
   context "when using --rsc with React 19.0.4" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
 
     specify "warn_about_react_version_for_rsc does not add warning" do
       allow(install_generator).to receive(:detect_react_version).and_return("19.0.4")
@@ -4154,7 +4178,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --rsc with React 19.1.0" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
 
     specify "warn_about_react_version_for_rsc adds version incompatibility warning" do
       allow(install_generator).to receive(:detect_react_version).and_return("19.1.0")
@@ -4167,7 +4191,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --rsc with React 18.2.0" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
 
     specify "warn_about_react_version_for_rsc adds version incompatibility warning" do
       allow(install_generator).to receive(:detect_react_version).and_return("18.2.0")
@@ -4179,7 +4203,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when using --rsc with React 19.0.0" do
-    let(:install_generator) { described_class.new([], { rsc: true }) }
+    let(:install_generator) { install_generator_fixture(rsc: true) }
 
     specify "warn_about_react_version_for_rsc adds minimum version warning" do
       allow(install_generator).to receive(:detect_react_version).and_return("19.0.0")
@@ -4192,7 +4216,7 @@ describe InstallGenerator, type: :generator do
   end
 
   context "when not using --rsc flag" do
-    let(:install_generator) { described_class.new }
+    let(:install_generator) { install_generator_fixture }
 
     specify "warn_about_react_version_for_rsc does not run" do
       allow(install_generator).to receive(:detect_react_version).and_return("18.2.0")


### PR DESCRIPTION
## Summary

Fixes #3631.

- Ignore stray `react_on_rails/.github/` generator output at the gem root so accidental CI workflow files do not pollute `git status` or hooks.
- Add a regression spec proving manual install-generator fixtures write `.github/workflows/ci.yml` into the generator destination, not the gem root.
- Harden manual install-generator specs to pass `destination_root:` through Thor constructor paths instead of relying on later stubs.

## Validation

- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb:88`
- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb` (482 examples, 0 failures)
- `(cd react_on_rails && bundle exec rubocop spec/react_on_rails/generators/install_generator_spec.rb --format simple)`
- `git diff --check origin/main...HEAD`
- `script/ci-changes-detector origin/main fix/3631-generator-ci-leak`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --no-web-search`
- Pre-push hook: branch Ruby RuboCop + changed-file Markdown link checks passed.

Labels: none. This is a focused generator-spec hardening and ignore-rule change; path-based CI should cover the generator/RSpec surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and ignore-rule changes only; no install generator runtime behavior is modified in this diff.
> 
> **Overview**
> Prevents install-generator specs from leaving **`.github/workflows/ci.yml`** under the **`react_on_rails`** gem root and adds coverage so CI workflow output stays in the generator test **destination**.
> 
> **`.gitignore`** now ignores **`react_on_rails/.github/`** so accidental generator CI files do not show up in git status or hooks.
> 
> **`install_generator_spec.rb`** adds **`install_generator_fixture`** (and a gem-root CI path helper), a regression example that **`chdir`s to the gem root** while calling **`add_ci_workflow`** and asserts the workflow exists only under the dummy destination, and refactors manual generator examples to pass **`destination_root:`** into **`described_class.new`** instead of stubbing **`destination_root`** afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1164e544a68736ec16cbad05a3a3a72fcc5a6511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to ignore additional directories.

* **Tests**
  * Refactored test suite with new helper functions for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->