### PR TITLE
[codex] Polish Pro Node Renderer diagram follow-ups

### DIFF
--- a/docs/pro/node-renderer.md
+++ b/docs/pro/node-renderer.md
@@ -35,8 +35,12 @@ flowchart LR
         N2 --> N5["Worker N<br/>renders HTML"]
     end
     style Exec fill:#fff4e5,stroke:#e0a000,color:#000
+    style E1 fill:#fff4e5,stroke:#e0a000,color:#000
+    style E2 fill:#fff4e5,stroke:#e0a000,color:#000
     style E3 fill:#ffe5e5,stroke:#d1242f,color:#000
     style Node fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style N1 fill:#e6f0ff,stroke:#2c6ecb,color:#000
+    style N2 fill:#e6ffed,stroke:#2da44e,color:#000
     style N3 fill:#e6ffed,stroke:#2da44e,color:#000
     style N4 fill:#e6ffed,stroke:#2da44e,color:#000
     style N5 fill:#e6ffed,stroke:#2da44e,color:#000
@@ -110,9 +114,9 @@ flowchart TB
         L3 -- "yes" --> Exec["Run JavaScript<br/>to make HTML"]
         L3 -- "no" --> L4{"Is the JS bundle<br/>saved on disk?"}
         L4 -- "yes" --> Exec
-        L4 -- "no" --> Upload["Rails sends<br/>the bundle once"]
-        Upload --> Exec
     end
+    L4 -- "no" --> Upload["Rails uploads<br/>the bundle"]
+    Upload --> Exec
     Exec --> Done
     Exec -. "during one render" .-> L5["Repeated data reads<br/>share one result"]
     Browser["Browser starts the page"] -. "later" .-> L6["Browser code chunks<br/>cached by the browser"]
@@ -488,8 +492,9 @@ As a trace, the spans nest under the root `ror.ssr.request`. On the warm path th
 ```mermaid
 flowchart TB
     Root["One server-render trace"]
-    Root --> Warm["Warm path<br/>load bundle -> run JavaScript -> prepare result"]
-    Root -. "cold start" .-> Cold["Upload bundle first<br/>then load it"]
+    Root --> Warm["Load bundle -> run JavaScript -> prepare result"]
+    Root -. "cold start" .-> Cold["Upload bundle<br/>and build cache-miss VM"]
+    Cold -- "then continue" --> Warm
     Warm -. "if JavaScript fetches data" .-> Http["Data-fetch spans"]
     Root -. "if slow data is streamed" .-> Inc["Streaming-data spans"]
     Inc --> Chunk["One span for each<br/>incoming data chunk"]

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -98,8 +98,8 @@ The view helper is `stream_react_component_with_async_props`, which yields an em
 
 ```erb
 <%= stream_react_component_with_async_props("Dashboard") do |emit|
-      # Sequential: posts waits for users. For parallel queries, see the fan-out pattern below.
-      # Treat users as the slow source here; fast data can use ordinary synchronous props.
+      # Sequential: both values are emitted asynchronously, one after the other.
+      # Put fast values in `props:`; use emit for values you want to stream.
       emit.call("users", User.active.limit(50).as_json(only: [:id, :name]))
       emit.call("posts", Post.recent.limit(20).as_json(only: [:id, :title]))
     end %>
@@ -118,7 +118,7 @@ sequenceDiagram
     autonumber
     participant Renderer as Node Renderer
     participant Rails as Rails API
-    participant Data as Rails data
+    participant Data as DB / Models
     Note over Renderer: Discouraged — usually let Rails pass the data instead
     Renderer->>Rails: Ask Rails API for data
     Rails->>Data: Load and authorize data


### PR DESCRIPTION
Closes #3511.

## Summary

- Move the bundle upload step outside the Node Renderer cache-flow subgraph so Rails owns the upload in the diagram.
- Add explicit styling for the first Node Renderer comparison diagram's key Rails/runtime/renderer nodes.
- Clarify the cold-path OTel trace flow so bundle upload/cache-miss work feeds back into the normal render path.
- Rename the discouraged direct-fetch data participant to `DB / Models` and update the async-props ERB comments so both emitted values are clearly async while fast values belong in `props:`.

## Validation

- `pnpm dlx prettier@3.6.2 --check docs/pro/node-renderer.md docs/pro/streaming-ssr.md` — passed.
- `git diff --check` — passed.
- `script/ci-changes-detector origin/main` — docs-only; recommended CI jobs: none.

## Notes

No doc IDs or sidebar entries changed, so `script/check-docs-sidebar` was not needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code, configuration, or security impact.
> 
> **Overview**
> **Documentation-only** polish for Pro Node Renderer and streaming SSR diagrams and examples—no runtime or API changes.
> 
> In **`node-renderer.md`**, Mermaid diagrams are tightened: the ExecJS vs Node comparison gets explicit node styling for Rails/runtime steps; the cache-flow chart moves **bundle upload** outside the Node Renderer subgraph so **Rails** is shown owning upload; the OpenTelemetry trace flow now shows cold-start **upload/cache-miss** work feeding back into the normal warm render path with clearer labels.
> 
> In **`streaming-ssr.md`**, the discouraged direct-`fetch` sequence renames the data participant to **`DB / Models`**, and the async-props ERB comments clarify that **`emit`** is for streamed values while fast data belongs in **`props:`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c413abfdd73feed94cd2d8b53c9a60863110d1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Adversarial PR Review Gate

- PR: #3756
- Base: `main`
- Head branch: `codex/issue-3511-pro-node-renderer-docs`
- Head SHA reviewed: `c413abfdd73feed94cd2d8b53c9a60863110d1e5`
- Merge state at review: `BLOCKED`; draft: yes; merged: no.
- Commands/data sources: issue #3511 body, local diff inspection, `pnpm dlx prettier@3.6.2 --check docs/pro/node-renderer.md docs/pro/streaming-ssr.md`, `git diff --check`, `script/ci-changes-detector origin/main`, `gh api graphql ... reviewThreads`, current GitHub checks/reviews.

Findings:

- `BLOCKING`: none.
- `DISCUSS`: none.
- `FOLLOWUP`: none.
- `NON_BLOCKING_DECISION`: kept the PR documentation-only and did not add doc-sidebar validation locally because no doc IDs or sidebar entries changed; GitHub `check-sidebar` passed.
- `NOISE`: initial `claude-review` failure was infrastructure/network during `git fetch origin main`; rerun passed and posted no review threads. CodeRabbit skipped review while draft.

Readiness note: current-head checks are green and there are no unresolved blocking/discuss findings. Ready for maintainer review/approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified streaming SSR component behavior and guidance for handling async properties
  * Enhanced diagrams and textual explanations in node renderer documentation for improved understanding of the build and cache workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->