### PR TITLE
Clarify RSC React compatibility policy

### DIFF
--- a/docs/pro/react-server-components/create-without-ssr.md
+++ b/docs/pro/react-server-components/create-without-ssr.md
@@ -23,21 +23,19 @@ yarn add --exact react-on-rails-pro@VERSION
 bundle add react_on_rails_pro --version="= VERSION"
 ```
 
-Also, install version 19 of React, React DOM, and `react-on-rails-rsc`:
+Also, install React 19.0.x, React DOM 19.0.x, and the exact `react-on-rails-rsc` release candidate currently used by the generator:
 
 ```bash
-yarn add react@19.0.4 react-dom@19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# npm install react@19.0.4 react-dom@19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# pnpm add react@19.0.4 react-dom@19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# bun add react@19.0.4 react-dom@19.0.4 react-on-rails-rsc@19.0.5-rc.6
+yarn add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
+# npm install react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
+# pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
+# bun add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
 ```
 
 > [!NOTE]
-> React on Rails Pro currently supports React 19 with a compatible `react-on-rails-rsc` version.
-> The example above pins `19.0.5-rc.6`, a release candidate. Once `react-on-rails-rsc@19.0.5`
-> stable is published, update to the latest stable `19.x` release that your `react-on-rails-rsc`
-> compatibility range allows. The RSC bundler APIs used internally can change between React minor
-> versions. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
+> React on Rails Pro RSC currently supports React 19.0.x with patch >= 19.0.4. Do not upgrade generated RSC apps to React 19.1 or 19.2 just because those versions are newer on npm; the RSC bundler APIs used internally can change between React minor versions. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
+>
+> The example above pins `react-on-rails-rsc@19.0.5-rc.6`, a release candidate. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is published and the generator/package metadata policy is reviewed together.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
 

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -12,8 +12,23 @@ The generator supports Rspack — when `assets_bundler: rspack` is detected in `
 The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides bundler-specific manifest plugins plus a shared loader:
 
 - **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`) — generates client/server component manifest files under webpack.
-- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported from `react-on-rails-rsc` 19.0.5-rc.6+ (switch to 19.0.5 stable once published).
+- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the exact `react-on-rails-rsc@19.0.5-rc.6` pin (switch to 19.0.5 stable once published).
 - **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`) — transforms `'use client'` files into client reference proxies in the RSC bundle. Works under both webpack and rspack.
+
+## React and Package Version Policy
+
+Generated RSC apps intentionally stay on React 19.0.x: `react@~19.0.4` and
+`react-dom@~19.0.4`. That range admits stable 19.0 patch releases with a 19.0.4
+minimum, but does not opt into React 19.1 or 19.2. The RSC runtime and bundler
+integration can change between React minor releases, so the generator range should
+advance only after the Webpack and Rspack paths are verified against the new React
+minor.
+
+The generator separately pins `react-on-rails-rsc@19.0.5-rc.6` exactly until a
+stable `react-on-rails-rsc@19.0.5` is published. That package pin is separate from
+the Pro package peer metadata tracked in [issue #3609](https://github.com/shakacode/react_on_rails/issues/3609):
+metadata can allow prerelease RSC packages broadly enough for `npm ls`, while the
+generator still installs the tested React range and exact RSC package pin.
 
 ## Compatibility Matrix
 

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -8,19 +8,19 @@ This guide walks you through adding React Server Components to an existing React
 
 Before running the generator, verify your environment:
 
-| Requirement              | Check command                                                                                                                  | Expected                                                                                                |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| React on Rails Pro gem   | `bundle show react_on_rails_pro`                                                                                               | v16.4.0+                                                                                                |
-| React on Rails gem       | `bundle show react_on_rails`                                                                                                   | v16.4.0+                                                                                                |
-| React on Rails Pro npm   | `npm ls react-on-rails-pro` / `yarn why react-on-rails-pro` / `pnpm list react-on-rails-pro` / `bun pm why react-on-rails-pro` | Matches gem version                                                                                     |
-| React version            | `npm ls react` / `yarn why react` / `pnpm list react` / `bun pm why react`                                                     | 19.0.4+ (see [v16.2.0 release notes](../../oss/upgrading/release-notes/16.2.0.md) for security context) |
-| React DOM version        | `npm ls react-dom` / `yarn why react-dom` / `pnpm list react-dom` / `bun pm why react-dom`                                     | Must match `react` version                                                                              |
-| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | Compatible with the current Pro peer-dependency range                                                   |
-| Node.js                  | `node --version`                                                                                                               | 18+                                                                                                     |
-| Pro initializer exists   | `ls config/initializers/react_on_rails_pro.rb`                                                                                 | File exists                                                                                             |
-| Node renderer configured | Check `react_on_rails_pro.rb` for `server_renderer = "NodeRenderer"`                                                           | NodeRenderer enabled                                                                                    |
+| Requirement              | Check command                                                                                                                  | Expected                                                                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| React on Rails Pro gem   | `bundle show react_on_rails_pro`                                                                                               | v16.4.0+                                                                                                                    |
+| React on Rails gem       | `bundle show react_on_rails`                                                                                                   | v16.4.0+                                                                                                                    |
+| React on Rails Pro npm   | `npm ls react-on-rails-pro` / `yarn why react-on-rails-pro` / `pnpm list react-on-rails-pro` / `bun pm why react-on-rails-pro` | Matches gem version                                                                                                         |
+| React version            | `npm ls react` / `yarn why react` / `pnpm list react` / `bun pm why react`                                                     | 19.0.x with patch >= 19.0.4 (see [v16.2.0 release notes](../../oss/upgrading/release-notes/16.2.0.md) for security context) |
+| React DOM version        | `npm ls react-dom` / `yarn why react-dom` / `pnpm list react-dom` / `bun pm why react-dom`                                     | Must match `react` version                                                                                                  |
+| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | Exact `19.0.5-rc.6` pin until stable `19.0.5` ships                                                                         |
+| Node.js                  | `node --version`                                                                                                               | 18+                                                                                                                         |
+| Pro initializer exists   | `ls config/initializers/react_on_rails_pro.rb`                                                                                 | File exists                                                                                                                 |
+| Node renderer configured | Check `react_on_rails_pro.rb` for `server_renderer = "NodeRenderer"`                                                           | NodeRenderer enabled                                                                                                        |
 
-If React is below 19.0.4, upgrade it first:
+If React is outside the supported 19.0.x range or below 19.0.4, upgrade it first:
 
 ```bash
 pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
@@ -28,10 +28,13 @@ pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
 # or: npm install react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
 ```
 
-> **React 19.0.4+** is recommended. Earlier 19.0.x versions (19.0.0--19.0.3) have known security vulnerabilities — see the [v16.2.0 release notes](../../oss/upgrading/release-notes/16.2.0.md) for details.
+> **React 19.0.x with patch >= 19.0.4** is recommended. Earlier 19.0.x versions (19.0.0--19.0.3) have known security vulnerabilities — see the [v16.2.0 release notes](../../oss/upgrading/release-notes/16.2.0.md) for details.
 
 > [!NOTE]
-> `react-on-rails-rsc@19.0.5-rc.6` is an exact release-candidate pin. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is available.
+> The RSC generator intentionally stays on React 19.0.x and does not widen generated apps to React 19.1 or 19.2 yet. React's RSC runtime and bundler APIs can change between minor releases, so advance the React range only when the generator, docs, and package metadata policy are reviewed together.
+
+> [!NOTE]
+> `react-on-rails-rsc@19.0.5-rc.6` is an exact release-candidate pin. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is available. This is separate from the Pro package peer metadata tracked in [issue #3609](https://github.com/shakacode/react_on_rails/issues/3609): metadata can allow prerelease RSC packages broadly enough for `npm ls`, while the generator still installs the tested exact RSC package pin.
 
 ## Pre-Migration: Audit Components for Client API Usage
 
@@ -260,8 +263,8 @@ Then run `bundle install` before retrying the generator.
 
 If the RSC bundle build fails but server and client builds succeed, the issue is likely in `rscWebpackConfig.js`. Common causes:
 
-- **Missing `react-on-rails-rsc` package**: Run `pnpm add react-on-rails-rsc`
-- **React or `react-on-rails-rsc` version mismatch**: RSC requires React 19 with a compatible `react-on-rails-rsc` version. Check with `pnpm list react react-dom react-on-rails-rsc`
+- **Missing `react-on-rails-rsc` package**: Run `pnpm add react-on-rails-rsc@19.0.5-rc.6`
+- **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.0.x with patch >= 19.0.4 and the exact `react-on-rails-rsc@19.0.5-rc.6` pin. Check with `pnpm list react react-dom react-on-rails-rsc`
 - **Custom webpack config incompatibility**: If your `serverWebpackConfig.js` was heavily customized, the generator's transforms may not apply cleanly. See [Preparing Your App: Step 4](../../oss/migrating/rsc-preparing-app.md#step-4-set-up-the-rsc-webpack-bundle) for the underlying intent of each webpack change
 
 ### Manifest Files Not Generated

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -140,10 +140,15 @@ module ReactOnRails
         react-on-rails-rsc
       ].freeze
 
-      # React peer-dependency range for RSC apps. This governs the `react` / `react-dom` installs
-      # (see add_react_dependencies) and is intentionally distinct from RSC_PACKAGE_VERSION_PIN below,
-      # which pins `react-on-rails-rsc`. The two track different versions during the RC window:
-      # react/react-dom stay on stable 19.0.x while react-on-rails-rsc rides an RC.
+      # React peer-dependency range for generated RSC apps. This governs the `react` / `react-dom`
+      # installs (see add_react_dependencies) and intentionally stays on the stable React 19.0.x
+      # line with a 19.0.4 minimum. Do not widen this to React 19.1/19.2 just because those releases
+      # are current on npm; React's RSC runtime and bundler integration can change between minors.
+      #
+      # This is intentionally distinct from RSC_PACKAGE_VERSION_PIN below, which pins
+      # `react-on-rails-rsc`. Coordination note for #3609: Pro package metadata may accept the
+      # prerelease RSC package broadly enough to keep `npm ls` healthy, but generator behavior still
+      # installs the tested React 19.0.x range and exact RSC package pin until both policies advance.
       RSC_REACT_VERSION_RANGE = "~19.0.4"
       # Pinned to 19.0.5-rc.6 because the discovery plugin export, native Rspack plugin, and
       # RSC manifest CSS fixes all ship in that prerelease.

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -661,7 +661,18 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
       expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.0.5-rc.6")
     end
 
-    it "pins react-on-rails-rsc to the React 19 compatibility track" do
+    it "keeps the generated RSC React policy on the 19.0.x patch track" do
+      range = ReactOnRails::Generators::JsDependencyManager::RSC_REACT_VERSION_RANGE
+      requirement = Gem::Requirement.new(range.sub(/\A~/, "~> "))
+
+      expect(requirement.satisfied_by?(Gem::Version.new("19.0.4"))).to be(true)
+      expect(requirement.satisfied_by?(Gem::Version.new("19.0.7"))).to be(true)
+      expect(requirement.satisfied_by?(Gem::Version.new("19.0.3"))).to be(false)
+      expect(requirement.satisfied_by?(Gem::Version.new("19.1.0"))).to be(false)
+      expect(requirement.satisfied_by?(Gem::Version.new("19.2.7"))).to be(false)
+    end
+
+    it "pins react-on-rails-rsc to the exact RSC package compatibility track" do
       expected_pin = ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN
       expect(instance.send(:rsc_packages_with_version)).to eq([["react-on-rails-rsc@#{expected_pin}"], true])
     end


### PR DESCRIPTION
## Summary

Fixes #3620 by documenting and testing the current generated-RSC compatibility policy.

- Clarifies that generated RSC apps intentionally stay on React `19.0.x` via `~19.0.4`, not React 19.1/19.2 just because those versions are current on npm.
- Keeps `react-on-rails-rsc` as an exact `19.0.5-rc.6` generator pin until a stable `19.0.5` release ships.
- Adds focused spec coverage for the React range behavior: accepts 19.0.4/19.0.7 and rejects 19.0.3/19.1.0/19.2.7.
- Coordinates with #3609 by separating package peer metadata compatibility from exact generator install behavior.

## Live package evidence

- `npm view react-on-rails-rsc dist-tags versions version peerDependencies --json`
  - `latest`: `19.0.4`
  - `next`: `19.0.5-rc.6`
  - no stable `19.0.5` is published
  - latest stable peer dependencies: `react: ^19.0.3`, `react-dom: ^19.0.3`, `webpack: ^5.59.0`
- `npm view react react-dom react-server-dom-webpack dist-tags version peerDependencies --json`
  - `react@latest`: `19.2.7`
  - `react-dom@latest`: `19.2.7`, peer `react: ^19.2.7`
  - `react-server-dom-webpack@latest`: `19.2.7`, peers `react: ^19.2.7`, `react-dom: ^19.2.7`, `webpack: ^5.59.0`

## Validation

- `bundle exec rspec react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb`
  - 79 examples, 0 failures
- `pnpm prettier --check docs/pro/react-server-components/upgrading-existing-pro-app.md docs/pro/react-server-components/create-without-ssr.md docs/pro/react-server-components/rspack-compatibility.md`
  - Passed; all matched files use Prettier style
- `script/ci-changes-detector origin/main`
  - Merge base: `30ec8e12b95b3ca56cee8f46ba62e6dde2b9433d`
  - Recommended CI: RSpec gem tests and Generator tests
- `git diff --check origin/main..HEAD`
  - Passed with no output
- Self-review:
  - Diff is limited to `js_dependency_manager.rb`, `js_dependency_manager_spec.rb`, and the targeted RSC docs.
  - Did not touch `install_generator_spec.rb`, active RSC generator PR files, workflow files, `rsc_setup.rb`, or `rsc_use_client_css.spec.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, comment, and spec-only changes; generator dependency constants are unchanged, so install behavior is unaffected.
> 
> **Overview**
> Documents and tests the **generated RSC compatibility policy** (fixes #3620): apps should stay on **React `19.0.x`** via `react@~19.0.4` / `react-dom@~19.0.4` (patch ≥ 19.0.4), not **19.1/19.2**, and keep **`react-on-rails-rsc@19.0.5-rc.6`** as an exact pin until stable **19.0.5** ships.
> 
> **Docs** (`create-without-ssr`, `upgrading-existing-pro-app`, `rspack-compatibility`) switch manual install examples from exact `19.0.4` to `~19.0.4`, tighten prerequisite/troubleshooting tables, add a **React and Package Version Policy** section for Rspack, and explain that **Pro peer metadata** (#3609) can differ from **generator install pins**.
> 
> **Generator** (`js_dependency_manager.rb`): richer comments on `RSC_REACT_VERSION_RANGE` vs `RSC_PACKAGE_VERSION_PIN`—no constant value changes in this diff.
> 
> **Tests**: `js_dependency_manager_spec` asserts `~19.0.4` accepts 19.0.4/19.0.7 and rejects 19.0.3/19.1.0/19.2.7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91366ab4a3ef65405c8a8b4cd5dee8fb9a441281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified React 19.0.x version requirements for Server Components with specific minimum patch versions
  * Added explicit version pinning guidance for server component package dependencies
  * Updated setup and troubleshooting instructions with exact version specifications
  * Added new "React and Package Version Policy" sections to clarify intended version targeting and upgrade guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->