### PR TITLE
Name the regressed benchmark+measure pairs in the issue body

### DIFF
--- a/benchmarks/report_regressions.rb
+++ b/benchmarks/report_regressions.rb
@@ -40,10 +40,12 @@ class RegressionIssueReporter
     new(**attributes).report(summary)
   end
 
-  def initialize(suite_name:, github_run_url:, bencher_url:, issue_number_cache: nil, report_comment_id_cache: nil)
+  def initialize(suite_name:, github_run_url:, bencher_url:, regressed_overview: "",
+                 issue_number_cache: nil, report_comment_id_cache: nil)
     @suite_name = suite_name
     @github_run_url = github_run_url
     @bencher_url = bencher_url
+    @regressed_overview = regressed_overview
     @issue_number_cache = issue_number_cache
     @report_comment_id_cache = report_comment_id_cache
     @commit_short = ENV.fetch("GITHUB_SHA")[0, 7]
@@ -63,7 +65,8 @@ class RegressionIssueReporter
 
   private
 
-  attr_reader :suite_name, :github_run_url, :bencher_url, :issue_number_cache, :report_comment_id_cache, :commit_short
+  attr_reader :suite_name, :github_run_url, :bencher_url, :regressed_overview, :issue_number_cache,
+              :report_comment_id_cache, :commit_short
 
   def ensure_regression_label
     GithubCli.run(
@@ -321,7 +324,7 @@ class RegressionIssueReporter
       | **Pushed by** | @#{github_actor} |
       | **Workflow run** | [Run ##{github_run_number}](#{github_run_url}) |
       | **Bencher dashboard** | [View history](#{bencher_url}) |
-
+      #{regressed_section}
       ### What to do
 
       1. Check the workflow run for the full Bencher HTML report
@@ -332,6 +335,24 @@ class RegressionIssueReporter
 
       ---
       *This issue was created automatically by the benchmark CI workflow.*
+    MARKDOWN
+  end
+
+  # A "What regressed" section naming the confirmed benchmark+measure pairs, so the issue
+  # body itself says what regressed (the per-suite tables flag only rps/p50, never the
+  # column-less failed_pct). Empty when no structured pairs were handed off, leaving the
+  # body unchanged.
+  def regressed_section
+    return "" if regressed_overview.to_s.strip.empty?
+
+    <<~MARKDOWN
+
+      ### What regressed
+
+      The fresh-runner confirmation re-alerted on these benchmark + measure pairs:
+
+      #{regressed_overview}
+
     MARKDOWN
   end
 
@@ -400,6 +421,23 @@ def shard_summary(payload)
   MARKDOWN
 end
 
+# A flat, deduped list of the confirmed benchmark+measure pairs across all suites, for the
+# issue body — so a reader sees what regressed without opening the per-suite tables. Built
+# from each payload's structured ALERTS ({benchmark, measure}); "" when no payload carried
+# them (older writer, or alerts with no benchmark name), which leaves the body unchanged.
+def regressed_overview_markdown(payloads)
+  payloads
+    .flat_map { |payload| payload[RegressionReport::ALERTS] || [] }
+    .select { |pair| pair.is_a?(Hash) && pair[RegressionReport::ALERT_BENCHMARK] }
+    .uniq
+    .map do |pair|
+      benchmark = pair[RegressionReport::ALERT_BENCHMARK]
+      measure = pair[RegressionReport::ALERT_MEASURE]
+      measure ? "- `#{benchmark}` — **#{measure}**" : "- `#{benchmark}`"
+    end
+    .join("\n")
+end
+
 # Reports the confirmed regressions. Returns:
 #   :clean  — no confirmed payloads (every first-run alert cleared as noise / ignored)
 #   :filed  — at least one confirmed regression filed/updated successfully
@@ -418,12 +456,17 @@ def report_regressions(artifacts_dir)
   # One section per suite: a sharded suite emits one payload per shard, so combine
   # them rather than filing a section per shard. Suites sorted for stable output.
   by_suite = readable.group_by { |payload| payload.fetch(RegressionReport::SUITE_NAME) }
+  # Name every confirmed benchmark+measure pair across all suites in the issue body so it is
+  # actionable on its own. Computed once and passed to each suite's reporter; only the
+  # reporter that creates the issue renders the body.
+  regressed_overview = regressed_overview_markdown(readable)
   issue_number_cache = {}
   report_comment_id_cache = {}
   reported_ok = by_suite.keys.sort.map do |suite_name|
     report_suite(
       suite_name,
       by_suite.fetch(suite_name),
+      regressed_overview:,
       issue_number_cache:,
       report_comment_id_cache:
     )
@@ -435,7 +478,7 @@ def report_regressions(artifacts_dir)
   :filed
 end
 
-def report_suite(suite_name, payloads, issue_number_cache: nil, report_comment_id_cache: nil)
+def report_suite(suite_name, payloads, regressed_overview: "", issue_number_cache: nil, report_comment_id_cache: nil)
   # Order shard summaries by shard number ("2/5" before "10/5"); each already
   # self-labels with its shard in its headers, so concatenation reads cleanly.
   summary = payloads
@@ -449,6 +492,7 @@ def report_suite(suite_name, payloads, issue_number_cache: nil, report_comment_i
     github_run_url: Github.run_url,
     bencher_url: BENCHER_URL,
     summary:,
+    regressed_overview:,
     issue_number_cache:,
     report_comment_id_cache:
   )

--- a/benchmarks/spec/report_regressions_spec.rb
+++ b/benchmarks/spec/report_regressions_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe "benchmark regression reporting" do
         expect(calls).to eq(["label create", "issue list", "issue create", "comment list", "comment create"])
       end
 
+      it "names the confirmed benchmark+measure pairs in the created issue body" do
+        described_class.report(
+          summary: "core regressed",
+          suite_name: "core",
+          github_run_url: "https://github.com/run/1",
+          bencher_url: "https://bencher.dev/dash",
+          regressed_overview: "- `/x: Core` — **rps**"
+        )
+        body = posted_bodies.fetch("issue create")
+        expect(body).to include("### What regressed")
+        expect(body).to include("- `/x: Core` — **rps**")
+      end
+
+      it "omits the what-regressed section when no pairs were handed off" do
+        report
+        expect(posted_bodies.fetch("issue create")).not_to include("What regressed")
+      end
+
       it "reuses a just-created issue number for later suites in the same reporter run" do
         issue_number_cache = {}
 
@@ -274,6 +292,25 @@ RSpec.describe "benchmark regression reporting" do
   # first-run/confirmation evidence rendering, and the exit status. A confirmed
   # regression fails the workflow (exit 1) even though the issue was filed successfully —
   # this job owns the final pass/fail.
+  describe "regressed_overview_markdown" do
+    it "renders deduped benchmark+measure bullets from each payload's ALERTS" do
+      payloads = [
+        { RegressionReport::ALERTS => [
+          { RegressionReport::ALERT_BENCHMARK => "/a: Core", RegressionReport::ALERT_MEASURE => "rps" },
+          { RegressionReport::ALERT_BENCHMARK => "/a: Core", RegressionReport::ALERT_MEASURE => "rps" }
+        ] },
+        { RegressionReport::ALERTS => [
+          { RegressionReport::ALERT_BENCHMARK => "/b: Pro", RegressionReport::ALERT_MEASURE => nil }
+        ] }
+      ]
+      expect(regressed_overview_markdown(payloads)).to eq("- `/a: Core` — **rps**\n- `/b: Pro`")
+    end
+
+    it "is empty when no payload carries structured alert pairs" do
+      expect(regressed_overview_markdown([{ RegressionReport::SUITE_NAME => "Core" }])).to eq("")
+    end
+  end
+
   describe "report_regressions.rb (script)" do
     script = File.expand_path("../report_regressions.rb", __dir__)
 


### PR DESCRIPTION
## Problem

A confirmed `performance-regression` issue currently only shows the per-suite summary tables. Those tables flag 🔴 on **rps** and **p50** but never on **failed_pct** (it has no column — it lives in the "Status" cell) and never on any untracked measure. So a reader has to open the tables to see what regressed, and a `failed_pct`-only regression renders with no visible 🔴 at all — the same "the issue names nothing actionable" problem behind #3782/#3795.

## Fix

Add a **"What regressed"** section to the issue body, built from the confirmed `ALERTS` payload (#3810's structured `{benchmark, measure}` pairs), aggregated across all suites and computed once in `report_regressions`:

```
### What regressed

The fresh-runner confirmation re-alerted on these benchmark + measure pairs:

- `/client_side_log_throw: Pro` — **rps**
- `/server_side_redux_app: Core` — **failed_pct**
```

- Threaded through `report_suite` → `RegressionIssueReporter`; only the reporter that *creates* the issue renders the body, so the cross-suite list is complete.
- `regressed_overview` defaults to `""` → the section is omitted and the body is byte-for-byte unchanged, so it composes with the existing flow and with older payloads that lack `ALERTS`.

## Validation

- `bundle exec rspec benchmarks/spec` — **233 examples, 0 failures** (4 new: helper rendering/dedup + issue-body inclusion/omission).
- `bundle exec rubocop benchmarks/...` — no offenses.
- Rendered the body locally with and without pairs to confirm clean Markdown spacing and that the no-pairs body is unchanged.

## Relationship to other work

Complements #3829 (filter alerts to tracked measures): #3829 stops the p90 false positives from filing at all; this makes the *real* confirmed regressions self-explanatory in the issue body. Refs #3755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI reporting and GitHub issue markdown only; no runtime app or auth changes.
> 
> **Overview**
> Adds a **"What regressed"** section to auto-filed `performance-regression` issue bodies, listing confirmed benchmark + measure pairs as markdown bullets (including measures like **failed_pct** that the per-suite tables do not surface clearly).
> 
> `report_regressions` builds the list once from each confirmed payload's structured `ALERTS` via new `regressed_overview_markdown` (deduped across suites) and passes `regressed_overview` into `RegressionIssueReporter`. The section is omitted when the overview is empty, so older payloads without `ALERTS` keep the previous body shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3068c935c629977c80f0e93dc45f86a54470151b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance regression reports now include a "What regressed" overview section, displaying all confirmed benchmark and measure pairs that regressed across test suites in a single consolidated view.

* **Tests**
  * Added comprehensive test coverage for the new regression overview markdown rendering logic and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->