### PR TITLE
Make PR batches skip customer-feedback issues

### DIFF
--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -28,6 +28,7 @@ Plan a PR batch
    - Record title, URL, state, branch/author for PRs, labels, linked PR/issue refs, and blockers. If a fact cannot be verified, write `UNKNOWN`.
 
 3. Shape
+   - Exclude issues labeled `needs-customer-feedback` from implementation batches unless the user explicitly provides customer evidence or maintainer approval for that issue; list them under "Excluded or deferred" with `needs-customer-feedback` as the reason.
    - For any issue that is speculative, AI/code-analysis-only, over-scoped, or unclear in value, priority, or fix scope, route through `.agents/skills/evaluate-issue/SKILL.md` before assigning it to implementation work.
    - Exclude closed or merged items unless the user explicitly asked to audit them.
    - Separate independent work from dependency-ordered work.

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -19,6 +19,7 @@ Use `.agents/workflows/pr-processing.md` as the deeper operating model for each 
 If the target scope is not verified yet, use `.agents/skills/plan-pr-batch/SKILL.md` first.
 For release-mode coordination, auto-merge confidence, and shared release tracker updates, follow `AGENTS.md` and the release-mode sections of `.agents/workflows/pr-processing.md`; do not invent new labels or overwrite tracker issue bodies from stale reads.
 If any target's value, priority, or proposed fix scope is unclear, use `.agents/skills/evaluate-issue/SKILL.md` before assigning implementation workers.
+Skip issues labeled `needs-customer-feedback` unless the user explicitly provides customer evidence or maintainer approval for that issue; report each skipped target with `needs-customer-feedback` as the reason.
 
 ## Non-Negotiable Safety Rules
 
@@ -60,6 +61,7 @@ Before implementation or worker launch, produce:
 
 1. A concrete goal name.
 2. A disposition summary for speculative, AI/code-analysis-only, over-scoped, or unclear candidates, or `N/A - all targets pre-approved`.
+   - Include any `needs-customer-feedback` targets skipped from implementation, with that label as the reason.
 3. A repo preflight: fetch/prune `main`, confirm the expected repository root, and verify nested repo paths before assigning work.
 4. A short batch table:
    - target number and title


### PR DESCRIPTION
## Summary

- Make `$pr-batch` explicitly skip issues labeled `needs-customer-feedback` unless the user provides customer evidence or maintainer approval.
- Make `$plan-pr-batch` report those skipped issues under excluded/deferred with the label as the reason.
- Add the skipped-label reason to the `$pr-batch` planning output expectations.

## Validation

- `pnpm start format.listDifferent`
- YAML frontmatter parse for `.agents/skills/pr-batch/SKILL.md` and `.agents/skills/plan-pr-batch/SKILL.md`
- `git diff --check`
- pre-commit hook
- pre-push hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent skill markdown; no runtime code, auth, or data paths change.
> 
> **Overview**
> **PR batch skills now treat `needs-customer-feedback` as out of scope by default.**
> 
> `$plan-pr-batch` excludes those issues from implementation batches unless the user supplies customer evidence or maintainer approval, and lists them under **Excluded or deferred** with that label as the reason. **`$pr-batch`** adds the same skip rule at workflow start and expects planning output to call out any skipped targets in the disposition summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b957154fe07ab55de182ce1a28bf6a967332fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced batch processing rules to exclude issues requiring customer feedback from implementation batches unless customer evidence or maintainer approval is provided. Deferred items are now clearly tracked in the disposition records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->