### PR TITLE
Pull redis CI service image from ECR Public mirror instead of Docker Hub

### DIFF
--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
     # Redis backs streamed RSC fixtures covered by the request specs.
     services:
       redis:
-        image: cimg/redis:6.2.6
+        image: public.ecr.aws/docker/library/redis:6.2.6
         ports:
           - 6379:6379
         options: >-
@@ -402,7 +402,7 @@ jobs:
     # Redis service container
     services:
       redis:
-        image: cimg/redis:6.2.6
+        image: public.ecr.aws/docker/library/redis:6.2.6
         ports:
           - 6379:6379
         options: >-
@@ -573,7 +573,7 @@ jobs:
       SHAKAPACKER_ASSETS_BUNDLER: rspack
     services:
       redis:
-        image: cimg/redis:6.2.6
+        image: public.ecr.aws/docker/library/redis:6.2.6
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -322,7 +322,7 @@ jobs:
     # Redis service container
     services:
       redis:
-        image: cimg/redis:6.2.6
+        image: public.ecr.aws/docker/library/redis:6.2.6
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
## Summary

Switches the redis CI service container in the Pro workflows from `cimg/redis:6.2.6` (Docker Hub) to `public.ecr.aws/docker/library/redis:6.2.6` (AWS ECR Public mirror of the Docker-official redis image).

## Why

On main at 0b994fa5, two jobs in **React on Rails Pro - Integration Tests** failed in GitHub Actions' "Initialize containers" step — before any repo code ran — because unauthenticated pulls of `cimg/redis:6.2.6` from Docker Hub timed out three times:

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Docker pull failed with exit code 1
```

Failed run: https://github.com/shakacode/react_on_rails/actions/runs/27261322791 (fixed by rerun — the failure was pure Docker Hub flakiness/rate limiting on shared GHA runner IPs, not a code regression).

ECR Public has no anonymous pull rate limits and is independent of Docker Hub availability, removing this class of flake.

## Details

- 4 occurrences updated: `pro-integration-tests.yml` (×3), `pro-test-package-and-gem.yml` (×1)
- Same pinned version (`6.2.6`), same port mapping (`6379:6379`)
- Health check (`redis-cli ping`) unchanged — the official redis image ships `redis-cli`, verified the `6.2.6` tag exists on the ECR Public mirror (manifest HEAD returns 200)
- `actionlint` and `prettier --check` pass on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with the same Redis tag and health checks; no application or runtime code is modified.
> 
> **Overview**
> Pro GitHub Actions jobs that start a **Redis service container** now pull `public.ecr.aws/docker/library/redis:6.2.6` instead of `cimg/redis:6.2.6` from Docker Hub. The update is in **four** jobs: three in `pro-integration-tests.yml` (RSpec with Node renderer, Playwright E2E, Rspack RSC runtime gate) and one in `pro-test-package-and-gem.yml` (`package-js-tests`).
> 
> **Redis version (`6.2.6`), port `6379`, and `redis-cli ping` health checks are unchanged**—only the image registry/source changes, aimed at avoiding Docker Hub pull timeouts/rate limits during "Initialize containers".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eddc3b2e6ab7c164198f2b34a04d9669b3988f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references in CI/CD test workflows.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->