### PR TITLE
Share base-ref helpers across guard scripts

### DIFF
--- a/bin/lefthook/get-changed-files
+++ b/bin/lefthook/get-changed-files
@@ -20,6 +20,8 @@ case "$CONTEXT" in
     source "$repo_root/script/lib/git-diff-base"
 
     base="$(git_diff_base_normalize_base_ref "${BASE_REF:-}")"
+    # Lefthook runs in developer clones that may be shallow or missing refs, so
+    # use lenient fetch handling and fail only if no usable merge base remains.
     if ! merge_base="$(git_diff_base_resolve "$base" HEAD lenient)"; then
       exit 1
     fi

--- a/bin/lefthook/get-changed-files
+++ b/bin/lefthook/get-changed-files
@@ -20,7 +20,9 @@ case "$CONTEXT" in
     source "$repo_root/script/lib/git-diff-base"
 
     # BASE_REF is trusted developer-local environment input here, not a GitHub
-    # event payload; downstream git calls still quote the normalized ref.
+    # event payload. The helper's branch-name validation is for PR-controlled
+    # refs; this path keeps downstream git calls quoted and requires a resolved
+    # merge base before diffing.
     base="$(git_diff_base_normalize_base_ref "${BASE_REF:-}")"
     # Lefthook runs in developer clones that may be shallow or missing refs, so
     # use lenient fetch handling and fail only if no usable merge base remains.

--- a/bin/lefthook/get-changed-files
+++ b/bin/lefthook/get-changed-files
@@ -14,7 +14,7 @@ case "$CONTEXT" in
     (git diff --cached --name-only --diff-filter=ACMR; git diff --name-only --diff-filter=ACMR; git ls-files --others --exclude-standard) | sort -u | grep -E "$PATTERN" || true
     ;;
   branch)
-    # Compare against main for this repo's default-branch workflow.
+    # Compare against BASE_REF (default: origin/main) using a merge-base diff.
     repo_root="$(git rev-parse --show-toplevel)"
     # shellcheck source=script/lib/git-diff-base
     source "$repo_root/script/lib/git-diff-base"

--- a/bin/lefthook/get-changed-files
+++ b/bin/lefthook/get-changed-files
@@ -19,6 +19,8 @@ case "$CONTEXT" in
     # shellcheck source=script/lib/git-diff-base
     source "$repo_root/script/lib/git-diff-base"
 
+    # BASE_REF is trusted developer-local environment input here, not a GitHub
+    # event payload; downstream git calls still quote the normalized ref.
     base="$(git_diff_base_normalize_base_ref "${BASE_REF:-}")"
     # Lefthook runs in developer clones that may be shallow or missing refs, so
     # use lenient fetch handling and fail only if no usable merge base remains.

--- a/bin/lefthook/get-changed-files
+++ b/bin/lefthook/get-changed-files
@@ -15,12 +15,15 @@ case "$CONTEXT" in
     ;;
   branch)
     # Compare against main for this repo's default-branch workflow.
-    base="origin/main"
-    if ! git rev-parse --verify --quiet "$base" >/dev/null; then
-      echo "Error: ${base} not found. Run: git fetch origin main" >&2
+    repo_root="$(git rev-parse --show-toplevel)"
+    # shellcheck source=script/lib/git-diff-base
+    source "$repo_root/script/lib/git-diff-base"
+
+    base="$(git_diff_base_normalize_base_ref "${BASE_REF:-}")"
+    if ! merge_base="$(git_diff_base_resolve "$base" HEAD lenient)"; then
       exit 1
     fi
-    git diff --name-only --diff-filter=ACMR "$base"...HEAD | grep -E "$PATTERN" || true
+    git diff --name-only --diff-filter=ACMR "$merge_base" HEAD | grep -E "$PATTERN" || true
     ;;
   *)
     echo "Usage: $0 {staged|all-changed|branch} [pattern]" >&2

--- a/script/check-docs-sidebar
+++ b/script/check-docs-sidebar
@@ -17,13 +17,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=script/lib/git-diff-base
 source "$SCRIPT_DIR/lib/git-diff-base"
 
-BASE_REF="${1:-origin/main}"
-CURRENT_REF="${2:-HEAD}"
-
-# Handle initial commits where before SHA is all zeros
-if [[ "$BASE_REF" =~ ^0+$ ]]; then
-  BASE_REF="origin/main"
-fi
+BASE_REF="$(git_diff_base_normalize_base_ref "${1:-}")"
+CURRENT_REF="$(git_diff_base_normalize_current_ref "${2:-}")"
 
 SIDEBAR_FILE="docs/sidebars.ts"
 EXCLUSIONS_FILE="docs/.sidebar-exclusions"

--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -15,13 +15,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=script/lib/git-diff-base
 source "$SCRIPT_DIR/lib/git-diff-base"
 
-BASE_REF="${1:-origin/main}"
-CURRENT_REF="${2:-HEAD}"
-
-# Handle initial commits where before SHA is all zeros
-if [[ "$BASE_REF" =~ ^0+$ ]]; then
-  BASE_REF="origin/main"
-fi
+BASE_REF="$(git_diff_base_normalize_base_ref "${1:-}")"
+CURRENT_REF="$(git_diff_base_normalize_current_ref "${2:-}")"
 
 # Colors for output
 RED='\033[0;31m'

--- a/script/lib/git-diff-base
+++ b/script/lib/git-diff-base
@@ -50,6 +50,22 @@ git_diff_base_remote_branch() {
   esac
 }
 
+git_diff_base_normalize_base_ref() {
+  local base_ref="${1:-origin/main}"
+
+  # GitHub push events use the all-zero SHA for initial branch pushes. Treat it
+  # like the repo default base so callers do not duplicate this guard.
+  if [[ "$base_ref" =~ ^0+$ ]]; then
+    base_ref="origin/main"
+  fi
+
+  printf '%s\n' "$base_ref"
+}
+
+git_diff_base_normalize_current_ref() {
+  printf '%s\n' "${1:-HEAD}"
+}
+
 git_diff_base_verify_ref() {
   local ref="$1"
 

--- a/script/lib/git-diff-base
+++ b/script/lib/git-diff-base
@@ -381,6 +381,7 @@ git_diff_base_resolve() {
         echo "Error: failed to fetch $base_ref from origin" >&2
         return 1
       fi
+      echo "Warning: failed to fetch $base_ref from origin; continuing with cached local history." >&2
     fi
   fi
 

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -129,6 +129,12 @@ test_normalize_base_ref_maps_zero_sha_to_origin_main() {
   assert_equals "origin/main" "$out" "zero SHA base ref"
 }
 
+test_normalize_base_ref_maps_short_zero_string_to_origin_main() {
+  local out
+  out="$(git_diff_base_normalize_base_ref "000")"
+  assert_equals "origin/main" "$out" "short zero string base ref"
+}
+
 test_normalize_base_ref_preserves_non_zero_ref() {
   local out
   out="$(git_diff_base_normalize_base_ref "origin/release")"
@@ -350,6 +356,35 @@ setup_repo_fixture() {
     || echo "  Warning: setup_repo_fixture: failed to fetch origin/main; some tests may fail unexpectedly" >&2
 }
 
+install_lefthook_fixture_scripts() {
+  local lefthook_source="$REPO_ROOT/bin/lefthook/get-changed-files"
+  local helper_source="$REPO_ROOT/script/lib/git-diff-base"
+
+  if [ ! -f "$lefthook_source" ]; then
+    fail "expected lefthook script at $lefthook_source"
+    return 1
+  fi
+
+  if [ ! -f "$helper_source" ]; then
+    fail "expected git-diff-base helper at $helper_source"
+    return 1
+  fi
+
+  mkdir -p bin/lefthook script/lib
+  ln -s "$lefthook_source" bin/lefthook/get-changed-files
+  ln -s "$helper_source" script/lib/git-diff-base
+
+  if [ ! -x bin/lefthook/get-changed-files ]; then
+    fail "lefthook fixture symlink is not executable"
+    return 1
+  fi
+
+  if [ ! -f script/lib/git-diff-base ]; then
+    fail "git-diff-base fixture symlink does not resolve"
+    return 1
+  fi
+}
+
 test_verify_ref_recognizes_existing_refs() {
   setup_repo_fixture full
   if ! git_diff_base_verify_ref HEAD; then
@@ -544,18 +579,29 @@ test_resolve_lenient_continues_after_initial_fetch_failure() {
     fail "lenient policy should succeed with cached history; stderr was: $(cat "$err_file")"
     return 1
   fi
+  assert_contains "$(cat "$err_file")" "continuing with cached local history" "lenient fetch warning"
   if ! git cat-file -e "$out^{commit}" 2>/dev/null; then
     fail "lenient path returned non-commit '$out'"
     return 1
   fi
 }
 
+test_lefthook_branch_defaults_to_origin_main() {
+  setup_repo_fixture full
+  install_lefthook_fixture_scripts || return 1
+
+  printf 'puts "changed"\n' > changed.rb
+  git add changed.rb
+  git commit -m "add changed ruby file" >/dev/null
+
+  local out
+  out="$(bin/lefthook/get-changed-files branch '\.rb$')"
+  assert_equals "changed.rb" "$out" "default lefthook branch changed files"
+}
+
 test_lefthook_branch_honors_base_ref() {
   setup_repo_fixture full
-
-  mkdir -p bin/lefthook script/lib
-  ln -s "$REPO_ROOT/bin/lefthook/get-changed-files" bin/lefthook/get-changed-files
-  ln -s "$REPO_ROOT/script/lib/git-diff-base" script/lib/git-diff-base
+  install_lefthook_fixture_scripts || return 1
 
   printf 'puts "release baseline"\n' > release_only.rb
   git add release_only.rb
@@ -662,6 +708,7 @@ ALL_TESTS=(
   test_remote_branch_rejects_non_origin
   test_normalize_base_ref_defaults_to_origin_main
   test_normalize_base_ref_maps_zero_sha_to_origin_main
+  test_normalize_base_ref_maps_short_zero_string_to_origin_main
   test_normalize_base_ref_preserves_non_zero_ref
   test_normalize_current_ref_defaults_to_head
   test_normalize_current_ref_preserves_explicit_ref
@@ -693,6 +740,7 @@ ALL_TESTS=(
   test_resolve_shallow_deepens_to_find_merge_base
   test_resolve_full_clone_missing_base_ref_errors
   test_resolve_lenient_continues_after_initial_fetch_failure
+  test_lefthook_branch_defaults_to_origin_main
   test_lefthook_branch_honors_base_ref
   test_resolve_unshallow_fallback_finds_merge_base
   test_resolve_logs_deepen_progress

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -140,6 +140,12 @@ test_normalize_current_ref_defaults_to_head() {
   assert_equals "HEAD" "$out" "default current ref"
 }
 
+test_normalize_current_ref_preserves_explicit_ref() {
+  local out
+  out="$(git_diff_base_normalize_current_ref "abc123")"
+  assert_equals "abc123" "$out" "explicit current ref"
+}
+
 test_fetch_refspec_format() {
   local out
   out="$(git_diff_base_fetch_refspec "main")"
@@ -651,6 +657,7 @@ ALL_TESTS=(
   test_normalize_base_ref_maps_zero_sha_to_origin_main
   test_normalize_base_ref_preserves_non_zero_ref
   test_normalize_current_ref_defaults_to_head
+  test_normalize_current_ref_preserves_explicit_ref
   test_fetch_refspec_format
   test_fetch_depth_uses_default_when_unset
   test_fetch_depth_accepts_valid_env

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -6,6 +6,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=script/lib/git-diff-base
 source "$SCRIPT_DIR/git-diff-base"
 
@@ -113,6 +114,30 @@ test_remote_branch_rejects_non_origin() {
     fail "expected non-zero for refs/heads/main"
     return 1
   fi
+}
+
+test_normalize_base_ref_defaults_to_origin_main() {
+  local out
+  out="$(git_diff_base_normalize_base_ref "")"
+  assert_equals "origin/main" "$out" "default base ref"
+}
+
+test_normalize_base_ref_maps_zero_sha_to_origin_main() {
+  local out
+  out="$(git_diff_base_normalize_base_ref "0000000000000000000000000000000000000000")"
+  assert_equals "origin/main" "$out" "zero SHA base ref"
+}
+
+test_normalize_base_ref_preserves_non_zero_ref() {
+  local out
+  out="$(git_diff_base_normalize_base_ref "origin/release")"
+  assert_equals "origin/release" "$out" "explicit base ref"
+}
+
+test_normalize_current_ref_defaults_to_head() {
+  local out
+  out="$(git_diff_base_normalize_current_ref "")"
+  assert_equals "HEAD" "$out" "default current ref"
 }
 
 test_fetch_refspec_format() {
@@ -518,6 +543,28 @@ test_resolve_lenient_continues_after_initial_fetch_failure() {
   fi
 }
 
+test_lefthook_branch_honors_base_ref() {
+  setup_repo_fixture full
+
+  mkdir -p bin/lefthook script/lib
+  ln -s "$REPO_ROOT/bin/lefthook/get-changed-files" bin/lefthook/get-changed-files
+  ln -s "$REPO_ROOT/script/lib/git-diff-base" script/lib/git-diff-base
+
+  printf 'puts "release baseline"\n' > release_only.rb
+  git add release_only.rb
+  git commit -m "add release baseline" >/dev/null
+  git push origin HEAD:refs/heads/release >/dev/null 2>&1
+  git fetch origin release:refs/remotes/origin/release >/dev/null 2>&1
+
+  printf 'puts "changed"\n' > changed.rb
+  git add changed.rb
+  git commit -m "add changed ruby file" >/dev/null
+
+  local out
+  out="$(BASE_REF=origin/release bin/lefthook/get-changed-files branch '\.rb$')"
+  assert_equals "changed.rb" "$out" "lefthook branch changed files"
+}
+
 test_resolve_unshallow_fallback_finds_merge_base() {
   # Force the deepen budget to exhaust without finding the merge base, so the
   # --unshallow fallback runs. The fixture adds 10 extra commits on main after
@@ -600,6 +647,10 @@ test_resolve_cross_repo_sha_hint_appears() {
 ALL_TESTS=(
   test_remote_branch_strips_origin_prefix
   test_remote_branch_rejects_non_origin
+  test_normalize_base_ref_defaults_to_origin_main
+  test_normalize_base_ref_maps_zero_sha_to_origin_main
+  test_normalize_base_ref_preserves_non_zero_ref
+  test_normalize_current_ref_defaults_to_head
   test_fetch_refspec_format
   test_fetch_depth_uses_default_when_unset
   test_fetch_depth_accepts_valid_env
@@ -628,6 +679,7 @@ ALL_TESTS=(
   test_resolve_shallow_deepens_to_find_merge_base
   test_resolve_full_clone_missing_base_ref_errors
   test_resolve_lenient_continues_after_initial_fetch_failure
+  test_lefthook_branch_honors_base_ref
   test_resolve_unshallow_fallback_finds_merge_base
   test_resolve_logs_deepen_progress
   test_resolve_cross_repo_sha_hint_appears

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -379,7 +379,7 @@ install_lefthook_fixture_scripts() {
     return 1
   fi
 
-  if [ ! -f script/lib/git-diff-base ]; then
+  if [ ! -f script/lib/git-diff-base ]; then # -f follows symlinks and catches a dangling target.
     fail "git-diff-base fixture symlink does not resolve"
     return 1
   fi

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -6,6 +6,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# This test harness lives under script/lib/, so ../.. resolves to the repo root.
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=script/lib/git-diff-base
 source "$SCRIPT_DIR/git-diff-base"
@@ -569,6 +570,10 @@ test_lefthook_branch_honors_base_ref() {
   local out
   out="$(BASE_REF=origin/release bin/lefthook/get-changed-files branch '\.rb$')"
   assert_equals "changed.rb" "$out" "lefthook branch changed files"
+  if grep -qx "release_only.rb" <<<"$out"; then
+    fail "lefthook branch output should not include files already on BASE_REF"
+    return 1
+  fi
 }
 
 test_resolve_unshallow_fallback_finds_merge_base() {

--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -570,6 +570,8 @@ test_lefthook_branch_honors_base_ref() {
   local out
   out="$(BASE_REF=origin/release bin/lefthook/get-changed-files branch '\.rb$')"
   assert_equals "changed.rb" "$out" "lefthook branch changed files"
+  # Defense in depth: keep verifying the BASE_REF-only file is absent if the
+  # exact-output assertion above is ever relaxed.
   if grep -qx "release_only.rb" <<<"$out"; then
     fail "lefthook branch output should not include files already on BASE_REF"
     return 1


### PR DESCRIPTION
Closes #3107.

## Summary

- Share a single git diff-base helper across guard scripts.
- Make lefthook branch diff resolution honor `BASE_REF` with shallow-clone-safe merge-base handling.
- Add self-contained bash coverage for base/current normalization, lenient resolution, and the lefthook `BASE_REF` path.
- Address review feedback with explicit safety comments, a lenient-fetch warning, short zero-string coverage, symlink target guards, and default-base lefthook coverage.

## Validation

Current head: `2434e0a6e10f843ca28c3e7bdb9bc66bfa11554e`.

- `bash -n bin/lefthook/get-changed-files script/check-docs-sidebar script/ci-changes-detector script/lib/git-diff-base script/lib/git-diff-base-test.bash && bash script/lib/git-diff-base-test.bash` - passed, 41 tests.
- `bash script/ci-changes-detector-test.bash` - passed, 43 tests.
- `bash -n bin/lefthook/get-changed-files script/lib/git-diff-base-test.bash && bash script/lib/git-diff-base-test.bash` - passed, 41 tests after latest review-comment follow-up.
- `shellcheck -x bin/lefthook/get-changed-files script/lib/git-diff-base script/lib/git-diff-base-test.bash` - passed after latest review-comment follow-up.
- `shellcheck bin/lefthook/get-changed-files script/check-docs-sidebar script/ci-changes-detector script/lib/git-diff-base script/lib/git-diff-base-test.bash` - passed before latest comment-only follow-up.
- `pnpm start format.listDifferent` - passed.
- `git diff --check origin/main...HEAD && git diff --check` - passed.
- `script/ci-changes-detector origin/main` - CI infrastructure; recommended `full-ci`; benchmarks not recommended.
- `script/check-docs-sidebar origin/main HEAD` - passed; no new published docs required sidebar entries.
- `codex review --base origin/main` - passed; no actionable regressions found.
- Pre-push hook - passed (`branch-lint`, `markdown-links`).

## Label recommendation

- `full-ci`
- No `benchmark`

## Adversarial PR Review Gate

- PR: #3764
- Base: `main`
- Head branch: `jg-codex/issue-3107-base-ref-helper`
- Head SHA reviewed: `2434e0a6e10f843ca28c3e7bdb9bc66bfa11554e`
- Merge state at review: `UNSTABLE` while fresh CI was pending; draft: no; merged: no.

Findings:

- `BLOCKING`: none after the review-fix batch.
- `DISCUSS`: none.
- `FOLLOWUP`: none required for merge.
- `NON_BLOCKING_DECISION`: kept lefthook on lenient fetch policy because developer clones may be shallow/offline; the script now warns when an initial fetch cannot refresh the base, and still fails if no usable merge base exists.
- `NON_BLOCKING_DECISION`: documented that `BASE_REF` is trusted developer-local environment input for lefthook and protected by quoted downstream git calls plus required merge-base resolution, rather than applying PR-controlled ref validation on the happy path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Change-detection scripts now use shared git-ref normalization, allowing configurable base/current refs and more lenient merge-base resolution in shallow clones (emits a warning if initial fetch fails).

* **Tests**
  * Added unit and integration tests covering ref normalization, lenient shallow-fetch behavior, and change-detection scenarios.

* **Chores**
  * Extracted common git-ref handling into reusable helpers for consistency and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->