### PR TITLE
Document dummy Redux state indexing rationale

### DIFF
--- a/react_on_rails/spec/dummy/client/app/store/reduxTypes.ts
+++ b/react_on_rails/spec/dummy/client/app/store/reduxTypes.ts
@@ -20,6 +20,7 @@ type StateProps = Record<string, unknown> & {
 };
 
 type ReduxAppState = StateProps & {
+  // combineReducers indexes state slices by reducer key; keep RailsContext fields while allowing that lookup.
   railsContext: RailsContext & Record<string, unknown>;
 };
 

--- a/react_on_rails/spec/dummy/client/app/store/reduxTypes.ts
+++ b/react_on_rails/spec/dummy/client/app/store/reduxTypes.ts
@@ -20,7 +20,8 @@ type StateProps = Record<string, unknown> & {
 };
 
 type ReduxAppState = StateProps & {
-  // combineReducers indexes state slices by reducer key; keep RailsContext fields while allowing that lookup.
+  // Redux's Reducer<S> requires S to be indexable; RailsContext is a discriminated union with no index
+  // signature, so intersect with Record<string, unknown> to satisfy that constraint while keeping known fields.
   railsContext: RailsContext & Record<string, unknown>;
 };
 


### PR DESCRIPTION
## Summary
- Document why the dummy Redux state keeps `railsContext` indexable while retaining the RailsContext fields.

Fixes #3648.

## Codex Decision Log
- **Non-blocking:** #3648 is a mixed bucket of optional PR #3606 review nits.
  - **Decision:** Implement only the bounded Redux state-indexing documentation note.
  - **Why:** It is a one-line explanation on the exact type shape under review and avoids broad generator, Redux Toolkit, path-regex, or shared startup refactors.
  - **Review later:** The remaining #3648 candidates should stay separate if maintainers want them.

## Test plan
- `script/ci-changes-detector origin/main` - pass; source comments only, recommends lint.
- `git diff --check origin/main..HEAD` - pass.
- `pnpm run lint` - pass.
- `pnpm start format.listDifferent` - pass.
- `pnpm run type-check` from `react_on_rails/spec/dummy` - pass.
- `bundle exec rubocop` - fails on pre-existing unrelated `react_on_rails/spike/3313_prism_gemfile_rewriter/*` offenses; this PR changes no Ruby files.

## Review gates
- Manual diff review used.
- `codex review --base origin/main` skipped because this is a trivial one-line source-comment change.
- Claude review and `/simplify` skipped; no high-risk/full-ci/benchmark scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in the spec dummy client; no logic, types, or runtime behavior modified.
> 
> **Overview**
> Adds inline comments on `ReduxAppState` in the dummy app’s `reduxTypes.ts` explaining why `railsContext` is typed as `RailsContext & Record<string, unknown>`: Redux’s `Reducer<S>` expects an indexable state type, while `RailsContext` is a discriminated union without an index signature.
> 
> The intersection documents intent for reviewers without changing runtime behavior or type shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527d8ada742da21aa23c2ec2d320b2c6cb0a9f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added clarifying comments to internal code documentation explaining type intersection requirements.

---

**Note:** This release contains no user-visible changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->