### PR TITLE
Fix /posts_page benchmark overfetching

### DIFF
--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -209,16 +209,20 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def posts_page
-    posts = fetch_posts.as_json
-    posts.each do |post|
-      post_comments = fetch_post_comments(post, []).as_json
-      post_comments.each do |comment|
-        comment["user"] = fetch_comment_user(comment).as_json
-      end
-      post["comments"] = post_comments
-    end
+    posts_count = posts_page_posts_count
+    posts = fetch_posts.first(posts_count)
+    comments_by_post_id = posts_page_comments_by_post_id(posts)
 
-    @posts = posts
+    @posts = posts.map do |post|
+      post_hash = post.as_json
+      post_hash["comments"] = comments_by_post_id.fetch(post.id, []).map do |comment|
+        comment_hash = comment.as_json
+        comment_hash["user"] = comment.user.as_json
+        comment_hash
+      end
+      post_hash
+    end
+    @posts_count = posts_count
     render "/pages/posts_page"
   end
 
@@ -281,6 +285,26 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   helper_method :read_async_props_from_redis
 
   private
+
+  def posts_page_posts_count
+    value = params[:posts_count]
+    return 2 if value.blank?
+
+    count = Integer(value, exception: false)
+    return 2 unless count
+
+    [count, 0].max
+  end
+
+  def posts_page_comments_by_post_id(posts)
+    post_ids = posts.map(&:id)
+    return {} if post_ids.empty?
+
+    Comment.with_delay(artificial_delay)
+           .includes(:user)
+           .where(post_id: post_ids)
+           .group_by(&:post_id)
+  end
 
   # Use the dummy-app-only RSC payload template so the async-props
   # incremental-rendering path can be exercised in tests without shipping

--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -321,16 +321,16 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   def posts_page_posts(posts_count, artificial_delay)
     return [] if posts_count.zero?
 
-    post_ids = Post.select(Arel.sql("MIN(id)"))
-                   .group(:user_id)
-                   .order(Arel.sql("MIN(id) ASC"))
-                   .limit(posts_count)
+    post_id_subquery = Post.select(Arel.sql("MIN(id)"))
+                           .group(:user_id)
+                           .order(Arel.sql("MIN(id) ASC"))
+                           .limit(posts_count)
 
     # PostgreSQL/SQLite honor ORDER BY + LIMIT in this WHERE IN subquery. MySQL
     # can ignore that LIMIT in this shape, so revisit this if the benchmark DB
     # adapter changes instead of assuming the clamp still limits rows loaded.
     # The outer order(:id) re-applies display ordering because WHERE IN does not.
-    Post.with_delay(artificial_delay).where(id: post_ids).order(:id).to_a
+    Post.with_delay(artificial_delay).where(id: post_id_subquery).order(:id).to_a
   end
 
   def posts_page_comments_and_users(posts, artificial_delay)
@@ -338,10 +338,10 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     # Early return when posts is empty; avoids an unnecessary WHERE IN (empty) query.
     return [{}, {}] if post_ids.empty?
 
-    # artificial_delay sleeps once per batched query (posts, comments, users),
-    # so total sleep = 3 * delay ms. This intentionally models per-query latency
-    # rather than end-to-end latency, which keeps query counts predictable for
-    # benchmark comparisons.
+    # artificial_delay sleeps once per batched query (posts, comments, and when
+    # comment authors exist, users), so total sleep = 2-3 * delay ms. This
+    # intentionally models per-query latency rather than end-to-end latency,
+    # which keeps query counts predictable for benchmark comparisons.
     comments = Comment.with_delay(artificial_delay).where(post_id: post_ids).to_a
     user_ids = comments.map(&:user_id).uniq
     users_by_id = if user_ids.empty?

--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -327,9 +327,10 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
                            .limit(posts_count)
 
     # PostgreSQL/SQLite honor ORDER BY + LIMIT in this WHERE IN subquery. MySQL
-    # can ignore that LIMIT in this shape, so revisit this if the benchmark DB
-    # adapter changes instead of assuming the clamp still limits rows loaded.
-    # The outer order(:id) re-applies display ordering because WHERE IN does not.
+    # rejects LIMIT inside a subquery used with IN (5.x syntax error; MySQL 8
+    # support is incomplete), so rewrite this query if the benchmark DB adapter
+    # changes. The outer order(:id) re-applies display ordering because WHERE IN
+    # does not preserve subquery order.
     Post.with_delay(artificial_delay).where(id: post_id_subquery).order(:id).to_a
   end
 
@@ -338,10 +339,11 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     # Early return when posts is empty; avoids an unnecessary WHERE IN (empty) query.
     return [{}, {}] if post_ids.empty?
 
-    # artificial_delay sleeps once per batched query (posts, comments, and when
-    # comment authors exist, users), so total sleep = 2-3 * delay ms. This
-    # intentionally models per-query latency rather than end-to-end latency,
-    # which keeps query counts predictable for benchmark comparisons.
+    # artificial_delay sleeps once per batched query issued here: comments, and
+    # when comment authors exist, users (1-2 sleeps total in this method). The
+    # posts sleep is in posts_page_posts, so the full action sleeps 2-3 times.
+    # This models per-query latency rather than end-to-end latency, keeping
+    # query counts predictable for benchmarks.
     comments = Comment.with_delay(artificial_delay).where(post_id: post_ids).to_a
     user_ids = comments.map(&:user_id).uniq
     users_by_id = if user_ids.empty?

--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -345,7 +345,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     # This models per-query latency rather than end-to-end latency, keeping
     # query counts predictable for benchmarks.
     comments = Comment.with_delay(artificial_delay).where(post_id: post_ids).to_a
-    user_ids = comments.map(&:user_id).uniq
+    user_ids = comments.filter_map(&:user_id).uniq
     users_by_id = if user_ids.empty?
                     {}
                   else

--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -9,6 +9,12 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
 
   XSS_PAYLOAD = { "<script>window.alert('xss1');</script>" => '<script>window.alert("xss2");</script>' }.freeze
   PROPS_NAME = "Mr. Server Side Rendering"
+  POSTS_PAGE_DEFAULT_ARTIFICIAL_DELAY = 0
+  POSTS_PAGE_DEFAULT_POSTS_COUNT = 2
+  POSTS_PAGE_MAX_ARTIFICIAL_DELAY = 10_000
+  POSTS_PAGE_MAX_POSTS_COUNT = 100
+  private_constant :POSTS_PAGE_DEFAULT_ARTIFICIAL_DELAY, :POSTS_PAGE_DEFAULT_POSTS_COUNT,
+                   :POSTS_PAGE_MAX_ARTIFICIAL_DELAY, :POSTS_PAGE_MAX_POSTS_COUNT
   APP_PROPS_SERVER_RENDER = {
     helloWorldData: {
       name: PROPS_NAME
@@ -210,19 +216,23 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
 
   def posts_page
     posts_count = posts_page_posts_count
-    posts = fetch_posts.first(posts_count)
-    comments_by_post_id = posts_page_comments_by_post_id(posts)
+    artificial_delay = posts_page_artificial_delay
+    posts = posts_page_posts(posts_count, artificial_delay)
+    comments_by_post_id, users_by_id = posts_page_comments_and_users(posts, artificial_delay)
 
     @posts = posts.map do |post|
       post_hash = post.as_json
       post_hash["comments"] = comments_by_post_id.fetch(post.id, []).map do |comment|
         comment_hash = comment.as_json
-        comment_hash["user"] = comment.user.as_json
+        # Deleted comment authors render as nil instead of failing this benchmark route.
+        comment_hash["user"] = users_by_id[comment.user_id]&.as_json
         comment_hash
       end
       post_hash
     end
-    @posts_count = posts_count
+    @artificial_delay = artificial_delay
+    # React receives the actual rendered count, not the requested posts_count param.
+    @posts_count = @posts.size
     render "/pages/posts_page"
   end
 
@@ -288,22 +298,58 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
 
   def posts_page_posts_count
     value = params[:posts_count]
-    return 2 if value.blank?
+    return POSTS_PAGE_DEFAULT_POSTS_COUNT if value.blank?
 
     count = Integer(value, exception: false)
-    return 2 unless count
+    return POSTS_PAGE_DEFAULT_POSTS_COUNT unless count
 
-    [count, 0].max
+    # Numeric out-of-range params are clamped, so probes can request an empty
+    # render with 0 while blank/invalid params keep the benchmark default.
+    count.clamp(0, POSTS_PAGE_MAX_POSTS_COUNT)
   end
 
-  def posts_page_comments_by_post_id(posts)
-    post_ids = posts.map(&:id)
-    return {} if post_ids.empty?
+  def posts_page_artificial_delay
+    value = params[:artificial_delay]
+    return POSTS_PAGE_DEFAULT_ARTIFICIAL_DELAY if value.blank?
 
-    Comment.with_delay(artificial_delay)
-           .includes(:user)
-           .where(post_id: post_ids)
-           .group_by(&:post_id)
+    delay = Integer(value, exception: false)
+    return POSTS_PAGE_DEFAULT_ARTIFICIAL_DELAY unless delay
+
+    delay.clamp(POSTS_PAGE_DEFAULT_ARTIFICIAL_DELAY, POSTS_PAGE_MAX_ARTIFICIAL_DELAY)
+  end
+
+  def posts_page_posts(posts_count, artificial_delay)
+    return [] if posts_count.zero?
+
+    post_ids = Post.select(Arel.sql("MIN(id)"))
+                   .group(:user_id)
+                   .order(Arel.sql("MIN(id) ASC"))
+                   .limit(posts_count)
+
+    # PostgreSQL/SQLite honor ORDER BY + LIMIT in this subquery; MySQL has
+    # historically not, so revisit this if the benchmark DB adapter changes.
+    # The outer order(:id) re-applies display ordering because WHERE IN does not.
+    Post.with_delay(artificial_delay).where(id: post_ids).order(:id).to_a
+  end
+
+  def posts_page_comments_and_users(posts, artificial_delay)
+    post_ids = posts.map(&:id)
+    # Early return when posts is empty; avoids an unnecessary WHERE IN (empty) query.
+    return [{}, {}] if post_ids.empty?
+
+    # artificial_delay sleeps once per batched query (posts, comments, users),
+    # so total sleep = 3 * delay ms. This intentionally models per-query latency
+    # rather than end-to-end latency, which keeps query counts predictable for
+    # benchmark comparisons.
+    comments = Comment.with_delay(artificial_delay).where(post_id: post_ids).to_a
+    user_ids = comments.map(&:user_id).uniq
+    users_by_id = if user_ids.empty?
+                    {}
+                  else
+                    User.with_delay(artificial_delay).where(id: user_ids).index_by(&:id)
+                  end
+
+    [comments.group_by(&:post_id), users_by_id]
   end
 
   # Use the dummy-app-only RSC payload template so the async-props

--- a/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
+++ b/react_on_rails_pro/spec/dummy/app/controllers/pages_controller.rb
@@ -326,8 +326,9 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
                    .order(Arel.sql("MIN(id) ASC"))
                    .limit(posts_count)
 
-    # PostgreSQL/SQLite honor ORDER BY + LIMIT in this subquery; MySQL has
-    # historically not, so revisit this if the benchmark DB adapter changes.
+    # PostgreSQL/SQLite honor ORDER BY + LIMIT in this WHERE IN subquery. MySQL
+    # can ignore that LIMIT in this shape, so revisit this if the benchmark DB
+    # adapter changes instead of assuming the clamp still limits rows loaded.
     # The outer order(:id) re-applies display ordering because WHERE IN does not.
     Post.with_delay(artificial_delay).where(id: post_ids).order(:id).to_a
   end

--- a/react_on_rails_pro/spec/dummy/app/views/pages/posts_page.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/pages/posts_page.html.erb
@@ -1,7 +1,7 @@
 <%= react_component("PostsPage",
     props: @app_props_server_render.merge(
       artificialDelay: params[:artificial_delay] || 0, 
-      postsCount: params[:posts_count] || 2,
+      postsCount: @posts_count,
       posts: @posts
     ),
     prerender: true,

--- a/react_on_rails_pro/spec/dummy/app/views/pages/posts_page.html.erb
+++ b/react_on_rails_pro/spec/dummy/app/views/pages/posts_page.html.erb
@@ -1,6 +1,6 @@
 <%= react_component("PostsPage",
     props: @app_props_server_render.merge(
-      artificialDelay: params[:artificial_delay] || 0, 
+      artificialDelay: @artificial_delay,
       postsCount: @posts_count,
       posts: @posts
     ),

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe "Posts page", :server_rendering do
     expect(response.body).to include("Sentinel Post 2")
   end
 
+  it "only loads comments and users for the requested post count" do
+    sql_queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+      next if payload[:name] == "SCHEMA"
+
+      sql_queries << payload[:sql]
+    end
+
+    begin
+      get "/posts_page", params: { posts_count: 1 }
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+    end
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Sentinel Post 1")
+    expect(response.body).not_to include("Sentinel Post 2")
+    expect(sql_queries.grep(/FROM "?comments"?/i).size).to eq(1)
+    expect(sql_queries.grep(/FROM "?users"?/i).size).to eq(1)
+  end
+
   it "returns 200 (not 500) when there are no posts to render" do
     Comment.delete_all
     Post.delete_all

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe "Posts page", :server_rendering do
     User.delete_all
   end
 
+  # Lazy: call `seeded_posts` explicitly in each example that requires DB rows.
+  # Examples that test the empty-table path intentionally omit it.
   let(:seeded_posts) do
     Array.new(2) do |i|
       user = User.create!(name: "User #{i + 1}", email: "user-#{i + 1}@example.com")

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -87,10 +87,12 @@ RSpec.describe "Posts page", :server_rendering do
     # SQL limit, so this guards the deterministic post selection explicitly.
     expect(response.body).to include(seeded_posts.first.title)
     expect(response.body).not_to include(seeded_posts.second.title)
+    # Rails names AR load notifications by model, so model names are more stable
+    # than matching SQL text across adapters. These names come from
+    # ActiveRecord::LogSubscriber rather than a public API, so this spec should be
+    # revisited if a Rails upgrade changes the notification naming convention.
     comments_queries = sql_events.select { |payload| payload[:name] == "Comment Load" }
     users_queries = sql_events.select { |payload| payload[:name] == "User Load" }
-    # Rails names AR load notifications by model, so model names are more stable
-    # than matching SQL text across adapters.
     # Exact counts guard the batching contract; extra loads would reintroduce
     # the overfetching/N+1 behavior this benchmark route is meant to catch.
     expect(comments_queries.size).to eq(1), "expected one batched comments load for seeded commented posts"
@@ -161,6 +163,8 @@ RSpec.describe "Posts page", :server_rendering do
     expect(parsed_posts_page_artificial_delay(99_999)).to eq(10_000)
   end
 
+  # Keep these local to the request spec while the parsing logic is only used by
+  # this benchmark route; move them to controller-level coverage if they grow.
   def parsed_posts_page_artificial_delay(value)
     controller = PagesController.new
     allow(controller).to receive(:params).and_return(ActionController::Parameters.new(artificial_delay: value))

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -129,6 +129,15 @@ RSpec.describe "Posts page", :server_rendering do
     expect(response.body).not_to include("Sentinel Post 2")
   end
 
+  it "clamps posts_count params without seeding benchmark-sized fixtures" do
+    expect(parsed_posts_page_posts_count(nil)).to eq(2)
+    expect(parsed_posts_page_posts_count("")).to eq(2)
+    expect(parsed_posts_page_posts_count("invalid")).to eq(2)
+    expect(parsed_posts_page_posts_count(-1)).to eq(0)
+    expect(parsed_posts_page_posts_count(1)).to eq(1)
+    expect(parsed_posts_page_posts_count(200)).to eq(100)
+  end
+
   it "returns 200 (not 500) when there are no posts to render" do
     Comment.delete_all
     Post.delete_all
@@ -157,5 +166,12 @@ RSpec.describe "Posts page", :server_rendering do
     allow(controller).to receive(:params).and_return(ActionController::Parameters.new(artificial_delay: value))
 
     controller.__send__(:posts_page_artificial_delay)
+  end
+
+  def parsed_posts_page_posts_count(value)
+    controller = PagesController.new
+    allow(controller).to receive(:params).and_return(ActionController::Parameters.new(posts_count: value))
+
+    controller.__send__(:posts_page_posts_count)
   end
 end

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -33,11 +33,14 @@ RSpec.describe "Posts page", :server_rendering do
     Comment.delete_all
     Post.delete_all
     User.delete_all
+  end
 
-    2.times do |i|
+  let(:seeded_posts) do
+    Array.new(2) do |i|
       user = User.create!(name: "User #{i + 1}", email: "user-#{i + 1}@example.com")
       post = user.posts.create!(title: "Sentinel Post #{i + 1}", body: "Body of sentinel post #{i + 1}.")
       post.comments.create!(user: user, body: "Comment on sentinel post #{i + 1}.")
+      post
     end
   end
 
@@ -48,6 +51,8 @@ RSpec.describe "Posts page", :server_rendering do
   end
 
   it "server-renders the seeded posts and returns 200" do
+    seeded_posts
+
     get "/posts_page"
 
     expect(response).to have_http_status(:ok)
@@ -62,11 +67,13 @@ RSpec.describe "Posts page", :server_rendering do
   end
 
   it "only loads comments and users for the requested post count" do
-    sql_queries = []
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-      next if payload[:name] == "SCHEMA"
+    seeded_posts
 
-      sql_queries << payload[:sql]
+    sql_events = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+      next if payload[:name].in?(%w[SCHEMA TRANSACTION CACHE])
+
+      sql_events << payload
     end
 
     begin
@@ -76,10 +83,50 @@ RSpec.describe "Posts page", :server_rendering do
     end
 
     expect(response).to have_http_status(:ok)
-    expect(response.body).to include("Sentinel Post 1")
+    # The controller orders by the first post id per user before applying the
+    # SQL limit, so this guards the deterministic post selection explicitly.
+    expect(response.body).to include(seeded_posts.first.title)
+    expect(response.body).not_to include(seeded_posts.second.title)
+    comments_queries = sql_events.select { |payload| payload[:name] == "Comment Load" }
+    users_queries = sql_events.select { |payload| payload[:name] == "User Load" }
+    # Rails names AR load notifications by model, so model names are more stable
+    # than matching SQL text across adapters.
+    # Exact counts guard the batching contract; extra loads would reintroduce
+    # the overfetching/N+1 behavior this benchmark route is meant to catch.
+    expect(comments_queries.size).to eq(1), "expected one batched comments load for seeded commented posts"
+    expect(users_queries.size).to eq(1), "expected one batched users load for seeded comment authors"
+  end
+
+  it "returns an empty page when posts_count is zero" do
+    seeded_posts
+
+    get "/posts_page", params: { posts_count: 0 }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("No posts found")
+    expect(response.body).not_to include("Sentinel Post 1")
     expect(response.body).not_to include("Sentinel Post 2")
-    expect(sql_queries.grep(/FROM "?comments"?/i).size).to eq(1)
-    expect(sql_queries.grep(/FROM "?users"?/i).size).to eq(1)
+  end
+
+  it "uses the default post count for invalid posts_count params" do
+    seeded_posts
+
+    get "/posts_page", params: { posts_count: "invalid" }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Sentinel Post 1")
+    expect(response.body).to include("Sentinel Post 2")
+  end
+
+  it "clamps negative posts_count params to an empty page" do
+    seeded_posts
+
+    get "/posts_page", params: { posts_count: -5 }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("No posts found")
+    expect(response.body).not_to include("Sentinel Post 1")
+    expect(response.body).not_to include("Sentinel Post 2")
   end
 
   it "returns 200 (not 500) when there are no posts to render" do
@@ -91,5 +138,24 @@ RSpec.describe "Posts page", :server_rendering do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include("No posts found")
+  end
+
+  it "uses the default artificial_delay for blank and invalid params" do
+    expect(parsed_posts_page_artificial_delay(nil)).to eq(0)
+    expect(parsed_posts_page_artificial_delay("")).to eq(0)
+    expect(parsed_posts_page_artificial_delay("invalid")).to eq(0)
+  end
+
+  it "clamps artificial_delay params without sleeping in the request spec" do
+    expect(parsed_posts_page_artificial_delay(-1)).to eq(0)
+    expect(parsed_posts_page_artificial_delay(1)).to eq(1)
+    expect(parsed_posts_page_artificial_delay(99_999)).to eq(10_000)
+  end
+
+  def parsed_posts_page_artificial_delay(value)
+    controller = PagesController.new
+    allow(controller).to receive(:params).and_return(ActionController::Parameters.new(artificial_delay: value))
+
+    controller.__send__(:posts_page_artificial_delay)
   end
 end

--- a/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
+++ b/react_on_rails_pro/spec/dummy/spec/requests/posts_page_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Posts page", :server_rendering do
   end
 
   it "returns an empty page when posts_count is zero" do
-    seeded_posts
+    seeded_posts # rows exist; posts_count=0 must still produce an empty render
 
     get "/posts_page", params: { posts_count: 0 }
 


### PR DESCRIPTION
## Summary

Refs #3669.

Fixes a real `/posts_page: Pro` benchmark inefficiency without changing Bencher criteria or regression suppression logic.

Root cause:

- `/posts_page` defaults to rendering 2 posts.
- The Rails controller fetched the one-post-per-user set, then loaded comments and users for every selected user before React sliced the payload down to `postsCount`.
- User records were loaded once per comment, so the default route did substantially more DB work than the page rendered.

What changed:

- Parse and share `postsCount` from the controller so Rails and React agree on the rendered subset.
- Build the preloaded payload only for the requested posts.
- Batch-load comments with their users for that subset.
- Add a request spec that verifies `posts_count=1` performs one comments query and one users query.

This intentionally does not remove `IGNORED_REGRESSION_BENCHMARKS` yet. The issue's 64-main-run Bencher window gate still needs to clear before the temporary reporting suppression can be safely reverted.

## Local performance evidence

Same local production setup for both runs:

- Pro dummy app in `RAILS_ENV=production`
- seeded benchmark DB: `50 posts`, `10 users`, `173 comments`
- Puma: `WEB_CONCURRENCY=3`, `RAILS_MAX_THREADS=3`, `RAILS_MIN_THREADS=3`
- `PRO=true ROUTES=/posts_page DURATION=30s RATE=max CONNECTIONS=10 MAX_CONNECTIONS=10 ruby benchmarks/bench.rb`

Before:

- `/posts_page`: `206.27 rps`, `40.82 ms p50`, `53.87 ms p90`, `200=6198`

After:

- `/posts_page`: `436.93 rps`, `17.04 ms p50`, `32.75 ms p90`, `200=13216`

## Validation

- `pnpm install --frozen-lockfile`
- `bundle install --jobs 4 --retry 3`
- `pnpm run build`
- `RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook && RAILS_ENV=test NODE_ENV=test SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true bin/shakapacker`
- `RAILS_ENV=production bundle exec rails db:prepare`
- `bin/prod-assets`
- `bundle exec rspec spec/requests/posts_page_spec.rb`
- `bundle exec rubocop --ignore-parent-exclusion spec/dummy/app/controllers/pages_controller.rb spec/dummy/spec/requests/posts_page_spec.rb`
- `bundle exec rubocop --ignore-parent-exclusion`
- `git diff --check`
- before/after production benchmark runs listed above

## CI labels

Labels: benchmark. This is a focused Pro dummy route performance fix, so benchmark CI should run; the standard path-relevant test CI plus local Pro validation should cover the code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Pro dummy benchmark route and its request specs; no production gem API or auth/data-path changes.
> 
> **Overview**
> Fixes **Pro dummy `/posts_page` benchmark overfetching** by aligning server-side data loading with the rendered post count instead of loading comments/users for every “one post per user” row before React trims the payload.
> 
> **`posts_page`** now parses and clamps `posts_count` (default 2, max 100, 0 allowed) and `artificial_delay` (default 0, max 10_000), selects only that many posts via a grouped `MIN(id)` subquery with `Post.with_delay`, then **batch-loads** comments and users for those post IDs. Comment authors use safe lookup (`users_by_id[comment.user_id]&.as_json`) so missing users do not 500 the route. React props use **`@artificial_delay` and `@posts_count`** (actual rendered size) rather than raw query params.
> 
> Request specs add **SQL notification assertions** for `posts_count=1` (one Comment Load, one User Load), empty/zero/invalid/clamped param behavior, and lazy **`seeded_posts`** fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69064eb35b131d13e3c2df837d6df8c97ad18f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side postsCount enforced for the rendered posts page (bounded default and limits).

* **Performance**
  * Faster page rendering by batching comment and user retrieval, reducing database queries.

* **Tests**
  * Added request specs ensuring posts count limiting, correct server-rendered output, and minimal queries for comments/users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Codex Decision Log

- **Non-blocking:** Keep the first-post-per-user query local to this controller instead of extracting a `Post` scope or adding an adapter guard now.
  - **Decision:** Keep the documented controller-local query.
  - **Why:** This is a Pro dummy benchmark route, current CI/benchmark adapters are green, and the code already documents the PostgreSQL/SQLite behavior plus MySQL caveat.
  - **Review later:** Extract a named scope or explicit adapter guard if this query is reused or the benchmark DB adapter changes.
- **Non-blocking:** Keep ActiveRecord load notification names inline in the request spec.
  - **Decision:** Leave `"Comment Load"` and `"User Load"` inline with the existing comment.
  - **Why:** They are used once, and the nearby comment already calls out the ActiveRecord-internal naming risk for future Rails upgrades.
  - **Review later:** Extract constants if additional SQL event assertions are added.
- **Non-blocking:** Keep the private param parsing assertions in the request spec.
  - **Decision:** Leave the local helper approach.
  - **Why:** The parsing logic is only used by this benchmark route, and the spec already says to move it to controller-level coverage if it grows.
  - **Review later:** Extract a controller spec or value object if more posts-page params are added.
- **Non-blocking:** Do not add a `Post Load` count assertion in this pass.
  - **Decision:** Keep the existing response assertions plus `Comment Load`/`User Load` batching assertions.
  - **Why:** The current assertions cover the overfetch/N+1 risk this PR fixes; adding a post-load count assertion would increase coupling to ActiveRecord notification internals.
  - **Review later:** Add it if a post-query regression appears or the test needs a stricter query-shape contract.