### PR TITLE
[codex] Centralize libyaml setup in Ruby action

### DIFF
--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Arbitrary cache-version value passed through to ruby/setup-ruby.
     required: false
     default: '0'
+  install-libyaml:
+    description: Whether setup-ruby should install libyaml-dev before Ruby/Bundler steps.
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -43,3 +47,4 @@ runs:
         bundler-cache: true
         frozen: ${{ inputs.frozen }}
         cache-version: ${{ inputs.cache-version }}
+        install-libyaml: ${{ inputs.install-libyaml }}

--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -22,7 +22,10 @@ inputs:
     required: false
     default: '0'
   install-libyaml:
-    description: Whether setup-ruby should install libyaml-dev before Ruby/Bundler steps.
+    description: >
+      Whether setup-ruby should install libyaml-dev before Ruby/Bundler steps.
+      Pass 'false' if a prior setup-ruby step in this job already installed libyaml-dev;
+      only takes effect on Linux runners.
     required: false
     default: 'true'
 

--- a/.github/actions/setup-bundle/action.yml
+++ b/.github/actions/setup-bundle/action.yml
@@ -1,7 +1,6 @@
 name: Setup Bundler dependencies
 description: >
-  Setup Ruby, cache, and install gems for a Bundler project. On Linux,
-  ensure libyaml-dev is already present or install it before calling this action.
+  Setup Ruby, cache, and install gems for a Bundler project.
 
 inputs:
   working-directory:
@@ -36,14 +35,11 @@ runs:
         fi
 
     - name: Setup Ruby and install cached gems
-      uses: ruby/setup-ruby@v1
-      env:
-        BUNDLE_FROZEN: ${{ inputs.frozen }}
-        BUNDLE_RETRY: '3'
-        BUNDLE_JOBS: '4'
+      uses: ./.github/actions/setup-ruby
       with:
         ruby-version: ${{ inputs.ruby-version }}
         working-directory: ${{ inputs.working-directory }}
-        bundler: ${{ inputs.bundler-version }}
+        bundler-version: ${{ inputs.bundler-version }}
         bundler-cache: true
+        frozen: ${{ inputs.frozen }}
         cache-version: ${{ inputs.cache-version }}

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: default
   working-directory:
-    description: Working directory passed through to ruby/setup-ruby.
+    description: Working directory passed through to ruby/setup-ruby for both cache and non-cache setup paths.
     required: false
     default: .
   bundler-cache:
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: 'false'
   frozen:
-    description: Whether to run Bundler in frozen mode when bundler-cache is enabled.
+    description: Whether to run Bundler in frozen mode when bundler-cache is enabled; has no effect otherwise.
     required: false
     default: 'true'
   cache-version:

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,5 +1,5 @@
 name: Setup Ruby runtime
-description: Install Ruby runtime prerequisites and setup Ruby without installing gems.
+description: Install Ruby runtime prerequisites and set up Ruby, optionally with cached Bundler dependencies.
 
 inputs:
   ruby-version:
@@ -9,11 +9,26 @@ inputs:
     description: >
       Bundler version selector passed through to ruby/setup-ruby.
       Use default, latest, none, Gemfile.lock, or x.y.z. Defaults to "default"
-      (the bundler shipped with the chosen Ruby) rather than "Gemfile.lock",
-      because this action has no working-directory and the repo-root Gemfile.lock
-      is gitignored — reading it would be meaningless here.
+      (the bundler shipped with the chosen Ruby). Most callers should use
+      setup-bundle instead, which defaults this to Gemfile.lock.
     required: false
     default: default
+  working-directory:
+    description: Working directory passed through to ruby/setup-ruby.
+    required: false
+    default: .
+  bundler-cache:
+    description: Whether ruby/setup-ruby should install and cache Bundler dependencies.
+    required: false
+    default: 'false'
+  frozen:
+    description: Whether to run Bundler in frozen mode when bundler-cache is enabled.
+    required: false
+    default: 'true'
+  cache-version:
+    description: Arbitrary cache-version value passed through to ruby/setup-ruby when bundler-cache is enabled.
+    required: false
+    default: '0'
   install-libyaml:
     description: Whether to install libyaml-dev before Ruby/Bundler steps.
     required: false
@@ -27,9 +42,27 @@ runs:
       shell: bash
       run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libyaml-dev
 
+    # Split the non-cache/cache paths because GitHub Actions does not support
+    # conditional env blocks on one step; Bundler env vars only affect installs.
     - name: Setup Ruby
+      if: inputs.bundler-cache != 'true'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
+        working-directory: ${{ inputs.working-directory }}
         bundler: ${{ inputs.bundler-version }}
         bundler-cache: false
+
+    - name: Setup Ruby and install cached gems
+      if: inputs.bundler-cache == 'true'
+      uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_FROZEN: ${{ inputs.frozen }}
+        BUNDLE_RETRY: '3'
+        BUNDLE_JOBS: '4'
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        working-directory: ${{ inputs.working-directory }}
+        bundler: ${{ inputs.bundler-version }}
+        bundler-cache: true
+        cache-version: ${{ inputs.cache-version }}

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -30,7 +30,9 @@ inputs:
     required: false
     default: '0'
   install-libyaml:
-    description: Whether to install libyaml-dev before Ruby/Bundler steps.
+    description: >
+      Whether to install libyaml-dev before Ruby/Bundler steps.
+      Only takes effect on Linux runners; silently ignored elsewhere.
     required: false
     default: 'true'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -331,6 +331,7 @@ jobs:
         with:
           working-directory: ${{ matrix.app_directory }}
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Generate file-system based entrypoints for Pro
         if: matrix.generate_packs == 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -146,14 +146,9 @@ jobs:
       # Only pay the Bundler setup when benchmarks will run or the scripts
       # themselves changed; unrelated PRs keep this job stdlib-only and fast.
       # TODO: when fixing #2214 this should switch to the new root Gemfile.
-      - name: Install libyaml-dev
-        # Must precede any gem install/load: psych links libyaml dynamically. On warm caches the
-        # missing-lib failure is silent; cold runs hit it.
-        if: steps.benchmark-matrices.outputs.run_benchmark_suites == 'true' || steps.detect.outputs.benchmarks_changed == 'true'
-        run: sudo apt-get install -y libyaml-dev
       - name: Setup Ruby
         if: steps.benchmark-matrices.outputs.run_benchmark_suites == 'true' || steps.detect.outputs.benchmarks_changed == 'true'
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
       # The benchmark specs only need rspec, which the root Gemfile provides (it
@@ -224,11 +219,6 @@ jobs:
           mkdir -p ~/bin
           echo "$HOME/bin" >> "$GITHUB_PATH"
 
-      - name: Install libyaml-dev
-        # Must precede any gem install/load: psych links libyaml dynamically. On warm caches the
-        # missing-lib failure is silent; cold runs hit it.
-        run: sudo apt-get install -y libyaml-dev
-
       - name: Setup k6
         if: matrix.benchmark_tool == 'k6'
         uses: grafana/setup-k6-action@v1
@@ -253,7 +243,7 @@ jobs:
           mv vegeta ~/bin/
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ./.github/actions/setup-ruby
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
 

--- a/.github/workflows/dummy-app-bundler-tests.yml
+++ b/.github/workflows/dummy-app-bundler-tests.yml
@@ -79,6 +79,7 @@ jobs:
           working-directory: react_on_rails/spec/dummy
           ruby-version: ${{ matrix.ruby-version }}
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
+          install-libyaml: 'false'
       - name: generate file system-based packs
         env:
           SHAKAPACKER_ASSETS_BUNDLER: ${{ matrix.bundler }}
@@ -199,12 +200,14 @@ jobs:
           working-directory: react_on_rails
           ruby-version: ${{ matrix.ruby-version }}
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
+          install-libyaml: 'false'
       - name: Install Ruby Gems for dummy app
         uses: ./.github/actions/setup-bundle
         with:
           working-directory: react_on_rails/spec/dummy
           ruby-version: ${{ matrix.ruby-version }}
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
+          install-libyaml: 'false'
       - name: Ensure minimum required Chrome version
         run: |
           echo -e "Already installed $(google-chrome --version)\n"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -171,6 +171,7 @@ jobs:
           # Minimum-dependency legs intentionally install with frozen=false after script/convert,
           # matching the historical bundle install behavior for converted dependency files.
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
+          install-libyaml: 'false'
       - name: Ensure minimum required Chrome version
         run: |
           echo -e "Already installed $(google-chrome --version)\n"

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -143,6 +143,7 @@ jobs:
           # Minimum-dependency legs intentionally install with frozen=false after script/convert,
           # matching the historical bundle install behavior for converted dependency files.
           frozen: ${{ matrix.dependency-level == 'minimum' && 'false' || 'true' }}
+          install-libyaml: 'false'
       - name: Git Stuff
         if: matrix.dependency-level == 'minimum'
         run: |

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           working-directory: react_on_rails
           ruby-version: '4.0'
+          install-libyaml: 'false'
       - name: Install Node modules with pnpm
         run: pnpm install --frozen-lockfile
 
@@ -184,6 +185,7 @@ jobs:
         with:
           working-directory: react_on_rails/spec/dummy
           ruby-version: '4.0'
+          install-libyaml: 'false'
       - name: generate file system-based packs
         run: cd react_on_rails/spec/dummy && RAILS_ENV="test" bundle exec rake react_on_rails:generate_packs
       - name: Detect dead code

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           working-directory: react_on_rails/spec/dummy
           ruby-version: '3.3'
+          install-libyaml: 'false'
 
       - name: Install Playwright browsers
         working-directory: react_on_rails/spec/dummy

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           working-directory: react_on_rails/spec/dummy
           ruby-version: '4.0'
+          install-libyaml: 'false'
       - name: Build ReScript files
         run: pnpm --filter "react_on_rails" run build:rescript
       - name: Generate file system-based packs

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -163,6 +163,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Generate file-system based entrypoints
         run: cd spec/dummy && bundle exec rake react_on_rails:generate_packs
@@ -277,6 +278,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Install Node modules with pnpm
         working-directory: .
@@ -465,6 +467,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Install Node modules with pnpm
         working-directory: .

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -145,6 +145,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Install Node modules with pnpm
         working-directory: .
@@ -158,6 +159,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Generate file-system based entrypoints
         run: cd spec/dummy && bundle exec rake react_on_rails:generate_packs
@@ -260,6 +262,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Generate file-system based entrypoints
         run: cd spec/dummy && bundle exec rake react_on_rails:generate_packs
@@ -428,6 +431,7 @@ jobs:
         with:
           working-directory: react_on_rails_pro
           ruby-version: ${{ matrix.ruby-version }}
+          install-libyaml: 'false'
 
       - name: Run RSpec tests for Pro package
         run: bundle exec rspec spec/react_on_rails_pro

--- a/.github/workflows/shakaperf-release-gates.yml
+++ b/.github/workflows/shakaperf-release-gates.yml
@@ -84,12 +84,14 @@ jobs:
         with:
           working-directory: react_on_rails_pro
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Install Ruby Gems for Pro dummy app
         uses: ./.github/actions/setup-bundle
         with:
           working-directory: react_on_rails_pro/spec/dummy
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
 
       - name: Build Pro JavaScript packages
         run: |

--- a/analysis/vm-script-caching-investigation-2026-06-07.md
+++ b/analysis/vm-script-caching-investigation-2026-06-07.md
@@ -159,12 +159,14 @@ Adding `vm.Script` caching would:
 
 ## Artifacts
 
-Benchmark scripts were run during the original investigation. The raw benchmark summary is included below;
-the local experiment directory was not committed.
+Benchmark scripts and raw data are captured in this committed analysis note:
+
+- Raw benchmark output: see the two sections below.
+- Original local experiment bundle: intentionally not retained because it was an ephemeral `tmp/` path.
 
 ### Raw Benchmark Output (Summary)
 
-```
+```text
 vm.Script Caching Benchmark
 ===========================
 Node: v22.12.0
@@ -181,7 +183,7 @@ Platform: darwin arm64
 
 ### Compilation Cost Analysis
 
-```
+```text
 Heavy Parse Patterns Test
 ============================================================
 Pattern                        |    Chars |  Compile


### PR DESCRIPTION
Closes #3521.

## Summary

- Extend the local `setup-ruby` composite action so it can optionally run `ruby/setup-ruby` with Bundler cache settings.
- Have `setup-bundle` delegate Ruby setup and gem caching through the shared `setup-ruby` action instead of calling `ruby/setup-ruby` directly.
- Replace benchmark workflow's manual `libyaml-dev` install steps with the shared `setup-ruby` action.
- Add an `install-libyaml` passthrough so workflows that already ran `setup-ruby` can call `setup-bundle` without a duplicate `libyaml-dev` install.
- Document that `install-libyaml` only takes effect on Linux runners, matching the guarded install step.
- Update the VM script-caching analysis artifact note to avoid pointing readers at an ephemeral local tmp path.

## Validation

- `actionlint` - passed.
- `ruby -e 'require "yaml"; files = Dir[".github/actions/*/action.yml", ".github/workflows/*.yml"].sort; files.each { |path| YAML.load_file(path) }; puts "parsed #{files.size} yaml files"'` - parsed 30 YAML files.
- `pnpm dlx prettier@3.6.2 --check .github/actions/setup-ruby/action.yml .github/actions/setup-bundle/action.yml .github/workflows/benchmark.yml .github/workflows/dummy-app-bundler-tests.yml .github/workflows/examples.yml .github/workflows/gem-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/playwright.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-test-package-and-gem.yml .github/workflows/shakaperf-release-gates.yml analysis/vm-script-caching-investigation-2026-06-07.md` - passed.
- `git diff --check` - passed.
- `script/ci-changes-detector origin/main` - CI infrastructure; recommended full suite, no benchmarks.
- `rg -n "sudo apt-get .*libyaml|Install libyaml-dev|ensure libyaml-dev|ruby/setup-ruby@v1|install-libyaml" .github/workflows .github/actions` - direct `libyaml-dev` install remains centralized in `setup-ruby`; workflow `setup-bundle` calls that already ran `setup-ruby` now pass `install-libyaml: 'false'`.

## Adversarial PR Review Gate

- PR: #3758 / #3521 implementation
- Base: `main`
- Head branch: `codex/issue-3521-centralize-libyaml`
- Head SHA reviewed: `dfbbeac38b82e54b51e51f7f739a4d2fbf8d24c9`
- Commands/data sources: issue #3521 body/comments, PR metadata/checks/reviews/comments, review threads, local diff inspection, `rg` over `.github/actions` and `.github/workflows`, YAML parser check, `actionlint`, Prettier check, `script/ci-changes-detector origin/main`, `git diff --check`.

Findings:

- `BLOCKING`: none remaining after current-head review fixes.
- `DISCUSS`: none requiring maintainer input.
- `FOLLOWUP`: optional future optimization: try installing `libyaml-dev` before `apt-get update` on warm runners. This is advisory, pre-existing behavior, and outside the centralization scope of this PR.
- `NON_BLOCKING_DECISION`: keep `ruby/setup-ruby@v1` usage inside the shared `setup-ruby` action; the centralization target is removal of workflow/local-action bypasses and manual `libyaml-dev` installs, not vendoring the upstream Ruby setup action. Keep `bundler-cache: false` explicit in the non-cache setup path for readability, even though it matches the upstream default. Keep `setup-bundle` focused on bundle setup while documenting the Linux-only `install-libyaml` behavior in `setup-ruby`; workflow call sites already pass `install-libyaml: 'false'` when `setup-ruby` has already run. Keep the `setup-ruby` split comment concise: the cache path is the only path where Bundler env vars can matter because the non-cache path does not run bundle install.
- `NOISE`: no code-runtime validation was run because this is CI composite-action wiring; GitHub Actions checks are the authoritative integration validation.

Readiness note: non-draft and ready to merge once current-head CI is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI composite-action wiring only; behavior should match prior Ruby/Bundler and libyaml steps, with integration validated by GitHub Actions runs.
> 
> **Overview**
> **libyaml** and Ruby/Bundler setup are consolidated in the local **`setup-ruby`** composite action, and **`setup-bundle`** now delegates to it instead of calling **`ruby/setup-ruby`** directly.
> 
> **`setup-ruby`** gains optional Bundler cache install (`working-directory`, `bundler-cache`, `frozen`, `cache-version`) with separate steps for cache vs non-cache paths, and keeps **`libyaml-dev`** install behind **`install-libyaml`** (Linux only). **`setup-bundle`** adds an **`install-libyaml`** passthrough; workflows that already run **`setup-ruby`** pass **`install-libyaml: 'false'`** on subsequent **`setup-bundle`** steps to avoid duplicate apt installs. Benchmark workflow drops inline **`libyaml-dev`** steps and uses **`./.github/actions/setup-ruby`**.
> 
> The VM script-caching analysis note is updated so artifact references stay in the committed doc instead of an ephemeral tmp path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbbeac38b82e54b51e51f7f739a4d2fbf8d24c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored Ruby and Bundler configuration in CI/CD pipelines with updated composite GitHub Actions for improved maintainability.
  * Added configurable control for optional libyaml installation dependencies across test and build workflows to improve flexibility in various environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


