### PR TITLE
Bump react-on-rails-rsc pin to 19.0.5-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Changed
+
+- **[Pro]** **Updated the RSC rollout pin to `react-on-rails-rsc@19.0.5-rc.7`**: The generator default, package manifests, lockfile, and Pro RSC install docs now point at `19.0.5-rc.7`, which fixes the Webpack client manifest CSS collection to exclude runtime-chunk CSS (so shared runtime CSS no longer leaks into every client component's Flight stylesheet hints, while the server manifest still retains runtime-chunk CSS for SSR coverage) and to skip `.hot-update.css` HMR files. The temporary exact prerelease pin policy is unchanged until stable `19.0.5` ships. [PR 3857](https://github.com/shakacode/react_on_rails/pull/3857) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.2] - 2026-06-09
 
 #### Added

--- a/docs/pro/react-server-components/create-without-ssr.md
+++ b/docs/pro/react-server-components/create-without-ssr.md
@@ -26,16 +26,16 @@ bundle add react_on_rails_pro --version="= VERSION"
 Also, install React 19.0.x, React DOM 19.0.x, and the exact `react-on-rails-rsc` release candidate currently used by the generator:
 
 ```bash
-yarn add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# npm install react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# bun add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
+yarn add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
+# npm install react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
+# pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
+# bun add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
 ```
 
 > [!NOTE]
 > React on Rails Pro RSC currently supports React 19.0.x with patch >= 19.0.4. Do not upgrade generated RSC apps to React 19.1 or 19.2 just because those versions are newer on npm; the RSC bundler APIs used internally can change between React minor versions. See the [React documentation on Server Components](https://react.dev/reference/rsc/server-components#how-do-i-build-support-for-server-components) for details.
 >
-> The example above pins `react-on-rails-rsc@19.0.5-rc.6`, a release candidate. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is published and the generator/package metadata policy is reviewed together.
+> The example above pins `react-on-rails-rsc@19.0.5-rc.7`, a release candidate. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is published and the generator/package metadata policy is reviewed together.
 
 2. Enable support for Server Components in React on Rails Pro configuration:
 

--- a/docs/pro/react-server-components/rspack-compatibility.md
+++ b/docs/pro/react-server-components/rspack-compatibility.md
@@ -12,7 +12,7 @@ The generator supports Rspack — when `assets_bundler: rspack` is detected in `
 The RSC implementation depends on the `react-on-rails-rsc` npm package, which provides bundler-specific manifest plugins plus a shared loader:
 
 - **WebpackPlugin** (`react-on-rails-rsc/WebpackPlugin`) — generates client/server component manifest files under webpack.
-- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the exact `react-on-rails-rsc@19.0.5-rc.6` pin (switch to 19.0.5 stable once published).
+- **RspackPlugin** (`react-on-rails-rsc/RspackPlugin`) — the rspack-native equivalent (`RSCRspackPlugin`). It emits the **same manifest JSON schema** using only standard rspack public APIs, so the RSC runtime resolves client references identically. Exported by the exact `react-on-rails-rsc@19.0.5-rc.7` pin (switch to 19.0.5 stable once published).
 - **WebpackLoader** (`react-on-rails-rsc/WebpackLoader`) — transforms `'use client'` files into client reference proxies in the RSC bundle. Works under both webpack and rspack.
 
 ## React and Package Version Policy
@@ -24,7 +24,7 @@ integration can change between React minor releases, so the generator range shou
 advance only after the Webpack and Rspack paths are verified against the new React
 minor.
 
-The generator separately pins `react-on-rails-rsc@19.0.5-rc.6` exactly until a
+The generator separately pins `react-on-rails-rsc@19.0.5-rc.7` exactly until a
 stable `react-on-rails-rsc@19.0.5` is published. That package pin is separate from
 the Pro package peer metadata tracked in [issue #3609](https://github.com/shakacode/react_on_rails/issues/3609):
 metadata can allow prerelease RSC packages broadly enough for `npm ls`, while the

--- a/docs/pro/react-server-components/upgrading-existing-pro-app.md
+++ b/docs/pro/react-server-components/upgrading-existing-pro-app.md
@@ -15,7 +15,7 @@ Before running the generator, verify your environment:
 | React on Rails Pro npm   | `npm ls react-on-rails-pro` / `yarn why react-on-rails-pro` / `pnpm list react-on-rails-pro` / `bun pm why react-on-rails-pro` | Matches gem version                                                                                                         |
 | React version            | `npm ls react` / `yarn why react` / `pnpm list react` / `bun pm why react`                                                     | 19.0.x with patch >= 19.0.4 (see [v16.2.0 release notes](../../oss/upgrading/release-notes/16.2.0.md) for security context) |
 | React DOM version        | `npm ls react-dom` / `yarn why react-dom` / `pnpm list react-dom` / `bun pm why react-dom`                                     | Must match `react` version                                                                                                  |
-| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | Exact `19.0.5-rc.6` pin until stable `19.0.5` ships                                                                         |
+| `react-on-rails-rsc`     | `npm ls react-on-rails-rsc` / `yarn why react-on-rails-rsc` / `pnpm list react-on-rails-rsc` / `bun pm why react-on-rails-rsc` | Exact `19.0.5-rc.7` pin until stable `19.0.5` ships                                                                         |
 | Node.js                  | `node --version`                                                                                                               | 18+                                                                                                                         |
 | Pro initializer exists   | `ls config/initializers/react_on_rails_pro.rb`                                                                                 | File exists                                                                                                                 |
 | Node renderer configured | Check `react_on_rails_pro.rb` for `server_renderer = "NodeRenderer"`                                                           | NodeRenderer enabled                                                                                                        |
@@ -23,9 +23,9 @@ Before running the generator, verify your environment:
 If React is outside the supported 19.0.x range or below 19.0.4, upgrade it first:
 
 ```bash
-pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# or: yarn add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
-# or: npm install react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
+pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
+# or: yarn add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
+# or: npm install react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.7
 ```
 
 > **React 19.0.x with patch >= 19.0.4** is recommended. Earlier 19.0.x versions (19.0.0--19.0.3) have known security vulnerabilities — see the [v16.2.0 release notes](../../oss/upgrading/release-notes/16.2.0.md) for details.
@@ -34,7 +34,7 @@ pnpm add react@~19.0.4 react-dom@~19.0.4 react-on-rails-rsc@19.0.5-rc.6
 > The RSC generator intentionally stays on React 19.0.x and does not widen generated apps to React 19.1 or 19.2 yet. React's RSC runtime and bundler APIs can change between minor releases, so advance the React range only when the generator, docs, and package metadata policy are reviewed together.
 
 > [!NOTE]
-> `react-on-rails-rsc@19.0.5-rc.6` is an exact release-candidate pin. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is available. This is separate from the Pro package peer metadata tracked in [issue #3609](https://github.com/shakacode/react_on_rails/issues/3609): metadata can allow prerelease RSC packages broadly enough for `npm ls`, while the generator still installs the tested exact RSC package pin.
+> `react-on-rails-rsc@19.0.5-rc.7` is an exact release-candidate pin. Keep that exact pin until a stable `react-on-rails-rsc@19.0.5` release is available. This is separate from the Pro package peer metadata tracked in [issue #3609](https://github.com/shakacode/react_on_rails/issues/3609): metadata can allow prerelease RSC packages broadly enough for `npm ls`, while the generator still installs the tested exact RSC package pin.
 
 ## Pre-Migration: Audit Components for Client API Usage
 
@@ -263,8 +263,8 @@ Then run `bundle install` before retrying the generator.
 
 If the RSC bundle build fails but server and client builds succeed, the issue is likely in `rscWebpackConfig.js`. Common causes:
 
-- **Missing `react-on-rails-rsc` package**: Run `pnpm add react-on-rails-rsc@19.0.5-rc.6`
-- **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.0.x with patch >= 19.0.4 and the exact `react-on-rails-rsc@19.0.5-rc.6` pin. Check with `pnpm list react react-dom react-on-rails-rsc`
+- **Missing `react-on-rails-rsc` package**: Run `pnpm add react-on-rails-rsc@19.0.5-rc.7`
+- **React or `react-on-rails-rsc` version mismatch**: RSC currently requires React 19.0.x with patch >= 19.0.4 and the exact `react-on-rails-rsc@19.0.5-rc.7` pin. Check with `pnpm list react react-dom react-on-rails-rsc`
 - **Custom webpack config incompatibility**: If your `serverWebpackConfig.js` was heavily customized, the generator's transforms may not apply cleanly. See [Preparing Your App: Step 4](../../oss/migrating/rsc-preparing-app.md#step-4-set-up-the-rsc-webpack-bundle) for the underlying intent of each webpack change
 
 ### Manifest Files Not Generated

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "publint": "^0.3.4",
     "react": "~19.0.4",
     "react-dom": "~19.0.4",
-    "react-on-rails-rsc": "19.0.5-rc.6",
+    "react-on-rails-rsc": "19.0.5-rc.7",
     "redux": "^4.2.1",
     "shaka-perf": "0.1.3",
     "shaka-shared": "0.1.3",

--- a/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
@@ -32,7 +32,7 @@ export interface RscPeerCheckInput {
 type VersionTuple = [number, number, number];
 
 // Strip build metadata (`+...`) and prerelease (`-...`) so a coordinated RC such as
-// `19.0.5-rc.6` compares as `19.0.5`. We only need major/minor/patch ordering, so this
+// `19.0.5-rc.7` compares as `19.0.5`. We only need major/minor/patch ordering, so this
 // avoids semver's prerelease rules (and a `semver` dependency) entirely.
 const parseTuple = (version: string): VersionTuple => {
   // `resolveVersion` is a public injection point, so tolerate a leading `v`/`=` (e.g. `v19.0.4`).

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -18,7 +18,7 @@
 //
 // `recommendedMin` deliberately starts at the stable floor we currently recommend.
 // Raise it to the stable `react-on-rails-rsc` release (expected 19.0.5) once
-// 19.0.5-rc.6 is promoted, which activates the warn tier for anyone still on an older
+// 19.0.5-rc.7 is promoted, which activates the warn tier for anyone still on an older
 // 19.x build.
 // Bump tracked by https://github.com/shakacode/react_on_rails/issues/3632
 // (the stable 19.0.5 ship/pin is tracked by issue #3634).

--- a/packages/react-on-rails-pro/package.json
+++ b/packages/react-on-rails-pro/package.json
@@ -117,7 +117,7 @@
     "mock-fs": "^5.5.0",
     "react": "~19.0.4",
     "react-dom": "~19.0.4",
-    "react-on-rails-rsc": "19.0.5-rc.6",
+    "react-on-rails-rsc": "19.0.5-rc.7",
     "ioredis": "5.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,8 +182,8 @@ importers:
         specifier: ~19.0.4
         version: 19.0.7(react@19.0.7)
       react-on-rails-rsc:
-        specifier: 19.0.5-rc.6
-        version: 19.0.5-rc.6(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.0.5-rc.7
+        version: 19.0.5-rc.7(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.105.2(@swc/core@1.15.3))
       redux:
         specifier: ^4.2.1
         version: 4.2.1
@@ -268,8 +268,8 @@ importers:
         specifier: ~19.0.4
         version: 19.0.7(react@19.0.7)
       react-on-rails-rsc:
-        specifier: 19.0.5-rc.6
-        version: 19.0.5-rc.6(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.105.2(@swc/core@1.15.3))
+        specifier: 19.0.5-rc.7
+        version: 19.0.5-rc.7(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.105.2(@swc/core@1.15.3))
 
   packages/react-on-rails-pro-node-renderer:
     dependencies:
@@ -747,8 +747,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.0.5-rc.6
-        version: 19.0.5-rc.6(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.104.1)
+        specifier: 19.0.5-rc.7
+        version: 19.0.5-rc.7(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8439,8 +8439,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-on-rails-rsc@19.0.5-rc.6:
-    resolution: {integrity: sha512-BCnSJ4lzLP6lqegQlr5smJW/54NAEwnQy1OMLBYUwXYKXEozuLlGH/GzLf0F0nR69fDmKyUL51fzcg6Khm4AkA==}
+  react-on-rails-rsc@19.0.5-rc.7:
+    resolution: {integrity: sha512-cyQwZm7YW9FS0PEgwael5P9S5HsNeHwhnMm10ScgepZTv38dOeidf+gWf9x+z6w0wrgJ92aExZ8uLjCgpImxcQ==}
     peerDependencies:
       react: ~19.0.4
       react-dom: ~19.0.4
@@ -19041,7 +19041,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-on-rails-rsc@19.0.5-rc.6(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.104.1):
+  react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
@@ -19050,7 +19050,7 @@ snapshots:
       webpack: 5.104.1(@swc/core@1.15.3)(esbuild@0.28.0)(webpack-cli@7.0.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.0.5-rc.6(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.105.2(@swc/core@1.15.3)):
+  react-on-rails-rsc@19.0.5-rc.7(react-dom@19.0.7(react@19.0.7))(react@19.0.7)(webpack@5.105.2(@swc/core@1.15.3)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2

--- a/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
+++ b/react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb
@@ -150,10 +150,10 @@ module ReactOnRails
       # prerelease RSC package broadly enough to keep `npm ls` healthy, but generator behavior still
       # installs the tested React 19.0.x range and exact RSC package pin until both policies advance.
       RSC_REACT_VERSION_RANGE = "~19.0.4"
-      # Pinned to 19.0.5-rc.6 because the discovery plugin export, native Rspack plugin, and
+      # Pinned to 19.0.5-rc.7 because the discovery plugin export, native Rspack plugin, and
       # RSC manifest CSS fixes all ship in that prerelease.
       # TODO(#3642): switch to a stable react-on-rails-rsc release after 19.0.5 stable ships.
-      RSC_PACKAGE_VERSION_PIN = "19.0.5-rc.6"
+      RSC_PACKAGE_VERSION_PIN = "19.0.5-rc.7"
 
       private
 

--- a/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/js_dependency_manager_spec.rb
@@ -274,10 +274,10 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
       instance.add_npm_dependencies_result = false
       allow(instance).to receive(:existing_package_names).and_return(%w[react-on-rails-rsc])
 
-      result = instance.send(:add_packages, ["react-on-rails-rsc@19.0.5-rc.6"])
+      result = instance.send(:add_packages, ["react-on-rails-rsc@19.0.5-rc.7"])
 
       expect(result).to be(true)
-      expect(instance.system_calls).to include(%w[npm install --save-exact react-on-rails-rsc@19.0.5-rc.6])
+      expect(instance.system_calls).to include(%w[npm install --save-exact react-on-rails-rsc@19.0.5-rc.7])
     end
   end
 
@@ -658,7 +658,7 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
   describe "#rsc_packages_with_version" do
     it "defines an explicit RSC package version pin independent from the React semver range prefix" do
       expect(ReactOnRails::Generators::JsDependencyManager::RSC_REACT_VERSION_RANGE).to eq("~19.0.4")
-      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.0.5-rc.6")
+      expect(ReactOnRails::Generators::JsDependencyManager::RSC_PACKAGE_VERSION_PIN).to eq("19.0.5-rc.7")
     end
 
     it "keeps the generated RSC React policy on the 19.0.x patch track" do
@@ -722,11 +722,11 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.0.5-rc.6")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.0.5-rc.7")
       expect(warning_text).to include("left the version pin in package.json")
       expect(warning_text).to include("react-on-rails-rsc/WebpackPlugin")
       expect(warning_text).to include("react-on-rails-rsc/RspackPlugin")
-      manual_command = "npm install --save-exact react-on-rails-rsc@19.0.5-rc.6"
+      manual_command = "npm install --save-exact react-on-rails-rsc@19.0.5-rc.7"
       expect(warning_text).to include(manual_command)
       expect(warning_text.scan(manual_command).size).to eq(1)
     end
@@ -734,9 +734,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
     it "keeps the pinned manual install instruction when the pinned install raises" do
       allow(instance)
         .to receive(:rsc_packages_with_version)
-        .and_return([["react-on-rails-rsc@19.0.5-rc.6"], true])
+        .and_return([["react-on-rails-rsc@19.0.5-rc.7"], true])
 
-      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.0.5-rc.6"]).and_raise("network down")
+      allow(instance).to receive(:add_packages).with(["react-on-rails-rsc@19.0.5-rc.7"]).and_raise("network down")
       allow(instance).to receive(:add_packages).with(["react-on-rails-rsc"]).and_return(true)
 
       instance.send(:add_rsc_dependencies)
@@ -745,9 +745,9 @@ describe ReactOnRails::Generators::JsDependencyManager, type: :generator do
 
       warning_text = warnings.join("\n")
       expect(warnings.size).to eq(1)
-      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.0.5-rc.6")
+      expect(warning_text).to include("Could not install the pinned react-on-rails-rsc@19.0.5-rc.7")
       expect(warning_text).to include("Error adding React Server Components dependencies: network down")
-      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.0.5-rc.6")
+      expect(warning_text).to include("npm install --save-exact react-on-rails-rsc@19.0.5-rc.7")
     end
 
     it "uses computed rsc packages for manual recovery when installation raises" do

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.0.5-rc.6",
+    "react-on-rails-rsc": "19.0.5-rc.7",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",


### PR DESCRIPTION
## Summary

Bumps the pinned `react-on-rails-rsc` dependency from `19.0.5-rc.6` to `19.0.5-rc.7` everywhere the pin is referenced:

- `react_on_rails/lib/generators/react_on_rails/js_dependency_manager.rb` — `RSC_PACKAGE_VERSION_PIN` (generator install pin) + spec expectations
- `package.json` (root), `packages/react-on-rails-pro/package.json`, `react_on_rails_pro/spec/dummy/package.json` + regenerated `pnpm-lock.yaml`
- RSC docs that document the exact pin (`create-without-ssr.md`, `upgrading-existing-pro-app.md`, `rspack-compatibility.md`)
- Version references in node-renderer peer-support comments

## What's in 19.0.5-rc.7

From the [upstream release](https://github.com/shakacode/react_on_rails_rsc/releases/tag/19.0.5-rc.7):

- Webpack client manifest CSS collection now excludes runtime-chunk CSS (matching the existing JS-chunk filtering), so shared runtime CSS no longer leaks into every client component's Flight stylesheet hints; the server manifest still retains runtime-chunk CSS for SSR coverage
- Skips `.hot-update.css` HMR files in client manifest CSS collection

npm: https://www.npmjs.com/package/react-on-rails-rsc

## Testing

- `bundle exec rspec spec/react_on_rails/generators/js_dependency_manager_spec.rb` — 79 examples, 0 failures
- `bundle exec rubocop` on changed Ruby files — no offenses
- Prettier check on changed JSON/MD/TS files — clean
- `pnpm install` regenerated the lockfile; no `19.0.5-rc.6` references remain in code/lockfile (CHANGELOG history entries intentionally untouched)

The exact-pin policy is unchanged; switching to stable `19.0.5` remains tracked by #3642 / #3634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation pin bump only; no runtime logic changes in this repo beyond aligning installs with upstream RSC bundler manifest fixes.
> 
> **Overview**
> Bumps the coordinated **`react-on-rails-rsc` exact pin** from `19.0.5-rc.6` to **`19.0.5-rc.7`** across the generator (`RSC_PACKAGE_VERSION_PIN`), root/Pro/dummy `package.json` files, **`pnpm-lock.yaml`**, Pro RSC install docs, and related spec expectations. The **exact prerelease pin policy** is unchanged until stable `19.0.5` ships.
> 
> The changelog documents why **rc.7** matters: Webpack **client manifest CSS** collection no longer pulls in **runtime-chunk CSS** (so shared runtime styles don’t leak into every client component’s Flight stylesheet hints) and skips **`.hot-update.css`** HMR files, while the server manifest still keeps runtime-chunk CSS for SSR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc9a130ae00ed3b444db25baa09f03cd3fd300a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated React Server Components tooling to prerelease version `19.0.5-rc.7`, including improvements to manifest and CSS file handling along with fixes for hot module replacement (HMR) functionality during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->