### PR TITLE
Retry skipped-CI workflow verification

### DIFF
--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -187,6 +187,7 @@ jobs:
                 );
                 await new Promise(resolve => setTimeout(resolve, delayMs));
 
+                // Drain the retry queue; only workflows pushed back below are retried.
                 const toVerify = notFound.splice(0);
 
                 for (const workflow of toVerify) {

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -145,8 +145,11 @@ jobs:
               console.log('ℹ️  No skipped checks found - triggering all workflows to ensure full coverage');
             }
 
-            // GitHub workflow-run timestamps are second-precision; subtract 2 s so
-            // a run created just before dispatch returns is still included.
+            // Capture the lower bound before dispatch. The search window is
+            // intentionally open-ended; workflow_id, event, and head_sha do the
+            // real narrowing. GitHub workflow-run timestamps are
+            // second-precision, so subtract 2 s to include a run created just
+            // before dispatch returns.
             const dispatchStartedAt = new Date(Date.now() - 2000).toISOString();
 
             // Trigger each workflow
@@ -200,8 +203,11 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       workflow_id: workflow.id,
-                      // Narrow the workflow-run search to this PR ref first;
-                      // head_sha still pins the exact dispatched commit.
+                      // Narrow the workflow-run search to this PR ref first.
+                      // head_sha intentionally pins the PR SHA captured at job
+                      // start; if the branch moves before GitHub starts the
+                      // run, verification stays incomplete and the final log
+                      // points maintainers at that SHA mismatch.
                       branch: prData.ref,
                       event: 'workflow_dispatch',
                       head_sha: prData.sha,

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -79,8 +79,7 @@ jobs:
               pull_number: context.issue.number
             });
             return {
-              ref: pr.data.head.ref,
-              sha: pr.data.head.sha
+              ref: pr.data.head.ref
             };
 
       - name: Get skipped checks and trigger workflows
@@ -96,6 +95,22 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number
             });
+
+            const repoFullName = `${context.repo.owner}/${context.repo.repo}`;
+            if (pr.head.repo.full_name !== repoFullName) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  'Unable to run full CI from `/run-skipped-ci` because the PR branch is from a fork.',
+                  '',
+                  'A maintainer should push the branch to this repository or trigger the required workflows manually.'
+                ].join('\n')
+              });
+              core.setFailed('Cannot trigger skipped-CI workflows for fork PR branches');
+              return;
+            }
 
             const checks = await github.rest.checks.listForRef({
               owner: context.repo.owner,
@@ -147,8 +162,8 @@ jobs:
 
             // Capture the lower bound before any dispatch is issued. The -2 s
             // buffer accounts for clock skew between the runner and GitHub's
-            // servers. workflow_id, event, branch, and head_sha do the real
-            // narrowing.
+            // servers. workflow_id, event, branch, and created timestamp do the
+            // real narrowing.
             const dispatchStartedAt = new Date(Date.now() - 2000).toISOString();
 
             // Trigger each workflow
@@ -214,22 +229,17 @@ jobs:
                   let found = false;
                   try {
                     console.log(
-                      `Searching for ${workflow.name} dispatched on SHA ${prData.sha} after ${dispatchStartedAt}...`
+                      `Searching for ${workflow.name} dispatched on ${prData.ref} after ${dispatchStartedAt}...`
                     );
                     const runs = await github.rest.actions.listWorkflowRuns({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       workflow_id: workflow.id,
-                      // Narrow the workflow-run search to this PR ref first.
-                      // head_sha intentionally pins the PR SHA captured at job
-                      // start; GitHub records a dispatched run's head_sha from
-                      // the ref at queue time. If those SHAs differ because the
-                      // branch moved or GitHub queued the run late, verification
-                      // stays incomplete and the warning below points
-                      // maintainers at that mismatch.
+                      // Narrow to workflow_dispatch runs for this PR branch after
+                      // dispatch began. Avoid head_sha because GitHub records it
+                      // from the ref at queue time, which can differ after a push.
                       branch: prData.ref,
                       event: 'workflow_dispatch',
-                      head_sha: prData.sha,
                       per_page: 20,
                       created: `>${dispatchStartedAt}`
                     });
@@ -253,7 +263,7 @@ jobs:
                   console.log(`Still waiting to verify: ${notFound.map(workflow => workflow.name).join(', ')}`);
                 } else {
                   core.warning(
-                    `Verification incomplete after ${maxVerificationAttempts} attempts. Unverified: ${notFound.map(workflow => workflow.name).join(', ')}. If this repeats, confirm the PR branch was not force-pushed during dispatch; the lookup pins runs to the PR SHA captured at job start.`
+                    `Verification incomplete after ${maxVerificationAttempts} attempts. Unverified: ${notFound.map(workflow => workflow.name).join(', ')}. If this repeats, confirm GitHub accepted the workflow dispatches and the workflow map still matches the workflow file names.`
                   );
                 }
               }
@@ -274,8 +284,6 @@ jobs:
             }
 
             // Don't list individual checks - keep it simple
-            const skippedChecksList = '';
-            const verifiedList = '';
             const notFoundList = notFound.length > 0
               ? `\n\n**Unverified (may still be queuing):**\n${notFound.map(workflow => `- ⏳ ${workflow.name}`).join('\n')}`
               : '';
@@ -284,8 +292,7 @@ jobs:
             const body = `🚀 **Full CI Mode Enabled**
 
             ${status}
-            ${skippedChecksList}
-            ${verifiedList}${notFoundList}${failedList}
+            ${notFoundList}${failedList}
 
             ${labelAdded && succeeded.length > 0 ? `\n**Note:** Added the \`full-ci\` label to this PR. All future commits will run the full CI suite (including minimum dependency tests) until the label is removed.
 

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -145,6 +145,8 @@ jobs:
               console.log('ℹ️  No skipped checks found - triggering all workflows to ensure full coverage');
             }
 
+            // GitHub workflow-run timestamps are second-precision; subtract 2 s so
+            // a run created just before dispatch returns is still included.
             const dispatchStartedAt = new Date(Math.floor(Date.now() / 1000) * 1000 - 2000).toISOString();
 
             // Trigger each workflow
@@ -174,6 +176,8 @@ jobs:
 
             if (succeeded.length > 0) {
               const maxVerificationAttempts = 3;
+              // Linear backoff: 5 s / 10 s / 15 s (30 s max) covers typical
+              // GitHub queue latency without over-waiting this helper job.
               const baseDelayMs = 5000;
 
               for (let attempt = 1; attempt <= maxVerificationAttempts; attempt++) {
@@ -214,6 +218,10 @@ jobs:
 
                 if (attempt < maxVerificationAttempts) {
                   console.log(`Still waiting to verify: ${notFound.map(workflow => workflow.name).join(', ')}`);
+                } else {
+                  console.log(
+                    `Verification incomplete after ${maxVerificationAttempts} attempts. Unverified: ${notFound.map(workflow => workflow.name).join(', ')}`
+                  );
                 }
               }
             }

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -195,6 +195,8 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     workflow_id: workflow.id,
+                    // Narrow the workflow-run search to this PR ref first;
+                    // head_sha still pins the exact dispatched commit.
                     branch: prData.ref,
                     event: 'workflow_dispatch',
                     head_sha: prData.sha,

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -191,21 +191,27 @@ jobs:
                 const toVerify = notFound.splice(0);
 
                 for (const workflow of toVerify) {
-                  const runs = await github.rest.actions.listWorkflowRuns({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: workflow.id,
-                    // Narrow the workflow-run search to this PR ref first;
-                    // head_sha still pins the exact dispatched commit.
-                    branch: prData.ref,
-                    event: 'workflow_dispatch',
-                    head_sha: prData.sha,
-                    per_page: 20,
-                    created: `>${dispatchStartedAt}`
-                  });
-
-                  // The API filters identify the dispatched run; path may include a ref suffix.
-                  const found = runs.data.workflow_runs.length > 0;
+                  let found = false;
+                  try {
+                    console.log(
+                      `Searching for ${workflow.name} dispatched on SHA ${prData.sha} after ${dispatchStartedAt}...`
+                    );
+                    const runs = await github.rest.actions.listWorkflowRuns({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      workflow_id: workflow.id,
+                      // Narrow the workflow-run search to this PR ref first;
+                      // head_sha still pins the exact dispatched commit.
+                      branch: prData.ref,
+                      event: 'workflow_dispatch',
+                      head_sha: prData.sha,
+                      per_page: 20,
+                      created: `>${dispatchStartedAt}`
+                    });
+                    found = runs.data.workflow_runs.length > 0;
+                  } catch (error) {
+                    console.log(`API error verifying ${workflow.name}: ${error.message}; will retry`);
+                  }
 
                   if (found) {
                     verified.push(workflow);

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -192,7 +192,7 @@ jobs:
 
             // Verify workflows are queued/running
             const verified = [];
-            let notFound = [...succeeded];
+            const notFound = [...succeeded];
 
             if (succeeded.length > 0) {
               const maxVerificationAttempts = 3;

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -145,11 +145,10 @@ jobs:
               console.log('ℹ️  No skipped checks found - triggering all workflows to ensure full coverage');
             }
 
-            // Capture the lower bound before dispatch. The search window is
-            // intentionally open-ended; workflow_id, event, and head_sha do the
-            // real narrowing. GitHub workflow-run timestamps are
-            // second-precision, so subtract 2 s to include a run created just
-            // before dispatch returns.
+            // Capture the lower bound before any dispatch is issued. The -2 s
+            // buffer accounts for clock skew between the runner and GitHub's
+            // servers. workflow_id, event, branch, and head_sha do the real
+            // narrowing.
             const dispatchStartedAt = new Date(Date.now() - 2000).toISOString();
 
             // Trigger each workflow
@@ -170,6 +169,24 @@ jobs:
               } catch (error) {
                 console.error(`❌ Failed to trigger ${workflowFile}:`, error.message);
                 failed.push({ workflow: workflowName, error: error.message });
+              }
+            }
+
+            // Add full-ci as soon as any dispatch succeeds so a new push during
+            // verification still runs the full matrix.
+            let labelAdded = false;
+            if (succeeded.length > 0) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: ['full-ci']
+                });
+                labelAdded = true;
+                console.log('✅ Added full-ci label to PR');
+              } catch (error) {
+                console.error('⚠️  Failed to add label:', error.message);
               }
             }
 
@@ -205,9 +222,11 @@ jobs:
                       workflow_id: workflow.id,
                       // Narrow the workflow-run search to this PR ref first.
                       // head_sha intentionally pins the PR SHA captured at job
-                      // start; if the branch moves before GitHub starts the
-                      // run, verification stays incomplete and the final log
-                      // points maintainers at that SHA mismatch.
+                      // start; GitHub records a dispatched run's head_sha from
+                      // the ref at queue time. If those SHAs differ because the
+                      // branch moved or GitHub queued the run late, verification
+                      // stays incomplete and the warning below points
+                      // maintainers at that mismatch.
                       branch: prData.ref,
                       event: 'workflow_dispatch',
                       head_sha: prData.sha,
@@ -233,7 +252,7 @@ jobs:
                 if (attempt < maxVerificationAttempts) {
                   console.log(`Still waiting to verify: ${notFound.map(workflow => workflow.name).join(', ')}`);
                 } else {
-                  console.log(
+                  core.warning(
                     `Verification incomplete after ${maxVerificationAttempts} attempts. Unverified: ${notFound.map(workflow => workflow.name).join(', ')}. If this repeats, confirm the PR branch was not force-pushed during dispatch; the lookup pins runs to the PR SHA captured at job start.`
                   );
                 }
@@ -259,21 +278,6 @@ jobs:
             const verifiedList = '';
             const notFoundList = '';
             const failedList = failed.length > 0 ? `\n\n**Failed to trigger:**\n${failed.map(f => `- ❌ ${f.workflow}: ${f.error}`).join('\n')}` : '';
-
-            // Add full-ci label only if we actually triggered workflows or if checks are already running
-            let labelAdded = false;
-            try {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: ['full-ci']
-              });
-              labelAdded = true;
-              console.log('✅ Added full-ci label to PR');
-            } catch (error) {
-              console.error('⚠️  Failed to add label:', error.message);
-            }
 
             const body = `🚀 **Full CI Mode Enabled**
 

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -79,7 +79,9 @@ jobs:
               pull_number: context.issue.number
             });
             return {
-              ref: pr.data.head.ref
+              ref: pr.data.head.ref,
+              sha: pr.data.head.sha,
+              headRepoFullName: pr.data.head.repo.full_name
             };
 
       - name: Get skipped checks and trigger workflows
@@ -89,15 +91,8 @@ jobs:
           script: |
             const prData = ${{ steps.pr.outputs.result }};
 
-            // Fetch PR checks to find skipped ones
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
             const repoFullName = `${context.repo.owner}/${context.repo.repo}`;
-            if (pr.head.repo.full_name !== repoFullName) {
+            if (prData.headRepoFullName !== repoFullName) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -115,7 +110,7 @@ jobs:
             const checks = await github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: pr.head.sha,
+              ref: prData.sha,
               per_page: 100
             });
 
@@ -206,7 +201,7 @@ jobs:
             }
 
             // Verify workflows are queued/running
-            const verified = [];
+            // Seed the retry queue with each successfully dispatched workflow.
             const notFound = [...succeeded];
 
             if (succeeded.length > 0) {
@@ -249,7 +244,7 @@ jobs:
                   }
 
                   if (found) {
-                    verified.push(workflow);
+                    console.log(`Verified ${workflow.name} workflow dispatch`);
                   } else {
                     notFound.push(workflow);
                   }

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -276,7 +276,9 @@ jobs:
             // Don't list individual checks - keep it simple
             const skippedChecksList = '';
             const verifiedList = '';
-            const notFoundList = '';
+            const notFoundList = notFound.length > 0
+              ? `\n\n**Unverified (may still be queuing):**\n${notFound.map(workflow => `- ⏳ ${workflow.name}`).join('\n')}`
+              : '';
             const failedList = failed.length > 0 ? `\n\n**Failed to trigger:**\n${failed.map(f => `- ❌ ${f.workflow}: ${f.error}`).join('\n')}` : '';
 
             const body = `🚀 **Full CI Mode Enabled**

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -145,6 +145,8 @@ jobs:
               console.log('ℹ️  No skipped checks found - triggering all workflows to ensure full coverage');
             }
 
+            const dispatchStartedAt = new Date(Math.floor(Date.now() / 1000) * 1000 - 2000).toISOString();
+
             // Trigger each workflow
             for (const workflowName of workflowsToTrigger) {
               const workflowFile = workflowMap[workflowName];
@@ -166,35 +168,55 @@ jobs:
               }
             }
 
-            // Wait a bit for workflows to queue
-            if (succeeded.length > 0) {
-              console.log('Waiting 5 seconds for workflows to queue...');
-              await new Promise(resolve => setTimeout(resolve, 5000));
-            }
-
             // Verify workflows are queued/running
             const verified = [];
-            const notFound = [];
+            let notFound = [];
 
             if (succeeded.length > 0) {
-              const runs = await github.rest.actions.listWorkflowRunsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                per_page: 100,
-                created: `>${new Date(Date.now() - 60000).toISOString()}`
-              });
+              const maxVerificationAttempts = 3;
+              const baseDelayMs = 5000;
 
-              for (const workflow of succeeded) {
-                const found = runs.data.workflow_runs.some(run =>
-                  run.path === `.github/workflows/${workflow.id}` &&
-                  run.head_sha === prData.sha &&
-                  run.event === 'workflow_dispatch'
+              for (let attempt = 1; attempt <= maxVerificationAttempts; attempt++) {
+                const delayMs = baseDelayMs * attempt;
+                console.log(
+                  `Waiting ${delayMs / 1000} seconds before verification attempt ${attempt}/${maxVerificationAttempts}...`
                 );
+                await new Promise(resolve => setTimeout(resolve, delayMs));
 
-                if (found) {
-                  verified.push(workflow);
-                } else {
-                  notFound.push(workflow);
+                verified.length = 0;
+                notFound = [];
+
+                for (const workflow of succeeded) {
+                  const runs = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflow.id,
+                    branch: prData.ref,
+                    event: 'workflow_dispatch',
+                    head_sha: prData.sha,
+                    per_page: 20,
+                    created: `>${dispatchStartedAt}`
+                  });
+
+                  const found = runs.data.workflow_runs.some(run =>
+                    run.path === `.github/workflows/${workflow.id}` &&
+                    run.head_sha === prData.sha &&
+                    run.event === 'workflow_dispatch'
+                  );
+
+                  if (found) {
+                    verified.push(workflow);
+                  } else {
+                    notFound.push(workflow);
+                  }
+                }
+
+                if (notFound.length === 0) {
+                  break;
+                }
+
+                if (attempt < maxVerificationAttempts) {
+                  console.log(`Still waiting to verify: ${notFound.map(workflow => workflow.name).join(', ')}`);
                 }
               }
             }

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -187,8 +187,7 @@ jobs:
                 );
                 await new Promise(resolve => setTimeout(resolve, delayMs));
 
-                const toVerify = notFound;
-                notFound = [];
+                const toVerify = notFound.splice(0);
 
                 for (const workflow of toVerify) {
                   const runs = await github.rest.actions.listWorkflowRuns({
@@ -222,7 +221,7 @@ jobs:
                   console.log(`Still waiting to verify: ${notFound.map(workflow => workflow.name).join(', ')}`);
                 } else {
                   console.log(
-                    `Verification incomplete after ${maxVerificationAttempts} attempts. Unverified: ${notFound.map(workflow => workflow.name).join(', ')}`
+                    `Verification incomplete after ${maxVerificationAttempts} attempts. Unverified: ${notFound.map(workflow => workflow.name).join(', ')}. If this repeats, confirm the PR branch was not force-pushed during dispatch; the lookup pins runs to the PR SHA captured at job start.`
                   );
                 }
               }

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -170,7 +170,7 @@ jobs:
 
             // Verify workflows are queued/running
             const verified = [];
-            let notFound = [];
+            let notFound = [...succeeded];
 
             if (succeeded.length > 0) {
               const maxVerificationAttempts = 3;
@@ -183,10 +183,10 @@ jobs:
                 );
                 await new Promise(resolve => setTimeout(resolve, delayMs));
 
-                verified.length = 0;
+                const toVerify = notFound;
                 notFound = [];
 
-                for (const workflow of succeeded) {
+                for (const workflow of toVerify) {
                   const runs = await github.rest.actions.listWorkflowRuns({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
@@ -198,11 +198,8 @@ jobs:
                     created: `>${dispatchStartedAt}`
                   });
 
-                  const found = runs.data.workflow_runs.some(run =>
-                    run.path === `.github/workflows/${workflow.id}` &&
-                    run.head_sha === prData.sha &&
-                    run.event === 'workflow_dispatch'
-                  );
+                  // The API filters identify the dispatched run; path may include a ref suffix.
+                  const found = runs.data.workflow_runs.length > 0;
 
                   if (found) {
                     verified.push(workflow);

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -147,7 +147,7 @@ jobs:
 
             // GitHub workflow-run timestamps are second-precision; subtract 2 s so
             // a run created just before dispatch returns is still included.
-            const dispatchStartedAt = new Date(Math.floor(Date.now() / 1000) * 1000 - 2000).toISOString();
+            const dispatchStartedAt = new Date(Date.now() - 2000).toISOString();
 
             // Trigger each workflow
             for (const workflowName of workflowsToTrigger) {

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -81,7 +81,7 @@ jobs:
             return {
               ref: pr.data.head.ref,
               sha: pr.data.head.sha,
-              headRepoFullName: pr.data.head.repo.full_name
+              headRepoFullName: pr.data.head.repo?.full_name ?? ''
             };
 
       - name: Get skipped checks and trigger workflows
@@ -116,7 +116,7 @@ jobs:
 
             // Find all skipped checks
             const skippedChecks = checks.data.check_runs.filter(check =>
-              check.conclusion === 'SKIPPED' && check.status === 'COMPLETED'
+              check.conclusion === 'skipped' && check.status === 'completed'
             );
 
             console.log(`Found ${skippedChecks.length} skipped checks:`);
@@ -143,7 +143,6 @@ jobs:
 
             const succeeded = [];
             const failed = [];
-            const notApplicable = [];
 
             // If no skipped checks found, trigger ALL workflows in the map
             // This handles the case where workflows haven't run yet (e.g., Pro tests on fresh PRs)


### PR DESCRIPTION
Closes #2000.

## Summary

- Retry verification for dispatched skipped-CI workflows instead of relying on one immediate global run lookup.
- Reuse the initial PR metadata lookup for branch ref, head SHA, and source repository, then reject fork/deleted-fork PR branches before dispatch because `workflow_dispatch` refs resolve in the base repository.
- Detect skipped checks with the lowercase Checks API `conclusion`/`status` values.
- Filter each workflow dispatch lookup by workflow file, PR branch, `workflow_dispatch` event, and dispatch start time.
- Keep transient workflow-run lookup failures in the retry path and surface incomplete verification with `core.warning()`.
- Add `full-ci` immediately after any dispatch succeeds, before the verification wait, so future commits do not miss the full matrix.
- List any unverified workflows in the PR comment so maintainers know what may still be queuing, without empty placeholder sections.

## Validation

Current head: `01e07f5f914370ad1b278c0a28fe7c1e71a39b11`.

- Merged current `origin/main` (`3ef90344089df6073e8bd46d658666d170ae2fe8`) into this branch before the latest pushes.
- `actionlint .github/workflows/run-skipped-ci.yml` - passed.
- `pnpm exec prettier --check .github/workflows/run-skipped-ci.yml` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `git diff --check` - passed.
- `script/ci-changes-detector origin/main` - CI infrastructure; recommended full CI; benchmarks not recommended.
- `codex review --base origin/main` - found the fork-PR branch-collision risk after dropping `head_sha`; fixed with a same-repo guard before dispatch.
- `codex review --base origin/main` - found no discrete, actionable regressions after the fork guard and verification updates.
- `codex review --base origin/main` - found no discrete regression after metadata cleanup.
- `codex review --base origin/main` - final pass after review-response fixes found no discrete, actionable regression in the workflow changes.
- Pre-commit hook - passed (`trailing-newlines`, `prettier`).
- Pre-push hook - passed (`branch-lint`, `markdown-links`).

Not run: `yamllint .github/workflows/run-skipped-ci.yml` is not installed in this checkout (`command not found`).

## Label recommendation

- `full-ci`
- No `benchmark`

## Codex Decision Log

- `NON_BLOCKING_DECISION`: removed the `head_sha` lookup filter to avoid false-negative verification when GitHub records the dispatched run from the ref at queue time. To keep that safe, fork PR branches are rejected before dispatch, and verification remains narrowed by workflow id, branch, event, and created timestamp.
- `NON_BLOCKING_DECISION`: kept `dispatchStartedAt` as one lower-bound timestamp captured before the dispatch loop. The reviewer flagged this as a minor scaling caveat but also noted the current approach is fine for the small workflow map; widening that behavior can be revisited if the map grows substantially.
