### PR TITLE
Classify renderer errors by origin

### DIFF
--- a/react_on_rails/lib/react_on_rails/error.rb
+++ b/react_on_rails/lib/react_on_rails/error.rb
@@ -5,4 +5,7 @@ module ReactOnRails
 
   class Error < StandardError
   end
+
+  class ServerBundleLoadError < Error
+  end
 end

--- a/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
+++ b/react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb
@@ -100,6 +100,8 @@ module ReactOnRails
                      else
                        js_evaluator.eval_js(js_code, render_options)
                      end
+          rescue ReactOnRails::ServerBundleLoadError
+            raise
           rescue StandardError => err
             msg = if renderer_connection_error?(err)
                     renderer_connection_error_message(err)
@@ -155,7 +157,7 @@ module ReactOnRails
           msg = "You specified server rendering JS file: #{server_js_file}, but it cannot be " \
                 "read. You may set the server_bundle_js_file in your configuration to be \"\" to " \
                 "avoid this warning.\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
-          raise ReactOnRails::Error, msg
+          raise ReactOnRails::ServerBundleLoadError, msg
         end
 
         def create_js_context
@@ -253,8 +255,17 @@ module ReactOnRails
         # re-wraps the original Errno inside its own error; a narrow message check then
         # catches connection failures that only survive as text. See issue #3604.
         def renderer_connection_error?(err)
+          return false if server_bundle_load_error_in_chain?(err)
+
           connection_error_class_in_chain?(err) ||
-            err.message.to_s.match?(RENDERER_CONNECTION_ERROR_REGEX)
+            connection_error_message_in_chain?(err)
+        end
+
+        def server_bundle_load_error_in_chain?(err)
+          each_in_cause_chain(err) do |current|
+            return true if current.is_a?(ReactOnRails::ServerBundleLoadError)
+          end
+          false
         end
 
         # Walks err and its #cause chain looking for a known connection Errno, so a wrapped
@@ -263,6 +274,13 @@ module ReactOnRails
         def connection_error_class_in_chain?(err)
           each_in_cause_chain(err) do |current|
             return true if RENDERER_CONNECTION_ERROR_CLASSES.any? { |klass| current.is_a?(klass) }
+          end
+          false
+        end
+
+        def connection_error_message_in_chain?(err)
+          each_in_cause_chain(err) do |current|
+            return true if current.message.to_s.match?(RENDERER_CONNECTION_ERROR_REGEX)
           end
           false
         end
@@ -393,7 +411,7 @@ module ReactOnRails
           response.body.force_encoding(encoding_type)
         rescue StandardError => e
           msg = "file_url_to_string #{url} failed\nError is: #{e}\n\n#{Utils.default_troubleshooting_section}"
-          raise ReactOnRails::Error, msg
+          raise ReactOnRails::ServerBundleLoadError, msg
         end
 
         def parse_render_result(result_string, render_options)

--- a/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb
@@ -139,6 +139,33 @@ module ReactOnRails
           end
         end
 
+        context "when an EPERM connect signature survives only as the error's #cause" do
+          let(:error) { wrapped_error(Errno::EPERM, "connect(2) for 127.0.0.1:3800", "renderer request failed") }
+
+          it "is classified as a connection failure via the cause message" do
+            message = render_error_for(error).message
+            expect(message).to include("could not connect to the Node renderer at 127.0.0.1:3800")
+            expect(message).not_to include("Check your webpack configuration")
+          end
+        end
+
+        context "when an HTTP-served server bundle cannot be loaded" do
+          let(:error) do
+            ReactOnRails::ServerBundleLoadError.new(
+              "You specified server rendering JS file: http://localhost:3035/server-bundle.js, " \
+              "but it cannot be read.\nError is: Failed to open TCP connection to localhost:3035"
+            )
+          end
+
+          it "preserves the bundle-load failure instead of reporting a renderer connection failure" do
+            raised_error = render_error_for(error)
+            expect(raised_error).to be_a(ReactOnRails::ServerBundleLoadError)
+            expect(raised_error.message).to include("server-bundle.js")
+            expect(raised_error.message).to include("cannot be read")
+            expect(raised_error.message).not_to include("could not connect to the Node renderer")
+          end
+        end
+
         context "when the renderer request times out (Pro 'Time out error on renderer request')" do
           let(:error) do
             StandardError.new(
@@ -271,6 +298,28 @@ module ReactOnRails
             expect(message).to include("Error evaluating server bundle. Check your webpack configuration.")
             expect(message).to include("code-splitting incorrectly enabled")
           end
+        end
+      end
+
+      describe ".read_bundle_js_code" do
+        it "raises a bundle-load error when an HTTP server bundle cannot be read" do
+          server_bundle_url = "http://localhost:3035/webpack/development/server-bundle.js"
+
+          allow(ReactOnRails::Utils).to receive_messages(
+            server_bundle_js_file_path: server_bundle_url,
+            server_bundle_path_is_http?: true
+          )
+          allow(Net::HTTP).to receive(:get_response).and_raise(
+            Errno::ECONNREFUSED.new("connect(2) for localhost:3035")
+          )
+
+          expect do
+            described_class.read_bundle_js_code
+          end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+            expect(error.message).to include(server_bundle_url)
+            expect(error.message).to include("cannot be read")
+            expect(error.message).to include("connect(2) for localhost:3035")
+          }
         end
       end
     end

--- a/react_on_rails_pro/lib/react_on_rails_pro/request.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/request.rb
@@ -382,7 +382,7 @@ module ReactOnRailsPro
         response.body
       rescue ReactOnRailsPro::RendererHttpClient::Error => e
         detail = e.is_a?(ReactOnRailsPro::RendererHttpClient::HTTPError) ? e.response.body : e
-        raise ReactOnRailsPro::Error, "Failed to fetch dev-server asset from #{path}: #{detail}"
+        raise ReactOnRails::ServerBundleLoadError, "Failed to fetch dev-server asset from #{path}: #{detail}"
       end
 
       def http_url?(path)

--- a/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb
@@ -228,7 +228,7 @@ describe ReactOnRailsPro::Request do
       expect(result).to eq(response_body)
     end
 
-    it "raises ReactOnRailsPro::Error when HTTP request fails" do
+    it "raises a bundle-load error when HTTP request fails" do
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
       allow(ReactOnRailsPro::RendererHttpClient).to receive(:get).and_raise(
         ReactOnRailsPro::RendererHttpClient::ConnectionError, "Connection refused"
@@ -236,10 +236,10 @@ describe ReactOnRailsPro::Request do
 
       expect do
         described_class.send(:get_form_body_for_file, url_path)
-      end.to raise_error(ReactOnRailsPro::Error, /#{Regexp.escape(url_path)}/)
+      end.to raise_error(ReactOnRails::ServerBundleLoadError, /#{Regexp.escape(url_path)}/)
     end
 
-    it "raises ReactOnRailsPro::Error when response has error status" do
+    it "raises a bundle-load error when response has error status" do
       error_response = instance_double(ReactOnRailsPro::RendererHttpClient::Response,
                                        error?: true, status: 404, body: "Not Found")
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
@@ -247,7 +247,7 @@ describe ReactOnRailsPro::Request do
 
       expect do
         described_class.send(:get_form_body_for_file, url_path)
-      end.to raise_error(ReactOnRailsPro::Error, /#{Regexp.escape(url_path)}/)
+      end.to raise_error(ReactOnRails::ServerBundleLoadError, /#{Regexp.escape(url_path)}/)
     end
   end
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/node_rendering_pool_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/node_rendering_pool_spec.rb
@@ -32,6 +32,69 @@ module ReactOnRailsPro
         end
       end
 
+      describe ".exec_server_render_js error classification" do
+        let(:js_code) { "console.log('x')" }
+        let(:render_path) { "/bundles/123/render/abc" }
+        let(:render_options) do
+          instance_double(
+            ReactOnRails::ReactComponent::RenderOptions,
+            trace: false,
+            streaming?: false
+          )
+        end
+
+        before do
+          allow(render_options).to receive(:set_option)
+          allow(described_class).to receive(:prepare_render_path).and_return(render_path)
+          allow(ReactOnRailsPro.configuration).to receive(:renderer_use_fallback_exec_js).and_return(false)
+        end
+
+        it "reports renderer request connection failures as renderer connection failures" do
+          renderer_error = ReactOnRailsPro::Error.new(
+            "Connection error on renderer request: #{render_path}.\n" \
+            "Original error:\nConnection refused - connect(2) for 127.0.0.1:3800\n"
+          )
+          allow(ReactOnRailsPro::Request).to receive(:render_code)
+            .with(render_path, js_code, false)
+            .and_raise(renderer_error)
+
+          expect do
+            described_class.exec_server_render_js(js_code, render_options)
+          end.to raise_error(ReactOnRails::Error) { |error|
+            expect(error).not_to be_a(ReactOnRails::ServerBundleLoadError)
+            expect(error.message).to include("could not connect to the Node renderer at 127.0.0.1:3800")
+            expect(error.message).not_to include("Check your webpack configuration")
+          }
+        end
+
+        it "preserves bundle-server fetch failures as bundle-load failures" do
+          send_bundle_response = instance_double(
+            ReactOnRailsPro::RendererHttpClient::Response,
+            status: ReactOnRailsPro::STATUS_SEND_BUNDLE,
+            body: "Bundle not found"
+          )
+          bundle_load_error = ReactOnRails::ServerBundleLoadError.new(
+            "Failed to fetch dev-server asset from http://localhost:3035/server-bundle.js: " \
+            "Connection refused - connect(2) for localhost:3035"
+          )
+
+          allow(ReactOnRailsPro::Request).to receive(:render_code)
+            .with(render_path, js_code, false)
+            .and_return(send_bundle_response)
+          allow(ReactOnRailsPro::Request).to receive(:render_code)
+            .with(render_path, js_code, true)
+            .and_raise(bundle_load_error)
+
+          expect do
+            described_class.exec_server_render_js(js_code, render_options)
+          end.to raise_error(ReactOnRails::ServerBundleLoadError) { |error|
+            expect(error.message).to include("Failed to fetch dev-server asset")
+            expect(error.message).to include("server-bundle.js")
+            expect(error.message).not_to include("could not connect to the Node renderer")
+          }
+        end
+      end
+
       describe ".prepare_incremental_render_path" do
         let(:js_code) { "console.log('test');" }
         let(:render_options) do


### PR DESCRIPTION
## Summary

Fixes #3628 by separating server-bundle load failures from renderer-connection failures.

- Adds `ReactOnRails::ServerBundleLoadError` for bundle read/fetch failures.
- Keeps renderer-connection classification focused on render-origin connection errors, including wrapped `connect(2)` failures found through the cause chain.
- Updates Pro request/node-rendering coverage for bundle-server-down versus renderer-down behavior.

## Validation

- `script/ci-changes-detector origin/main`
- `git diff --check origin/main..HEAD`
- `bundle exec rspec react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb`
  - 23 examples, 0 failures
- `cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/request_spec.rb spec/react_on_rails_pro/server_rendering_pool/node_rendering_pool_spec.rb`
  - 34 examples, 0 failures, 1 known pending
  - Output includes existing fakefs frozen-string warnings and the known async-task warning tied to pending #3300, but the suite passed.
- `RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop react_on_rails/lib/react_on_rails/error.rb react_on_rails/lib/react_on_rails/server_rendering_pool/ruby_embedded_java_script.rb react_on_rails/spec/react_on_rails/server_rendering_pool/ruby_embedded_java_script_spec.rb react_on_rails_pro/lib/react_on_rails_pro/request.rb react_on_rails_pro/spec/react_on_rails_pro/request_spec.rb react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/node_rendering_pool_spec.rb`
  - 6 files inspected, no offenses detected

## Notes

This stays in the bounded file set for #3628. I did not add a broader Pro dummy integration test; the focused OSS and Pro unit specs cover the bundle-load versus renderer-connection acceptance boundary directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which exception types and messages users see during SSR setup and Pro dev-server fetches; behavior is limited to diagnostics/classification but affects a common failure path.
> 
> **Overview**
> Introduces **`ReactOnRails::ServerBundleLoadError`** so failures to read or fetch the server bundle are distinct from “cannot reach the Node renderer” failures (fixes #3628).
> 
> **OSS:** `read_bundle_js_code`, HTTP `file_url_to_string`, and related paths now raise `ServerBundleLoadError` instead of a generic `ReactOnRails::Error`. `exec_server_render_js` **re-raises** that type unchanged. Renderer connection detection skips errors whose `#cause` chain includes `ServerBundleLoadError`, and connection-style message matching now walks the **full cause chain** (e.g. wrapped `connect(2)` / EPERM).
> 
> **Pro:** Dev-server HTTP bundle/asset fetches in `Request#get_form_body_for_file` raise `ServerBundleLoadError` instead of `ReactOnRailsPro::Error`.
> 
> Specs cover bundle-server-down vs renderer-down, cause-chain classification, and Pro node pool behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817e75b12aea539c8274c3f9ad409cb125001eb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to accurately distinguish bundle load failures from renderer connectivity issues, ensuring more precise error reporting.

* **Tests**
  * Added comprehensive test coverage for error classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->