### PR TITLE
Enforce Pro license headers in CI + pre-commit (2/2)

### DIFF
--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -168,6 +168,14 @@ jobs:
         working-directory: .
         run: pnpm --filter react-on-rails-pro build
 
+      # Dependency-free guard (just git + ruby): every proprietary Pro file must
+      # carry the non-MIT license header. See script/check-pro-license-headers.
+      - name: Check Pro license headers
+        working-directory: .
+        run: |
+          ruby script/check-pro-license-headers --self-test
+          ruby script/check-pro-license-headers --check
+
       # These steps need the Pro package Gemfile (which carries rubocop/rbs),
       # so pin it via absolute path — robust to changes in defaults.run.
       - name: Lint Ruby

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -108,6 +108,15 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-version: 2.5.4
 
+      # Dependency-free guard (just git + ruby): every proprietary Pro file must
+      # carry the non-MIT license header. See script/check-pro-license-headers.
+      # Keep this early so missing headers fail before Node, pnpm, gems, or build.
+      - name: Check Pro license headers
+        working-directory: .
+        run: |
+          ruby script/check-pro-license-headers --self-test
+          ruby script/check-pro-license-headers --check
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -167,14 +176,6 @@ jobs:
       - name: Build react-on-rails-pro package
         working-directory: .
         run: pnpm --filter react-on-rails-pro build
-
-      # Dependency-free guard (just git + ruby): every proprietary Pro file must
-      # carry the non-MIT license header. See script/check-pro-license-headers.
-      - name: Check Pro license headers
-        working-directory: .
-        run: |
-          ruby script/check-pro-license-headers --self-test
-          ruby script/check-pro-license-headers --check
 
       # These steps need the Pro package Gemfile (which carries rubocop/rbs),
       # so pin it via absolute path — robust to changes in defaults.run.

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -112,6 +112,8 @@ jobs:
       # carry the non-MIT license header. See script/check-pro-license-headers.
       # Keep this early so missing headers fail before Node, pnpm, gems, or build.
       - name: Check Pro license headers
+        # Override this workflow's react_on_rails_pro default; the checker lives at the repo root.
+        working-directory: .
         run: |
           ruby script/check-pro-license-headers --self-test
           ruby script/check-pro-license-headers --check

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -112,7 +112,6 @@ jobs:
       # carry the non-MIT license header. See script/check-pro-license-headers.
       # Keep this early so missing headers fail before Node, pnpm, gems, or build.
       - name: Check Pro license headers
-        working-directory: .
         run: |
           ruby script/check-pro-license-headers --self-test
           ruby script/check-pro-license-headers --check

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -33,6 +33,12 @@ pre-commit:
       run: bin/lefthook/check-trailing-newlines all-changed
       stage_fixed: true
 
+    # When any Pro file is staged, verify every proprietary Pro file carries the
+    # non-MIT license header. Check-only (run `--fix` to insert/upgrade).
+    pro-license-headers:
+      glob: "{react_on_rails_pro/**/*,packages/react-on-rails-pro/**/*,packages/react-on-rails-pro-node-renderer/**/*}"
+      run: script/check-pro-license-headers
+
 pre-push:
   commands:
     branch-lint:

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -36,6 +36,7 @@ pre-commit:
     # When any Pro file is staged, verify the staged index for every proprietary
     # Pro file. Check-only (run `--fix` and re-stage to insert/upgrade).
     pro-license-headers:
+      # Mirrors PRO_TREES in script/check-pro-license-headers; keep in sync when adding a new Pro tree.
       glob: "{react_on_rails_pro/*,react_on_rails_pro/**/*,packages/react-on-rails-pro/*,packages/react-on-rails-pro/**/*,packages/react-on-rails-pro-node-renderer/*,packages/react-on-rails-pro-node-renderer/**/*}"
       run: ruby script/check-pro-license-headers --check-staged
 

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -33,11 +33,11 @@ pre-commit:
       run: bin/lefthook/check-trailing-newlines all-changed
       stage_fixed: true
 
-    # When any Pro file is staged, verify every proprietary Pro file carries the
-    # non-MIT license header. Check-only (run `--fix` to insert/upgrade).
+    # When any Pro file is staged, verify the staged index for every proprietary
+    # Pro file. Check-only (run `--fix` and re-stage to insert/upgrade).
     pro-license-headers:
-      glob: "{react_on_rails_pro/**/*,packages/react-on-rails-pro/**/*,packages/react-on-rails-pro-node-renderer/**/*}"
-      run: script/check-pro-license-headers
+      glob: "{react_on_rails_pro/*,react_on_rails_pro/**/*,packages/react-on-rails-pro/*,packages/react-on-rails-pro/**/*,packages/react-on-rails-pro-node-renderer/*,packages/react-on-rails-pro-node-renderer/**/*}"
+      run: ruby script/check-pro-license-headers --check-staged
 
 pre-push:
   commands:

--- a/script/check-pro-license-headers
+++ b/script/check-pro-license-headers
@@ -238,8 +238,8 @@ def tracked_in_scope_files
 end
 
 def index_file_content(path)
-  out, status = Open3.capture2("git", "show", ":#{path}")
-  abort "git show :#{path} failed" unless status.success?
+  out, err, status = Open3.capture3("git", "show", ":#{path}")
+  abort "git show :#{path} failed: #{err.strip}" unless status.success?
 
   out
 end
@@ -263,11 +263,11 @@ def run_check_staged
   files = tracked_in_scope_files
   missing = files.reject { |p| index_file_content(p).include?(render_header(comment_style(p))) }
   if missing.empty?
-    puts "All #{files.size} staged/index in-scope Pro files have the current license header."
+    puts "All #{files.size} tracked Pro files have the current license header in the index."
     return 0
   end
 
-  warn "Missing or outdated Pro license header in #{missing.size} staged/index file(s):"
+  warn "Missing or outdated Pro license header in the index for #{missing.size} tracked Pro file(s):"
   missing.each { |p| warn "  #{p}" }
   warn ""
   warn "Run `script/check-pro-license-headers --fix`, then stage the updated files."

--- a/script/check-pro-license-headers
+++ b/script/check-pro-license-headers
@@ -66,8 +66,7 @@ EXCLUDE_PATTERNS = [
   # covering those would need shebang-based shell detection plus a binstub
   # heuristic, deferred as a low-value follow-up (they are test-harness glue).
   %r{(\A|/)bin/},
-  %r{/fixtures/}, # test fixtures: loaded/byte-asserted by tests,
-  # sometimes VM-evaluated; not product source
+  %r{/fixtures/}, # test fixtures: byte-asserted or VM-evaluated by tests, not product source
   %r{/db/schema\.rb\z}, # generated
   %r{(\A|/)public/}, # built/vendored assets
   %r{(\A|/)vendor/},
@@ -421,11 +420,12 @@ def run_self_test
     returned = true
   rescue SystemExit => e
     exit_status = e.status
+  ensure
+    $stderr = original_stderr
   end
-  $stderr = original_stderr
   assert !returned, "index_file_content should abort on missing path"
   assert exit_status == 1, "index_file_content exits non-zero on missing path"
-  assert error_output.string.include?("exit 128"), "index_file_content reports git exit status"
+  assert error_output.string.match?(/exit \d+/), "index_file_content error message includes git exit code"
 
   puts "self-test: all assertions passed"
   0

--- a/script/check-pro-license-headers
+++ b/script/check-pro-license-headers
@@ -9,6 +9,7 @@
 #
 # Usage:
 #   script/check-pro-license-headers           # check; non-zero exit lists offenders
+#   script/check-pro-license-headers --check-staged  # check staged/index contents
 #   script/check-pro-license-headers --fix     # insert/upgrade headers in place
 #   script/check-pro-license-headers --list    # print the in-scope file set and exit
 #   script/check-pro-license-headers --self-test  # run the in-memory unit tests
@@ -236,6 +237,13 @@ def tracked_in_scope_files
   out.split("\x00").reject(&:empty?).select { |p| in_scope?(p) }.sort
 end
 
+def index_file_content(path)
+  out, status = Open3.capture2("git", "show", ":#{path}")
+  abort "git show :#{path} failed" unless status.success?
+
+  out
+end
+
 def run_check
   files = tracked_in_scope_files
   missing = files.reject { |p| File.read(p).include?(render_header(comment_style(p))) }
@@ -248,6 +256,21 @@ def run_check
   missing.each { |p| warn "  #{p}" }
   warn ""
   warn "Run `script/check-pro-license-headers --fix` to insert/upgrade them."
+  1
+end
+
+def run_check_staged
+  files = tracked_in_scope_files
+  missing = files.reject { |p| index_file_content(p).include?(render_header(comment_style(p))) }
+  if missing.empty?
+    puts "All #{files.size} staged/index in-scope Pro files have the current license header."
+    return 0
+  end
+
+  warn "Missing or outdated Pro license header in #{missing.size} staged/index file(s):"
+  missing.each { |p| warn "  #{p}" }
+  warn ""
+  warn "Run `script/check-pro-license-headers --fix`, then stage the updated files."
   1
 end
 
@@ -389,10 +412,11 @@ if $PROGRAM_NAME == __FILE__
     when "--fix" then run_fix
     when "--list" then run_list
     when "--self-test" then run_self_test
+    when "--check-staged" then run_check_staged
     when nil, "--check" then run_check
     else
       warn "Unknown option: #{ARGV[0]}"
-      warn "Usage: script/check-pro-license-headers [--check|--fix|--list|--self-test]"
+      warn "Usage: script/check-pro-license-headers [--check|--check-staged|--fix|--list|--self-test]"
       2
     end
   )

--- a/script/check-pro-license-headers
+++ b/script/check-pro-license-headers
@@ -19,6 +19,7 @@
 # This file is OSS tooling, so it carries no Pro header itself.
 
 require "open3"
+require "stringio"
 
 PRO_TREES = %w[
   react_on_rails_pro
@@ -65,13 +66,13 @@ EXCLUDE_PATTERNS = [
   # covering those would need shebang-based shell detection plus a binstub
   # heuristic, deferred as a low-value follow-up (they are test-harness glue).
   %r{(\A|/)bin/},
-  %r{/fixtures/},                  # test fixtures: loaded/byte-asserted by tests,
-                                   # sometimes VM-evaluated; not product source
-  %r{/db/schema\.rb\z},            # generated
-  %r{(\A|/)public/},               # built/vendored assets
+  %r{/fixtures/}, # test fixtures: loaded/byte-asserted by tests,
+  # sometimes VM-evaluated; not product source
+  %r{/db/schema\.rb\z}, # generated
+  %r{(\A|/)public/}, # built/vendored assets
   %r{(\A|/)vendor/},
   %r{/ssr-generated/},
-  /\.lock\z/                       # Bundler/Yarn lockfiles (generated, not source)
+  /\.lock\z/ # Bundler/Yarn lockfiles (generated, not source)
 ].freeze
 
 # Returns :block, :hash, :erb, :html, or nil (not headerable).
@@ -95,10 +96,11 @@ def in_scope?(path)
   !comment_style(path).nil? && !excluded?(path)
 end
 
+# rubocop:disable Metrics/CyclomaticComplexity
 def render_header(style)
   case style
   when :block
-    +"/*\n" + HEADER_LINES.map { |l| l.empty? ? " *\n" : " * #{l}\n" }.join + " */\n"
+    "/*\n#{HEADER_LINES.map { |l| l.empty? ? " *\n" : " * #{l}\n" }.join} */\n"
   when :hash
     HEADER_LINES.map { |l| l.empty? ? "#\n" : "# #{l}\n" }.join
   when :erb
@@ -107,11 +109,12 @@ def render_header(style)
     # body. A plain %> (or a trailing newline here) would leave leading bytes in
     # the rendered template, which corrupts text/streaming responses such as
     # .text.erb RSC payloads.
-    +"<%#\n" + HEADER_LINES.map { |l| "#{l}\n" }.join + "-%>"
+    "<%#\n#{HEADER_LINES.map { |l| "#{l}\n" }.join}-%>"
   when :html
-    +"<!--\n" + HEADER_LINES.map { |l| "#{l}\n" }.join + "-->\n"
+    "<!--\n#{HEADER_LINES.map { |l| "#{l}\n" }.join}-->\n"
   end
 end
+# rubocop:enable Metrics/CyclomaticComplexity
 
 # JS/TS pragmas that must stay in the FIRST comment block of a file: jest reads
 # @jest-environment from the first docblock, Flow reads @flow. A license block
@@ -130,6 +133,7 @@ DOCKER_DIRECTIVE = /\A#\s*(?:syntax|escape|check)\s*=/i
 # Leading content that must stay first: shebang, Ruby/YAML magic comments, JS/TS
 # pragma docblocks (@jest-environment, @flow, …), and Dockerfile parser
 # directives. The header is inserted immediately after this preamble.
+# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 def split_preamble(style, content)
   case style
   when :hash
@@ -164,10 +168,12 @@ def split_preamble(style, content)
     ["", content]
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
 # Remove an existing Pro header (identified by the sentinel) from the leading
 # comment region, wherever it sits — including after a pragma docblock — so
 # --fix upgrades/repositions instead of stacking a second header.
+# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 def strip_legacy(style, content)
   case style
   when :block
@@ -210,6 +216,7 @@ def strip_legacy(style, content)
     preamble + (lines[k..]&.join || "")
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
 # Pure transform: returns content with the canonical header applied, or the
 # input unchanged when the file is not in scope. Idempotent by construction —
@@ -239,7 +246,8 @@ end
 
 def index_file_content(path)
   out, err, status = Open3.capture3("git", "show", ":#{path}")
-  abort "git show :#{path} failed: #{err.strip}" unless status.success?
+  message = "git show :#{path} failed (exit #{status.exitstatus}): #{err.strip}"
+  abort message unless status.success?
 
   out
 end
@@ -308,6 +316,7 @@ def assert(cond, msg)
   raise "ASSERTION FAILED: #{msg}" unless cond
 end
 
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 def run_self_test
   # Ruby: header goes below frozen_string_literal (must stay line 1), with a
   # blank line after the magic comment.
@@ -370,7 +379,7 @@ def run_self_test
   legacy = "/*\n * Copyright (c) 2025 Shakacode LLC\n *\n * This file is " \
            "NOT licensed under the MIT (open source) license.\n */\n\nconst y = 2;\n"
   upgraded = apply_header("c.js", legacy)
-  assert upgraded.scan(/Copyright \(c\) 2025/).size == 1, "legacy header replaced, not stacked"
+  assert upgraded.scan("Copyright (c) 2025").size == 1, "legacy header replaced, not stacked"
   assert upgraded.include?("AI AGENTS:"), "upgraded header has agent warning"
   assert upgraded.end_with?("const y = 2;\n"), "body preserved after upgrade"
 
@@ -402,9 +411,26 @@ def run_self_test
   assert !in_scope?("react_on_rails_pro/Gemfile.lock"), "lockfiles not in scope"
   assert in_scope?("react_on_rails_pro/lib/react_on_rails_pro/foo.rb"), "pro rb in scope"
 
+  original_stderr = $stderr
+  error_output = StringIO.new
+  $stderr = error_output
+  exit_status = nil
+  returned = false
+  begin
+    index_file_content("__nonexistent_path_for_self_test__")
+    returned = true
+  rescue SystemExit => e
+    exit_status = e.status
+  end
+  $stderr = original_stderr
+  assert !returned, "index_file_content should abort on missing path"
+  assert exit_status == 1, "index_file_content exits non-zero on missing path"
+  assert error_output.string.include?("exit 128"), "index_file_content reports git exit status"
+
   puts "self-test: all assertions passed"
   0
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
 # --- entry point ----------------------------------------------------------
 

--- a/script/check-pro-license-headers
+++ b/script/check-pro-license-headers
@@ -260,14 +260,16 @@ def run_check
 end
 
 def run_check_staged
+  # Lefthook calls this before commit. Validate every in-scope tracked file as
+  # represented in the index so untouched Pro files cannot carry stale headers.
   files = tracked_in_scope_files
   missing = files.reject { |p| index_file_content(p).include?(render_header(comment_style(p))) }
   if missing.empty?
-    puts "All #{files.size} tracked Pro files have the current license header in the index."
+    puts "All #{files.size} in-scope Pro files have the current license header in the index."
     return 0
   end
 
-  warn "Missing or outdated Pro license header in the index for #{missing.size} tracked Pro file(s):"
+  warn "Missing or outdated Pro license header in the index for #{missing.size} in-scope Pro file(s):"
   missing.each { |p| warn "  #{p}" }
   warn ""
   warn "Run `script/check-pro-license-headers --fix`, then stage the updated files."


### PR DESCRIPTION
## What

Turns on enforcement for the Pro license headers. **Stacked on #3820** (which adds `script/check-pro-license-headers`, backfills all headers, and adds the agent copy-protection docs). Merge #3820 first; this PR only makes sense once the script and headers exist.

## Changes

- **CI** — a `Check Pro license headers` step in the `pro-lint` job of `pro-test-package-and-gem.yml`. It runs `--self-test` then `--check` using only git + ruby (no bundle/build needed), placed before the slower lint steps so a missing header fails fast. It rides the existing `run_pro_lint` change-detection, so it runs whenever Pro files change and is skipped otherwise.
- **Pre-commit** — a check-only `pro-license-headers` command in `.lefthook.yml`, globbed to the three Pro trees. When any Pro file is staged it runs the whole-tree check (~0.2s) and blocks the commit if a header is missing, pointing the dev at `--fix`. It skips when no Pro files are staged.

## Verification (local)

- `actionlint` on the workflow ✅
- `bundle exec lefthook validate` ✅
- Hook **fires and passes** on a staged Pro file; **skips** ("no matching staged files") for non-Pro files
- `--check` exits non-zero when a Pro file lacks the header (probed with a temp unheadered file), exit 0 when clean

## Labels

`Labels: none` — touches only the Pro lint job and the pre-commit config; no runtime/build behavior change. (Per AGENTS.md, CI-workflow changes are "ask first" — flagging that explicitly for maintainer review.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI, git hooks, and OSS tooling; no runtime or Pro product behavior.
> 
> **Overview**
> Wires **Pro proprietary license header** enforcement into CI and local pre-commit, building on the checker script from the stacked PR.
> 
> **CI:** The `pro-lint` job in `pro-test-package-and-gem.yml` runs `script/check-pro-license-headers --self-test` then `--check` at the repo root right after Ruby setup (git + Ruby only), so missing or outdated headers fail before Node, bundle, or build steps.
> 
> **Pre-commit:** `.lefthook.yml` adds a `pro-license-headers` hook (globbed to the three Pro trees). When any Pro path is staged, it runs `--check-staged`, which validates **every** in-scope tracked Pro file against the **git index**—not just staged paths—so commits cannot slip through with stale headers on untouched files.
> 
> **Script:** Adds `--check-staged`, `index_file_content` via `git show :path`, and self-test coverage for index lookup failures; minor RuboCop/style cleanups in header rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca8c71b77f5d61ba3c3206cffd4fffd8a9a7478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs an early license-header check for proprietary Pro files so missing or invalid headers fail fast before build/test steps.
  * Pre-commit hooks validate staged Pro files’ license headers to prevent committing files with missing or outdated headers.
  * Header-check tooling gained a staged-index mode to compare staged file contents and return a non-zero status on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->