### PR TITLE
Expand direct ProRendering test coverage

### DIFF
--- a/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb
@@ -72,6 +72,7 @@ module ReactOnRailsPro
 
           # Pass back the cache key in the results only if the result is a Hash
           if result.is_a?(Hash)
+            result = result.dup # Prevent response-only metadata from mutating the cached hash
             result[:RORP_CACHE_KEY] = prerender_cache_key
             result[:RORP_CACHE_HIT] = prerender_cache_hit
           end

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
@@ -2,131 +2,289 @@
 
 require_relative "../spec_helper"
 
-module ReactOnRailsPro
-  module ServerRenderingPool
-    RSpec.describe ProRendering do
-      describe ".set_request_digest_on_render_options" do
-        let(:logger_mock) { instance_double(ActiveSupport::Logger).as_null_object }
-        let(:render_options_class) do
-          Struct.new(:request_digest, keyword_init: true) do
-            def random_dom_id?
-              true
-            end
-
-            def react_component_name
-              "CacheProbe"
-            end
-
-            def internal_option(_name)
-              nil
-            end
-
-            def streaming?
-              false
-            end
-
-            def prerender
-              true
-            end
-          end
-        end
-
-        before do
-          allow(Rails).to receive(:logger).and_return(logger_mock)
-        end
-
-        def request_digest_for(js_code)
-          render_options = render_options_class.new
-
-          described_class.set_request_digest_on_render_options(js_code, render_options)
-
-          render_options.request_digest
-        end
-
-        def render_js(dom_node_id:, quote:, props: '{"name":"same"}')
-          quoted_dom_node_id = quote == :single ? "'#{dom_node_id}'" : dom_node_id.to_json
-
-          <<~JS
-            return ReactOnRails['serverRenderReactComponent']({
-              name: "CacheProbe",
-              domNodeId: #{quoted_dom_node_id},
-              props: #{props},
-              trace: false,
-              railsContext: {},
-            });
-          JS
-        end
-
-        it "ignores single-quoted random domNodeId values when calculating the request digest" do
-          first_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-1", quote: :single))
-          second_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-2", quote: :single))
-
-          expect(first_digest).to eq(second_digest)
-        end
-
-        it "ignores double-quoted random domNodeId values when calculating the request digest" do
-          first_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double))
-          second_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-2", quote: :double))
-
-          expect(first_digest).to eq(second_digest)
-        end
-
-        it "still changes the request digest when non-random render input changes" do
-          first_digest = request_digest_for(
-            render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double, props: '{"name":"first"}')
-          )
-          second_digest = request_digest_for(
-            render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double, props: '{"name":"second"}')
-          )
-
-          expect(first_digest).not_to eq(second_digest)
-        end
-
-        context "with prerender caching enabled" do
-          let(:pool) do
-            Class.new do
-              def exec_server_render_js(_js_code, _render_options)
-                { html: "rendered" }
-              end
-            end.new
-          end
-          let(:cache_store) do
-            Class.new do
-              def initialize
-                @store = {}
-              end
-
-              def fetch(key)
-                return @store[key] if @store.key?(key)
-
-                @store[key] = yield
-              end
-            end.new
-          end
-
-          before do
-            allow(pool).to receive(:exec_server_render_js).and_call_original
-            allow(described_class).to receive(:pool).and_return(pool)
-            allow(Rails).to receive(:cache).and_return(cache_store)
-            allow(ReactOnRailsPro.configuration).to receive(:prerender_caching).and_return(true)
-            allow(ReactOnRailsPro::Cache).to receive(:base_cache_key).and_return(%w[ror_pro_rendered_html test])
-            allow(ReactOnRailsPro::Utils).to receive(:with_trace).and_yield
-          end
-
-          it "reuses the cached render for current double-quoted random domNodeId values" do
-            described_class.exec_server_render_js(
-              render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double),
-              render_options_class.new
-            )
-            described_class.exec_server_render_js(
-              render_js(dom_node_id: "CacheProbe-react-component-2", quote: :double),
-              render_options_class.new
-            )
-
-            expect(pool).to have_received(:exec_server_render_js).once
-          end
-        end
+RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
+  let(:logger_mock) { instance_double(ActiveSupport::Logger).as_null_object }
+  let(:render_options_class) do
+    Struct.new(
+      :request_digest,
+      :random_dom_id,
+      :streaming,
+      :prerender,
+      :internal_options,
+      keyword_init: true
+    ) do
+      def random_dom_id?
+        random_dom_id
       end
+
+      def react_component_name
+        "CacheProbe"
+      end
+
+      def internal_option(name)
+        internal_options.fetch(name, nil)
+      end
+
+      def streaming?
+        streaming
+      end
+    end
+  end
+
+  before do
+    allow(Rails).to receive(:logger).and_return(logger_mock)
+  end
+
+  def build_render_options(request_digest: nil, random_dom_id: true, streaming: false, prerender: true,
+                           internal_options: {})
+    render_options_class.new(
+      request_digest: request_digest,
+      random_dom_id: random_dom_id,
+      streaming: streaming,
+      prerender: prerender,
+      internal_options: internal_options
+    )
+  end
+
+  def render_js(dom_node_id:, quote:, props: '{"name":"same"}')
+    quoted_dom_node_id = quote == :single ? "'#{dom_node_id}'" : dom_node_id.to_json
+
+    <<~JS
+      return ReactOnRails['serverRenderReactComponent']({
+        name: "CacheProbe",
+        domNodeId: #{quoted_dom_node_id},
+        props: #{props},
+        trace: false,
+        railsContext: {},
+      });
+    JS
+  end
+
+  describe ".set_request_digest_on_render_options" do
+    def request_digest_for(js_code, render_options: build_render_options)
+      described_class.set_request_digest_on_render_options(js_code, render_options)
+
+      render_options.request_digest
+    end
+
+    it "ignores single-quoted random domNodeId values when calculating the request digest" do
+      first_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-1", quote: :single))
+      second_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-2", quote: :single))
+
+      expect(first_digest).to eq(second_digest)
+    end
+
+    it "ignores double-quoted random domNodeId values when calculating the request digest" do
+      first_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double))
+      second_digest = request_digest_for(render_js(dom_node_id: "CacheProbe-react-component-2", quote: :double))
+
+      expect(first_digest).to eq(second_digest)
+    end
+
+    it "still changes the request digest when non-random render input changes" do
+      first_digest = request_digest_for(
+        render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double, props: '{"name":"first"}')
+      )
+      second_digest = request_digest_for(
+        render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double, props: '{"name":"second"}')
+      )
+
+      expect(first_digest).not_to eq(second_digest)
+    end
+
+    it "keeps an existing request digest without recalculating it" do
+      render_options = build_render_options(request_digest: "already-set")
+
+      digest = request_digest_for(
+        render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double),
+        render_options: render_options
+      )
+
+      expect(digest).to eq("already-set")
+    end
+
+    it "hashes the full JavaScript when dom IDs are not random" do
+      first_js = render_js(dom_node_id: "CacheProbe-react-component", quote: :double)
+      second_js = render_js(dom_node_id: "other-cache-probe-node", quote: :double)
+
+      first_digest = request_digest_for(first_js, render_options: build_render_options(random_dom_id: false))
+      second_digest = request_digest_for(second_js, render_options: build_render_options(random_dom_id: false))
+
+      expect(first_digest).to eq(Digest::MD5.hexdigest(first_js))
+      expect(first_digest).not_to eq(second_digest)
+    end
+  end
+
+  describe ".exec_server_render_js" do
+    let(:pool_class) do
+      Class.new do
+        def exec_server_render_js(_js_code, _render_options); end
+      end
+    end
+    let(:stream_class) { Class.new }
+    let(:pool) { instance_double(pool_class) }
+    let(:cache_store) do
+      Class.new do
+        attr_reader :fetch_calls
+
+        def initialize
+          @store = {}
+          @fetch_calls = []
+        end
+
+        def fetch(key)
+          @fetch_calls << key
+          return @store[key] if @store.key?(key)
+
+          @store[key] = yield
+        end
+      end.new
+    end
+    let(:js_code) { render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double) }
+
+    before do
+      allow(pool).to receive(:exec_server_render_js).and_return({ html: "rendered" })
+      allow(described_class).to receive(:pool).and_return(pool)
+      allow(Rails).to receive(:cache).and_return(cache_store)
+      allow(ReactOnRailsPro::Cache).to receive(:base_cache_key).and_return(%w[ror_pro_rendered_html test])
+      allow(ReactOnRailsPro::Utils).to receive(:with_trace).and_yield
+    end
+
+    context "when prerender caching is disabled" do
+      before do
+        allow(ReactOnRailsPro.configuration).to receive(:prerender_caching).and_return(false)
+      end
+
+      it "renders directly through the selected pool without touching Rails.cache" do
+        render_options = build_render_options
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+
+        expect(result).to eq({ html: "rendered" })
+        expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
+        expect(cache_store.fetch_calls).to be_empty
+      end
+    end
+
+    context "when skip_prerender_cache is set" do
+      before do
+        allow(ReactOnRailsPro.configuration).to receive(:prerender_caching).and_return(true)
+      end
+
+      it "renders directly through the selected pool" do
+        render_options = build_render_options(internal_options: { skip_prerender_cache: true })
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+
+        expect(result).to eq({ html: "rendered" })
+        expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
+        expect(cache_store.fetch_calls).to be_empty
+      end
+    end
+
+    context "when prerender caching is enabled for non-streaming renders" do
+      before do
+        allow(ReactOnRailsPro.configuration).to receive(:prerender_caching).and_return(true)
+      end
+
+      it "renders cache misses through the selected pool and stores the result" do
+        render_options = build_render_options
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+
+        expect(result[:html]).to eq("rendered")
+        expect(result[:RORP_CACHE_HIT]).to be(false)
+        expect(result[:RORP_CACHE_KEY]).to eq(["ror_pro_rendered_html", "test", render_options.request_digest])
+        expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
+        expect(cache_store.fetch_calls).to eq([result[:RORP_CACHE_KEY]])
+      end
+
+      it "returns cached render results for different random domNodeId values without rendering again" do
+        first_options = build_render_options
+        second_options = build_render_options
+        first_js = render_js(dom_node_id: "CacheProbe-react-component-1", quote: :double)
+        second_js = render_js(dom_node_id: "CacheProbe-react-component-2", quote: :double)
+
+        described_class.exec_server_render_js(first_js, first_options)
+        result = described_class.exec_server_render_js(second_js, second_options)
+
+        expect(result[:html]).to eq("rendered")
+        expect(result[:RORP_CACHE_HIT]).to be(true)
+        expect(result[:RORP_CACHE_KEY]).to eq(["ror_pro_rendered_html", "test", second_options.request_digest])
+        expect(pool).to have_received(:exec_server_render_js).once
+      end
+
+      it "does not inject cache metadata into non-hash render results" do
+        allow(pool).to receive(:exec_server_render_js).and_return("rendered")
+
+        result = described_class.exec_server_render_js(js_code, build_render_options)
+
+        expect(result).to eq("rendered")
+      end
+    end
+
+    context "when prerender caching is enabled for streaming renders" do
+      before do
+        allow(ReactOnRailsPro.configuration).to receive(:prerender_caching).and_return(true)
+      end
+
+      it "returns cached streams directly without rendering through the selected pool" do
+        render_options = build_render_options(streaming: true)
+        cached_stream = instance_double(stream_class)
+        allow(ReactOnRailsPro::StreamCache).to receive(:fetch_stream).and_return(cached_stream)
+        allow(ReactOnRailsPro::StreamCache).to receive(:wrap_and_cache)
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+
+        expect(result).to eq(cached_stream)
+        expect(pool).not_to have_received(:exec_server_render_js)
+        expect(ReactOnRailsPro::StreamCache).not_to have_received(:wrap_and_cache)
+      end
+
+      it "wraps cache misses and forwards cache options" do
+        cache_options = { expires_in: 60.seconds }
+        render_options = build_render_options(streaming: true, internal_options: { cache_options: cache_options })
+        upstream_stream = instance_double(stream_class)
+        wrapped_stream = instance_double(stream_class)
+        allow(pool).to receive(:exec_server_render_js).and_return(upstream_stream)
+        allow(ReactOnRailsPro::StreamCache).to receive_messages(fetch_stream: nil, wrap_and_cache: wrapped_stream)
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+
+        expect(result).to eq(wrapped_stream)
+        expect(ReactOnRailsPro::StreamCache).to have_received(:wrap_and_cache)
+          .with(["ror_pro_rendered_html", "test", render_options.request_digest],
+                upstream_stream,
+                cache_options: cache_options)
+      end
+    end
+  end
+
+  describe ".pool" do
+    before do
+      clear_memoized_pool
+    end
+
+    after do
+      clear_memoized_pool
+    end
+
+    def clear_memoized_pool
+      return unless described_class.instance_variable_defined?(:@pool)
+
+      described_class.remove_instance_variable(:@pool)
+    end
+
+    it "chooses the Node renderer pool when configured" do
+      allow(ReactOnRailsPro.configuration).to receive(:node_renderer?).and_return(true)
+
+      expect(described_class.pool).to eq(ReactOnRailsPro::ServerRenderingPool::NodeRenderingPool)
+    end
+
+    it "chooses the Ruby embedded JavaScript pool when the Node renderer is disabled" do
+      allow(ReactOnRailsPro.configuration).to receive(:node_renderer?).and_return(false)
+
+      expect(described_class.pool).to eq(ReactOnRails::ServerRenderingPool::RubyEmbeddedJavaScript)
     end
   end
 end

--- a/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
       end
 
       def internal_option(name)
-        internal_options.fetch(name, nil)
+        internal_options&.fetch(name, nil)
       end
 
       def streaming?
@@ -121,7 +121,11 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
         def exec_server_render_js(_js_code, _render_options); end
       end
     end
-    let(:stream_class) { Class.new }
+    let(:stream_result_class) do
+      Class.new do
+        def each; end
+      end
+    end
     let(:pool) { instance_double(pool_class) }
     let(:cache_store) do
       Class.new do
@@ -136,7 +140,12 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
           @fetch_calls << key
           return @store[key] if @store.key?(key)
 
+          # Store the original object reference so the spec catches cache metadata mutation leaks.
           @store[key] = yield
+        end
+
+        def value_for(key)
+          @store.fetch(key)
         end
       end.new
     end
@@ -180,6 +189,16 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
         expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
         expect(cache_store.fetch_calls).to be_empty
       end
+
+      it "bypasses cache when skip_prerender_cache is any non-nil value, including false" do
+        render_options = build_render_options(internal_options: { skip_prerender_cache: false })
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+
+        expect(result).to eq({ html: "rendered" })
+        expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
+        expect(cache_store.fetch_calls).to be_empty
+      end
     end
 
     context "when prerender caching is enabled for non-streaming renders" do
@@ -199,6 +218,16 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
         expect(cache_store.fetch_calls).to eq([result[:RORP_CACHE_KEY]])
       end
 
+      it "does not write response-only cache metadata back into the stored value" do
+        render_options = build_render_options
+
+        result = described_class.exec_server_render_js(js_code, render_options)
+        stored = cache_store.value_for(result[:RORP_CACHE_KEY])
+
+        expect(stored).to eq({ html: "rendered" })
+        expect(stored.keys).not_to include(:RORP_CACHE_KEY, :RORP_CACHE_HIT)
+      end
+
       it "returns cached render results for different random domNodeId values without rendering again" do
         first_options = build_render_options
         second_options = build_render_options
@@ -212,6 +241,7 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
         expect(result[:RORP_CACHE_HIT]).to be(true)
         expect(result[:RORP_CACHE_KEY]).to eq(["ror_pro_rendered_html", "test", second_options.request_digest])
         expect(pool).to have_received(:exec_server_render_js).once
+        expect(cache_store.value_for(result[:RORP_CACHE_KEY])).to eq({ html: "rendered" })
       end
 
       it "does not inject cache metadata into non-hash render results" do
@@ -230,7 +260,7 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
 
       it "returns cached streams directly without rendering through the selected pool" do
         render_options = build_render_options(streaming: true)
-        cached_stream = instance_double(stream_class)
+        cached_stream = instance_double(stream_result_class)
         allow(ReactOnRailsPro::StreamCache).to receive(:fetch_stream).and_return(cached_stream)
         allow(ReactOnRailsPro::StreamCache).to receive(:wrap_and_cache)
 
@@ -244,8 +274,8 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
       it "wraps cache misses and forwards cache options" do
         cache_options = { expires_in: 60.seconds }
         render_options = build_render_options(streaming: true, internal_options: { cache_options: cache_options })
-        upstream_stream = instance_double(stream_class)
-        wrapped_stream = instance_double(stream_class)
+        upstream_stream = instance_double(stream_result_class)
+        wrapped_stream = instance_double(stream_result_class)
         allow(pool).to receive(:exec_server_render_js).and_return(upstream_stream)
         allow(ReactOnRailsPro::StreamCache).to receive_messages(fetch_stream: nil, wrap_and_cache: wrapped_stream)
 
@@ -256,6 +286,7 @@ RSpec.describe ReactOnRailsPro::ServerRenderingPool::ProRendering do
           .with(["ror_pro_rendered_html", "test", render_options.request_digest],
                 upstream_stream,
                 cache_options: cache_options)
+        expect(pool).to have_received(:exec_server_render_js).with(js_code, render_options).once
       end
     end
   end


### PR DESCRIPTION
Closes #3710.

## Summary

- Expand direct specs for `ReactOnRailsPro::ServerRenderingPool::ProRendering`.
- Prevent response-only cache metadata from mutating cached hash render results in `ProRendering`.
- Cover request digest preservation, full-JS hashing when DOM IDs are stable, cache bypass paths including existing non-nil `skip_prerender_cache` semantics, non-streaming cache miss/hit metadata isolation, streaming cache hit/miss behavior, forwarded cache options, and pool selection.
- Keep the existing random `domNodeId` cache-reuse coverage with different generated DOM IDs.


## Post-merge review-thread classification

- `NON_BLOCKING_DECISION`: keep the shallow `dup` cache metadata fix as merged. It intentionally isolates top-level response metadata keys from cached hashes; `deep_dup` would be unnecessary allocation for the current render result shape.
- `FOLLOWUP`: `skip_prerender_cache: false` bypassing cache is pre-existing nil-check semantics and may deserve a separate issue/PR because changing it would alter public behavior.
- `FOLLOWUP`: optional test readability/diagnostic polish includes class-vs-instance verifying doubles, stream stand-in comments, explicit pool-call assertions, and cache-hit-path mirror assertions. These are not blockers for the merged regression coverage.
- `NOISE`: repeated Claude comments restating the same shallow-copy and pre-existing-semantics decisions were resolved after classification.

## Validation

Current head: `45b5c0b8da842d65d35c9cfaeba198b5a93d6943`

- PASS `script/ci-changes-detector origin/main` - recommended broad CI because the Pro spec path is uncategorized by the detector and Pro Ruby core changed.
- PASS `(cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb)` - 16 examples, 0 failures.
- PASS `(cd react_on_rails_pro && bundle exec rubocop --ignore-parent-exclusion spec/react_on_rails_pro/server_rendering_pool/pro_rendering_spec.rb lib/react_on_rails_pro/server_rendering_pool/pro_rendering.rb)` - 2 files inspected, no offenses.
- PASS `git diff --check origin/main...HEAD`.
- PASS post-review follow-up pass: focused ProRendering RSpec, focused Pro RuboCop, `git diff --check`, and `script/ci-changes-detector origin/main`.
- PASS GitHub Actions at current head before lifting draft: no failed checks; Pro package tests, Pro integration tests, benchmarks, CodeQL, lint, and generator checks completed successfully.

Root `bundle exec rubocop --format simple` was run earlier and fails on pre-existing unrelated offenses in `react_on_rails/spike/3313_prism_gemfile_rewriter/*`; the changed Pro files are clean under the focused Pro RuboCop command.

## Label Recommendation

None. Pro-only targeted coverage plus a one-line cached-hash mutation fix; no workflow, lockfile, or changelog changes.

## Pro / Change Risk

Pro production behavior changes only by duplicating hash render results before adding `RORP_CACHE_KEY` / `RORP_CACHE_HIT`, so cached hash values are not mutated by response metadata. The behavior is covered by direct ProRendering specs.

## Adversarial PR Review Gate

- PR: #3751
- Base: `main`
- Head branch: `jg-codex/issue-3710-pro-rendering-specs`
- Head SHA reviewed: `45b5c0b8da842d65d35c9cfaeba198b5a93d6943`
- Merge state at review: `BLOCKED`; draft: yes; merged: no.
- Commands/data sources: `gh pr view 3751 --json ...`, `gh api graphql ... reviewThreads`, local diff inspection, `script/ci-changes-detector origin/main`, focused Pro RSpec, focused Pro RuboCop, `git diff --check origin/main...HEAD`.

Findings:

- `BLOCKING`: none from the local diff.
- `DISCUSS`: none.
- `FOLLOWUP`: `skip_prerender_cache: false` currently bypasses cache because the existing production check is nil-based. This PR documents/tests the current behavior; changing it to truthiness is public semantics work and should be a separate issue/PR.
- `NON_BLOCKING_DECISION`: keep `result.dup` as a shallow copy. It isolates the response-only top-level cache metadata this PR adds; current SSR hash values are not mutated in place, so `deep_dup` is unnecessary overhead for this fix.
- `NOISE`: CodeRabbit skipped review while draft; previous review anchors may remain unresolved until GitHub marks them outdated/resolved, but their substance is addressed in code.

Readiness note: current-head GitHub checks were green before lifting draft. Do not merge until any post-ready review/check reruns are green and any new actionable feedback is triaged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a caching issue where cached rendering results could be unintentionally modified across requests, improving cache stability.

* **Tests**
  * Expanded test coverage for server-side rendering functionality, including caching behavior, streaming, and pool selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->