### PR TITLE
Remove temporary /posts_page: Pro regression-issue suppression (#3669 revert)

### DIFF
--- a/benchmarks/lib/regression_report.rb
+++ b/benchmarks/lib/regression_report.rb
@@ -47,26 +47,14 @@ module RegressionReport
   FIRST_RUN_SUMMARY = "first_run_summary"
   CONFIRMATION_SUMMARY = "confirmation_summary"
 
-  # TEMPORARY — benchmarks whose regressions must NOT open an issue, by the exact
-  # benchmark name Bencher reports (the leading-slash name shown in the summary table,
-  # matched against REGRESSED_BENCHMARKS in each suite's payload).
-  #
-  # /posts_page: Pro spent weeks hard-500ing on every request (failed_pct = 100), so the
-  # route was effectively an instant error and Bencher built its rps/latency baseline
-  # from those bogus-fast failure responses. Now that the route is fixed, its real
-  # (slower) timings read as large regressions against that fast baseline and would file
-  # a spurious regression issue on every main push. We can't surgically delete just this
-  # benchmark's history in Bencher (the delete is blocked by a FOREIGN KEY constraint
-  # from its reports/alerts), so we suppress it here instead — and short-circuit it
-  # BEFORE a confirmation rerun (plan_confirmation.rb), so we don't burn a fresh runner
-  # confirming a benchmark we would suppress anyway.
-  #
-  # REMOVE this entry (restoring unconditional filing) once the failure-era samples have
-  # rolled out of Bencher's 64-run t-test window for /posts_page: Pro on main — i.e. once
-  # the dashboard baseline reflects real timings again. After that a regression for it is
-  # genuine and must be reported. Tracking issue + full revert steps:
-  # https://github.com/shakacode/react_on_rails/issues/3669
-  IGNORED_REGRESSION_BENCHMARKS = ["/posts_page: Pro"].freeze
+  # Benchmarks whose regressions must NOT open an issue, by the exact benchmark name
+  # Bencher reports (the leading-slash name shown in the summary table, matched against
+  # REGRESSED_BENCHMARKS in each suite's payload). Entries here are TEMPORARY
+  # suppressions: plan_confirmation.rb short-circuits a candidate whose only regressed
+  # benchmarks are listed here BEFORE a confirmation rerun (no fresh runner, no issue).
+  # Empty means every confirmed regression is reported. Any entry added here must have a
+  # tracking issue stating the revert criteria.
+  IGNORED_REGRESSION_BENCHMARKS = [].freeze
 
   # Build a structured alert hash for the ALERTS payload key.
   def alert(benchmark, measure)

--- a/benchmarks/spec/plan_confirmation_spec.rb
+++ b/benchmarks/spec/plan_confirmation_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe "plan_confirmation" do
     }
   end
 
-  let(:ignored) { RegressionReport::IGNORED_REGRESSION_BENCHMARKS.first }
+  # The production list is empty (no active suppressions); stub a sample entry so these
+  # examples keep pinning the ignore-list short-circuit machinery.
+  let(:ignored) { "/ignored: Pro" }
+
+  before { stub_const("RegressionReport::IGNORED_REGRESSION_BENCHMARKS", [ignored]) }
 
   describe ".fully_ignored?" do
     it "is true only when every named benchmark is ignored" do

--- a/benchmarks/spec/regression_report_spec.rb
+++ b/benchmarks/spec/regression_report_spec.rb
@@ -60,7 +60,11 @@ RSpec.describe RegressionReport do
   end
 
   describe "the ignore-list helpers" do
-    let(:ignored) { described_class::IGNORED_REGRESSION_BENCHMARKS.first }
+    # The production list is empty (no active suppressions); stub a sample entry so
+    # these examples keep pinning the general filtering machinery.
+    let(:ignored) { "/ignored: Pro" }
+
+    before { stub_const("RegressionReport::IGNORED_REGRESSION_BENCHMARKS", [ignored]) }
 
     it "drops ignored benchmarks from alert pairs" do
       alerts = [alert(ignored, "rps"), alert("/real: Pro", "rps")]

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -329,7 +329,10 @@ RSpec.describe "track_benchmarks" do
       end
 
       it "ignores a candidate alert on a temporarily-ignored benchmark" do
-        ignored = RegressionReport::IGNORED_REGRESSION_BENCHMARKS.first
+        # The production list is empty (no active suppressions); stub a sample entry so
+        # this example keeps pinning the ignore handling in the confirmation outcome.
+        ignored = "/ignored: Pro"
+        stub_const("RegressionReport::IGNORED_REGRESSION_BENCHMARKS", [ignored])
         report = BencherReport.parse(
           JSON.generate(
             "results" => [[result(ignored, [rps_measure])]],


### PR DESCRIPTION
## Summary

The revert gate for the temporary `/posts_page: Pro` regression-issue suppression has been verified PASSED (gate evidence: https://github.com/shakacode/react_on_rails/issues/3669#issuecomment-4667465624 — the failure-era samples have rolled out of Bencher's 64-run t-test window and the baseline reflects real timings). This PR removes the suppression entry so a confirmed regression on `/posts_page: Pro` files an issue again.

This is a **minimal revert**: `IGNORED_REGRESSION_BENCHMARKS` is emptied, but the general ignore machinery is kept (see decision log below). The issue's original "How to revert" steps are partially stale after #3670/#3810; this follows the updated plan.

Closes #3669

## Changes

- `benchmarks/lib/regression_report.rb`: `IGNORED_REGRESSION_BENCHMARKS` is now `[].freeze`; the /posts_page-specific temporary-suppression comment block is replaced with a short doc of the general-purpose mechanism (exact Bencher name matching, pre-rerun short-circuit, tracking-issue requirement for any future entry).
- Specs that read `IGNORED_REGRESSION_BENCHMARKS.first` (regression_report_spec, plan_confirmation_spec, and the confirmation-outcome example in track_benchmarks_spec) now `stub_const` a sample entry (`"/ignored: Pro"`) so they keep pinning the machinery against the now-empty production list. No coverage was deleted.
- `"/posts_page: Pro"` remains in track_benchmarks_spec only as an inert fixture name in report-parsing examples.

## Validation

- `bundle exec rspec benchmarks/spec/regression_report_spec.rb benchmarks/spec/plan_confirmation_spec.rb benchmarks/spec/track_benchmarks_spec.rb` (root bundle) → 63 examples, 0 failures
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` → 214 files, no offenses
- `BUNDLE_GEMFILE=Gemfile bundle exec rubocop benchmarks/` → 36 files, no offenses
- `script/ci-changes-detector origin/main` → Benchmark scripts; recommended job: Lint (Ruby + JS)
- `git grep "3669"` / `git grep "posts_page: Pro"` → no live suppression references remain (fixture-only uses kept)
- Codex review: skipped — CLI usage limit reached (resets Jun 10 6:30 PM); self-review performed instead

Labels: none — this changes benchmark regression-reporting tooling only, fully validated by its specs; it is not a performance-sensitive runtime path, and a benchmark run would not exercise the suppression branch (it only activates when a Bencher alert fires on a main push).

## Codex Decision Log

- **Minimal revert scope (coordinator decision):** emptied the ignore list but KEPT `ignored_benchmark?`, `actionable_alerts`, `actionable_benchmarks`, and plan_confirmation.rb's `fully_ignored?`/suppressed handling. Why: #3810 made the ignore list load-bearing general plumbing in the confirmation gate; full machinery removal is out of scope for #3669. Maintainers may revisit whether the machinery should be removed entirely if no new suppression is ever needed.
- **Specs converted to `stub_const`** instead of deleted: the examples previously sampled the live list (`.first`), which is now empty. Stubbing `RegressionReport::IGNORED_REGRESSION_BENCHMARKS` keeps the machinery pinned independent of production contents. Note: track_benchmarks_spec.rb line 332 also sampled the live list (the issue's plan assumed it was fixture-only — stale), so it got the same conversion to avoid a nil-driven false `:confirmed` outcome.
- **plan_confirmation.rb comments left untouched:** they document the general mechanism and never claim an active suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark CI reporting tooling only; no runtime app behavior, and specs still cover the ignore path via stubs.
> 
> **Overview**
> Reverts the temporary **`/posts_page: Pro`** regression-issue suppression (#3669): **`IGNORED_REGRESSION_BENCHMARKS`** is now **`[]`**, so confirmed regressions on that benchmark can open issues again. The long `/posts_page`-specific comment is replaced with a short description of the general ignore mechanism (exact Bencher names, pre-rerun short-circuit, tracking issue required for future entries).
> 
> Specs that previously used **`IGNORED_REGRESSION_BENCHMARKS.first`** now **`stub_const`** a sample **`"/ignored: Pro"`** so ignore-list behavior stays covered while production has no active suppressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a79526d4faad88b677af321df10018ab2557b229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleared the regression benchmark suppression list; all confirmed regressions will now be reported.
  * Updated test setup with deterministic test data to ensure stable regression report behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Score: 9/10
Auto-merge recommendation: yes
Affected areas: benchmarks regression-reporting tooling (no runtime/perf surface)
CI detector: `script/ci-changes-detector origin/main` -> Benchmark scripts; recommended job: Lint (Ruby + JS)
Validation run:
- `bundle exec rspec benchmarks/spec/regression_report_spec.rb benchmarks/spec/plan_confirmation_spec.rb benchmarks/spec/track_benchmarks_spec.rb` -> 63 examples, 0 failures
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> no offenses; `BUNDLE_GEMFILE=Gemfile bundle exec rubocop benchmarks/` -> no offenses
Review/check gate:
- Claude review: complete for a79526d4faad88b677af321df10018ab2557b229 (claude-review SUCCESS), no confirmed blocker; one OPTIONAL spec-scoping nit triaged with reply + resolved
- Codex review: skipped — CLI usage limit (resets Jun 10 6:30 PM), evidence in PR body; claude-review served as the independent gate
- GitHub checks: complete for a79526d4, all pass; skips are path-selection per detector
Known residual risk: none — suppression-list removal is fully covered by the updated specs; 1-point deduction for the skipped secondary Codex pass
Finalized by: Claude Code Review check `claude-review` (SUCCESS for head a79526d4, GitHub Checks API record)
