### PR TITLE
Docs: align pr-batch closeout confidence handoff

### DIFF
--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -114,11 +114,11 @@ For high-risk cases above, run Claude's `/simplify` after all required review pa
 
 Before merge, wait for requested or configured review agents such as Claude, CodeRabbit, Greptile, Cursor Bugbot, and Codex review to finish for the current head SHA. Poll CI with bounded commands and timeouts; use narrow required-check commands such as `gh pr checks <PR> --required` for required CI readiness, then also fetch all checks or explicit review-agent checks so non-required reviewers are not hidden. Avoid long-lived `gh ... --watch`. Ignore superseded cancelled workflow rows unless they are current required checks or current configured review-agent checks. If live state cannot be verified, report it as `UNKNOWN` instead of guessing. AI review systems are advisory unless they identify a confirmed blocker: correctness regression, failing test, security issue, API contract break, data-loss risk, or missing required maintainer approval. Their approvals, positive issue comments, and "no actionable comments" summaries are useful evidence, but they do not count as required GitHub approval objects. For high-risk or concurrent-batch PRs, run or request the adversarial PR review workflow in `.agents/workflows/adversarial-pr-review.md`. A completed check is not enough when review comments exist: classify and resolve or explicitly waive actionable findings before merging. Treat untriaged `BLOCKING`, `Must Fix`, `MUST-FIX`, `Changes Requested`, correctness, security, regression, compatibility, and missing-changelog findings as merge blockers unless a maintainer explicitly waives them.
 
-At the final review/readiness gate, apply the canonical full-CI uncertainty rule and Coordinator Closeout Lane from `.agents/workflows/pr-processing.md` under **Plan To Goal Handoff**.
+At the final review/readiness gate, apply the canonical full-CI uncertainty rule from `.agents/workflows/pr-processing.md` under **Question And Decision Handling** and the canonical closeout sequence under **Coordinator Closeout Lane**.
 
 For blocking questions, stop work on that target, surface a structured question to the coordinator or maintainer, and mark the issue/PR with the agreed pending-question state. Report the question/comment URL as `blocked needing user input`; do not open a speculative PR. For non-blocking questions where you make a decision and continue, record the decision in the PR description before review or merge.
 
-Before final handoff, follow the canonical final-state and `Immediate maintainer attention` / `FYI / decisions made` split in `.agents/workflows/pr-processing.md`.
+Before final handoff, follow the canonical final-state and `Immediate maintainer attention` / `FYI / decisions made` split in `.agents/workflows/pr-processing.md` under **Batch Handoff Format**.
 ```
 
 ## Question And Decision Handling
@@ -150,6 +150,8 @@ Suggested PR description section:
 Before merge or final readiness, scan the PR description for the decision log and make sure each non-blocking decision is still accurate after review changes.
 
 ## Batch Handoff Format
+
+<!-- Keep this handoff summary in sync with `.agents/workflows/pr-processing.md` -> `### Batch Handoff Format`. -->
 
 Use the canonical Batch Handoff Format in
 `.agents/workflows/pr-processing.md`. In short, split final batch handoffs into

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -276,7 +276,7 @@ Before merge, wait for requested or configured review agents such as Claude, Cod
 
 At the final review/readiness gate, after local validation, PR creation or update, review-thread triage, and the final push for the current head SHA, request full CI with `+ci-run-full` if you are unsure whether path-selected CI is enough. Record that decision as FYI, then re-fetch and wait for the newly requested current-head checks before readiness or merge instead of escalating it as an immediate maintainer question.
 
-After workers finish, the coordinator must keep working through the Coordinator Closeout Lane instead of stopping at PR creation: re-fetch live PR status, wait for current-head checks and reviews, triage/resolve or explicitly waive current unresolved review threads, update stale release-mode classification or accelerated-RC confidence block, request full CI when uncertainty remains, re-fetch and wait for the newly requested current-head checks, and merge eligible ready PRs when authorized under the current release mode.
+After workers finish, the coordinator must keep working through the Coordinator Closeout Lane instead of stopping at PR creation: re-fetch live PR status, wait for current-head checks and reviews, triage/resolve or explicitly waive current unresolved review threads, update stale release-mode classification, refresh the finalized PR-body `Agent Merge Confidence` block when accelerated-RC readiness requires it, request full CI when uncertainty remains, re-fetch and wait for the newly requested current-head checks, and merge eligible ready PRs when authorized under the current release mode.
 
 For blocking questions, stop work on that target, surface a structured question to the coordinator or maintainer, and mark the issue/PR with the agreed pending-question state. Report the question/comment URL as `blocked needing user input`; do not open a speculative PR. For non-blocking questions where you make a decision and continue, record the decision in the PR description before review or merge.
 
@@ -377,10 +377,10 @@ The closeout lane is:
    polling.
 3. Fetch current unresolved review threads and triage them as fixed, waived, or
    still blocking.
-4. Refresh stale release-mode classification or accelerated-RC confidence block
-   (the `Agent Confidence:` block in the release tracker required by
-   accelerated-RC mode; canonical definition in `AGENTS.md`) before readiness or
-   merge.
+4. Refresh stale release-mode classification from the release tracker when
+   needed. For accelerated-RC merge readiness, refresh the latest finalized
+   PR-body `Agent Merge Confidence` block required by `AGENTS.md`; keep this
+   distinct from tracker mode/classification updates.
 5. After the final push, if local validation passed and the only uncertainty is
    whether full CI is needed, request full CI with `+ci-run-full` and record the
    reason as FYI, then loop back to re-fetch and wait for the newly requested


### PR DESCRIPTION
## Summary

- Corrects the coordinator closeout lane so accelerated-RC readiness points to the finalized PR-body `Agent Merge Confidence` block instead of a tracker-side confidence block.
- Keeps release tracker mode/classification handling separate from accelerated-RC confidence refreshes.
- Tightens `pr-batch` final-readiness pointers to the canonical `Question And Decision Handling`, `Coordinator Closeout Lane`, and `Batch Handoff Format` sections.
- Adds a sync marker for the `pr-batch` batch handoff summary to reduce future drift.

Closes #3833

## Validation

- `pnpm exec prettier --write .agents/workflows/pr-processing.md .agents/skills/pr-batch/SKILL.md` -> unchanged
- `git diff --check` -> passed
- `lychee --config .lychee.toml .agents/workflows/pr-processing.md .agents/skills/pr-batch/SKILL.md` -> passed
- pre-commit hook -> trailing newlines, offline markdown links, Prettier passed
- pre-push hook -> branch-lint skipped Ruby lint as no Ruby files changed; online markdown links passed

Labels: none. Docs/process-only change outside CI, runtime, build, generator, SSR, hydration, Pro/core, or benchmark surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process documentation only; no runtime, CI, or application code changes.
> 
> **Overview**
> Aligns **pr-batch** and **pr-processing** docs so coordinator closeout no longer treats accelerated-RC confidence as a release-tracker block.
> 
> The **Coordinator Closeout Lane** now separates refreshing stale **release-mode classification** on the tracker from refreshing the finalized PR-body **`Agent Merge Confidence`** block required for accelerated-RC merge readiness (per `AGENTS.md`). The post-worker coordinator summary matches that split.
> 
> The **pr-batch** goal template points final-readiness steps at the canonical **Question And Decision Handling** (full-CI uncertainty), **Coordinator Closeout Lane**, and **Batch Handoff Format** sections instead of the older **Plan To Goal Handoff** wording. A sync comment was added so the batch handoff summary stays aligned with `pr-processing.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 358f00b787e8e63f38ae9ced2a6d9952cad337ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow documentation to clarify coordination procedures for PR processing and merge readiness assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->