### PR TITLE
Keep root RuboCop bundle lint-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,10 +62,10 @@ updates:
           - "shakapacker"
     multi-ecosystem-group: "execjs-dummy-shakapacker"
 
-  # Ruby gems - Open source and Pro gems (including dummy apps)
-  # Root directory is not included because it reuses the Gemfile from react_on_rails
+  # Ruby gems - root tooling plus Open source and Pro gems (including dummy apps)
   - package-ecosystem: "bundler"
     directories:
+      - "/"
       - "/react_on_rails"
       - "/react_on_rails/spec/dummy"
       - "/react_on_rails_pro"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,12 @@ If there is a conflict, `AGENTS.md` wins.
 # Install dependencies
 # The committed root Gemfile.lock is generated with Bundler 4.0.10; use Bundler
 # 4.0.10 or newer before running root bundle commands.
-bundle && pnpm install
+bundle && (cd react_on_rails && bundle) && pnpm install
 
-# After changing react_on_rails/Gemfile or Gemfile.shared_dev_dependencies,
-# also run bundle install at the repo root to keep the root Gemfile.lock synced.
+# The root Gemfile is intentionally limited to repo-wide lint, hook, release,
+# and benchmark script spec tooling. After changing package Gemfiles, run bundle
+# install in that package directory; after changing the root Gemfile, run bundle
+# install at the repo root to sync the tooling lock.
 
 # Build TypeScript → JavaScript
 pnpm run build
@@ -53,35 +55,36 @@ pnpm run build
 (cd react_on_rails_pro && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion)
 pnpm run lint                                                    # JS/TS via ESLint
 pnpm start format.listDifferent                                  # Check Prettier formatting
-rake lint                                                        # All linting (Ruby + JS + formatting)
+(cd react_on_rails && bundle exec rake lint)                     # Package lint task (Ruby + JS + formatting)
 
 # Optional Ruby diagnostic from the repo root (not the CI contract)
 BUNDLE_GEMFILE=Gemfile bundle exec rubocop
 
 # Auto-fix formatting
-rake autofix                         # Preferred for all formatting
+(cd react_on_rails && bundle exec rake autofix) # Preferred for all formatting
 
 # Run tests
-rake run_rspec:gem                   # Ruby unit tests (gem code)
-rake run_rspec:dummy                 # Ruby integration tests (dummy Rails app)
+(cd react_on_rails && bundle exec rake run_rspec:gem)   # Ruby unit tests (gem code)
+(cd react_on_rails && bundle exec rake run_rspec:dummy) # Ruby integration tests (dummy Rails app)
 pnpm run test                        # JavaScript/TypeScript tests
-rake                                 # Full suite (lint + all tests except examples)
+(cd react_on_rails && bundle exec rake)                 # Full package suite (lint + tests except examples)
 
 # Type checking
 pnpm run type-check                  # TypeScript
-bundle exec rake rbs:validate        # RBS signatures
+(cd react_on_rails && bundle exec rake rbs:validate) # RBS signatures
 
 # Additional test subsets
-rake run_rspec                       # All Ruby tests
-rake all_but_examples                # All tests except generated examples
-rake run_rspec:shakapacker_examples_basic  # Single example test
+(cd react_on_rails && bundle exec rake run_rspec) # All Ruby tests
+(cd react_on_rails && bundle exec rake all_but_examples) # All tests except generated examples
+(cd react_on_rails && bundle exec rake run_rspec:shakapacker_examples_basic) # Single example test
 
 # Documentation checks
 script/check-docs-sidebar            # Validate docs sidebar coverage
 bin/check-links                      # Markdown link checks (requires lychee)
 
 # Full initial setup
-bundle && pnpm install && rake shakapacker_examples:gen_all && rake node_package && rake
+bundle && (cd react_on_rails && bundle) && pnpm install && \
+  (cd react_on_rails && bundle exec rake shakapacker_examples:gen_all node_package && bundle exec rake)
 
 # CI/workflow linting
 actionlint                           # GitHub Actions lint

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-# Root Gemfile for developer convenience and RuboCop tooling.
-# RuboCop is owned here so the monorepo uses one locked version.
+source "https://rubygems.org"
 
-# Use the open-source gem's Gemfile
-eval_gemfile File.expand_path("react_on_rails/Gemfile", __dir__)
-
+# Root Gemfile for repo-wide lint, hook, release, and benchmark script spec tooling only.
+# Package/runtime dependencies stay in the package Gemfiles so root bundle install
+# remains small.
 group :development, :test do
+  gem "benchmark", "0.5.0", require: false
+  gem "gem-release", "2.2.4", require: false
+  gem "lefthook", "2.1.9", require: false
+  gem "rake", "13.4.2", require: false
+  gem "rspec", "3.13.2", require: false
   gem "rubocop", "1.61.0", require: false
   gem "rubocop-performance", "1.20.2", require: false
   gem "rubocop-rspec", "2.31.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,319 +1,27 @@
-PATH
-  remote: react_on_rails
-  specs:
-    react_on_rails (17.0.0.rc.1)
-      addressable
-      connection_pool
-      execjs (~> 2.5)
-      rails (>= 5.2)
-      rainbow (~> 3.0)
-      shakapacker (>= 6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.1.6)
-      actionpack (= 7.1.6)
-      activesupport (= 7.1.6)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-      zeitwerk (~> 2.6)
-    actionmailbox (7.1.6)
-      actionpack (= 7.1.6)
-      activejob (= 7.1.6)
-      activerecord (= 7.1.6)
-      activestorage (= 7.1.6)
-      activesupport (= 7.1.6)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.1.6)
-      actionpack (= 7.1.6)
-      actionview (= 7.1.6)
-      activejob (= 7.1.6)
-      activesupport (= 7.1.6)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.2)
-    actionpack (7.1.6)
-      actionview (= 7.1.6)
-      activesupport (= 7.1.6)
-      cgi
-      nokogiri (>= 1.8.5)
-      racc
-      rack (>= 2.2.4)
-      rack-session (>= 1.0.1)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
-    actiontext (7.1.6)
-      actionpack (= 7.1.6)
-      activerecord (= 7.1.6)
-      activestorage (= 7.1.6)
-      activesupport (= 7.1.6)
-      globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
-    actionview (7.1.6)
-      activesupport (= 7.1.6)
-      builder (~> 3.1)
-      cgi
-      erubi (~> 1.11)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
-    activejob (7.1.6)
-      activesupport (= 7.1.6)
-      globalid (>= 0.3.6)
-    activemodel (7.1.6)
-      activesupport (= 7.1.6)
-    activerecord (7.1.6)
-      activemodel (= 7.1.6)
-      activesupport (= 7.1.6)
-      timeout (>= 0.4.0)
-    activestorage (7.1.6)
-      actionpack (= 7.1.6)
-      activejob (= 7.1.6)
-      activerecord (= 7.1.6)
-      activesupport (= 7.1.6)
-      marcel (~> 1.0)
-    activesupport (7.1.6)
-      base64
-      benchmark (>= 0.3)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      mutex_m
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0)
-    addressable (2.9.0)
-      public_suffix (>= 2.0.2, < 8.0)
-    amazing_print (2.0.0)
     ast (2.4.3)
-    base64 (0.3.0)
     benchmark (0.5.0)
-    bigdecimal (4.1.2)
-    bootsnap (1.24.6)
-      msgpack (~> 1.2)
-    builder (3.3.0)
-    byebug (13.0.0)
-      reline (>= 0.6.0)
-    capybara (3.40.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.11)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-    capybara-screenshot (1.0.27)
-      capybara (>= 1.0, < 4)
-      launchy
-    cgi (0.5.1)
-    childprocess (5.1.0)
-      logger (~> 1.5)
-    coderay (1.1.3)
-    concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
-    crass (1.0.6)
-    csv (3.3.5)
-    cypress-on-rails (1.20.0)
-      rack
-    date (3.5.1)
-    debug (1.11.1)
-      irb (~> 1.10)
-      reline (>= 0.3.8)
     diff-lcs (1.6.2)
-    docile (1.4.1)
-    drb (2.2.3)
-    equivalent-xml (0.6.0)
-      nokogiri (>= 1.4.3)
-    erb (6.0.4)
-    erubi (1.13.1)
-    execjs (2.10.1)
-    ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-aarch64-linux-musl)
-    ffi (1.17.4-arm-linux-gnu)
-    ffi (1.17.4-arm-linux-musl)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x86_64-darwin)
-    ffi (1.17.4-x86_64-linux-gnu)
-    ffi (1.17.4-x86_64-linux-musl)
-    fileutils (1.8.0)
     gem-release (2.2.4)
-    generator_spec (0.10.0)
-      activesupport (>= 3.0.0)
-      railties (>= 3.0.0)
-    globalid (1.3.0)
-      activesupport (>= 6.1)
-    i18n (1.14.8)
-      concurrent-ruby (~> 1.0)
-    interception (0.5)
-    io-console (0.8.2)
-    irb (1.18.0)
-      pp (>= 0.6.0)
-      prism (>= 1.3.0)
-      rdoc (>= 4.0.0)
-      reline (>= 0.4.2)
-    jbuilder (2.15.1)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
-    jquery-rails (4.6.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.19.8)
     language_server-protocol (3.17.0.5)
-    launchy (3.1.1)
-      addressable (~> 2.8)
-      childprocess (~> 5.0)
-      logger (~> 1.6)
     lefthook (2.1.9)
-    listen (3.10.0)
-      logger
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
-    loofah (2.25.1)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.12.0)
-    mail (2.9.0)
-      logger
-      mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
-    marcel (1.2.1)
-    matrix (0.4.3)
-    method_source (1.1.0)
-    mini_mime (1.1.5)
-    minitest (6.0.6)
-      drb (~> 2.0)
-      prism (~> 1.5)
-    msgpack (1.8.2)
-    mutex_m (0.3.0)
-    net-imap (0.6.4)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
-    net-protocol (0.2.2)
-      timeout
-    net-smtp (0.5.1)
-      net-protocol
-    nio4r (2.7.5)
-    nokogiri (1.19.3-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-musl)
-      racc (~> 1.4)
-    ostruct (0.6.3)
-    package_json (0.2.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
-      prettyprint
-    prettyprint (0.2.0)
     prism (1.9.0)
-    pry (0.16.0)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      reline (>= 0.6.0)
-    pry-byebug (3.12.0)
-      byebug (~> 13.0)
-      pry (>= 0.13, < 0.17)
-    pry-doc (1.7.0)
-      pry (~> 0.11)
-      yard (~> 0.9.21)
-    pry-rails (0.3.11)
-      pry (>= 0.13.0)
-    pry-rescue (1.6.0)
-      interception (>= 0.5)
-      pry (>= 0.12.0)
-    psych (5.4.0)
-      date
-      stringio
-    public_suffix (7.0.5)
-    puma (6.6.1)
-      nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.6)
-    rack-proxy (0.8.2)
-      rack
-    rack-session (2.1.2)
-      base64 (>= 0.1.0)
-      rack (>= 3.0.0)
-    rack-test (2.2.0)
-      rack (>= 1.3)
-    rackup (2.3.1)
-      rack (>= 3)
-    rails (7.1.6)
-      actioncable (= 7.1.6)
-      actionmailbox (= 7.1.6)
-      actionmailer (= 7.1.6)
-      actionpack (= 7.1.6)
-      actiontext (= 7.1.6)
-      actionview (= 7.1.6)
-      activejob (= 7.1.6)
-      activemodel (= 7.1.6)
-      activerecord (= 7.1.6)
-      activestorage (= 7.1.6)
-      activesupport (= 7.1.6)
-      bundler (>= 1.15.0)
-      railties (= 7.1.6)
-    rails-dom-testing (2.3.0)
-      activesupport (>= 5.0.0)
-      minitest
-      nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
-      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    railties (7.1.6)
-      actionpack (= 7.1.6)
-      activesupport (= 7.1.6)
-      cgi
-      irb
-      rackup (>= 1.0.0)
-      rake (>= 12.2)
-      thor (~> 1.0, >= 1.2.2)
-      tsort (>= 0.2)
-      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
-    rbs (4.0.2)
-      logger
-      prism (>= 1.6.0)
-      tsort
-    rdoc (7.2.0)
-      erb
-      psych (>= 4.0.0)
-      tsort
     regexp_parser (2.12.0)
-    reline (0.6.3)
-      io-console (~> 0.5)
     rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -322,19 +30,7 @@ GEM
     rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (7.1.1)
-      actionpack (>= 7.0)
-      activesupport (>= 7.0)
-      railties (>= 7.0)
-      rspec-core (~> 3.13)
-      rspec-expectations (~> 3.13)
-      rspec-mocks (~> 3.13)
-      rspec-support (~> 3.13)
-    rspec-retry (0.6.2)
-      rspec-core (> 3.3)
     rspec-support (3.13.7)
-    rspec_junit_formatter (0.6.0)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.61.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -364,102 +60,7 @@ GEM
     rubocop-rspec_rails (2.29.1)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
-    rubyzip (2.4.1)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
-    sdoc (2.6.5)
-      rdoc (>= 5.0)
-    securerandom (0.4.1)
-    selenium-webdriver (4.9.0)
-      rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
-      websocket (~> 1.0)
-    semantic_range (3.1.1)
-    shakapacker (10.1.0)
-      activesupport (>= 5.2)
-      package_json
-      rack-proxy (>= 0.6.1)
-      railties (>= 5.2)
-      semantic_range (>= 2.3.0)
-    simplecov (0.16.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    spring (4.6.0)
-    sprockets (4.2.2)
-      concurrent-ruby (~> 1.0)
-      logger
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      sprockets (>= 3.0.0)
-    sqlite3 (2.9.5-aarch64-linux-gnu)
-    sqlite3 (2.9.5-aarch64-linux-musl)
-    sqlite3 (2.9.5-arm-linux-gnu)
-    sqlite3 (2.9.5-arm-linux-musl)
-    sqlite3 (2.9.5-arm64-darwin)
-    sqlite3 (2.9.5-x86_64-darwin)
-    sqlite3 (2.9.5-x86_64-linux-gnu)
-    sqlite3 (2.9.5-x86_64-linux-musl)
-    steep (2.0.0)
-      concurrent-ruby (>= 1.1.10)
-      csv (>= 3.0.9)
-      fileutils (>= 1.1.0)
-      json (>= 2.1.0)
-      language_server-protocol (>= 3.17.0.4, < 4.0)
-      listen (~> 3.0)
-      logger (>= 1.3.0)
-      parser (>= 3.2)
-      prism (>= 0.25.0)
-      rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 4.0)
-      securerandom (>= 0.1)
-      strscan (>= 1.0.0)
-      terminal-table (>= 2, < 5)
-      uri (>= 0.12.0)
-    stringio (3.2.0)
-    strscan (3.1.8)
-    terminal-table (4.0.0)
-      unicode-display_width (>= 1.1.1, < 4)
-    thor (1.5.0)
-    tilt (2.7.0)
-    timeout (0.6.1)
-    tsort (0.2.0)
-    turbo-rails (2.0.23)
-      actionpack (>= 7.1.0)
-      railties (>= 7.1.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.6.0)
-    uri (1.1.1)
-    webdrivers (5.3.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
-    websocket (1.2.11)
-    websocket-driver (0.8.1)
-      base64
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
-    yard (0.9.44)
-    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -473,181 +74,36 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  amazing_print
-  benchmark
-  bootsnap
-  capybara (~> 3.40)
-  capybara-screenshot
-  cypress-on-rails (~> 1.19)
-  debug
-  equivalent-xml
-  gem-release
-  generator_spec
-  jbuilder
-  jquery-rails
-  launchy
-  lefthook
-  listen
-  logger
-  ostruct
-  package_json
-  pry
-  pry-byebug
-  pry-doc
-  pry-rails
-  pry-rescue
-  puma (~> 6.0)
-  rails (~> 7.1.0)
-  rbs
-  react_on_rails!
-  rspec-rails
-  rspec-retry
-  rspec_junit_formatter
+  benchmark (= 0.5.0)
+  gem-release (= 2.2.4)
+  lefthook (= 2.1.9)
+  rake (= 13.4.2)
+  rspec (= 3.13.2)
   rubocop (= 1.61.0)
   rubocop-performance (= 1.20.2)
   rubocop-rspec (= 2.31.0)
-  sass-rails (~> 6.0)
-  sdoc
-  selenium-webdriver (= 4.9.0)
-  shakapacker (= 10.1.0)
-  simplecov (~> 0.16.1)
-  spring (~> 4.0)
-  sprockets (~> 4.0)
-  sqlite3 (~> 2.0)
-  steep
-  turbo-rails
-  turbolinks
-  uglifier
-  webdrivers (= 5.3.0)
 
 CHECKSUMS
-  actioncable (7.1.6) sha256=ad428d5f0a810452160820ae3cf3d9d68d8f59e7c76de3bd1f1de2a5ad03c3da
-  actionmailbox (7.1.6) sha256=ded958ad8ec147a5f14555833541f07063af188777b09b50cfeeaa623bc2f731
-  actionmailer (7.1.6) sha256=b07f6420ec66bd299a9da5a35c075849fbd5504e82793301b0c275fa4211d273
-  actionpack (7.1.6) sha256=3fa42da36fdcfc3690a711ed35ac5d527b87d3d676f8d111238aa399151203eb
-  actiontext (7.1.6) sha256=79d657422dd67cc8cb46866a7bec9d89ec8699f7fa5647c0eab3472dc0297e66
-  actionview (7.1.6) sha256=11147d81f90465ae062b2a77805c6f8f446e044e309c51bd9449bdbd43edf566
-  activejob (7.1.6) sha256=0dd9cd051d494608349dd9223a3e61c3933250db77e35ab6617c26c1d52dccbb
-  activemodel (7.1.6) sha256=f72f510018a560b5969e3ffc88214441ff09eed60b310feba678a597b2a2e721
-  activerecord (7.1.6) sha256=1aa298cd7fc97ed8639ebb05a46bd17243a1218d89945bdc2bac1e61e673f079
-  activestorage (7.1.6) sha256=2f1acb8e6592ba783d9cbc3da93ac4477d441dffc5d533ceccbbfab39f4bf398
-  activesupport (7.1.6) sha256=7f12140a813b1c4922a322663e547129aef1840fc512fa262378f6d7e7fd3a7c
-  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  amazing_print (2.0.0) sha256=2e36aba46ac78d37ed27ca0e2056afe3583183bb5c64f157c246b267355e5d6a
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
-  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
-  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
-  capybara-screenshot (1.0.27) sha256=afa1896cc23df77be1774e8d3b3ce3953bf060aeaa04ff87607b5daf689174f2
-  cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
-  childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
-  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
-  cypress-on-rails (1.20.0) sha256=36e79d77d073f4b83d73a275b4908cb838e103adbad305882a683db0eb2ca7e4
-  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
-  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  equivalent-xml (0.6.0) sha256=8919761efa848ad0846369ff8be1f646b17e5061698c4867b09829000cc3f487
-  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
-  erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
-  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
-  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
-  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
-  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
-  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
-  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
-  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
-  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
-  fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02
   gem-release (2.2.4) sha256=2f11124c1580c811507c3b47e875e420cf3ed792a98105b49df11971e6e94db3
-  generator_spec (0.10.0) sha256=4343152308dcfb30bba7583fc0e79acf8c626597686cfe3e9b168f6ab745b37a
-  globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  interception (0.5) sha256=a53818d636752a8df90d8c1bb2f7b6e13a7b828543cb02b50fbde98b849d7907
-  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  jbuilder (2.15.1) sha256=2430bec28fb0cebacb5875b1009cf9d8bc3c303ccb810c4c8b062a4b51457637
-  jquery-rails (4.6.1) sha256=619f3496cdcdeaae1fd6dafa52dbac3fc45b745d4e09712da4184a16b3a8d9c0
   json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
-  launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   lefthook (2.1.9) sha256=2d4d2e028d4ac4b265675c1180fe1f7c50230200630e65c3aff7d3ed90a1a334
-  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
-  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
-  marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
-  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
-  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  msgpack (1.8.2) sha256=e440d11c99d6dfe8b2fbc4feb74c3518c1ba024357c70bbd734d9bb1a44d0d25
-  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
-  net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
-  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
-  net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
-  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
-  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
-  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
-  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
-  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
-  nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
-  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
-  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
-  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
-  package_json (0.2.0) sha256=92c022dc2999a9e57e835f1ec1a84c9a6c2be08e0fd68886c6f86d94101b6b4d
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
-  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
-  pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
-  pry-doc (1.7.0) sha256=6ada9fec062b54441c6444e44f94c345e5c8c0af499d654e40d5a581eb222d8e
-  pry-rails (0.3.11) sha256=a69e28e24a34d75d1f60bcf241192a54253f8f7ef8a62cba1e75750a9653593d
-  pry-rescue (1.6.0) sha256=985bfd506d9866b587fd86790cf8445266a41b7f92c627fc5b21ec7d92aba6db
-  psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
-  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
-  puma (6.6.1) sha256=b9b56e4a4ea75d1bfa6d9e1972ee2c9f43d0883f011826d914e8e37b3694ea1e
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
-  rack-proxy (0.8.2) sha256=d3086e865cbe74e627d41d2c6cd24521206c68d9e0308576760ea06d68e11ab0
-  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
-  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
-  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
-  rails (7.1.6) sha256=9a0a335e510de3daad7542cd791af3d8ff710c644e1da17ed12e96d2f28a7470
-  rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
-  railties (7.1.6) sha256=2a10e97f2eaca66d11f0fef4b1f4d826e6ee28d4cf01ff16624420dd45e7de1c
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
-  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
-  rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25
-  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
-  react_on_rails (17.0.0.rc.1)
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
-  rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
-  rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
-  rspec_junit_formatter (0.6.0) sha256=40dde674e6ae4e6cc0ff560da25497677e34fefd2338cc467a8972f602b62b15
   rubocop (1.61.0) sha256=0c35a94bc6c088205d525b8082affd3b412d75347faff52c1f71a6205301b48e
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-capybara (2.21.0) sha256=5d264efdd8b6c7081a3d4889decf1451a1cfaaec204d81534e236bc825b280ab
@@ -656,50 +112,7 @@ CHECKSUMS
   rubocop-rspec (2.31.0) sha256=2bae19388d78e1ceace44cd95fd34f3209f4ef20cac1b168d0a1325cbba3d672
   rubocop-rspec_rails (2.29.1) sha256=4ae95abbe9ca5a9b6d8be14e50d230fb5b6ba033b05d4c0981b5b76fc44988e4
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
-  sass-rails (6.0.0) sha256=e0b6448ea1c7929fd5929fc7a8eb2d78045e44cc82fc0765a249d3fa1c5810d3
-  sassc (2.4.0) sha256=4c60a2b0a3b36685c83b80d5789401c2f678c1652e3288315a1551d811d9f83e
-  sassc-rails (2.1.2) sha256=5f4fdf3881fc9bdc8e856ffbd9850d70a2878866feae8114aa45996179952db5
-  sdoc (2.6.5) sha256=7998b61c10775ee3179ccb0253774332d139e2c0649c251091f5868107a09b86
-  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  selenium-webdriver (4.9.0) sha256=0f5fc4118ab231e5ef1895b1e14a4366eb9d73d60a8e42b0d84f69cdfdd8b6cf
-  semantic_range (3.1.1) sha256=508333196ef0c7ba33e79579d4df7eb0a41080595e6a655c2515b03d634ec4a9
-  shakapacker (10.1.0) sha256=69017102e169ea3baeb26b71b27223ff2689b987770867bf054f48ed71d63da9
-  simplecov (0.16.1) sha256=8724f0911bbb2b7a3c11155e6d57987cad311f9e5ce7b305b1e2e67fdc73dee9
-  simplecov-html (0.10.2) sha256=f65306e2695913c007ddc8d31d6318f37ae074f2ee1cea1647b3bf4c94ca30d2
-  spring (4.6.0) sha256=e9e41f9a56fa5f111df7c85110a7d606ca731dc116c906ba395fd74c9fd474e3
-  sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
-  sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
-  sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
-  sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
-  sqlite3 (2.9.5-arm-linux-gnu) sha256=1bdfca0c7d63998c60b0f4a8e3c8df2d33800ccc4abd2d612eddbbbc92a4c48b
-  sqlite3 (2.9.5-arm-linux-musl) sha256=bae1109d12b2e9f588455967729b008e1ff4feb7761749df695019c9079913c6
-  sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2
-  sqlite3 (2.9.5-x86_64-darwin) sha256=8e9caae38bd7ebb29cbeee3e7ab1d12dc2327d9a1b92c7fcf0dda05589627a81
-  sqlite3 (2.9.5-x86_64-linux-gnu) sha256=233dbcb6714148dd23bc5aeb33e8efd6eac974969564ddd5794c23d5f52b231e
-  sqlite3 (2.9.5-x86_64-linux-musl) sha256=e7d3a7474e8af0f96150c21abc203fbab5437206bfcdf11deab7741c0ca516f2
-  steep (2.0.0) sha256=6eb0ecc09637bbb54f0a5f2cf63daea6d3208ccace64b4f1107d976333605c30
-  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
-  strscan (3.1.8) sha256=aae2db611a225559f21ffbb71765c9a4e60fd262534a9ea84f4f11c7f32f679e
-  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
-  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
-  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
-  timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
-  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
-  turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
-  turbolinks (5.2.1) sha256=5fea5889c4e2a78a5bd9abda3860c565342b50c6e2593697d5558a08e15cce9c
-  turbolinks-source (5.2.0) sha256=362a41fa851a22b0f15cf8f944b6c7c5788f645dc1f61ae25478bb25c3bc85d4
-  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  uglifier (4.2.1) sha256=75d42b81b10bfd21e7a427fabb1d49ff5ea7bda3c4a5039ddb2a78d194c6f5aa
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
-  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
-  webdrivers (5.3.0) sha256=ea767a601a1e5904f83b0d6ae4531357922805d999d4dad22dc93731026f1033
-  websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
-  websocket-driver (0.8.1) sha256=5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96
-  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
-  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
-  yard (0.9.44) sha256=eb087e9b631ccd887b049f303d489963945452d5e2a7eb49a5a74a7cf6887f28
-  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH
   4.0.10

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-# Root Rakefile for monorepo development
+require "bundler"
+
+# Root Rakefile for monorepo-level tasks
 #
-# This file enables running rake tasks from the monorepo root directory.
-# It loads:
-#   1. Monorepo-level tasks from ./rakelib/ (e.g., release task for both gems)
-#   2. The react_on_rails gem's Rakefile
-#   3. The react_on_rails gem's rakelib tasks
+# Package-specific task implementations live in the package Rakefiles and run
+# with that package's bundle. The root Rakefile keeps compatibility wrappers for
+# common root commands without loading package dependencies into the root bundle.
 #
-# Usage: bundle exec rake -T (from monorepo root)
+# This keeps the root bundle focused on lint/tooling/release gems while Rake still
+# auto-loads monorepo-level tasks from ./rakelib/.
 #
 # Note: This is for development only. When the gem is installed in a Rails app,
 # Rails::Engine handles rake task loading automatically from lib/tasks/.
@@ -18,13 +19,150 @@ def gem_root
   File.expand_path("react_on_rails", __dir__)
 end
 
-# Load the open-source gem's Rakefile
-load File.expand_path("Rakefile", gem_root)
+def package_rake_task(task_name, *task_args)
+  task_invocation = if task_args.empty?
+                      task_name.to_s
+                    else
+                      "#{task_name}[#{task_args.join(',')}]"
+                    end
 
-# Load all rake tasks from the gem's rakelib directory
-# Rake only auto-loads from ./rakelib in the current working directory,
-# so we must explicitly load from the subdirectory.
-Dir[File.join(gem_root, "rakelib", "*.rake")].each { |rake_file| load rake_file }
+  ensure_package_bundle
+
+  Dir.chdir(gem_root) do
+    Bundler.with_unbundled_env do
+      sh "bundle", "exec", "rake", task_invocation
+    end
+  end
+end
+
+def ensure_package_bundle
+  bundle_ready = Dir.chdir(gem_root) do
+    Bundler.with_unbundled_env do
+      system("bundle", "check")
+    end
+  end
+
+  return if bundle_ready
+
+  puts "Installing react_on_rails bundle before delegated rake task..."
+  Dir.chdir(gem_root) do
+    Bundler.with_unbundled_env do
+      sh "bundle", "install"
+    end
+  end
+end
+
+def root_bundle_exec_in(directory, *command)
+  Bundler.with_unbundled_env do
+    Dir.chdir(directory) do
+      sh({ "BUNDLE_GEMFILE" => File.expand_path("Gemfile", __dir__) }, "bundle", "exec", *command)
+    end
+  end
+end
+
+def define_package_task(task_name, *arg_names)
+  desc "Delegates to react_on_rails #{task_name}"
+  task task_name, arg_names do |_task, args|
+    package_rake_task(task_name, *arg_names.filter_map { |arg_name| args[arg_name] })
+  end
+end
+
+namespace :lint do
+  desc "Run root RuboCop with the root tooling bundle"
+  task :rubocop do
+    root_bundle_exec_in(gem_root, "rubocop", "--version")
+    root_bundle_exec_in(gem_root, "rubocop", ".")
+  end
+
+  desc "Run root RuboCop linting"
+  task lint: :rubocop do
+    puts "Completed root RuboCop linting"
+  end
+
+  desc "Auto-fix root RuboCop violations"
+  task :rubocop_autofix do
+    root_bundle_exec_in(gem_root, "rubocop", "-A")
+    puts "Completed root RuboCop auto-fix"
+  end
+end
+
+%w[
+  all_but_examples
+  ci
+  default
+  docker
+  docker:eslint
+  docker:lint
+  docker:rubocop
+  docker:scss
+  dummy_apps
+  js_tests
+  lint:autofix
+  lint:eslint
+  lint:scss
+  node_package
+  prepare_for_ci
+  rbs:all
+  rbs:check
+  rbs:list
+  rbs:steep
+  rbs:validate
+  run_rspec
+  run_rspec:all_but_examples
+  run_rspec:all_dummy
+  run_rspec:dummy
+  run_rspec:dummy_no_turbolinks
+  run_rspec:gem
+  run_rspec:shakapacker_examples
+  run_rspec:shakapacker_examples_basic
+  run_rspec:shakapacker_examples_basic-react16
+  run_rspec:shakapacker_examples_basic-react17
+  run_rspec:shakapacker_examples_basic-react18
+  run_rspec:shakapacker_examples_basic-server-rendering
+  run_rspec:shakapacker_examples_basic-server-rendering-react16
+  run_rspec:shakapacker_examples_basic-server-rendering-react17
+  run_rspec:shakapacker_examples_basic-server-rendering-react18
+  run_rspec:shakapacker_examples_latest
+  run_rspec:shakapacker_examples_pinned
+  run_rspec:shakapacker_examples_react16
+  run_rspec:shakapacker_examples_react17
+  run_rspec:shakapacker_examples_react18
+  run_rspec:shakapacker_examples_redux
+  run_rspec:shakapacker_examples_redux-server-rendering
+  shakapacker_examples
+  shakapacker_examples:clobber
+  shakapacker_examples:clobber_basic
+  shakapacker_examples:clobber_basic-react16
+  shakapacker_examples:clobber_basic-react17
+  shakapacker_examples:clobber_basic-react18
+  shakapacker_examples:clobber_basic-server-rendering
+  shakapacker_examples:clobber_basic-server-rendering-react16
+  shakapacker_examples:clobber_basic-server-rendering-react17
+  shakapacker_examples:clobber_basic-server-rendering-react18
+  shakapacker_examples:clobber_redux
+  shakapacker_examples:clobber_redux-server-rendering
+  shakapacker_examples:gen_all
+  shakapacker_examples:gen_basic
+  shakapacker_examples:gen_basic-react16
+  shakapacker_examples:gen_basic-react17
+  shakapacker_examples:gen_basic-react18
+  shakapacker_examples:gen_basic-server-rendering
+  shakapacker_examples:gen_basic-server-rendering-react16
+  shakapacker_examples:gen_basic-server-rendering-react17
+  shakapacker_examples:gen_basic-server-rendering-react18
+  shakapacker_examples:gen_redux
+  shakapacker_examples:gen_redux-server-rendering
+].each { |task_name| define_package_task(task_name) }
+
+desc "Run root RuboCop linting. Use `(cd react_on_rails && bundle exec rake lint)` for package lint."
+task lint: ["lint:lint"]
+
+desc "Auto-fix all linting violations via the package task"
+task autofix: ["lint:autofix"]
+
+define_package_task("run_rspec:run_rspec", :packer)
+define_package_task("shakapacker:update_version", :version)
+define_package_task("update_changelog", :mode_or_tag)
 
 # NOTE: Monorepo-level rake tasks from ./rakelib/ are auto-loaded by Rake.
 # Do NOT explicitly load them here, as that would cause tasks to be defined twice

--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,7 @@ def root_bundle_exec_in(directory, *command)
 end
 
 def root_rubocop_paths
+  # Root lint covers repo-root tooling only; package-owned rakelib files stay under package RuboCop.
   %w[Gemfile Rakefile rakelib]
 end
 
@@ -167,7 +168,9 @@ end
 ].each { |task_name| define_package_task(task_name) }
 
 desc "Run root-bundle RuboCop only; full lint: cd react_on_rails && bundle exec rake lint"
-task lint: ["lint:rubocop"]
+task lint: ["lint:rubocop"] do
+  puts "For full package lint: cd react_on_rails && bundle exec rake lint"
+end
 
 desc "Auto-fix full package lint; broader than root rake lint (ESLint, Prettier, Stylelint, RuboCop)"
 task autofix: ["lint:autofix"]

--- a/Rakefile
+++ b/Rakefile
@@ -94,8 +94,10 @@ end
 
 # MAINTAINER NOTE: When adding a package Rake task that should work from the
 # monorepo root, add it here so `rake <task>` delegates into the react_on_rails
-# bundle. To audit drift, compare root `bundle exec rake -T` with
-# `(cd react_on_rails && bundle exec rake -T)`.
+# bundle.
+# Audit drift:
+#   diff <(bundle exec rake -T | awk '{print $2}' | sort) \
+#        <(cd react_on_rails && bundle exec rake -T | awk '{print $2}' | sort)
 %w[
   all_but_examples
   ci

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ end
 def ensure_package_bundle
   bundle_ready = Dir.chdir(gem_root) do
     Bundler.with_unbundled_env do
-      system("bundle", "check")
+      system("bundle", "check", out: File::NULL, err: File::NULL)
     end
   end
 
@@ -61,7 +61,7 @@ def root_bundle_exec_in(directory, *command)
 end
 
 def root_rubocop_paths
-  %w[Gemfile Rakefile rakelib react_on_rails]
+  %w[Gemfile Rakefile rakelib]
 end
 
 def define_package_task(task_name, *arg_names)
@@ -72,12 +72,12 @@ def define_package_task(task_name, *arg_names)
 end
 
 namespace :lint do
-  desc "Run root-bundle RuboCop on root tooling and OSS package files"
+  desc "Run root-bundle RuboCop on root tooling files"
   task :rubocop do
     root_bundle_exec_in(__dir__, "rubocop", *root_rubocop_paths)
   end
 
-  desc "Auto-fix root-bundle RuboCop violations in root tooling and OSS package files"
+  desc "Auto-fix root-bundle RuboCop violations in root tooling files"
   task :rubocop_autofix do
     root_bundle_exec_in(__dir__, "rubocop", "-A", *root_rubocop_paths)
     puts "Completed root RuboCop auto-fix"

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,8 @@ def gem_root
   File.expand_path("react_on_rails", __dir__)
 end
 
+@package_bundle_ready = false
+
 def package_rake_task(task_name, *task_args)
   task_invocation = if task_args.empty?
                       task_name.to_s
@@ -36,13 +38,18 @@ def package_rake_task(task_name, *task_args)
 end
 
 def ensure_package_bundle
+  return if @package_bundle_ready
+
   bundle_ready = Dir.chdir(gem_root) do
     Bundler.with_unbundled_env do
       system("bundle", "check", out: File::NULL, err: File::NULL)
     end
   end
 
-  return if bundle_ready
+  if bundle_ready
+    @package_bundle_ready = true
+    return
+  end
 
   puts "Installing react_on_rails bundle before delegated rake task..."
   Dir.chdir(gem_root) do
@@ -50,6 +57,7 @@ def ensure_package_bundle
       sh "bundle", "install"
     end
   end
+  @package_bundle_ready = true
 end
 
 def root_bundle_exec_in(directory, *command)
@@ -159,7 +167,7 @@ end
 desc "Run root-bundle RuboCop only; full lint: cd react_on_rails && bundle exec rake lint"
 task lint: ["lint:rubocop"]
 
-desc "Auto-fix all linting violations via the package task"
+desc "Auto-fix full package lint; broader than root rake lint (ESLint, Prettier, Stylelint, RuboCop)"
 task autofix: ["lint:autofix"]
 
 define_package_task("run_rspec:run_rspec", :packer)

--- a/Rakefile
+++ b/Rakefile
@@ -68,24 +68,21 @@ def define_package_task(task_name, *arg_names)
 end
 
 namespace :lint do
-  desc "Run root RuboCop with the root tooling bundle"
+  desc "Run root-bundle RuboCop on the OSS package directory"
   task :rubocop do
     root_bundle_exec_in(gem_root, "rubocop", "--version")
     root_bundle_exec_in(gem_root, "rubocop", ".")
   end
 
-  desc "Run root RuboCop linting"
-  task lint: :rubocop do
-    puts "Completed root RuboCop linting"
-  end
-
-  desc "Auto-fix root RuboCop violations"
+  desc "Auto-fix root-bundle RuboCop violations in the OSS package directory"
   task :rubocop_autofix do
     root_bundle_exec_in(gem_root, "rubocop", "-A")
     puts "Completed root RuboCop auto-fix"
   end
 end
 
+# NOTE: When adding a new package task that should work from the monorepo root,
+# add it here so `rake <task>` delegates into the react_on_rails bundle.
 %w[
   all_but_examples
   ci
@@ -154,8 +151,8 @@ end
   shakapacker_examples:gen_redux-server-rendering
 ].each { |task_name| define_package_task(task_name) }
 
-desc "Run root RuboCop linting. Use `(cd react_on_rails && bundle exec rake lint)` for package lint."
-task lint: ["lint:lint"]
+desc "Run root-bundle RuboCop on the OSS package directory"
+task lint: ["lint:rubocop"]
 
 desc "Auto-fix all linting violations via the package task"
 task autofix: ["lint:autofix"]

--- a/Rakefile
+++ b/Rakefile
@@ -60,6 +60,10 @@ def root_bundle_exec_in(directory, *command)
   end
 end
 
+def root_rubocop_paths
+  %w[Gemfile Rakefile rakelib react_on_rails]
+end
+
 def define_package_task(task_name, *arg_names)
   desc "Delegates to react_on_rails #{task_name}"
   task task_name, arg_names do |_task, args|
@@ -68,15 +72,15 @@ def define_package_task(task_name, *arg_names)
 end
 
 namespace :lint do
-  desc "Run root-bundle RuboCop on the OSS package directory"
+  desc "Run root-bundle RuboCop on root tooling and OSS package files"
   task :rubocop do
-    root_bundle_exec_in(gem_root, "rubocop", "--version")
-    root_bundle_exec_in(gem_root, "rubocop", ".")
+    root_bundle_exec_in(__dir__, "rubocop", "--version")
+    root_bundle_exec_in(__dir__, "rubocop", *root_rubocop_paths)
   end
 
-  desc "Auto-fix root-bundle RuboCop violations in the OSS package directory"
+  desc "Auto-fix root-bundle RuboCop violations in root tooling and OSS package files"
   task :rubocop_autofix do
-    root_bundle_exec_in(gem_root, "rubocop", "-A")
+    root_bundle_exec_in(__dir__, "rubocop", "-A", *root_rubocop_paths)
     puts "Completed root RuboCop auto-fix"
   end
 end
@@ -151,7 +155,7 @@ end
   shakapacker_examples:gen_redux-server-rendering
 ].each { |task_name| define_package_task(task_name) }
 
-desc "Run root-bundle RuboCop on the OSS package directory"
+desc "Run root-bundle RuboCop on root tooling and OSS package files"
 task lint: ["lint:rubocop"]
 
 desc "Auto-fix all linting violations via the package task"

--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,6 @@ end
 namespace :lint do
   desc "Run root-bundle RuboCop on root tooling and OSS package files"
   task :rubocop do
-    root_bundle_exec_in(__dir__, "rubocop", "--version")
     root_bundle_exec_in(__dir__, "rubocop", *root_rubocop_paths)
   end
 
@@ -85,8 +84,10 @@ namespace :lint do
   end
 end
 
-# NOTE: When adding a new package task that should work from the monorepo root,
-# add it here so `rake <task>` delegates into the react_on_rails bundle.
+# MAINTAINER NOTE: When adding a package Rake task that should work from the
+# monorepo root, add it here so `rake <task>` delegates into the react_on_rails
+# bundle. To audit drift, compare root `bundle exec rake -T` with
+# `(cd react_on_rails && bundle exec rake -T)`.
 %w[
   all_but_examples
   ci
@@ -155,7 +156,7 @@ end
   shakapacker_examples:gen_redux-server-rendering
 ].each { |task_name| define_package_task(task_name) }
 
-desc "Run root-bundle RuboCop on root tooling and OSS package files"
+desc "Run root-bundle RuboCop only; full lint: cd react_on_rails && bundle exec rake lint"
 task lint: ["lint:rubocop"]
 
 desc "Auto-fix all linting violations via the package task"

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -37,8 +37,28 @@ NC='\033[0m' # No Color
 echo -e "${BLUE}=== React on Rails Local CI ===${NC}"
 echo ""
 
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+ROOT_GEMFILE="$ROOT_DIR/Gemfile"
+OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
+PRO_GEMFILE="$ROOT_DIR/react_on_rails_pro/Gemfile"
+
+bundle_command() {
+  local gemfile="$1"
+  shift
+
+  env \
+    -u BUNDLE_APP_CONFIG \
+    -u BUNDLE_BIN_PATH \
+    -u BUNDLE_GEMFILE \
+    -u BUNDLER_VERSION \
+    -u RUBYOPT \
+    BUNDLE_GEMFILE="$gemfile" \
+    "$@"
+}
+
 # Track failures
 FAILED_JOBS=()
+OSS_DEPS_READY=false
 PRO_DEPS_READY=false
 
 # Internal implementation: runs a shell command string via the shell, so
@@ -188,7 +208,7 @@ ensure_pro_dependencies() {
 
   if [ ! -d "react_on_rails_pro/node_modules" ] || [ ! -d "react_on_rails_pro/vendor/bundle" ]; then
     echo -e "${YELLOW}Installing React on Rails Pro dependencies...${NC}"
-    if ! (cd react_on_rails_pro && bundle install && pnpm install); then
+    if ! (cd react_on_rails_pro && bundle_command "$PRO_GEMFILE" bundle install && pnpm install); then
       echo -e "${YELLOW}⚠ Pro dependencies installation failed, skipping Pro tests${NC}"
       RUN_PRO_LINT=false
       RUN_PRO_TESTS=false
@@ -197,6 +217,23 @@ ensure_pro_dependencies() {
   fi
 
   PRO_DEPS_READY=true
+}
+
+ensure_oss_dependencies() {
+  if [ "$OSS_DEPS_READY" = true ]; then
+    return 0
+  fi
+
+  if ! (cd react_on_rails && bundle_command "$OSS_GEMFILE" bundle check >/dev/null 2>&1); then
+    echo -e "${YELLOW}Installing react_on_rails Ruby dependencies...${NC}"
+    if ! (cd react_on_rails && bundle_command "$OSS_GEMFILE" bundle install); then
+      echo -e "${RED}✗ react_on_rails dependency installation failed${NC}"
+      echo -e "${RED}Cannot proceed without dependencies. Please fix the errors above.${NC}"
+      exit 1
+    fi
+  fi
+
+  OSS_DEPS_READY=true
 }
 
 # Ensure dependencies are installed
@@ -220,9 +257,13 @@ fi
 # gives contributors a complete failure report from a single local run.
 run_job_argv "Docs Sidebar Check" script/check-docs-sidebar "$BASE_REF" || true
 
+if [ "$RUN_RUBY" = true ] || [ "$RUN_DUMMY" = true ] || [ "$RUN_GENERATORS" = true ]; then
+  ensure_oss_dependencies
+fi
+
 # Run linting
 if [ "$RUN_LINT" = true ]; then
-  run_job "RuboCop" "BUNDLE_GEMFILE=\"$(git rev-parse --show-toplevel)/Gemfile\" bundle exec rubocop"
+  run_job "RuboCop" "bundle_command \"$ROOT_GEMFILE\" bundle exec rubocop"
   run_job "ESLint" "pnpm run eslint --report-unused-disable-directives"
   run_job "Prettier Check" "pnpm start format.listDifferent"
   run_job "TypeScript Type Check" "pnpm run type-check"
@@ -236,9 +277,9 @@ fi
 # Run Ruby gem tests
 if [ "$RUN_RUBY" = true ]; then
   if [ "$FAST_MODE" = true ]; then
-    run_job "RSpec (Gem Only - Fast)" "bundle exec rspec spec/react_on_rails"
+    run_job "RSpec (Gem Only - Fast)" "cd react_on_rails && bundle_command \"$OSS_GEMFILE\" bundle exec rspec spec/react_on_rails"
   else
-    run_job "RSpec (Gem Only)" "bundle exec rake run_rspec:gem"
+    run_job "RSpec (Gem Only)" "cd react_on_rails && bundle_command \"$OSS_GEMFILE\" bundle exec rake run_rspec:gem"
   fi
 fi
 
@@ -255,10 +296,10 @@ if [ "$RUN_DUMMY" = true ]; then
         echo -e "${YELLOW}⚠ Dummy app setup failed, skipping dummy app tests${NC}"
         echo ""
       else
-        run_job "Dummy App Integration Tests" "bundle exec rake run_rspec:dummy"
+        run_job "Dummy App Integration Tests" "cd react_on_rails && bundle_command \"$OSS_GEMFILE\" bundle exec rake run_rspec:dummy"
       fi
     else
-      run_job "Dummy App Integration Tests" "bundle exec rake run_rspec:dummy"
+      run_job "Dummy App Integration Tests" "cd react_on_rails && bundle_command \"$OSS_GEMFILE\" bundle exec rake run_rspec:dummy"
     fi
   fi
 fi
@@ -269,7 +310,7 @@ if [ "$RUN_GENERATORS" = true ]; then
     echo -e "${YELLOW}Skipping generator tests in --fast mode (they are slow)${NC}"
     echo ""
   else
-    run_job "Generator Tests" "bundle exec rake run_rspec:shakapacker_examples"
+    run_job "Generator Tests" "cd react_on_rails && bundle_command \"$OSS_GEMFILE\" bundle exec rake run_rspec:shakapacker_examples"
   fi
 fi
 
@@ -284,8 +325,8 @@ fi
 
 if [ "$RUN_PRO_LINT" = true ]; then
   if ensure_pro_dependencies; then
-    run_job "React on Rails Pro RuboCop" "cd react_on_rails_pro && BUNDLE_GEMFILE=\"$(git rev-parse --show-toplevel)/Gemfile\" bundle exec rubocop --ignore-parent-exclusion"
-    run_job "React on Rails Pro RBS Validate" "cd react_on_rails_pro && bundle exec rake rbs:validate"
+    run_job "React on Rails Pro RuboCop" "cd react_on_rails_pro && bundle_command \"$ROOT_GEMFILE\" bundle exec rubocop --ignore-parent-exclusion"
+    run_job "React on Rails Pro RBS Validate" "cd react_on_rails_pro && bundle_command \"$PRO_GEMFILE\" bundle exec rake rbs:validate"
     run_job "React on Rails Pro TypeScript Check" "pnpm run nps check-typescript"
   fi
 fi
@@ -297,7 +338,7 @@ if [ "$RUN_PRO_TESTS" = true ]; then
     echo ""
   elif ensure_pro_dependencies; then
     run_job "React on Rails Pro JS Tests" "cd react_on_rails_pro && pnpm run nps test"
-    run_job "React on Rails Pro RSpec" "cd react_on_rails_pro && bundle exec rspec"
+    run_job "React on Rails Pro RSpec" "cd react_on_rails_pro && bundle_command \"$PRO_GEMFILE\" bundle exec rspec"
   fi
 fi
 

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -41,6 +41,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 ROOT_GEMFILE="$ROOT_DIR/Gemfile"
 OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
 PRO_GEMFILE="$ROOT_DIR/react_on_rails_pro/Gemfile"
+cd "$ROOT_DIR"
 
 # Keep this helper in sync with bin/ci-rerun-failures and bin/setup.
 bundle_command() {
@@ -226,9 +227,9 @@ ensure_oss_dependencies() {
     return 0
   fi
 
-  if ! (cd react_on_rails && bundle_command "$OSS_GEMFILE" bundle check >/dev/null 2>&1); then
+  if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle check >/dev/null 2>&1); then
     echo -e "${YELLOW}Installing react_on_rails Ruby dependencies...${NC}"
-    if ! (cd react_on_rails && bundle_command "$OSS_GEMFILE" bundle install); then
+    if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle install); then
       echo -e "${RED}✗ react_on_rails dependency installation failed${NC}"
       echo -e "${RED}Cannot proceed without dependencies. Please fix the errors above.${NC}"
       exit 1

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -42,6 +42,7 @@ ROOT_GEMFILE="$ROOT_DIR/Gemfile"
 OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
 PRO_GEMFILE="$ROOT_DIR/react_on_rails_pro/Gemfile"
 
+# Keep this helper in sync with bin/ci-rerun-failures and bin/setup.
 bundle_command() {
   local gemfile="$1"
   shift

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -68,7 +68,8 @@ _run_job_shell() {
   local job_name="$1"
   local command="$2"
   echo -e "${BLUE}▶ Running: $job_name${NC}"
-  if eval "$command"; then
+  # Keep legacy shell-command side effects, especially `cd`, scoped to the job.
+  if (eval "$command"); then
     echo -e "${GREEN}✓ $job_name passed${NC}"
     echo ""
     return 0
@@ -239,7 +240,7 @@ ensure_oss_dependencies() {
 # Ensure dependencies are installed
 if [ ! -d "node_modules" ] || [ ! -d "vendor/bundle" ]; then
   echo -e "${YELLOW}Installing dependencies...${NC}"
-  if ! (bundle install && pnpm install); then
+  if ! (bundle_command "$ROOT_GEMFILE" bundle install && pnpm install); then
     echo -e "${RED}✗ Dependency installation failed${NC}"
     echo -e "${RED}Cannot proceed without dependencies. Please fix the errors above.${NC}"
     exit 1

--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -20,6 +20,7 @@ ROOT_GEMFILE="$ROOT_DIR/Gemfile"
 OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
 OSS_DEPS_READY=false
 
+# Keep this helper in sync with bin/ci-local and bin/setup.
 bundle_command() {
   local gemfile="$1"
   shift

--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -15,6 +15,53 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+ROOT_GEMFILE="$ROOT_DIR/Gemfile"
+OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
+OSS_DEPS_READY=false
+
+bundle_command() {
+  local gemfile="$1"
+  shift
+
+  env \
+    -u BUNDLE_APP_CONFIG \
+    -u BUNDLE_BIN_PATH \
+    -u BUNDLE_GEMFILE \
+    -u BUNDLER_VERSION \
+    -u RUBYOPT \
+    BUNDLE_GEMFILE="$gemfile" \
+    "$@"
+}
+
+ensure_oss_dependencies() {
+  if [ "$OSS_DEPS_READY" = true ]; then
+    return 0
+  fi
+
+  if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle check >/dev/null 2>&1); then
+    echo -e "${YELLOW}Installing react_on_rails Ruby dependencies...${NC}"
+    if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle install); then
+      echo -e "${RED}✗ react_on_rails dependency installation failed${NC}"
+      echo -e "${RED}Cannot proceed without dependencies. Please fix the errors above.${NC}"
+      exit 1
+    fi
+  fi
+
+  OSS_DEPS_READY=true
+}
+
+requires_oss_bundle() {
+  case "$1" in
+    "rspec-package-tests"|"dummy-app-integration-tests"|"examples")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 # Show help
 show_help() {
   cat << EOF
@@ -125,7 +172,9 @@ if [ "$USE_PREVIOUS" = true ]; then
 
     if [ "$FAILURE_COUNT" -gt 0 ]; then
       echo -e "${GREEN}Found $FAILURE_COUNT failed check(s) in commit ${COMMIT_SHA:0:8}${NC}"
-      STATUS_JSON=$(echo "$CHECK_RUNS" | jq '{statusCheckRollup: [.[] | {name: .name, conclusion: .conclusion, status: .status}], number: '$PR_NUMBER'}')
+      STATUS_JSON=$(echo "$CHECK_RUNS" |
+        jq --argjson number "$PR_NUMBER" \
+          '{statusCheckRollup: [.[] | {name: .name, conclusion: .conclusion, status: .status}], number: $number}')
       FOUND_FAILURES=true
       break
     fi
@@ -188,19 +237,21 @@ run_command() {
   local cmd_id="$1"
   case "$cmd_id" in
     "lint-js-and-ruby")
-      bundle exec rubocop && pnpm run eslint --report-unused-disable-directives && pnpm start format.listDifferent
+      bundle_command "$ROOT_GEMFILE" bundle exec rubocop &&
+        pnpm run eslint --report-unused-disable-directives &&
+        pnpm start format.listDifferent
       ;;
     "rspec-package-tests")
-      bundle exec rake run_rspec:gem
+      (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake run_rspec:gem)
       ;;
     "package-js-tests")
       pnpm test
       ;;
     "dummy-app-integration-tests")
-      bundle exec rake run_rspec:all_dummy
+      (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake run_rspec:all_dummy)
       ;;
     "examples")
-      bundle exec rake run_rspec:shakapacker_examples
+      (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake run_rspec:shakapacker_examples)
       ;;
     *)
       echo "Unknown command ID: $cmd_id"
@@ -287,12 +338,20 @@ fi
 
 echo ""
 
-# Ensure dependencies
-if [ ! -d "node_modules" ] || [ ! -d "vendor/bundle" ]; then
+# Ensure root dependencies
+cd "$ROOT_DIR"
+if [ ! -d "node_modules" ] || ! bundle_command "$ROOT_GEMFILE" bundle check >/dev/null 2>&1; then
   echo -e "${YELLOW}Installing dependencies...${NC}"
-  bundle install && pnpm install
+  bundle_command "$ROOT_GEMFILE" bundle install && pnpm install
   echo ""
 fi
+
+for cmd_id in "${!COMMANDS_TO_RUN[@]}"; do
+  if requires_oss_bundle "$cmd_id"; then
+    ensure_oss_dependencies
+    break
+  fi
+done
 
 # Run commands
 FAILED_COMMANDS=()

--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -52,19 +52,6 @@ ensure_oss_dependencies() {
   OSS_DEPS_READY=true
 }
 
-# Keep this list in sync with run_command() below. Every branch that uses
-# bundle_command "$OSS_GEMFILE" needs an entry here so OSS dependencies install first.
-requires_oss_bundle() {
-  case "$1" in
-    "rspec-package-tests"|"dummy-app-integration-tests"|"examples")
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-}
-
 # Show help
 show_help() {
   cat << EOF
@@ -245,15 +232,18 @@ run_command() {
         pnpm start format.listDifferent
       ;;
     "rspec-package-tests")
+      ensure_oss_dependencies
       (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake run_rspec:gem)
       ;;
     "package-js-tests")
       pnpm test
       ;;
     "dummy-app-integration-tests")
+      ensure_oss_dependencies
       (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake run_rspec:all_dummy)
       ;;
     "examples")
+      ensure_oss_dependencies
       (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake run_rspec:shakapacker_examples)
       ;;
     *)
@@ -348,13 +338,6 @@ if [ ! -d "node_modules" ] || ! bundle_command "$ROOT_GEMFILE" bundle check >/de
   bundle_command "$ROOT_GEMFILE" bundle install && pnpm install
   echo ""
 fi
-
-for cmd_id in "${!COMMANDS_TO_RUN[@]}"; do
-  if requires_oss_bundle "$cmd_id"; then
-    ensure_oss_dependencies
-    break
-  fi
-done
 
 # Run commands
 FAILED_COMMANDS=()

--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -52,6 +52,8 @@ ensure_oss_dependencies() {
   OSS_DEPS_READY=true
 }
 
+# Keep this list in sync with run_command() below. Every branch that uses
+# bundle_command "$OSS_GEMFILE" needs an entry here so OSS dependencies install first.
 requires_oss_bundle() {
   case "$1" in
     "rspec-package-tests"|"dummy-app-integration-tests"|"examples")

--- a/bin/setup
+++ b/bin/setup
@@ -74,6 +74,7 @@ print_success() {
   echo -e "${GREEN}✓${NC} $1"
 }
 
+# Keep this helper in sync with bin/ci-local and bin/ci-rerun-failures.
 bundle_command() {
   local gemfile="$1"
   shift

--- a/bin/setup
+++ b/bin/setup
@@ -50,11 +50,12 @@ show_help() {
   echo ""
   echo "This script will:"
   echo "  1. Install root pnpm and bundle dependencies"
-  echo "  2. Build the node package"
-  echo "  3. Set up react_on_rails/spec/dummy"
-  echo "  4. Set up react_on_rails_pro (if present and not skipped)"
-  echo "  5. Set up react_on_rails_pro/spec/dummy (if present and not skipped)"
-  echo "  6. Set up react_on_rails_pro/spec/execjs-compatible-dummy (if present and not skipped)"
+  echo "  2. Set up react_on_rails"
+  echo "  3. Build the node package"
+  echo "  4. Set up react_on_rails/spec/dummy"
+  echo "  5. Set up react_on_rails_pro (if present and not skipped)"
+  echo "  6. Set up react_on_rails_pro/spec/dummy (if present and not skipped)"
+  echo "  7. Set up react_on_rails_pro/spec/execjs-compatible-dummy (if present and not skipped)"
 }
 
 print_step() {
@@ -71,6 +72,20 @@ print_error() {
 
 print_success() {
   echo -e "${GREEN}✓${NC} $1"
+}
+
+bundle_command() {
+  local gemfile="$1"
+  shift
+
+  env \
+    -u BUNDLE_APP_CONFIG \
+    -u BUNDLE_BIN_PATH \
+    -u BUNDLE_GEMFILE \
+    -u BUNDLER_VERSION \
+    -u RUBYOPT \
+    BUNDLE_GEMFILE="$gemfile" \
+    "$@"
 }
 
 check_prerequisites() {
@@ -176,6 +191,7 @@ install_dependencies() {
 
   # Install Ruby dependencies if Gemfile exists
   if [ -f "Gemfile" ]; then
+    local gemfile_path="$dir/Gemfile"
     local required_ruby_version
     local current_ruby_version
 
@@ -205,10 +221,10 @@ install_dependencies() {
     fi
 
     echo "  Installing Ruby dependencies..."
-    if bundle check &> /dev/null; then
+    if bundle_command "$gemfile_path" bundle check &> /dev/null; then
       print_success "Ruby dependencies already satisfied"
     else
-      if ! bundle install; then
+      if ! bundle_command "$gemfile_path" bundle install; then
         print_error "Failed to install Ruby dependencies in $name"
         exit 1
       fi
@@ -237,7 +253,7 @@ build_node_package() {
   # Builds TypeScript packages. This compiles src/ to lib/.
   # The dummy apps use workspace:* protocol so pnpm install links them automatically.
   print_step "Building node package..."
-  if ! rake node_package; then
+  if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$ROOT_DIR/react_on_rails/Gemfile" bundle exec rake node_package); then
     print_error "Failed to build node package"
     exit 1
   fi
@@ -257,7 +273,8 @@ verify_build_artifacts() {
 }
 
 show_elapsed_time() {
-  local END_TIME=$(date +%s)
+  local END_TIME
+  END_TIME=$(date +%s)
   local ELAPSED=$((END_TIME - START_TIME))
   local MINUTES=$((ELAPSED / 60))
   local SECONDS=$((ELAPSED % 60))
@@ -306,6 +323,9 @@ main() {
 
   # Root dependencies
   install_dependencies "$ROOT_DIR" "root directory"
+
+  # Open source gem dependencies
+  install_dependencies "$ROOT_DIR/react_on_rails" "react_on_rails"
 
   # Build node package
   build_node_package

--- a/bin/setup
+++ b/bin/setup
@@ -23,6 +23,7 @@ NC='\033[0m' # No Color
 # Script directory (for running from anywhere)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OSS_GEMFILE="$ROOT_DIR/react_on_rails/Gemfile"
 
 # Optional directories that should be skipped (not hard-fail) when Ruby doesn't match Gemfile.
 OPTIONAL_SETUP_DIRS=(
@@ -254,7 +255,7 @@ build_node_package() {
   # Builds TypeScript packages. This compiles src/ to lib/.
   # The dummy apps use workspace:* protocol so pnpm install links them automatically.
   print_step "Building node package..."
-  if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$ROOT_DIR/react_on_rails/Gemfile" bundle exec rake node_package); then
+  if ! (cd "$ROOT_DIR/react_on_rails" && bundle_command "$OSS_GEMFILE" bundle exec rake node_package); then
     print_error "Failed to build node package"
     exit 1
   fi

--- a/conductor-setup.sh
+++ b/conductor-setup.sh
@@ -95,6 +95,7 @@ install_matching_bundler() {
 
 LOCKFILE_DIRS=(
     "."
+    "react_on_rails"
     "react_on_rails/spec/dummy"
     "react_on_rails_pro"
     "react_on_rails_pro/spec/dummy"

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -12,7 +12,6 @@ require "tmpdir"
 require_relative "task_helpers"
 require_relative "../react_on_rails/lib/react_on_rails/version_syntax_converter"
 require_relative "../react_on_rails/lib/react_on_rails/git_utils"
-require_relative "../react_on_rails/lib/react_on_rails/utils"
 
 class RaisingMessageHandler
   def add_error(error)
@@ -35,6 +34,10 @@ SHAKAPERF_RELEASE_GATE_WATCH_TIMEOUT_SECONDS = 50 * 60
 
 def current_monorepo_root
   File.expand_path("..", __dir__)
+end
+
+def release_truthy?(value)
+  [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
 end
 
 def release_paths(monorepo_root)
@@ -536,13 +539,11 @@ def expected_bump_type_from_changelog_section(changelog_section)
 end
 
 def version_policy_override_enabled?(override_flag)
-  ReactOnRails::Utils.object_to_boolean(override_flag) ||
-    ReactOnRails::Utils.object_to_boolean(ENV.fetch("RELEASE_VERSION_POLICY_OVERRIDE", nil))
+  release_truthy?(override_flag) || release_truthy?(ENV.fetch("RELEASE_VERSION_POLICY_OVERRIDE", nil))
 end
 
 def ci_status_override_enabled?(override_flag)
-  ReactOnRails::Utils.object_to_boolean(override_flag) ||
-    ReactOnRails::Utils.object_to_boolean(ENV.fetch("RELEASE_CI_STATUS_OVERRIDE", nil))
+  release_truthy?(override_flag) || release_truthy?(ENV.fetch("RELEASE_CI_STATUS_OVERRIDE", nil))
 end
 
 # Statuses considered "incomplete" — anything not yet a finalized conclusion.
@@ -1716,7 +1717,7 @@ task :release, %i[version dry_run override_version_policy override_ci_status] do
 
   args_hash = args.to_hash
 
-  is_dry_run = ReactOnRails::Utils.object_to_boolean(args_hash[:dry_run])
+  is_dry_run = release_truthy?(args_hash[:dry_run])
   is_verbose = ENV["VERBOSE"] == "1"
   allow_version_policy_override = version_policy_override_enabled?(args_hash[:override_version_policy])
   allow_ci_status_override = ci_status_override_enabled?(args_hash[:override_ci_status])
@@ -2027,7 +2028,7 @@ Examples:
 task :sync_github_release, %i[gem_version dry_run] do |_t, args|
   monorepo_root = current_monorepo_root
   args_hash = args.to_hash
-  is_dry_run = ReactOnRails::Utils.object_to_boolean(args_hash[:dry_run])
+  is_dry_run = release_truthy?(args_hash[:dry_run])
 
   requested_gem_version = args_hash[:gem_version].to_s.strip
   if requested_gem_version.empty?

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -37,6 +37,7 @@ def current_monorepo_root
 end
 
 def release_truthy?(value)
+  # Includes "t" to preserve the former ReactOnRails::Utils.object_to_boolean contract.
   [true, "true", "yes", 1, "1", "t"].include?(value.instance_of?(String) ? value.downcase : value)
 end
 

--- a/react_on_rails/rakelib/lint.rake
+++ b/react_on_rails/rakelib/lint.rake
@@ -5,14 +5,20 @@ require_relative "task_helpers"
 namespace :lint do # rubocop:disable Metrics/BlockLength
   include ReactOnRails::TaskHelpers
 
+  def root_bundle_command(command)
+    root_gemfile = File.join(monorepo_root, "Gemfile")
+    "BUNDLE_GEMFILE=\"#{root_gemfile}\" #{command}"
+  end
+
   desc "Run Rubocop as shell"
   task :rubocop do
-    root_gemfile = File.join(monorepo_root, "Gemfile")
-    sh_in_dir(
-      gem_root,
-      "BUNDLE_GEMFILE=\"#{root_gemfile}\" bundle exec rubocop --version",
-      "BUNDLE_GEMFILE=\"#{root_gemfile}\" bundle exec rubocop ."
-    )
+    Bundler.with_unbundled_env do
+      sh_in_dir(
+        gem_root,
+        root_bundle_command("bundle exec rubocop --version"),
+        root_bundle_command("bundle exec rubocop .")
+      )
+    end
   end
 
   desc "Run stylelint as shell"
@@ -32,11 +38,12 @@ namespace :lint do # rubocop:disable Metrics/BlockLength
 
   desc "Auto-fix all linting violations"
   task :autofix do
-    root_gemfile = File.join(monorepo_root, "Gemfile")
     sh_in_dir(gem_root, "pnpm run eslint . --fix")
     sh_in_dir(gem_root, "pnpm run prettier --write .")
     sh_in_dir(gem_root, stylelint_fix_command)
-    sh_in_dir(gem_root, "BUNDLE_GEMFILE=\"#{root_gemfile}\" bundle exec rubocop -A")
+    Bundler.with_unbundled_env do
+      sh_in_dir(gem_root, root_bundle_command("bundle exec rubocop -A"))
+    end
     puts "Completed auto-fixing all linting violations"
   end
 


### PR DESCRIPTION
## Summary

Closes #3837.

- Keep the root Gemfile focused on repo-wide RuboCop, hook, release, and benchmark script tooling instead of evaluating the OSS package Gemfile.
- Delegate package Rake tasks from the monorepo root through the `react_on_rails` bundle so root callers keep working without contaminating package locks.
- Update setup/CI helpers and contributor docs so each command selects the intended Gemfile explicitly.

## Validation

- `bundle install`
- `bundle exec rake lint`
- `(cd react_on_rails && bundle exec rake lint:rubocop)` with package/root lockfile hashes unchanged
- `bundle exec rubocop Rakefile Gemfile rakelib/release.rake react_on_rails/rakelib/lint.rake`
- `bundle exec ruby -c Rakefile`
- `ruby -c rakelib/release.rake`
- `ruby -c react_on_rails/rakelib/lint.rake`
- `bundle exec rspec benchmarks/spec`
- `zsh -n conductor-setup.sh`
- `bash -n bin/ci-local bin/ci-rerun-failures bin/setup`
- `shellcheck bin/ci-rerun-failures bin/ci-local bin/setup`
- `pnpm exec prettier --check AGENTS.md .github/dependabot.yml`
- `bundle exec bin/setup --help`
- `bundle exec rake node_package`
- `(cd react_on_rails && bundle exec rake rbs:validate)`
- `(cd react_on_rails && bundle check)`
- `(cd react_on_rails && BUNDLE_GEMFILE="$PWD/Gemfile" bundle exec rspec spec/react_on_rails/ruby_version_support_spec.rb)`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --format simple --cache false -- Rakefile ../Rakefile ../rakelib/release.rake)`
- `codex review --base origin/main`
- `git diff --check`

Full CI and benchmark are requested because this changes root/package Rake delegation and setup/CI bundle selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches root vs package bundle boundaries, Rake delegation, and local CI/setup scripts; wrong Gemfile selection could break contributor workflows, but runtime gem behavior is unchanged.
> 
> **Overview**
> **Splits the monorepo root Ruby bundle from the OSS gem** so `bundle install` at the repo root only pulls lint, hooks, release, and benchmark-spec tooling (RuboCop, Rake, RSpec, lefthook, etc.), instead of evaluating `react_on_rails/Gemfile` and dragging in Rails and the full test stack. `Gemfile.lock` shrinks accordingly; Dependabot’s bundler config now includes `/` for that lock.
> 
> **Root `rake` still works via delegation**: the root `Rakefile` no longer loads the package Rakefile; it runs common tasks (`lint`, `run_rspec:*`, `shakapacker_examples:*`, `node_package`, etc.) inside `react_on_rails` with `bundle exec`, auto-installing that bundle when needed. Root `rake lint` is root-tooling RuboCop only; full package lint stays `cd react_on_rails && bundle exec rake lint`.
> 
> **Contributor and CI scripts** (`AGENTS.md`, `bin/setup`, `bin/ci-local`, `bin/ci-rerun-failures`, `conductor-setup.sh`) now install and invoke the correct Gemfile per directory via a shared `bundle_command` helper. Package lint still invokes root RuboCop through `BUNDLE_GEMFILE=../Gemfile` with `Bundler.with_unbundled_env`.
> 
> **Release rake** drops the `ReactOnRails::Utils` require and uses a local `release_truthy?` for dry-run/override flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82993589292d0d9bd6e9fa0246eb22213b42f763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Bundler/Gemfile handling across the repo, CI, and setup scripts to ensure correct dependency installation and selection.
  * Improved dependency bootstrapping order and environment isolation for OSS and Pro flows.
  * Unified truthiness parsing for release tooling.

* **Documentation**
  * Clarified workflow and setup commands to consistently scope package-specific bundle and task invocations.

* **Refactor**
  * Reworked root-level task delegation and lint/test wrappers for clearer, safer task execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Score: 9/10
Auto-merge recommendation: yes
Affected areas: root/OSS bundle separation, RuboCop lint routing, setup/CI scripts, Dependabot config.
Checks: current head `82993589292d0d9bd6e9fa0246eb22213b42f763` has 49 passing checks and 5 expected selector-skipped checks; full CI and benchmark labels are present and exercised.
Review threads: 0 unresolved current review threads.
Known residual risk: root bundle/package boundary touches setup and CI helper routing; mitigated by local shell/Rake/RuboCop/lint validations, full CI and benchmark pass, and current-head AI review checks.
Finalized by: Claude Code Review check `claude-review` for current head `82993589292d0d9bd6e9fa0246eb22213b42f763` (SUCCESS).