### PR TITLE
fix(node-renderer): gracefully drain workers on SIGTERM/SIGINT to stop orphaned processes (#3863)

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/master.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/master.ts
@@ -46,6 +46,14 @@ const MASTER_WORKER_SHUTDOWN_MESSAGE_GRACE_MS = 1000;
 // message grace window plus the worker hook budget. If a worker is stuck after
 // that point, this guarantees the master still exits.
 const MASTER_SHUTDOWN_TIMEOUT_MS = MASTER_WORKER_SHUTDOWN_MESSAGE_GRACE_MS + WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS;
+// When a worker's event loop is blocked (synchronous render) it can process
+// neither SHUTDOWN_WORKER_MESSAGE nor a disconnect, so only SIGKILL can stop
+// it — and the master must send that SIGKILL while it is still alive itself.
+// Process supervisors kill the master well before MASTER_SHUTDOWN_TIMEOUT_MS
+// (Foreman's default SIGTERM-to-SIGKILL window is 5s), so survivors are
+// force-killed early: after the message grace window has given draining a
+// chance, but safely inside the supervisor's window.
+const SHUTDOWN_WORKER_FORCE_KILL_TIMEOUT_MS = 2000;
 const SIGNAL_EXIT_CODES: Partial<Record<NodeJS.Signals, number>> = {
   SIGINT: 130,
   SIGTERM: 143,
@@ -196,8 +204,17 @@ export default function masterRun(runningConfig?: Partial<Config>) {
     }, MASTER_SHUTDOWN_TIMEOUT_MS);
     if (typeof shutdownTimer.unref === 'function') shutdownTimer.unref();
 
+    // Early force-kill of workers that cannot drain (blocked event loop).
+    // Their SIGKILL-induced exits complete the disconnect, which lets the
+    // normal waitForWorkerExits path below finish the shutdown promptly.
+    const forceKillTimer = setTimeout(() => {
+      forceKillSurvivingWorkers(workersAtShutdown);
+    }, SHUTDOWN_WORKER_FORCE_KILL_TIMEOUT_MS);
+    if (typeof forceKillTimer.unref === 'function') forceKillTimer.unref();
+
     const finishShutdown = () => {
       clearTimeout(shutdownTimer);
+      clearTimeout(forceKillTimer);
       process.exit(exitCode);
     };
 

--- a/packages/react-on-rails-pro-node-renderer/src/master.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/master.ts
@@ -144,7 +144,9 @@ export default function masterRun(runningConfig?: Partial<Config>) {
   const forceKillSurvivingWorkers = (workers: Worker[]) => {
     workers.forEach((worker) => {
       const workerProcess = worker.process;
-      if (worker.isDead() || workerProcess.killed) return;
+      // isDead() only: ChildProcess.killed means a signal was sent, not that
+      // the process died — e.g. a blocked worker surviving destroy()'s SIGTERM.
+      if (worker.isDead()) return;
 
       try {
         workerProcess.kill('SIGKILL');

--- a/packages/react-on-rails-pro-node-renderer/src/master.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/master.ts
@@ -36,6 +36,10 @@ const ORPHAN_CLEANUP_INTERVAL_MS = 5 * MILLISECONDS_IN_MINUTE;
 // Set well above the longest realistic upload duration so that large bundle
 // uploads in progress are never deleted by the cleanup timer.
 const ORPHAN_AGE_THRESHOLD_MS = 30 * MILLISECONDS_IN_MINUTE;
+// Hard deadline for the master to exit after it begins draining workers. If a
+// worker is stuck (leaked handle, blocking syscall, etc.) this guarantees the
+// master still exits, following the same pattern as restartWorkers.ts.
+const MASTER_SHUTDOWN_TIMEOUT_MS = 5000;
 
 export default function masterRun(runningConfig?: Partial<Config>) {
   // This is memoized after the wrapper path runs, but still protects direct `./master` entrypoint users.
@@ -100,13 +104,36 @@ export default function masterRun(runningConfig?: Partial<Config>) {
 
   let isAbortingForStartupFailure = false;
   let fatalStartupFailure: { workerId: number; failure: WorkerStartupFailureMessage } | null = null;
-  let hasInitiatedShutdown = false;
+  // Set as soon as any shutdown path (external signal or startup-failure abort)
+  // begins. Read by the `cluster.on('exit')` handler to suppress re-forking
+  // workers that exit because we are intentionally tearing the cluster down.
+  let isShuttingDown = false;
+
+  // Drain every live worker, then exit with `exitCode`. Idempotent: only the
+  // first call performs the disconnect + exit; later calls are no-ops so that
+  // an external signal and a near-simultaneous startup-failure abort can't both
+  // disconnect or schedule duplicate exits.
+  //
+  // cluster.disconnect() is async — the callback fires once every worker has
+  // disconnected (Node closes each worker's servers and waits for in-flight
+  // connections to finish before severing the IPC channel). A hard-deadline
+  // timer guarantees the master still exits if a worker is stuck.
+  const shutdownGracefully = (exitCode: number) => {
+    if (isShuttingDown) return;
+    isShuttingDown = true;
+
+    const shutdownTimer = setTimeout(() => process.exit(exitCode), MASTER_SHUTDOWN_TIMEOUT_MS);
+    if (typeof shutdownTimer.unref === 'function') shutdownTimer.unref();
+    cluster.disconnect(() => {
+      clearTimeout(shutdownTimer);
+      process.exit(exitCode);
+    });
+  };
 
   const abortForStartupFailure = (): boolean => {
     if (!(isAbortingForStartupFailure && fatalStartupFailure)) return false;
 
-    if (!hasInitiatedShutdown) {
-      hasInitiatedShutdown = true;
+    if (!isShuttingDown) {
       // Note: the exiting worker may differ from the one that sent the
       // failure message if multiple workers exit in rapid succession.
       // We always report the first failure received.
@@ -117,18 +144,8 @@ export default function masterRun(runningConfig?: Partial<Config>) {
           : `Node renderer startup failed in worker ${failedWorkerId}: ${failure.message}`;
 
       errorReporter.message(msg);
-      // Disconnect all live workers so they release their ports before the
-      // master exits. cluster.disconnect() is async — the callback fires
-      // once every worker has disconnected. A hard-deadline timer guarantees
-      // the master still exits if a worker is stuck (leaked handle, blocking
-      // syscall, etc.), following the same pattern as restartWorkers.ts.
-      const MASTER_SHUTDOWN_TIMEOUT_MS = 5000;
-      const shutdownTimer = setTimeout(() => process.exit(1), MASTER_SHUTDOWN_TIMEOUT_MS);
-      if (typeof shutdownTimer.unref === 'function') shutdownTimer.unref();
-      cluster.disconnect(() => {
-        clearTimeout(shutdownTimer);
-        process.exit(1);
-      });
+      // Exit non-zero so supervisors (Foreman/systemd/k8s) see the failed start.
+      shutdownGracefully(1);
     }
 
     return true;
@@ -149,6 +166,14 @@ export default function masterRun(runningConfig?: Partial<Config>) {
 
   // Listen for dying workers:
   cluster.on('exit', (worker) => {
+    // If we are intentionally tearing the cluster down (external SIGTERM/SIGINT
+    // or a startup-failure abort), workers are expected to exit — never re-fork
+    // them, or we would resurrect the processes we are trying to drain and leave
+    // them orphaned after the master exits.
+    if (isShuttingDown) {
+      return;
+    }
+
     // Once a startup failure has been detected, abort regardless of whether
     // this particular exit was from the failing worker, a scheduled restart,
     // or an unrelated crash. Don't fork any more workers.
@@ -165,7 +190,9 @@ export default function masterRun(runningConfig?: Partial<Config>) {
     // Give in-flight startup-failure IPC messages one event-loop turn to be
     // processed before classifying this as an ordinary runtime crash.
     setImmediate(() => {
-      if (abortForStartupFailure()) return;
+      // A shutdown signal may have arrived during this event-loop turn; if so,
+      // don't resurrect the worker we are intentionally draining.
+      if (isShuttingDown || abortForStartupFailure()) return;
 
       // TODO: Track last rendering request per worker.id
       // TODO: Consider blocking a given rendering request if it kills a worker more than X times
@@ -174,6 +201,18 @@ export default function masterRun(runningConfig?: Partial<Config>) {
       cluster.fork();
     });
   });
+
+  // Drain workers on external shutdown signals. Process managers (Foreman,
+  // systemd, Kubernetes, Docker) send SIGTERM (and SIGINT on Ctrl-C in a
+  // foreground terminal) to the master. Without these handlers the master is
+  // killed immediately and its forked workers are left orphaned, holding their
+  // ports. Exit 0 because a clean external shutdown is not an error.
+  const handleShutdownSignal = (signal: NodeJS.Signals) => {
+    log.info('Received %s, draining workers before shutting down the node renderer master', signal);
+    shutdownGracefully(0);
+  };
+  process.on('SIGTERM', () => handleShutdownSignal('SIGTERM'));
+  process.on('SIGINT', () => handleShutdownSignal('SIGINT'));
 
   // Schedule regular restarts of workers
   if (allWorkersRestartInterval && delayBetweenIndividualWorkerRestarts) {

--- a/packages/react-on-rails-pro-node-renderer/src/master.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/master.ts
@@ -18,7 +18,7 @@
  * @module master
  */
 import path from 'path';
-import cluster from 'cluster';
+import cluster, { type Worker } from 'cluster';
 import { readdir, stat, rm } from 'fs/promises';
 import log from './shared/log.js';
 import packageJson from './shared/packageJson.js';
@@ -28,6 +28,8 @@ import * as errorReporter from './shared/errorReporter.js';
 import { getLicenseStatus } from './shared/licenseValidator.js';
 import { runRscPeerCompatibilityCheck } from './shared/runRscPeerCompatibilityCheck.js';
 import { isWorkerStartupFailureMessage, type WorkerStartupFailureMessage } from './shared/workerMessages.js';
+import { SHUTDOWN_WORKER_MESSAGE } from './shared/utils.js';
+import { WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS } from './worker/shutdownHooks.js';
 
 const MILLISECONDS_IN_MINUTE = 60000;
 // How often to scan for orphaned upload directories.
@@ -36,10 +38,18 @@ const ORPHAN_CLEANUP_INTERVAL_MS = 5 * MILLISECONDS_IN_MINUTE;
 // Set well above the longest realistic upload duration so that large bundle
 // uploads in progress are never deleted by the cleanup timer.
 const ORPHAN_AGE_THRESHOLD_MS = 30 * MILLISECONDS_IN_MINUTE;
-// Hard deadline for the master to exit after it begins draining workers. If a
-// worker is stuck (leaked handle, blocking syscall, etc.) this guarantees the
-// master still exits, following the same pattern as restartWorkers.ts.
-const MASTER_SHUTDOWN_TIMEOUT_MS = 5000;
+// Give workers a short window to receive SHUTDOWN_WORKER_MESSAGE and enter
+// their own graceful shutdown path before the master falls back to disconnect().
+const MASTER_WORKER_SHUTDOWN_MESSAGE_GRACE_MS = 1000;
+// Hard deadline for the master to exit after it begins draining workers. It
+// starts before workers receive SHUTDOWN_WORKER_MESSAGE, so it must include the
+// message grace window plus the worker hook budget. If a worker is stuck after
+// that point, this guarantees the master still exits.
+const MASTER_SHUTDOWN_TIMEOUT_MS = MASTER_WORKER_SHUTDOWN_MESSAGE_GRACE_MS + WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS;
+const SIGNAL_EXIT_CODES: Partial<Record<NodeJS.Signals, number>> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
 
 export default function masterRun(runningConfig?: Partial<Config>) {
   // This is memoized after the wrapper path runs, but still protects direct `./master` entrypoint users.
@@ -103,6 +113,7 @@ export default function masterRun(runningConfig?: Partial<Config>) {
   }, ORPHAN_CLEANUP_INTERVAL_MS);
 
   let isAbortingForStartupFailure = false;
+  let hasReportedStartupFailure = false;
   let fatalStartupFailure: { workerId: number; failure: WorkerStartupFailureMessage } | null = null;
   // Set as soon as any shutdown path (external signal or startup-failure abort)
   // begins. Read by the `cluster.on('exit')` handler to suppress re-forking
@@ -114,36 +125,119 @@ export default function masterRun(runningConfig?: Partial<Config>) {
   // an external signal and a near-simultaneous startup-failure abort can't both
   // disconnect or schedule duplicate exits.
   //
-  // cluster.disconnect() is async — the callback fires once every worker has
-  // disconnected (Node closes each worker's servers and waits for in-flight
-  // connections to finish before severing the IPC channel). A hard-deadline
-  // timer guarantees the master still exits if a worker is stuck.
-  const shutdownGracefully = (exitCode: number) => {
+  // cluster.disconnect() is async, but its callback only proves workers have
+  // disconnected from IPC. Workers may still be draining in-flight requests, so
+  // external signal shutdown also waits for their exit events before the master
+  // exits. A hard-deadline timer guarantees the master still exits if a worker
+  // is stuck.
+  const currentWorkers = (): Worker[] =>
+    Object.values(cluster.workers ?? {}).filter((worker): worker is Worker => Boolean(worker));
+
+  const forceKillSurvivingWorkers = (workers: Worker[]) => {
+    workers.forEach((worker) => {
+      const workerProcess = worker.process;
+      if (worker.isDead() || workerProcess.killed) return;
+
+      try {
+        workerProcess.kill('SIGKILL');
+      } catch (err: unknown) {
+        log.warn({ msg: 'Error sending SIGKILL to worker during node renderer master shutdown', err });
+      }
+    });
+  };
+
+  const sendGracefulShutdownMessageToWorkers = (workers: Worker[]) => {
+    workers.forEach((worker) => {
+      try {
+        worker.send(SHUTDOWN_WORKER_MESSAGE);
+      } catch (err: unknown) {
+        log.warn({ msg: 'Error sending graceful shutdown message to worker', err });
+      }
+    });
+  };
+
+  const waitForWorkerExits = (workers: Worker[], onAllWorkersExited: () => void) => {
+    let remainingWorkers = 0;
+    let hasFinished = false;
+
+    const finishIfComplete = () => {
+      if (hasFinished || remainingWorkers > 0) return;
+      hasFinished = true;
+      onAllWorkersExited();
+    };
+
+    workers.forEach((worker) => {
+      if (worker.isDead()) return;
+
+      remainingWorkers += 1;
+      const markWorkerExited = () => {
+        remainingWorkers -= 1;
+        finishIfComplete();
+      };
+      worker.once('exit', markWorkerExited);
+
+      if (worker.isDead()) {
+        worker.off('exit', markWorkerExited);
+        markWorkerExited();
+      }
+    });
+
+    finishIfComplete();
+  };
+
+  const shutdownGracefully = (exitCode: number, notifyWorkersBeforeDisconnect = false) => {
     if (isShuttingDown) return;
     isShuttingDown = true;
+    const workersAtShutdown = currentWorkers();
 
-    const shutdownTimer = setTimeout(() => process.exit(exitCode), MASTER_SHUTDOWN_TIMEOUT_MS);
+    const shutdownTimer = setTimeout(() => {
+      forceKillSurvivingWorkers(workersAtShutdown);
+      process.exit(exitCode);
+    }, MASTER_SHUTDOWN_TIMEOUT_MS);
     if (typeof shutdownTimer.unref === 'function') shutdownTimer.unref();
-    cluster.disconnect(() => {
+
+    const finishShutdown = () => {
       clearTimeout(shutdownTimer);
       process.exit(exitCode);
-    });
+    };
+
+    const disconnectCluster = () => {
+      cluster.disconnect(() => {
+        if (notifyWorkersBeforeDisconnect) {
+          waitForWorkerExits(workersAtShutdown, finishShutdown);
+          return;
+        }
+
+        finishShutdown();
+      });
+    };
+
+    if (notifyWorkersBeforeDisconnect) {
+      sendGracefulShutdownMessageToWorkers(workersAtShutdown);
+      setTimeout(disconnectCluster, MASTER_WORKER_SHUTDOWN_MESSAGE_GRACE_MS);
+      return;
+    }
+
+    disconnectCluster();
   };
 
   const abortForStartupFailure = (): boolean => {
     if (!(isAbortingForStartupFailure && fatalStartupFailure)) return false;
+    if (hasReportedStartupFailure) return true;
+
+    // Note: the exiting worker may differ from the one that sent the
+    // failure message if multiple workers exit in rapid succession.
+    // We always report the first failure received.
+    const { failure, workerId: failedWorkerId } = fatalStartupFailure;
+    const msg =
+      failure.code === 'EADDRINUSE'
+        ? `Node renderer startup failed: ${failure.host}:${failure.port} is already in use`
+        : `Node renderer startup failed in worker ${failedWorkerId}: ${failure.message}`;
+
+    errorReporter.message(msg);
+    hasReportedStartupFailure = true;
 
     if (!isShuttingDown) {
-      // Note: the exiting worker may differ from the one that sent the
-      // failure message if multiple workers exit in rapid succession.
-      // We always report the first failure received.
-      const { failure, workerId: failedWorkerId } = fatalStartupFailure;
-      const msg =
-        failure.code === 'EADDRINUSE'
-          ? `Node renderer startup failed: ${failure.host}:${failure.port} is already in use`
-          : `Node renderer startup failed in worker ${failedWorkerId}: ${failure.message}`;
-
-      errorReporter.message(msg);
       // Exit non-zero so supervisors (Foreman/systemd/k8s) see the failed start.
       shutdownGracefully(1);
     }
@@ -160,24 +254,22 @@ export default function masterRun(runningConfig?: Partial<Config>) {
     fatalStartupFailure = { workerId: worker.id, failure: message };
   });
 
-  for (let i = 0; i < workersCount; i += 1) {
-    cluster.fork();
-  }
-
   // Listen for dying workers:
   cluster.on('exit', (worker) => {
+    // Once a startup failure has been detected, abort regardless of whether
+    // this particular exit was from the failing worker, a scheduled restart,
+    // or an unrelated crash. Don't fork any more workers. If an external signal
+    // already started shutdown, still report the recorded failure once while
+    // preserving the signal-style exit code and avoiding duplicate disconnects.
+    if (abortForStartupFailure()) {
+      return;
+    }
+
     // If we are intentionally tearing the cluster down (external SIGTERM/SIGINT
     // or a startup-failure abort), workers are expected to exit — never re-fork
     // them, or we would resurrect the processes we are trying to drain and leave
     // them orphaned after the master exits.
     if (isShuttingDown) {
-      return;
-    }
-
-    // Once a startup failure has been detected, abort regardless of whether
-    // this particular exit was from the failing worker, a scheduled restart,
-    // or an unrelated crash. Don't fork any more workers.
-    if (abortForStartupFailure()) {
       return;
     }
 
@@ -190,9 +282,9 @@ export default function masterRun(runningConfig?: Partial<Config>) {
     // Give in-flight startup-failure IPC messages one event-loop turn to be
     // processed before classifying this as an ordinary runtime crash.
     setImmediate(() => {
-      // A shutdown signal may have arrived during this event-loop turn; if so,
-      // don't resurrect the worker we are intentionally draining.
-      if (isShuttingDown || abortForStartupFailure()) return;
+      // A startup failure may have arrived during this event-loop turn; report
+      // it before any signal-shutdown bail-out suppresses crash classification.
+      if (abortForStartupFailure() || isShuttingDown) return;
 
       // TODO: Track last rendering request per worker.id
       // TODO: Consider blocking a given rendering request if it kills a worker more than X times
@@ -206,13 +298,17 @@ export default function masterRun(runningConfig?: Partial<Config>) {
   // systemd, Kubernetes, Docker) send SIGTERM (and SIGINT on Ctrl-C in a
   // foreground terminal) to the master. Without these handlers the master is
   // killed immediately and its forked workers are left orphaned, holding their
-  // ports. Exit 0 because a clean external shutdown is not an error.
+  // ports.
   const handleShutdownSignal = (signal: NodeJS.Signals) => {
     log.info('Received %s, draining workers before shutting down the node renderer master', signal);
-    shutdownGracefully(0);
+    shutdownGracefully(SIGNAL_EXIT_CODES[signal] ?? 0, true);
   };
   process.on('SIGTERM', () => handleShutdownSignal('SIGTERM'));
   process.on('SIGINT', () => handleShutdownSignal('SIGINT'));
+
+  for (let i = 0; i < workersCount; i += 1) {
+    cluster.fork();
+  }
 
   // Schedule regular restarts of workers
   if (allWorkersRestartInterval && delayBetweenIndividualWorkerRestarts) {

--- a/packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts
@@ -51,6 +51,9 @@ function buildStartupFailureMessage(
 function setupMasterRunHarness() {
   const operations: string[] = [];
   const clusterHandlers: Partial<ClusterHandlers> = {};
+  // Capture process signal handlers instead of letting masterRun attach them to
+  // the real process (which would leak across tests and fire on a real SIGTERM).
+  const signalHandlers: Partial<Record<NodeJS.Signals, () => void>> = {};
   const mockFork = jest.fn(() => {
     operations.push('fork');
     return {};
@@ -93,6 +96,16 @@ function setupMasterRunHarness() {
   const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
     throw new Error(`process.exit:${code}`);
   }) as typeof process.exit);
+  const realProcessOn = process.on.bind(process);
+  const processOnSpy = jest
+    .spyOn(process, 'on')
+    .mockImplementation((event: string | symbol, listener: (...args: unknown[]) => void) => {
+      if (event === 'SIGTERM' || event === 'SIGINT') {
+        signalHandlers[event] = listener as () => void;
+        return process;
+      }
+      return realProcessOn(event as never, listener as never);
+    });
 
   jest.doMock('cluster', () => ({
     __esModule: true,
@@ -147,6 +160,7 @@ function setupMasterRunHarness() {
   return {
     operations,
     clusterHandlers: clusterHandlers as ClusterHandlers,
+    signalHandlers,
     mockFork,
     mockCluster,
     mockErrorReporterMessage,
@@ -154,6 +168,7 @@ function setupMasterRunHarness() {
     setIntervalSpy,
     setTimeoutSpy,
     processExitSpy,
+    processOnSpy,
   };
 }
 
@@ -320,5 +335,77 @@ describe('master startup failure handling via masterRun wiring', () => {
     );
     expect(harness.mockFork).toHaveBeenCalledTimes(3);
     expect(harness.processExitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('master graceful shutdown on external signals via masterRun wiring', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('registers SIGTERM and SIGINT handlers', () => {
+    const harness = setupMasterRunHarness();
+
+    expect(harness.processOnSpy).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+    expect(harness.processOnSpy).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+    expect(typeof harness.signalHandlers.SIGTERM).toBe('function');
+    expect(typeof harness.signalHandlers.SIGINT).toBe('function');
+  });
+
+  it.each(['SIGTERM', 'SIGINT'] as const)('drains workers and exits 0 on %s', (signal) => {
+    const harness = setupMasterRunHarness();
+
+    expect(() => harness.signalHandlers[signal]!()).toThrow('process.exit:0');
+    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.processExitSpy).toHaveBeenCalledWith(0);
+    // No error is reported for a clean external shutdown.
+    expect(harness.mockErrorReporterMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fork workers that exit while shutting down', () => {
+    const harness = setupMasterRunHarness();
+    // disconnect does not invoke its callback so we can observe later exits
+    // without the harness throwing on process.exit.
+    harness.mockCluster.disconnect.mockImplementation(() => {});
+
+    harness.signalHandlers.SIGTERM!();
+    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+
+    const forkCountAtShutdown = harness.mockFork.mock.calls.length;
+
+    // An ordinary exit during shutdown must NOT be reforked...
+    harness.clusterHandlers.exit({ id: 1, process: { exitCode: 0 } });
+    // ...nor a scheduled-restart worker that happens to exit mid-drain.
+    harness.clusterHandlers.exit({ id: 2, isScheduledRestart: true, process: { exitCode: 0 } });
+
+    expect(harness.mockFork).toHaveBeenCalledTimes(forkCountAtShutdown);
+    expect(harness.mockErrorReporterMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not classify a worker exit during shutdown as an unexpected crash', async () => {
+    const harness = setupMasterRunHarness();
+    harness.mockCluster.disconnect.mockImplementation(() => {});
+
+    harness.signalHandlers.SIGTERM!();
+    const forkCountAtShutdown = harness.mockFork.mock.calls.length;
+
+    harness.clusterHandlers.exit({ id: 3, process: { exitCode: 1 } });
+    // The deferred crash classification runs on the next tick; it must bail out
+    // because we are shutting down.
+    await waitForSetImmediate();
+
+    expect(harness.mockErrorReporterMessage).not.toHaveBeenCalled();
+    expect(harness.mockFork).toHaveBeenCalledTimes(forkCountAtShutdown);
+  });
+
+  it('is idempotent: a second signal does not disconnect or exit again', () => {
+    const harness = setupMasterRunHarness();
+    harness.mockCluster.disconnect.mockImplementation(() => {});
+
+    harness.signalHandlers.SIGTERM!();
+    harness.signalHandlers.SIGINT!();
+
+    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts
@@ -14,11 +14,23 @@
  */
 
 import { WORKER_STARTUP_FAILURE, type WorkerStartupFailureMessage } from '../src/shared/workerMessages';
+import { SHUTDOWN_WORKER_MESSAGE } from '../src/shared/utils';
+import { WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS } from '../src/worker/shutdownHooks';
 
 type MockWorker = {
   id: number;
   isScheduledRestart?: boolean;
   process: { exitCode: number | null };
+};
+
+type MockClusterWorker = {
+  send: jest.Mock<boolean, [message: unknown]>;
+  process: { killed: boolean; kill: jest.Mock<void, [signal: NodeJS.Signals]> };
+  isDead: jest.Mock<boolean, []>;
+  once: jest.Mock<MockClusterWorker, [event: string, handler: () => void]>;
+  off: jest.Mock<MockClusterWorker, [event: string, handler: () => void]>;
+  exited: boolean;
+  exitHandler?: () => void;
 };
 
 type ClusterHandlers = {
@@ -30,6 +42,7 @@ type MockCluster = {
   on: jest.Mock<MockCluster, [event: string, handler: (...args: unknown[]) => void]>;
   fork: jest.Mock<unknown, []>;
   disconnect: jest.Mock<void, [callback?: () => void]>;
+  workers: Record<string, MockClusterWorker | undefined>;
 };
 
 function buildStartupFailureMessage(
@@ -54,12 +67,61 @@ function setupMasterRunHarness() {
   // Capture process signal handlers instead of letting masterRun attach them to
   // the real process (which would leak across tests and fire on a real SIGTERM).
   const signalHandlers: Partial<Record<NodeJS.Signals, () => void>> = {};
+  const shutdownTimeouts: Array<{ callback: () => void; delay: number | undefined }> = [];
+  const mockWorkerProcesses = {
+    first: { killed: false, kill: jest.fn<void, [NodeJS.Signals]>() },
+    second: { killed: false, kill: jest.fn<void, [NodeJS.Signals]>() },
+  };
+  const mockWorkerSends = {
+    first: jest.fn<boolean, [unknown]>((message) => {
+      operations.push(`send:first:${String(message)}`);
+      return true;
+    }),
+    second: jest.fn<boolean, [unknown]>((message) => {
+      operations.push(`send:second:${String(message)}`);
+      return true;
+    }),
+  };
   const mockFork = jest.fn(() => {
     operations.push('fork');
     return {};
   });
+  const createMockClusterWorker = (
+    label: 'first' | 'second',
+    send: jest.Mock<boolean, [unknown]>,
+    workerProcess: (typeof mockWorkerProcesses)[typeof label],
+  ): MockClusterWorker => {
+    const worker = {} as MockClusterWorker;
+    worker.exited = false;
+    worker.process = workerProcess;
+    worker.process.kill.mockImplementation((signal) => {
+      operations.push(`kill:${label}:${signal}`);
+      worker.process.killed = true;
+    });
+    worker.send = send;
+    worker.isDead = jest.fn(() => worker.exited);
+    worker.once = jest.fn((event: string, handler: () => void) => {
+      if (event === 'exit') worker.exitHandler = handler;
+      return worker;
+    });
+    worker.off = jest.fn((event: string, handler: () => void) => {
+      if (event === 'exit' && worker.exitHandler === handler) worker.exitHandler = undefined;
+      return worker;
+    });
+    return worker;
+  };
+  const mockClusterWorkers = {
+    first: createMockClusterWorker('first', mockWorkerSends.first, mockWorkerProcesses.first),
+    second: createMockClusterWorker('second', mockWorkerSends.second, mockWorkerProcesses.second),
+  };
   const mockCluster = {} as MockCluster;
+  mockCluster.workers = {
+    1: mockClusterWorkers.first,
+    2: mockClusterWorkers.second,
+    3: undefined,
+  };
   mockCluster.disconnect = jest.fn((callback?: () => void) => {
+    operations.push('disconnect');
     if (callback) callback();
   });
   mockCluster.on = jest.fn((event: string, handler: (...args: unknown[]) => void) => {
@@ -90,9 +152,10 @@ function setupMasterRunHarness() {
   const mockGetLicenseStatus = jest.fn(() => 'valid');
   const mockRunRscPeerCompatibilityCheck = jest.fn();
   const setIntervalSpy = jest.spyOn(global, 'setInterval').mockReturnValue(0 as unknown as NodeJS.Timeout);
-  const setTimeoutSpy = jest
-    .spyOn(global, 'setTimeout')
-    .mockReturnValue({ unref: jest.fn() } as unknown as NodeJS.Timeout);
+  const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation(((callback, delay) => {
+    shutdownTimeouts.push({ callback: callback as () => void, delay });
+    return { unref: jest.fn() } as unknown as NodeJS.Timeout;
+  }) as typeof setTimeout);
   const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
     throw new Error(`process.exit:${code}`);
   }) as typeof process.exit);
@@ -101,6 +164,7 @@ function setupMasterRunHarness() {
     .spyOn(process, 'on')
     .mockImplementation((event: string | symbol, listener: (...args: unknown[]) => void) => {
       if (event === 'SIGTERM' || event === 'SIGINT') {
+        operations.push(`process:on:${event}`);
         signalHandlers[event] = listener as () => void;
         return process;
       }
@@ -161,6 +225,10 @@ function setupMasterRunHarness() {
     operations,
     clusterHandlers: clusterHandlers as ClusterHandlers,
     signalHandlers,
+    shutdownTimeouts,
+    mockWorkerProcesses,
+    mockWorkerSends,
+    mockClusterWorkers,
     mockFork,
     mockCluster,
     mockErrorReporterMessage,
@@ -176,6 +244,26 @@ async function waitForSetImmediate() {
   await new Promise<void>((resolve) => {
     setImmediate(resolve);
   });
+}
+
+function findShutdownTimeout(harness: ReturnType<typeof setupMasterRunHarness>, delay: number) {
+  const timeout = harness.shutdownTimeouts.find((candidate) => candidate.delay === delay);
+  if (!timeout) {
+    throw new Error(`Could not find shutdown timeout with delay ${delay}`);
+  }
+  return timeout;
+}
+
+function emitWorkerExit(worker: MockClusterWorker) {
+  worker.exited = true;
+  const exitHandler = worker.exitHandler;
+  worker.exitHandler = undefined;
+  exitHandler?.();
+}
+
+function emitAllWorkerExits(harness: ReturnType<typeof setupMasterRunHarness>) {
+  emitWorkerExit(harness.mockClusterWorkers.first);
+  emitWorkerExit(harness.mockClusterWorkers.second);
 }
 
 describe('master startup failure handling via masterRun wiring', () => {
@@ -214,7 +302,8 @@ describe('master startup failure handling via masterRun wiring', () => {
   ])('registers listeners before forking and aborts without reforking on $testName', (scenario) => {
     const harness = setupMasterRunHarness();
 
-    expect(harness.operations).toEqual(['on:message', 'fork', 'fork', 'on:exit']);
+    expect(harness.operations.indexOf('on:message')).toBeLessThan(harness.operations.indexOf('fork'));
+    expect(harness.operations.indexOf('on:exit')).toBeLessThan(harness.operations.indexOf('fork'));
     expect(harness.mockFork).toHaveBeenCalledTimes(2);
     expect(harness.setIntervalSpy).toHaveBeenCalledTimes(1);
 
@@ -353,14 +442,68 @@ describe('master graceful shutdown on external signals via masterRun wiring', ()
     expect(typeof harness.signalHandlers.SIGINT).toBe('function');
   });
 
-  it.each(['SIGTERM', 'SIGINT'] as const)('drains workers and exits 0 on %s', (signal) => {
+  it('registers signal handlers before forking workers', () => {
+    const harness = setupMasterRunHarness();
+    const firstForkIndex = harness.operations.indexOf('fork');
+
+    expect(harness.operations.indexOf('process:on:SIGTERM')).toBeLessThan(firstForkIndex);
+    expect(harness.operations.indexOf('process:on:SIGINT')).toBeLessThan(firstForkIndex);
+  });
+
+  it.each([
+    ['SIGTERM', 143],
+    ['SIGINT', 130],
+  ] as const)('drains workers on %s and exits with signal-style code %i', (signal, exitCode) => {
     const harness = setupMasterRunHarness();
 
-    expect(() => harness.signalHandlers[signal]!()).toThrow('process.exit:0');
+    harness.signalHandlers[signal]!();
+    expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
+
+    findShutdownTimeout(harness, 1000).callback();
     expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
-    expect(harness.processExitSpy).toHaveBeenCalledWith(0);
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+
+    expect(() => emitAllWorkerExits(harness)).toThrow(`process.exit:${exitCode}`);
+    expect(harness.processExitSpy).toHaveBeenCalledWith(exitCode);
     // No error is reported for a clean external shutdown.
     expect(harness.mockErrorReporterMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends the worker graceful-shutdown message before disconnecting the cluster on external shutdown', () => {
+    const harness = setupMasterRunHarness();
+
+    harness.signalHandlers.SIGTERM!();
+
+    expect(harness.mockWorkerSends.first).toHaveBeenCalledWith(SHUTDOWN_WORKER_MESSAGE);
+    expect(harness.mockWorkerSends.second).toHaveBeenCalledWith(SHUTDOWN_WORKER_MESSAGE);
+    expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
+
+    findShutdownTimeout(harness, 1000).callback();
+    expect(harness.mockWorkerSends.first.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.mockCluster.disconnect.mock.invocationCallOrder[0],
+    );
+    expect(harness.mockWorkerSends.second.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.mockCluster.disconnect.mock.invocationCallOrder[0],
+    );
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+
+    expect(() => emitAllWorkerExits(harness)).toThrow('process.exit:143');
+  });
+
+  it('waits for workers to exit after cluster.disconnect before exiting the master', () => {
+    const harness = setupMasterRunHarness();
+
+    harness.signalHandlers.SIGTERM!();
+    findShutdownTimeout(harness, 1000).callback();
+
+    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+
+    emitWorkerExit(harness.mockClusterWorkers.first);
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+
+    expect(() => emitWorkerExit(harness.mockClusterWorkers.second)).toThrow('process.exit:143');
+    expect(harness.processExitSpy).toHaveBeenCalledWith(143);
   });
 
   it('does not re-fork workers that exit while shutting down', () => {
@@ -370,7 +513,7 @@ describe('master graceful shutdown on external signals via masterRun wiring', ()
     harness.mockCluster.disconnect.mockImplementation(() => {});
 
     harness.signalHandlers.SIGTERM!();
-    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
 
     const forkCountAtShutdown = harness.mockFork.mock.calls.length;
 
@@ -399,6 +542,51 @@ describe('master graceful shutdown on external signals via masterRun wiring', ()
     expect(harness.mockFork).toHaveBeenCalledTimes(forkCountAtShutdown);
   });
 
+  it('reports startup failure recorded before signal shutdown when deferred crash handling runs', async () => {
+    const harness = setupMasterRunHarness();
+    const worker = { id: 1, process: { exitCode: 1 } };
+
+    harness.clusterHandlers.exit(worker);
+    harness.clusterHandlers.message(worker, buildStartupFailureMessage());
+    harness.signalHandlers.SIGTERM!();
+    await waitForSetImmediate();
+
+    expect(harness.mockErrorReporterMessage).toHaveBeenCalledWith(
+      'Node renderer startup failed: localhost:3800 is already in use',
+    );
+    expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
+
+    findShutdownTimeout(harness, 1000).callback();
+    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+
+    expect(() => emitAllWorkerExits(harness)).toThrow('process.exit:143');
+    expect(harness.mockFork).toHaveBeenCalledTimes(2);
+    expect(harness.processExitSpy).toHaveBeenCalledWith(143);
+  });
+
+  it('reports an already-recorded startup failure that exits during signal shutdown', () => {
+    const harness = setupMasterRunHarness();
+
+    harness.clusterHandlers.message({ id: 1, process: { exitCode: 1 } }, buildStartupFailureMessage());
+    harness.signalHandlers.SIGTERM!();
+
+    harness.clusterHandlers.exit({ id: 1, process: { exitCode: 1 } });
+
+    expect(harness.mockErrorReporterMessage).toHaveBeenCalledWith(
+      'Node renderer startup failed: localhost:3800 is already in use',
+    );
+    expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
+
+    findShutdownTimeout(harness, 1000).callback();
+    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+
+    expect(() => emitAllWorkerExits(harness)).toThrow('process.exit:143');
+    expect(harness.mockFork).toHaveBeenCalledTimes(2);
+    expect(harness.processExitSpy).toHaveBeenCalledWith(143);
+  });
+
   it('is idempotent: a second signal does not disconnect or exit again', () => {
     const harness = setupMasterRunHarness();
     harness.mockCluster.disconnect.mockImplementation(() => {});
@@ -406,6 +594,26 @@ describe('master graceful shutdown on external signals via masterRun wiring', ()
     harness.signalHandlers.SIGTERM!();
     harness.signalHandlers.SIGINT!();
 
-    expect(harness.mockCluster.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
+    expect(harness.setTimeoutSpy).toHaveBeenCalledTimes(2);
+    expect(harness.processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it('SIGKILLs surviving worker processes when the shutdown deadline expires', () => {
+    const harness = setupMasterRunHarness();
+    harness.mockCluster.disconnect.mockImplementation(() => {});
+    const expectedMasterShutdownTimeoutMs = WORKER_SHUTDOWN_HOOKS_TIMEOUT_MS + 1000;
+
+    harness.signalHandlers.SIGTERM!();
+
+    expect(harness.shutdownTimeouts.map(({ delay }) => delay)).toEqual(
+      expect.arrayContaining([expectedMasterShutdownTimeoutMs, 1000]),
+    );
+    expect(() => findShutdownTimeout(harness, expectedMasterShutdownTimeoutMs).callback()).toThrow(
+      'process.exit:143',
+    );
+    expect(harness.mockWorkerProcesses.first.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(harness.mockWorkerProcesses.second.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(harness.processExitSpy).toHaveBeenCalledWith(143);
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts
@@ -595,7 +595,9 @@ describe('master graceful shutdown on external signals via masterRun wiring', ()
     harness.signalHandlers.SIGINT!();
 
     expect(harness.mockCluster.disconnect).not.toHaveBeenCalled();
-    expect(harness.setTimeoutSpy).toHaveBeenCalledTimes(2);
+    // One hard-deadline timer, one early worker force-kill timer, one
+    // message-grace timer — armed once despite the second signal.
+    expect(harness.setTimeoutSpy).toHaveBeenCalledTimes(3);
     expect(harness.processExitSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Closes #3863

## Summary

- Adds `SIGTERM` and `SIGINT` handlers in the node-renderer master before worker forks, so Foreman/local-dev and other supervisors drain workers instead of killing only the master.
- Uses signal-style exit codes: `SIGINT` -> 130, `SIGTERM` -> 143.
- Sends `SHUTDOWN_WORKER_MESSAGE` to the worker snapshot, waits a short grace period, calls `cluster.disconnect()`, and then waits for the original workers' `exit` events before exiting the master.
- Uses the same shutdown-time worker snapshot for the hard `SIGKILL` fallback, so disconnected-but-still-running workers are not missed after `cluster.workers` is emptied.
- Suppresses reforks while shutdown is in progress and preserves startup-failure reporting without duplicate disconnects.

## Validation

- `pnpm exec jest tests/masterStartupFailure.test.ts --runInBand` -> 22 passed
- `pnpm --filter react-on-rails-pro-node-renderer run type-check` -> passed
- `pnpm --filter react-on-rails-pro-node-renderer run build` -> passed
- `pnpm exec eslint packages/react-on-rails-pro-node-renderer/src/master.ts` -> passed
- `pnpm exec prettier --check packages/react-on-rails-pro-node-renderer/src/master.ts packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts` -> passed
- `git diff --check -- packages/react-on-rails-pro-node-renderer/src/master.ts packages/react-on-rails-pro-node-renderer/tests/masterStartupFailure.test.ts` -> passed
- `redis-server --daemonize yes && pnpm --filter react-on-rails-pro-node-renderer run test` -> 30 suites passed, 358 tests passed; Redis shut down afterward
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> passed
- pre-commit hook -> passed
- `script/ci-changes-detector origin/main` -> Pro node renderer package; recommends Pro lint/tests plus Pro and node-renderer benchmarks

## Review Gate

- `codex review --base origin/main` first found a P1 issue: `cluster.disconnect()` can empty `cluster.workers` before worker processes exit, so the master could still exit too early and miss survivors.
- Fixed by waiting for worker `exit` events and force-killing the shutdown-time worker snapshot.
- Final `codex review --base origin/main` -> clean, no actionable issues.
- Claude second-engine attempt was unavailable locally: `claude --bare --print ...` failed with `Not logged in · Please run /login`.

## Manual / Residual Risk

- Manual Foreman/local-dev shutdown was not run in this workspace. The behavior is covered by the master wiring tests and full package suite, but the Foreman end-to-end process check remains UNKNOWN until CI/manual verification runs against an app.

Labels: full-ci, benchmark. This changes Pro node-renderer process lifecycle and benchmark-relevant shutdown/reliability behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust, idempotent graceful shutdown: master drains workers, notifies them before disconnect, avoids restarting workers during shutdown, enforces a hard deadline, force-kills lingering workers, logs SIGTERM/SIGINT and exits with signal-specific codes (143/130).

* **Tests**
  * Added deterministic harness and tests validating signal-driven shutdown wiring, handler ordering, worker draining, non-reforking during shutdown, idempotence, deadline enforcement, and expected exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->