### PR TITLE
Fix auto-bundled component pack normalization

### DIFF
--- a/react_on_rails/lib/react_on_rails/helper.rb
+++ b/react_on_rails/lib/react_on_rails/helper.rb
@@ -394,13 +394,14 @@ module ReactOnRails
       result[:cspNonce] = nonce if nonce.present?
     end
 
-    def load_pack_for_generated_component(react_component_name, render_options)
+    def load_pack_for_generated_component(_react_component_name, render_options)
       return unless render_options.auto_load_bundle
 
       ReactOnRails::PackerUtils.raise_nested_entries_disabled unless ReactOnRails::PackerUtils.nested_entries?
+      generated_component_name = render_options.react_component_name
       if Rails.env.development?
-        is_component_pack_present = File.exist?(generated_components_pack_path(react_component_name))
-        raise_missing_autoloaded_bundle(react_component_name) unless is_component_pack_present
+        is_component_pack_present = File.exist?(generated_components_pack_path(generated_component_name))
+        raise_missing_autoloaded_bundle(generated_component_name) unless is_component_pack_present
       end
 
       options = { defer: ReactOnRails.configuration.generated_component_packs_loading_strategy == :defer }
@@ -408,8 +409,8 @@ module ReactOnRails
       # ReactOnRails.configure already validates if async loading is supported by the installed Shakapacker version.
       # Therefore, we only need to pass the async option if the loading strategy is explicitly set to :async
       options[:async] = true if ReactOnRails.configuration.generated_component_packs_loading_strategy == :async
-      append_javascript_pack_tag("generated/#{react_component_name}", **options)
-      append_stylesheet_pack_tag("generated/#{react_component_name}")
+      append_javascript_pack_tag("generated/#{generated_component_name}", **options)
+      append_stylesheet_pack_tag("generated/#{generated_component_name}")
     end
 
     def load_pack_for_generated_store(store_name, explicit_auto_load: false)

--- a/react_on_rails/lib/react_on_rails/packs_generator.rb
+++ b/react_on_rails/lib/react_on_rails/packs_generator.rb
@@ -174,7 +174,12 @@ module ReactOnRails
     def check_for_component_store_name_conflicts
       component_names = common_component_to_path.keys + client_component_to_path.keys
       store_names = store_to_path.keys
-      conflicts = component_names & store_names
+      conflicts = component_names.filter_map do |component_name|
+        store_name = store_names.find { |name| component_name.casecmp?(name) }
+        next unless store_name
+
+        component_name == store_name ? component_name : "#{component_name} (component) / #{store_name} (store)"
+      end
 
       return if conflicts.empty?
 
@@ -715,8 +720,19 @@ module ReactOnRails
 
     def component_name(file_path)
       basename = File.basename(file_path, File.extname(file_path))
+      derived_name = basename.sub(CONTAINS_CLIENT_OR_SERVER_REGEX, "")
 
-      basename.sub(CONTAINS_CLIENT_OR_SERVER_REGEX, "")
+      return derived_name unless auto_bundled_component_file?(file_path)
+
+      derived_name.camelize
+    end
+
+    def auto_bundled_component_file?(file_path)
+      components_subdirectory = ReactOnRails.configuration.components_subdirectory
+      return false if components_subdirectory.blank?
+      return false unless file_path.match?(COMPONENT_EXTENSIONS)
+
+      Pathname(file_path).each_filename.include?(components_subdirectory)
     end
 
     def component_name_to_path(paths)

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -61,20 +61,23 @@ describe ReactOnRailsHelper do
   end
 
   describe "#load_pack_for_generated_component" do
+    let(:react_component_name) { "component_name" }
+    let(:generated_component_name) { "ComponentName" }
     let(:render_options) do
-      ReactOnRails::ReactComponent::RenderOptions.new(react_component_name: "component_name",
+      ReactOnRails::ReactComponent::RenderOptions.new(react_component_name:,
                                                       options: {})
     end
 
     it "appends js/css pack tag" do
       allow(helper).to receive(:append_javascript_pack_tag)
       allow(helper).to receive(:append_stylesheet_pack_tag)
-      expect { helper.load_pack_for_generated_component("component_name", render_options) }.not_to raise_error
+      expect { helper.load_pack_for_generated_component(react_component_name, render_options) }.not_to raise_error
 
       # Default loading strategy is now always :defer to prevent race conditions
       # between component registration and hydration, regardless of async support
-      expect(helper).to have_received(:append_javascript_pack_tag).with("generated/component_name", { defer: true })
-      expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/component_name")
+      expect(helper).to have_received(:append_javascript_pack_tag).with("generated/#{generated_component_name}",
+                                                                        { defer: true })
+      expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/#{generated_component_name}")
     end
 
     context "when async loading is enabled" do
@@ -95,12 +98,12 @@ describe ReactOnRailsHelper do
 
           allow(helper).to receive(:append_javascript_pack_tag)
           allow(helper).to receive(:append_stylesheet_pack_tag)
-          expect { helper.load_pack_for_generated_component("component_name", render_options) }.not_to raise_error
+          expect { helper.load_pack_for_generated_component(react_component_name, render_options) }.not_to raise_error
           expect(helper).to have_received(:append_javascript_pack_tag).with(
-            "generated/component_name",
+            "generated/#{generated_component_name}",
             { defer: false, async: true }
           )
-          expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/component_name")
+          expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/#{generated_component_name}")
         ensure
           helper.define_singleton_method(:append_javascript_pack_tag, original_append_javascript_pack_tag)
         end
@@ -115,15 +118,20 @@ describe ReactOnRailsHelper do
       it "appends the defer attribute to the script tag" do
         allow(helper).to receive(:append_javascript_pack_tag)
         allow(helper).to receive(:append_stylesheet_pack_tag)
-        expect { helper.load_pack_for_generated_component("component_name", render_options) }.not_to raise_error
-        expect(helper).to have_received(:append_javascript_pack_tag).with("generated/component_name", { defer: true })
-        expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/component_name")
+        expect { helper.load_pack_for_generated_component(react_component_name, render_options) }.not_to raise_error
+        expect(helper).to have_received(:append_javascript_pack_tag).with("generated/#{generated_component_name}",
+                                                                          { defer: true })
+        expect(helper).to have_received(:append_stylesheet_pack_tag).with("generated/#{generated_component_name}")
       end
     end
 
     it "throws an error in development if generated component isn't found" do
+      missing_render_options = ReactOnRails::ReactComponent::RenderOptions.new(
+        react_component_name: "nonexisting_component",
+        options: {}
+      )
       allow(Rails.env).to receive(:development?).and_return(true)
-      expect { helper.load_pack_for_generated_component("nonexisting_component", render_options) }
+      expect { helper.load_pack_for_generated_component("nonexisting_component", missing_render_options) }
         .to raise_error(ReactOnRails::SmartError, /Auto-loaded Bundle Missing/)
     end
   end

--- a/react_on_rails/spec/dummy/spec/packs_generator_spec.rb
+++ b/react_on_rails/spec/dummy/spec/packs_generator_spec.rb
@@ -1420,14 +1420,32 @@ module ReactOnRails
         it { is_expected.to eq "MyComponent" }
       end
 
+      context "with snake_case component file" do
+        let(:file_path) { "/path/to/ror_components/my_component.jsx" }
+
+        it { is_expected.to eq "MyComponent" }
+      end
+
       context "with client component file" do
         let(:file_path) { "/path/to/MyComponent.client.jsx" }
 
         it { is_expected.to eq "MyComponent" }
       end
 
+      context "with snake_case client component file" do
+        let(:file_path) { "/path/to/ror_components/my_component.client.jsx" }
+
+        it { is_expected.to eq "MyComponent" }
+      end
+
       context "with server component file" do
         let(:file_path) { "/path/to/MyComponent.server.jsx" }
+
+        it { is_expected.to eq "MyComponent" }
+      end
+
+      context "with snake_case server component file" do
+        let(:file_path) { "/path/to/ror_components/my_component.server.jsx" }
 
         it { is_expected.to eq "MyComponent" }
       end

--- a/react_on_rails/spec/dummy/spec/packs_generator_spec.rb
+++ b/react_on_rails/spec/dummy/spec/packs_generator_spec.rb
@@ -1162,9 +1162,12 @@ module ReactOnRails
             .and_return("#{stores_fixture_path}/StoreWithNameConflict")
         end
 
-        it "raises an error for name conflict" do
+        it "raises an error for case-only name conflict" do
           expect { described_class.instance.generate_packs_if_stale }
-            .to raise_error(ReactOnRails::Error, /names are used for both components and stores/)
+            .to raise_error(
+              ReactOnRails::Error,
+              %r{Conflicting \(component\) / conflicting \(store\)}
+            )
         end
       end
     end
@@ -1424,6 +1427,12 @@ module ReactOnRails
         let(:file_path) { "/path/to/ror_components/my_component.jsx" }
 
         it { is_expected.to eq "MyComponent" }
+      end
+
+      context "with snake_case component file outside components_subdirectory" do
+        let(:file_path) { "/path/to/other_dir/my_component.jsx" }
+
+        it { is_expected.to eq "my_component" }
       end
 
       context "with client component file" do


### PR DESCRIPTION
## Summary

- Normalize auto-bundled component pack loading through `RenderOptions#react_component_name`, so `react_component("component_name")` loads `generated/ComponentName` consistently with DOM/SSR lookup.
- Camelize generated public component names for actual files under the configured auto-bundling component subdirectory, while preserving server-bundle and store filename behavior.
- Preserve component/store generated-pack conflict protection for names that now differ only by case.

Fixes #3809.

## Validation

- `bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb:63 spec/packs_generator_spec.rb:1414` from `react_on_rails/spec/dummy` -> 12 examples, 0 failures.
- `bundle exec rspec spec/packs_generator_spec.rb` from `react_on_rails/spec/dummy` -> 157 examples, 0 failures.
- `bundle exec rubocop lib/react_on_rails/helper.rb lib/react_on_rails/packs_generator.rb spec/dummy/spec/helpers/react_on_rails_helper_spec.rb spec/dummy/spec/packs_generator_spec.rb` from `react_on_rails` -> 4 files, no offenses.
- `bundle exec rubocop` from `react_on_rails` -> 214 files, no offenses.
- `git diff --check` -> passed.
- `script/ci-changes-detector origin/main` -> Ruby core source code + dummy app; recommended broad CI set.
- Pre-commit hook -> trailing newlines, autofix, RuboCop passed.
- Pre-push hook -> branch Ruby lint and markdown-links passed.

Known validation note: full `spec/helpers/react_on_rails_helper_spec.rb` reaches unrelated SSR examples that require `public/webpack/test/server-bundle.js`; the focused changed helper group passed. A `codex review --base origin/main` run was started, inspected the diff and Pro call sites, then was stopped after timing out without final findings; its attempted broad helper spec also hit sandbox-only Capybara port binding failures.

## Labels

Labels: full-ci

Reason: this is a small diff, but it affects runtime auto-bundled pack loading and generated pack naming, so path-based full CI is appropriate for generator/dummy-app coverage. No `benchmark` label recommended; the change does not affect performance-sensitive rendering or benchmark code paths.

## Release Mode

Current live tracker read: #3570 appears to be the active central RC tracker, but it has no `Agent Release Mode` block. Per AGENTS.md, treating merge decisions as `strict-rc` and not auto-merging.

## Agent Merge Confidence

Mode: strict-rc
Score: 7/10
Auto-merge recommendation: no
Affected areas: auto-bundling, generated pack loading, dummy app specs
CI detector: `script/ci-changes-detector origin/main` -> Ruby core source code + dummy app; broad CI recommended
Validation run:
- `bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb:63 spec/packs_generator_spec.rb:1414` -> passed, 12 examples
- `bundle exec rspec spec/packs_generator_spec.rb` -> passed, 157 examples
- `bundle exec rubocop` in `react_on_rails` -> passed, 214 files
- focused RuboCop on touched files -> passed, 4 files
- `git diff --check` -> passed
Review/check gate:
- Local self-review: complete
- Codex review: timed out/stopped after exploratory output; no final findings emitted
- GitHub checks: pending PR creation
Known residual risk: full CI not yet complete; full helper spec needs generated SSR bundle assets and was not used as local pass/fail evidence
Finalized by: not independently finalized

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime generated pack paths and public component names for auto-bundled apps; mis-scoped camelization could break existing snake_case registrations until packs are regenerated.
> 
> **Overview**
> Aligns **auto-bundled** pack naming and loading so snake_case view names (e.g. `react_component("component_name")`) resolve to the same **camelized** public name as generated packs (`generated/ComponentName`).
> 
> **`load_pack_for_generated_component`** now uses `RenderOptions#react_component_name` for dev existence checks and `append_*_pack_tag` paths instead of the raw helper argument, matching SSR/DOM registration.
> 
> **`PacksGenerator#component_name`** camelizes basenames only for component files under the configured `components_subdirectory`; files outside that path keep the previous basename behavior. Component/store conflict detection is **case-insensitive**, with clearer error text when casing differs.
> 
> Specs cover camelized pack tags, snake_case naming rules, and case-only component/store conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 481b10808dbf3eea5eca3fcbce40e9fd83d7fc91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Component/store name conflict detection is now case-insensitive, catching more naming issues.
  * Component name normalization improved for snake_case and client/server filename variants for consistent runtime names.

* **Tests**
  * Updated specs to reflect the refined naming behavior and generated pack expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->