### PR TITLE
Centralize CI dependency profile constants in .ci-dependency-versions

### DIFF
--- a/.ci-dependency-versions
+++ b/.ci-dependency-versions
@@ -1,0 +1,8 @@
+# CI dependency profile versions for bin/ci-switch-config (latest/minimum profiles).
+# Same "<name> <version>" line format as .tool-versions, parsed by bin/read-tool-version.
+# These are npm/gem dependency targets, not runtimes: asdf/mise do not manage them,
+# so they cannot live in .tool-versions alongside Ruby/Node.
+minimum-shakapacker 8.2.0
+minimum-react 18.0.0
+latest-shakapacker 10.1.0
+latest-react 19.0.0

--- a/bin/ci-switch-config
+++ b/bin/ci-switch-config
@@ -13,10 +13,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MINIMUM_TOOL_VERSIONS_FILE="$PROJECT_ROOT/.minimum.tool-versions"
 MAXIMUM_TOOL_VERSIONS_FILE="$PROJECT_ROOT/.maximum.tool-versions"
 MAXIMUM_TOOL_VERSIONS_HEAD_FILE="$PROJECT_ROOT/.maximum.tool-versions.head"
+CI_DEPENDENCY_VERSIONS_FILE="$PROJECT_ROOT/.ci-dependency-versions"
 
-require_minimum_tool_versions_file() {
-  if [ ! -f "$MINIMUM_TOOL_VERSIONS_FILE" ]; then
-    echo "Error: $MINIMUM_TOOL_VERSIONS_FILE not found. This file is required at script load time and should be committed." >&2
+require_committed_file() {
+  local file="$1"
+
+  if [ ! -f "$file" ]; then
+    echo "Error: $file not found. This file is required at script load time and should be committed." >&2
     exit 1
   fi
 }
@@ -122,20 +125,22 @@ reload_latest_tool_version_globals() {
 }
 
 # Run at load time (outside main) so sourced test harnesses get populated globals.
-# Requires .minimum.tool-versions to be present before sourcing.
-require_minimum_tool_versions_file
+# Requires .minimum.tool-versions and .ci-dependency-versions to be present before sourcing.
+require_committed_file "$MINIMUM_TOOL_VERSIONS_FILE"
+require_committed_file "$CI_DEPENDENCY_VERSIONS_FILE"
 
 MINIMUM_RUBY_VERSION="$(read_tool_version "$MINIMUM_TOOL_VERSIONS_FILE" ruby)"
 MINIMUM_RUBY_MINOR_VERSION="${MINIMUM_RUBY_VERSION%.*}"
 MINIMUM_NODE_VERSION="$(read_tool_version "$MINIMUM_TOOL_VERSIONS_FILE" nodejs)"
 MINIMUM_NODE_MAJOR_VERSION="${MINIMUM_NODE_VERSION%%.*}"
-MINIMUM_REACT_VERSION="18.0.0" # Update when minimum CI moves to a newer React version.
+# Shakapacker/React profile versions live in .ci-dependency-versions: asdf/mise
+# do not manage npm packages, so they cannot live in .tool-versions alongside Ruby/Node.
+MINIMUM_SHAKAPACKER_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" minimum-shakapacker)"
+MINIMUM_REACT_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" minimum-react)"
 MINIMUM_REACT_MAJOR_VERSION="${MINIMUM_REACT_VERSION%%.*}"
 reload_latest_tool_version_globals false
-# Shakapacker/React stay as literals here: asdf/mise do not manage npm packages,
-# so they cannot live in .tool-versions alongside Ruby/Node.
-LATEST_SHAKAPACKER_VERSION="10.1.0" # Update when latest CI moves to a newer Shakapacker.
-LATEST_REACT_VERSION="19.0.0" # Update when latest CI moves to a newer React version.
+LATEST_SHAKAPACKER_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" latest-shakapacker)"
+LATEST_REACT_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" latest-react)"
 LATEST_REACT_MAJOR_VERSION="${LATEST_REACT_VERSION%%.*}"
 
 # Color codes for output
@@ -455,7 +460,7 @@ show_status() {
   fi
 
   echo ""
-  if [[ "${SHAKAPACKER_GEM}" == "8.2.0" ]] && [[ "${REACT_ROOT}" =~ ^\^?${MINIMUM_REACT_MAJOR_VERSION}(\.|$) ]]; then
+  if [[ "${SHAKAPACKER_GEM}" == "$MINIMUM_SHAKAPACKER_VERSION" ]] && [[ "${REACT_ROOT}" =~ ^\^?${MINIMUM_REACT_MAJOR_VERSION}(\.|$) ]]; then
     echo -e "Current config: ${GREEN}minimum${NC} (matches CI: Ruby $MINIMUM_RUBY_MINOR_VERSION, Node $MINIMUM_NODE_MAJOR_VERSION, minimum deps)"
   elif [[ "${SHAKAPACKER_GEM}" == "$LATEST_SHAKAPACKER_VERSION" ]] && [[ "${REACT_ROOT}" =~ ^\^?${LATEST_REACT_MAJOR_VERSION}(\.|$) ]]; then
     echo -e "Current config: ${GREEN}latest${NC} (matches CI: Ruby $LATEST_RUBY_MINOR_VERSION, Node $LATEST_NODE_MAJOR_VERSION, latest deps)"
@@ -468,7 +473,7 @@ switch_to_minimum() {
   local VERSION_MANAGER=$(check_version_manager)
 
   print_header "Switching to MINIMUM configuration"
-  echo "  Target: Ruby $MINIMUM_RUBY_MINOR_VERSION, Node $MINIMUM_NODE_MAJOR_VERSION, Shakapacker 8.2.0, React $MINIMUM_REACT_VERSION"
+  echo "  Target: Ruby $MINIMUM_RUBY_MINOR_VERSION, Node $MINIMUM_NODE_MAJOR_VERSION, Shakapacker $MINIMUM_SHAKAPACKER_VERSION, React $MINIMUM_REACT_VERSION"
   echo "  Using version manager: $VERSION_MANAGER"
   echo ""
 
@@ -750,7 +755,7 @@ main() {
       echo "Usage: $0 {minimum|latest|status}"
       echo ""
       echo "Commands:"
-      echo "  minimum  - Switch to Ruby $MINIMUM_RUBY_MINOR_VERSION, Node $MINIMUM_NODE_MAJOR_VERSION, minimum dependencies (Shakapacker 8.2.0, React $MINIMUM_REACT_VERSION)"
+      echo "  minimum  - Switch to Ruby $MINIMUM_RUBY_MINOR_VERSION, Node $MINIMUM_NODE_MAJOR_VERSION, minimum dependencies (Shakapacker $MINIMUM_SHAKAPACKER_VERSION, React $MINIMUM_REACT_VERSION)"
       echo "  latest   - Switch to Ruby $LATEST_RUBY_MINOR_VERSION, Node $LATEST_NODE_MAJOR_VERSION, latest dependencies (Shakapacker $LATEST_SHAKAPACKER_VERSION, React $LATEST_REACT_VERSION)"
       echo "  status   - Show current configuration"
       echo ""

--- a/react_on_rails/spec/react_on_rails/ci_switch_config_spec.rb
+++ b/react_on_rails/spec/react_on_rails/ci_switch_config_spec.rb
@@ -266,6 +266,22 @@ RSpec.describe "bin/ci-switch-config" do
     end
   end
 
+  it "reports a friendly error when the CI dependency versions file is missing" do
+    Dir.mktmpdir do |tmpdir|
+      fake_script_path = install_ci_switch_scripts(tmpdir)
+
+      FileUtils.cp(File.join(repo_root, ".tool-versions"), File.join(tmpdir, ".tool-versions"))
+      FileUtils.cp(File.join(repo_root, ".minimum.tool-versions"), File.join(tmpdir, ".minimum.tool-versions"))
+      FileUtils.rm(File.join(tmpdir, ".ci-dependency-versions"))
+
+      _stdout, stderr, status = Open3.capture3(fake_script_path, "status", chdir: tmpdir)
+
+      expect(status).not_to be_success
+      expect(stderr).to include("Error: #{File.join(tmpdir, '.ci-dependency-versions')} not found.")
+      expect(stderr).to include("This file is required at script load time and should be committed.")
+    end
+  end
+
   def install_ci_switch_scripts(tmpdir)
     script_copy_path = File.join(tmpdir, "bin/ci-switch-config")
 
@@ -273,6 +289,8 @@ RSpec.describe "bin/ci-switch-config" do
     FileUtils.cp(source_script_path, script_copy_path)
     # bin/ci-switch-config sources this shared parser from its own directory.
     FileUtils.cp(read_tool_version_path, File.join(tmpdir, "bin/read-tool-version"))
+    # Dependency profile versions are read from this committed file at load time.
+    FileUtils.cp(File.join(repo_root, ".ci-dependency-versions"), File.join(tmpdir, ".ci-dependency-versions"))
     FileUtils.chmod("+x", script_copy_path)
 
     script_copy_path

--- a/react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
+++ b/react_on_rails/spec/react_on_rails/ruby_version_support_spec.rb
@@ -257,7 +257,12 @@ RSpec.describe "Ruby version support" do
       'MINIMUM_NODE_VERSION="$(read_tool_version "$MINIMUM_TOOL_VERSIONS_FILE" nodejs)"'
     )
     expect(ci_switch_config).to include('MINIMUM_NODE_MAJOR_VERSION="${MINIMUM_NODE_VERSION%%.*}"')
-    expect(ci_switch_config).to include('MINIMUM_REACT_VERSION="18.0.0"')
+    expect(ci_switch_config).to include(
+      'MINIMUM_SHAKAPACKER_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" minimum-shakapacker)"'
+    )
+    expect(ci_switch_config).to include(
+      'MINIMUM_REACT_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" minimum-react)"'
+    )
     expect(ci_switch_config).to include('MINIMUM_REACT_MAJOR_VERSION="${MINIMUM_REACT_VERSION%%.*}"')
     expect(ci_switch_config).to include('MAXIMUM_TOOL_VERSIONS_HEAD_FILE="$PROJECT_ROOT/.maximum.tool-versions.head"')
     expect(ci_switch_config).to include("saved_tool_versions_valid_for_restore()")
@@ -274,9 +279,20 @@ RSpec.describe "Ruby version support" do
       'LATEST_NODE_VERSION="$(read_latest_tool_version nodejs "$emit_warnings")"'
     )
     expect(ci_switch_config).to include('LATEST_NODE_MAJOR_VERSION="${LATEST_NODE_VERSION%%.*}"')
-    expect(ci_switch_config).to include('LATEST_SHAKAPACKER_VERSION="10.1.0"')
-    expect(ci_switch_config).to include('LATEST_REACT_VERSION="19.0.0"')
+    expect(ci_switch_config).to include(
+      'LATEST_SHAKAPACKER_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" latest-shakapacker)"'
+    )
+    expect(ci_switch_config).to include(
+      'LATEST_REACT_VERSION="$(read_tool_version "$CI_DEPENDENCY_VERSIONS_FILE" latest-react)"'
+    )
     expect(ci_switch_config).to include('LATEST_REACT_MAJOR_VERSION="${LATEST_REACT_VERSION%%.*}"')
+
+    # The dependency profile matrix itself lives in the committed data file.
+    dependency_versions = tool_versions(".ci-dependency-versions")
+    expect(dependency_versions.fetch("minimum-shakapacker")).to eq("8.2.0")
+    expect(dependency_versions.fetch("minimum-react")).to eq("18.0.0")
+    expect(dependency_versions.fetch("latest-shakapacker")).to eq("10.1.0")
+    expect(dependency_versions.fetch("latest-react")).to eq("19.0.0")
     expect(ci_switch_config).to match(/set_ruby_version "\$LATEST_RUBY_VERSION"/)
     expect(ci_switch_config).to match(/set_node_version "\$LATEST_NODE_VERSION"/)
     expect(ci_switch_config).to include('[[ "${REACT_ROOT}" =~ ^\^?${MINIMUM_REACT_MAJOR_VERSION}(\.|$) ]]')


### PR DESCRIPTION
## Summary

Follow-up to #3785 (and stacked on #3838's shared parser): moves the hardcoded React/Shakapacker CI profile constants out of `bin/ci-switch-config` into a committed `.ci-dependency-versions` data file.

- New `.ci-dependency-versions` uses the same plain `<name> <version>` line format as `.tool-versions` and is parsed by the shared `bin/read-tool-version` helper from #3838 — the simplest format consistent with the existing pattern.
- `bin/ci-switch-config` reads `minimum-shakapacker`, `minimum-react`, `latest-shakapacker`, `latest-react` from the file at load time and fails fast with the existing friendly "required at script load time and should be committed" error if it is missing (`require_minimum_tool_versions_file` generalized to `require_committed_file`).
- The inline `8.2.0` minimum-Shakapacker literals in status/usage output now use the same source.
- Ruby/Node `.tool-versions` behavior is unchanged; no dependency versions were bumped — values are relocated verbatim.
- Specs pin the expected profile matrix via the data file and cover the missing-file error.

Stacked on #3854 (`jg/3838-shared-tool-version-parser`); merge that PR first. This PR's base is the #3854 branch and will be retargeted to `main` after it merges.

Fixes #3839

## Validation

- `bash -n bin/ci-switch-config bin/read-tool-version` — OK
- `shellcheck` — no new findings vs `main` (pre-existing SC1091/SC2155 info/warnings only)
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/ci_switch_config_spec.rb spec/react_on_rails/ruby_version_support_spec.rb` — 25 examples, 0 failures
- `bundle exec rubocop` on touched spec files — no offenses
- Functional: `bin/read-tool-version .ci-dependency-versions <key>` returns 8.2.0 / 18.0.0 / 10.1.0 / 19.0.0; sourcing `bin/ci-switch-config` populates all profile globals from the file; `bin/ci-switch-config status` exits 0. Latest/minimum switching paths exercised via the tmpdir spec harnesses rather than mutating the real checkout's dependency state.
- `script/ci-changes-detector` — flags CI infrastructure, recommends full suite

Labels: full-ci — CI tooling/config change feeding the local CI switch workflow and version-matrix specs; AGENTS.md treats CI infrastructure changes as full-ci candidates. (No `benchmark`: no runtime/performance surface.)

## Codex Decision Log

- Stacked on #3854 instead of branching from `main`: the data file is parsed by the shared helper introduced there, and both branches rewrite the same spec-harness region — an independent branch would conflict.
- Included `minimum-shakapacker 8.2.0` in the data file (beyond the three constants at former lines 146–152): the acceptance note says "latest and minimum read React/Shakapacker profile versions from the shared source", and leaving the inline `8.2.0` literals would have left the minimum profile half-centralized.
- `script/convert` still hardcodes its own downgrade targets (React 18.0.0 etc.); left untouched per "do not broaden" — candidate follow-up if drift there becomes a problem.
- `SWITCHING_CI_CONFIGS.md` version tables left as-is (docs, not constants); they remain guarded by the spec assertions.
- Codex CLI review skipped: usage limit (`try again at Jun 10th, 2026 6:30 PM`); manual self-review performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/local dev tooling only; no runtime, auth, or dependency version bumps—values moved verbatim with added fail-fast if the data file is missing.
> 
> **Overview**
> Moves the **minimum/latest Shakapacker and React** CI profile targets out of hardcoded literals in `bin/ci-switch-config` into a new committed **`.ci-dependency-versions`** file, using the same `<name> <version>` format and **`bin/read-tool-version`** parser as `.tool-versions`.
> 
> The script now **requires** that file at load time (via generalized **`require_committed_file`**), loads **`MINIMUM_*` / `LATEST_*`** globals from it, and uses those variables for **status detection**, **switch output**, and **usage** text instead of inline `8.2.0` / `10.1.0` / `18.0.0` / `19.0.0`. **Ruby/Node** behavior is unchanged; version values are relocated, not bumped.
> 
> Specs assert the new file-driven assignments, pin the profile matrix in **`.ci-dependency-versions`**, copy the file in the CI switch harness, and add coverage for a **missing `.ci-dependency-versions`** error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71ed7fd82ff68ebaf2f383dafd594f364b3711b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI configuration now loads Shakapacker and React dependency versions from an external configuration file instead of hardcoded values.

* **Tests**
  * Added validation tests to ensure required configuration files are present during execution.
  * Enhanced test coverage for dependency version detection and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Score: 9/10
Auto-merge recommendation: yes
Affected areas: CI infrastructure (local CI switch tooling + committed version data file)
CI detector: `script/ci-changes-detector` -> RSpec tests + CI infrastructure; full-ci label applied and full matrix ran
Validation run:
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/ci_switch_config_spec.rb spec/react_on_rails/ruby_version_support_spec.rb)` -> 25 examples, 0 failures
- `bash -n` + `shellcheck` (no new findings vs main) -> OK
- Functional: helper returns 8.2.0/18.0.0/10.1.0/19.0.0 from `.ci-dependency-versions`; sourcing `bin/ci-switch-config` populates all profile globals; `status` exits 0
Review/check gate:
- Claude review: complete for 71ed7fd82ff68ebaf2f383dafd594f364b3711b1 (claude-review SUCCESS), no confirmed blocker; two OPTIONAL comment-only clarity suggestions triaged with replies + resolved (deferred to avoid a no-op full-ci rerun)
- Codex review: skipped — CLI usage limit (resets Jun 10 6:30 PM), evidence in PR body; claude-review served as the independent gate
- GitHub checks: full CI complete for 71ed7fd8 after rebase onto main (post-#3854 merge), all pass
Known residual risk: none — values relocated verbatim, matrix pinned by specs; 1-point deduction for the skipped secondary Codex pass
Finalized by: Claude Code Review check `claude-review` (SUCCESS for head 71ed7fd8, GitHub Checks API record)
