### PR TITLE
fix(ci): stop running benchmarks on docs-only and CI-config-only PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -110,16 +110,8 @@ jobs:
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
           previous-sha: ${{ github.event.before }}
-      # Which benchmark suites to run is now decided entirely by the change
-      # detector (script/ci-changes-detector emits run_core_benchmarks /
-      # run_pro_benchmarks / run_pro_node_renderer_benchmarks). Those are driven by
-      # genuine product-SOURCE changes only — never by CI plumbing (scripts,
-      # actions, or the suite-specific workflow YAML files), which change how the
-      # suite runs but cannot move runtime performance. That is what stops Bencher
-      # from posting on docs-only (#3717) and CI-config-only (#3697) PRs. On push
-      # to main and workflow_dispatch, generate_matrix.rb runs every suite
-      # regardless; the 'benchmark' PR label still forces a run for workflow
-      # self-tests.
+      # script/ci-changes-detector owns benchmark-suite selection via
+      # run_core_benchmarks / run_pro_benchmarks / run_pro_node_renderer_benchmarks.
       - name: Set benchmark matrices
         id: benchmark-matrices
         # Always runs. GitHub Actions evaluates `strategy.matrix` for downstream jobs at

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -110,37 +110,16 @@ jobs:
         with:
           docs-only: ${{ steps.detect.outputs.docs_only }}
           previous-sha: ${{ github.event.before }}
-      - name: Set benchmark outputs
-        id: benchmark-outputs
-        if: steps.detect.outputs.non_runtime_only != 'true'
-        run: |
-          RUN_CORE_BENCHMARKS=false
-          RUN_PRO_BENCHMARKS=false
-          RUN_PRO_NODE_RENDERER_BENCHMARKS=false
-
-          if [ "${{ steps.detect.outputs.run_ruby_tests }}" = "true" ] ||
-             [ "${{ steps.detect.outputs.run_js_tests }}" = "true" ] ||
-             [ "${{ steps.detect.outputs.run_dummy_tests }}" = "true" ]; then
-            RUN_CORE_BENCHMARKS=true
-            RUN_PRO_BENCHMARKS=true
-          fi
-
-          if [ "${{ steps.detect.outputs.run_pro_tests }}" = "true" ] ||
-             [ "${{ steps.detect.outputs.run_pro_dummy_tests }}" = "true" ]; then
-            RUN_PRO_BENCHMARKS=true
-          fi
-
-          if [ "${{ steps.detect.outputs.run_pro_node_renderer_tests }}" = "true" ]; then
-            RUN_PRO_BENCHMARKS=true
-            RUN_PRO_NODE_RENDERER_BENCHMARKS=true
-          fi
-
-          {
-            echo "run_core_benchmarks=$RUN_CORE_BENCHMARKS"
-            echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS"
-            echo "run_pro_node_renderer_benchmarks=$RUN_PRO_NODE_RENDERER_BENCHMARKS"
-          } >> "$GITHUB_OUTPUT"
-        shell: bash
+      # Which benchmark suites to run is now decided entirely by the change
+      # detector (script/ci-changes-detector emits run_core_benchmarks /
+      # run_pro_benchmarks / run_pro_node_renderer_benchmarks). Those are driven by
+      # genuine product-SOURCE changes only — never by CI plumbing (scripts,
+      # actions, or the suite-specific workflow YAML files), which change how the
+      # suite runs but cannot move runtime performance. That is what stops Bencher
+      # from posting on docs-only (#3717) and CI-config-only (#3697) PRs. On push
+      # to main and workflow_dispatch, generate_matrix.rb runs every suite
+      # regardless; the 'benchmark' PR label still forces a run for workflow
+      # self-tests.
       - name: Set benchmark matrices
         id: benchmark-matrices
         # Always runs. GitHub Actions evaluates `strategy.matrix` for downstream jobs at
@@ -157,9 +136,9 @@ jobs:
           BENCHMARK_PULL_REQUEST_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
           BENCHMARK_PULL_REQUEST_LABELS: ${{ github.event_name == 'pull_request' && toJSON(github.event.pull_request.labels.*.name) || '[]' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          RUN_CORE_BENCHMARKS: ${{ steps.benchmark-outputs.outputs.run_core_benchmarks || 'false' }}
-          RUN_PRO_BENCHMARKS: ${{ steps.benchmark-outputs.outputs.run_pro_benchmarks || 'false' }}
-          RUN_PRO_NODE_RENDERER_BENCHMARKS: ${{ steps.benchmark-outputs.outputs.run_pro_node_renderer_benchmarks || 'false' }}
+          RUN_CORE_BENCHMARKS: ${{ steps.detect.outputs.run_core_benchmarks || 'false' }}
+          RUN_PRO_BENCHMARKS: ${{ steps.detect.outputs.run_pro_benchmarks || 'false' }}
+          RUN_PRO_NODE_RENDERER_BENCHMARKS: ${{ steps.detect.outputs.run_pro_node_renderer_benchmarks || 'false' }}
         run: |
           BENCHMARK_MATRIX=$(ruby benchmarks/generate_matrix.rb)
           export BENCHMARK_MATRIX

--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -171,7 +171,10 @@ jobs:
                 filename === '.lychee.toml' ||
                 filename.startsWith('docs/') ||
                 filename.startsWith('internal/') ||
-                filename.startsWith('.github/ISSUE_TEMPLATE/');
+                filename.startsWith('.github/ISSUE_TEMPLATE/') ||
+                filename.startsWith('.claude/') ||
+                filename.startsWith('.agents/') ||
+                filename.startsWith('.cursor/');
             }
 
             function isDocsOnly(files) {

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -260,7 +260,12 @@ while IFS= read -r file; do
     # (see the #3474 regression and the benchmarks-on-a-docs-PR case in #3597).
     #   - internal/**              : planning, contributor-info, testimonials, history docs
     #   - .github/ISSUE_TEMPLATE/** : GitHub issue templates (repo metadata, not CI infra)
-    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|internal/*|internal/**/*|.github/ISSUE_TEMPLATE/*|.github/ISSUE_TEMPLATE/**/*|.lychee.toml)
+    #   - .claude/** .agents/** .cursor/** : agent/editor tooling (skills, prompts,
+    #     hooks, workflows). These run locally for coding agents, never in GitHub
+    #     Actions CI, so they don't affect the runtime, tests, or benchmarks. The
+    #     non-extension .claude/skills symlink is what slipped through the catch-all
+    #     and ran benchmarks on the docs-only PR #3717.
+    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|internal/*|internal/**/*|.github/ISSUE_TEMPLATE/*|.github/ISSUE_TEMPLATE/**/*|.claude/*|.claude/**/*|.agents/*|.agents/**/*|.cursor/*|.cursor/**/*|.lychee.toml)
       # Don't change DOCS_ONLY flag, just continue
       ;;
 

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -254,13 +254,11 @@ source_file_comment_only_change() {
   [ "$saw_changed_line" = true ]
 }
 
-# A file that selects a test suite but is NOT itself benchmark-relevant: the
-# suite-specific workflow YAML files (gem-tests.yml, integration-tests.yml, …).
-# They share a case arm with their source dirs so editing the workflow re-runs
-# that suite's tests, but they must not flip the BENCH_* flags — a workflow edit
-# can't move runtime performance (#3697). Plain CI plumbing (script/, bin/,
-# .github/actions/, .lefthook.yml) never reaches a source arm; it lands in the
-# CI-infrastructure arm, which sets no BENCH_* flag at all.
+# Suite-specific workflow YAML files are test selectors, not benchmark inputs.
+# Some of them live in source/spec arms so the right tests still run, but a
+# workflow edit cannot move runtime performance (#3697). Plain CI plumbing
+# (script/, bin/, .github/actions/, .lefthook.yml) lands in the CI-infrastructure
+# arm instead, which sets no BENCH_* flag at all.
 is_benchmark_irrelevant_path() {
   case "$1" in
     .github/workflows/*) return 0 ;;
@@ -392,7 +390,9 @@ while IFS= read -r file; do
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_RUBY_CORE_CHANGED=true
-        BENCH_PRO_CHANGED=true
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -81,8 +81,19 @@ PRO_JS_CHANGED=false
 PRO_DUMMY_CHANGED=false
 PRO_NODE_RENDERER_CHANGED=false
 UNCATEGORIZED_CHANGED=false
+CI_INFRA_CHANGED=false
 SOURCE_COMMENT_ONLY_CHANGED=false
 PRO_SOURCE_COMMENT_ONLY_CHANGED=false
+# Benchmark relevance, tracked separately from the test-selection flags above.
+# Benchmarks measure runtime performance, so they must fire ONLY when genuine
+# product SOURCE changes — never on CI plumbing (scripts, actions) or the
+# suite-specific workflow YAML files, which change how the suite runs but cannot
+# move performance (the Bencher-on-a-config-PR noise in #3697). These three drive
+# run_core_benchmarks / run_pro_benchmarks / run_pro_node_renderer_benchmarks,
+# which benchmark.yml reads directly.
+BENCH_CORE_CHANGED=false
+BENCH_PRO_CHANGED=false
+BENCH_PRO_NODE_RENDERER_CHANGED=false
 
 comment_line_is_runtime_directive() {
   local line="$1"
@@ -243,6 +254,20 @@ source_file_comment_only_change() {
   [ "$saw_changed_line" = true ]
 }
 
+# A file that selects a test suite but is NOT itself benchmark-relevant: the
+# suite-specific workflow YAML files (gem-tests.yml, integration-tests.yml, …).
+# They share a case arm with their source dirs so editing the workflow re-runs
+# that suite's tests, but they must not flip the BENCH_* flags — a workflow edit
+# can't move runtime performance (#3697). Plain CI plumbing (script/, bin/,
+# .github/actions/, .lefthook.yml) never reaches a source arm; it lands in the
+# CI-infrastructure arm, which sets no BENCH_* flag at all.
+is_benchmark_irrelevant_path() {
+  case "$1" in
+    .github/workflows/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Analyze each changed file
 while IFS= read -r file; do
   # A here-string yields a single empty line for empty input, so skip blank lines —
@@ -276,6 +301,11 @@ while IFS= read -r file; do
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         GENERATORS_CHANGED=true
+        # Generator source feeds the core dummy app the core+pro suites benchmark.
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_CORE_CHANGED=true
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 
@@ -286,6 +316,11 @@ while IFS= read -r file; do
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         RUBY_CORE_CHANGED=true
+        # Core gem code underlies every suite (Pro depends on core, the node
+        # renderer renders core output), so it benchmarks all three.
+        BENCH_CORE_CHANGED=true
+        BENCH_PRO_CHANGED=true
+        BENCH_PRO_NODE_RENDERER_CHANGED=true
       fi
       ;;
 
@@ -296,6 +331,13 @@ while IFS= read -r file; do
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         RSPEC_CHANGED=true
+        # Mirrors the existing benchmark behavior: a core gem-spec change runs the
+        # core+pro suites (run_ruby_tests fed them). The gem-tests.yml workflow in
+        # this arm is guarded out — editing it can't move performance.
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_CORE_CHANGED=true
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 
@@ -319,6 +361,11 @@ while IFS= read -r file; do
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         JS_CHANGED=true
+        # Core JS package code drives the core+pro suites' bundles.
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_CORE_CHANGED=true
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 
@@ -329,6 +376,12 @@ while IFS= read -r file; do
         SOURCE_COMMENT_ONLY_CHANGED=true
       else
         SPEC_DUMMY_CHANGED=true
+        # The core suite benchmarks this dummy app; the pro suite shares core. The
+        # integration-tests.yml workflow in this arm is guarded out.
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_CORE_CHANGED=true
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 
@@ -339,6 +392,7 @@ while IFS= read -r file; do
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_RUBY_CORE_CHANGED=true
+        BENCH_PRO_CHANGED=true
       fi
       ;;
 
@@ -349,6 +403,9 @@ while IFS= read -r file; do
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_JS_CHANGED=true
+        # Pro JS is bundled by both the Pro Rails suite and the node renderer.
+        BENCH_PRO_CHANGED=true
+        BENCH_PRO_NODE_RENDERER_CHANGED=true
       fi
       ;;
 
@@ -359,6 +416,10 @@ while IFS= read -r file; do
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_RSPEC_CHANGED=true
+        # pro-gem-tests.yml in this arm is guarded out (a workflow edit can't move perf).
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 
@@ -369,6 +430,12 @@ while IFS= read -r file; do
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_DUMMY_CHANGED=true
+        # The Pro Rails suite benchmarks this dummy app. pro-integration-tests.yml
+        # in this arm is guarded out — that workflow edit (PR #3697) is exactly
+        # what spuriously triggered the Pro benchmark.
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_PRO_CHANGED=true
+        fi
       fi
       ;;
 
@@ -379,6 +446,12 @@ while IFS= read -r file; do
         PRO_SOURCE_COMMENT_ONLY_CHANGED=true
       else
         PRO_NODE_RENDERER_CHANGED=true
+        # Node renderer source drives the node-renderer suite and the Pro suite.
+        # node-renderer-tests.yml in this arm is guarded out.
+        if ! is_benchmark_irrelevant_path "$file"; then
+          BENCH_PRO_CHANGED=true
+          BENCH_PRO_NODE_RENDERER_CHANGED=true
+        fi
       fi
       ;;
 
@@ -394,18 +467,19 @@ while IFS= read -r file; do
       PRO_LINT_CONFIG_CHANGED=true
       ;;
 
-    # CI infrastructure files (scripts, workflows, CI configs)
-    # Changes to CI infrastructure should trigger tests to validate the changes work
+    # CI infrastructure files (scripts, workflows, CI configs).
+    # These change HOW the suite runs but never the gem/package runtime, so they
+    # trigger the full TEST suite to validate the change (see the CI_INFRA_CHANGED
+    # run-flag block below) WITHOUT triggering benchmarks: performance cannot move
+    # when only CI plumbing changes, so a benchmark run here is pure Bencher noise
+    # (see the CI-workflow-edit case in #3697). The 'benchmark' PR label still
+    # forces a run for workflow self-tests (benchmarks/generate_matrix.rb honors
+    # labels independently of these change-detection flags).
+    # NOTE: keep this as its own flag rather than setting the source *_CHANGED
+    # flags directly — that conflation is exactly what made benchmarks run here.
     script/*|script/**/*|bin/*|bin/**/*|.github/workflows/*|.github/actions/*|.github/actions/**/*|.lefthook.yml)
       DOCS_ONLY=false
-      RUBY_CORE_CHANGED=true  # Trigger all tests for CI infrastructure changes
-      JS_CHANGED=true
-      SPEC_DUMMY_CHANGED=true
-      GENERATORS_CHANGED=true
-      PRO_RUBY_CORE_CHANGED=true
-      PRO_JS_CHANGED=true
-      PRO_DUMMY_CHANGED=true
-      PRO_NODE_RENDERER_CHANGED=true
+      CI_INFRA_CHANGED=true
       ;;
 
     # Catch-all: any file not explicitly categorized above
@@ -414,6 +488,11 @@ while IFS= read -r file; do
     *)
       DOCS_ONLY=false
       UNCATEGORIZED_CHANGED=true
+      # Unknown file: benchmark every suite too (safety, matching the full-suite
+      # test run below). A new runtime path must never silently skip benchmarks.
+      BENCH_CORE_CHANGED=true
+      BENCH_PRO_CHANGED=true
+      BENCH_PRO_NODE_RENDERER_CHANGED=true
       ;;
   esac
 done <<< "$CHANGED_FILES"
@@ -435,6 +514,7 @@ elif [ "$SOURCE_COMMENT_ONLY_CHANGED" = true ] || [ "$PRO_SOURCE_COMMENT_ONLY_CH
     [ "$PRO_JS_CHANGED" = false ] &&
     [ "$PRO_DUMMY_CHANGED" = false ] &&
     [ "$PRO_NODE_RENDERER_CHANGED" = false ] &&
+    [ "$CI_INFRA_CHANGED" = false ] &&
     [ "$UNCATEGORIZED_CHANGED" = false ]; then
     NON_RUNTIME_ONLY=true
   fi
@@ -461,6 +541,9 @@ if [ "$DOCS_ONLY" = true ]; then
     "run_pro_tests:false"
     "run_pro_dummy_tests:false"
     "run_pro_node_renderer_tests:false"
+    "run_core_benchmarks:false"
+    "run_pro_benchmarks:false"
+    "run_pro_node_renderer_benchmarks:false"
     "benchmarks_changed:false"
   )
 
@@ -512,6 +595,7 @@ echo "Changed file categories:"
 [ "$PRO_LINT_CONFIG_CHANGED" = true ] && echo -e "${YELLOW}  • React on Rails Pro lint configuration${NC}"
 [ "$SOURCE_COMMENT_ONLY_CHANGED" = true ] && echo -e "${YELLOW}  • Source comments only${NC}"
 [ "$PRO_SOURCE_COMMENT_ONLY_CHANGED" = true ] && echo -e "${YELLOW}  • React on Rails Pro source comments only${NC}"
+[ "$CI_INFRA_CHANGED" = true ] && echo -e "${YELLOW}  • CI infrastructure (full test suite, no benchmarks)${NC}"
 [ "$UNCATEGORIZED_CHANGED" = true ] && echo -e "${YELLOW}  • Uncategorized changes (running full suite for safety)${NC}"
 
 echo ""
@@ -589,6 +673,24 @@ if [ "$PRO_NODE_RENDERER_CHANGED" = true ] || [ "$PRO_JS_CHANGED" = true ] || [ 
   RUN_PRO_NODE_RENDERER_TESTS=true
 fi
 
+# CI infrastructure changes run the full TEST suite to validate the change. Unlike
+# the uncategorized catch-all below, they set no BENCH_* flag, so the benchmark
+# outputs stay false: CI plumbing can't move runtime performance, so a Bencher run
+# here is noise (#3697). This block requests every test job while benchmarks stay
+# off.
+if [ "$CI_INFRA_CHANGED" = true ]; then
+  RUN_LINT=true
+  RUN_RUBY_TESTS=true
+  RUN_JS_TESTS=true
+  RUN_DUMMY_TESTS=true
+  RUN_GENERATORS=true
+  RUN_E2E_TESTS=true
+  RUN_PRO_LINT=true
+  RUN_PRO_TESTS=true
+  RUN_PRO_DUMMY_TESTS=true
+  RUN_PRO_NODE_RENDERER_TESTS=true
+fi
+
 # If we encounter a change that isn't explicitly categorized, default to running everything
 if [ "$UNCATEGORIZED_CHANGED" = true ]; then
   RUN_LINT=true
@@ -603,6 +705,16 @@ if [ "$UNCATEGORIZED_CHANGED" = true ]; then
   RUN_PRO_NODE_RENDERER_TESTS=true
 fi
 
+# Benchmark suite selection (consumed by .github/workflows/benchmark.yml). One
+# output per suite, driven purely by the BENCH_* source-relevance flags set in
+# the categorization above — never by the test run_* flags, which CI plumbing and
+# the suite-workflow YAML files inflate. This keeps Bencher off docs-only (#3717)
+# and CI-config-only (#3697) PRs. On push to main / workflow_dispatch the suites
+# run regardless (generate_matrix.rb), so these only gate PR runs.
+RUN_CORE_BENCHMARKS=$BENCH_CORE_CHANGED
+RUN_PRO_BENCHMARKS=$BENCH_PRO_CHANGED
+RUN_PRO_NODE_RENDERER_BENCHMARKS=$BENCH_PRO_NODE_RENDERER_CHANGED
+
 [ "$RUN_LINT" = true ] && echo "  ✓ Lint (Ruby + JS)"
 [ "$RUN_RUBY_TESTS" = true ] && echo "  ✓ RSpec gem tests"
 [ "$RUN_JS_TESTS" = true ] && echo "  ✓ JS unit tests"
@@ -613,6 +725,9 @@ fi
 [ "$RUN_PRO_TESTS" = true ] && echo "  ✓ React on Rails Pro RSpec unit tests (Ruby + JS)"
 [ "$RUN_PRO_DUMMY_TESTS" = true ] && echo "  ✓ React on Rails Pro Dummy app integration tests"
 [ "$RUN_PRO_NODE_RENDERER_TESTS" = true ] && echo "  ✓ React on Rails Pro Node Renderer tests"
+[ "$RUN_CORE_BENCHMARKS" = true ] && echo "  ✓ Core benchmarks"
+[ "$RUN_PRO_BENCHMARKS" = true ] && echo "  ✓ React on Rails Pro benchmarks"
+[ "$RUN_PRO_NODE_RENDERER_BENCHMARKS" = true ] && echo "  ✓ React on Rails Pro Node Renderer benchmarks"
 
 # Export as GitHub Actions outputs if running in CI
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
@@ -629,6 +744,9 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "run_pro_tests=$RUN_PRO_TESTS"
     echo "run_pro_dummy_tests=$RUN_PRO_DUMMY_TESTS"
     echo "run_pro_node_renderer_tests=$RUN_PRO_NODE_RENDERER_TESTS"
+    echo "run_core_benchmarks=$RUN_CORE_BENCHMARKS"
+    echo "run_pro_benchmarks=$RUN_PRO_BENCHMARKS"
+    echo "run_pro_node_renderer_benchmarks=$RUN_PRO_NODE_RENDERER_BENCHMARKS"
     echo "benchmarks_changed=$BENCHMARKS_CHANGED"
   } >> "$GITHUB_OUTPUT"
 fi
@@ -649,6 +767,9 @@ if [ "${CI_JSON_OUTPUT:-}" = "1" ]; then
   "run_pro_tests": $RUN_PRO_TESTS,
   "run_pro_dummy_tests": $RUN_PRO_DUMMY_TESTS,
   "run_pro_node_renderer_tests": $RUN_PRO_NODE_RENDERER_TESTS,
+  "run_core_benchmarks": $RUN_CORE_BENCHMARKS,
+  "run_pro_benchmarks": $RUN_PRO_BENCHMARKS,
+  "run_pro_node_renderer_benchmarks": $RUN_PRO_NODE_RENDERER_BENCHMARKS,
   "benchmarks_changed": $BENCHMARKS_CHANGED
 }
 EOF

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -277,6 +277,86 @@ test_agent_tooling_changes_are_non_runtime_only() {
   assert_contains "$out" '"benchmarks_changed": false' "agent tooling output"
 }
 
+# Regression for PR #3697 (the exact file set): a CI-infrastructure PR — a
+# suite-specific workflow YAML plus the detector's own test harness — must still
+# run the relevant TEST suites to validate the change, but must NOT run any
+# benchmark suite. CI plumbing can't move runtime performance, so a Bencher run
+# is noise. The script/ harness lands in the CI-infra arm (all tests, no bench),
+# and pro-integration-tests.yml runs pro dummy tests but is guarded out of the
+# BENCH_* flags.
+test_ci_infrastructure_only_change_runs_tests_but_skips_benchmarks() {
+  setup_repo
+  mkdir -p .github/workflows script
+  printf 'name: Pro integration\non: [pull_request]\n' > .github/workflows/pro-integration-tests.yml
+  printf '# detector test harness tweak\n' >> script/ci-changes-detector-test.bash
+  commit_change "ci: fix pro dummy integration gating"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": false' "ci infra output"
+  assert_contains "$out" '"non_runtime_only": false' "ci infra output"
+  # Tests still run to validate the CI change (script/ forces the full suite,
+  # pro-integration-tests.yml independently requests pro dummy tests) ...
+  assert_contains "$out" '"run_ruby_tests": true' "ci infra output"
+  assert_contains "$out" '"run_pro_dummy_tests": true' "ci infra output"
+  assert_contains "$out" '"run_pro_node_renderer_tests": true' "ci infra output"
+  # ... but every benchmark suite is off.
+  assert_contains "$out" '"run_core_benchmarks": false' "ci infra output"
+  assert_contains "$out" '"run_pro_benchmarks": false' "ci infra output"
+  assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "ci infra output"
+}
+
+# A suite-specific workflow YAML on its own runs that suite's TESTS (preserving
+# the targeted-CI optimization) but no benchmark — editing the workflow can't
+# move performance. This is the part of #3697 that the CI-infra arm doesn't cover.
+test_suite_workflow_file_runs_its_tests_but_no_benchmark() {
+  setup_repo
+  mkdir -p .github/workflows
+  printf 'name: Pro integration\non: [pull_request]\n' > .github/workflows/pro-integration-tests.yml
+  commit_change "tweak pro integration workflow"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_pro_dummy_tests": true' "workflow-only output"
+  assert_contains "$out" '"run_pro_benchmarks": false' "workflow-only output"
+  assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "workflow-only output"
+}
+
+# A CI-infra change mixed with a real runtime-source change DOES benchmark: the
+# genuine source edit sets the BENCH_* flags the workflow/script changes don't.
+test_ci_infra_plus_runtime_source_still_benchmarks() {
+  setup_repo
+  mkdir -p .github/workflows
+  printf 'name: Pro integration\non: [pull_request]\n' > .github/workflows/pro-integration-tests.yml
+  # A genuine executable edit (string value change, not a comment) to core gem code.
+  perl -0pi -e 's/"ok"/"changed"/' react_on_rails/lib/react_on_rails/example.rb
+  commit_change "ci tweak plus real source change"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"non_runtime_only": false' "mixed output"
+  assert_contains "$out" '"run_ruby_tests": true' "mixed output"
+  # Core gem source underlies all three benchmark suites.
+  assert_contains "$out" '"run_core_benchmarks": true' "mixed output"
+  assert_contains "$out" '"run_pro_benchmarks": true' "mixed output"
+  assert_contains "$out" '"run_pro_node_renderer_benchmarks": true' "mixed output"
+}
+
+# Genuine node-renderer package source must benchmark the node-renderer suite —
+# the case the spurious #3697 run pretended to cover.
+test_node_renderer_source_change_runs_node_renderer_benchmark() {
+  setup_repo
+  printf 'export const x = 1;\n' > packages/react-on-rails-pro-node-renderer/src/example.ts
+  commit_change "node renderer source change"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"run_pro_node_renderer_benchmarks": true' "node renderer output"
+  assert_contains "$out" '"run_pro_benchmarks": true' "node renderer output"
+  # Node renderer changes don't touch the core suite.
+  assert_contains "$out" '"run_core_benchmarks": false' "node renderer output"
+}
+
 test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   setup_repo
   perl -0pi -e 's/class Example/class Example\n    # Explain the fixture./' \
@@ -702,6 +782,10 @@ run_test test_internal_non_markdown_docs_are_non_runtime_only
 run_test test_issue_template_changes_are_non_runtime_only
 run_test test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only
 run_test test_agent_tooling_changes_are_non_runtime_only
+run_test test_ci_infrastructure_only_change_runs_tests_but_skips_benchmarks
+run_test test_suite_workflow_file_runs_its_tests_but_no_benchmark
+run_test test_ci_infra_plus_runtime_source_still_benchmarks
+run_test test_node_renderer_source_change_runs_node_renderer_benchmark
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_wrapping_ruby_code_with_block_comment_delimiters_remains_runtime_affecting

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -326,6 +326,7 @@ test_suite_workflow_file_runs_its_tests_but_no_benchmark() {
   assert_contains "$out" '"run_pro_tests": false' "workflow-only output"
   assert_contains "$out" '"run_pro_dummy_tests": true' "workflow-only output"
   assert_contains "$out" '"run_pro_node_renderer_tests": false' "workflow-only output"
+  assert_contains "$out" '"run_core_benchmarks": false' "workflow-only output"
   assert_contains "$out" '"run_pro_benchmarks": false' "workflow-only output"
   assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "workflow-only output"
 }

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -253,6 +253,30 @@ test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only() {
   assert_contains "$out" '"benchmarks_changed": false' "docs PR output"
 }
 
+# Regression for PR #3717: agent/editor tooling under .claude/** and .agents/**
+# is non-runtime. The .claude/skills symlink (a tracked path with no extension)
+# used to miss every category and hit the catch-all, forcing the full test +
+# benchmark suite — Bencher even posted results on that docs-only PR.
+test_agent_tooling_changes_are_non_runtime_only() {
+  setup_repo
+  mkdir -p .agents/skills/verify .claude
+  printf 'verify skill\n' > .agents/skills/verify/SKILL.md
+  # Mirror the offending file: an extensionless path under .claude/ (the PR added
+  # it as a symlink; the detector categorizes purely by path, so a plain file at
+  # the same path exercises the same case branch).
+  printf '../.agents/skills\n' > .claude/skills
+  commit_change "convert claude commands to agent skills"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "agent tooling output"
+  assert_contains "$out" '"non_runtime_only": true' "agent tooling output"
+  assert_contains "$out" '"run_lint": false' "agent tooling output"
+  assert_contains "$out" '"run_ruby_tests": false' "agent tooling output"
+  assert_contains "$out" '"run_js_tests": false' "agent tooling output"
+  assert_contains "$out" '"benchmarks_changed": false' "agent tooling output"
+}
+
 test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint() {
   setup_repo
   perl -0pi -e 's/class Example/class Example\n    # Explain the fixture./' \
@@ -677,6 +701,7 @@ run_test test_docs_changes_are_non_runtime_only
 run_test test_internal_non_markdown_docs_are_non_runtime_only
 run_test test_issue_template_changes_are_non_runtime_only
 run_test test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only
+run_test test_agent_tooling_changes_are_non_runtime_only
 run_test test_ruby_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_ruby_block_comment_only_change_skips_heavy_tests_but_keeps_lint
 run_test test_wrapping_ruby_code_with_block_comment_delimiters_remains_runtime_affecting

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -259,12 +259,15 @@ test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only() {
 # benchmark suite — Bencher even posted results on that docs-only PR.
 test_agent_tooling_changes_are_non_runtime_only() {
   setup_repo
-  mkdir -p .agents/skills/verify .claude
+  mkdir -p .agents/skills/verify .claude .cursor
   printf 'verify skill\n' > .agents/skills/verify/SKILL.md
   # Mirror the offending file: an extensionless path under .claude/ (the PR added
   # it as a symlink; the detector categorizes purely by path, so a plain file at
   # the same path exercises the same case branch).
   printf '../.agents/skills\n' > .claude/skills
+  # Exercise extensionless files under the other agent/editor tooling globs too.
+  printf 'entry\n' > .agents/skills/verify/run
+  printf 'rules\n' > .cursor/rules
   commit_change "convert claude commands to agent skills"
 
   local out
@@ -748,6 +751,9 @@ test_benchmark_source_change_lints_and_flags_benchmarks_only() {
   assert_contains "$out" '"run_dummy_tests": false' "benchmark source output"
   assert_contains "$out" '"run_e2e_tests": false' "benchmark source output"
   assert_contains "$out" '"run_pro_tests": false' "benchmark source output"
+  assert_contains "$out" '"run_core_benchmarks": false' "benchmark source output"
+  assert_contains "$out" '"run_pro_benchmarks": false' "benchmark source output"
+  assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "benchmark source output"
 }
 
 test_benchmark_comment_only_change_is_non_runtime_but_keeps_lint() {

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -309,8 +309,8 @@ test_ci_infrastructure_only_change_runs_tests_but_skips_benchmarks() {
   assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "ci infra output"
 }
 
-# A suite-specific workflow YAML on its own runs that suite's TESTS (preserving
-# the targeted-CI optimization) but no benchmark — editing the workflow can't
+# A suite-specific workflow YAML on its own runs only that suite's tests, not the
+# full CI-infrastructure suite, and never benchmarks — editing the workflow can't
 # move performance. This is the part of #3697 that the CI-infra arm doesn't cover.
 test_suite_workflow_file_runs_its_tests_but_no_benchmark() {
   setup_repo
@@ -320,7 +320,12 @@ test_suite_workflow_file_runs_its_tests_but_no_benchmark() {
 
   local out
   out="$(detector_output)"
+  assert_contains "$out" '"run_ruby_tests": false' "workflow-only output"
+  assert_contains "$out" '"run_js_tests": false' "workflow-only output"
+  assert_contains "$out" '"run_dummy_tests": false' "workflow-only output"
+  assert_contains "$out" '"run_pro_tests": false' "workflow-only output"
   assert_contains "$out" '"run_pro_dummy_tests": true' "workflow-only output"
+  assert_contains "$out" '"run_pro_node_renderer_tests": false' "workflow-only output"
   assert_contains "$out" '"run_pro_benchmarks": false' "workflow-only output"
   assert_contains "$out" '"run_pro_node_renderer_benchmarks": false' "workflow-only output"
 }


### PR DESCRIPTION
## Why

Bencher kept posting benchmark results on PRs that can't possibly affect runtime performance. Two reported cases:

- **[#3717](https://github.com/shakacode/react_on_rails/pull/3717#issuecomment-4640034371)** — a markdown/agent-tooling PR whose only non-`.md` file was a new `.claude/skills` symlink.
- **[#3697](https://github.com/shakacode/react_on_rails/pull/3697#issuecomment-4638077974)** — a CI-config-only PR (`.github/workflows/pro-integration-tests.yml` + the detector's own test harness).

Both slipped through because the change detector (`script/ci-changes-detector`) is the single gate feeding every test workflow **and** the benchmark matrix.

### Root cause 1 — non-`.md` repo metadata hits the catch-all (#3717)
The extensionless `.claude/skills` symlink matched no detector category → fell into the `*` catch-all ("run everything for safety") → `non_runtime_only=false` → full suite + benchmarks. Same class as #3597.

### Root cause 2 — benchmarks piggyback on the test run-flags (#3697)
`benchmark.yml` derived which suites to run from the test `run_*` flags. Those flags are intentionally inflated by CI plumbing: the CI-infrastructure catch-all (`script/`, `bin/`, actions) runs the full suite, and the suite-specific workflow YAMLs map to test categories (`pro-integration-tests.yml` → `PRO_DUMMY`, `node-renderer-tests.yml` → `PRO_NODE_RENDERER`, …). None of that moves runtime performance, but it all dragged in benchmarks.

## Fix

**Commit 1 — agent/editor tooling is non-runtime.** Categorize `.claude/**`, `.agents/**`, `.cursor/**` alongside docs/`internal/**`/issue-templates, so agent-tooling PRs are `non_runtime_only` (no tests, no benchmarks).

**Commit 2 — decouple benchmark selection from test selection.**
- The detector tracks `BENCH_CORE` / `BENCH_PRO` / `BENCH_PRO_NODE_RENDERER`, set **only** by genuine product-source arms (gem/app/package/dummy code) and the uncategorized catch-all. CI plumbing (new `CI_INFRA_CHANGED` flag) and the suite-workflow YAMLs (`is_benchmark_irrelevant_path` guard) set no `BENCH` flag — they still run their **tests** but never benchmarks. The targeted per-workflow test mapping (`ci-optimization.md`) is preserved.
- The detector emits `run_core_benchmarks` / `run_pro_benchmarks` / `run_pro_node_renderer_benchmarks`; `benchmark.yml` reads them directly instead of re-deriving from `run_*`. The mapping mirrors the old derivation **exactly** for every genuine-source category, so legitimate benchmark runs are unchanged — only CI-plumbing-triggered runs are dropped.
- `push`-to-main, `workflow_dispatch`, and the `benchmark` PR label still run suites regardless (the label is the escape hatch for validating `benchmark.yml`/workflow edits).

## Verification

- Replayed both PRs' exact file sets against the patched detector: #3717 → `non_runtime_only: true`; #3697 → all three `run_*_benchmarks: false` while tests still run.
- Confirmed legit benchmark behavior is unchanged: core source → all 3 suites; node-renderer source → pro + node-renderer; pro-ruby → pro only; a suite-workflow-only edit → its tests but no benchmark.
- `script/ci-changes-detector-test.bash`: **43 run, 0 failed** (added regressions for both root causes). `actionlint` clean on `benchmark.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now separates benchmark gating from test-selection, treats additional agent/editor/tooling paths as docs/non-runtime-only, treats CI-infrastructure edits as infra-only (forcing tests but suppressing benchmarks), and exposes per-suite benchmark run flags in CI outputs while preventing docs-only when CI infra changes.

* **Tests**
  * Added regression tests covering docs/tooling paths, CI-infra-only edits, suite-specific gating, combined infra+runtime edits, and node-renderer benchmark behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central CI gating logic for all workflows and benchmarks; behavior is heavily regression-tested but misclassification could skip needed benchmarks or still run Bencher on non-runtime PRs.
> 
> **Overview**
> Stops Bencher from running on PRs that only touch docs, agent tooling, or CI config by tightening **what counts as non-runtime** and **when benchmarks are selected**.
> 
> **`script/ci-changes-detector`** now treats `.claude/**`, `.agents/**`, and `.cursor/**` like docs (fixes extensionless paths such as `.claude/skills` hitting the catch-all). CI plumbing uses a dedicated **`CI_INFRA_CHANGED`** flag: it still forces the full **test** matrix but does **not** set benchmark flags. Benchmark gating is decoupled from test `run_*` flags via **`BENCH_*`** flags and new outputs **`run_core_benchmarks`**, **`run_pro_benchmarks`**, and **`run_pro_node_renderer_benchmarks`**; workflow YAML under `.github/workflows/*` is excluded from benchmark relevance via **`is_benchmark_irrelevant_path`**.
> 
> **`.github/workflows/benchmark.yml`** drops inline benchmark derivation and reads those detector outputs directly. **`ci-commands.yml`** aligns the docs-only heuristic with the same agent/editor paths.
> 
> Regression coverage in **`script/ci-changes-detector-test.bash`** covers agent tooling, CI-only vs workflow-only edits, mixed CI + source, and node-renderer benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ba2bdc28f4e04ef7011e12ab35b5d4dd16a14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Codex Decision Log

- Full-matrix validation: accepted CodeRabbit's current-head nit and added the existing `full-ci` label so detector/benchmark-gating changes receive full CI coverage before merge.