### PR TITLE
RSC: stop serializing props into embedded payload cache key

### DIFF
--- a/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
+++ b/packages/react-on-rails-pro/src/getReactServerComponent.client.ts
@@ -15,7 +15,7 @@
 import * as React from 'react';
 import { createFromReadableStream } from 'react-on-rails-rsc/client.browser';
 import { RailsContext } from 'react-on-rails/types';
-import { createRSCPayloadKey, fetch, wrapInNewPromise, extractErrorMessage } from './utils.ts';
+import { createEmbeddedPayloadKey, fetch, wrapInNewPromise, extractErrorMessage } from './utils.ts';
 import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import LengthPrefixedStreamParser from './parseLengthPrefixedStream.ts';
 import {
@@ -302,7 +302,7 @@ const getReactServerComponent =
   (domNodeId: string, railsContext: RailsContext) =>
   ({ componentName, componentProps, enforceRefetch = false }: ClientGetReactServerComponentProps) => {
     if (!enforceRefetch && window.REACT_ON_RAILS_RSC_PAYLOADS) {
-      const rscPayloadKey = createRSCPayloadKey(componentName, componentProps, domNodeId);
+      const rscPayloadKey = createEmbeddedPayloadKey(componentName, componentProps, domNodeId);
       const payloads = window.REACT_ON_RAILS_RSC_PAYLOADS[rscPayloadKey];
       if (payloads) {
         return createFromPreloadedPayloads(

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -15,7 +15,7 @@
 import { PassThrough } from 'stream';
 import { PipeableOrReadableStream } from 'react-on-rails/types';
 import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
-import { createRSCPayloadKey } from './utils.ts';
+import { createEmbeddedPayloadKey } from './utils.ts';
 import RSCRequestTracker from './RSCRequestTracker.ts';
 import safePipe from './safePipe.ts';
 import LengthPrefixedStreamParser from './parseLengthPrefixedStream.ts';
@@ -333,7 +333,7 @@ export default function injectRSCPayload(
 
       rscRequestTracker.onRSCPayloadGenerated((streamInfo) => {
         const { stream, props, componentName } = streamInfo;
-        const rscPayloadKey = createRSCPayloadKey(componentName, props, domNodeId);
+        const rscPayloadKey = createEmbeddedPayloadKey(componentName, props, domNodeId);
 
         // CRITICAL TIMING: Initialize global array IMMEDIATELY when component requests RSC
         // This ensures the array exists before the component's HTML is rendered and sent.

--- a/packages/react-on-rails-pro/src/utils.ts
+++ b/packages/react-on-rails-pro/src/utils.ts
@@ -25,22 +25,25 @@ export const createRSCPayloadKey = (componentName: string, componentProps: unkno
   return `${componentName}-${JSON.stringify(componentProps)}${domNodeId ? `-${domNodeId}` : ''}`;
 };
 
-/* eslint-disable no-bitwise, no-plusplus */
-function djb2Hash(input: string): string {
-  let hash = 5381;
-  for (let i = 0; i < input.length; i++) {
-    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+/* eslint-disable no-bitwise */
+function hashString(input: string): string {
+  let h1 = 0x811c9dc5 | 0;
+  let h2 = 0x050c5d1f | 0;
+  for (let i = 0; i < input.length; i += 1) {
+    const c = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ c, 0x01000193);
+    h2 = Math.imul(h2 ^ c, 0x0100019d);
   }
-  return (hash >>> 0).toString(36);
+  return (((h1 >>> 0) & 0xfffff) * 0x100000000 + (h2 >>> 0)).toString(36);
 }
-/* eslint-enable no-bitwise, no-plusplus */
+/* eslint-enable no-bitwise */
 
 export const createEmbeddedPayloadKey = (
   componentName: string,
   componentProps: unknown,
   domNodeId?: string,
 ) => {
-  const propsHash = djb2Hash(JSON.stringify(componentProps));
+  const propsHash = hashString(JSON.stringify(componentProps) ?? 'undefined');
   return domNodeId ? `${componentName}-${propsHash}-${domNodeId}` : `${componentName}-${propsHash}`;
 };
 

--- a/packages/react-on-rails-pro/src/utils.ts
+++ b/packages/react-on-rails-pro/src/utils.ts
@@ -25,6 +25,25 @@ export const createRSCPayloadKey = (componentName: string, componentProps: unkno
   return `${componentName}-${JSON.stringify(componentProps)}${domNodeId ? `-${domNodeId}` : ''}`;
 };
 
+/* eslint-disable no-bitwise, no-plusplus */
+function djb2Hash(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+/* eslint-enable no-bitwise, no-plusplus */
+
+export const createEmbeddedPayloadKey = (
+  componentName: string,
+  componentProps: unknown,
+  domNodeId?: string,
+) => {
+  const propsHash = djb2Hash(JSON.stringify(componentProps));
+  return domNodeId ? `${componentName}-${propsHash}-${domNodeId}` : `${componentName}-${propsHash}`;
+};
+
 /**
  * Wraps a promise from react-server-dom-webpack in a standard JavaScript Promise.
  *

--- a/packages/react-on-rails-pro/src/utils.ts
+++ b/packages/react-on-rails-pro/src/utils.ts
@@ -26,6 +26,7 @@ export const createRSCPayloadKey = (componentName: string, componentProps: unkno
 };
 
 /* eslint-disable no-bitwise */
+// Dual-FNV-1a: two independent 32-bit FNV-1a streams combined into a 52-bit output.
 function hashString(input: string): string {
   let h1 = 0x811c9dc5 | 0;
   let h2 = 0x050c5d1f | 0;

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -15,7 +15,7 @@ const toLengthPrefixedWithMetadata = (content: string, metadata: Record<string, 
   return `${JSON.stringify(metadata)}\t${contentBuf.length.toString(16).padStart(8, '0')}\n${content}`;
 };
 
-const rscPayloadKey = 'test-3horh-test-node';
+const rscPayloadKey = 'test-fun4a7ngv9-test-node';
 const rscPayloadKeyReference = `[${JSON.stringify(rscPayloadKey)}]`;
 const expectedInitializationScript = `<script>delete (self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference};(self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]</script>`;
 const expectedPayloadPushScript = (chunk: string) =>
@@ -146,7 +146,7 @@ describe('injectRSCPayload', () => {
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
-    expect(resultStr).toContain('["test-3horh-test-node"]||=');
+    expect(resultStr).toContain('["test-fun4a7ngv9-test-node"]||=');
     expect(resultStr).toContain('useState is not a function');
     expect(resultStr).toContain('/app/components/Broken.server.tsx');
     expect(resultStr).toContain('REACT_ON_RAILS_RSC_PAYLOADS');

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -15,7 +15,7 @@ const toLengthPrefixedWithMetadata = (content: string, metadata: Record<string, 
   return `${JSON.stringify(metadata)}\t${contentBuf.length.toString(16).padStart(8, '0')}\n${content}`;
 };
 
-const rscPayloadKey = 'test-{}-test-node';
+const rscPayloadKey = 'test-3horh-test-node';
 const rscPayloadKeyReference = `[${JSON.stringify(rscPayloadKey)}]`;
 const expectedInitializationScript = `<script>delete (self.REACT_ON_RAILS_RSC_ERRORS||={})${rscPayloadKeyReference};(self.REACT_ON_RAILS_RSC_PAYLOADS||={})${rscPayloadKeyReference}||=[]</script>`;
 const expectedPayloadPushScript = (chunk: string) =>
@@ -146,7 +146,7 @@ describe('injectRSCPayload', () => {
     const resultStr = await collectStreamData(result);
 
     expect(resultStr).toContain('REACT_ON_RAILS_RSC_ERRORS');
-    expect(resultStr).toContain('["test-{}-test-node"]||=');
+    expect(resultStr).toContain('["test-3horh-test-node"]||=');
     expect(resultStr).toContain('useState is not a function');
     expect(resultStr).toContain('/app/components/Broken.server.tsx');
     expect(resultStr).toContain('REACT_ON_RAILS_RSC_PAYLOADS');

--- a/packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx
@@ -184,7 +184,7 @@ enableFetchMocks();
     it('uses preloaded RSC payloads without making a fetch request', async () => {
       // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS
       window.REACT_ON_RAILS_RSC_PAYLOADS = {
-        'TestComponent-{}-test-container': [`${chunk1}\n`, `${chunk2}\n`],
+        'TestComponent-3horh-test-container': [`${chunk1}\n`, `${chunk2}\n`],
       };
 
       await act(async () => {
@@ -208,7 +208,7 @@ enableFetchMocks();
 
       // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS with only the first chunk initially
       window.REACT_ON_RAILS_RSC_PAYLOADS = {
-        'TestComponent-{}-test-container': [`${chunk1}\n`],
+        'TestComponent-3horh-test-container': [`${chunk1}\n`],
       };
 
       await act(async () => {
@@ -226,7 +226,7 @@ enableFetchMocks();
 
       // Now push the second chunk to the preloaded array and set document to complete
       await act(async () => {
-        window.REACT_ON_RAILS_RSC_PAYLOADS['TestComponent-{}-test-container'].push(`${chunk2}\n`);
+        window.REACT_ON_RAILS_RSC_PAYLOADS['TestComponent-3horh-test-container'].push(`${chunk2}\n`);
 
         // Set document.readyState to 'complete' and dispatch readystatechange event
         Object.defineProperty(document, 'readyState', { value: 'complete', writable: true });

--- a/packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx
+++ b/packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx
@@ -184,7 +184,7 @@ enableFetchMocks();
     it('uses preloaded RSC payloads without making a fetch request', async () => {
       // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS
       window.REACT_ON_RAILS_RSC_PAYLOADS = {
-        'TestComponent-3horh-test-container': [`${chunk1}\n`, `${chunk2}\n`],
+        'TestComponent-fun4a7ngv9-test-container': [`${chunk1}\n`, `${chunk2}\n`],
       };
 
       await act(async () => {
@@ -208,7 +208,7 @@ enableFetchMocks();
 
       // Mock the global window.REACT_ON_RAILS_RSC_PAYLOADS with only the first chunk initially
       window.REACT_ON_RAILS_RSC_PAYLOADS = {
-        'TestComponent-3horh-test-container': [`${chunk1}\n`],
+        'TestComponent-fun4a7ngv9-test-container': [`${chunk1}\n`],
       };
 
       await act(async () => {
@@ -226,7 +226,7 @@ enableFetchMocks();
 
       // Now push the second chunk to the preloaded array and set document to complete
       await act(async () => {
-        window.REACT_ON_RAILS_RSC_PAYLOADS['TestComponent-3horh-test-container'].push(`${chunk2}\n`);
+        window.REACT_ON_RAILS_RSC_PAYLOADS['TestComponent-fun4a7ngv9-test-container'].push(`${chunk2}\n`);
 
         // Set document.readyState to 'complete' and dispatch readystatechange event
         Object.defineProperty(document, 'readyState', { value: 'complete', writable: true });

--- a/packages/react-on-rails-pro/tests/utils.test.js
+++ b/packages/react-on-rails-pro/tests/utils.test.js
@@ -17,11 +17,11 @@ describe('createEmbeddedPayloadKey', () => {
   });
 
   it('handles undefined props', () => {
-    expect(createEmbeddedPayloadKey('Comp', undefined, 'node-1')).toMatch(/^Comp-[a-z0-9]+-node-1$/);
+    expect(createEmbeddedPayloadKey('Comp', undefined, 'node-1')).toBe('Comp-4naxctcn8d-node-1');
   });
 
   it('handles null props', () => {
-    expect(createEmbeddedPayloadKey('Comp', null, 'node-1')).toMatch(/^Comp-[a-z0-9]+-node-1$/);
+    expect(createEmbeddedPayloadKey('Comp', null, 'node-1')).toBe('Comp-k7whjxr9t4-node-1');
   });
 
   it('omits domNodeId when not provided', () => {

--- a/packages/react-on-rails-pro/tests/utils.test.js
+++ b/packages/react-on-rails-pro/tests/utils.test.js
@@ -1,9 +1,33 @@
 import { enableFetchMocks } from 'jest-fetch-mock';
 
-import { fetch } from '../src/utils.ts';
+import { fetch, createEmbeddedPayloadKey } from '../src/utils.ts';
 import { createNodeReadableStream, getNodeVersion } from './testUtils.ts';
 
 enableFetchMocks();
+
+describe('createEmbeddedPayloadKey', () => {
+  it('hashes empty props into a stable key', () => {
+    expect(createEmbeddedPayloadKey('Comp', {}, 'node-1')).toBe('Comp-fun4a7ngv9-node-1');
+  });
+
+  it('produces different hashes for different props', () => {
+    const key1 = createEmbeddedPayloadKey('Comp', { a: 1 }, 'node-1');
+    const key2 = createEmbeddedPayloadKey('Comp', { a: 2 }, 'node-1');
+    expect(key1).not.toBe(key2);
+  });
+
+  it('handles undefined props', () => {
+    expect(createEmbeddedPayloadKey('Comp', undefined, 'node-1')).toMatch(/^Comp-[a-z0-9]+-node-1$/);
+  });
+
+  it('handles null props', () => {
+    expect(createEmbeddedPayloadKey('Comp', null, 'node-1')).toMatch(/^Comp-[a-z0-9]+-node-1$/);
+  });
+
+  it('omits domNodeId when not provided', () => {
+    expect(createEmbeddedPayloadKey('Comp', {})).toBe('Comp-fun4a7ngv9');
+  });
+});
 
 // The fetch mock functionality that returns a ReadableStream is not supported in Node.js v16.
 // Additionally, fetch function is used in RSCClientRoot only that is compatible with Node.js v18+,

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_route_ssr_false.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_route_ssr_false.spec.ts
@@ -4,10 +4,11 @@ const MIXED_ROUTE_PATH = '/server_router/mixed-ssr-and-deferred-server-component
 const UNWRAPPED_ROUTE_PATH = '/unwrapped_rsc_route_client_render';
 const UNWRAPPED_STREAM_ROUTE_PATH = '/unwrapped_rsc_route_stream_render';
 const NORMAL_CLIENT_ROUTE_PATH = '/client_side_hello_world';
-const DEFAULT_PAYLOAD_KEY = 'MyServerComponent-{}-ServerComponentRouter-react-component-0';
-const DEFERRED_PAYLOAD_KEY = 'SimpleComponent-{}-ServerComponentRouter-react-component-0';
-const UNWRAPPED_PAYLOAD_KEY = 'SimpleComponent-{}-UnwrappedRSCRouteDemo-react-component-0';
-const UNWRAPPED_STREAM_PAYLOAD_KEY = 'SimpleComponent-{}-UnwrappedStreamRSCRouteDemo-react-component-0';
+const DEFAULT_PAYLOAD_KEY = 'MyServerComponent-fun4a7ngv9-ServerComponentRouter-react-component-0';
+const DEFERRED_PAYLOAD_KEY = 'SimpleComponent-fun4a7ngv9-ServerComponentRouter-react-component-0';
+const UNWRAPPED_PAYLOAD_KEY = 'SimpleComponent-fun4a7ngv9-UnwrappedRSCRouteDemo-react-component-0';
+const UNWRAPPED_STREAM_PAYLOAD_KEY =
+  'SimpleComponent-fun4a7ngv9-UnwrappedStreamRSCRouteDemo-react-component-0';
 const RSC_ROUTE_SSR_FALSE_BAILOUT_DIGEST = 'REACT_ON_RAILS_RSC_ROUTE_SSR_FALSE_BAILOUT';
 
 test.describe('RSCRoute ssr=false', () => {


### PR DESCRIPTION
## Summary

- Replace the full `JSON.stringify(componentProps)` in the embedded RSC payload cache key with a compact dual-FNV-1a hash (max 11 base-36 chars)
- The key format changes from `ComponentName-{"full":"json",...}-domNodeId` to `ComponentName-fun4a7ngv9-domNodeId`
- RSCProvider in-memory promise cache (`createRSCPayloadKey`) is deliberately unchanged — it keys on full props for correct deduplication and never appears in HTML

### Why

For every RSC component embedded in server-rendered HTML, the full serialized props appear **N+1 times** in the page (once in the init script + once per Flight chunk). A 1KB props object with 10 chunks = ~12KB of repeated JSON in render-blocking `<script>` tags. The `domNodeId` already uniquely identifies each on-page instance; the serialized props in the key are redundant for the embedded-payload lookup.

### Impact

| Scenario | Before | After | Savings |
|----------|--------|-------|---------|
| 1KB props, 10 chunks | ~12KB repeated props | ~120 bytes | ~99% |
| 100KB props, 10 chunks | ~1.2MB repeated props | ~120 bytes | ~99.99% |

### Design decisions

- **Dual-FNV-1a hash over dropping props entirely**: A single `react_component` call (one `domNodeId`) can render multiple `<RSCRoute>` components with the same `componentName` but different props. The hash preserves differentiation.
- **Hash over sequence index**: A sequence-index approach would create an ordering dependency between SSR and client hydration. The hash is fully deterministic regardless of render order.
- **Collision safety**: Two independent 32-bit FNV-1a streams are combined into a 52-bit output (~67 million birthday bound). A collision also requires matching `componentName` AND `domNodeId`. In the astronomically unlikely event of a collision on embedded payloads, both components would share the same Flight data array, producing incorrect rendered output. The HTTP fetch fallback does not apply — it only activates when no embedded payload exists for a key.

### Files changed

- `packages/react-on-rails-pro/src/utils.ts` — add `hashString()` (dual-FNV-1a) + `createEmbeddedPayloadKey()`
- `packages/react-on-rails-pro/src/injectRSCPayload.ts` — use `createEmbeddedPayloadKey` for HTML embedding
- `packages/react-on-rails-pro/src/getReactServerComponent.client.ts` — use `createEmbeddedPayloadKey` for hydration lookup
- `packages/react-on-rails-pro/tests/injectRSCPayload.test.ts` — update hardcoded key expectations
- `packages/react-on-rails-pro/tests/registerServerComponent.client.test.jsx` — update hardcoded key expectations
- `packages/react-on-rails-pro/tests/utils.test.js` — add unit tests for `createEmbeddedPayloadKey`

## Test plan

- [x] TypeScript check passes (`pnpm run nps check-typescript`)
- [x] ESLint passes on all changed files
- [x] Test expectations updated for new key format
- [x] Unit tests for `createEmbeddedPayloadKey` covering empty, undefined, null, and non-trivial props
- [ ] CI passes (E2E tests verify RSC hydration end-to-end)
- [ ] Verify on a representative RSC page that HTML no longer contains full serialized props in script tags

Closes #3796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved React Server Component payload caching with a deterministic embedded payload key to speed client-side hydration and reduce unnecessary network fetches.
* **Tests**
  * Updated and added unit tests to validate stable payload-key generation and adjusted fixtures to match the new key format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->