### PR TITLE
Filter stale Bencher alerts before reporting

### DIFF
--- a/benchmarks/lib/bencher_report.rb
+++ b/benchmarks/lib/bencher_report.rb
@@ -84,7 +84,7 @@ class BencherReport
     raise FormatError, "report is not a JSON object (got #{raw.class})" unless raw.is_a?(Hash)
 
     @boundaries = index_boundaries(raw)
-    @alerts = parse_alerts(raw)
+    @alerts, @filtered_alerts = parse_alerts(raw).partition { |alert| current_regression_alert?(alert) }
     # Per-benchmark perf links are informational (they only decide whether a name links
     # out), so they live in a separate, fully-lenient builder — a missing field yields an
     # unlinked name, never a FormatError that would fail the job over a cosmetic link.
@@ -93,9 +93,9 @@ class BencherReport
 
   attr_reader :alerts
 
-  def regression?
-    !@alerts.empty?
-  end
+  def regression? = !@alerts.empty?
+
+  def filtered_alert? = !@filtered_alerts.empty?
 
   # Boundary for a benchmark+measure, or nil if absent from the report.
   def boundary(benchmark_name, measure_key)
@@ -118,9 +118,7 @@ class BencherReport
   # plain name. A single benchmark missing its own uuid stays silent (a per-row cosmetic
   # miss); losing the shared context instead is a likely report-contract drift, so the
   # caller surfaces it as a ::warning:: — never a FormatError (the links are cosmetic).
-  def perf_links_unavailable?
-    @perf_urls.any_benchmarks? && !@perf_urls.context_ready?
-  end
+  def perf_links_unavailable? = @perf_urls.any_benchmarks? && !@perf_urls.context_ready?
 
   private
 
@@ -188,6 +186,31 @@ class BencherReport
       )
     end
   end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def current_regression_alert?(alert)
+    return true unless alert.benchmark
+
+    direction = { "lower" => :lower, "upper" => :upper }[normalize(alert.limit)]
+    return true unless direction
+
+    unless alert.measure
+      matching_boundaries = @boundaries.fetch(alert.benchmark, {}).values.select do |boundary|
+        threshold_side?(boundary, direction)
+      end
+      return true if matching_boundaries.empty?
+
+      return matching_boundaries.any? { |boundary| boundary.significance(direction) == :regression }
+    end
+
+    boundary = boundary(alert.benchmark, alert.measure)
+    return true unless boundary && threshold_side?(boundary, direction)
+
+    boundary.significance(direction) == :regression
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  def threshold_side?(boundary, direction) = direction == :lower ? boundary.lower_limit : boundary.upper_limit
 
   def normalize(key)
     key.to_s.downcase.gsub(/[-\s]+/, "_")

--- a/benchmarks/spec/bencher_report_spec.rb
+++ b/benchmarks/spec/bencher_report_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe BencherReport do
     JSON.generate("results" => results, "alerts" => alerts)
   end
 
+  def rps_regression_result(name: "/foo: Core", value: 80.0)
+    benchmark_result(
+      name:,
+      measures: [measure_entry(slug: "rps", name: "rps", value:, baseline: 100.0,
+                               lower_limit: 90.0, upper_limit: nil)]
+    )
+  end
+
   describe ".parse / #regression?" do
     it "reports no regression when alerts is empty" do
       report = described_class.parse(report_json)
@@ -46,15 +54,146 @@ RSpec.describe BencherReport do
       expect(report.alerts).to be_empty
     end
 
-    it "reports a regression and exposes the active alert's benchmark/measure/side" do
+    it "reports a current regression and exposes the active alert's benchmark/measure/side" do
       report = described_class.parse(
-        report_json(alerts: [alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")])
+        report_json(
+          results: [[rps_regression_result]],
+          alerts: [alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")]
+        )
       )
       expect(report.regression?).to be(true)
       expect(report.alerts.size).to eq(1)
       expect(report.alerts.first.benchmark).to eq("/foo: Core")
       expect(report.alerts.first.measure).to eq("rps")
       expect(report.alerts.first.limit).to eq("lower")
+    end
+
+    it "ignores active alerts when the current metric is not a regression" do
+      report = described_class.parse(
+        report_json(
+          results: [[rps_regression_result(value: 95.0)]],
+          alerts: [alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")]
+        )
+      )
+
+      expect(report.regression?).to be(false)
+      expect(report.alerts).to be_empty
+      expect(report.filtered_alert?).to be(true)
+    end
+
+    it "keeps active alerts with no benchmark name fail-safe" do
+      malformed_alert = alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")
+      malformed_alert.delete("benchmark")
+
+      report = described_class.parse(report_json(alerts: [malformed_alert]))
+
+      expect(report.regression?).to be(true)
+      expect(report.alerts.first.benchmark).to be_nil
+      expect(report.filtered_alert?).to be(false)
+    end
+
+    it "keeps active alerts with no matching boundary fail-safe" do
+      report = described_class.parse(
+        report_json(
+          results: [[benchmark_result(
+            name: "/foo: Core",
+            measures: [measure_entry(slug: "rps", name: "rps", value: 95.0, boundary: nil)]
+          )]],
+          alerts: [alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")]
+        )
+      )
+
+      expect(report.regression?).to be(true)
+      expect(report.filtered_alert?).to be(false)
+    end
+
+    it "keeps measure-less active alerts fail-safe when no boundary exists on the alert side" do
+      measureless_alert = alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")
+      measureless_alert["threshold"] = {}
+
+      report = described_class.parse(
+        report_json(
+          results: [[benchmark_result(
+            name: "/foo: Core",
+            measures: [measure_entry(slug: "p50-latency", name: "p50_latency", value: 5.5,
+                                     baseline: 5.0, lower_limit: nil, upper_limit: 6.0)]
+          )]],
+          alerts: [measureless_alert]
+        )
+      )
+
+      expect(report.regression?).to be(true)
+      expect(report.filtered_alert?).to be(false)
+    end
+
+    it "keeps measure-less active alerts when the benchmark has a current regression on the alert side" do
+      measureless_alert = alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")
+      measureless_alert["threshold"] = {}
+
+      report = described_class.parse(
+        report_json(
+          results: [[rps_regression_result]],
+          alerts: [measureless_alert]
+        )
+      )
+
+      expect(report.regression?).to be(true)
+      expect(report.alerts.first.benchmark).to eq("/foo: Core")
+      expect(report.alerts.first.measure).to be_nil
+    end
+
+    it "ignores measure-less active alerts when the benchmark has no current regression on the alert side" do
+      measureless_alert = alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")
+      measureless_alert["threshold"] = {}
+
+      report = described_class.parse(
+        report_json(
+          results: [[rps_regression_result(value: 95.0)]],
+          alerts: [measureless_alert]
+        )
+      )
+
+      expect(report.regression?).to be(false)
+      expect(report.alerts).to be_empty
+    end
+
+    it "ignores opposite-side improvements when matching measure-less active alerts" do
+      measureless_alert = alert(benchmark: "/foo: Core", measure_slug: "rps", limit: "lower")
+      measureless_alert["threshold"] = {}
+
+      report = described_class.parse(
+        report_json(
+          results: [[benchmark_result(
+            name: "/foo: Core",
+            measures: [
+              measure_entry(slug: "rps", name: "rps", value: 100.0,
+                            baseline: 100.0, lower_limit: 90.0, upper_limit: nil),
+              measure_entry(slug: "p50-latency", name: "p50_latency", value: 3.0,
+                            baseline: 5.0, lower_limit: nil, upper_limit: 6.0)
+            ]
+          )]],
+          alerts: [measureless_alert]
+        )
+      )
+
+      expect(report.regression?).to be(false)
+      expect(report.alerts).to be_empty
+    end
+
+    it "still reports hidden failed_pct regressions when the current value crosses its upper boundary" do
+      report = described_class.parse(
+        report_json(
+          results: [[benchmark_result(
+            name: "/foo: Core",
+            measures: [measure_entry(slug: "failed-pct", name: "failed_pct", value: 2.0,
+                                     baseline: 0.0, lower_limit: nil, upper_limit: 1.0)]
+          )]],
+          alerts: [alert(benchmark: "/foo: Core", measure_slug: "failed-pct", limit: "upper")]
+        )
+      )
+
+      expect(report.regression?).to be(true)
+      expect(report.alerts.first.measure).to eq("failed-pct")
     end
 
     it "ignores dismissed/silenced alerts (only active counts as a regression)" do

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -14,17 +14,41 @@ require_relative "../lib/bmf_helpers"
 # mutually exclusive by design: an alert must never trigger a start-point-hash retry,
 # or a real regression would be silently re-measured against the wrong baseline.
 RSpec.describe "track_benchmarks" do
+  def result(name, measures)
+    { "benchmark" => { "name" => name }, "measures" => measures }
+  end
+
+  def rps_measure(value: 80.0)
+    {
+      "measure" => { "slug" => "rps", "name" => "rps" },
+      "metric" => { "value" => value },
+      "boundary" => { "baseline" => 100.0, "lower_limit" => 90.0, "upper_limit" => nil }
+    }
+  end
+
+  def p50_measure(value: 7.0)
+    {
+      "measure" => { "slug" => "p50-latency", "name" => "p50_latency" },
+      "metric" => { "value" => value },
+      "boundary" => { "baseline" => 5.0, "lower_limit" => nil, "upper_limit" => 6.0 }
+    }
+  end
+
+  def active_alert(benchmark: "/x", measure: "rps", limit: "lower")
+    {
+      "benchmark" => { "name" => benchmark },
+      "threshold" => { "measure" => { "slug" => measure } },
+      "metric" => { "value" => 1.0 },
+      "limit" => limit,
+      "status" => "active"
+    }
+  end
+
   def report_with_alert
     BencherReport.parse(
       JSON.generate(
-        "results" => [],
-        "alerts" => [{
-          "benchmark" => { "name" => "/x" },
-          "threshold" => { "measure" => { "slug" => "rps" } },
-          "metric" => { "value" => 1.0 },
-          "limit" => "lower",
-          "status" => "active"
-        }]
+        "results" => [[result("/x", [rps_measure])]],
+        "alerts" => [active_alert]
       )
     )
   end
@@ -51,14 +75,14 @@ RSpec.describe "track_benchmarks" do
     it "returns the deduped benchmark names from active alerts" do
       report = BencherReport.parse(
         JSON.generate(
-          "results" => [],
+          "results" => [[
+            result("/posts_page: Pro", [rps_measure, p50_measure]),
+            result("/other: Pro", [rps_measure])
+          ]],
           "alerts" => [
-            { "benchmark" => { "name" => "/posts_page: Pro" },
-              "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" },
-            { "benchmark" => { "name" => "/posts_page: Pro" },
-              "threshold" => { "measure" => { "slug" => "p50-latency" } }, "status" => "active" },
-            { "benchmark" => { "name" => "/other: Pro" },
-              "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }
+            active_alert(benchmark: "/posts_page: Pro"),
+            active_alert(benchmark: "/posts_page: Pro", measure: "p50-latency", limit: "upper"),
+            active_alert(benchmark: "/other: Pro")
           ]
         )
       )
@@ -143,17 +167,28 @@ RSpec.describe "track_benchmarks" do
       it "returns deduped benchmark+measure pairs from active alerts, dropping nameless ones" do
         report = BencherReport.parse(
           JSON.generate(
-            "results" => [],
+            "results" => [[result("/x: Pro", [rps_measure])]],
             "alerts" => [
-              { "benchmark" => { "name" => "/x: Pro" },
-                "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" },
-              { "benchmark" => { "name" => "/x: Pro" },
-                "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" },
+              active_alert(benchmark: "/x: Pro"),
+              active_alert(benchmark: "/x: Pro"),
               { "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }
             ]
           )
         )
         expect(regressed_alert_pairs(report)).to eq([{ "benchmark" => "/x: Pro", "measure" => "rps" }])
+      end
+
+      it "preserves benchmark-only fallback pairs when Bencher omits the alert measure slug" do
+        measureless_alert = active_alert(benchmark: "/x: Pro")
+        measureless_alert["threshold"] = {}
+        report = BencherReport.parse(
+          JSON.generate(
+            "results" => [[result("/x: Pro", [rps_measure])]],
+            "alerts" => [measureless_alert]
+          )
+        )
+
+        expect(regressed_alert_pairs(report)).to eq([{ "benchmark" => "/x: Pro", "measure" => nil }])
       end
     end
 
@@ -217,9 +252,8 @@ RSpec.describe "track_benchmarks" do
       it "is confirmed when the same benchmark+measure re-alerts" do
         report = BencherReport.parse(
           JSON.generate(
-            "results" => [],
-            "alerts" => [{ "benchmark" => { "name" => "/x: Pro" },
-                           "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }]
+            "results" => [[result("/x: Pro", [rps_measure])]],
+            "alerts" => [active_alert(benchmark: "/x: Pro")]
           )
         )
         status, confirmed = confirmation_outcome(report, 1, [pair("/x: Pro", "rps")])
@@ -230,9 +264,8 @@ RSpec.describe "track_benchmarks" do
       it "is cleared when a different benchmark/measure alerts than the candidate's" do
         report = BencherReport.parse(
           JSON.generate(
-            "results" => [],
-            "alerts" => [{ "benchmark" => { "name" => "/y: Pro" },
-                           "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }]
+            "results" => [[result("/y: Pro", [rps_measure])]],
+            "alerts" => [active_alert(benchmark: "/y: Pro")]
           )
         )
         expect(confirmation_outcome(report, 1, [pair("/x: Pro", "rps")])).to eq([:cleared, []])
@@ -242,9 +275,8 @@ RSpec.describe "track_benchmarks" do
         ignored = RegressionReport::IGNORED_REGRESSION_BENCHMARKS.first
         report = BencherReport.parse(
           JSON.generate(
-            "results" => [],
-            "alerts" => [{ "benchmark" => { "name" => ignored },
-                           "threshold" => { "measure" => { "slug" => "rps" } }, "status" => "active" }]
+            "results" => [[result(ignored, [rps_measure])]],
+            "alerts" => [active_alert(benchmark: ignored)]
           )
         )
         expect(confirmation_outcome(report, 1, [pair(ignored, "rps")])).to eq([:cleared, []])
@@ -271,6 +303,39 @@ RSpec.describe "track_benchmarks" do
 
       expect { run_bencher("branch", []) }
         .to output(/::warning::Bencher report listed benchmarks but no perf-link context/).to_stdout
+    end
+
+    it "preserves the original alert exit so retry handling can run first" do
+      status = instance_double(Process::Status, exitstatus: 1)
+      report_json = JSON.generate(
+        "results" => [[result("/x", [rps_measure(value: 95.0)])]],
+        "alerts" => [active_alert]
+      )
+
+      allow(Open3).to receive(:capture3).and_return([report_json, "", status])
+      allow(File).to receive(:write).with(REPORT_JSON, report_json)
+
+      _stderr, exit_code, report = run_bencher("branch", [])
+
+      expect(exit_code).to eq(1)
+      expect(report).not_to be_regression
+      expect(report.filtered_alert?).to be(true)
+      expect(retry_without_start_point_hash?("Head Version abc123 not found", exit_code, report)).to be(true)
+    end
+
+    it "normalizes an alert exit to success after retry handling when every active alert is stale" do
+      report = BencherReport.parse(
+        JSON.generate(
+          "results" => [[result("/x", [rps_measure(value: 95.0)])]],
+          "alerts" => [active_alert]
+        )
+      )
+
+      exit_code = nil
+      expect { exit_code = normalized_bencher_exit_code(1, report) }
+        .to output(/::notice::Bencher reported only stale active alert/).to_stdout
+
+      expect(exit_code).to eq(0)
     end
   end
 

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -195,7 +195,15 @@ def run_bencher(branch, start_point_args)
       )
     end
   end
+
   [stderr, status.exitstatus, report]
+end
+
+def normalized_bencher_exit_code(exit_code, report)
+  return exit_code unless exit_code != 0 && report&.filtered_alert? && !regression?(report)
+
+  Github.notice("Bencher reported only stale active alert(s); no current boundary-backed regression remains.")
+  0
 end
 
 def append_step_summary(markdown)
@@ -573,6 +581,7 @@ if __FILE__ == $PROGRAM_NAME
     # and this path only triggers when the first run had no regression.
     _retry_stderr, bencher_exit_code, report = run_bencher(branch, retry_args)
   end
+  bencher_exit_code = normalized_bencher_exit_code(bencher_exit_code, report)
 
   # Build the Markdown summary table once; the same body feeds the job summary, the
   # PR comment, and the candidate/confirmation hand-offs.


### PR DESCRIPTION
## Summary

- Filter active Bencher alerts against the current report boundaries before treating them as regressions.
- Keep malformed or unmatchable active alerts fail-safe so report-shape drift still fails visibly.
- Normalize stale-only Bencher alert exits after the start-point retry and operational checks so cleared alerts do not file regression issues.
- Add parser and benchmark tracking specs for stale alerts, measure-less alerts, fail-safe cases, and stale-only exit normalization.

Fixes #3795.
Refs #3798, #3799, #3807.

## Validation

- `bundle exec rubocop benchmarks/lib/bencher_report.rb benchmarks/track_benchmarks.rb benchmarks/spec/bencher_report_spec.rb benchmarks/spec/track_benchmarks_spec.rb` -> 4 files inspected, no offenses
- `bundle exec rspec benchmarks/spec/bencher_report_spec.rb benchmarks/spec/track_benchmarks_spec.rb benchmarks/spec/report_table_integration_spec.rb` -> 83 examples, 0 failures
- `bundle exec rspec benchmarks/spec` -> 229 examples, 0 failures
- `git diff --check` -> passed
- `script/ci-changes-detector origin/main` -> Benchmark scripts; recommends `Lint (Ruby + JS)`
- `(cd react_on_rails && bundle exec rubocop)` -> 214 files inspected, no offenses
- `codex review --base origin/main` -> no actionable correctness issues found
- `git push` pre-push hook -> branch Ruby RuboCop passed on changed Ruby files; Markdown link check had no Markdown files

Labels: benchmark. Benchmark reporting is performance-sensitive; `full-ci` is not recommended because this is a focused benchmark script/parser/spec change and the CI detector only recommends lint.

## Agent Merge Confidence

Mode: development (no open `Release gate:` tracker found by title search; batch assignment: `rc-accelerated-2026-06-08-two-machine`)
Score: 8/10
Auto-merge recommendation: no (user requested no auto-merge; no independent finalizer)
Affected areas: benchmark regression reporting, Bencher report parsing, benchmark confirmation handoff
CI detector: `script/ci-changes-detector origin/main` -> Benchmark scripts; recommends `Lint (Ruby + JS)`
Validation run:
- `bundle exec rubocop benchmarks/lib/bencher_report.rb benchmarks/track_benchmarks.rb benchmarks/spec/bencher_report_spec.rb benchmarks/spec/track_benchmarks_spec.rb` -> 4 files inspected, no offenses
- `bundle exec rspec benchmarks/spec/bencher_report_spec.rb benchmarks/spec/track_benchmarks_spec.rb benchmarks/spec/report_table_integration_spec.rb` -> 83 examples, 0 failures
- `bundle exec rspec benchmarks/spec` -> 229 examples, 0 failures
- `git diff --check` -> passed
- `(cd react_on_rails && bundle exec rubocop)` -> 214 files inspected, no offenses
- `codex review --base origin/main` -> no actionable correctness issues found
Review/check gate:
- Codex review: complete for `c84a4be3`, no actionable correctness issues
- GitHub checks: pending after PR creation
Known residual risk: No live Bencher service run was available locally; coverage uses pinned JSON fixtures/specs for the Bencher CLI v0.6.2 report shape.
Finalized by: not finalized; authoring agent only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark regression gating and CI exit codes; incorrect filtering could hide real regressions or clear jobs that should fail, though fail-safe paths and extensive specs mitigate this.
> 
> **Overview**
> **Bencher regression detection** now cross-checks active `alerts[]` against current report **boundaries** before counting a regression. Stale alerts (metrics back within limits) are dropped from `#alerts` / `#regression?` but tracked via new `#filtered_alert?`.
> 
> **Fail-safe behavior** is unchanged for ambiguous cases: missing benchmark, unmatchable boundary, unknown limit side, or measure-less alerts with no regression on the alert side still count as regressions so schema drift stays visible.
> 
> **CI exit handling** adds `normalized_bencher_exit_code`: after start-point-hash retry, a non-zero Bencher exit with only filtered (stale) alerts and no real regression is normalized to **0** with a `::notice::`, avoiding false regression filing while preserving the raw exit for retry logic first.
> 
> Specs cover stale vs current alerts, measure-less alerts, fail-safe paths, and exit normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84a4be36a94906ada15115dfabde33df51145ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved alert classification to distinguish actual performance regressions from other active alerts.
  * Enhanced exit code handling to prevent false workflow failures when only non-regression alerts are present.

* **Tests**
  * Expanded test coverage for edge cases in alert filtering and regression detection.
  * Added tests for retry behavior and exit code normalization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->