### PR TITLE
docs: fix quick-start advertising a non-existent react_on_rails:component generator (#3869)

### DIFF
--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -232,8 +232,11 @@ Start at [React on Rails Pro](../../pro/react-on-rails-pro.md) for the canonical
 # Generate React on Rails files with TypeScript support
 bin/rails generate react_on_rails:install --typescript
 
-# Create a new component
-bin/rails generate react_on_rails:component MyComponent
+# Add a new component: create a file under a `ror_components` directory, then
+# render it with `<%= react_component("MyComponent") %>` in any Rails view.
+# With auto-bundling there's no generator and no manual registration step.
+mkdir -p app/javascript/src/MyComponent/ror_components
+touch app/javascript/src/MyComponent/ror_components/MyComponent.tsx
 
 # Build for production (use your package manager)
 pnpm run build  # or: yarn run build, npm run build


### PR DESCRIPTION
## Problem

The OSS quick-start guide's "Essential Commands" section (`docs/oss/getting-started/quick-start.md`) advertised a generator that does not exist:

```bash
# Create a new component
bin/rails generate react_on_rails:component MyComponent
```

React on Rails ships only the `install` and `rsc` generators (verify with `ls react_on_rails/lib/generators/react_on_rails/`). There is no `component` generator. Any user — or agent — following the quick-start hit a hard failure at this step.

## Fix

Replace the bogus generator line with accurate guidance that matches the auto-bundling workflow the same doc already teaches earlier (creating a file under a `ror_components/` directory and rendering it with `react_component(...)`, no manual registration needed):

```bash
# Add a new component: create a file under a `ror_components` directory, then
# render it with `<%= react_component("MyComponent") %>` in any Rails view.
# With auto-bundling there's no generator and no manual registration step.
mkdir -p app/javascript/src/MyComponent/ror_components
touch app/javascript/src/MyComponent/ror_components/MyComponent.tsx
```

Minimal, focused diff (5 insertions, 2 deletions); no other lines reformatted. Confirmed via `grep -rn "react_on_rails:component" docs/ react_on_rails/ packages/` that this was the only reference to the non-existent generator. Passes the repo's lefthook prettier / markdown-link / trailing-newline checks.

## Scope

Part of #3869 (Part A: doc fix; Part B = build the generator). This PR is **documentation only** and intentionally does **not** auto-close #3869, since the issue also tracks building the generator itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Fixes the OSS quick-start **Essential Commands** section so it no longer documents `bin/rails generate react_on_rails:component MyComponent`, which is not shipped by the gem.
> 
> The bogus generator line is replaced with the **auto-bundling** workflow already described earlier in the same guide: create a component under `app/javascript/.../ror_components/`, then render it with `react_component("MyComponent")` in a view—no generator and no manual registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b38c58bec45fe88aa1d32127890e4f4afc61e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated component creation workflow: components can now be created in a dedicated directory with automatic bundling via `react_component`, eliminating manual generator steps and registration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->