### PR TITLE
Decouple webpack dependency-level integration legs

### DIFF
--- a/.github/workflows/dummy-app-bundler-tests.yml
+++ b/.github/workflows/dummy-app-bundler-tests.yml
@@ -1,26 +1,19 @@
 name: Dummy App Bundler Tests
 
-# Reusable workflow: builds the dummy-app test bundles and runs the integration tests for a SINGLE
-# bundler's matrix (passed in via the `matrix` input). integration-tests.yml calls this once per
-# bundler (webpack, rspack), so each bundler gets its own build -> integration job chain.
+# Reusable workflow: builds the dummy-app test bundles and runs the integration tests for one
+# independent matrix (passed in via the `matrix` input). integration-tests.yml calls this once per
+# build -> integration chain: webpack latest, webpack minimum in full-matrix runs, and rspack latest.
 #
 # Why this exists (#3593, follow-up to #3481 / #3581): GitHub Actions `needs` gates job-to-job, not
-# matrix-leg-to-leg. When build + integration shared a single job each, a build failure in EITHER
-# bundler marked the whole build job failed and skipped EVERY integration leg — including the
-# bundler that built fine. Splitting the build/integration pair into a per-bundler reusable-workflow
-# call decouples the bundlers: a failed build here only skips THIS call's integration job; the other
-# bundler's separate call runs independently.
-#
-# Remaining (pre-existing, out of scope for #3593; tracked in #3622): within one call the build ->
-# integration `needs` still couples that bundler's own dependency-level legs (e.g. webpack latest +
-# minimum) — if either build leg fails, this call's integration job is skipped. Only the
-# webpack/rspack dimension is decoupled here; the latest/minimum coupling predates the bundler split.
+# matrix-leg-to-leg. Splitting the build/integration pair into separate reusable-workflow calls
+# decouples the chains: a failed build here only skips THIS call's integration job; the other
+# bundler/dependency-level calls run independently. Refs #3622 for the webpack latest/minimum split.
 
 on:
   workflow_call:
     inputs:
       matrix:
-        description: 'JSON matrix (an object with an `include` array) of legs to build + test for this bundler.'
+        description: 'JSON matrix (an object with an `include` array) of legs to build + test for one independent bundler/dependency-level chain.'
         required: true
         type: string
 
@@ -30,10 +23,10 @@ permissions:
 jobs:
   build-dummy-app-test-bundles:
     strategy:
-      # fail-fast: false keeps this bundler's own matrix legs independent: a failure in one leg
+      # fail-fast: false keeps this call's matrix legs independent: a failure in one leg
       # (e.g. webpack minimum) must not cancel the others (the default fail-fast: true would).
-      # Cross-bundler independence (a webpack failure not cancelling rspack) comes from the two
-      # callers being separate top-level jobs in integration-tests.yml, not from fail-fast. Refs #3481.
+      # Cross-chain independence comes from separate caller jobs in integration-tests.yml, not from
+      # fail-fast. Refs #3481 / #3622.
       fail-fast: false
       matrix: ${{ fromJson(inputs.matrix) }}
     runs-on: ubuntu-22.04
@@ -139,9 +132,8 @@ jobs:
           key: dummy-app-bundle-${{ steps.get-sha.outputs.sha }}-ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}-${{ matrix.bundler }}
 
   dummy-app-integration-tests:
-    # Decoupled per-bundler (#3593): this job needs only THIS call's build job, so a build failure in
-    # the other bundler's separate reusable-workflow call cannot skip these tests. See the header
-    # comment for the remaining pre-existing latest/minimum coupling within a single call.
+    # Decoupled per chain (#3593 / #3622): this job needs only THIS call's build job, so a build
+    # failure in another bundler or dependency-level call cannot skip these tests.
     needs: build-dummy-app-test-bundles
     strategy:
       # Keep the legs reporting independently: a failure in one leg must not cancel the others (the

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,52 +82,60 @@ jobs:
   setup-integration-matrix:
     needs: detect-changes
     runs-on: ubuntu-22.04
-    # Emit one matrix per bundler. Each is fed to a separate per-bundler reusable-workflow call
-    # (webpack-dummy-app-tests / rspack-dummy-app-tests) so the bundlers' build -> integration
-    # chains are fully decoupled: a build failure in one bundler can no longer skip the other
-    # bundler's integration tests. Refs #3593 (follow-up to #3481 / #3581).
+    # Emit one matrix per independent build -> integration chain. Webpack latest keeps the
+    # existing webpack-dummy-app-tests caller; full-matrix runs add a separate webpack minimum
+    # caller so dependency-level build failures cannot skip each other's integration tests.
+    # Rspack remains a single latest-only caller. Refs #3593 / #3622 (follow-up to #3481 / #3581).
     outputs:
       webpack_matrix: ${{ steps.set-matrix.outputs.webpack_matrix }}
+      webpack_minimum_matrix: ${{ steps.set-matrix.outputs.webpack_minimum_matrix }}
       rspack_matrix: ${{ steps.set-matrix.outputs.rspack_matrix }}
+      run_full_matrix: ${{ steps.set-matrix.outputs.run_full_matrix }}
     steps:
       - id: set-matrix
         run: |
           # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label).
-          # Legs are built with `jq -nc` so the JSON stays readable/diffable (one leg per line) while
-          # still emitting compact single-line output for $GITHUB_OUTPUT. Refs #3481.
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]] || \
              [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
-            # Full matrix: test both latest and minimum supported versions for Webpack.
-            webpack_matrix="$(jq -nc '{
-              "include": [
-                {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"},
-                {"ruby-version":"3.3","node-version":"20","dependency-level":"minimum","bundler":"webpack"}
-              ]
-            }')"
+            run_full_matrix=true
           else
-            # PR matrix: test only latest versions for fast feedback.
-            webpack_matrix="$(jq -nc '{
-              "include": [
-                {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"}
-              ]
-            }')"
+            run_full_matrix=false
           fi
+          # Legs are built with `jq -nc` so the JSON stays readable/diffable (one leg per line) while
+          # still emitting compact single-line output for $GITHUB_OUTPUT. Refs #3481.
+          # Primary Webpack leg: test latest versions in both full and PR modes.
+          webpack_matrix="$(jq -nc '{
+            "include": [
+              {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"webpack"}
+            ]
+          }')"
+          # Full matrix only: test minimum supported versions for Webpack in its own reusable-workflow
+          # call so its build -> integration chain is independent from Webpack latest. Refs #3622.
+          webpack_minimum_matrix="$(jq -nc '{
+            "include": [
+              {"ruby-version":"3.3","node-version":"20","dependency-level":"minimum","bundler":"webpack"}
+            ]
+          }')"
           # Rspack runs the latest leg in both full and PR modes (it has no minimum-version leg yet).
           rspack_matrix="$(jq -nc '{
             "include": [
               {"ruby-version":"4.0","node-version":"22","dependency-level":"latest","bundler":"rspack"}
             ]
           }')"
-          echo "webpack_matrix=${webpack_matrix}" >> "$GITHUB_OUTPUT"
-          echo "rspack_matrix=${rspack_matrix}" >> "$GITHUB_OUTPUT"
+          {
+            echo "webpack_matrix=${webpack_matrix}"
+            echo "webpack_minimum_matrix=${webpack_minimum_matrix}"
+            echo "rspack_matrix=${rspack_matrix}"
+            echo "run_full_matrix=${run_full_matrix}"
+          } >> "$GITHUB_OUTPUT"
 
-  # One reusable-workflow call per bundler. Each call owns its own build -> integration job chain
-  # (see dummy-app-bundler-tests.yml) with a matched 1:1 `needs`, so a build failure in one bundler
-  # no longer skips the other bundler's integration tests. Refs #3593 (follow-up to #3481 / #3581).
-  # The gating `if:` below is identical for both calls; it preserves the prior skip behavior
-  # (docs/comment-only commits skip heavy jobs while main code changes always run full CI).
+  # One reusable-workflow call per independent bundler/dependency-level chain. Each call owns its
+  # own build -> integration job chain (see dummy-app-bundler-tests.yml), so a build failure in one
+  # chain no longer skips another chain's integration tests. Refs #3593 / #3622.
+  # The shared gating preserves the prior skip behavior (docs/comment-only commits skip heavy jobs
+  # while main code changes always run full CI). The webpack minimum call adds the full-matrix gate.
   webpack-dummy-app-tests:
     needs: [detect-changes, setup-integration-matrix]
     if: |
@@ -145,6 +153,24 @@ jobs:
     uses: ./.github/workflows/dummy-app-bundler-tests.yml
     with:
       matrix: ${{ needs.setup-integration-matrix.outputs.webpack_matrix }}
+
+  webpack-minimum-dummy-app-tests:
+    needs: [detect-changes, setup-integration-matrix]
+    if: |
+      needs.setup-integration-matrix.outputs.run_full_matrix == 'true' && !(
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        needs.detect-changes.outputs.non_runtime_only == 'true'
+      ) && (
+        github.ref == 'refs/heads/main' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.run_dummy_tests == 'true'
+      )
+    permissions:
+      contents: read
+    uses: ./.github/workflows/dummy-app-bundler-tests.yml
+    with:
+      matrix: ${{ needs.setup-integration-matrix.outputs.webpack_minimum_matrix }}
 
   rspack-dummy-app-tests:
     needs: [detect-changes, setup-integration-matrix]


### PR DESCRIPTION
## Summary

Fixes #3622 by splitting the webpack latest and minimum build -> integration chains into separate reusable-workflow callers.

- Keeps `webpack-dummy-app-tests` as the existing latest webpack chain.
- Adds `webpack-minimum-dummy-app-tests`, gated to full-matrix runs only.
- Leaves `rspack-dummy-app-tests` latest-only behavior unchanged.
- Updates workflow comments so the build -> integration dependency boundaries are explicit.

## Validation

- `script/ci-changes-detector origin/main`
  - Merge base: `e29fd2a0d553a322ef863dccdb95d3fd7afdad6e`
  - Passed; reported the expected broad workflow-triggered CI recommendations.
- `actionlint .github/workflows/integration-tests.yml .github/workflows/dummy-app-bundler-tests.yml`
  - Passed with no output.
- `git diff --check origin/main..HEAD`
  - Passed with no output.
- Matrix dry-run for edited setup logic:
  - `pull_request: run_full_matrix=false`
  - `main: run_full_matrix=true`
  - `workflow_dispatch: run_full_matrix=true`
  - `force_run: run_full_matrix=true`
  - `full_ci: run_full_matrix=true`
  - Verified webpack latest, webpack minimum, and rspack latest JSON matrices each contain the expected single leg.
- Self-review:
  - Diff is limited to `.github/workflows/integration-tests.yml` and `.github/workflows/dummy-app-bundler-tests.yml`.
  - No `.github/workflows/benchmark.yml` or RSC generator files were touched.

## Check-name risk

The existing `webpack-dummy-app-tests` and `rspack-dummy-app-tests` callers remain. This PR intentionally adds a new `webpack-minimum-dummy-app-tests` workflow caller for full-matrix runs, so there will be a new check context for the minimum webpack chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow orchestration and comments; no application runtime or test logic is modified, aside from a new full-matrix check name.
> 
> **Overview**
> Fixes **#3622** by decoupling webpack **latest** and **minimum** dummy-app integration chains so a failed build in one leg no longer skips the other’s integration job (GitHub Actions `needs` is job-level, not per matrix leg).
> 
> In **`integration-tests.yml`**, `setup-integration-matrix` now always emits a **latest-only** `webpack_matrix`, adds a separate **`webpack_minimum_matrix`** and **`run_full_matrix`** flag, and introduces **`webpack-minimum-dummy-app-tests`**—a second reusable call to `dummy-app-bundler-tests.yml` gated to full-matrix runs (main, `workflow_dispatch`, `force_run`, full-ci label). PRs keep webpack latest + rspack only; full CI gains an extra check context for the minimum webpack chain.
> 
> **`dummy-app-bundler-tests.yml`** comments are updated to describe per-chain callers (webpack latest, webpack minimum, rspack latest) instead of per-bundler-only wording; job behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e954d0bf7b659494a1c1bada7f7fffad65cde77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal CI/CD workflow improvements for test organization and matrix setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->