### PR TITLE
Confirm benchmark regressions on a fresh runner before filing the main issue

### DIFF
--- a/.github/workflows/benchmark-suite.yml
+++ b/.github/workflows/benchmark-suite.yml
@@ -1,0 +1,485 @@
+name: Benchmark Suite (reusable)
+
+# Runs one benchmark suite/shard end to end and tracks it with Bencher. Called twice by
+# benchmark.yml so the INITIAL run and the fresh-runner CONFIRMATION rerun execute the
+# exact same steps (no drift):
+#
+#   mode: initial  — the normal run. On a main-push alert, track_benchmarks.rb writes a
+#                    NON-FATAL regression candidate artifact (the suite stays green).
+#   mode: confirm  — downloads that candidate, reruns the suite against main's baseline on
+#                    a fresh runner WITHOUT polluting main's series, and writes a confirmed
+#                    artifact only if the SAME benchmark+measure pair(s) re-alert.
+#
+# The whole matrix row from benchmarks/generate_matrix.rb is passed as a JSON string and
+# unpacked into job-level env once, so callers only wire two inputs.
+on:
+  workflow_call:
+    inputs:
+      matrix_row:
+        description: 'JSON-encoded benchmark matrix row (one entry of generate_matrix.rb include[])'
+        required: true
+        type: string
+      mode:
+        description: 'initial (normal run) or confirm (fresh-runner confirmation rerun)'
+        required: false
+        default: 'initial'
+        type: string
+
+# Same benchmark parameters as benchmark.yml's top-level env: a reusable workflow does
+# NOT inherit the caller's env, but it DOES see the caller's github context, so the
+# workflow_dispatch inputs resolve identically (empty on push/pull_request).
+env:
+  RUBY_VERSION: '3.3.7'
+  K6_VERSION: '2.0.0'
+  VEGETA_VERSION: '12.13.0'
+  ROUTES: ${{ github.event.inputs.routes }}
+  RATE: ${{ github.event.inputs.rate || 'max' }}
+  DURATION: ${{ github.event.inputs.duration }}
+  REQUEST_TIMEOUT: ${{ github.event.inputs.request_timeout }}
+  CONNECTIONS: ${{ github.event.inputs.connections }}
+  MAX_CONNECTIONS: ${{ github.event.inputs.connections }}
+  WEB_CONCURRENCY: ${{ github.event.inputs.web_concurrency }}
+  RAILS_MAX_THREADS: ${{ github.event.inputs.rails_threads || 3 }}
+  RAILS_MIN_THREADS: ${{ github.event.inputs.rails_threads || 3 }}
+
+jobs:
+  run-suite:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      checks: write
+    env:
+      SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
+      REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      # Matrix row unpacked once. Names that begin with BENCHMARK_ are read by the bench
+      # scripts and track_benchmarks.rb directly; the rest drive step conditions/paths.
+      BENCHMARK_MODE: ${{ inputs.mode }}
+      BENCHMARK_SHARD_INDEX: ${{ fromJSON(inputs.matrix_row).shard_index }}
+      BENCHMARK_TOTAL_SHARDS: ${{ fromJSON(inputs.matrix_row).shard_total }}
+      BENCHMARK_SHARD_LABEL: ${{ fromJSON(inputs.matrix_row).shard_label }}
+      BENCHMARK_SUITE_NAME: ${{ fromJSON(inputs.matrix_row).bencher_suite_name }}
+      BENCHMARK_SUITE_GROUP: ${{ fromJSON(inputs.matrix_row).suite_name }}
+      BENCHER_REPORT_MARKER: ${{ fromJSON(inputs.matrix_row).report_marker }}
+      SUITE_NAME: ${{ fromJSON(inputs.matrix_row).suite_name }}
+      SHARD_LABEL: ${{ fromJSON(inputs.matrix_row).shard_label }}
+      APP_DIRECTORY: ${{ fromJSON(inputs.matrix_row).app_directory }}
+      BENCHMARK_TOOL: ${{ fromJSON(inputs.matrix_row).benchmark_tool }}
+      BENCHMARK_SCRIPT: ${{ fromJSON(inputs.matrix_row).benchmark_script }}
+      SERVER_KIND: ${{ fromJSON(inputs.matrix_row).server_kind }}
+      PRO_ENV: ${{ fromJSON(inputs.matrix_row).pro_env }}
+      GENERATE_PACKS: ${{ fromJSON(inputs.matrix_row).generate_packs }}
+      SUMMARY_FILE: ${{ fromJSON(inputs.matrix_row).summary_file }}
+      SUMMARY_TITLE: ${{ fromJSON(inputs.matrix_row).summary_title }}
+      # Artifact names. The results artifact is prefixed in confirm mode so the
+      # confirmation rerun never collides with the initial run's upload.
+      RESULTS_ARTIFACT_NAME: ${{ inputs.mode == 'confirm' && 'confirm-' || '' }}${{ fromJSON(inputs.matrix_row).artifact_name_prefix }}-${{ github.run_number }}${{ fromJSON(inputs.matrix_row).artifact_name_suffix }}
+      CANDIDATE_ARTIFACT_NAME: regression-candidate-${{ fromJSON(inputs.matrix_row).artifact_name_prefix }}-${{ github.run_number }}${{ fromJSON(inputs.matrix_row).artifact_name_suffix }}
+      CONFIRMED_ARTIFACT_NAME: regression-confirmed-${{ fromJSON(inputs.matrix_row).artifact_name_prefix }}-${{ github.run_number }}${{ fromJSON(inputs.matrix_row).artifact_name_suffix }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Bencher CLI
+        # Pinned: reporting parses Bencher's `--format json` report — results +
+        # boundaries drive the summary-table significance highlighting, and the
+        # alerts[] array drives regression detection (benchmarks/track_benchmarks.rb
+        # via benchmarks/lib/bencher_report.rb). That JSON shape is not a documented
+        # stability contract, so the parser fails loudly on unexpected shapes and the
+        # CLI is pinned; before bumping, re-verify the shape against
+        # benchmarks/spec/bencher_report_spec.rb AND diff a live `--format json` run
+        # against a reference payload to confirm each boundary is still symmetric about
+        # baseline (lower_limit/upper_limit equidistant). The spec checks the parsing
+        # logic, not the payload's statistical symmetry that Boundary#mirror relies on.
+        uses: bencherdev/bencher@v0.6.2
+
+      - name: Add tools directory to PATH
+        run: |
+          mkdir -p ~/bin
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Setup k6
+        if: env.BENCHMARK_TOOL == 'k6'
+        uses: grafana/setup-k6-action@v1
+        with:
+          k6-version: ${{ env.K6_VERSION }}
+
+      - name: Cache Vegeta binary
+        id: cache-vegeta
+        if: env.BENCHMARK_TOOL == 'vegeta'
+        uses: actions/cache@v5
+        with:
+          path: ~/bin/vegeta
+          key: vegeta-${{ runner.os }}-${{ runner.arch }}-${{ env.VEGETA_VERSION }}
+
+      - name: Install Vegeta
+        if: env.BENCHMARK_TOOL == 'vegeta' && steps.cache-vegeta.outputs.cache-hit != 'true'
+        run: |
+          ARCH=$(dpkg --print-architecture)
+          echo "Installing Vegeta v${VEGETA_VERSION} (${ARCH})"
+          wget -q "https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_${ARCH}.tar.gz"
+          tar -xzf "vegeta_${VEGETA_VERSION}_linux_${ARCH}.tar.gz"
+          mv vegeta ~/bin/
+
+      - name: Setup Ruby
+        uses: ./.github/actions/setup-ruby
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+
+      - name: Get gem home directory
+        id: gem-home
+        run: echo "path=$(gem env home)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache foreman gem
+        id: cache-foreman
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.gem-home.outputs.path }}
+          key: foreman-gem-${{ runner.os }}-${{ runner.arch }}-ruby-${{ env.RUBY_VERSION }}
+
+      - name: Install foreman
+        if: steps.cache-foreman.outputs.cache-hit != 'true'
+        run: gem install foreman
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          cache: true
+          cache_dependency_path: '**/pnpm-lock.yaml'
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Print system information
+        run: |
+          echo "Linux release: "
+          cat /etc/issue
+          echo "Current user: "
+          whoami
+          echo "Current directory: "
+          pwd
+          echo "Ruby version: "
+          ruby -v
+          echo "Node version: "
+          node -v
+          echo "Pnpm version: "
+          pnpm --version
+          echo "Bundler version: "
+          bundle --version
+
+      - name: Configure benchmark commands
+        run: |
+          NPROC=$(nproc)
+          echo "Available CPUs: $NPROC"
+
+          if [ "$NPROC" -le 1 ]; then
+            SERVER_CMD="bin/prod"
+            BENCH_CMD="ruby"
+          else
+            SERVER_CMD="taskset -c 1-$((NPROC-1)) bin/prod"
+            BENCH_CMD="taskset -c 0 ruby"
+          fi
+
+          echo "SERVER_CMD=$SERVER_CMD" >> "$GITHUB_ENV"
+          echo "BENCH_CMD=$BENCH_CMD" >> "$GITHUB_ENV"
+
+          if [ -z "$WEB_CONCURRENCY" ]; then
+            # Clamp to >=1 so single-CPU runners don't end up with WEB_CONCURRENCY=0 (Puma
+            # would start in single-mode, which the benchmarks aren't tuned for).
+            WEB_CONCURRENCY=$((NPROC > 1 ? NPROC - 1 : 1))
+            echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> "$GITHUB_ENV"
+            echo "WEB_CONCURRENCY (auto): $WEB_CONCURRENCY"
+          else
+            echo "WEB_CONCURRENCY (from input): $WEB_CONCURRENCY"
+          fi
+
+          echo "SERVER_CMD: $SERVER_CMD"
+          echo "BENCH_CMD: $BENCH_CMD"
+
+      - name: Install Node modules with pnpm
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        run: pnpm run build
+
+      - name: Install Ruby Gems for the benchmarked app
+        uses: ./.github/actions/setup-bundle
+        with:
+          working-directory: ${{ env.APP_DIRECTORY }}
+          ruby-version: ${{ env.RUBY_VERSION }}
+          install-libyaml: 'false'
+
+      - name: Generate file-system based entrypoints for Pro
+        if: env.GENERATE_PACKS == 'true'
+        working-directory: ${{ env.APP_DIRECTORY }}
+        run: bundle exec rake react_on_rails:generate_packs
+
+      - name: Prepare production assets
+        working-directory: ${{ env.APP_DIRECTORY }}
+        run: |
+          set -e
+          echo "🔨 Building $SUITE_NAME production assets..."
+
+          if ! bin/prod-assets; then
+            echo "❌ ERROR: Failed to build production assets"
+            exit 1
+          fi
+
+          echo "✅ Production assets built successfully"
+
+      - name: Prepare and seed benchmark database
+        # The Pro Rails suite serves DB-backed routes (e.g. /posts_page). Without
+        # a migrated + seeded database those routes 500 on every request (the
+        # `posts` table does not exist), so the benchmark must create and seed it
+        # before the server starts. On a fresh CI runner `db:prepare` creates the
+        # database, loads the schema, and — because the database is newly created —
+        # runs db/seeds.rb (deterministic and faker-free so it works under
+        # RAILS_ENV=production). Note: `db:prepare` only seeds on first creation, so
+        # the row-count check below fails the job loudly if seeding was skipped (an
+        # empty table would otherwise serve a 200 "No posts found" payload that the
+        # benchmark scores as healthy).
+        if: env.SERVER_KIND == 'rails' && env.PRO_ENV == 'true'
+        working-directory: ${{ env.APP_DIRECTORY }}
+        env:
+          RAILS_ENV: production
+        run: |
+          set -euo pipefail
+          echo "🌱 Preparing and seeding $SUITE_NAME benchmark database..."
+          bundle exec rails db:prepare
+          # Guard every table `/posts_page` reads (posts, plus the users and
+          # comments it joins), not just posts: a partial seed would otherwise
+          # let the route 500 (or render an empty page) while the job stayed
+          # green.
+          bundle exec rails runner - <<'RUBY'
+          counts = {
+            posts: Post.count,
+            users: User.count,
+            comments: Comment.count
+          }
+
+          empty_tables = counts.select { |_, count| count.zero? }.keys
+          if empty_tables.any?
+            abort(
+              "Benchmark DB seeding incomplete after db:prepare " \
+              "(empty: #{empty_tables.join(', ')}); seeds did not run"
+            )
+          end
+
+          puts "✅ Database seeded (#{counts.map { |table, count| "#{count} #{table}" }.join(', ')})"
+          RUBY
+
+      - name: Start Pro node renderer
+        if: env.SERVER_KIND == 'node-renderer'
+        working-directory: ${{ env.APP_DIRECTORY }}
+        env:
+          RAILS_ENV: production
+          NODE_ENV: production
+          RENDERER_LOG_LEVEL: error
+          RENDERER_PORT: 3800
+        run: |
+          set -e
+          echo "🔧 Pre-seeding node renderer bundle cache..."
+          bundle exec rake react_on_rails_pro:pre_seed_renderer_cache MODE=symlink
+
+          echo "🚀 Starting $SUITE_NAME node renderer..."
+          renderer_log="${RUNNER_TEMP:-$PWD}/node-renderer.log"
+          echo "TARGET_LOG=$renderer_log" >> "$GITHUB_ENV"
+          node renderer/node-renderer.js > "$renderer_log" 2>&1 &
+          renderer_pid=$!
+          # Persist the PID so "Execute benchmark suite" can confirm the renderer
+          # survived the run; a backgrounded child under `set -e` does not
+          # propagate its failure to the step.
+          echo "TARGET_PID=$renderer_pid" >> "$GITHUB_ENV"
+          echo "Node renderer started in background (PID $renderer_pid)"
+
+          echo "⏳ Waiting for node renderer to be ready..."
+          for i in {1..30}; do
+            # Fail fast if the renderer bound the port and then crashed, instead
+            # of looping until the timeout (or racing a dead/restarting target).
+            if ! kill -0 "$renderer_pid" 2>/dev/null; then
+              echo "::error::Node renderer (PID $renderer_pid) exited during startup"
+              cat "$renderer_log" || true
+              exit 1
+            fi
+            if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close"; then
+              echo "✅ Node renderer is ready and listening (PID $renderer_pid)"
+              exit 0
+            fi
+            echo "  Attempt $i/30: Node renderer not ready yet..."
+            sleep 1
+          done
+
+          echo "::error::Node renderer failed to start within 30 seconds"
+          cat "$renderer_log" || true
+          exit 1
+
+      - name: Start Rails production server
+        if: env.SERVER_KIND == 'rails'
+        working-directory: ${{ env.APP_DIRECTORY }}
+        run: |
+          set -e
+          echo "🚀 Starting $SUITE_NAME production server..."
+          $SERVER_CMD &
+          server_pid=$!
+          # Persist the PID so "Execute benchmark suite" can confirm the server
+          # survived the run; a backgrounded child under `set -e` does not
+          # propagate its failure to the step.
+          echo "TARGET_PID=$server_pid" >> "$GITHUB_ENV"
+          echo "Server started in background (PID $server_pid)"
+
+          echo "⏳ Waiting for server to be ready..."
+          for i in {1..30}; do
+            # Fail fast if the server bound the port and then crashed, instead of
+            # looping until the timeout (or racing a dead/restarting target).
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "::error::Server (PID $server_pid) exited during startup"
+              exit 1
+            fi
+            if curl -fsS http://localhost:3001 > /dev/null; then
+              echo "✅ Server is ready and responding (PID $server_pid)"
+              exit 0
+            fi
+            echo "  Attempt $i/30: Server not ready yet..."
+            sleep 1
+          done
+
+          echo "::error::Server failed to start within 30 seconds"
+          exit 1
+
+      - name: Execute benchmark suite
+        timeout-minutes: ${{ fromJSON(inputs.matrix_row).benchmark_timeout_minutes }}
+        run: |
+          set -e
+          echo "🏃 Running $SUITE_NAME benchmark suite..."
+
+          if [ "$PRO_ENV" = "true" ]; then
+            if ! PRO=true $BENCH_CMD "$BENCHMARK_SCRIPT"; then
+              echo "❌ ERROR: Benchmark execution failed"
+              exit 1
+            fi
+          elif ! $BENCH_CMD "$BENCHMARK_SCRIPT"; then
+            echo "❌ ERROR: Benchmark execution failed"
+            exit 1
+          fi
+
+          # The benchmark target was backgrounded in a prior step, so `set -e`
+          # never saw it crash. Confirm it survived the whole run: a mid-run
+          # death means the metrics were measured against a dead/restarting
+          # target and must not ship to Bencher, so fail the job.
+          if [ -z "$TARGET_PID" ]; then
+            echo "::error::TARGET_PID is unset; cannot verify the benchmark target stayed alive"
+            exit 1
+          fi
+          if ! kill -0 "$TARGET_PID" 2>/dev/null; then
+            echo "::error::Benchmark target (PID $TARGET_PID) died during the benchmark run; metrics are unreliable"
+            exit 1
+          fi
+          if [ -n "${TARGET_LOG:-}" ] && [ -f "$TARGET_LOG" ]; then
+            if grep -q "died UNEXPECTEDLY" "$TARGET_LOG"; then
+              echo "::error::Benchmark target logged an unexpected worker restart; metrics are unreliable"
+              grep -n "died UNEXPECTEDLY" "$TARGET_LOG" || true
+              exit 1
+            fi
+          fi
+
+          echo "✅ Benchmark suite completed successfully"
+
+      - name: Validate benchmark results
+        run: |
+          set -e
+          echo "🔍 Validating $SUITE_NAME benchmark results..."
+
+          if [ ! -f "$SUMMARY_FILE" ]; then
+            echo "❌ ERROR: benchmark summary file not found"
+            exit 1
+          fi
+          echo "📊 $SUMMARY_TITLE:"
+          column -t -s $'\t' "$SUMMARY_FILE"
+          echo ""
+
+          if [ ! -f "bench_results/benchmark.json" ]; then
+            echo "❌ ERROR: benchmark JSON file not found"
+            exit 1
+          fi
+
+          echo "✅ Benchmark results validated"
+          echo ""
+          echo "Generated files:"
+          ls -lh bench_results/
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ${{ env.RESULTS_ARTIFACT_NAME }}
+          path: bench_results/
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Confirmation reruns need the first run's candidate to learn which
+      # benchmark+measure pair(s) to re-confirm. Download it (by exact name) before the
+      # tracking step; a missing candidate makes track_benchmarks.rb treat the
+      # confirmation as inconclusive (fail without filing).
+      - name: Download first-run candidate
+        if: inputs.mode == 'confirm'
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ env.CANDIDATE_ARTIFACT_NAME }}
+          path: candidate
+
+      - name: Track benchmarks with Bencher
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          # Confirmation mode reads the downloaded candidate from here (recursive glob).
+          BENCHMARK_CANDIDATE_DIR: candidate
+        run: ruby benchmarks/track_benchmarks.rb
+
+      # Initial mode: on a main-push alert, track_benchmarks.rb wrote a NON-FATAL
+      # candidate. Upload it on always() so the plan-confirmation gate can read it.
+      - name: Upload regression candidate
+        if: always() && inputs.mode != 'confirm'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.CANDIDATE_ARTIFACT_NAME }}
+          path: bench_results/regression-candidate.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Confirm mode: track_benchmarks.rb wrote a confirmed payload only if the same
+      # benchmark+measure re-alerted. Upload it so report-regressions can file the issue.
+      - name: Upload confirmed regression
+        if: always() && inputs.mode == 'confirm'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.CONFIRMED_ARTIFACT_NAME }}
+          path: bench_results/regression-confirmed.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Benchmark workflow summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          RUN_NUMBER: ${{ github.run_number }}
+          ACTOR: ${{ github.actor }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "📋 Benchmark Workflow Summary"
+          echo "===================================="
+          echo "Mode: $BENCHMARK_MODE"
+          echo "Suite: $SUITE_NAME"
+          echo "Shard: $SHARD_LABEL"
+          echo "Status: $JOB_STATUS"
+          echo "Run number: $RUN_NUMBER"
+          echo "Triggered by: $ACTOR"
+          echo "Branch: $REF_NAME"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,20 +68,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
+  # Only RUBY_VERSION is used in this file (detect-changes). The benchmark parameters
+  # (routes/rate/...) and tool versions live in benchmark-suite.yml, where the suite
+  # actually runs — a reusable workflow does not inherit the caller's env.
   RUBY_VERSION: '3.3.7'
-  K6_VERSION: '2.0.0'
-  VEGETA_VERSION: '12.13.0'
-  # Benchmark parameters (defaults in bench.rb unless overridden here for CI)
-  ROUTES: ${{ github.event.inputs.routes }}
-  RATE: ${{ github.event.inputs.rate || 'max' }}
-  DURATION: ${{ github.event.inputs.duration }}
-  REQUEST_TIMEOUT: ${{ github.event.inputs.request_timeout }}
-  CONNECTIONS: ${{ github.event.inputs.connections }}
-  MAX_CONNECTIONS: ${{ github.event.inputs.connections }}
-  # WEB_CONCURRENCY default is set dynamically to NPROC-1 in "Configure benchmark commands" step
-  WEB_CONCURRENCY: ${{ github.event.inputs.web_concurrency }}
-  RAILS_MAX_THREADS: ${{ github.event.inputs.rails_threads || 3 }}
-  RAILS_MIN_THREADS: ${{ github.event.inputs.rails_threads || 3 }}
 
 jobs:
   detect-changes:
@@ -168,448 +158,101 @@ jobs:
         if: steps.benchmark-matrices.outputs.run_benchmark_suites == 'true' || steps.detect.outputs.benchmarks_changed == 'true'
         run: bundle exec rspec benchmarks/spec
 
+  # Initial run of every selected suite/shard. Delegates to the reusable benchmark-suite
+  # workflow in "initial" mode. Which events/labels actually select suites is decided in
+  # benchmarks/generate_matrix.rb (suite_requested_by_event? / suite_selected_by_input?):
+  # push to main, workflow_dispatch, relevant test-impact changes, or same-repo PRs with
+  # suite-specific benchmark labels. On a main-push alert this no longer fails the suite —
+  # track_benchmarks.rb writes a non-fatal candidate that the gate/confirmation jobs act on.
   benchmark:
     needs: detect-changes
+    name: ${{ matrix.job_name }}
+    if: needs.detect-changes.outputs.run_benchmark_suites == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-changes.outputs.benchmark_matrix) }}
-    # Which events/labels actually select suites is decided in
-    # benchmarks/generate_matrix.rb (suite_requested_by_event? / suite_selected_by_input?):
-    # push to main, workflow_dispatch, relevant test-impact changes, or same-repo PRs
-    # with suite-specific benchmark labels. The 'full-ci' label is intentionally
-    # excluded — it controls test workflows, not benchmarks. This job just runs
-    # whatever non-empty matrix that produces; the same-repo PR gating follows
-    # https://bencher.dev/docs/how-to/github-actions/#pull-requests.
-    name: ${{ matrix.job_name }}
-    if: needs.detect-changes.outputs.run_benchmark_suites == 'true'
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write
       pull-requests: write
       checks: write
-    env:
-      SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
-      REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
-      BENCHMARK_SHARD_INDEX: ${{ matrix.shard_index }}
-      BENCHMARK_TOTAL_SHARDS: ${{ matrix.shard_total }}
-      BENCHMARK_SHARD_LABEL: ${{ matrix.shard_label }}
+    uses: ./.github/workflows/benchmark-suite.yml
+    with:
+      matrix_row: ${{ toJSON(matrix) }}
+      mode: initial
+    secrets: inherit
 
+  # The confirmation gate. Reads the first-run candidates, drops the ones whose only
+  # regressed benchmarks are temporarily ignored (no rerun, no issue), and emits a matrix
+  # of just the alerting suite/shard(s) to rerun on fresh runners. Main pushes only.
+  plan-confirmation:
+    needs: [detect-changes, benchmark]
+    # always() so it still runs after a suite reports a candidate; gated to main pushes
+    # that actually ran benchmark suites so it doesn't spin up on PRs or benchmark-less pushes.
+    if: >-
+      always()
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.detect-changes.outputs.run_benchmark_suites == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      has_confirmations: ${{ steps.plan.outputs.has_confirmations }}
+      confirmation_matrix: ${{ steps.plan.outputs.confirmation_matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Install Bencher CLI
-        # Pinned: reporting parses Bencher's `--format json` report — results +
-        # boundaries drive the summary-table significance highlighting, and the
-        # alerts[] array drives regression detection (benchmarks/track_benchmarks.rb
-        # via benchmarks/lib/bencher_report.rb). That JSON shape is not a documented
-        # stability contract, so the parser fails loudly on unexpected shapes and the
-        # CLI is pinned; before bumping, re-verify the shape against
-        # benchmarks/spec/bencher_report_spec.rb AND diff a live `--format json` run
-        # against a reference payload to confirm each boundary is still symmetric about
-        # baseline (lower_limit/upper_limit equidistant). The spec checks the parsing
-        # logic, not the payload's statistical symmetry that Boundary#mirror relies on.
-        uses: bencherdev/bencher@v0.6.2
-
-      - name: Add tools directory to PATH
-        run: |
-          mkdir -p ~/bin
-          echo "$HOME/bin" >> "$GITHUB_PATH"
-
-      - name: Setup k6
-        if: matrix.benchmark_tool == 'k6'
-        uses: grafana/setup-k6-action@v1
+      - name: Download regression candidates
+        uses: actions/download-artifact@v7
         with:
-          k6-version: ${{ env.K6_VERSION }}
-
-      - name: Cache Vegeta binary
-        id: cache-vegeta
-        if: matrix.benchmark_tool == 'vegeta'
-        uses: actions/cache@v5
-        with:
-          path: ~/bin/vegeta
-          key: vegeta-${{ runner.os }}-${{ runner.arch }}-${{ env.VEGETA_VERSION }}
-
-      - name: Install Vegeta
-        if: matrix.benchmark_tool == 'vegeta' && steps.cache-vegeta.outputs.cache-hit != 'true'
-        run: |
-          ARCH=$(dpkg --print-architecture)
-          echo "Installing Vegeta v${VEGETA_VERSION} (${ARCH})"
-          wget -q "https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_${ARCH}.tar.gz"
-          tar -xzf "vegeta_${VEGETA_VERSION}_linux_${ARCH}.tar.gz"
-          mv vegeta ~/bin/
-
-      - name: Setup Ruby
-        uses: ./.github/actions/setup-ruby
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-
-      - name: Get gem home directory
-        id: gem-home
-        run: echo "path=$(gem env home)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache foreman gem
-        id: cache-foreman
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.gem-home.outputs.path }}
-          key: foreman-gem-${{ runner.os }}-${{ runner.arch }}-ruby-${{ env.RUBY_VERSION }}
-
-      - name: Install foreman
-        if: steps.cache-foreman.outputs.cache-hit != 'true'
-        run: gem install foreman
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          cache: true
-          cache_dependency_path: '**/pnpm-lock.yaml'
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Print system information
-        run: |
-          echo "Linux release: "
-          cat /etc/issue
-          echo "Current user: "
-          whoami
-          echo "Current directory: "
-          pwd
-          echo "Ruby version: "
-          ruby -v
-          echo "Node version: "
-          node -v
-          echo "Pnpm version: "
-          pnpm --version
-          echo "Bundler version: "
-          bundle --version
-
-      - name: Configure benchmark commands
-        run: |
-          NPROC=$(nproc)
-          echo "Available CPUs: $NPROC"
-
-          if [ "$NPROC" -le 1 ]; then
-            SERVER_CMD="bin/prod"
-            BENCH_CMD="ruby"
-          else
-            SERVER_CMD="taskset -c 1-$((NPROC-1)) bin/prod"
-            BENCH_CMD="taskset -c 0 ruby"
-          fi
-
-          echo "SERVER_CMD=$SERVER_CMD" >> "$GITHUB_ENV"
-          echo "BENCH_CMD=$BENCH_CMD" >> "$GITHUB_ENV"
-
-          if [ -z "$WEB_CONCURRENCY" ]; then
-            # Clamp to >=1 so single-CPU runners don't end up with WEB_CONCURRENCY=0 (Puma
-            # would start in single-mode, which the benchmarks aren't tuned for).
-            WEB_CONCURRENCY=$((NPROC > 1 ? NPROC - 1 : 1))
-            echo "WEB_CONCURRENCY=$WEB_CONCURRENCY" >> "$GITHUB_ENV"
-            echo "WEB_CONCURRENCY (auto): $WEB_CONCURRENCY"
-          else
-            echo "WEB_CONCURRENCY (from input): $WEB_CONCURRENCY"
-          fi
-
-          echo "SERVER_CMD: $SERVER_CMD"
-          echo "BENCH_CMD: $BENCH_CMD"
-
-      - name: Install Node modules with pnpm
-        run: pnpm install --frozen-lockfile
-
-      - name: Build workspace packages
-        run: pnpm run build
-
-      - name: Install Ruby Gems for the benchmarked app
-        uses: ./.github/actions/setup-bundle
-        with:
-          working-directory: ${{ matrix.app_directory }}
-          ruby-version: ${{ env.RUBY_VERSION }}
-          install-libyaml: 'false'
-
-      - name: Generate file-system based entrypoints for Pro
-        if: matrix.generate_packs == 'true'
-        working-directory: ${{ matrix.app_directory }}
-        run: bundle exec rake react_on_rails:generate_packs
-
-      - name: Prepare production assets
-        working-directory: ${{ matrix.app_directory }}
-        run: |
-          set -e
-          echo "🔨 Building ${{ matrix.suite_name }} production assets..."
-
-          if ! bin/prod-assets; then
-            echo "❌ ERROR: Failed to build production assets"
-            exit 1
-          fi
-
-          echo "✅ Production assets built successfully"
-
-      - name: Prepare and seed benchmark database
-        # The Pro Rails suite serves DB-backed routes (e.g. /posts_page). Without
-        # a migrated + seeded database those routes 500 on every request (the
-        # `posts` table does not exist), so the benchmark must create and seed it
-        # before the server starts. On a fresh CI runner `db:prepare` creates the
-        # database, loads the schema, and — because the database is newly created —
-        # runs db/seeds.rb (deterministic and faker-free so it works under
-        # RAILS_ENV=production). Note: `db:prepare` only seeds on first creation, so
-        # the row-count check below fails the job loudly if seeding was skipped (an
-        # empty table would otherwise serve a 200 "No posts found" payload that the
-        # benchmark scores as healthy).
-        if: matrix.server_kind == 'rails' && matrix.pro_env == 'true'
-        working-directory: ${{ matrix.app_directory }}
-        # Pass the matrix value via env (treated as data, not interpolated into
-        # the shell), matching the "Execute benchmark suite" step below.
+          path: candidate-artifacts
+          pattern: regression-candidate-*
+      # Stdlib-only script, so the runner's system Ruby is enough (no Bundler/Rails boot).
+      - name: Plan confirmation reruns
+        id: plan
         env:
-          RAILS_ENV: production
-          SUITE_NAME: ${{ matrix.suite_name }}
-        run: |
-          set -euo pipefail
-          echo "🌱 Preparing and seeding $SUITE_NAME benchmark database..."
-          bundle exec rails db:prepare
-          # Guard every table `/posts_page` reads (posts, plus the users and
-          # comments it joins), not just posts: a partial seed would otherwise
-          # let the route 500 (or render an empty page) while the job stayed
-          # green.
-          bundle exec rails runner - <<'RUBY'
-          counts = {
-            posts: Post.count,
-            users: User.count,
-            comments: Comment.count
-          }
+          BENCHMARK_MATRIX: ${{ needs.detect-changes.outputs.benchmark_matrix }}
+        run: ruby benchmarks/plan_confirmation.rb candidate-artifacts
 
-          empty_tables = counts.select { |_, count| count.zero? }.keys
-          if empty_tables.any?
-            abort(
-              "Benchmark DB seeding incomplete after db:prepare " \
-              "(empty: #{empty_tables.join(', ')}); seeds did not run"
-            )
-          end
+  # Fresh-runner confirmation reruns of just the alerting suite/shard(s). Runs the same
+  # benchmark-suite workflow in "confirm" mode: re-tests against main's baseline without
+  # polluting main's series, and writes a confirmed artifact only when the SAME
+  # benchmark+measure re-alerts. Skipped when there is nothing to confirm.
+  confirm-regressions:
+    needs: [detect-changes, plan-confirmation]
+    if: needs.plan-confirmation.outputs.has_confirmations == 'true'
+    name: ${{ matrix.job_name }} (confirmation)
+    strategy:
+      fail-fast: false
+      # Fall back to an empty (but valid) matrix if plan-confirmation was skipped/crashed
+      # before setting the output: its output is then "" and fromJSON("") would error at
+      # matrix-construction time even though the if: gate skips this job. The empty matrix
+      # produces zero jobs; the if: gate is what actually decides whether confirmation runs.
+      matrix: ${{ fromJSON(needs.plan-confirmation.outputs.confirmation_matrix || '{"include":[]}') }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      checks: write
+    uses: ./.github/workflows/benchmark-suite.yml
+    with:
+      matrix_row: ${{ toJSON(matrix) }}
+      mode: confirm
+    secrets: inherit
 
-          puts "✅ Database seeded (#{counts.map { |table, count| "#{count} #{table}" }.join(', ')})"
-          RUBY
-
-      - name: Start Pro node renderer
-        if: matrix.server_kind == 'node-renderer'
-        working-directory: ${{ matrix.app_directory }}
-        env:
-          RAILS_ENV: production
-          NODE_ENV: production
-          RENDERER_LOG_LEVEL: error
-          RENDERER_PORT: 3800
-        run: |
-          set -e
-          echo "🔧 Pre-seeding node renderer bundle cache..."
-          bundle exec rake react_on_rails_pro:pre_seed_renderer_cache MODE=symlink
-
-          echo "🚀 Starting ${{ matrix.suite_name }} node renderer..."
-          renderer_log="${RUNNER_TEMP:-$PWD}/node-renderer.log"
-          echo "TARGET_LOG=$renderer_log" >> "$GITHUB_ENV"
-          node renderer/node-renderer.js > "$renderer_log" 2>&1 &
-          renderer_pid=$!
-          # Persist the PID so "Execute benchmark suite" can confirm the renderer
-          # survived the run; a backgrounded child under `set -e` does not
-          # propagate its failure to the step.
-          echo "TARGET_PID=$renderer_pid" >> "$GITHUB_ENV"
-          echo "Node renderer started in background (PID $renderer_pid)"
-
-          echo "⏳ Waiting for node renderer to be ready..."
-          for i in {1..30}; do
-            # Fail fast if the renderer bound the port and then crashed, instead
-            # of looping until the timeout (or racing a dead/restarting target).
-            if ! kill -0 "$renderer_pid" 2>/dev/null; then
-              echo "::error::Node renderer (PID $renderer_pid) exited during startup"
-              cat "$renderer_log" || true
-              exit 1
-            fi
-            if ruby -e "require 'socket'; TCPSocket.new('localhost', 3800).close"; then
-              echo "✅ Node renderer is ready and listening (PID $renderer_pid)"
-              exit 0
-            fi
-            echo "  Attempt $i/30: Node renderer not ready yet..."
-            sleep 1
-          done
-
-          echo "::error::Node renderer failed to start within 30 seconds"
-          cat "$renderer_log" || true
-          exit 1
-
-      - name: Start Rails production server
-        if: matrix.server_kind == 'rails'
-        working-directory: ${{ matrix.app_directory }}
-        run: |
-          set -e
-          echo "🚀 Starting ${{ matrix.suite_name }} production server..."
-          $SERVER_CMD &
-          server_pid=$!
-          # Persist the PID so "Execute benchmark suite" can confirm the server
-          # survived the run; a backgrounded child under `set -e` does not
-          # propagate its failure to the step.
-          echo "TARGET_PID=$server_pid" >> "$GITHUB_ENV"
-          echo "Server started in background (PID $server_pid)"
-
-          echo "⏳ Waiting for server to be ready..."
-          for i in {1..30}; do
-            # Fail fast if the server bound the port and then crashed, instead of
-            # looping until the timeout (or racing a dead/restarting target).
-            if ! kill -0 "$server_pid" 2>/dev/null; then
-              echo "::error::Server (PID $server_pid) exited during startup"
-              exit 1
-            fi
-            if curl -fsS http://localhost:3001 > /dev/null; then
-              echo "✅ Server is ready and responding (PID $server_pid)"
-              exit 0
-            fi
-            echo "  Attempt $i/30: Server not ready yet..."
-            sleep 1
-          done
-
-          echo "::error::Server failed to start within 30 seconds"
-          exit 1
-
-      - name: Execute benchmark suite
-        timeout-minutes: ${{ matrix.benchmark_timeout_minutes }}
-        # Route matrix values through env so the shell treats them as data, not code
-        # (GitHub Actions injection hardening), even though they come from our own
-        # generate_matrix.rb.
-        env:
-          SUITE_NAME: ${{ matrix.suite_name }}
-          PRO_ENV: ${{ matrix.pro_env }}
-          BENCHMARK_SCRIPT: ${{ matrix.benchmark_script }}
-        run: |
-          set -e
-          echo "🏃 Running $SUITE_NAME benchmark suite..."
-
-          if [ "$PRO_ENV" = "true" ]; then
-            if ! PRO=true $BENCH_CMD "$BENCHMARK_SCRIPT"; then
-              echo "❌ ERROR: Benchmark execution failed"
-              exit 1
-            fi
-          elif ! $BENCH_CMD "$BENCHMARK_SCRIPT"; then
-            echo "❌ ERROR: Benchmark execution failed"
-            exit 1
-          fi
-
-          # The benchmark target was backgrounded in a prior step, so `set -e`
-          # never saw it crash. Confirm it survived the whole run: a mid-run
-          # death means the metrics were measured against a dead/restarting
-          # target and must not ship to Bencher, so fail the job.
-          if [ -z "$TARGET_PID" ]; then
-            echo "::error::TARGET_PID is unset; cannot verify the benchmark target stayed alive"
-            exit 1
-          fi
-          if ! kill -0 "$TARGET_PID" 2>/dev/null; then
-            echo "::error::Benchmark target (PID $TARGET_PID) died during the benchmark run; metrics are unreliable"
-            exit 1
-          fi
-          if [ -n "${TARGET_LOG:-}" ] && [ -f "$TARGET_LOG" ]; then
-            if grep -q "died UNEXPECTEDLY" "$TARGET_LOG"; then
-              echo "::error::Benchmark target logged an unexpected worker restart; metrics are unreliable"
-              grep -n "died UNEXPECTEDLY" "$TARGET_LOG" || true
-              exit 1
-            fi
-          fi
-
-          echo "✅ Benchmark suite completed successfully"
-
-      - name: Validate benchmark results
-        env:
-          SUITE_NAME: ${{ matrix.suite_name }}
-          SUMMARY_FILE: ${{ matrix.summary_file }}
-          SUMMARY_TITLE: ${{ matrix.summary_title }}
-        run: |
-          set -e
-          echo "🔍 Validating $SUITE_NAME benchmark results..."
-
-          if [ ! -f "$SUMMARY_FILE" ]; then
-            echo "❌ ERROR: benchmark summary file not found"
-            exit 1
-          fi
-          echo "📊 $SUMMARY_TITLE:"
-          column -t -s $'\t' "$SUMMARY_FILE"
-          echo ""
-
-          if [ ! -f "bench_results/benchmark.json" ]; then
-            echo "❌ ERROR: benchmark JSON file not found"
-            exit 1
-          fi
-
-          echo "✅ Benchmark results validated"
-          echo ""
-          echo "Generated files:"
-          ls -lh bench_results/
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: ${{ matrix.artifact_name_prefix }}-${{ github.run_number }}${{ matrix.artifact_name_suffix }}
-          path: bench_results/
-          retention-days: 30
-          if-no-files-found: warn
-
-      - name: Track benchmarks with Bencher
-        env:
-          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          BENCHER_REPORT_MARKER: ${{ matrix.report_marker }}
-          BENCHMARK_SUITE_NAME: ${{ matrix.bencher_suite_name }}
-          # Un-sharded name so report-regressions can combine a suite's shards.
-          BENCHMARK_SUITE_GROUP: ${{ matrix.suite_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-        run: ruby benchmarks/track_benchmarks.rb
-
-      # On a main-push regression, track_benchmarks.rb writes regression.json and
-      # exits non-zero (failing this suite). Upload it on always() so the single
-      # report-regressions job can file one issue serially after the matrix; the
-      # main "Upload benchmark results" step runs before Bencher, so it can't.
-      - name: Upload regression report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: regression-${{ matrix.artifact_name_prefix }}-${{ github.run_number }}${{ matrix.artifact_name_suffix }}
-          path: bench_results/regression.json
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Benchmark workflow summary
-        if: always()
-        # Route context/matrix values through env so the shell treats them as data,
-        # not code (GitHub Actions injection hardening; ref_name can be attacker-set).
-        env:
-          SUITE_NAME: ${{ matrix.suite_name }}
-          SHARD_LABEL: ${{ matrix.shard_label }}
-          JOB_STATUS: ${{ job.status }}
-          RUN_NUMBER: ${{ github.run_number }}
-          ACTOR: ${{ github.actor }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          echo "📋 Benchmark Workflow Summary"
-          echo "===================================="
-          echo "Suite: $SUITE_NAME"
-          echo "Shard: $SHARD_LABEL"
-          echo "Status: $JOB_STATUS"
-          echo "Run number: $RUN_NUMBER"
-          echo "Triggered by: $ACTOR"
-          echo "Branch: $REF_NAME"
-
-  # Files a single GitHub issue for any benchmark regressions detected on main.
-  # Runs once after the whole matrix (always(), since a regression fails its suite)
-  # so reporting is serialized: parallel matrix suites doing this themselves would
-  # create duplicate issues and clobber each other's sections in the shared comment.
-  # No-ops when no suite uploaded a regression report (the common, healthy case).
+  # Files a single GitHub issue for any CONFIRMED benchmark regressions, with the first
+  # run and confirmation summaries side by side. Runs once after confirmation (always(),
+  # since a confirmed regression / inconclusive rerun fails its job) so reporting is
+  # serialized: parallel suites doing this themselves would create duplicate issues and
+  # clobber each other's sections in the shared comment. This job owns the final pass/fail
+  # — a confirmed regression fails the workflow here. No-ops (exit 0) when every first-run
+  # alert was cleared as noise or short-circuited as ignored.
   report-regressions:
-    needs: [detect-changes, benchmark]
-    # always() so it still runs when a suite fails (a regression fails its suite);
-    # gated to main pushes that actually ran benchmark suites so it doesn't spin up
-    # a no-op job on labeled PRs or benchmark-less main pushes.
+    needs: [detect-changes, benchmark, plan-confirmation, confirm-regressions]
     if: >-
       always()
       && github.event_name == 'push'
@@ -625,13 +268,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Download regression reports
+      - name: Download confirmed regressions
         uses: actions/download-artifact@v7
         with:
-          path: regression-artifacts
-          pattern: regression-*
+          path: confirmed-artifacts
+          pattern: regression-confirmed-*
       # Stdlib-only script, so the runner's system Ruby is enough (no Bundler/Rails boot).
       - name: File regression issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ruby benchmarks/report_regressions.rb regression-artifacts
+        run: ruby benchmarks/report_regressions.rb confirmed-artifacts

--- a/benchmarks/lib/regression_report.rb
+++ b/benchmarks/lib/regression_report.rb
@@ -1,16 +1,120 @@
 # frozen_string_literal: true
 
-# Shared constants between track_benchmarks.rb and report_regressions.rb.
+# Shared contract for the benchmark regression hand-off across the three jobs in the
+# confirmation pipeline (see .github/workflows/benchmark.yml and benchmark-suite.yml):
+#
+#   1. track_benchmarks.rb (initial run, main push)
+#      On a Bencher alert it writes a CANDIDATE payload (CANDIDATE_FILENAME) and exits
+#      0 — the alert is non-fatal until confirmed. The candidate carries the structured
+#      ALERTS (benchmark+measure pairs) so the rerun can match the SAME pairs.
+#   2. plan_confirmation.rb (gate job)
+#      Reads every candidate, drops the ones whose only regressed benchmarks are
+#      IGNORED_REGRESSION_BENCHMARKS, and emits a matrix of just the alerting
+#      suite/shard(s) to rerun on fresh runners.
+#   3. track_benchmarks.rb (confirmation run, BENCHMARK_MODE=confirm)
+#      Reruns the suite/shard against main's baseline WITHOUT polluting main's series,
+#      intersects this run's alerts with the candidate's, and writes a CONFIRMED payload
+#      (CONFIRMED_FILENAME) only when the SAME benchmark+measure pair(s) re-alert.
+#   4. report_regressions.rb (report job)
+#      Files/updates the single performance-regression issue from CONFIRMED payloads,
+#      showing the first-run and confirmation summaries side by side.
 module RegressionReport
-  # The contract for the benchmark regression hand-off between two jobs: the writer
-  # (track_benchmarks.rb) drops a regression.json into each matrix job's bench_results/,
-  # and the reader (report_regressions.rb) globs this basename under the downloaded
-  # artifacts and reads these keys.
-  FILENAME = "regression.json"
+  module_function
 
-  # Payload keys
+  # Hand-off filenames. Distinct basenames (not just distinct artifact names) so a
+  # confirmed glob can never accidentally pick up a candidate and vice versa.
+  CANDIDATE_FILENAME = "regression-candidate.json"
+  CONFIRMED_FILENAME = "regression-confirmed.json"
+
+  # Payload keys shared by candidate and confirmed payloads.
   SUITE_NAME = "suite_name"
   SHARD_LABEL = "shard_label"
-  SUMMARY = "summary"
+  # The benchmark names Bencher raised an active alert for, deduped. Drives the
+  # IGNORED_REGRESSION_BENCHMARKS short-circuit (name-based) and is shown in the issue.
   REGRESSED_BENCHMARKS = "regressed_benchmarks"
+  # Structured alert identifiers: an array of { ALERT_BENCHMARK, ALERT_MEASURE } so the
+  # confirmation run can require the SAME benchmark+measure pair to re-alert, not just
+  # any alert in the suite. measure may be null (Bencher omitted it); see #alerts_match?.
+  ALERTS = "alerts"
+  ALERT_BENCHMARK = "benchmark"
+  ALERT_MEASURE = "measure"
+
+  # Candidate-only: the first run's rendered summary table.
+  SUMMARY = "summary"
+
+  # Confirmed-only: the first-run table and the confirmation-run table, kept distinct so
+  # the issue can show both numbers side by side (the comparison is the evidence).
+  FIRST_RUN_SUMMARY = "first_run_summary"
+  CONFIRMATION_SUMMARY = "confirmation_summary"
+
+  # TEMPORARY — benchmarks whose regressions must NOT open an issue, by the exact
+  # benchmark name Bencher reports (the leading-slash name shown in the summary table,
+  # matched against REGRESSED_BENCHMARKS in each suite's payload).
+  #
+  # /posts_page: Pro spent weeks hard-500ing on every request (failed_pct = 100), so the
+  # route was effectively an instant error and Bencher built its rps/latency baseline
+  # from those bogus-fast failure responses. Now that the route is fixed, its real
+  # (slower) timings read as large regressions against that fast baseline and would file
+  # a spurious regression issue on every main push. We can't surgically delete just this
+  # benchmark's history in Bencher (the delete is blocked by a FOREIGN KEY constraint
+  # from its reports/alerts), so we suppress it here instead — and short-circuit it
+  # BEFORE a confirmation rerun (plan_confirmation.rb), so we don't burn a fresh runner
+  # confirming a benchmark we would suppress anyway.
+  #
+  # REMOVE this entry (restoring unconditional filing) once the failure-era samples have
+  # rolled out of Bencher's 64-run t-test window for /posts_page: Pro on main — i.e. once
+  # the dashboard baseline reflects real timings again. After that a regression for it is
+  # genuine and must be reported. Tracking issue + full revert steps:
+  # https://github.com/shakacode/react_on_rails/issues/3669
+  IGNORED_REGRESSION_BENCHMARKS = ["/posts_page: Pro"].freeze
+
+  # Build a structured alert hash for the ALERTS payload key.
+  def alert(benchmark, measure)
+    { ALERT_BENCHMARK => benchmark, ALERT_MEASURE => measure }
+  end
+
+  # Normalize a measure key the same way BencherReport does (slug vs name, dashes vs
+  # underscores, case) so "p50-latency" and "p50_latency" compare equal.
+  def normalize_measure(measure)
+    return nil if measure.nil?
+
+    measure.to_s.downcase.gsub(/[-\s]+/, "_")
+  end
+
+  # Do two alerts identify the same regression? Same benchmark is required. Measures
+  # must match when both are present; if EITHER side omitted the measure (Bencher's
+  # alert payload is read leniently, so measure can be nil), fall back to matching on
+  # the benchmark name alone — the explicitly-allowed fallback when measure-level alert
+  # data is not available (see the issue's "Match the same benchmark+measure").
+  def alerts_match?(left, right)
+    return false unless left[ALERT_BENCHMARK] == right[ALERT_BENCHMARK]
+
+    left_measure = normalize_measure(left[ALERT_MEASURE])
+    right_measure = normalize_measure(right[ALERT_MEASURE])
+    left_measure.nil? || right_measure.nil? || left_measure == right_measure
+  end
+
+  # The candidate alerts that re-alerted in the confirmation run (same benchmark+measure
+  # pair). This is the set the confirmation publishes as confirmed.
+  def confirmed_alerts(candidate_alerts, confirmation_alerts)
+    candidate_alerts.select do |candidate|
+      confirmation_alerts.any? { |confirmation| alerts_match?(candidate, confirmation) }
+    end
+  end
+
+  def ignored_benchmark?(name)
+    IGNORED_REGRESSION_BENCHMARKS.include?(name)
+  end
+
+  # Alerts whose benchmark is NOT temporarily ignored — the ones worth confirming and
+  # reporting. An ignored benchmark never reaches a confirmation rerun or the issue.
+  def actionable_alerts(alerts)
+    alerts.reject { |entry| ignored_benchmark?(entry[ALERT_BENCHMARK]) }
+  end
+
+  # The regressed benchmark names not in the ignore-list. Empty => every regressed
+  # benchmark is ignored, so the suite/shard short-circuits (no rerun, no issue).
+  def actionable_benchmarks(regressed_benchmarks)
+    Array(regressed_benchmarks).reject { |name| ignored_benchmark?(name) }
+  end
 end

--- a/benchmarks/plan_confirmation.rb
+++ b/benchmarks/plan_confirmation.rb
@@ -31,7 +31,13 @@ def candidate_payload_paths(artifacts_dir)
 end
 
 def load_candidate_payload(path)
-  JSON.parse(File.read(path))
+  parsed = JSON.parse(File.read(path))
+  required_keys = [RegressionReport::SUITE_NAME, RegressionReport::SHARD_LABEL]
+  unless parsed.is_a?(Hash) && required_keys.all? { |key| parsed.key?(key) }
+    raise "expected a JSON object with #{required_keys.join(', ')}"
+  end
+
+  parsed
 rescue StandardError => e
   warn "::error::Failed to read regression candidate #{path}: #{e.class}: #{e.message}"
   nil

--- a/benchmarks/plan_confirmation.rb
+++ b/benchmarks/plan_confirmation.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# The confirmation gate. Runs once after the initial benchmark matrix on a main push,
+# reads every first-run regression CANDIDATE (see track_benchmarks.rb / regression_report.rb),
+# and decides which suite/shard(s) to rerun on fresh runners before any issue is filed.
+#
+# It does two things:
+#   1. Short-circuits the IGNORED_REGRESSION_BENCHMARKS list BEFORE spending a rerun: a
+#      candidate whose only regressed benchmarks are ignored is dropped (no fresh-runner
+#      rerun, no issue), surfaced as a workflow notice.
+#   2. Emits a GitHub Actions matrix of just the alerting suite/shard rows (verbatim from
+#      the original benchmark matrix, so the confirmation job can run them identically)
+#      plus a has_confirmations flag the confirmation job gates on.
+#
+# A missing/corrupt candidate, or a candidate that matches no matrix row, is an
+# operational failure: the gate exits non-zero (the workflow goes red) and emits no
+# confirmations, so report-regressions files nothing. That matches the issue's
+# "inconclusive confirmation fails the workflow without filing an issue."
+#
+# Usage: ruby benchmarks/plan_confirmation.rb <candidate-artifacts-dir>
+#   env BENCHMARK_MATRIX = the benchmark matrix JSON ({ "include": [ ...rows... ] })
+
+require "json"
+
+require_relative "lib/github"
+require_relative "lib/regression_report"
+
+def candidate_payload_paths(artifacts_dir)
+  Dir.glob(File.join(artifacts_dir, "**", RegressionReport::CANDIDATE_FILENAME))
+end
+
+def load_candidate_payload(path)
+  JSON.parse(File.read(path))
+rescue StandardError => e
+  warn "::error::Failed to read regression candidate #{path}: #{e.class}: #{e.message}"
+  nil
+end
+
+# Every regressed benchmark this candidate named is ignored — drop it (no rerun, no
+# issue). When the candidate named NO benchmarks (older writer / hand-off that couldn't
+# name them) we cannot suppress what we cannot name, so fall through and confirm it.
+def fully_ignored?(regressed_benchmarks)
+  names = Array(regressed_benchmarks)
+  !names.empty? && RegressionReport.actionable_benchmarks(names).empty?
+end
+
+def matrix_row_key(suite_name, shard_label)
+  [suite_name.to_s, shard_label.to_s]
+end
+
+# Decide the confirmation plan from the candidate payloads and the benchmark matrix.
+# Returns a hash:
+#   confirm_rows: matrix rows (verbatim) to rerun on fresh runners
+#   suppressed:   ignored benchmark names that short-circuited (for the notice)
+#   unmatched:    [suite_name, shard_label] candidates with no matrix row (operational bug)
+def build_plan(payloads, matrix_rows)
+  rows_by_key = matrix_rows.each_with_object({}) do |row, index|
+    index[matrix_row_key(row["suite_name"], row["shard_label"])] = row
+  end
+
+  confirm_rows = {}
+  suppressed = []
+  unmatched = []
+
+  payloads.each do |payload|
+    regressed = payload[RegressionReport::REGRESSED_BENCHMARKS]
+    if fully_ignored?(regressed)
+      suppressed.concat(Array(regressed) & RegressionReport::IGNORED_REGRESSION_BENCHMARKS)
+      next
+    end
+
+    key = matrix_row_key(payload[RegressionReport::SUITE_NAME], payload[RegressionReport::SHARD_LABEL])
+    row = rows_by_key[key]
+    if row.nil?
+      unmatched << key
+    else
+      confirm_rows[key] = row
+    end
+  end
+
+  { confirm_rows: confirm_rows.values, suppressed: suppressed.uniq, unmatched: }
+end
+
+def benchmark_matrix_rows
+  raw = ENV.fetch("BENCHMARK_MATRIX", "")
+  return [] if raw.empty?
+
+  parsed = JSON.parse(raw)
+  rows = parsed.is_a?(Hash) ? parsed["include"] : nil
+  rows.is_a?(Array) ? rows : []
+rescue JSON::ParserError => e
+  warn "::error::BENCHMARK_MATRIX is not valid JSON: #{e.message}"
+  []
+end
+
+def set_output(name, value)
+  path = ENV.fetch("GITHUB_OUTPUT", nil)
+  File.write(path, "#{name}=#{value}\n", mode: "a") if path && !path.empty?
+  puts "#{name}=#{value}"
+end
+
+def emit_no_confirmations
+  set_output("has_confirmations", "false")
+  set_output("confirmation_matrix", JSON.generate(include: []))
+end
+
+def emit_confirmations(rows)
+  described = rows.map { |row| row["bencher_suite_name"] || row["suite_name"] }.join(", ")
+  puts "Scheduling confirmation reruns for: #{described}"
+  set_output("has_confirmations", "true")
+  set_output("confirmation_matrix", JSON.generate(include: rows))
+end
+
+def announce_suppressed(suppressed)
+  return if suppressed.empty?
+
+  Github.notice(
+    "Skipped confirmation for temporarily-ignored benchmark(s) (#{suppressed.join(', ')}); " \
+    "no rerun and no issue. Remove IGNORED_REGRESSION_BENCHMARKS in benchmarks/lib/regression_report.rb " \
+    "once their Bencher baseline recovers."
+  )
+end
+
+def warn_unmatched(unmatched)
+  described = unmatched.map { |suite, shard| "#{suite} (#{shard})" }.join(", ")
+  warn "::error::Regression candidate(s) #{described} matched no benchmark matrix row, so they " \
+       "cannot be rerun. Treating confirmation as inconclusive and failing the workflow without filing."
+end
+
+# Returns true on success (outputs emitted), false on an operational failure that must
+# fail the workflow without filing anything.
+def plan_confirmation(artifacts_dir)
+  paths = candidate_payload_paths(artifacts_dir)
+  if paths.empty?
+    puts "No benchmark regression candidates were reported by any suite."
+    emit_no_confirmations
+    return true
+  end
+
+  payloads = paths.map { |path| load_candidate_payload(path) }
+  if payloads.any?(&:nil?)
+    warn "::error::One or more regression candidates were unreadable; treating confirmation as " \
+         "inconclusive and failing the workflow without filing an issue."
+    emit_no_confirmations
+    return false
+  end
+
+  plan = build_plan(payloads, benchmark_matrix_rows)
+  announce_suppressed(plan[:suppressed])
+
+  unless plan[:unmatched].empty?
+    warn_unmatched(plan[:unmatched])
+    emit_no_confirmations
+    return false
+  end
+
+  if plan[:confirm_rows].empty?
+    puts "All regression candidates were temporarily ignored; nothing to confirm."
+    emit_no_confirmations
+    return true
+  end
+
+  emit_confirmations(plan[:confirm_rows])
+  true
+end
+
+if __FILE__ == $PROGRAM_NAME
+  artifacts_dir = ARGV.fetch(0, "candidate-artifacts")
+  exit 1 unless plan_confirmation(artifacts_dir)
+end

--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -1,16 +1,22 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Files a single GitHub issue for benchmark regressions detected on main.
+# Files a single GitHub issue for benchmark regressions CONFIRMED on main.
 #
-# Each benchmark matrix suite runs in its own parallel job; on a regression it
-# records a regression.json payload (see track_benchmarks.rb) that the workflow
-# uploads as an artifact. This script runs once, after the matrix, reads every
-# payload, and reports them serially through RegressionIssueReporter. Doing it in
-# one process is what makes the dedup/upsert safe: parallel suites reporting
-# directly would create duplicate issues and clobber the shared comment.
+# A main-push alert is non-fatal until a fresh-runner confirmation rerun re-alerts on
+# the same benchmark+measure (see track_benchmarks.rb confirmation mode). Each confirmed
+# suite/shard records a regression-confirmed.json payload (see regression_report.rb) that
+# the workflow uploads as an artifact. This script runs once, after the confirmation
+# matrix, reads every confirmed payload, and reports them serially through
+# RegressionIssueReporter. Doing it in one process is what makes the dedup/upsert safe:
+# parallel suites reporting directly would create duplicate issues and clobber the shared
+# comment.
 #
-# Usage: ruby benchmarks/report_regressions.rb <artifacts-dir>
+# This job owns the final pass/fail: a confirmed regression fails the workflow (exit 1)
+# AND files the issue; no confirmed payloads means every first-run alert was cleared as
+# noise (or short-circuited as ignored upstream), so it exits 0.
+#
+# Usage: ruby benchmarks/report_regressions.rb <confirmed-artifacts-dir>
 
 require "json"
 
@@ -19,25 +25,6 @@ require_relative "lib/github_cli"
 require_relative "lib/regression_report"
 
 BENCHER_URL = "https://bencher.dev/perf/react-on-rails-t8a9ncxo"
-
-# TEMPORARY — benchmarks whose regressions must NOT open an issue, by the exact
-# benchmark name Bencher reports (the leading-slash name shown in the summary table,
-# matched against RegressionReport::REGRESSED_BENCHMARKS in each suite's payload).
-#
-# /posts_page: Pro spent weeks hard-500ing on every request (failed_pct = 100), so the
-# route was effectively an instant error and Bencher built its rps/latency baseline
-# from those bogus-fast failure responses. Now that the route is fixed, its real
-# (slower) timings read as large regressions against that fast baseline and would file
-# a spurious regression issue on every main push. We can't surgically delete just this
-# benchmark's history in Bencher (the delete is blocked by a FOREIGN KEY constraint
-# from its reports/alerts), so we suppress its issue here instead.
-#
-# REMOVE this entry (restoring unconditional filing) once the failure-era samples have
-# rolled out of Bencher's 64-run t-test window for /posts_page: Pro on main — i.e. once
-# the dashboard baseline reflects real timings again. After that a regression for it is
-# genuine and must be reported. Tracking issue + full revert steps:
-# https://github.com/shakacode/react_on_rails/issues/3669
-IGNORED_REGRESSION_BENCHMARKS = ["/posts_page: Pro"].freeze
 
 # Creates (or updates) the single per-commit regression issue and upserts one
 # section per suite into a shared comment. Only safe to drive from a single
@@ -324,7 +311,9 @@ class RegressionIssueReporter
       ## Performance Regression Detected on main
 
       Statistically significant benchmark regressions were detected by [Bencher](#{bencher_url})
-      using a Student's t-test (95% confidence interval, up to 64 sample history).
+      using a Student's t-test (95% confidence interval, up to 64 sample history), and
+      **confirmed by a second run on a fresh runner** (re-tested against main's baseline)
+      that re-alerted on the same benchmark+measure — so this is unlikely to be runner noise.
 
       | Detail | Value |
       |--------|-------|
@@ -368,63 +357,53 @@ class RegressionIssueReporter
 end
 # rubocop:enable Metrics/ClassLength
 
-def regression_payload_paths(artifacts_dir)
+def confirmed_payload_paths(artifacts_dir)
   # Recursive glob so it works regardless of how download-artifact nests each
   # suite's artifact under the download path.
-  Dir.glob(File.join(artifacts_dir, "**", RegressionReport::FILENAME))
+  Dir.glob(File.join(artifacts_dir, "**", RegressionReport::CONFIRMED_FILENAME))
 end
 
 def load_payload(path)
   JSON.parse(File.read(path))
 rescue StandardError => e
-  # A regression was detected but its report is unreadable/corrupt. Surface it and
+  # A regression was confirmed but its report is unreadable/corrupt. Surface it and
   # let the caller fail rather than silently dropping the suite from the issue.
-  warn "::error::Failed to read regression payload #{path}: #{e.class}: #{e.message}"
+  warn "::error::Failed to read confirmed regression payload #{path}: #{e.class}: #{e.message}"
   nil
 end
 
-# Returns the regressed benchmarks to suppress only when every payload reports its
-# regressed benchmarks AND all of them are in IGNORED_REGRESSION_BENCHMARKS. Fails
-# safe toward filing: no payloads, a payload missing the list (older writer / hand-off
-# that couldn't name them), an empty list, or any non-ignored benchmark returns nil.
-def suppressed_regressed_benchmarks(payloads)
-  return nil if payloads.empty?
+# The per-shard evidence block for one confirmed payload: the first-run table and the
+# confirmation-run table side by side (the comparison is what a reader wants).
+def shard_summary(payload)
+  shard_label = payload.fetch(RegressionReport::SHARD_LABEL, "").to_s
+  heading = shard_label.empty? ? "" : "#### Shard #{shard_label}\n\n"
+  first_run = payload.fetch(RegressionReport::FIRST_RUN_SUMMARY, "").to_s
+  confirmation = payload.fetch(RegressionReport::CONFIRMATION_SUMMARY, "").to_s
+  <<~MARKDOWN
+    #{heading}**First run**
 
-  per_payload = payloads.map { |payload| payload[RegressionReport::REGRESSED_BENCHMARKS] }
-  return nil unless per_payload.all? { |names| names.is_a?(Array) && !names.empty? }
+    #{first_run}
 
-  regressed_benchmarks = per_payload.flatten.uniq
-  return nil unless regressed_benchmarks.all? { |name| IGNORED_REGRESSION_BENCHMARKS.include?(name) }
+    **Confirmation run** (fresh runner, re-tested against main's baseline)
 
-  regressed_benchmarks
+    #{confirmation}
+  MARKDOWN
 end
 
+# Reports the confirmed regressions. Returns:
+#   :clean  — no confirmed payloads (every first-run alert cleared as noise / ignored)
+#   :filed  — at least one confirmed regression filed/updated successfully
+#   :error  — a payload was unreadable or filing the issue failed (operational failure)
 def report_regressions(artifacts_dir)
-  paths = regression_payload_paths(artifacts_dir)
+  paths = confirmed_payload_paths(artifacts_dir)
 
   if paths.empty?
-    puts "No benchmark regressions were reported by any suite."
-    return true
+    puts "No confirmed benchmark regressions to report."
+    return :clean
   end
 
   payloads = paths.map { |path| load_payload(path) }
   readable = payloads.compact
-
-  # Skip filing when every regressed benchmark is temporarily ignored. Gated on all
-  # payloads being readable: an unreadable payload is an unknown regression that could
-  # be anything, so fall through and let the normal flow file (and then fail) rather
-  # than suppress it.
-  suppressed_benchmarks = suppressed_regressed_benchmarks(readable) if readable.size == payloads.size
-  if suppressed_benchmarks
-    # Surface as a run-summary notice (not a plain log line) so it is visible that the
-    # suppression is active and still needs removing once the baseline recovers.
-    Github.notice(
-      "Benchmark regression issue suppressed: the only regressed benchmark(s) are " \
-      "temporarily ignored (#{suppressed_benchmarks.join(', ')}). Remove " \
-      "IGNORED_REGRESSION_BENCHMARKS in report_regressions.rb once their Bencher baseline recovers."
-    )
-    return true
-  end
 
   # One section per suite: a sharded suite emits one payload per shard, so combine
   # them rather than filing a section per shard. Suites sorted for stable output.
@@ -441,7 +420,9 @@ def report_regressions(artifacts_dir)
   end.all?
 
   # Fail if any payload was unreadable: a lost report must not pass as success.
-  reported_ok && readable.size == payloads.size
+  return :error unless reported_ok && readable.size == payloads.size
+
+  :filed
 end
 
 def report_suite(suite_name, payloads, issue_number_cache: nil, report_comment_id_cache: nil)
@@ -449,9 +430,9 @@ def report_suite(suite_name, payloads, issue_number_cache: nil, report_comment_i
   # self-labels with its shard in its headers, so concatenation reads cleanly.
   summary = payloads
             .sort_by { |payload| payload.fetch(RegressionReport::SHARD_LABEL, "").split("/").first.to_i }
-            .map { |payload| payload.fetch(RegressionReport::SUMMARY) }
+            .map { |payload| shard_summary(payload) }
             .join("\n")
-  puts "Filing regression report for #{suite_name} (#{payloads.size} shard report(s))"
+  puts "Filing confirmed regression report for #{suite_name} (#{payloads.size} shard report(s))"
 
   issue_number = RegressionIssueReporter.report(
     suite_name:,
@@ -467,11 +448,21 @@ def report_suite(suite_name, payloads, issue_number_cache: nil, report_comment_i
     return false
   end
 
-  puts "Reported #{suite_name} regression to issue ##{issue_number}"
+  puts "Reported #{suite_name} confirmed regression to issue ##{issue_number}"
   true
 end
 
 if __FILE__ == $PROGRAM_NAME
-  artifacts_dir = ARGV.fetch(0, "regression-artifacts")
-  exit 1 unless report_regressions(artifacts_dir)
+  artifacts_dir = ARGV.fetch(0, "confirmed-artifacts")
+  case report_regressions(artifacts_dir)
+  when :clean
+    exit 0
+  when :filed
+    # A regression was confirmed on a fresh runner and the issue filed/updated. This
+    # job owns the final pass/fail, so fail the workflow to surface the regression.
+    warn "::error::Confirmed benchmark regression(s) on main; see the filed performance-regression issue."
+    exit 1
+  else
+    exit 1
+  end
 end

--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -364,7 +364,17 @@ def confirmed_payload_paths(artifacts_dir)
 end
 
 def load_payload(path)
-  JSON.parse(File.read(path))
+  parsed = JSON.parse(File.read(path))
+  required_keys = [
+    RegressionReport::SUITE_NAME,
+    RegressionReport::FIRST_RUN_SUMMARY,
+    RegressionReport::CONFIRMATION_SUMMARY
+  ]
+  unless parsed.is_a?(Hash) && required_keys.all? { |key| parsed.key?(key) }
+    raise "expected a JSON object with #{required_keys.join(', ')}"
+  end
+
+  parsed
 rescue StandardError => e
   # A regression was confirmed but its report is unreadable/corrupt. Surface it and
   # let the caller fail rather than silently dropping the suite from the issue.

--- a/benchmarks/spec/plan_confirmation_spec.rb
+++ b/benchmarks/spec/plan_confirmation_spec.rb
@@ -180,6 +180,17 @@ RSpec.describe "plan_confirmation" do
       end
     end
 
+    it "fails (no confirmations) when a candidate has the wrong JSON shape" do
+      Dir.mktmpdir do |dir|
+        malformed_payload = JSON.generate(%w[not a hash])
+        write_candidate(dir, artifact: "regression-candidate-core", suite: "Core", raw: malformed_payload)
+        result, outputs, _stdout = run_plan(dir, default_matrix)
+
+        expect(result).to be(false)
+        expect(outputs["has_confirmations"]).to eq("false")
+      end
+    end
+
     it "fails when a candidate matches no benchmark matrix row" do
       Dir.mktmpdir do |dir|
         write_candidate(dir, artifact: "regression-candidate-ghost", suite: "Ghost", regressed: ["/x: Ghost"])

--- a/benchmarks/spec/plan_confirmation_spec.rb
+++ b/benchmarks/spec/plan_confirmation_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../plan_confirmation"
+require "stringio"
+require "tmpdir"
+require "fileutils"
+
+# Pins the confirmation gate: which alerting suite/shard(s) get rerun on fresh runners,
+# the IGNORED_REGRESSION_BENCHMARKS short-circuit (no rerun, no issue) that used to live
+# in report_regressions.rb, and the operational-failure exits (corrupt / unmatched
+# candidate) that fail the workflow without filing.
+RSpec.describe "plan_confirmation" do
+  include BenchmarkEnvHelper
+
+  def candidate(suite, shard_label: "1/1", regressed: :unset)
+    payload = { RegressionReport::SUITE_NAME => suite, RegressionReport::SHARD_LABEL => shard_label }
+    payload[RegressionReport::REGRESSED_BENCHMARKS] = regressed unless regressed == :unset
+    payload
+  end
+
+  def matrix_row(suite, shard_label: "1/1")
+    {
+      "suite_name" => suite,
+      "shard_label" => shard_label,
+      "bencher_suite_name" => shard_label == "1/1" ? suite : "#{suite} (shard #{shard_label})",
+      "artifact_name_prefix" => "benchmark-#{suite.downcase}-results",
+      "artifact_name_suffix" => shard_label == "1/1" ? "" : "-shard-#{shard_label.tr('/', '-of-')}"
+    }
+  end
+
+  let(:ignored) { RegressionReport::IGNORED_REGRESSION_BENCHMARKS.first }
+
+  describe ".fully_ignored?" do
+    it "is true only when every named benchmark is ignored" do
+      expect(fully_ignored?([ignored])).to be(true)
+      expect(fully_ignored?([ignored, "/real: Pro"])).to be(false)
+    end
+
+    it "is false (fall through to confirm) when no benchmarks were named" do
+      expect(fully_ignored?([])).to be(false)
+      expect(fully_ignored?(nil)).to be(false)
+    end
+  end
+
+  describe ".build_plan" do
+    let(:matrix) { [matrix_row("Core"), matrix_row("Pro", shard_label: "1/2"), matrix_row("Pro", shard_label: "2/2")] }
+
+    it "selects the matrix rows for candidates with at least one non-ignored benchmark" do
+      payloads = [candidate("Core", regressed: ["/hello: Core"]),
+                  candidate("Pro", shard_label: "1/2", regressed: ["/x: Pro"])]
+      plan = build_plan(payloads, matrix)
+
+      expect(plan[:confirm_rows].map { |row| row["bencher_suite_name"] }).to contain_exactly("Core", "Pro (shard 1/2)")
+      expect(plan[:suppressed]).to be_empty
+      expect(plan[:unmatched]).to be_empty
+    end
+
+    it "drops candidates whose only regressed benchmarks are ignored" do
+      payloads = [candidate("Pro", shard_label: "1/2", regressed: [ignored])]
+      plan = build_plan(payloads, matrix)
+
+      expect(plan[:confirm_rows]).to be_empty
+      expect(plan[:suppressed]).to eq([ignored])
+    end
+
+    it "confirms a candidate that omits the regressed list (fail-safe)" do
+      plan = build_plan([candidate("Core")], matrix)
+      expect(plan[:confirm_rows].map { |row| row["suite_name"] }).to eq(["Core"])
+    end
+
+    it "records candidates that match no matrix row as unmatched" do
+      plan = build_plan([candidate("Ghost", regressed: ["/x: Ghost"])], matrix)
+      expect(plan[:confirm_rows]).to be_empty
+      expect(plan[:unmatched]).to eq([["Ghost", "1/1"]])
+    end
+  end
+
+  describe "plan_confirmation (script function)" do
+    def write_candidate(dir, artifact:, suite:, shard_label: "1/1", regressed: :unset, raw: nil)
+      artifact_dir = File.join(dir, artifact)
+      FileUtils.mkdir_p(artifact_dir)
+      path = File.join(artifact_dir, RegressionReport::CANDIDATE_FILENAME)
+      File.write(path, raw || JSON.generate(candidate(suite, shard_label:, regressed:)))
+    end
+
+    def capture_stdout
+      original = $stdout
+      $stdout = StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = original
+    end
+
+    def parse_outputs(path)
+      File.readlines(path, chomp: true).reject(&:empty?).to_h { |line| line.split("=", 2) }
+    end
+
+    # Runs the script function with a matrix and a GITHUB_OUTPUT file, returning
+    # [result_boolean, parsed_outputs_hash, captured_stdout].
+    def run_plan(dir, matrix_rows)
+      output_file = File.join(dir, "github-output")
+      File.write(output_file, "")
+      result = nil
+      stdout = nil
+      with_env(
+        "BENCHMARK_MATRIX" => JSON.generate(include: matrix_rows),
+        "GITHUB_OUTPUT" => output_file,
+        "GITHUB_SERVER_URL" => "https://github.com",
+        "GITHUB_REPOSITORY" => "shakacode/react_on_rails",
+        "GITHUB_RUN_ID" => "999"
+      ) do
+        stdout = capture_stdout { result = plan_confirmation(dir) }
+      end
+      [result, parse_outputs(output_file), stdout]
+    end
+
+    let(:default_matrix) do
+      [matrix_row("Core"), matrix_row("Pro", shard_label: "1/2"), matrix_row("Pro", shard_label: "2/2")]
+    end
+
+    it "emits no confirmations when there are no candidates" do
+      Dir.mktmpdir do |dir|
+        result, outputs, stdout = run_plan(dir, default_matrix)
+        expect(result).to be(true)
+        expect(outputs["has_confirmations"]).to eq("false")
+        expect(JSON.parse(outputs["confirmation_matrix"]).fetch("include")).to be_empty
+        expect(stdout).to match(/No benchmark regression candidates/)
+      end
+    end
+
+    it "schedules a confirmation rerun for an alerting suite" do
+      Dir.mktmpdir do |dir|
+        write_candidate(dir, artifact: "regression-candidate-core", suite: "Core", regressed: ["/hello: Core"])
+        result, outputs, _stdout = run_plan(dir, default_matrix)
+
+        expect(result).to be(true)
+        expect(outputs["has_confirmations"]).to eq("true")
+        include_rows = JSON.parse(outputs["confirmation_matrix"]).fetch("include")
+        expect(include_rows.map { |row| row["suite_name"] }).to eq(["Core"])
+      end
+    end
+
+    it "short-circuits a fully-ignored candidate with a notice and no rerun" do
+      Dir.mktmpdir do |dir|
+        write_candidate(dir, artifact: "regression-candidate-pro", suite: "Pro", shard_label: "1/2",
+                             regressed: [ignored])
+        result, outputs, stdout = run_plan(dir, default_matrix)
+
+        expect(result).to be(true)
+        expect(outputs["has_confirmations"]).to eq("false")
+        expect(stdout).to match(/Skipped confirmation for temporarily-ignored/)
+        expect(stdout).to include(ignored)
+      end
+    end
+
+    it "confirms the non-ignored suite while skipping a fully-ignored one" do
+      Dir.mktmpdir do |dir|
+        write_candidate(dir, artifact: "regression-candidate-pro", suite: "Pro", shard_label: "1/2",
+                             regressed: [ignored])
+        write_candidate(dir, artifact: "regression-candidate-core", suite: "Core", regressed: ["/hello: Core"])
+        result, outputs, stdout = run_plan(dir, default_matrix)
+
+        expect(result).to be(true)
+        expect(outputs["has_confirmations"]).to eq("true")
+        include_rows = JSON.parse(outputs["confirmation_matrix"]).fetch("include")
+        expect(include_rows.map { |row| row["suite_name"] }).to eq(["Core"])
+        expect(stdout).to match(/Skipped confirmation for temporarily-ignored/)
+      end
+    end
+
+    it "fails (no confirmations) when a candidate is corrupt" do
+      Dir.mktmpdir do |dir|
+        write_candidate(dir, artifact: "regression-candidate-core", suite: "Core", raw: "{ not valid json")
+        result, outputs, _stdout = run_plan(dir, default_matrix)
+
+        expect(result).to be(false)
+        expect(outputs["has_confirmations"]).to eq("false")
+      end
+    end
+
+    it "fails when a candidate matches no benchmark matrix row" do
+      Dir.mktmpdir do |dir|
+        write_candidate(dir, artifact: "regression-candidate-ghost", suite: "Ghost", regressed: ["/x: Ghost"])
+        result, outputs, _stdout = run_plan(dir, default_matrix)
+
+        expect(result).to be(false)
+        expect(outputs["has_confirmations"]).to eq("false")
+      end
+    end
+  end
+end

--- a/benchmarks/spec/regression_report_spec.rb
+++ b/benchmarks/spec/regression_report_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../lib/regression_report"
+
+# Pins the shared hand-off contract: how candidate alerts are matched against a
+# confirmation run's alerts (the "same benchmark+measure re-alerted" rule, with the
+# name-only fallback when a measure is absent) and the ignore-list filtering that
+# short-circuits temporarily-suppressed benchmarks before a rerun.
+RSpec.describe RegressionReport do
+  def alert(benchmark, measure)
+    described_class.alert(benchmark, measure)
+  end
+
+  describe ".normalize_measure" do
+    it "folds dashes, spaces, and case so slug and name forms compare equal" do
+      expect(described_class.normalize_measure("p50-latency")).to eq("p50_latency")
+      expect(described_class.normalize_measure("P50 Latency")).to eq("p50_latency")
+      expect(described_class.normalize_measure(nil)).to be_nil
+    end
+  end
+
+  describe ".alerts_match?" do
+    it "matches the same benchmark and measure" do
+      expect(described_class.alerts_match?(alert("/x", "rps"), alert("/x", "rps"))).to be(true)
+    end
+
+    it "treats slug and name spellings of a measure as equal" do
+      expect(described_class.alerts_match?(alert("/x", "p50-latency"), alert("/x", "p50_latency"))).to be(true)
+    end
+
+    it "does not match a different benchmark" do
+      expect(described_class.alerts_match?(alert("/x", "rps"), alert("/y", "rps"))).to be(false)
+    end
+
+    it "does not match the same benchmark on a different measure" do
+      expect(described_class.alerts_match?(alert("/x", "rps"), alert("/x", "p50_latency"))).to be(false)
+    end
+
+    it "falls back to benchmark-name-only when either measure is absent" do
+      expect(described_class.alerts_match?(alert("/x", nil), alert("/x", "rps"))).to be(true)
+      expect(described_class.alerts_match?(alert("/x", "rps"), alert("/x", nil))).to be(true)
+      expect(described_class.alerts_match?(alert("/x", nil), alert("/y", "rps"))).to be(false)
+    end
+  end
+
+  describe ".confirmed_alerts" do
+    it "returns the candidate alerts that re-alerted on the same benchmark+measure" do
+      candidate = [alert("/x", "rps"), alert("/x", "p50_latency"), alert("/y", "rps")]
+      confirmation = [alert("/x", "rps"), alert("/y", "rps"), alert("/z", "rps")]
+
+      expect(described_class.confirmed_alerts(candidate, confirmation))
+        .to contain_exactly(alert("/x", "rps"), alert("/y", "rps"))
+    end
+
+    it "is empty when nothing re-alerted (the first run was noise)" do
+      expect(described_class.confirmed_alerts([alert("/x", "rps")], [alert("/y", "rps")])).to eq([])
+      expect(described_class.confirmed_alerts([alert("/x", "rps")], [])).to eq([])
+    end
+  end
+
+  describe "the ignore-list helpers" do
+    let(:ignored) { described_class::IGNORED_REGRESSION_BENCHMARKS.first }
+
+    it "drops ignored benchmarks from alert pairs" do
+      alerts = [alert(ignored, "rps"), alert("/real: Pro", "rps")]
+      expect(described_class.actionable_alerts(alerts)).to eq([alert("/real: Pro", "rps")])
+    end
+
+    it "drops ignored benchmark names" do
+      expect(described_class.actionable_benchmarks([ignored, "/real: Pro"])).to eq(["/real: Pro"])
+      expect(described_class.actionable_benchmarks([ignored])).to eq([])
+      expect(described_class.actionable_benchmarks(nil)).to eq([])
+    end
+  end
+end

--- a/benchmarks/spec/report_regressions_spec.rb
+++ b/benchmarks/spec/report_regressions_spec.rb
@@ -452,5 +452,21 @@ RSpec.describe "benchmark regression reporting" do
         )
       end
     end
+
+    it "reports valid payloads but still fails when one payload has the wrong JSON shape" do
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core")
+        invalid = File.join(dir, "regression-confirmed-pro")
+        FileUtils.mkdir_p(invalid)
+        File.write(File.join(invalid, RegressionReport::CONFIRMED_FILENAME), JSON.generate(%w[not a hash]))
+
+        output, status = run_script(script, dir, gh_stub: fake_gh)
+        expect(status).not_to be_success
+        expect(output).to match(/Filing confirmed regression report for Core/)
+        expect(output).to match(
+          %r{::error::Failed to read confirmed regression payload .*/regression-confirmed-pro/}
+        )
+      end
+    end
   end
 end

--- a/benchmarks/spec/report_regressions_spec.rb
+++ b/benchmarks/spec/report_regressions_spec.rb
@@ -270,8 +270,10 @@ RSpec.describe "benchmark regression reporting" do
   end
 
   # These drive the script end-to-end as a subprocess with a fake `gh` on PATH (no
-  # network), pinning the artifact scan, the per-suite shard combining, and the
-  # exit status.
+  # network), pinning the confirmed-artifact scan, the per-suite shard combining, the
+  # first-run/confirmation evidence rendering, and the exit status. A confirmed
+  # regression fails the workflow (exit 1) even though the issue was filed successfully —
+  # this job owns the final pass/fail.
   describe "report_regressions.rb (script)" do
     script = File.expand_path("../report_regressions.rb", __dir__)
 
@@ -306,42 +308,49 @@ RSpec.describe "benchmark regression reporting" do
       end
     end
 
-    def write_payload(dir, artifact:, suite:, shard_label: "1/1", summary: nil, regressed: nil)
+    # Writes a CONFIRMED regression payload (the only thing report_regressions consumes
+    # now). first_run/confirmation default to recognizable strings so the side-by-side
+    # rendering can be asserted.
+    def write_payload(dir, artifact:, suite:, shard_label: "1/1", first_run: nil, confirmation: nil)
       artifact_dir = File.join(dir, artifact)
       FileUtils.mkdir_p(artifact_dir)
-      payload = { suite_name: suite, shard_label:,
-                  summary: summary || "#{suite} #{shard_label} regressed" }
-      # Omit the key entirely when regressed is nil so the "older writer" fail-safe path
-      # (payload without REGRESSED_BENCHMARKS) stays covered by the existing examples.
-      payload[RegressionReport::REGRESSED_BENCHMARKS] = regressed unless regressed.nil?
-      File.write(File.join(artifact_dir, RegressionReport::FILENAME), JSON.generate(payload))
+      payload = {
+        RegressionReport::SUITE_NAME => suite,
+        RegressionReport::SHARD_LABEL => shard_label,
+        RegressionReport::FIRST_RUN_SUMMARY => first_run || "#{suite} #{shard_label} first run",
+        RegressionReport::CONFIRMATION_SUMMARY => confirmation || "#{suite} #{shard_label} confirmation",
+        RegressionReport::REGRESSED_BENCHMARKS => ["/x: #{suite}"]
+      }
+      File.write(File.join(artifact_dir, RegressionReport::CONFIRMED_FILENAME), JSON.generate(payload))
     end
 
-    it "exits 0 and reports nothing when no payloads are present" do
+    it "exits 0 and reports nothing when no confirmed payloads are present" do
       Dir.mktmpdir do |dir|
         output, status = run_script(script, dir, gh_stub: fake_gh)
         expect(status).to be_success
-        expect(output).to match(/No benchmark regressions/)
+        expect(output).to match(/No confirmed benchmark regressions/)
       end
     end
 
-    it "files one report per suite for distinct suites (nested arbitrarily deep)" do
+    it "files one report per suite for distinct suites (nested arbitrarily deep) and fails the run" do
       Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-core", suite: "Core")
-        write_payload(dir, artifact: "regression-pro", suite: "Pro")
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core")
+        write_payload(dir, artifact: "regression-confirmed-pro", suite: "Pro")
 
         output, status = run_script(script, dir, gh_stub: fake_gh)
-        expect(status).to be_success
-        expect(output).to match(/Filing regression report for Core \(1 shard report\(s\)\)/)
-        expect(output).to match(/Filing regression report for Pro \(1 shard report\(s\)\)/)
+        # A confirmed regression fails the workflow even though filing succeeded.
+        expect(status).not_to be_success
+        expect(output).to match(/Filing confirmed regression report for Core \(1 shard report\(s\)\)/)
+        expect(output).to match(/Filing confirmed regression report for Pro \(1 shard report\(s\)\)/)
         expect(output).to match(/issue #7/)
+        expect(output).to match(/Confirmed benchmark regression/)
       end
     end
 
     it "creates only one issue for multiple suites even when live issue lookup stays empty" do
       Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-core", suite: "Core")
-        write_payload(dir, artifact: "regression-pro", suite: "Pro")
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core")
+        write_payload(dir, artifact: "regression-confirmed-pro", suite: "Pro")
 
         call_log = File.join(dir, "gh-calls.log")
         counting_gh = <<~BASH
@@ -355,19 +364,42 @@ RSpec.describe "benchmark regression reporting" do
           exit 0
         BASH
 
-        output, status = run_script(script, dir, gh_stub: counting_gh, extra_env: { "GH_CALL_LOG" => call_log })
+        output, _status = run_script(script, dir, gh_stub: counting_gh, extra_env: { "GH_CALL_LOG" => call_log })
 
-        expect(status).to be_success
         expect(output).to match(/issue #7/)
         expect(File.readlines(call_log).count { |line| line.start_with?("issue create") }).to eq(1)
         expect(File.readlines(call_log).count { |line| line.start_with?("api -X POST") }).to eq(1)
       end
     end
 
+    it "renders the first-run and confirmation summaries side by side" do
+      Dir.mktmpdir do |dir|
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core",
+                           first_run: "FIRST RUN TABLE", confirmation: "CONFIRMATION TABLE")
+
+        posted = File.join(dir, "posted-body.txt")
+        capturing_gh = <<~BASH
+          #!/usr/bin/env bash
+          if [ "$1" = "issue" ] && [ "$2" = "create" ]; then
+            echo "https://github.com/shakacode/react_on_rails/issues/7"
+          elif [ "$1" = "api" ] && [ "$2" = "-X" ] && [ "$3" = "POST" ]; then
+            cat > "$POSTED_BODY"
+            echo "777"
+          fi
+          exit 0
+        BASH
+
+        run_script(script, dir, gh_stub: capturing_gh, extra_env: { "POSTED_BODY" => posted })
+        body = JSON.parse(File.read(posted)).fetch("body")
+        expect(body).to include("First run").and include("FIRST RUN TABLE")
+        expect(body).to include("Confirmation run").and include("CONFIRMATION TABLE")
+      end
+    end
+
     it "shares one issue-number cache across suite reports in the same run" do
       Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-core", suite: "Core")
-        write_payload(dir, artifact: "regression-pro", suite: "Pro")
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core")
+        write_payload(dir, artifact: "regression-confirmed-pro", suite: "Pro")
 
         caches = []
         allow(Github).to receive(:run_url).and_return("https://github.com/run/1")
@@ -377,7 +409,7 @@ RSpec.describe "benchmark regression reporting" do
           "7"
         end
 
-        expect(report_regressions(dir)).to be(true)
+        expect(report_regressions(dir)).to eq(:filed)
         expect(caches.size).to eq(2)
         expect(caches[0]).to equal(caches[1])
       end
@@ -385,99 +417,39 @@ RSpec.describe "benchmark regression reporting" do
 
     it "combines a sharded suite's payloads into a single report" do
       Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-pro-shard-1", suite: "Pro", shard_label: "1/2")
-        write_payload(dir, artifact: "regression-pro-shard-2", suite: "Pro", shard_label: "2/2")
+        write_payload(dir, artifact: "regression-confirmed-pro-shard-1", suite: "Pro", shard_label: "1/2")
+        write_payload(dir, artifact: "regression-confirmed-pro-shard-2", suite: "Pro", shard_label: "2/2")
 
         output, status = run_script(script, dir, gh_stub: fake_gh)
-        expect(status).to be_success
-        expect(output).to match(/Filing regression report for Pro \(2 shard report\(s\)\)/)
-        expect(output.scan("Filing regression report for Pro").size).to eq(1)
+        expect(status).not_to be_success
+        expect(output).to match(/Filing confirmed regression report for Pro \(2 shard report\(s\)\)/)
+        expect(output.scan("Filing confirmed regression report for Pro").size).to eq(1)
       end
     end
 
     it "exits non-zero when filing an issue fails" do
       failing_gh = "#!/usr/bin/env bash\nexit 1\n"
       Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-core", suite: "Core")
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core")
         output, status = run_script(script, dir, gh_stub: failing_gh)
         expect(status).not_to be_success
         expect(output).to match(/Failed to file regression issue for Core/)
       end
     end
 
-    # The temporary /posts_page: Pro suppression (IGNORED_REGRESSION_BENCHMARKS). These
-    # examples (and the constant) should be deleted when that suppression is lifted.
-    it "suppresses the issue when every regressed benchmark is ignored" do
-      ignored = IGNORED_REGRESSION_BENCHMARKS.first
-      Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-pro", suite: "Pro", regressed: [ignored])
-        output, status = run_script(script, dir, gh_stub: fake_gh)
-        expect(status).to be_success
-        expect(output).to match(/temporarily ignored/)
-        expect(output).not_to match(/Filing regression report/)
-      end
-    end
-
-    it "reports only the ignored benchmarks that actually regressed in the suppression notice" do
-      ignored = IGNORED_REGRESSION_BENCHMARKS.first
-      unused_ignored = "/unused_route: Pro"
-      stub_const("IGNORED_REGRESSION_BENCHMARKS", [ignored, unused_ignored].freeze)
-
-      Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-pro", suite: "Pro", regressed: [ignored])
-        expect do
-          expect(report_regressions(dir)).to be(true)
-        end.to output(
-          satisfy do |text|
-            text.include?("temporarily ignored (#{ignored})") && !text.include?(unused_ignored)
-          end
-        ).to_stdout
-      end
-    end
-
-    it "still files when a non-ignored benchmark also regressed alongside an ignored one" do
-      ignored = IGNORED_REGRESSION_BENCHMARKS.first
-      Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-pro", suite: "Pro",
-                           regressed: [ignored, "/some_other_route: Pro"])
-        output, status = run_script(script, dir, gh_stub: fake_gh)
-        expect(status).to be_success
-        expect(output).to match(/Filing regression report for Pro/)
-      end
-    end
-
-    it "still files when another suite regressed even if this suite's regression is ignored" do
-      ignored = IGNORED_REGRESSION_BENCHMARKS.first
-      Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-pro", suite: "Pro", regressed: [ignored])
-        write_payload(dir, artifact: "regression-core", suite: "Core", regressed: ["/hello: Core"])
-        output, status = run_script(script, dir, gh_stub: fake_gh)
-        expect(status).to be_success
-        expect(output).to match(/Filing regression report for Core/)
-        expect(output).to match(/Filing regression report for Pro/)
-      end
-    end
-
-    it "files normally when a payload omits the regressed-benchmarks list (fail-safe)" do
-      Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-pro", suite: "Pro") # no regressed key
-        output, status = run_script(script, dir, gh_stub: fake_gh)
-        expect(status).to be_success
-        expect(output).to match(/Filing regression report for Pro/)
-      end
-    end
-
     it "reports valid payloads but still fails when one payload is corrupt" do
       Dir.mktmpdir do |dir|
-        write_payload(dir, artifact: "regression-core", suite: "Core")
-        corrupt = File.join(dir, "regression-pro")
+        write_payload(dir, artifact: "regression-confirmed-core", suite: "Core")
+        corrupt = File.join(dir, "regression-confirmed-pro")
         FileUtils.mkdir_p(corrupt)
-        File.write(File.join(corrupt, RegressionReport::FILENAME), "{ not valid json")
+        File.write(File.join(corrupt, RegressionReport::CONFIRMED_FILENAME), "{ not valid json")
 
         output, status = run_script(script, dir, gh_stub: fake_gh)
         expect(status).not_to be_success
-        expect(output).to match(/Filing regression report for Core/)
-        expect(output).to match(%r{::error::Failed to read regression payload .*/regression-pro/regression\.json})
+        expect(output).to match(/Filing confirmed regression report for Core/)
+        expect(output).to match(
+          %r{::error::Failed to read confirmed regression payload .*/regression-confirmed-pro/}
+        )
       end
     end
   end

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -103,6 +103,109 @@ RSpec.describe "track_benchmarks" do
     end
   end
 
+  # Confirmation mode (BENCHMARK_MODE=confirm): a fresh-runner rerun of a main-push
+  # candidate. These pin the synthetic-branch/reset-baseline targeting, the structured
+  # alert pairs handed off to the confirmation, and the confirmed/cleared/inconclusive
+  # classification that decides whether an issue is filed.
+  describe "confirmation mode" do
+    around do |example|
+      snapshot = ENV.to_h
+      example.run
+    ensure
+      ENV.replace(snapshot)
+    end
+
+    describe "#slugify / #confirmation_branch" do
+      it "builds a branch-safe, never-main name unique per run and suite/shard" do
+        expect(slugify("Pro (shard 1/2)")).to eq("pro-shard-1-2")
+        expect(confirmation_branch("12345", "Pro (shard 1/2)")).to eq("confirm-main-12345-pro-shard-1-2")
+      end
+    end
+
+    describe "#branch_and_start_point_args" do
+      it "targets a throwaway branch and re-tests against main without polluting its series" do
+        ENV["BENCHMARK_MODE"] = "confirm"
+        ENV["GITHUB_RUN_ID"] = "777"
+        ENV["BENCHMARK_SUITE_NAME"] = "Core"
+
+        branch, start_point_args = branch_and_start_point_args
+        expect(branch).to eq("confirm-main-777-core")
+        expect(branch).not_to eq("main")
+        expect(start_point_args).to eq(
+          %w[--start-point main --start-point-clone-thresholds --start-point-reset]
+        )
+      end
+    end
+
+    describe "#regressed_alert_pairs" do
+      it "returns deduped benchmark+measure pairs from active alerts, dropping nameless ones" do
+        report = BencherReport.parse(
+          JSON.generate(
+            "results" => [],
+            "alerts" => [
+              { "benchmark" => { "name" => "/x: Pro" },
+                "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" },
+              { "benchmark" => { "name" => "/x: Pro" },
+                "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" },
+              { "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }
+            ]
+          )
+        )
+        expect(regressed_alert_pairs(report)).to eq([{ "benchmark" => "/x: Pro", "measure" => "rps" }])
+      end
+    end
+
+    describe "#confirmation_outcome" do
+      def pair(benchmark, measure)
+        { "benchmark" => benchmark, "measure" => measure }
+      end
+
+      it "is inconclusive when there is no parseable report" do
+        expect(confirmation_outcome(nil, 1, [pair("/x: Pro", "rps")])).to eq([:inconclusive, []])
+      end
+
+      it "is inconclusive on a non-zero exit with no alert (operational failure)" do
+        expect(confirmation_outcome(report_without_alert, 1, [pair("/x: Pro", "rps")])).to eq([:inconclusive, []])
+      end
+
+      it "is confirmed when the same benchmark+measure re-alerts" do
+        report = BencherReport.parse(
+          JSON.generate(
+            "results" => [],
+            "alerts" => [{ "benchmark" => { "name" => "/x: Pro" },
+                           "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }]
+          )
+        )
+        status, confirmed = confirmation_outcome(report, 1, [pair("/x: Pro", "rps")])
+        expect(status).to eq(:confirmed)
+        expect(confirmed).to eq([pair("/x: Pro", "rps")])
+      end
+
+      it "is cleared when a different benchmark/measure alerts than the candidate's" do
+        report = BencherReport.parse(
+          JSON.generate(
+            "results" => [],
+            "alerts" => [{ "benchmark" => { "name" => "/y: Pro" },
+                           "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }]
+          )
+        )
+        expect(confirmation_outcome(report, 1, [pair("/x: Pro", "rps")])).to eq([:cleared, []])
+      end
+
+      it "ignores a candidate alert on a temporarily-ignored benchmark" do
+        ignored = RegressionReport::IGNORED_REGRESSION_BENCHMARKS.first
+        report = BencherReport.parse(
+          JSON.generate(
+            "results" => [],
+            "alerts" => [{ "benchmark" => { "name" => ignored },
+                           "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }]
+          )
+        )
+        expect(confirmation_outcome(report, 1, [pair(ignored, "rps")])).to eq([:cleared, []])
+      end
+    end
+  end
+
   describe "#run_bencher" do
     it "emits the perf-link context warning to stdout so GitHub Actions annotates it" do
       status = instance_double(Process::Status, exitstatus: 0)

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "optparse"
+require "fileutils"
+require "tmpdir"
 require_relative "spec_helper"
 require_relative "../track_benchmarks"
 require_relative "../lib/bmf_helpers"
@@ -152,6 +154,50 @@ RSpec.describe "track_benchmarks" do
           )
         )
         expect(regressed_alert_pairs(report)).to eq([{ "benchmark" => "/x: Pro", "measure" => "rps" }])
+      end
+    end
+
+    describe "#load_candidate" do
+      def write_candidate(dir, payload)
+        artifact_dir = File.join(dir, "candidate")
+        FileUtils.mkdir_p(artifact_dir)
+        File.write(
+          File.join(artifact_dir, RegressionReport::CANDIDATE_FILENAME),
+          JSON.generate(payload)
+        )
+      end
+
+      it "returns alerts and summary for a valid candidate" do
+        Dir.mktmpdir do |dir|
+          alerts = [{ "benchmark" => "/x: Pro", "measure" => "rps" }]
+          write_candidate(dir, RegressionReport::ALERTS => alerts, RegressionReport::SUMMARY => "first run")
+
+          expect(load_candidate(dir)).to eq([alerts, "first run"])
+        end
+      end
+
+      it "treats missing alerts as inconclusive" do
+        Dir.mktmpdir do |dir|
+          write_candidate(dir, RegressionReport::SUMMARY => "first run")
+
+          expect(load_candidate(dir)).to eq([nil, "first run"])
+        end
+      end
+
+      it "treats non-array alerts as inconclusive" do
+        Dir.mktmpdir do |dir|
+          write_candidate(dir, RegressionReport::ALERTS => "not an array", RegressionReport::SUMMARY => "first run")
+
+          expect(load_candidate(dir)).to eq([nil, "first run"])
+        end
+      end
+
+      it "treats empty alerts as inconclusive" do
+        Dir.mktmpdir do |dir|
+          write_candidate(dir, RegressionReport::ALERTS => [], RegressionReport::SUMMARY => "first run")
+
+          expect(load_candidate(dir)).to eq([nil, "first run"])
+        end
       end
     end
 

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -47,9 +47,51 @@ REPORT_JSON = ENV.fetch("BENCHER_REPORT_JSON", "bench_results/bencher_report.jso
 # NOTE: benchmark_config.rb independently defines DISPLAY_JSON with the same default
 # path; the bench scripts and this tracker run as separate programs, so keep them in sync.
 DISPLAY_JSON = ENV.fetch("BENCHMARK_DISPLAY_JSON", "bench_results/benchmark_display.json")
-REGRESSION_REPORT_JSON = File.join("bench_results", RegressionReport::FILENAME)
+# Initial-run hand-off: a non-fatal candidate written when Bencher alerts on main.
+CANDIDATE_REPORT_JSON = File.join("bench_results", RegressionReport::CANDIDATE_FILENAME)
+# Confirmation-run hand-off: written only when the candidate's alert(s) re-alert.
+CONFIRMED_REPORT_JSON = File.join("bench_results", RegressionReport::CONFIRMED_FILENAME)
+# Directory the first-run candidate artifact was downloaded into (confirmation mode).
+# Read via a recursive glob, not a fixed path, so it works regardless of how
+# upload/download-artifact nests the single file under the download path.
+CANDIDATE_INPUT_DIR = ENV.fetch("BENCHMARK_CANDIDATE_DIR", "candidate")
+
+# A confirmation rerun (BENCHMARK_MODE=confirm) re-tests a main-push regression candidate
+# on a fresh runner before the issue is filed. It must NOT pollute main's Bencher series,
+# so it submits to a throwaway per-run branch and re-tests against main's cloned baseline.
+def confirmation_mode?
+  ENV.fetch("BENCHMARK_MODE", "initial") == "confirm"
+end
+
+# Bencher branch-safe slug: lowercase, runs of non-alphanumerics collapsed to a single
+# dash, no leading/trailing dash. "Pro (shard 1/2)" -> "pro-shard-1-2".
+def slugify(value)
+  value.to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+end
+
+# A unique synthetic Bencher branch for the confirmation rerun, e.g.
+# "confirm-main-123456-pro-shard-1-2". Unique per run AND suite/shard so concurrent
+# confirmation reruns never share a series, and never "main" so the confirmation sample
+# is not appended to main's history.
+def confirmation_branch(run_id, suite_name)
+  "confirm-main-#{run_id}-#{slugify(suite_name)}"
+end
+
+# Re-test against main's baseline without writing into main's series: clone main's
+# thresholds onto the throwaway branch and reset it to a fresh copy of main's head each
+# run. This is the same anchoring the PR path uses (branch_and_start_point_args).
+def confirmation_start_point_args
+  ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
+end
 
 def branch_and_start_point_args
+  if confirmation_mode?
+    return [
+      confirmation_branch(ENV.fetch("GITHUB_RUN_ID"), ENV.fetch("BENCHMARK_SUITE_NAME")),
+      confirmation_start_point_args
+    ]
+  end
+
   case ENV.fetch("GITHUB_EVENT_NAME")
   when "push"
     ["main", []]
@@ -290,6 +332,70 @@ def regressed_benchmark_names(report)
   report.alerts.filter_map(&:benchmark).uniq
 end
 
+# The structured benchmark+measure pairs Bencher raised an active alert for, deduped.
+# Read from the same alerts[] as #regression?/#regressed_benchmark_names. Handed off in
+# the candidate so a confirmation rerun can require the SAME pair to re-alert (not just
+# any alert in the suite). An alert with no benchmark name is dropped — it can't be
+# matched. measure may be nil; the matcher falls back to name-only for those.
+def regressed_alert_pairs(report)
+  return [] unless report
+
+  report.alerts
+        .select(&:benchmark)
+        .map { |alert| RegressionReport.alert(alert.benchmark, alert.measure) }
+        .uniq
+end
+
+# Read the downloaded first-run candidate (found by recursive glob under dir): its
+# structured alerts and rendered summary. Returns [nil, ""] when the payload is
+# missing/corrupt so the caller can treat the confirmation as inconclusive (an
+# operational failure) rather than silently clearing it.
+def load_candidate(dir)
+  path = Dir.glob(File.join(dir, "**", RegressionReport::CANDIDATE_FILENAME)).first
+  unless path
+    warn "::error::No confirmation candidate (#{RegressionReport::CANDIDATE_FILENAME}) found under " \
+         "#{dir}; treating the confirmation as inconclusive."
+    return [nil, ""]
+  end
+
+  parsed = JSON.parse(File.read(path))
+  alerts = parsed[RegressionReport::ALERTS]
+  alerts = [] unless alerts.is_a?(Array)
+  [alerts, parsed[RegressionReport::SUMMARY].to_s]
+rescue StandardError => e
+  warn "::error::Could not read confirmation candidate #{path} (#{e.class}: #{e.message}); " \
+       "treating the confirmation as inconclusive."
+  [nil, ""]
+end
+
+# Classify a confirmation rerun. Pure so it is unit-testable.
+#   :inconclusive — no parseable report, or a non-zero exit with no alert (operational
+#                   failure: auth/API/network/CLI). Must fail the workflow, file nothing.
+#   :cleared      — the report parsed but none of the candidate's (non-ignored) alerts
+#                   re-alerted. The first run was noise.
+#   :confirmed    — the same benchmark+measure pair(s) re-alerted; returns just those.
+# Ignored benchmarks are dropped from the candidate side first so a confirmation can
+# never be carried by a benchmark we would suppress anyway.
+def confirmation_outcome(report, bencher_exit_code, candidate_alerts)
+  return [:inconclusive, []] if report.nil?
+  return [:inconclusive, []] if bencher_exit_code != 0 && !regression?(report)
+
+  confirmed = RegressionReport.confirmed_alerts(
+    RegressionReport.actionable_alerts(candidate_alerts),
+    regressed_alert_pairs(report)
+  )
+  return [:cleared, []] if confirmed.empty?
+
+  [:confirmed, confirmed]
+end
+
+# Human-readable "benchmark (measure)" for the workflow summary / logs.
+def describe_alert(alert)
+  benchmark = alert[RegressionReport::ALERT_BENCHMARK]
+  measure = alert[RegressionReport::ALERT_MEASURE]
+  measure ? "#{benchmark} (#{measure})" : benchmark
+end
+
 # A missing start-point baseline (operational, not a regression): retrying without
 # the start-point hash falls back to the latest baseline. The no-regression guard is
 # load-bearing — a real regression must not be silently re-run against a different
@@ -302,6 +408,130 @@ end
 
 def main_push?
   ENV.fetch("GITHUB_EVENT_NAME") == "push" && ENV.fetch("GITHUB_REF") == "refs/heads/main"
+end
+
+# A main-push Bencher alert is now a NON-FATAL candidate: the gate/confirmation jobs
+# rerun the alerting suite/shard on a fresh runner and only file the issue if the SAME
+# benchmark+measure re-alerts, so write the candidate hand-off and exit 0 — the
+# report-regressions job owns the final pass/fail. (A lost hand-off is the one case we
+# still fail the suite, rather than silently drop the regression.) A non-zero exit with
+# NO alert is an operational failure, not a regression, and still fails the suite.
+def report_main_push_candidate(report, report_markdown, bencher_exit_code, suite_name)
+  if regression?(report)
+    exit 1 unless write_candidate(report, report_markdown, suite_name)
+  else
+    warn "::error::Bencher exited #{bencher_exit_code} on main with no regression alert for " \
+         "#{suite_name}; this indicates an operational failure (auth/API/network/CLI), not a " \
+         "performance regression. Check the logs above."
+    exit bencher_exit_code
+  end
+end
+
+# Write the non-fatal first-run candidate for the gate/confirmation jobs. Records the
+# structured alert pairs so the confirmation rerun can require the SAME pair(s) to
+# re-alert, plus the un-sharded suite name (so a suite's shards combine downstream) and
+# the rendered summary. Returns true on success; false means the hand-off was lost, so
+# the caller fails the suite rather than silently dropping the regression.
+def write_candidate(report, report_markdown, suite_name)
+  File.write(
+    CANDIDATE_REPORT_JSON,
+    JSON.generate(
+      RegressionReport::SUITE_NAME => ENV.fetch("BENCHMARK_SUITE_GROUP", suite_name),
+      RegressionReport::SHARD_LABEL => ENV.fetch("BENCHMARK_SHARD_LABEL", ""),
+      RegressionReport::SUMMARY => regression_handoff_summary(report_markdown),
+      RegressionReport::REGRESSED_BENCHMARKS => regressed_benchmark_names(report),
+      RegressionReport::ALERTS => regressed_alert_pairs(report)
+    )
+  )
+  Github.notice(
+    "Bencher flagged a #{suite_name} regression CANDIDATE on main. It is non-fatal until a " \
+    "fresh-runner confirmation rerun re-alerts on the same benchmark+measure. " \
+    "See the Bencher dashboard and the workflow run: #{Github.run_url}"
+  )
+  true
+rescue StandardError => e
+  warn "::error::Bencher flagged a #{suite_name} regression candidate on main but its payload " \
+       "could not be written (#{e.class}: #{e.message}); confirmation cannot run and the issue will " \
+       "NOT be auto-filed — investigate using GitHub run logs: #{Github.run_url}"
+  false
+end
+
+# Write the confirmed hand-off for report-regressions: the first run and confirmation
+# summaries side by side (the comparison is the evidence) and the confirmed alert pairs.
+def write_confirmed(confirmed_alerts, first_run_summary, confirmation_markdown, suite_name)
+  File.write(
+    CONFIRMED_REPORT_JSON,
+    JSON.generate(
+      RegressionReport::SUITE_NAME => ENV.fetch("BENCHMARK_SUITE_GROUP", suite_name),
+      RegressionReport::SHARD_LABEL => ENV.fetch("BENCHMARK_SHARD_LABEL", ""),
+      RegressionReport::FIRST_RUN_SUMMARY => first_run_summary,
+      RegressionReport::CONFIRMATION_SUMMARY => regression_handoff_summary(confirmation_markdown),
+      RegressionReport::ALERTS => confirmed_alerts,
+      RegressionReport::REGRESSED_BENCHMARKS =>
+        confirmed_alerts.filter_map { |alert| alert[RegressionReport::ALERT_BENCHMARK] }.uniq
+    )
+  )
+  true
+rescue StandardError => e
+  warn "::error::A #{suite_name} regression was confirmed on a fresh runner but its payload " \
+       "could not be written (#{e.class}: #{e.message}); the issue will NOT be auto-filed — " \
+       "investigate using GitHub run logs: #{Github.run_url}"
+  false
+end
+
+# State the confirmation outcome in the workflow run summary (acceptance criterion:
+# every first-run alert is visibly confirmed, cleared as noise, or inconclusive).
+def append_confirmation_summary(status, confirmed_alerts, suite_name)
+  body =
+    case status
+    when :confirmed
+      lines = confirmed_alerts.map { |alert| "- #{describe_alert(alert)}" }.join("\n")
+      "## #{suite_name} confirmation: ✅ CONFIRMED\n\n" \
+        "These first-run alerts re-alerted on a fresh runner (re-tested against main's " \
+        "baseline) and will be reported:\n\n#{lines}\n\n"
+    when :cleared
+      "## #{suite_name} confirmation: 🟢 CLEARED (noise)\n\n" \
+      "The first-run alert(s) did not re-alert on a fresh runner. No issue will be filed.\n\n"
+    else
+      "## #{suite_name} confirmation: ⚠️ INCONCLUSIVE\n\n" \
+      "The confirmation rerun could not be evaluated (benchmark execution or Bencher " \
+      "reporting failed). Treated as an operational failure; no issue will be filed.\n\n"
+    end
+  append_step_summary(body)
+end
+
+# The confirmation rerun (BENCHMARK_MODE=confirm). Owns its own exit code:
+#   confirmed   -> write the confirmed hand-off, exit 0 (report-regressions fails the run)
+#   cleared     -> exit 0 (the first-run alert was noise)
+#   inconclusive-> exit 1 (operational failure: fail the workflow, file nothing)
+def run_confirmation(report, bencher_exit_code, confirmation_markdown, suite_name)
+  candidate_alerts, first_run_summary = load_candidate(CANDIDATE_INPUT_DIR)
+  # A missing/corrupt candidate is an operational failure, not a cleared alert.
+  return finish_confirmation(:inconclusive, [], suite_name) if candidate_alerts.nil?
+
+  status, confirmed_alerts = confirmation_outcome(report, bencher_exit_code, candidate_alerts)
+  if status == :confirmed && !write_confirmed(confirmed_alerts, first_run_summary, confirmation_markdown, suite_name)
+    # The regression confirmed but its hand-off was lost: fail rather than drop it.
+    return finish_confirmation(:inconclusive, [], suite_name)
+  end
+
+  finish_confirmation(status, confirmed_alerts, suite_name)
+end
+
+def finish_confirmation(status, confirmed_alerts, suite_name)
+  append_confirmation_summary(status, confirmed_alerts, suite_name)
+  case status
+  when :confirmed
+    Github.notice("Confirmed #{confirmed_alerts.size} #{suite_name} regression alert(s) on a fresh runner.")
+    exit 0
+  when :cleared
+    Github.notice("Cleared #{suite_name} first-run alert(s) as noise; no re-alert on the fresh runner.")
+    exit 0
+  else
+    warn "::error::#{suite_name} confirmation rerun was inconclusive (operational failure); " \
+         "failing the workflow without filing an issue. Investigate: #{Github.run_url}"
+    exit 1
+  end
 end
 
 # Only run the benchmark tracking when invoked as a script; `require`-ing the file
@@ -334,66 +564,39 @@ if __FILE__ == $PROGRAM_NAME
   end
 
   # Build the Markdown summary table once; the same body feeds the job summary, the
-  # PR comment, and (on a main regression) the report-regressions hand-off.
+  # PR comment, and the candidate/confirmation hand-offs.
   report_markdown = rendered_report(report, SUITE_NAME)
   post_report_to_summary(report_markdown)
-  pr_event = ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
-  if report.nil? && pr_event
-    # A nil report means Bencher produced no parseable output (operational failure). On
-    # a PR, replacing the comment now would delete the previous run's real report and
-    # make an auth/API/network failure look like a normal un-highlighted summary, while
-    # the job still exits 0. Keep the prior comment intact and surface the failure
-    # instead. (post_report_to_summary above is per-run and clobbers nothing.)
-    Github.warning(
-      "Bencher produced no report for #{SUITE_NAME} (operational failure); " \
-      "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
-    )
-  elsif pr_event && regression?(report) && report_markdown.empty?
-    # A real regression but no table to render (display sidecar missing/empty). Don't
-    # leave the stale PR comment looking unchanged — post the run-URL fallback (which
-    # also emits ::error::) so the regression is visible in the PR thread, mirroring the
-    # main-push report-regressions hand-off.
-    replace_pr_comments(regression_handoff_summary(report_markdown))
-  else
-    replace_pr_comments(report_markdown)
-  end
 
-  if main_push? && bencher_exit_code != 0
-    if regression?(report)
-      # Record the regression for the post-matrix report-regressions job rather than
-      # filing the issue here: parallel matrix suites would otherwise race to create
-      # duplicate issues and clobber each other's sections in the shared comment.
-      # Use the un-sharded suite name so that job can combine a suite's shards into a
-      # single section (shard_label keeps their ordering deterministic).
-      handoff_summary = regression_handoff_summary(report_markdown)
-      begin
-        File.write(
-          REGRESSION_REPORT_JSON,
-          JSON.generate(
-            RegressionReport::SUITE_NAME => ENV.fetch("BENCHMARK_SUITE_GROUP", SUITE_NAME),
-            RegressionReport::SHARD_LABEL => ENV.fetch("BENCHMARK_SHARD_LABEL", ""),
-            RegressionReport::SUMMARY => handoff_summary,
-            RegressionReport::REGRESSED_BENCHMARKS => regressed_benchmark_names(report)
-          )
-        )
-        Github.warning(
-          "Bencher flagged a #{SUITE_NAME} regression on main (exit #{bencher_exit_code}). " \
-          "The report-regressions job will file the issue. " \
-          "See the Bencher dashboard and the workflow run: #{Github.run_url}"
-        )
-      rescue StandardError => e # rubocop:disable Metrics/BlockNesting
-        # The suite still fails (exit 1 below), so the regression is surfaced; but the
-        # hand-off payload is gone, so report-regressions can't auto-file the issue.
-        warn "::error::Bencher flagged a #{SUITE_NAME} regression on main but its report payload " \
-             "could not be written (#{e.class}: #{e.message}); the issue will NOT be auto-filed — " \
-             "investigate using GitHub run logs: #{Github.run_url}"
-      end
-      exit 1
+  if confirmation_mode?
+    # Fresh-runner rerun of a main-push candidate. Owns its own exit code (confirmed /
+    # cleared / inconclusive) and never posts PR comments.
+    run_confirmation(report, bencher_exit_code, report_markdown, SUITE_NAME)
+  else
+    pr_event = ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+    if report.nil? && pr_event
+      # A nil report means Bencher produced no parseable output (operational failure). On
+      # a PR, replacing the comment now would delete the previous run's real report and
+      # make an auth/API/network failure look like a normal un-highlighted summary, while
+      # the job still exits 0. Keep the prior comment intact and surface the failure
+      # instead. (post_report_to_summary above is per-run and clobbers nothing.)
+      Github.warning(
+        "Bencher produced no report for #{SUITE_NAME} (operational failure); " \
+        "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
+      )
+    elsif pr_event && regression?(report) && report_markdown.empty?
+      # A real regression but no table to render (display sidecar missing/empty). Don't
+      # leave the stale PR comment looking unchanged — post the run-URL fallback (which
+      # also emits ::error::) so the regression is visible in the PR thread, mirroring the
+      # main-push candidate hand-off.
+      replace_pr_comments(regression_handoff_summary(report_markdown))
     else
-      warn "::error::Bencher exited #{bencher_exit_code} on main with no regression alert for #{SUITE_NAME}; " \
-           "this indicates an operational failure (auth/API/network/CLI), not a performance regression. " \
-           "Check the logs above."
-      exit bencher_exit_code
+      replace_pr_comments(report_markdown)
+    end
+
+    if main_push? && bencher_exit_code != 0
+      report_main_push_candidate(report, report_markdown, bencher_exit_code,
+                                 SUITE_NAME)
     end
   end
 end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -359,8 +359,19 @@ def load_candidate(dir)
   end
 
   parsed = JSON.parse(File.read(path))
+  unless parsed.is_a?(Hash)
+    warn "::error::Confirmation candidate #{path} is not a JSON object (got #{parsed.class}); " \
+         "treating the confirmation as inconclusive."
+    return [nil, ""]
+  end
+
   alerts = parsed[RegressionReport::ALERTS]
-  alerts = [] unless alerts.is_a?(Array)
+  unless alerts.is_a?(Array) && !alerts.empty?
+    warn "::error::Confirmation candidate #{path} has empty or missing " \
+         "#{RegressionReport::ALERTS}; treating the confirmation as inconclusive."
+    return [nil, parsed[RegressionReport::SUMMARY].to_s]
+  end
+
   [alerts, parsed[RegressionReport::SUMMARY].to_s]
 rescue StandardError => e
   warn "::error::Could not read confirmation candidate #{path} (#{e.class}: #{e.message}); " \


### PR DESCRIPTION
## Summary

Fixes #3670. A single noisy Bencher alert on `main` could previously create/update a `performance-regression` issue. This adds a **fresh-runner confirmation step** between the initial benchmark run and the `main` issue: a main-push alert is now a non-fatal *candidate* that must re-alert on an independent rerun before any issue is filed. Requiring a second, independent alert turns the per-commit false-positive rate from ~p into ~p² for runner noise.

Scope is exactly as the issue specifies: **only `main` issue creation is gated**. PR summary comments still post unconditionally (initial mode, unchanged).

## Pipeline (`benchmark.yml`)

```
benchmark (initial)   on a main alert -> write a NON-FATAL candidate artifact
                      (regression-candidate-*); the suite stays GREEN
        │
plan-confirmation     read candidates; short-circuit IGNORED_REGRESSION_BENCHMARKS
                      BEFORE spending a rerun; emit a matrix of just the alerting suite/shard(s)
        │
confirm-regressions   rerun those on fresh runners against main's baseline WITHOUT polluting
                      main's series; write a confirmed artifact only if the SAME
                      benchmark+measure re-alerts
        │
report-regressions    consume confirmed artifacts; file one issue with the first-run and
                      confirmation summaries side by side; fail the workflow (it owns pass/fail)
```

The per-suite execution is extracted into a **reusable workflow** (`benchmark-suite.yml`, modes `initial`/`confirm`) so the initial run and the confirmation rerun share one set of steps with no drift.

## Behavior

| Situation | Workflow result | Issue filed? |
|---|---|---|
| Alert does not reproduce (noise) | 🟢 green | no |
| Same benchmark+measure re-alerts | 🔴 red | yes (first-run + confirmation evidence) |
| Inconclusive rerun (bench/Bencher failure, corrupt/unmatched candidate) | 🔴 red | no |
| Every alert is in `IGNORED_REGRESSION_BENCHMARKS` | 🟢 green (notice) | no |

The workflow summary states **confirmed / cleared-as-noise / inconclusive** per alert.

## Key implementation notes

- **Don't pollute the baseline:** the confirmation submits to a unique synthetic Bencher branch `confirm-main-<run_id>-<suite-slug>` (never `main`) with `--start-point main --start-point-clone-thresholds --start-point-reset`, so the confirmation sample is compared against main's baseline but never appended to main's series — exactly the anchoring the PR path already uses.
- **Same benchmark+measure matching** uses the structured alert pairs now carried in the candidate payload (`BencherReport::Alert` already exposes the measure slug). Falls back to benchmark-name-only when a measure is absent, as the issue permits.
- **Exit-code contract change:** the first-run alert no longer fails the suite job; `report-regressions` owns the final pass/fail. A confirmed regression fails the workflow there.
- `IGNORED_REGRESSION_BENCHMARKS` (#3668) moved to the shared `benchmarks/lib/regression_report.rb` and is now applied in `plan-confirmation`, short-circuiting a rerun for benchmarks that would be suppressed anyway.
- Candidate vs confirmed artifacts/payloads are kept distinct (`regression-candidate-*` / `regression-confirmed-*`).

## Out of scope (sequenced follow-up, per #3670)

Loosening the `THRESHOLDS` to buy back the statistical power that double-gating costs is intentionally a separate, **empirical** follow-up: it requires measuring the post-confirmation false-positive and missed-regression rates on real `main` data, so it cannot be tuned blindly here.

### Known tradeoff (acknowledged in the issue)

The confirmation clones main's baseline *after* the initial run appended its (regressing) sample to main's series, so a borderline regression can be slightly diluted by its own already-merged sample. This is inherent to confirming post-merge and is what the threshold-loosening follow-up addresses. A future refinement could pin the clone to the commit's parent via `--start-point-hash`.

## Testing

- `bundle exec rspec benchmarks/spec` — **212 examples, 0 failures** (26 new: `regression_report_spec`, `plan_confirmation_spec`, confirmation-mode cases in `track_benchmarks_spec`; `report_regressions_spec` reworked for the confirmed-artifact contract).
- `actionlint` clean on both `benchmark.yml` and `benchmark-suite.yml`.
- `rubocop` clean on all changed/new Ruby files.
- End-to-end candidate→confirm→report file round-trip verified locally.

**Live validation gap:** the multi-job GitHub Actions DAG (reusable-workflow calls, dynamic confirmation matrix, fresh-runner reruns, Bencher submissions) cannot be exercised locally — it needs a real `main` push with a Bencher token. A maintainer should watch the first alerting `main` run to confirm the candidate→confirm→report handoff end to end. No CHANGELOG entry: per the repo's changelog guidelines this is internal CI/benchmark tooling, not a user-visible source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CI workflow refactor changes when benchmark workflows fail and when regression issues are filed; mistakes could miss real regressions or spam issues, but scope is internal benchmark tooling only.
> 
> **Overview**
> Adds a **two-stage main regression pipeline**: Bencher alerts on the first `main` run are **non-fatal candidates** (`regression-candidate.json` artifacts) instead of failing the suite or filing immediately. New jobs **`plan-confirmation`** (filter ignored benchmarks, build rerun matrix) and **`confirm-regressions`** rerun only alerting suite/shards on fresh runners via a shared reusable workflow **`benchmark-suite.yml`** (`initial` / `confirm` modes).
> 
> **`track_benchmarks.rb`** writes candidates with structured **benchmark+measure** alert pairs; confirmation submits to a synthetic Bencher branch against `main`'s baseline without appending to `main`'s series, and emits **`regression-confirmed.json`** only when the same pairs re-alert. **`report_regressions.rb`** files issues from confirmed payloads only, shows first-run vs confirmation tables, and **owns final workflow failure** on confirmed regressions. **`IGNORED_REGRESSION_BENCHMARKS`** moves to **`regression_report.rb`** and short-circuits before confirmation reruns in **`plan_confirmation.rb`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985121de99bfed01df9098896155cb69a88560b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-stage benchmark regression flow: initial candidate runs then optional confirmation reruns before filing issues.
  * Reports now include side-by-side "First run" vs "Confirmation" summaries for clearer comparison.

* **Refactor**
  * Benchmark CI converted to a reusable, modular workflow for shard-level end-to-end runs and confirmation orchestration.

* **Tests**
  * Added comprehensive tests covering confirmation planning, regression matching, and reporting behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->