### PR TITLE
Clean up benchmark DB seed check

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -406,7 +406,6 @@ jobs:
         # the shell), matching the "Execute benchmark suite" step below.
         env:
           RAILS_ENV: production
-          NODE_ENV: production
           SUITE_NAME: ${{ matrix.suite_name }}
         run: |
           set -euo pipefail
@@ -415,9 +414,24 @@ jobs:
           # Guard every table `/posts_page` reads (posts, plus the users and
           # comments it joins), not just posts: a partial seed would otherwise
           # let the route 500 (or render an empty page) while the job stayed
-          # green. `set -o pipefail` keeps this abort fatal even if the command
-          # is ever piped.
-          bundle exec rails runner 'counts = { posts: Post.count, users: User.count, comments: Comment.count }; empty = counts.select { |_, c| c.zero? }.keys; abort("Benchmark DB seeding incomplete after db:prepare (empty: #{empty.join(", ")}); seeds did not run") if empty.any?; puts "✅ Database seeded (#{counts.map { |k, v| "#{v} #{k}" }.join(", ")})"'
+          # green.
+          bundle exec rails runner - <<'RUBY'
+          counts = {
+            posts: Post.count,
+            users: User.count,
+            comments: Comment.count
+          }
+
+          empty_tables = counts.select { |_, count| count.zero? }.keys
+          if empty_tables.any?
+            abort(
+              "Benchmark DB seeding incomplete after db:prepare " \
+              "(empty: #{empty_tables.join(', ')}); seeds did not run"
+            )
+          end
+
+          puts "✅ Database seeded (#{counts.map { |table, count| "#{count} #{table}" }.join(', ')})"
+          RUBY
 
       - name: Start Pro node renderer
         if: matrix.server_kind == 'node-renderer'

--- a/react_on_rails_pro/spec/dummy/db/seeds.rb
+++ b/react_on_rails_pro/spec/dummy/db/seeds.rb
@@ -49,7 +49,7 @@ users.each_with_index do |user, user_index|
     seed = (user_index * 11) + post_index
     posts << user.posts.create!(
       title: lorem_sentence.call(3, seed),
-      body: Array.new(3) { |p| lorem_paragraph.call(4, seed + p) }.join("\n\n")
+      body: Array.new(3) { |paragraph_index| lorem_paragraph.call(4, seed + paragraph_index) }.join("\n\n")
     )
   end
 end


### PR DESCRIPTION
## Summary

- rename the short benchmark seed block parameter for readability
- simplify the benchmark DB preparation step by removing the unnecessary `NODE_ENV`
- replace the dense `rails runner` one-liner with a heredoc row-count check that keeps the same failure behavior

## Issue scope

Covers the bounded cleanup requested by #3638. This intentionally does not redesign the benchmark workflow or touch unrelated benchmark logic.

## Validation

- `script/ci-changes-detector origin/main`
- `ruby -c react_on_rails_pro/spec/dummy/db/seeds.rb`
- `actionlint .github/workflows/benchmark.yml`
- extracted workflow DB prep shell block piped to `bash -n`
- executed the extracted DB prep/run block in the Pro dummy app; seeded counts: `50 posts, 10 users, 173 comments`
- `git diff --check`
- self-review: only `.github/workflows/benchmark.yml` and `react_on_rails_pro/spec/dummy/db/seeds.rb` changed

Note: the focused Rails validation emitted the existing `Prism::VERSION` warning but exited successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and seed readability only; same seed-count guard behavior and no auth or data-model changes.
> 
> **Overview**
> Cleans up the Pro Rails **Prepare and seed benchmark database** CI step: drops unused **`NODE_ENV: production`** from that step’s env (asset/renderer steps still set it where needed), and replaces the inline `rails runner` one-liner with a **heredoc** script that still aborts if `posts`, `users`, or `comments` are empty after `db:prepare`.
> 
> In **`react_on_rails_pro/spec/dummy/db/seeds.rb`**, renames the post-body block variable from `p` to `paragraph_index` for clarity; seed output is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa838b24022437019d987f28f7ba13c90132216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced benchmark database seeding workflow with improved verification logic and clearer output reporting.
  * Improved code readability in seed data generation through more descriptive variable naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->