### PR TITLE
Docs: clarify RuboCop autofix ownership

### DIFF
--- a/internal/contributor-info/linters.md
+++ b/internal/contributor-info/linters.md
@@ -16,7 +16,8 @@ If you haven't tried the autofix options for `eslint` and `rubocop`, you're seri
 (cd react_on_rails && bundle exec rubocop -A)
 
 # Pro Ruby or RuboCop config changes:
-# --ignore-parent-exclusion is required because the root .rubocop.yml excludes subdirectories.
+# --ignore-parent-exclusion prevents root AllCops Exclude patterns, written as root-relative paths,
+# from being applied while running inside react_on_rails_pro/.
 (cd react_on_rails_pro && bundle exec rubocop -A --ignore-parent-exclusion)
 ```
 

--- a/internal/contributor-info/linters.md
+++ b/internal/contributor-info/linters.md
@@ -8,10 +8,10 @@ If you haven't tried the autofix options for `eslint` and `rubocop`, you're seri
 
 1. Be **SURE** you have a clean git status, as you'll want to review what the autofix does to your code!
 2. **RuboCop:** In this monorepo, use the package-scoped bundle that owns the Ruby files. For routine
-   formatting, prefer `rake autofix`; for targeted Ruby autofix on a specific package:
+   OSS Ruby and JS/TS formatting, prefer `rake autofix`; for targeted Ruby autofix on a specific package:
 
 ```bash
-# OSS Ruby (react_on_rails package only; skip if you already ran rake autofix):
+# OSS Ruby (react_on_rails package only; equivalent to rake autofix's Ruby step):
 # -A includes unsafe cops, matching the set rake autofix applies.
 (cd react_on_rails && bundle exec rubocop -A)
 

--- a/internal/contributor-info/linters.md
+++ b/internal/contributor-info/linters.md
@@ -8,12 +8,14 @@ If you haven't tried the autofix options for `eslint` and `rubocop`, you're seri
 
 1. Be **SURE** you have a clean git status, as you'll want to review what the autofix does to your code!
 2. **RuboCop:** In this monorepo, use the package-scoped bundle that owns the Ruby files. For routine
-   formatting, prefer `rake autofix`; for targeted Ruby autofix, run the matching package command:
+   formatting, prefer `rake autofix`; for targeted Ruby autofix on a specific package:
 
 ```bash
-(cd react_on_rails && bundle exec rubocop -a)
-# Also run when autofixing Pro Ruby or RuboCop config:
-(cd react_on_rails_pro && bundle exec rubocop -a --ignore-parent-exclusion)
+# OSS Ruby (react_on_rails package only; skip if you already ran rake autofix):
+(cd react_on_rails && bundle exec rubocop -A)
+
+# Pro Ruby or RuboCop config changes:
+(cd react_on_rails_pro && bundle exec rubocop -A --ignore-parent-exclusion)
 ```
 
 3. **ESLint:** Be sure to be in the correct directory where you have JS files.

--- a/internal/contributor-info/linters.md
+++ b/internal/contributor-info/linters.md
@@ -12,9 +12,11 @@ If you haven't tried the autofix options for `eslint` and `rubocop`, you're seri
 
 ```bash
 # OSS Ruby (react_on_rails package only; skip if you already ran rake autofix):
+# -A includes unsafe cops, matching the set rake autofix applies.
 (cd react_on_rails && bundle exec rubocop -A)
 
 # Pro Ruby or RuboCop config changes:
+# --ignore-parent-exclusion is required because the root .rubocop.yml excludes subdirectories.
 (cd react_on_rails_pro && bundle exec rubocop -A --ignore-parent-exclusion)
 ```
 

--- a/internal/contributor-info/linters.md
+++ b/internal/contributor-info/linters.md
@@ -7,10 +7,13 @@ These linters support the [ShakaCode Style Guidelines](../../docs/oss/misc/style
 If you haven't tried the autofix options for `eslint` and `rubocop`, you're seriously missing out!
 
 1. Be **SURE** you have a clean git status, as you'll want to review what the autofix does to your code!
-2. **Rubocop:** Be sure to be in the correct directory where you have Ruby files, usually the top level of your Rails project.
+2. **RuboCop:** In this monorepo, use the package-scoped bundle that owns the Ruby files. For routine
+   formatting, prefer `rake autofix`; for targeted Ruby autofix, run the matching package command:
 
 ```bash
-bundle exec rubocop -a
+(cd react_on_rails && bundle exec rubocop -a)
+# Also run when autofixing Pro Ruby or RuboCop config:
+(cd react_on_rails_pro && bundle exec rubocop -a --ignore-parent-exclusion)
 ```
 
 3. **ESLint:** Be sure to be in the correct directory where you have JS files.


### PR DESCRIPTION
## Summary

- Updates `internal/contributor-info/linters.md` so RuboCop autofix guidance uses the package-scoped OSS and Pro bundle commands instead of a generic root `bundle exec rubocop -a` snippet.
- Keeps the broader root Gemfile/Gemfile.lock ownership decision out of this tiny docs patch.

Refs #3825.

## Research Notes

- No open duplicate found for #3825. Related history: #2214 is closed and explicitly superseded by #3825; PR #2153 unified RuboCop config/shared deps; PR #3312 clarified the AGENTS RuboCop lint contract; PR #3378 completed JS/TS/Pro workflow lint consolidation.
- `AGENTS.md` already distinguishes OSS CI RuboCop, Pro CI RuboCop, and root diagnostic RuboCop.
- The root `Gemfile` still delegates to `react_on_rails/Gemfile`; RuboCop gems remain centralized in `Gemfile.shared_dev_dependencies` and imported by package dev Gemfiles.
- CI pins package bundles for OSS and Pro linting; no root `Gemfile.lock` is currently present.

## Remaining Decisions

- UNKNOWN whether maintainers want the root `Gemfile` to become a RuboCop-only orchestration layer with a committed root `Gemfile.lock`.
- UNKNOWN whether the benchmark workflow TODO that still references #2214 should move now or wait for the root lockfile decision.

## Review Follow-up

- `940d3fca` addresses Claude review feedback from 2026-06-09 by aligning targeted RuboCop autofix commands with `rake autofix` (`-A`) and clarifying that the Pro command is for Pro Ruby or RuboCop config changes, not an always-run second step.

- `9f7864fa` addresses follow-up Claude feedback from 2026-06-09 by documenting that targeted `-A` matches `rake autofix` including unsafe cops, and explaining why Pro needs `--ignore-parent-exclusion`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check internal/contributor-info/linters.md`
- pre-commit hook: trailing newline, markdown link, and Prettier checks
- `git diff --check origin/main..HEAD`
- `script/ci-changes-detector origin/main` -> documentation-only, recommended CI jobs: none
- pre-push hook: branch lint and online markdown links

## Labels

Labels: none. Internal docs-only change; no CI expansion recommended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal documentation only; no runtime, CI, or lint behavior changes.
> 
> **Overview**
> Updates contributor **RuboCop autofix** guidance in `internal/contributor-info/linters.md` so it matches how this monorepo actually runs lint fixes.
> 
> Instead of a generic root `bundle exec rubocop -a`, the doc now tells contributors to use **`rake autofix`** for routine OSS Ruby and JS/TS formatting, and gives **package-scoped** commands when autofixing Ruby in a specific package: `(cd react_on_rails && bundle exec rubocop -A)` for OSS (noting `-A` matches `rake autofix`, including unsafe cops), and `(cd react_on_rails_pro && bundle exec rubocop -A --ignore-parent-exclusion)` for Pro Ruby or RuboCop config work, with a short note on why Pro needs `--ignore-parent-exclusion`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5dcb6bcc1d01bf6c03692bf2b0c05ccf422cf2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor linter/autofix guidance: run RuboCop from each Ruby-owning package directory rather than a single top-level command; prefer using the project’s routine autofix task for everyday formatting; added package-scoped guidance for OSS Ruby packages and separate guidance for Pro package scenarios, including how to handle Pro configuration changes and parent-exclusion cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->