### PR TITLE
docs: triage cleanup sweep for #3843 (SKILL.md closeout wording + AGENTS.md rubocop example)

### DIFF
--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -201,5 +201,7 @@ When worker subagents are explicitly authorized:
 For the complete numbered sequence, follow the canonical closeout lane in
 `.agents/workflows/pr-processing.md` instead of stopping at PR creation. The
 coordinator owns the live re-fetch, current-head checks and review-thread triage,
-release-mode or accelerated-RC confidence refresh, full-CI request and waitback
-when uncertainty remains, and any authorized ready/merge action.
+stale release-mode classification updates and the finalized PR-body
+`Agent Merge Confidence` block refresh required for accelerated-RC readiness (kept
+distinct), full-CI request and waitback when uncertainty remains, and any
+authorized ready/merge action.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ pnpm start format.listDifferent                                  # Check Prettie
 (cd react_on_rails && bundle exec rake lint)                     # Package lint task (Ruby + JS + formatting)
 
 # Optional Ruby diagnostic from the repo root (not the CI contract)
-BUNDLE_GEMFILE=Gemfile bundle exec rubocop
+BUNDLE_GEMFILE="$(git rev-parse --show-toplevel)/Gemfile" bundle exec rubocop
 
 # Auto-fix formatting
 (cd react_on_rails && bundle exec rake autofix) # Preferred for all formatting


### PR DESCRIPTION
Closes #3843.

One-pass triage cleanup sweep covering three loose ends left after PRs #3784, #3835, and #3836 merged. This PR carries the two doc-only edits (Parts 2 and 3); Part 1 was executed directly on the already-merged PR #3784.

## Part 1 — PR #3784 review-thread triage (done on the merged PR, not in this diff)

At merge, #3784's confidence block claimed "no unresolved review threads," but 6 `claude` review threads were still unresolved (all quality nits on benchmark-only code under `react_on_rails_pro/scripts/load/`). Each was given a per-thread disposition reply and resolved via GraphQL:

- transport_probe.rb:432 — redundant outer `rescue Errno::ESRCH` (harmless) — resolved
- transport_probe_server.mjs:114 — eager vs lazy stream-chunk allocation — deferred, resolved
- transport_probe.rb:481 — `wait_readable` StringIO guard — deferred, resolved
- transport_probe.rb:291 — `rps` understates throughput when `failures > 0`: replied-and-resolved as acceptable for a benchmark-only metric (renaming the emitted field would change the summary-JSON contract, so no trivial one-line fix; no follow-up PR opened)
- transport_probe.rb:323 — `baseline_name` computed twice — deferred, resolved
- transport_probe_server.mjs:242 — cross-transport `stream_response` caveat — deferred, resolved

Counts: 6 resolved-now, 0 already-resolved, 0 UNKNOWN. A `Confidence Block Updated:` correction comment was posted on #3784 noting the merge-time block was inaccurate and the threads are now triaged/resolved.

## Part 2 — SKILL.md Coordinator Closeout Lane wording fix

The "Coordinator Closeout Lane" summary in `.agents/skills/pr-batch/SKILL.md` still read "release-mode or accelerated-RC confidence refresh" — the exact `or`-conflation that PR #3835 corrected in `pr-processing.md`. Updated the summary to keep the two concerns distinct (stale release-mode classification updates vs. the finalized PR-body `Agent Merge Confidence` block refresh required for accelerated-RC readiness), matching the canonical terminology #3835 established.

## Part 3 — AGENTS.md rubocop example robustness fix + #3836 thread

Applied the Greptile P2 fix from #3836 to the bare `BUNDLE_GEMFILE=Gemfile bundle exec rubocop` diagnostic example in `AGENTS.md`, switching to the absolute `BUNDLE_GEMFILE="$(git rev-parse --show-toplevel)/Gemfile"` form so the example does not silently pick up the wrong lockfile when the shell CWD is not the repo root. The corresponding #3836 Greptile review thread was replied to and resolved.

## Review gates

`codex review` / `/simplify`: N/A — this PR is doc-only Markdown (low risk); the heavy review gates are not required for this scope.

Lint/format on changed files: prettier (`pnpm exec prettier`), markdown link check (lychee offline), and trailing-newline checks all passed via the lefthook pre-commit hooks; both files end with a trailing newline.

Concurrent batch: the PR for #3844 also edits SKILL.md at a different region (~L115); whichever PR merges second should `git pull --rebase origin main` and resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime, CI, or security impact.
> 
> **Overview**
> Doc-only triage for #3843: agent workflow docs are aligned with the canonical closeout wording and a safer RuboCop example.
> 
> **`.agents/skills/pr-batch/SKILL.md`** — The **Coordinator Closeout Lane** blurb no longer conflates “release-mode” and “accelerated-RC confidence refresh” with `or`. It now lists **stale release-mode classification updates** and refreshing the PR-body **`Agent Merge Confidence`** block for accelerated-RC readiness as **separate** coordinator duties, consistent with `.agents/workflows/pr-processing.md` (post #3835).
> 
> **`AGENTS.md`** — The optional root **RuboCop** diagnostic uses `BUNDLE_GEMFILE="$(git rev-parse --show-toplevel)/Gemfile"` instead of a relative `Gemfile`, so the example does not bind the wrong lockfile when the shell CWD is not the repo root (Greptile follow-up from #3836).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffbd965f4db353ad52c818ece9b9d4da4be7c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Enhanced PR finalization workflow with improved release mode classification and PR body refresh procedures
- Fixed RuboCop lint command configuration to ensure correct file path resolution from repository root

<!-- end of auto-generated comment: release notes by coderabbit.ai -->