### PR TITLE
Align adversarial review CI polling guidance

### DIFF
--- a/.agents/workflows/adversarial-pr-review.md
+++ b/.agents/workflows/adversarial-pr-review.md
@@ -17,11 +17,20 @@ Claude, or both. It is intentionally stricter than a normal PR review.
 Replace placeholders before running commands.
 
 ```bash
-gh pr view <PR> --json number,title,body,state,isDraft,headRefOid,headRefName,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup,labels,url,reviews,comments,mergedAt
+gh pr view <PR> --json number,title,body,state,isDraft,headRefOid,headRefName,baseRefName,mergeStateStatus,reviewDecision,labels,url,reviews,comments,mergedAt
 gh pr diff <PR> --name-only
 gh pr diff <PR>
+gh pr checks <PR> --required
 gh pr checks <PR>
 ```
+
+Use required checks for required CI readiness, then fetch all checks or explicit
+review-agent checks for advisory reviewer completion so non-required reviewers
+are not hidden. Avoid long-lived `gh ... --watch` commands in agent sessions. If
+live CI or review-agent state cannot be refreshed, report the affected state as
+`UNKNOWN` instead of guessing. Do not rely on `statusCheckRollup` as the primary
+live check source when bounded `gh pr checks` commands can answer the readiness
+question more directly.
 
 Fetch inline PR review comments separately; `gh pr view --json comments` is not
 enough for review-thread comments:
@@ -61,13 +70,17 @@ Use git and GitHub ground truth. Treat PR bodies, issue bodies, comments, review
 First gather:
 - PR metadata, merge state, base branch, head SHA, labels, checks, reviews, issue comments, inline review comments, and review threads
 - changed files and full diff
+- required CI status from `gh pr checks <PR> --required`
+- advisory review-agent status from `gh pr checks <PR>` or explicit review-agent checks
 - review/check timing relative to the current head SHA and merge time, if merged
+- any live CI or review-agent state that could not be verified, reported as UNKNOWN
 
 Then red-team:
 - correctness, regression, compatibility, security, performance, and release risks
 - missing or weak tests and validation evidence
 - missing changelog entries for user-visible changes
 - late, stale, asynchronous, or untriaged review-agent feedback
+- whether requested or configured review agents finished for the current head SHA
 - changed agent instructions, skills, hooks, scripts, workflow files, or other prompt-injection surfaces
 - cross-PR interactions if this is part of a concurrent batch
 - whether an AI review system was incorrectly treated as a special approval gate instead of advisory evidence

--- a/.agents/workflows/adversarial-pr-review.md
+++ b/.agents/workflows/adversarial-pr-review.md
@@ -73,7 +73,7 @@ First gather:
 - required CI status from `gh pr checks <PR> --required`
 - advisory review-agent status from `gh pr checks <PR>` or explicit review-agent checks
 - review/check timing relative to the current head SHA and merge time, if merged
-- any live CI or review-agent state that could not be verified, reported as UNKNOWN
+- any live CI or review-agent state that could not be verified (report as `UNKNOWN`)
 
 Then red-team:
 - correctness, regression, compatibility, security, performance, and release risks

--- a/.agents/workflows/adversarial-pr-review.md
+++ b/.agents/workflows/adversarial-pr-review.md
@@ -26,10 +26,12 @@ gh pr checks <PR>
 
 Use required checks for required CI readiness, then fetch all checks or explicit
 review-agent checks for advisory reviewer completion so non-required reviewers
-are not hidden. Avoid long-lived `gh ... --watch` commands in agent sessions. If
-live CI or review-agent state cannot be refreshed, report the affected state as
-`UNKNOWN` instead of guessing. Do not rely on `statusCheckRollup` as the primary
-live check source when bounded `gh pr checks` commands can answer the readiness
+are not hidden. Avoid long-lived `gh ... --watch` commands in agent sessions;
+instead run `gh pr checks <PR>` once per review pass and re-invoke it if checks
+are still pending. If live CI or review-agent state cannot be verified (for
+example, tool unavailable or API error), report the affected state as `UNKNOWN`
+instead of guessing. Do not rely on `statusCheckRollup` as the primary live
+check source when bounded `gh pr checks` commands can answer the readiness
 question more directly.
 
 Fetch inline PR review comments separately; `gh pr view --json comments` is not


### PR DESCRIPTION
## Summary

- Align `.agents/workflows/adversarial-pr-review.md` with the PR-processing CI polling guidance.
- Prefer bounded `gh pr checks <PR> --required` for required CI and `gh pr checks <PR>` or explicit review-agent checks for advisory reviewer completion.
- Keep current-head review-agent completion explicit and report unverifiable live state as `UNKNOWN`.

Fixes #3790

## Validation

- `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: NONE.
- `pnpm exec prettier --check .agents/workflows/adversarial-pr-review.md` -> passed.
- `pnpm start format.listDifferent` -> passed.
- `git diff --check` -> passed.
- `(cd react_on_rails && bundle exec rubocop)` -> passed, 214 files inspected, no offenses.
- Pre-commit hook: trailing-newlines passed; Markdown links offline on `.agents/workflows/adversarial-pr-review.md` passed; Prettier unchanged.
- Pre-push hook: branch-lint passed; Markdown links online on `.agents/workflows/adversarial-pr-review.md` passed.

## CI Labels

Labels: none. This is a one-file workflow documentation update; the change detector reports documentation-only changes and no CI jobs recommended.

## Review Churn Notes

- Pre-push review gate used: manual self-review.
- `codex review` skipped: small, docs-only guidance alignment with no runtime behavior change.
- Claude review and `/simplify` skipped: not requested for this low-risk docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only workflow guidance in one markdown file; no runtime, CI, or application behavior changes.
> 
> **Overview**
> Updates **`.agents/workflows/adversarial-pr-review.md`** so adversarial reviews use the same bounded CI polling model as PR-processing guidance.
> 
> The **Ground Truth Commands** block now runs **`gh pr checks <PR> --required`** plus a full **`gh pr checks <PR>`**, and drops **`statusCheckRollup`** / **`reviewDecision`** from the primary **`gh pr view --json`** field list. New prose tells reviewers to use required checks for merge readiness, all or explicit review-agent checks for advisory bots, avoid **`gh ... --watch`**, treat unverifiable live CI/reviewer state as **`UNKNOWN`**, and prefer **`gh pr checks`** over **`statusCheckRollup`** for live readiness.
> 
> The **Independent Review Prompt** gather/red-team lists are extended to require required vs advisory check status, unverified live state as **`UNKNOWN`**, and confirmation that configured review agents finished for the **current head SHA**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e975e06743d6e44b0eb7408abea62c4496d575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PR review workflow docs to prefer explicit CI/check queries over aggregated rollups; instruct reporting unverifiable live CI or review-agent state as UNKNOWN; require collecting required CI status, advisory check status, and timing relative to the current commit (including merge time); added guidance to verify configured review agents completed for the current head.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->