### PR TITLE
no ruby directive

### DIFF
--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile
@@ -15,7 +15,11 @@
 
 source "https://rubygems.org"
 
-ruby "3.3.7"
+# No `ruby` directive here on purpose: CI pins this app's Ruby via
+# .minimum.tool-versions, and `rake release` runs `bundle install` in this
+# directory with whatever Ruby the release operator uses. An exact pin makes
+# that release step abort (e.g. "Your Ruby version is X, but your Gemfile
+# specified 3.3.7"). This matches the other dummy apps, which have no pin.
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1", ">= 7.1.3.2"

--- a/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
+++ b/react_on_rails_pro/spec/execjs-compatible-dummy/Gemfile.lock
@@ -317,12 +317,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3-aarch64-linux)
-    sqlite3 (1.7.3-arm-linux)
-    sqlite3 (1.7.3-arm64-darwin)
-    sqlite3 (1.7.3-x86-linux)
-    sqlite3 (1.7.3-x86_64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.0)
@@ -373,9 +369,6 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   tzinfo-data
   web-console
-
-RUBY VERSION
-   ruby 3.3.7p123
 
 BUNDLED WITH
    2.5.9


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-dummy Gemfile/lockfile only; no runtime or production dependency behavior change.
> 
> **Overview**
> Removes the exact **`ruby "3.3.7"`** pin from the **execjs-compatible-dummy** `Gemfile` and documents why: CI already pins Ruby via **`.minimum.tool-versions`**, while **`rake release`** runs **`bundle install`** in this app with the release operator’s Ruby—an exact pin can abort that step. The lockfile is updated accordingly: the **`RUBY VERSION`** section is dropped, and **`sqlite3`** is recorded as a single generic **`1.7.3`** gem (with **`mini_portile2`**) instead of multiple platform-specific builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0761b89dab3d6c89fe032bb91e57d55828aa7395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve release process reliability by refining Ruby version management strategy.

* **Documentation**
  * Added clarification regarding CI and release procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->