### PR TITLE
Share tool-version parsing between CI action and ci-switch-config

### DIFF
--- a/.github/actions/read-tool-versions/action.yml
+++ b/.github/actions/read-tool-versions/action.yml
@@ -41,37 +41,17 @@ runs:
       run: |
         set -euo pipefail
 
-        # Mirrors read_tool_version() in bin/ci-switch-config; keep parsing in sync.
-        # react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
-        # fails if the workflow action and local switch tool parsers drift.
-        read_tool_version() {
-          local file="$1"
-          local tool="$2"
-          local version
-
-          if [ ! -f "$file" ]; then
-            echo "::error file=$file::Missing $file"
-            exit 1
-          fi
-
-          version="$(
-            awk -v tool="$tool" '$1 == tool { print $2; exit }' "$file"
-          )"
-          if [ -z "$version" ]; then
-            echo "::error file=$file::Missing $tool version in $file"
-            exit 1
-          fi
-
-          echo "$version"
-        }
-
-        latest_ruby_version="$(read_tool_version ".tool-versions" ruby)"
-        latest_node_version="$(read_tool_version ".tool-versions" nodejs)"
+        # bin/read-tool-version is the shared parser also sourced by
+        # bin/ci-switch-config, so the workflow action and the local switch
+        # tool cannot drift. The parity is verified by
+        # react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb.
+        latest_ruby_version="$(bin/read-tool-version .tool-versions ruby)"
+        latest_node_version="$(bin/read-tool-version .tool-versions nodejs)"
         minimum_ruby_version="$(
-          read_tool_version ".minimum.tool-versions" ruby
+          bin/read-tool-version .minimum.tool-versions ruby
         )"
         minimum_node_version="$(
-          read_tool_version ".minimum.tool-versions" nodejs
+          bin/read-tool-version .minimum.tool-versions nodejs
         )"
 
         {

--- a/bin/ci-switch-config
+++ b/bin/ci-switch-config
@@ -21,24 +21,10 @@ require_minimum_tool_versions_file() {
   fi
 }
 
-read_tool_version() {
-  local file="$1"
-  local tool="$2"
-  local version
-
-  if [ ! -f "$file" ]; then
-    echo "Missing $file" >&2
-    exit 1
-  fi
-
-  version="$(awk -v tool="$tool" '$1 == tool { print $2; exit }' "$file")"
-  if [ -z "$version" ]; then
-    echo "Missing $tool version in $file" >&2
-    exit 1
-  fi
-
-  echo "$version"
-}
+# Shared .tool-versions parser (defines read_tool_version); the
+# .github/actions/read-tool-versions workflow action executes the same helper.
+# shellcheck source=bin/read-tool-version
+source "$SCRIPT_DIR/read-tool-version"
 
 current_git_head() {
   # Non-git contexts return an empty string; callers must guard empty output.

--- a/bin/read-tool-version
+++ b/bin/read-tool-version
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Shared parser for asdf/mise ".tool-versions"-style files (plain "tool version"
+# lines). Single source of truth for bin/ci-switch-config (which sources this
+# file) and .github/actions/read-tool-versions/action.yml (which executes it),
+# so the local switch tool and the workflow action cannot drift.
+#
+# Usage:
+#   bin/read-tool-version <tool-versions-file> <tool>   # prints the version
+#   source bin/read-tool-version                        # defines read_tool_version()
+
+read_tool_version() {
+  local file="$1"
+  local tool="$2"
+  local version
+
+  if [ ! -f "$file" ]; then
+    echo "Missing $file" >&2
+    exit 1
+  fi
+
+  version="$(awk -v tool="$tool" '$1 == tool { print $2; exit }' "$file")"
+  if [ -z "$version" ]; then
+    echo "Missing $tool version in $file" >&2
+    exit 1
+  fi
+
+  echo "$version"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <tool-versions-file> <tool>" >&2
+    exit 1
+  fi
+
+  read_tool_version "$@"
+fi

--- a/react_on_rails/spec/react_on_rails/ci_switch_config_spec.rb
+++ b/react_on_rails/spec/react_on_rails/ci_switch_config_spec.rb
@@ -10,6 +10,7 @@ require_relative "spec_helper"
 RSpec.describe "bin/ci-switch-config" do
   let(:repo_root) { File.expand_path("../../..", __dir__) }
   let(:source_script_path) { File.join(repo_root, "bin/ci-switch-config") }
+  let(:read_tool_version_path) { File.join(repo_root, "bin/read-tool-version") }
 
   it "reports shakapacker-webpack before core shakapacker in status output" do
     stdout, stderr, status = ci_switch_status({
@@ -200,10 +201,8 @@ RSpec.describe "bin/ci-switch-config" do
   it "warns when a non-git checkout falls back from latest to the local minimum profile" do
     Dir.mktmpdir do |tmpdir|
       harness_path = File.join(tmpdir, "bin/ci-switch-tool-versions")
-      script_copy_path = File.join(tmpdir, "bin/ci-switch-config")
+      script_copy_path = install_ci_switch_scripts(tmpdir)
 
-      FileUtils.mkdir_p(File.dirname(harness_path))
-      FileUtils.cp(source_script_path, script_copy_path)
       File.write(harness_path, ci_switch_tool_versions_harness(script_copy_path))
       FileUtils.cp(File.join(repo_root, ".minimum.tool-versions"), File.join(tmpdir, ".tool-versions"))
       FileUtils.cp(File.join(repo_root, ".minimum.tool-versions"), File.join(tmpdir, ".minimum.tool-versions"))
@@ -218,14 +217,46 @@ RSpec.describe "bin/ci-switch-config" do
     end
   end
 
+  it "parses plain mise/asdf tool version lines via the shared bin/read-tool-version helper" do
+    Dir.mktmpdir do |tmpdir|
+      tool_versions_path = File.join(tmpdir, ".tool-versions")
+      File.write(tool_versions_path, "ruby 3.3.7\nnodejs 22.12.0\n")
+
+      stdout, stderr, status = Open3.capture3(read_tool_version_path, tool_versions_path, "nodejs")
+
+      expect(status).to be_success, stderr
+      expect(stdout.strip).to eq("22.12.0")
+    end
+  end
+
+  it "fails via the shared bin/read-tool-version helper when the tool-versions file is missing" do
+    Dir.mktmpdir do |tmpdir|
+      missing_path = File.join(tmpdir, ".tool-versions")
+
+      _stdout, stderr, status = Open3.capture3(read_tool_version_path, missing_path, "ruby")
+
+      expect(status).not_to be_success
+      expect(stderr).to include("Missing #{missing_path}")
+    end
+  end
+
+  it "fails via the shared bin/read-tool-version helper when the tool is not listed" do
+    Dir.mktmpdir do |tmpdir|
+      tool_versions_path = File.join(tmpdir, ".tool-versions")
+      File.write(tool_versions_path, "ruby 3.3.7\n")
+
+      _stdout, stderr, status = Open3.capture3(read_tool_version_path, tool_versions_path, "nodejs")
+
+      expect(status).not_to be_success
+      expect(stderr).to include("Missing nodejs version in #{tool_versions_path}")
+    end
+  end
+
   it "reports a friendly error when the minimum tool-version file is missing" do
     Dir.mktmpdir do |tmpdir|
-      fake_script_path = File.join(tmpdir, "bin/ci-switch-config")
+      fake_script_path = install_ci_switch_scripts(tmpdir)
 
-      FileUtils.mkdir_p(File.dirname(fake_script_path))
-      FileUtils.cp(source_script_path, fake_script_path)
       FileUtils.cp(File.join(repo_root, ".tool-versions"), File.join(tmpdir, ".tool-versions"))
-      FileUtils.chmod("+x", fake_script_path)
 
       _stdout, stderr, status = Open3.capture3(fake_script_path, "status", chdir: tmpdir)
 
@@ -235,17 +266,26 @@ RSpec.describe "bin/ci-switch-config" do
     end
   end
 
+  def install_ci_switch_scripts(tmpdir)
+    script_copy_path = File.join(tmpdir, "bin/ci-switch-config")
+
+    FileUtils.mkdir_p(File.dirname(script_copy_path))
+    FileUtils.cp(source_script_path, script_copy_path)
+    # bin/ci-switch-config sources this shared parser from its own directory.
+    FileUtils.cp(read_tool_version_path, File.join(tmpdir, "bin/read-tool-version"))
+    FileUtils.chmod("+x", script_copy_path)
+
+    script_copy_path
+  end
+
   def ci_switch_status(dependencies, tool_versions_source: ".tool-versions")
     Dir.mktmpdir do |tmpdir|
-      fake_script_path = File.join(tmpdir, "bin/ci-switch-config")
+      fake_script_path = install_ci_switch_scripts(tmpdir)
       package_json_path = File.join(tmpdir, "react_on_rails/spec/dummy/package.json")
 
-      FileUtils.mkdir_p(File.dirname(fake_script_path))
       FileUtils.mkdir_p(File.dirname(package_json_path))
-      FileUtils.cp(source_script_path, fake_script_path)
       FileUtils.cp(File.join(repo_root, tool_versions_source), File.join(tmpdir, ".tool-versions"))
       FileUtils.cp(File.join(repo_root, ".minimum.tool-versions"), File.join(tmpdir, ".minimum.tool-versions"))
-      FileUtils.chmod("+x", fake_script_path)
 
       File.write(package_json_path, JSON.pretty_generate("dependencies" => dependencies))
 
@@ -256,10 +296,8 @@ RSpec.describe "bin/ci-switch-config" do
   def with_ci_switch_tool_versions_repo
     Dir.mktmpdir do |tmpdir|
       harness_path = File.join(tmpdir, "bin/ci-switch-tool-versions")
-      script_copy_path = File.join(tmpdir, "bin/ci-switch-config")
+      script_copy_path = install_ci_switch_scripts(tmpdir)
 
-      FileUtils.mkdir_p(File.dirname(harness_path))
-      FileUtils.cp(source_script_path, script_copy_path)
       File.write(harness_path, ci_switch_tool_versions_harness(script_copy_path))
       FileUtils.cp(File.join(repo_root, ".tool-versions"), File.join(tmpdir, ".tool-versions"))
       FileUtils.cp(File.join(repo_root, ".minimum.tool-versions"), File.join(tmpdir, ".minimum.tool-versions"))

--- a/react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
+++ b/react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe "Ruby version support" do
     version.split(".").first
   end
 
+  # The action executes the shared bin/read-tool-version helper from the workspace root.
+  def install_shared_tool_version_helper(tmpdir)
+    helper_copy_path = File.join(tmpdir, "bin/read-tool-version")
+
+    FileUtils.mkdir_p(File.dirname(helper_copy_path))
+    FileUtils.cp(File.join(repo_root, "bin/read-tool-version"), helper_copy_path)
+    FileUtils.chmod("+x", helper_copy_path)
+  end
+
   def read_tool_versions_action_outputs
     action = YAML.safe_load(read_repo_file(".github/actions/read-tool-versions/action.yml"))
     run_script = action.fetch("runs").fetch("steps").find { |step| step["id"] == "versions" }.fetch("run")
@@ -49,6 +58,7 @@ RSpec.describe "Ruby version support" do
 
       File.write(File.join(tmpdir, ".tool-versions"), committed_tool_versions(".tool-versions"))
       FileUtils.cp(File.join(repo_root, ".minimum.tool-versions"), File.join(tmpdir, ".minimum.tool-versions"))
+      install_shared_tool_version_helper(tmpdir)
 
       stdout, stderr, status = Open3.capture3(
         { "GITHUB_OUTPUT" => github_output }, "bash", "-c", run_script, chdir: tmpdir


### PR DESCRIPTION
## Summary

Extracts the duplicated `.tool-versions` parser into a single shared helper, `bin/read-tool-version`, as recommended in the #3785 follow-up:

- `bin/ci-switch-config` now `source`s the helper (same `read_tool_version` function name and behavior).
- `.github/actions/read-tool-versions/action.yml` now executes `bin/read-tool-version <file> <tool>` instead of carrying its own inline copy.
- The helper keeps supporting plain `tool version` lines used by both mise and asdf, with the same missing-file / missing-tool failure modes.
- Action failure messages move from `::error` annotations (previously emitted inside command substitution, so GitHub never rendered them) to plain stderr messages that actually appear in step logs.
- Specs: tmpdir harnesses install the shared helper next to the copied script; `ci_switch_config_spec` gains direct coverage of the helper (parse, missing file, missing tool). The action/script parity test in `ruby_version_support_spec` is kept as a wiring regression test.

Fixes #3838

## Validation

- `bash -n bin/read-tool-version bin/ci-switch-config` — OK
- `shellcheck bin/read-tool-version bin/ci-switch-config` — helper clean; remaining findings on `ci-switch-config` are pre-existing info/warning classes also present on `main` (SC1091/SC2155); `shellcheck -x` follows the new `source` cleanly
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/ci_switch_config_spec.rb spec/react_on_rails/ruby_version_support_spec.rb` — 24 examples, 0 failures
- `actionlint` — OK; `yamllint` not installed locally (skipped)
- `bundle exec rubocop` on touched spec files — no offenses
- Smoke: `bin/ci-switch-config status` exits 0 end to end; `bin/read-tool-version` returns 4.0.5/22.12.0 (latest) and 3.3.7/20.19.0 (minimum) against the committed files, and fails with exit 1 + clear stderr for missing file/tool
- `script/ci-changes-detector origin/main` — flags CI infrastructure, recommends full suite

Labels: full-ci — this changes a CI composite action consumed by gem-tests/examples/integration workflows and the local CI switch tooling (AGENTS.md classifies CI workflow changes as high-risk).

## Codex Decision Log

- Codex CLI review skipped: usage limit reached (`try again at Jun 10th, 2026 6:30 PM`); performed manual self-review instead.
- Action error output switched from `::error` workflow commands to plain stderr: the annotations were previously swallowed by `$( ... )` command substitution (workflow commands are only parsed from uncaptured stdout), so this is a strict log-visibility improvement, not a regression.
- Kept the parser-parity spec (`keeps the workflow action and local CI switch tool-version parsers in sync`) even though both sides now share one implementation — it still guards the wiring (action must successfully execute the helper from the workspace root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a composite CI action used by gem/examples workflows and local CI switch tooling; behavior should match but wiring and error output format changed.
> 
> **Overview**
> Introduces **`bin/read-tool-version`** as the single parser for mise/asdf-style `.tool-versions` files, usable as a CLI (`bin/read-tool-version <file> <tool>`) or via `source` (`read_tool_version()`).
> 
> **`bin/ci-switch-config`** drops its inline duplicate and **sources** the shared helper. The **`read-tool-versions`** composite action now **invokes** that script instead of an embedded bash function, so CI and local switching stay aligned.
> 
> Parse failures now emit **plain stderr** (e.g. `Missing …`) rather than `::error` workflow commands that were swallowed inside `$(…)` substitution.
> 
> Specs copy the helper into tmpdir harnesses, add direct tests for success/missing-file/missing-tool, and keep the action vs `ci-switch-config` output parity check in `ruby_version_support_spec`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2247364f63312eae15b8da8caf7e3d0c661c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal tool version parsing logic to reduce code duplication across multiple components.

* **Tests**
  * Expanded test coverage for tool version parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Score: 9/10
Auto-merge recommendation: yes
Affected areas: CI infrastructure (composite action + local CI switch tooling)
CI detector: `script/ci-changes-detector origin/main` -> RSpec tests + CI infrastructure; recommends full suite (full-ci label applied)
Validation run:
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/ci_switch_config_spec.rb spec/react_on_rails/ruby_version_support_spec.rb)` -> 24 examples, 0 failures
- `bash -n` + `shellcheck` (no new findings vs main) + `actionlint` -> OK
- Functional smoke: `bin/ci-switch-config status` exit 0; helper returns correct latest/minimum versions and correct exit-1 failure modes
Review/check gate:
- Claude review: complete for aa2247364f63312eae15b8da8caf7e3d0c661c1f (claude-review SUCCESS), no confirmed blocker; one OPTIONAL sourced-function style note triaged with reply + resolved
- Codex review: skipped — CLI usage limit (resets Jun 10 6:30 PM), evidence in PR body; claude-review served as the independent gate
- GitHub checks: full CI ran for aa224736 (full-ci label), all pass
Known residual risk: none — full matrix exercised the composite action on real workflows; 1-point deduction for the skipped secondary Codex pass
Finalized by: Claude Code Review check `claude-review` (SUCCESS for head aa224736, GitHub Checks API record)
