### PR TITLE
Tighten benchmark confirmation workflow permissions

### DIFF
--- a/.github/workflows/benchmark-suite.yml
+++ b/.github/workflows/benchmark-suite.yml
@@ -24,6 +24,11 @@ on:
         required: false
         default: 'initial'
         type: string
+    secrets:
+      REACT_ON_RAILS_PRO_LICENSE_V2:
+        required: true
+      BENCHER_API_TOKEN:
+        required: true
 
 # Same benchmark parameters as benchmark.yml's top-level env: a reusable workflow does
 # NOT inherit the caller's env, but it DOES see the caller's github context, so the
@@ -45,11 +50,8 @@ env:
 jobs:
   run-suite:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-      checks: write
+    # Token permissions are set by each caller in benchmark.yml: initial mode can
+    # update PR comments, while confirm mode only reads the candidate and writes checks.
     env:
       SECRET_KEY_BASE: 'dummy-secret-key-for-ci-testing-not-used-in-production'
       REACT_ON_RAILS_PRO_LICENSE: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -180,7 +180,9 @@ jobs:
     with:
       matrix_row: ${{ toJSON(matrix) }}
       mode: initial
-    secrets: inherit
+    secrets:
+      REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
   # The confirmation gate. Reads the first-run candidates, drops the ones whose only
   # regressed benchmarks are temporarily ignored (no rerun, no issue), and emits a matrix
@@ -235,14 +237,14 @@ jobs:
       matrix: ${{ fromJSON(needs.plan-confirmation.outputs.confirmation_matrix || '{"include":[]}') }}
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
       checks: write
     uses: ./.github/workflows/benchmark-suite.yml
     with:
       matrix_row: ${{ toJSON(matrix) }}
       mode: confirm
-    secrets: inherit
+    secrets:
+      REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
   # Files a single GitHub issue for any CONFIRMED benchmark regressions, with the first
   # run and confirmation summaries side by side. Runs once after confirmation (always(),

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -181,7 +181,7 @@ jobs:
       matrix_row: ${{ toJSON(matrix) }}
       mode: initial
     secrets:
-      REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}  # yamllint disable-line rule:line-length
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
   # The confirmation gate. Reads the first-run candidates, drops the ones whose only
@@ -243,7 +243,7 @@ jobs:
       matrix_row: ${{ toJSON(matrix) }}
       mode: confirm
     secrets:
-      REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}
+      REACT_ON_RAILS_PRO_LICENSE_V2: ${{ secrets.REACT_ON_RAILS_PRO_LICENSE_V2 }}  # yamllint disable-line rule:line-length
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
   # Files a single GitHub issue for any CONFIRMED benchmark regressions, with the first

--- a/benchmarks/plan_confirmation.rb
+++ b/benchmarks/plan_confirmation.rb
@@ -155,6 +155,8 @@ def plan_confirmation(artifacts_dir)
   plan = build_plan(payloads, benchmark_matrix_rows)
   announce_suppressed(plan[:suppressed])
 
+  # Confirmation is all-or-nothing: if any candidate cannot be mapped back to a
+  # suite/shard, filing a partial issue could hide a real regression elsewhere.
   unless plan[:unmatched].empty?
     warn_unmatched(plan[:unmatched])
     emit_no_confirmations


### PR DESCRIPTION
## Summary

- Replace `secrets: inherit` in the benchmark reusable-workflow callers with explicit `REACT_ON_RAILS_PRO_LICENSE_V2` and `BENCHER_API_TOKEN` mappings.
- Move reusable benchmark workflow token permissions to the callers so initial mode keeps PR/comment scopes while confirmation mode drops `issues: write` and `pull-requests: write`.
- Add focused comments for the caller-owned permission contract and all-or-nothing confirmation planning.

Closes #3815.

## Validation

- `actionlint .github/workflows/benchmark.yml .github/workflows/benchmark-suite.yml` -> pass
- `ruby -e 'require "yaml"; %w[.github/workflows/benchmark.yml .github/workflows/benchmark-suite.yml].each { |p| YAML.load_file(p); puts "#{p}: OK" }'` -> pass
- `ruby -c benchmarks/plan_confirmation.rb` -> pass
- `(cd react_on_rails && bundle exec rubocop)` -> pass, 214 files inspected, no offenses
- `bundle exec rspec benchmarks/spec` in clean validation worktree with only this PR diff -> pass, 218 examples, 0 failures
- `script/ci-changes-detector origin/main` in clean validation worktree -> benchmark scripts + CI infrastructure; recommended full test suite, no benchmarks
- pre-commit hook -> pass after `pnpm install --frozen-lockfile` restored local Prettier
- pre-push hook -> pass
- `yamllint .github/workflows/benchmark.yml .github/workflows/benchmark-suite.yml` -> not run; `yamllint` is not installed (`command not found`, `python3 -m yamllint` missing, `pnpm exec yamllint` missing)

## Churn Notes

- Initial `bundle exec rspec benchmarks/spec` in the shared worktree failed because unrelated dirty benchmark files were present; reran the same command in `/tmp/ror-b3815-validate` from clean `origin/main` plus only this PR diff, and it passed.
- `codex review --base origin/main` initially found a caller/callee permission compatibility issue; fixed by removing the reusable workflow job-level permission block and letting each caller set the token scope.
- Claude review initially flagged explicit `GITHUB_TOKEN` plumbing as redundant for reusable workflows; fixed by relying on the automatically available `secrets.GITHUB_TOKEN` and only declaring/passing the two non-default secrets.
- Final Claude `/code-review origin/main` found no correctness blocker. It suggested dropping `checks: write`; I classified that as optional/noise for this PR because #3815 explicitly scoped confirmation mode to `contents: read` + `checks: write` for Bencher synthetic-branch submission.
- Final `codex review --base origin/main` rerun exited abnormally after inspection before a final verdict, so it is recorded as unavailable rather than clean.
- Claude `/simplify origin/main` found no simplification to apply.

## Labels

Labels: `full-ci`

Workflow CI changes are high-risk and should run the full suite. `benchmark` is not recommended because `script/ci-changes-detector origin/main` classifies this as CI infrastructure / benchmark scripts with no benchmark runtime jobs.

## Codex Decision Log

- **Non-blocking:** Whether to drop `checks: write` as an additional least-privilege cleanup.
  - **Decision:** Keep `checks: write` in both benchmark callers.
  - **Why:** The assigned issue explicitly says confirmation mode should retain `checks: write` for Bencher synthetic-branch submission; removing it would widen this PR beyond the requested fix.
  - **Review later:** A separate audit can verify whether Bencher still needs GitHub Checks write access.

## Agent Merge Confidence

Mode: development
Score: 7/10
Auto-merge recommendation: no
Affected areas: CI, benchmark workflow, benchmark scripts
CI detector: `script/ci-changes-detector origin/main` -> Benchmark scripts + CI infrastructure; full test suite recommended; no benchmark runtime jobs recommended.
Validation run:
- `actionlint .github/workflows/benchmark.yml .github/workflows/benchmark-suite.yml` -> pass
- YAML load check for both workflow files -> pass
- `ruby -c benchmarks/plan_confirmation.rb` -> pass
- `(cd react_on_rails && bundle exec rubocop)` -> pass
- `bundle exec rspec benchmarks/spec` in clean validation worktree -> pass, 218 examples, 0 failures
- pre-commit and pre-push hooks -> pass
Review/check gate:
- Claude review: complete for `fc9aa6f6`; no correctness blocker; optional `checks: write` suggestion classified as non-blocking/noise for this scoped issue
- Codex review: initial actionable finding fixed; final rerun exited abnormally before final verdict
- GitHub checks: pending/not yet available at PR creation
Known residual risk: GitHub-hosted workflow execution still needs CI validation; local tools cannot fully exercise reusable workflow runtime semantics.
Finalized by: not finalized; authoring worker draft only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI token scopes and secret wiring for benchmark jobs; misconfiguration could break Bencher tracking or PR comments, but scope is limited to benchmark workflows.
> 
> **Overview**
> Tightens benchmark CI **least-privilege** by moving `GITHUB_TOKEN` scopes to the callers in `benchmark.yml` instead of the reusable `benchmark-suite.yml` job.
> 
> **Initial** benchmark runs still get `issues: write` and `pull-requests: write` for PR/comment updates; **confirmation** reruns drop those scopes and keep only `contents: read` and `checks: write`. The reusable workflow now declares required secrets explicitly and callers pass only `REACT_ON_RAILS_PRO_LICENSE_V2` and `BENCHER_API_TOKEN` instead of `secrets: inherit`.
> 
> Adds a short comment in `plan_confirmation.rb` documenting all-or-nothing confirmation when a candidate cannot be mapped to a matrix row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26847460fd14f58a1d5befd070169360a5f94b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Benchmark automation now requires explicit credential declarations for reusable runs and callers pass those credentials explicitly.
  * Removed redundant job-level permission settings from the reusable run configuration.
* **Documentation**
  * Clarified confirmation behavior: regressions are treated all-or-nothing to avoid filing partial issues when candidates can’t be fully mapped back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->