### PR TITLE
Pro RSC: avoid caching failed Flight renders

### DIFF
--- a/packages/react-on-rails-pro/src/cache/unstable_cache.ts
+++ b/packages/react-on-rails-pro/src/cache/unstable_cache.ts
@@ -70,7 +70,13 @@ export function unstable_cache<TArgs extends unknown[]>(
     // --- MISS path ---
     const reactTree = await originalFn(...args);
     const { renderToPipeableStream } = await getServerRenderer();
-    const rscPipeable = renderToPipeableStream(reactTree);
+    let renderHadError = false;
+    const rscPipeable = renderToPipeableStream(reactTree, {
+      onError: (err) => {
+        renderHadError = true;
+        console.error(err);
+      },
+    });
 
     const source = new PassThrough();
     const forCache = new PassThrough();
@@ -92,6 +98,8 @@ export function unstable_cache<TArgs extends unknown[]>(
 
     bufferNodeStream(forCache)
       .then((chunks) => {
+        if (renderHadError) return undefined;
+
         const newEntry: CacheEntry = {
           value: chunks,
           revalidate,

--- a/packages/react-on-rails-pro/tests/unstable_cacheRSC.rsc.test.tsx
+++ b/packages/react-on-rails-pro/tests/unstable_cacheRSC.rsc.test.tsx
@@ -4,7 +4,9 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 
+import type { ReactNode } from 'react';
 import { setBuildId } from '../src/cache/buildIdProvider';
+import type { CacheEntry, CacheHandler } from '../src/cache/CacheHandler';
 import { registerCacheHandler } from '../src/cache/cacheHandlerRegistry';
 import { InMemoryLRUCacheHandler } from '../src/cache/InMemoryLRUCacheHandler';
 
@@ -172,6 +174,43 @@ describe('unstable_cache', () => {
 
     expect(String(result)).toBe('still-works');
     expect(consoleSpy).toHaveBeenCalledWith('unstable_cache: failed to store cache entry', expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+
+  test('does not cache RSC payloads that contain render errors', async () => {
+    class RecordingCacheHandler implements CacheHandler {
+      get = jest.fn<Promise<CacheEntry | null>, [string]>().mockResolvedValue(null);
+
+      set = jest.fn<Promise<void>, [string, CacheEntry]>().mockResolvedValue(undefined);
+    }
+
+    function ThrowingServerComponent(): ReactNode {
+      throw new Error('boom during RSC render');
+    }
+
+    const handler = new RecordingCacheHandler();
+    registerCacheHandler('recording-error-rsc', handler);
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    let callCount = 0;
+    const cachedFn = unstable_cache(
+      () => {
+        callCount += 1;
+        return <ThrowingServerComponent />;
+      },
+      { id: 'rsc-render-error', kind: 'recording-error-rsc' },
+    );
+
+    await expect(cachedFn()).rejects.toThrow('boom during RSC render');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await expect(cachedFn()).rejects.toThrow('boom during RSC render');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(handler.get).toHaveBeenCalledTimes(2);
+    expect(handler.set).not.toHaveBeenCalled();
+    expect(callCount).toBe(2);
 
     consoleSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- Track React Flight render errors reported by `renderToPipeableStream` inside Pro RSC `unstable_cache`.
- Skip cache writes for RSC payloads that contain render errors, so later requests retry instead of replaying a failed Flight payload.
- Preserve React's default error logging behavior while adding the cache-write guard.
- Add regression coverage proving failed RSC render payloads are not cached.

Fixes #3774.

## Test plan

- `cd packages/react-on-rails-pro && NODE_CONDITIONS=react-server mise exec node@22.12.0 -- pnpm exec jest tests/unstable_cacheRSC.rsc.test.tsx --runInBand`
- `mise exec node@22.12.0 -- pnpm exec eslint packages/react-on-rails-pro/src/cache/unstable_cache.ts packages/react-on-rails-pro/tests/unstable_cacheRSC.rsc.test.tsx`
- `mise exec node@22.12.0 -- pnpm exec prettier --check packages/react-on-rails-pro/src/cache/unstable_cache.ts packages/react-on-rails-pro/tests/unstable_cacheRSC.rsc.test.tsx`
- `mise exec node@22.12.0 -- pnpm run lint`
- `(cd react_on_rails && bundle exec rubocop)`
- `mise exec node@22.12.0 -- pnpm start format.listDifferent`
- `mise exec node@22.12.0 -- pnpm run type-check`

Additional validation: applied the same guard to #3705's single-flight miss flow in a separate experiment worktree; the focused RSC cache suite passed with an added concurrent successful-miss probe.
