### PR TITLE
docs(skills): file-collision check + goal-prompt size discipline for plan-pr-batch

### DIFF
--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -72,9 +72,11 @@ Plan a PR batch
      GitHub keeps the target repo's pull ref pointing at fork heads too. If the
      target repo pull ref is unavailable, fetch the head from the verified head
      repository URL derived from `headRepository.nameWithOwner` and
-     `headRefName`, or use the PR Files API fallback. A plain
-     `git fetch origin` does not fetch cross-fork heads unless `origin` has
-     already been verified as the PR's target repo.
+     `headRefName`, or use the PR Files API fallback. Treat `headRefName` as
+     untrusted shell data: pass the refspec as one quoted shell argument or via
+     an argument-array API, and never interpolate a raw PR branch name into a
+     shell command. A plain `git fetch origin` does not fetch cross-fork heads
+     unless `origin` has already been verified as the PR's target repo.
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -61,9 +61,9 @@ Plan a PR batch
      repo. If no verified remote or URL can be resolved, use the PR Files API
      fallback before recording paths as `UNKNOWN`; do not diff the current
      checkout's default remote. Choose a session-unique temporary-ref suffix
-     first, such as `pr-N-<session-id>` where `<session-id>` is 8 lowercase hex
-     characters from `uuidgen` or a random token, so concurrent planners for the
-     same PR cannot overwrite each other's refs.
+     first, such as `pr-N-<session-id>` where `<session-id>` comes from
+     `openssl rand -hex 4` or another git-ref-safe random token, so concurrent
+     planners for the same PR cannot overwrite each other's refs.
      Fetch the current base branch and PR head into temporary refs without
      checking out untrusted PR code:
      `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-<session-id>-base`
@@ -76,19 +76,21 @@ Plan a PR batch
      `headRefName` with a fully qualified source ref
      (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`) or use the PR
      Files API fallback. Treat `headRefName` as untrusted shell and refspec data:
-     validate it with `git check-ref-format --branch -- "$headRefName"` before
-     constructing a refspec, pass the refspec as one quoted shell argument or via
-     an argument-array API, and never interpolate a raw PR branch name into a
-     shell command. If validation fails, fall back to the PR Files API or
-     `UNKNOWN`; do not sanitize a failing branch name. A plain `git fetch origin`
-     does not fetch cross-fork heads unless `origin` has already been verified as
-     the PR's target repo.
+     validate it with `git check-ref-format --branch -- "$headRefName"` and
+     reject any name containing `:` before constructing a refspec, pass the
+     refspec as one quoted shell argument or via an argument-array API, and never
+     interpolate a raw PR branch name into a shell command. If validation fails,
+     fall back to the PR Files API or `UNKNOWN`; do not sanitize a failing branch
+     name. A plain `git fetch origin` does not fetch cross-fork heads unless
+     `origin` has already been verified as the PR's target repo.
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
      If the three-dot diff fails because the merge base is missing in a shallow
-     clone, run `git fetch --deepen=50 <verified-base-repo-url>` once and retry
-     before falling back to the PR Files API.
+     clone, run a bounded deepen such as
+     `git fetch --deepen=200 <verified-base-repo-url>` and retry once before
+     falling back to the PR Files API; the deepen value is a best-effort
+     heuristic, not a guarantee.
      Delete the temporary refs on both success and failure, then proceed to the
      API fallback or `UNKNOWN` decision:
      `git update-ref -d refs/tmp/pr-N-<session-id>-base` and
@@ -104,7 +106,7 @@ Plan a PR batch
      API response is capped, incomplete, or unavailable. Use the API as the
      scheduling source only when the local diff cannot run. Run the API
      pipeline in one shell invocation with `pipefail` enabled, for example
-     `bash -o pipefail -c "gh api --paginate repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s 'add // []'"`;
+     `bash -o pipefail -c 'gh api --paginate --method GET "repos/OWNER/REPO/pulls/N/files?per_page=100" | jq -s "add // []"'`;
      if either command fails, the response is an error-shaped object such as
      `{"message": ...}` / `{"errors": ...}`, or any row lacks `.filename`, record
      the paths as `UNKNOWN` instead of trusting an empty array from a broken
@@ -122,19 +124,23 @@ Plan a PR batch
      `changedFiles` is at or above that cap, or any row with `status: "renamed"`
      is missing
      `.previous_filename`, record the PR paths as `UNKNOWN` and treat the item
-     as serial. If the paginated count differs from `changedFiles`, re-read
-     `changedFiles` once before recording `UNKNOWN` so freshly pushed PRs do not
-     fail the sanity check on transient metadata lag. If counts still diverge
-     after the re-read, record paths as `UNKNOWN` and treat the item as serial.
+     as serial. If the paginated count differs from `changedFiles` in either
+     direction, re-read `changedFiles` once before recording `UNKNOWN` so freshly
+     pushed PRs do not fail the sanity check on transient metadata lag. If counts
+     still diverge after the re-read, record paths as `UNKNOWN` and treat the
+     item as serial; note any known submodule or binary-file count mismatch in
+     the Batch Plan instead of silently trusting an incomplete API path list.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,
      record them as `UNKNOWN` and treat the item as serial.
    - File-touch map, collision and wave scheduling: items that affect the same
      path cannot run as parallel worktrees; keep only file-disjoint items in the
-     parallel first batch and sequence or defer collisions. An `UNKNOWN` item
-     runs as a serial "discovery lane" — a lane that first determines its real
-     paths instead of editing in parallel. Never run discovery lanes
+     parallel first batch and sequence or defer collisions. A directory rename
+     reserves descendants under both the old and new directory names, so any
+     create/delete/edit under either tree collides with that rename. An `UNKNOWN`
+     item runs as a serial "discovery lane" — a lane that first determines its
+     real paths instead of editing in parallel. Never run discovery lanes
      concurrently with active editor lanes. For items already in the scheduling
      set, complete discovery before the editor wave starts. If the coordinator
      adds items after an editor wave has already started, wait for that wave to
@@ -190,7 +196,7 @@ Preflight first: if this session cannot run workers without blocking approval pr
 
 Repository: OWNER/REPO
 Batch objective: ...
-File-touch map:
+File-touch map (one line per item; pick the applicable format):
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
 - PR/Issue #N -> summarized path pattern(s) plus collision-relevant exact paths/renames/deletes (owner: lane/name)
 - PR/Issue #N -> UNKNOWN (paths not determinable from issue body/design notes; treat as serial)

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -61,12 +61,15 @@ Plan a PR batch
      repo. If no verified remote or URL can be resolved, record paths as
      `UNKNOWN` instead of diffing the current checkout's default remote. Fetch
      the current base branch and PR head into temporary refs without checking
-     out untrusted PR code. Fetch the base into `refs/tmp/pr-N-base` and the
-     head into `refs/tmp/pr-N-head` using the base repo's `pull/N/head` ref;
-     GitHub keeps that pull ref pointing at fork heads too. If the base pull
-     ref is unavailable, fetch from the verified head repository URL derived
-     from `headRepository.nameWithOwner` and `headRefName`, or use the PR Files
-     API fallback. A plain `git fetch origin` does not fetch cross-fork heads.
+     out untrusted PR code:
+     `git fetch <verified-base-repo-url> <baseRefName>:refs/tmp/pr-N-base` and
+     `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-head`.
+     GitHub keeps the target repo's pull ref pointing at fork heads too. If the
+     target repo pull ref is unavailable, fetch the head from the verified head
+     repository URL derived from `headRepository.nameWithOwner` and
+     `headRefName`, or use the PR Files API fallback. A plain
+     `git fetch origin` does not fetch cross-fork heads unless `origin` has
+     already been verified as the PR's target repo.
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-base...refs/tmp/pr-N-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
@@ -81,7 +84,11 @@ Plan a PR batch
      When the local diff succeeds, keep those paths authoritative even if the
      API response is capped, incomplete, or unavailable. Use the API as the
      scheduling source only when the local diff cannot run. Fetch with
+     `set -o pipefail` enabled, then
      `gh api --paginate --method GET repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s 'add // []'`;
+     if either command fails, record the paths as `UNKNOWN` instead of trusting
+     an empty array from a broken pipeline. Do not confuse API/auth/rate-limit
+     failures with a real empty PR file list.
      the default page size is 30, so a small unpaginated page can look complete
      while truncated. `jq -s 'add // []'` collects all paginated arrays before
      counting paths or extracting filenames and returns an empty array for an
@@ -92,8 +99,9 @@ Plan a PR batch
      `gh pr view N --repo OWNER/REPO --json changedFiles`. GitHub caps the
      Files API at ~3000 files; if the API is the only available source and
      `changedFiles` is at or above that cap, the paginated count does not match
-     `changedFiles`, or the response only reports new paths, record the PR paths
-     as `UNKNOWN` and treat the item as serial.
+     `changedFiles`, or a renamed file is expected but the API row is missing
+     its `.previous_filename`, record the PR paths as `UNKNOWN` and treat the
+     item as serial.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,
@@ -104,7 +112,9 @@ Plan a PR batch
      runs as a serial "discovery lane" — a lane that first determines its real
      paths instead of editing in parallel. Never run discovery lanes
      concurrently with active editor lanes: complete discovery before an editor
-     wave starts, or wait until the active editor wave is finished.
+     wave starts. If new items arrive while an editor wave is already running,
+     wait for that wave to finish before starting discovery for those new
+     items.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -50,14 +50,31 @@ Plan a PR batch
      Coordinators must create or update the private backend
      `batches/<batch-id>.json` with those lane refs before dependent workers
      start; otherwise `agent-coord status` cannot report `blocked_on` lanes.
-   - Build a file-touch map for the batch: list the files each item changes and the files it intends to create (read issue/PR bodies; grep the repo to confirm existing paths, do not guess). Items that touch the same file, including creating the same new path, cannot run as parallel worktrees — they will conflict at merge. Keep only file-disjoint items in the parallel first batch; group colliding or dependency-ordered items into one sequenced sub-batch, or defer them to a later batch.
+   - Build a file-touch map for the batch: list the paths each item changes or
+     intends to affect, including creates, deletes, and renames. For PR
+     targets, fetch the PR's base/head refs and run
+     `git diff --name-status --find-renames <base>...<head>` for the
+     rename-aware changed-file list. A paginated PR Files API response is
+     acceptable only when it is proven complete and records both `.filename` and
+     `.previous_filename` when present. If the API result may have hit GitHub's
+     file-list cap, cannot prove there are no more pages, or only reports new
+     paths, record the PR paths as `UNKNOWN` and treat the item as serial rather
+     than parallel. For issue targets, read the issue body, record proposed new
+     paths from issue/design notes, and grep the repo to confirm existing paths.
+     If paths cannot be determined from the issue body or design notes, record
+     them as `UNKNOWN` and treat the item as serial rather than parallel. Do not
+     guess. Items that affect the same path cannot run as parallel worktrees;
+     keep only file-disjoint items in the parallel first batch and sequence or
+     defer collisions.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it (e.g. `wc -m`), do not eyeball it. Record the measured fixed-template budget with the short SHA used for the measurement, remeasure after template changes, and keep the filled file-touch map, `Worker notes`, and `Done when` terse (target ~150 chars per item) — the worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
+   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it with `wc -m`; do not eyeball it.
+   - Record the measured fixed-template section size and the short SHA of the measurement in the Batch Plan so it can be compared after template edits. Remeasure whenever the template changes.
+   - Keep each filled entry terse (target ~150 chars for `Worker notes` and `Done when`). The worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
    - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.
 
@@ -88,6 +105,7 @@ Repository: OWNER/REPO
 Batch objective: ...
 File-touch map:
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
+- PR/Issue #N -> UNKNOWN (paths not determinable from issue body/design notes; treat as serial)
 - Deferred/reserved paths -> path(s) (reason: ... / later owner: lane/name)
 
 Items:

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -121,7 +121,19 @@ Items:
 Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required.
-- Treat the items as file-disjoint: a worker must not edit a file listed for another item in the file-touch map or reserved for a deferred batch. If a worker concludes it must, stop and report instead of editing.
+- Treat parallel items as file-disjoint: a worker must edit only files owned by
+  its lane in the File-touch map.
+  - Deferred or reserved paths block only lanes that do not own that path; the
+    lane listed as owner in the File-touch map may edit its declared files even
+    when a later deferred item will also need them.
+  - An `UNKNOWN` item may run only as a serial discovery lane. The worker must
+    identify the needed files, report or record those discovered paths with the
+    coordinator, and wait for confirmation that no active lane owns them before
+    editing.
+  - If a worker concludes it needs an unlisted file or another lane's file, stop
+    and report so the coordinator can sequence or split the work.
+  - Sequenced or dependency-ordered lanes may share declared files only in the
+    stated order.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
   lane name per lane. Declare lane dependencies with `depends_on` refs such as

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -64,16 +64,18 @@ Plan a PR batch
      Delete the temporary ref after recording paths:
      `git update-ref -d refs/tmp/pr-N-head`. A rename row (`R100  old  new`)
      owns **both** the old and new path. If a ref cannot be fetched or the diff
-     cannot run, record the PR paths as `UNKNOWN` and treat the item as serial.
+     cannot run, try the PR Files API fallback before marking the paths
+     `UNKNOWN`.
    - File-touch map, PR Files API fallback: prefer the local `git diff` above
      as the authoritative source; treat the API as a best-effort cross-check.
      When the local diff succeeds, keep those paths authoritative even if the
      API response is capped, incomplete, or unavailable. Use the API as the
      scheduling source only when the local diff cannot run. Fetch with
-     `gh api --paginate --method GET repos/{owner}/{repo}/pulls/N/files -f per_page=100`;
+     `gh api --paginate --method GET repos/{owner}/{repo}/pulls/N/files -f per_page=100 | jq -s 'add'`;
      the default page size is 30, so a small unpaginated page can look complete
-     while truncated. `--paginate` follows all pages automatically; no Link
-     header check is needed after the command returns. The response is
+     while truncated. `jq -s 'add'` collects all paginated arrays before
+     counting paths or extracting filenames; no Link header check is needed
+     after the command returns. The response is
      acceptable only when it records both `.filename` and `.previous_filename`
      when present, and its listed-file count matches the PR's `changedFiles`
      value from `gh pr view N --json changedFiles`. GitHub caps the Files API at
@@ -99,8 +101,8 @@ Plan a PR batch
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under ~4000 characters total so bulky audit detail stays in the Batch Plan. Measure it, do not eyeball it: `wc -c` gives a locale-independent byte ceiling (`wc -m` counts characters only in a UTF-8 locale and bytes otherwise). Treat 4000 as an approximate budget.
-   - Budget for template overhead: the fixed template plus execution rules already consume roughly 3000 characters before any items are filled in, leaving little room for the File-touch map and per-item content. Prefer splitting into multiple goals over trimming the safety, ownership, or review content.
+   - Keep the fenced goal prompt under ~4000 bytes total so bulky audit detail stays in the Batch Plan. Measure it, do not eyeball it: `wc -c` gives a locale-independent byte count (`wc -m` counts Unicode code points in a UTF-8 locale and bytes otherwise). Treat 4000 as an approximate budget.
+   - Budget for template overhead: the fixed template plus execution rules already consume roughly 3000 bytes before any items are filled in, leaving little room for the File-touch map and per-item content. Prefer splitting into multiple goals over trimming the safety, ownership, or review content.
    - Keep full path evidence in the Batch Plan when it would bloat the prompt.
      In the goal prompt, use the narrowest unambiguous directory/pattern summary
      that still proves ownership. If compression would hide a collision or make

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -65,13 +65,14 @@ Plan a PR batch
      `openssl rand -hex 4` or another git-ref-safe random token, so concurrent
      planners for the same PR cannot overwrite each other's refs.
      Treat `baseRefName` and `headRefName` as untrusted shell and refspec data.
-     Validate each branch name as a fully qualified refs path, for example
-     `git check-ref-format "refs/heads/$baseRefName"` and
-     `git check-ref-format "refs/heads/$headRefName"`, and reject any name
-     containing `:` before constructing a refspec. If base branch validation
-     fails, fall back to the PR Files API or `UNKNOWN`; do not sanitize a failing
-     branch name. Fetch the current base branch and PR head into temporary refs
-     without checking out untrusted PR code:
+     Validate each branch name with Git's branch-name rules, for example
+     `git check-ref-format --branch "$baseRefName"` and
+     `git check-ref-format --branch "$headRefName"`, and reject any name
+     containing `:` before constructing a refspec. Pass the branch name as a
+     single command argument instead of interpolating it into a shell string. If
+     base branch validation fails, fall back to the PR Files API or `UNKNOWN`;
+     do not sanitize a failing branch name. Fetch the current base branch and PR
+     head into temporary refs without checking out untrusted PR code:
      `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-<session-id>-base`
      and
      `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-<session-id>-head`.
@@ -82,13 +83,16 @@ Plan a PR batch
      `headRefName` with a fully qualified source ref
      (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`). If
      `headRefName` validation fails or the branch ref is unavailable, validate
-     `headRefOid` as a full hex object ID and try an OID fetch from the verified
-     head repository URL (`<headRefOid>:refs/tmp/pr-N-<session-id>-head`) before
-     using the PR Files API fallback. Pass each refspec as one quoted shell
-     argument or via an argument-array API, and never interpolate a raw PR branch
-     name into a shell command. A plain `git fetch origin` does not fetch
-     cross-fork heads unless `origin` has already been verified as the PR's
-     target repo.
+     `headRefOid` as the full 40-character lowercase hexadecimal SHA-1 object ID
+     GitHub returns today, for example `^[0-9a-f]{40}$`, and try an OID fetch
+     from the verified head repository URL
+     (`<headRefOid>:refs/tmp/pr-N-<session-id>-head`) before using the PR Files
+     API fallback. If GitHub changes the repository hash format, update this
+     validation before accepting a different OID length. Pass each refspec as
+     one quoted shell argument or via an argument-array API, and never
+     interpolate a raw PR branch name into a shell command. A plain
+     `git fetch origin` does not fetch cross-fork heads unless `origin` has
+     already been verified as the PR's target repo.
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
@@ -101,11 +105,14 @@ Plan a PR batch
      API fallback or `UNKNOWN` decision:
      `git update-ref -d refs/tmp/pr-N-<session-id>-base` and
      `git update-ref -d refs/tmp/pr-N-<session-id>-head`. If cleanup fails, log
-     the ref name and continue to fallback or `UNKNOWN` recording. A rename row
+     the ref name and continue to fallback or `UNKNOWN` recording. If repeated
+     cleanup failures leave stale `refs/tmp/pr-*` refs, run a periodic sweep with
+     `git for-each-ref refs/tmp/ --format='%(refname)'` and delete only stale
+     planner-owned refs with `git update-ref -d "$ref"`. A rename row
      (`R100  old  new`) owns **both** the old and new path; a directory rename
-     implicitly reserves descendants under both old and new directory names. If a
-     ref cannot be fetched or the diff cannot run, try the PR Files API fallback
-     before marking the paths `UNKNOWN`.
+     implicitly reserves descendants under both old and new directory names. If
+     a ref cannot be fetched or the diff cannot run, try the PR Files API
+     fallback before marking the paths `UNKNOWN`.
    - File-touch map, PR Files API fallback: prefer the local `git diff` above
      as the authoritative source; treat the API as a best-effort cross-check.
      When the local diff succeeds, keep those paths authoritative even if the

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -57,7 +57,7 @@ Plan a PR batch
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it (e.g. `wc -m`), do not eyeball it. Reserve ~1100 characters for the preflight and execution-rules boilerplate, remeasure after template changes, and keep the file-touch map, `Worker notes`, and `Done when` terse — the worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
+   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it (e.g. `wc -m`), do not eyeball it. Record the measured fixed-template budget with the short SHA used for the measurement, remeasure after template changes, and keep the filled file-touch map, `Worker notes`, and `Done when` terse (target ~150 chars per item) — the worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
    - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.
 
@@ -86,7 +86,9 @@ Preflight first: if this session cannot run workers without blocking approval pr
 
 Repository: OWNER/REPO
 Batch objective: ...
-File-touch map: PR/Issue #N -> touched/created paths; deferred/reserved paths -> reason.
+File-touch map:
+- PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
+- Deferred/reserved paths -> path(s) (reason: ... / later owner: lane/name)
 
 Items:
 - PR #N: URL

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -50,27 +50,43 @@ Plan a PR batch
      Coordinators must create or update the private backend
      `batches/<batch-id>.json` with those lane refs before dependent workers
      start; otherwise `agent-coord status` cannot report `blocked_on` lanes.
-   - Build a file-touch map for the batch: list the paths each item changes or
-     intends to affect, including creates, deletes, and renames. For PR
-     targets, fetch the PR's base/head refs and run
-     `git diff --name-status --find-renames <base>...<head>` for the
-     rename-aware changed-file list. If the base or head ref is not present
-     locally, fetch the PR head and base branch first; if the fetch or diff
-     still cannot run, record the PR paths as `UNKNOWN` and treat the item as
-     serial. A paginated PR Files API response is acceptable only when it
-     records both `.filename` and `.previous_filename` when present, has no
-     `Link: ...; rel="next"` response header, and its listed-file count matches
-     the PR's `changedFiles` value from `gh pr view N --json changedFiles`.
-     If the API result may have hit GitHub's
-     file-list cap, cannot prove there are no more pages, or only reports new
-     paths, record the PR paths as `UNKNOWN` and treat the item as serial rather
-     than parallel. For issue targets, read the issue body, record proposed new
-     paths from issue/design notes, and grep the repo to confirm existing paths.
-     If paths cannot be determined from the issue body or design notes, record
-     them as `UNKNOWN` and treat the item as serial rather than parallel.
-     Never guess paths. Items that affect the same path cannot run as parallel
-     worktrees; keep only file-disjoint items in the parallel first batch and
-     sequence or defer collisions. Do not dispatch `UNKNOWN` discovery lanes
+   - Build a File-touch map for the batch: list the paths each item changes or
+     intends to affect, including creates, deletes, and renames. Never guess
+     paths.
+   - File-touch map, PR path discovery: get refs with
+     `gh pr view N --json headRefName,baseRefName`, then fetch the current base
+     branch and PR head into refs without checking out untrusted PR code:
+     `git fetch --prune origin <baseRefName>` and
+     `git fetch origin pull/N/head:refs/tmp/pr-N-head`. A plain
+     `git fetch origin` does not fetch cross-fork heads. Run
+     `git diff --name-status --find-renames origin/<baseRefName>...refs/tmp/pr-N-head`;
+     three-dot diffs from the merge-base, which matches GitHub's PR file list.
+     Delete the temporary ref after recording paths:
+     `git update-ref -d refs/tmp/pr-N-head`. A rename row (`R100  old  new`)
+     owns **both** the old and new path. If a ref cannot be fetched or the diff
+     cannot run, record the PR paths as `UNKNOWN` and treat the item as serial.
+   - File-touch map, PR Files API fallback: prefer the local `git diff` above
+     as the authoritative source; treat the API as a best-effort cross-check.
+     Fetch with
+     `gh api --paginate --method GET repos/{owner}/{repo}/pulls/N/files -f per_page=100`;
+     the default page size is 30, so a small unpaginated page can look complete
+     while truncated. The response is acceptable only when it records both
+     `.filename` and
+     `.previous_filename` when present, has no `Link: ...; rel="next"` response
+     header, and its listed-file count matches the PR's `changedFiles` value
+     from `gh pr view N --json changedFiles`. GitHub caps the Files API at
+     ~3000 files; if `changedFiles` is at or near that cap, the response cannot
+     prove there are no more pages, or it only reports new paths, record the PR
+     paths as `UNKNOWN` and treat the item as serial.
+   - File-touch map, issue path discovery: read the issue body, record proposed
+     new paths from issue/design notes, and grep the repo to confirm existing
+     paths. If paths cannot be determined from the issue body or design notes,
+     record them as `UNKNOWN` and treat the item as serial.
+   - File-touch map, collision and wave scheduling: items that affect the same
+     path cannot run as parallel worktrees; keep only file-disjoint items in the
+     parallel first batch and sequence or defer collisions. An `UNKNOWN` item
+     runs as a serial "discovery lane" — a lane that first determines its real
+     paths instead of editing in parallel. Do not dispatch discovery lanes
      alongside active editor lanes; run them before the parallel edit wave or
      after the current wave is idle.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
@@ -79,14 +95,12 @@ Plan a PR batch
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it with `wc -m`; do not eyeball it.
+   - Keep the fenced goal prompt under ~4000 characters total so bulky audit detail stays in the Batch Plan. Measure it, do not eyeball it: `wc -c` gives a locale-independent byte ceiling (`wc -m` counts characters only in a UTF-8 locale and bytes otherwise). Treat 4000 as an approximate budget.
+   - Budget for template overhead: the fixed template plus execution rules already consume roughly 3000 characters before any items are filled in, leaving little room for the File-touch map and per-item content. Prefer splitting into multiple goals over trimming the safety, ownership, or review content.
    - Keep full path evidence in the Batch Plan when it would bloat the prompt.
      In the goal prompt, use the narrowest unambiguous directory/pattern summary
      that still proves ownership. If compression would hide a collision or make
      ownership unclear, mark the item `UNKNOWN` and run it serially.
-   - Record the measured fixed-template section size and the short SHA of the
-     `SKILL.md` commit at measurement time in the Batch Plan so it can be
-     compared after template edits. Remeasure whenever the template changes.
    - Keep each filled entry terse (target ~150 chars for `Worker notes` and `Done when`). The worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
    - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.
@@ -137,9 +151,11 @@ Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch only the current file-disjoint wave. Hold serial and `UNKNOWN`
   discovery lanes until no active editor lane can collide with them.
-- Workers edit only owned File-touch map paths. If an `UNKNOWN`, unlisted, or
-  other-lane path is needed, stop, report discovered paths, and wait for an
-  updated map or explicit coordinator confirmation before editing.
+- Workers edit only owned File-touch map paths; this map is how the batch makes
+  pr-batch's "disjoint write scopes" concrete, since pr-batch's own template has
+  no File-touch map slot. If an `UNKNOWN`, unlisted, or other-lane path is
+  needed, stop, report discovered paths, and wait for an updated map or explicit
+  coordinator confirmation before editing.
 - Sequenced lanes may share declared files only in the stated order.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
@@ -170,5 +186,5 @@ Execution rules:
   item as serial.
 - Do not omit links; use GitHub URLs for every item.
 - Do not put full audit evidence in the goal prompt; put bulky details in the Batch Plan outside the goal.
-- Do not fan out items that change the same file as parallel worktrees; they will conflict — sequence them or split into a later batch.
-- Do not eyeball the goal-prompt length; measure it (e.g. `wc -m`) and split into smaller goals if it exceeds 4000 characters.
+- Do not fan out items that change the same path as parallel worktrees; they will conflict — sequence them or split into a later batch.
+- Do not eyeball the goal-prompt length; apply the Output-section size gate and split into smaller goals if it is over budget.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -73,7 +73,9 @@ Plan a PR batch
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
    - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it with `wc -m`; do not eyeball it.
-   - Record the measured fixed-template section size and the short SHA of the measurement in the Batch Plan so it can be compared after template edits. Remeasure whenever the template changes.
+   - Record the measured fixed-template section size and the short SHA of the
+     `SKILL.md` commit at measurement time in the Batch Plan so it can be
+     compared after template edits. Remeasure whenever the template changes.
    - Keep each filled entry terse (target ~150 chars for `Worker notes` and `Done when`). The worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
    - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -75,7 +75,8 @@ Plan a PR batch
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
      Delete the temporary refs on both success and failure, then proceed to the
      API fallback or `UNKNOWN` decision: `git update-ref -d refs/tmp/pr-N-base`
-     and `git update-ref -d refs/tmp/pr-N-head`. A rename row
+     and `git update-ref -d refs/tmp/pr-N-head`. If cleanup fails, log the ref
+     name and continue to fallback or `UNKNOWN` recording. A rename row
      (`R100  old  new`) owns **both** the old and new path. If a ref cannot be
      fetched or the diff cannot run, try the PR Files API fallback before
      marking the paths `UNKNOWN`.
@@ -95,15 +96,15 @@ Plan a PR batch
      while truncated. `jq -s 'add // []'` collects all paginated arrays before
      counting paths or extracting filenames and returns an empty array for an
      empty stream; no Link header check is needed after the command returns.
-     The response is acceptable only when it records both `.filename` and
-     `.previous_filename` when present, and its listed-file count matches the
-     PR's `changedFiles` value from
+     The response is acceptable only when every row records `.filename`, every
+     row with `status: "renamed"` records `.previous_filename`, and its
+     listed-file count matches the PR's `changedFiles` value from
      `gh pr view N --repo OWNER/REPO --json changedFiles`. GitHub caps the
      Files API at ~3000 files; if the API is the only available source and
      `changedFiles` is at or above that cap, the paginated count does not match
-     `changedFiles`, or a renamed file is expected but the API row is missing
-     its `.previous_filename`, record the PR paths as `UNKNOWN` and treat the
-     item as serial.
+     `changedFiles`, or any row with `status: "renamed"` is missing
+     `.previous_filename`, record the PR paths as `UNKNOWN` and treat the item
+     as serial.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,
@@ -123,7 +124,7 @@ Plan a PR batch
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under ~4000 bytes total so bulky audit detail stays in the Batch Plan. Measure it, do not eyeball it: `wc -c` gives a locale-independent byte count (`wc -m` counts Unicode code points in a UTF-8 locale and bytes otherwise). Treat 4000 as an approximate budget.
+   - Keep the fenced goal prompt under ~4000 bytes total so bulky audit detail stays in the Batch Plan. Measure it, do not eyeball it: `wc -c` gives a locale-independent byte count (`wc -m` counts characters using the current locale's multibyte rules — UTF-8 gives code points, C/POSIX gives bytes). Treat 4000 as an approximate budget.
    - Measure the actual filled template overhead when the prompt is near the
      byte budget; do not rely on a fixed estimate. Prefer splitting into
      multiple goals over trimming the safety, ownership, or review content.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -50,14 +50,14 @@ Plan a PR batch
      Coordinators must create or update the private backend
      `batches/<batch-id>.json` with those lane refs before dependent workers
      start; otherwise `agent-coord status` cannot report `blocked_on` lanes.
-   - Build a file-touch map for the batch: list the files each item changes (read issue/PR bodies and grep the repo to confirm, do not guess). Items that edit the same file cannot run as parallel worktrees — they will conflict at merge. Keep only file-disjoint items in the parallel first batch; group colliding or dependency-ordered items into one sequenced sub-batch, or defer them to a later batch.
+   - Build a file-touch map for the batch: list the files each item changes and the files it intends to create (read issue/PR bodies; grep the repo to confirm existing paths, do not guess). Items that touch the same file, including creating the same new path, cannot run as parallel worktrees — they will conflict at merge. Keep only file-disjoint items in the parallel first batch; group colliding or dependency-ordered items into one sequenced sub-batch, or defer them to a later batch.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it (e.g. `wc -m`), do not eyeball it. The preflight and execution-rules boilerplate already costs ~900 characters, so keep `Worker notes`/`Done when` terse — the worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
+   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it (e.g. `wc -m`), do not eyeball it. Reserve ~1100 characters for the preflight and execution-rules boilerplate, remeasure after template changes, and keep the file-touch map, `Worker notes`, and `Done when` terse — the worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
    - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.
 
@@ -86,6 +86,7 @@ Preflight first: if this session cannot run workers without blocking approval pr
 
 Repository: OWNER/REPO
 Batch objective: ...
+File-touch map: PR/Issue #N -> touched/created paths; deferred/reserved paths -> reason.
 
 Items:
 - PR #N: URL
@@ -100,7 +101,7 @@ Items:
 Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required.
-- Treat the items as file-disjoint: a worker must not edit a file another item owns or that a deferred batch reserves. If a worker concludes it must, stop and report instead of editing.
+- Treat the items as file-disjoint: a worker must not edit a file listed for another item in the file-touch map or reserved for a deferred batch. If a worker concludes it must, stop and report instead of editing.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
   lane name per lane. Declare lane dependencies with `depends_on` refs such as

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -89,7 +89,7 @@ Plan a PR batch
      if either command fails, record the paths as `UNKNOWN` instead of trusting
      an empty array from a broken pipeline. Do not confuse API/auth/rate-limit
      failures with a real empty PR file list.
-     the default page size is 30, so a small unpaginated page can look complete
+     The default page size is 30, so a small unpaginated page can look complete
      while truncated. `jq -s 'add // []'` collects all paginated arrays before
      counting paths or extracting filenames and returns an empty array for an
      empty stream; no Link header check is needed after the command returns.
@@ -111,10 +111,10 @@ Plan a PR batch
      parallel first batch and sequence or defer collisions. An `UNKNOWN` item
      runs as a serial "discovery lane" — a lane that first determines its real
      paths instead of editing in parallel. Never run discovery lanes
-     concurrently with active editor lanes: complete discovery before an editor
-     wave starts. If new items arrive while an editor wave is already running,
-     wait for that wave to finish before starting discovery for those new
-     items.
+     concurrently with active editor lanes: for items known at scheduling time,
+     complete discovery before the editor wave starts. If new items arrive while
+     an editor wave is already running, wait for that wave to finish before
+     starting discovery for those new items.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -64,8 +64,14 @@ Plan a PR batch
      first, such as `pr-N-<session-id>` where `<session-id>` comes from
      `openssl rand -hex 4` or another git-ref-safe random token, so concurrent
      planners for the same PR cannot overwrite each other's refs.
-     Fetch the current base branch and PR head into temporary refs without
-     checking out untrusted PR code:
+     Treat `baseRefName` and `headRefName` as untrusted shell and refspec data.
+     Validate each branch name as a fully qualified refs path, for example
+     `git check-ref-format "refs/heads/$baseRefName"` and
+     `git check-ref-format "refs/heads/$headRefName"`, and reject any name
+     containing `:` before constructing a refspec. If base branch validation
+     fails, fall back to the PR Files API or `UNKNOWN`; do not sanitize a failing
+     branch name. Fetch the current base branch and PR head into temporary refs
+     without checking out untrusted PR code:
      `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-<session-id>-base`
      and
      `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-<session-id>-head`.
@@ -74,15 +80,15 @@ Plan a PR batch
      target repo pull ref is unavailable, fetch the head from the verified head
      repository URL derived from `headRepository.nameWithOwner` and
      `headRefName` with a fully qualified source ref
-     (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`) or use the PR
-     Files API fallback. Treat `headRefName` as untrusted shell and refspec data:
-     validate it with `git check-ref-format --branch -- "$headRefName"` and
-     reject any name containing `:` before constructing a refspec, pass the
-     refspec as one quoted shell argument or via an argument-array API, and never
-     interpolate a raw PR branch name into a shell command. If validation fails,
-     fall back to the PR Files API or `UNKNOWN`; do not sanitize a failing branch
-     name. A plain `git fetch origin` does not fetch cross-fork heads unless
-     `origin` has already been verified as the PR's target repo.
+     (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`). If
+     `headRefName` validation fails or the branch ref is unavailable, validate
+     `headRefOid` as a full hex object ID and try an OID fetch from the verified
+     head repository URL (`<headRefOid>:refs/tmp/pr-N-<session-id>-head`) before
+     using the PR Files API fallback. Pass each refspec as one quoted shell
+     argument or via an argument-array API, and never interpolate a raw PR branch
+     name into a shell command. A plain `git fetch origin` does not fetch
+     cross-fork heads unless `origin` has already been verified as the PR's
+     target repo.
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -65,10 +65,11 @@ Plan a PR batch
      `openssl rand -hex 4` or another git-ref-safe random token, so concurrent
      planners for the same PR cannot overwrite each other's refs.
      Treat `baseRefName` and `headRefName` as untrusted shell and refspec data.
-     Validate each branch name with Git's branch-name rules, for example
-     `git check-ref-format --branch "$baseRefName"` and
-     `git check-ref-format --branch "$headRefName"`, and reject any name
-     containing `:` before constructing a refspec. Pass the branch name as a
+     Validate each branch name with Git's branch-name rules using an
+     argument-array API equivalent to
+     `["git", "check-ref-format", "--branch", baseRefName]` and
+     `["git", "check-ref-format", "--branch", headRefName]`, and reject any
+     name containing `:` before constructing a refspec. Pass the branch name as a
      single command argument instead of interpolating it into a shell string. If
      base branch validation fails, fall back to the PR Files API or `UNKNOWN`;
      do not sanitize a failing branch name. Fetch the current base branch and PR
@@ -97,10 +98,12 @@ Plan a PR batch
      `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
      If the three-dot diff fails because the merge base is missing in a shallow
-     clone, run a bounded deepen such as
-     `git fetch --deepen=200 <verified-base-repo-url>` and retry once before
-     falling back to the PR Files API; the deepen value is a best-effort
-     heuristic, not a guarantee.
+     clone, run a bounded deepen for the relevant base branch such as
+     `git fetch --deepen=200 <verified-base-repo-url> refs/heads/<baseRefName>`
+     and retry the same
+     `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`
+     command once before falling back to the PR Files API; the deepen value is a
+     best-effort heuristic, not a guarantee.
      Delete the temporary refs on both success and failure, then proceed to the
      API fallback or `UNKNOWN` decision:
      `git update-ref -d refs/tmp/pr-N-<session-id>-base` and

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -62,8 +62,9 @@ Plan a PR batch
      fallback before recording paths as `UNKNOWN`; do not diff the current
      checkout's default remote. Fetch the current base branch and PR head into
      temporary refs without checking out untrusted PR code:
-     `git fetch <verified-base-repo-url> <baseRefName>:refs/tmp/pr-N-base` and
+     `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-base` and
      `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-head`.
+     Fully qualifying the base branch avoids tag/branch name ambiguity.
      GitHub keeps the target repo's pull ref pointing at fork heads too. If the
      target repo pull ref is unavailable, fetch the head from the verified head
      repository URL derived from `headRepository.nameWithOwner` and

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -50,13 +50,14 @@ Plan a PR batch
      Coordinators must create or update the private backend
      `batches/<batch-id>.json` with those lane refs before dependent workers
      start; otherwise `agent-coord status` cannot report `blocked_on` lanes.
+   - Build a file-touch map for the batch: list the files each item changes (read issue/PR bodies and grep the repo to confirm, do not guess). Items that edit the same file cannot run as parallel worktrees — they will conflict at merge. Keep only file-disjoint items in the parallel first batch; group colliding or dependency-ordered items into one sequenced sub-batch, or defer them to a later batch.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
 
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
-   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan.
+   - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it (e.g. `wc -m`), do not eyeball it. The preflight and execution-rules boilerplate already costs ~900 characters, so keep `Worker notes`/`Done when` terse — the worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
    - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.
 
@@ -99,6 +100,7 @@ Items:
 Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required.
+- Treat the items as file-disjoint: a worker must not edit a file another item owns or that a deferred batch reserves. If a worker concludes it must, stop and report instead of editing.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
   lane name per lane. Declare lane dependencies with `depends_on` refs such as
@@ -126,3 +128,5 @@ Execution rules:
 - Do not hide missing GitHub data; say `UNKNOWN`.
 - Do not omit links; use GitHub URLs for every item.
 - Do not put full audit evidence in the goal prompt; put bulky details in the Batch Plan outside the goal.
+- Do not fan out items that change the same file as parallel worktrees; they will conflict — sequence them or split into a later batch.
+- Do not eyeball the goal-prompt length; measure it (e.g. `wc -m`) and split into smaller goals if it exceeds 4000 characters.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -60,7 +60,7 @@ Plan a PR batch
      serial. A paginated PR Files API response is acceptable only when it
      records both `.filename` and `.previous_filename` when present, has no
      `Link: ...; rel="next"` response header, and its listed-file count matches
-     the PR's `changed_files` value from `gh pr view N --json changedFiles`.
+     the PR's `changedFiles` value from `gh pr view N --json changedFiles`.
      If the API result may have hit GitHub's
      file-list cap, cannot prove there are no more pages, or only reports new
      paths, record the PR paths as `UNKNOWN` and treat the item as serial rather
@@ -70,7 +70,9 @@ Plan a PR batch
      them as `UNKNOWN` and treat the item as serial rather than parallel.
      Never guess paths. Items that affect the same path cannot run as parallel
      worktrees; keep only file-disjoint items in the parallel first batch and
-     sequence or defer collisions.
+     sequence or defer collisions. Do not dispatch `UNKNOWN` discovery lanes
+     alongside active editor lanes; run them before the parallel edit wave or
+     after the current wave is idle.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
@@ -78,6 +80,10 @@ Plan a PR batch
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
    - Keep the fenced goal prompt under 4000 characters total so bulky audit detail stays in the Batch Plan. Measure it with `wc -m`; do not eyeball it.
+   - Keep full path evidence in the Batch Plan when it would bloat the prompt.
+     In the goal prompt, use the narrowest unambiguous directory/pattern summary
+     that still proves ownership. If compression would hide a collision or make
+     ownership unclear, mark the item `UNKNOWN` and run it serially.
    - Record the measured fixed-template section size and the short SHA of the
      `SKILL.md` commit at measurement time in the Batch Plan so it can be
      compared after template edits. Remeasure whenever the template changes.
@@ -112,6 +118,7 @@ Repository: OWNER/REPO
 Batch objective: ...
 File-touch map:
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
+- PR/Issue #N -> summarized path pattern(s); full path list in Batch Plan (owner: lane/name)
 - PR/Issue #N -> UNKNOWN (paths not determinable from issue body/design notes; treat as serial)
 # Batch-level reservations, not tied to a single item:
 - Deferred/reserved paths -> path(s) (reason: ... / later owner: lane/name)
@@ -128,22 +135,12 @@ Items:
 
 Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
-- Dispatch one subagent per independent item; group dependent items only when shared context is required.
-- Treat parallel items as file-disjoint: a worker must edit only files owned by
-  its lane in the File-touch map.
-  - Deferred or reserved paths block only lanes that do not own that path; the
-    lane listed as owner in the File-touch map may edit its declared files even
-    when a later deferred item will also need them.
-  - An `UNKNOWN` item may run only as a serial discovery lane. The worker must
-    identify the needed files, report or record those discovered paths with the
-    coordinator, and wait for confirmation that no active lane owns them before
-    editing. The coordinator must update the file-touch map entry in
-    `batches/<batch-id>.json` when the private backend is available, or leave an
-    equivalent GitHub/thread comment when it is unavailable.
-  - If a worker concludes it needs an unlisted file or another lane's file, stop
-    and report so the coordinator can sequence or split the work.
-  - Sequenced or dependency-ordered lanes may share declared files only in the
-    stated order.
+- Dispatch only the current file-disjoint wave. Hold serial and `UNKNOWN`
+  discovery lanes until no active editor lane can collide with them.
+- Workers edit only owned File-touch map paths. If an `UNKNOWN`, unlisted, or
+  other-lane path is needed, stop, report discovered paths, and wait for an
+  updated map or explicit coordinator confirmation before editing.
+- Sequenced lanes may share declared files only in the stated order.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
   lane name per lane. Declare lane dependencies with `depends_on` refs such as

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -60,10 +60,14 @@ Plan a PR batch
      then resolve a local remote or fetch URL that points at the verified base
      repo. If no verified remote or URL can be resolved, use the PR Files API
      fallback before recording paths as `UNKNOWN`; do not diff the current
-     checkout's default remote. Fetch the current base branch and PR head into
-     temporary refs without checking out untrusted PR code:
-     `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-base` and
-     `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-head`.
+     checkout's default remote. Choose a session-unique temporary-ref suffix
+     first, such as `pr-N-<session-id>` from a UUID prefix or random token, so
+     concurrent planners for the same PR cannot overwrite each other's refs.
+     Fetch the current base branch and PR head into temporary refs without
+     checking out untrusted PR code:
+     `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-<session-id>-base`
+     and
+     `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-<session-id>-head`.
      Fully qualifying the base branch avoids tag/branch name ambiguity.
      GitHub keeps the target repo's pull ref pointing at fork heads too. If the
      target repo pull ref is unavailable, fetch the head from the verified head
@@ -72,12 +76,13 @@ Plan a PR batch
      `git fetch origin` does not fetch cross-fork heads unless `origin` has
      already been verified as the PR's target repo.
      Run
-     `git diff --name-status --find-renames refs/tmp/pr-N-base...refs/tmp/pr-N-head`;
+     `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
      Delete the temporary refs on both success and failure, then proceed to the
-     API fallback or `UNKNOWN` decision: `git update-ref -d refs/tmp/pr-N-base`
-     and `git update-ref -d refs/tmp/pr-N-head`. If cleanup fails, log the ref
-     name and continue to fallback or `UNKNOWN` recording. A rename row
+     API fallback or `UNKNOWN` decision:
+     `git update-ref -d refs/tmp/pr-N-<session-id>-base` and
+     `git update-ref -d refs/tmp/pr-N-<session-id>-head`. If cleanup fails, log
+     the ref name and continue to fallback or `UNKNOWN` recording. A rename row
      (`R100  old  new`) owns **both** the old and new path. If a ref cannot be
      fetched or the diff cannot run, try the PR Files API fallback before
      marking the paths `UNKNOWN`.
@@ -120,7 +125,9 @@ Plan a PR batch
      concurrently with active editor lanes: for items already in the scheduling
      set, complete discovery before the editor wave starts. If the coordinator
      adds items after an editor wave has already started, wait for that wave to
-     finish before starting discovery for those new items.
+     finish before starting discovery for those new items. A collision
+     discovered mid-flight cannot safely redirect an active editor lane; the
+     only recovery is abort-and-restart, which is worse than waiting.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -73,12 +73,12 @@ Plan a PR batch
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-base...refs/tmp/pr-N-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
-     Delete the temporary refs on both success and failure, before any API
-     fallback or `UNKNOWN` decision: `git update-ref -d refs/tmp/pr-N-base` and
-     `git update-ref -d refs/tmp/pr-N-head`. A rename row (`R100  old  new`)
-     owns **both** the old and new path. If a ref cannot be fetched or the diff
-     cannot run, try the PR Files API fallback before marking the paths
-     `UNKNOWN`.
+     Delete the temporary refs on both success and failure, then proceed to the
+     API fallback or `UNKNOWN` decision: `git update-ref -d refs/tmp/pr-N-base`
+     and `git update-ref -d refs/tmp/pr-N-head`. A rename row
+     (`R100  old  new`) owns **both** the old and new path. If a ref cannot be
+     fetched or the diff cannot run, try the PR Files API fallback before
+     marking the paths `UNKNOWN`.
    - File-touch map, PR Files API fallback: prefer the local `git diff` above
      as the authoritative source; treat the API as a best-effort cross-check.
      When the local diff succeeds, keep those paths authoritative even if the
@@ -86,9 +86,11 @@ Plan a PR batch
      scheduling source only when the local diff cannot run. Fetch with
      `set -o pipefail` enabled, then
      `gh api --paginate --method GET repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s 'add // []'`;
-     if either command fails, record the paths as `UNKNOWN` instead of trusting
-     an empty array from a broken pipeline. Do not confuse API/auth/rate-limit
-     failures with a real empty PR file list.
+     if either command fails, the response is an error-shaped object such as
+     `{"message": ...}` / `{"errors": ...}`, or any row lacks `.filename`, record
+     the paths as `UNKNOWN` instead of trusting an empty array from a broken
+     pipeline. Do not confuse API/auth/rate-limit failures with a real empty PR
+     file list.
      The default page size is 30, so a small unpaginated page can look complete
      while truncated. `jq -s 'add // []'` collects all paginated arrays before
      counting paths or extracting filenames and returns an empty array for an
@@ -111,9 +113,9 @@ Plan a PR batch
      parallel first batch and sequence or defer collisions. An `UNKNOWN` item
      runs as a serial "discovery lane" — a lane that first determines its real
      paths instead of editing in parallel. Never run discovery lanes
-     concurrently with active editor lanes: for items known at scheduling time,
-     complete discovery before the editor wave starts. If new items arrive while
-     an editor wave is already running, wait for that wave to finish before
+     concurrently with active editor lanes: for items already in the scheduling
+     set, complete discovery before the editor wave starts. If new items arrive
+     while an editor wave is already running, wait for that wave to finish before
      starting discovery for those new items.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -54,18 +54,23 @@ Plan a PR batch
      intends to affect, including creates, deletes, and renames. For PR
      targets, fetch the PR's base/head refs and run
      `git diff --name-status --find-renames <base>...<head>` for the
-     rename-aware changed-file list. A paginated PR Files API response is
-     acceptable only when it is proven complete and records both `.filename` and
-     `.previous_filename` when present. If the API result may have hit GitHub's
+     rename-aware changed-file list. If the base or head ref is not present
+     locally, fetch the PR head and base branch first; if the fetch or diff
+     still cannot run, record the PR paths as `UNKNOWN` and treat the item as
+     serial. A paginated PR Files API response is acceptable only when it
+     records both `.filename` and `.previous_filename` when present, has no
+     `Link: ...; rel="next"` response header, and its listed-file count matches
+     the PR's `changed_files` value from `gh pr view N --json changedFiles`.
+     If the API result may have hit GitHub's
      file-list cap, cannot prove there are no more pages, or only reports new
      paths, record the PR paths as `UNKNOWN` and treat the item as serial rather
      than parallel. For issue targets, read the issue body, record proposed new
      paths from issue/design notes, and grep the repo to confirm existing paths.
      If paths cannot be determined from the issue body or design notes, record
-     them as `UNKNOWN` and treat the item as serial rather than parallel. Do not
-     guess. Items that affect the same path cannot run as parallel worktrees;
-     keep only file-disjoint items in the parallel first batch and sequence or
-     defer collisions.
+     them as `UNKNOWN` and treat the item as serial rather than parallel.
+     Never guess paths. Items that affect the same path cannot run as parallel
+     worktrees; keep only file-disjoint items in the parallel first batch and
+     sequence or defer collisions.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
@@ -108,6 +113,7 @@ Batch objective: ...
 File-touch map:
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
 - PR/Issue #N -> UNKNOWN (paths not determinable from issue body/design notes; treat as serial)
+# Batch-level reservations, not tied to a single item:
 - Deferred/reserved paths -> path(s) (reason: ... / later owner: lane/name)
 
 Items:
@@ -131,7 +137,9 @@ Execution rules:
   - An `UNKNOWN` item may run only as a serial discovery lane. The worker must
     identify the needed files, report or record those discovered paths with the
     coordinator, and wait for confirmation that no active lane owns them before
-    editing.
+    editing. The coordinator must update the file-touch map entry in
+    `batches/<batch-id>.json` when the private backend is available, or leave an
+    equivalent GitHub/thread comment when it is unavailable.
   - If a worker concludes it needs an unlisted file or another lane's file, stop
     and report so the coordinator can sequence or split the work.
   - Sequenced or dependency-ordered lanes may share declared files only in the
@@ -161,6 +169,8 @@ Execution rules:
 - Do not infer PR vs issue from a bare number.
 - Do not batch unrelated risky changes just because they are small.
 - Do not hide missing GitHub data; say `UNKNOWN`.
+- Do not guess file paths; record unverifiable paths as `UNKNOWN` and treat that
+  item as serial.
 - Do not omit links; use GitHub URLs for every item.
 - Do not put full audit evidence in the goal prompt; put bulky details in the Batch Plan outside the goal.
 - Do not fan out items that change the same file as parallel worktrees; they will conflict — sequence them or split into a later batch.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -58,10 +58,10 @@ Plan a PR batch
      with
      `gh pr view N --repo OWNER/REPO --json baseRefName,headRefName,headRepository,headRepositoryOwner`,
      then resolve a local remote or fetch URL that points at the verified base
-     repo. If no verified remote or URL can be resolved, record paths as
-     `UNKNOWN` instead of diffing the current checkout's default remote. Fetch
-     the current base branch and PR head into temporary refs without checking
-     out untrusted PR code:
+     repo. If no verified remote or URL can be resolved, use the PR Files API
+     fallback before recording paths as `UNKNOWN`; do not diff the current
+     checkout's default remote. Fetch the current base branch and PR head into
+     temporary refs without checking out untrusted PR code:
      `git fetch <verified-base-repo-url> <baseRefName>:refs/tmp/pr-N-base` and
      `git fetch <verified-base-repo-url> pull/N/head:refs/tmp/pr-N-head`.
      GitHub keeps the target repo's pull ref pointing at fork heads too. If the

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -85,9 +85,9 @@ Plan a PR batch
      as the authoritative source; treat the API as a best-effort cross-check.
      When the local diff succeeds, keep those paths authoritative even if the
      API response is capped, incomplete, or unavailable. Use the API as the
-     scheduling source only when the local diff cannot run. Fetch with
-     `set -o pipefail` enabled, then
-     `gh api --paginate --method GET repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s 'add // []'`;
+     scheduling source only when the local diff cannot run. Run the API
+     pipeline in one shell invocation with `pipefail` enabled, for example
+     `bash -o pipefail -c 'gh api --paginate --method GET repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s '"'"'add // []'"'"''`;
      if either command fails, the response is an error-shaped object such as
      `{"message": ...}` / `{"errors": ...}`, or any row lacks `.filename`, record
      the paths as `UNKNOWN` instead of trusting an empty array from a broken
@@ -98,14 +98,16 @@ Plan a PR batch
      counting paths or extracting filenames and returns an empty array for an
      empty stream; no Link header check is needed after the command returns.
      The response is acceptable only when every row records `.filename`, every
-     row with `status: "renamed"` records `.previous_filename`, and its
-     listed-file count matches the PR's `changedFiles` value from
+     row with `status: "renamed"` records `.previous_filename`, and the
+     listed-file count is sane against the PR's `changedFiles` value from
      `gh pr view N --repo OWNER/REPO --json changedFiles`. GitHub caps the
      Files API at ~3000 files; if the API is the only available source and
-     `changedFiles` is at or above that cap, the paginated count does not match
+     `changedFiles` is at or above that cap, the paginated count is greater than
      `changedFiles`, or any row with `status: "renamed"` is missing
      `.previous_filename`, record the PR paths as `UNKNOWN` and treat the item
-     as serial.
+     as serial. If the paginated count is lower than `changedFiles`, re-read
+     `changedFiles` once before recording `UNKNOWN` so freshly pushed PRs do not
+     fail the sanity check on transient metadata lag.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,
@@ -116,9 +118,9 @@ Plan a PR batch
      runs as a serial "discovery lane" — a lane that first determines its real
      paths instead of editing in parallel. Never run discovery lanes
      concurrently with active editor lanes: for items already in the scheduling
-     set, complete discovery before the editor wave starts. If new items arrive
-     while an editor wave is already running, wait for that wave to finish before
-     starting discovery for those new items.
+     set, complete discovery before the editor wave starts. If the coordinator
+     adds items after an editor wave has already started, wait for that wave to
+     finish before starting discovery for those new items.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -67,7 +67,9 @@ Plan a PR batch
      cannot run, record the PR paths as `UNKNOWN` and treat the item as serial.
    - File-touch map, PR Files API fallback: prefer the local `git diff` above
      as the authoritative source; treat the API as a best-effort cross-check.
-     Fetch with
+     When the local diff succeeds, keep those paths authoritative even if the
+     API response is capped, incomplete, or unavailable. Use the API as the
+     scheduling source only when the local diff cannot run. Fetch with
      `gh api --paginate --method GET repos/{owner}/{repo}/pulls/N/files -f per_page=100`;
      the default page size is 30, so a small unpaginated page can look complete
      while truncated. `--paginate` follows all pages automatically; no Link
@@ -75,9 +77,10 @@ Plan a PR batch
      acceptable only when it records both `.filename` and `.previous_filename`
      when present, and its listed-file count matches the PR's `changedFiles`
      value from `gh pr view N --json changedFiles`. GitHub caps the Files API at
-     ~3000 files; if `changedFiles` is at or near that cap, the response cannot
-     prove there are no more pages, or it only reports new paths, record the PR
-     paths as `UNKNOWN` and treat the item as serial.
+     ~3000 files; if the API is the only available source and `changedFiles` is
+     at or near that cap, the response cannot prove there are no more pages, or
+     it only reports new paths, record the PR paths as `UNKNOWN` and treat the
+     item as serial.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -56,7 +56,7 @@ Plan a PR batch
    - File-touch map, PR path discovery: get refs with
      `gh pr view N --json headRefName,baseRefName`, then fetch the current base
      branch and PR head into refs without checking out untrusted PR code:
-     `git fetch --prune origin <baseRefName>` and
+     `git fetch origin <baseRefName>` and
      `git fetch origin pull/N/head:refs/tmp/pr-N-head`. A plain
      `git fetch origin` does not fetch cross-fork heads. Run
      `git diff --name-status --find-renames origin/<baseRefName>...refs/tmp/pr-N-head`;
@@ -70,11 +70,11 @@ Plan a PR batch
      Fetch with
      `gh api --paginate --method GET repos/{owner}/{repo}/pulls/N/files -f per_page=100`;
      the default page size is 30, so a small unpaginated page can look complete
-     while truncated. The response is acceptable only when it records both
-     `.filename` and
-     `.previous_filename` when present, has no `Link: ...; rel="next"` response
-     header, and its listed-file count matches the PR's `changedFiles` value
-     from `gh pr view N --json changedFiles`. GitHub caps the Files API at
+     while truncated. `--paginate` follows all pages automatically; no Link
+     header check is needed after the command returns. The response is
+     acceptable only when it records both `.filename` and `.previous_filename`
+     when present, and its listed-file count matches the PR's `changedFiles`
+     value from `gh pr view N --json changedFiles`. GitHub caps the Files API at
      ~3000 files; if `changedFiles` is at or near that cap, the response cannot
      prove there are no more pages, or it only reports new paths, record the PR
      paths as `UNKNOWN` and treat the item as serial.
@@ -86,9 +86,10 @@ Plan a PR batch
      path cannot run as parallel worktrees; keep only file-disjoint items in the
      parallel first batch and sequence or defer collisions. An `UNKNOWN` item
      runs as a serial "discovery lane" — a lane that first determines its real
-     paths instead of editing in parallel. Do not dispatch discovery lanes
-     alongside active editor lanes; run them before the parallel edit wave or
-     after the current wave is idle.
+     paths instead of editing in parallel. Do not run discovery lanes
+     concurrently with active editor lanes. Either complete all discovery lanes
+     first and then dispatch the editor wave, or wait until all active editor
+     lanes have finished before starting discovery lanes.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -61,8 +61,9 @@ Plan a PR batch
      repo. If no verified remote or URL can be resolved, use the PR Files API
      fallback before recording paths as `UNKNOWN`; do not diff the current
      checkout's default remote. Choose a session-unique temporary-ref suffix
-     first, such as `pr-N-<session-id>` from a UUID prefix or random token, so
-     concurrent planners for the same PR cannot overwrite each other's refs.
+     first, such as `pr-N-<session-id>` where `<session-id>` is 8 lowercase hex
+     characters from `uuidgen` or a random token, so concurrent planners for the
+     same PR cannot overwrite each other's refs.
      Fetch the current base branch and PR head into temporary refs without
      checking out untrusted PR code:
      `git fetch <verified-base-repo-url> refs/heads/<baseRefName>:refs/tmp/pr-N-<session-id>-base`
@@ -73,30 +74,37 @@ Plan a PR batch
      target repo pull ref is unavailable, fetch the head from the verified head
      repository URL derived from `headRepository.nameWithOwner` and
      `headRefName` with a fully qualified source ref
-     (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`), fetch by
-     `headRefOid`, or use the PR Files API fallback. Treat `headRefName` as
-     untrusted shell data: pass the refspec as one quoted shell argument or via
+     (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`) or use the PR
+     Files API fallback. Treat `headRefName` as untrusted shell and refspec data:
+     validate it with `git check-ref-format --branch -- "$headRefName"` before
+     constructing a refspec, pass the refspec as one quoted shell argument or via
      an argument-array API, and never interpolate a raw PR branch name into a
-     shell command. A plain `git fetch origin` does not fetch cross-fork heads
-     unless `origin` has already been verified as the PR's target repo.
+     shell command. If validation fails, fall back to the PR Files API or
+     `UNKNOWN`; do not sanitize a failing branch name. A plain `git fetch origin`
+     does not fetch cross-fork heads unless `origin` has already been verified as
+     the PR's target repo.
      Run
      `git diff --name-status --find-renames refs/tmp/pr-N-<session-id>-base...refs/tmp/pr-N-<session-id>-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
+     If the three-dot diff fails because the merge base is missing in a shallow
+     clone, run `git fetch --deepen=50 <verified-base-repo-url>` once and retry
+     before falling back to the PR Files API.
      Delete the temporary refs on both success and failure, then proceed to the
      API fallback or `UNKNOWN` decision:
      `git update-ref -d refs/tmp/pr-N-<session-id>-base` and
      `git update-ref -d refs/tmp/pr-N-<session-id>-head`. If cleanup fails, log
      the ref name and continue to fallback or `UNKNOWN` recording. A rename row
-     (`R100  old  new`) owns **both** the old and new path. If a ref cannot be
-     fetched or the diff cannot run, try the PR Files API fallback before
-     marking the paths `UNKNOWN`.
+     (`R100  old  new`) owns **both** the old and new path; a directory rename
+     implicitly reserves descendants under both old and new directory names. If a
+     ref cannot be fetched or the diff cannot run, try the PR Files API fallback
+     before marking the paths `UNKNOWN`.
    - File-touch map, PR Files API fallback: prefer the local `git diff` above
      as the authoritative source; treat the API as a best-effort cross-check.
      When the local diff succeeds, keep those paths authoritative even if the
      API response is capped, incomplete, or unavailable. Use the API as the
      scheduling source only when the local diff cannot run. Run the API
      pipeline in one shell invocation with `pipefail` enabled, for example
-     `bash -o pipefail -c 'gh api --paginate --method GET repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s '"'"'add // []'"'"''`;
+     `bash -o pipefail -c "gh api --paginate repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s 'add // []'"`;
      if either command fails, the response is an error-shaped object such as
      `{"message": ...}` / `{"errors": ...}`, or any row lacks `.filename`, record
      the paths as `UNKNOWN` instead of trusting an empty array from a broken
@@ -111,12 +119,13 @@ Plan a PR batch
      listed-file count is sane against the PR's `changedFiles` value from
      `gh pr view N --repo OWNER/REPO --json changedFiles`. GitHub caps the
      Files API at ~3000 files; if the API is the only available source and
-     `changedFiles` is at or above that cap, the paginated count is greater than
-     `changedFiles`, or any row with `status: "renamed"` is missing
+     `changedFiles` is at or above that cap, or any row with `status: "renamed"`
+     is missing
      `.previous_filename`, record the PR paths as `UNKNOWN` and treat the item
-     as serial. If the paginated count is lower than `changedFiles`, re-read
+     as serial. If the paginated count differs from `changedFiles`, re-read
      `changedFiles` once before recording `UNKNOWN` so freshly pushed PRs do not
-     fail the sanity check on transient metadata lag.
+     fail the sanity check on transient metadata lag. If counts still diverge
+     after the re-read, record paths as `UNKNOWN` and treat the item as serial.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,
@@ -126,12 +135,13 @@ Plan a PR batch
      parallel first batch and sequence or defer collisions. An `UNKNOWN` item
      runs as a serial "discovery lane" — a lane that first determines its real
      paths instead of editing in parallel. Never run discovery lanes
-     concurrently with active editor lanes: for items already in the scheduling
+     concurrently with active editor lanes. For items already in the scheduling
      set, complete discovery before the editor wave starts. If the coordinator
      adds items after an editor wave has already started, wait for that wave to
      finish before starting discovery for those new items. A collision
      discovered mid-flight cannot safely redirect an active editor lane; the
-     only recovery is abort-and-restart, which is worse than waiting.
+     coordinator would have to abort the wave, release claims, and restart it,
+     which is worse than waiting.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
@@ -184,7 +194,7 @@ File-touch map:
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
 - PR/Issue #N -> summarized path pattern(s) plus collision-relevant exact paths/renames/deletes (owner: lane/name)
 - PR/Issue #N -> UNKNOWN (paths not determinable from issue body/design notes; treat as serial)
-# Batch-level reservations, not tied to a single item:
+Batch-level reservations, not tied to a single item:
 - Deferred/reserved paths -> path(s) (reason: ... / later owner: lane/name)
 
 Items:

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -72,7 +72,9 @@ Plan a PR batch
      GitHub keeps the target repo's pull ref pointing at fork heads too. If the
      target repo pull ref is unavailable, fetch the head from the verified head
      repository URL derived from `headRepository.nameWithOwner` and
-     `headRefName`, or use the PR Files API fallback. Treat `headRefName` as
+     `headRefName` with a fully qualified source ref
+     (`refs/heads/<headRefName>:refs/tmp/pr-N-<session-id>-head`), fetch by
+     `headRefOid`, or use the PR Files API fallback. Treat `headRefName` as
      untrusted shell data: pass the refspec as one quoted shell argument or via
      an argument-array API, and never interpolate a raw PR branch name into a
      shell command. A plain `git fetch origin` does not fetch cross-fork heads

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -88,10 +88,13 @@ Plan a PR batch
      GitHub returns today, for example `^[0-9a-f]{40}$`, and try an OID fetch
      from the verified head repository URL
      (`<headRefOid>:refs/tmp/pr-N-<session-id>-head`) before using the PR Files
-     API fallback. If GitHub changes the repository hash format, update this
-     validation before accepting a different OID length. Pass each refspec as
-     one quoted shell argument or via an argument-array API, and never
-     interpolate a raw PR branch name into a shell command. A plain
+     API fallback. Treat an OID fetch rejection as an expected portability
+     outcome on older Git clients or servers that do not advertise reachable SHA
+     fetch support, not as a planner setup failure. If GitHub changes the
+     repository hash format, update this validation before accepting a different
+     OID length. Pass each refspec as one quoted shell argument or via an
+     argument-array API, and never interpolate a raw PR branch name into a shell
+     command. A plain
      `git fetch origin` does not fetch cross-fork heads unless `origin` has
      already been verified as the PR's target repo.
      Run

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -53,15 +53,25 @@ Plan a PR batch
    - Build a File-touch map for the batch: list the paths each item changes or
      intends to affect, including creates, deletes, and renames. Never guess
      paths.
-   - File-touch map, PR path discovery: get refs with
-     `gh pr view N --json headRefName,baseRefName`, then fetch the current base
-     branch and PR head into refs without checking out untrusted PR code:
-     `git fetch origin <baseRefName>` and
-     `git fetch origin pull/N/head:refs/tmp/pr-N-head`. A plain
-     `git fetch origin` does not fetch cross-fork heads. Run
-     `git diff --name-status --find-renames origin/<baseRefName>...refs/tmp/pr-N-head`;
+
+   - File-touch map, PR path discovery: get refs from the verified target repo
+     with
+     `gh pr view N --repo OWNER/REPO --json baseRefName,headRefName,headRepository,headRepositoryOwner`,
+     then resolve a local remote or fetch URL that points at the verified base
+     repo. If no verified remote or URL can be resolved, record paths as
+     `UNKNOWN` instead of diffing the current checkout's default remote. Fetch
+     the current base branch and PR head into temporary refs without checking
+     out untrusted PR code. Fetch the base into `refs/tmp/pr-N-base` and the
+     head into `refs/tmp/pr-N-head` using the base repo's `pull/N/head` ref;
+     GitHub keeps that pull ref pointing at fork heads too. If the base pull
+     ref is unavailable, fetch from the verified head repository URL derived
+     from `headRepository.nameWithOwner` and `headRefName`, or use the PR Files
+     API fallback. A plain `git fetch origin` does not fetch cross-fork heads.
+     Run
+     `git diff --name-status --find-renames refs/tmp/pr-N-base...refs/tmp/pr-N-head`;
      three-dot diffs from the merge-base, which matches GitHub's PR file list.
-     Delete the temporary ref after recording paths:
+     Delete the temporary refs on both success and failure, before any API
+     fallback or `UNKNOWN` decision: `git update-ref -d refs/tmp/pr-N-base` and
      `git update-ref -d refs/tmp/pr-N-head`. A rename row (`R100  old  new`)
      owns **both** the old and new path. If a ref cannot be fetched or the diff
      cannot run, try the PR Files API fallback before marking the paths
@@ -71,18 +81,19 @@ Plan a PR batch
      When the local diff succeeds, keep those paths authoritative even if the
      API response is capped, incomplete, or unavailable. Use the API as the
      scheduling source only when the local diff cannot run. Fetch with
-     `gh api --paginate --method GET repos/{owner}/{repo}/pulls/N/files -f per_page=100 | jq -s 'add'`;
+     `gh api --paginate --method GET repos/OWNER/REPO/pulls/N/files -f per_page=100 | jq -s 'add // []'`;
      the default page size is 30, so a small unpaginated page can look complete
-     while truncated. `jq -s 'add'` collects all paginated arrays before
-     counting paths or extracting filenames; no Link header check is needed
-     after the command returns. The response is
-     acceptable only when it records both `.filename` and `.previous_filename`
-     when present, and its listed-file count matches the PR's `changedFiles`
-     value from `gh pr view N --json changedFiles`. GitHub caps the Files API at
-     ~3000 files; if the API is the only available source and `changedFiles` is
-     at or near that cap, the response cannot prove there are no more pages, or
-     it only reports new paths, record the PR paths as `UNKNOWN` and treat the
-     item as serial.
+     while truncated. `jq -s 'add // []'` collects all paginated arrays before
+     counting paths or extracting filenames and returns an empty array for an
+     empty stream; no Link header check is needed after the command returns.
+     The response is acceptable only when it records both `.filename` and
+     `.previous_filename` when present, and its listed-file count matches the
+     PR's `changedFiles` value from
+     `gh pr view N --repo OWNER/REPO --json changedFiles`. GitHub caps the
+     Files API at ~3000 files; if the API is the only available source and
+     `changedFiles` is at or above that cap, the paginated count does not match
+     `changedFiles`, or the response only reports new paths, record the PR paths
+     as `UNKNOWN` and treat the item as serial.
    - File-touch map, issue path discovery: read the issue body, record proposed
      new paths from issue/design notes, and grep the repo to confirm existing
      paths. If paths cannot be determined from the issue body or design notes,
@@ -91,10 +102,9 @@ Plan a PR batch
      path cannot run as parallel worktrees; keep only file-disjoint items in the
      parallel first batch and sequence or defer collisions. An `UNKNOWN` item
      runs as a serial "discovery lane" — a lane that first determines its real
-     paths instead of editing in parallel. Do not run discovery lanes
-     concurrently with active editor lanes. Either complete all discovery lanes
-     first and then dispatch the editor wave, or wait until all active editor
-     lanes have finished before starting discovery lanes.
+     paths instead of editing in parallel. Never run discovery lanes
+     concurrently with active editor lanes: complete discovery before an editor
+     wave starts, or wait until the active editor wave is finished.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
@@ -102,14 +112,20 @@ Plan a PR batch
 4. Output
    - Return a concise "Batch Plan" and a fenced "Goal Prompt for pr-batch".
    - Keep the fenced goal prompt under ~4000 bytes total so bulky audit detail stays in the Batch Plan. Measure it, do not eyeball it: `wc -c` gives a locale-independent byte count (`wc -m` counts Unicode code points in a UTF-8 locale and bytes otherwise). Treat 4000 as an approximate budget.
-   - Budget for template overhead: the fixed template plus execution rules already consume roughly 3000 bytes before any items are filled in, leaving little room for the File-touch map and per-item content. Prefer splitting into multiple goals over trimming the safety, ownership, or review content.
-   - Keep full path evidence in the Batch Plan when it would bloat the prompt.
-     In the goal prompt, use the narrowest unambiguous directory/pattern summary
-     that still proves ownership. If compression would hide a collision or make
-     ownership unclear, mark the item `UNKNOWN` and run it serially.
+   - Measure the actual filled template overhead when the prompt is near the
+     byte budget; do not rely on a fixed estimate. Prefer splitting into
+     multiple goals over trimming the safety, ownership, or review content.
+   - Keep full path evidence in the Batch Plan when it would bloat the prompt,
+     but do not leave the worker handoff with an external-only pointer. In the
+     goal prompt, use the narrowest unambiguous directory/pattern summary that
+     still proves ownership, and include any exceptions, renames, deletes, or
+     collision-relevant exact paths inline. If compression would hide a collision
+     or make ownership unclear, mark the item `UNKNOWN` and run it serially.
    - Keep each filled entry terse (target ~150 chars for `Worker notes` and `Done when`). The worker reads the issue/PR URL for full detail; push evidence and audit notes to the Batch Plan instead.
    - If the batch will not fit, split it into smaller goals and output only the first ready goal.
-   - Do not start `$pr-batch` unless the user asks; then hand them the fenced goal prompt and tell them to run `$pr-batch` with it.
+   - Do not start `$pr-batch` unless the user asks; then hand them the fenced
+     goal prompt and any Batch Plan path appendix that the prompt explicitly
+     depends on, in the same request.
 
 ## Batch Plan Format
 
@@ -118,6 +134,7 @@ Plan a PR batch
 - Included items:
   - `PR #N` or `Issue #N`: title, URL, state, role in batch
 - Excluded or deferred:
+- File-touch map and path evidence:
 - Dependencies and sequencing:
 - Subagent split:
 - Concurrent activity and dependency status:
@@ -138,7 +155,7 @@ Repository: OWNER/REPO
 Batch objective: ...
 File-touch map:
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
-- PR/Issue #N -> summarized path pattern(s); full path list in Batch Plan (owner: lane/name)
+- PR/Issue #N -> summarized path pattern(s) plus collision-relevant exact paths/renames/deletes (owner: lane/name)
 - PR/Issue #N -> UNKNOWN (paths not determinable from issue body/design notes; treat as serial)
 # Batch-level reservations, not tied to a single item:
 - Deferred/reserved paths -> path(s) (reason: ... / later owner: lane/name)


### PR DESCRIPTION
## What

Two focused improvements to the `plan-pr-batch` skill, updated on current `main` after #3977's coordination workflow landed.

1. Require a file-touch map before fanning out parallel work. PR targets use verified target-repo refs, session-unique temporary refs, rename-aware changed-file lists, and a paginated PR Files API fallback; issue targets record proposed paths from issue/design notes, mark unknown paths as `UNKNOWN`, and treat unknown/colliding paths as serial.
2. Make the goal-prompt budget measurable as an approximate byte budget with `wc -c`, documented `wc -m` locale caveats, measured-overhead guidance, terse per-item guidance, and an explicit Batch Plan path-evidence slot.

## Scope

Docs-only change to `.agents/skills/plan-pr-batch/SKILL.md`. No CHANGELOG entry because this is internal agent tooling. This does not touch #3963-reserved docs areas.

## Agent Merge Confidence

Mode: accelerated-rc (#3823)
Current head SHA: 4cc62859e39c42ef62381ba3d20ebaa252b5a74d
Score: 9/10
Auto-merge recommendation: yes
Affected areas: plan-pr-batch skill/process docs
CI detector: `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs none.
Validation run:
- `/Users/justin/.codex/worktrees/7e0e/react_on_rails/node_modules/.bin/prettier --check .agents/skills/plan-pr-batch/SKILL.md` -> passed.
- `PATH=/tmp/lychee-v0.23.0:/Users/justin/.codex/worktrees/7e0e/react_on_rails/node_modules/.bin:$PATH lychee --config .lychee.toml .agents/skills/plan-pr-batch/SKILL.md` -> passed.
- `git diff --check` and `git diff --check origin/main...HEAD` -> passed.
- `script/ci-changes-detector origin/main` -> documentation-only, no CI jobs recommended.
- Pre-commit hooks passed through current head `4cc62859e39c42ef62381ba3d20ebaa252b5a74d`.
- Pre-push hooks passed for current head `4cc62859e39c42ef62381ba3d20ebaa252b5a74d` with repo-compatible lychee on `PATH`.
Review/check gate:
- GitHub checks: complete for current head `4cc62859e39c42ef62381ba3d20ebaa252b5a74d`; 12 pass / 2 skipped / 0 pending / 0 failed.
- Skips: `claude` workflow rows skipped after the `claude-review` check completed successfully; `docs-format-check` skipped by the Lint JS and Ruby selector while `detect-changes`, `build`, markdown checks, and CodeQL all passed.
- Review threads: GraphQL unresolved count is 0 for current head `4cc62859e39c42ef62381ba3d20ebaa252b5a74d`.
- Current-head reviewer verdicts: `claude-review` completed SUCCESS for current head; Cursor Bugbot and CodeRabbit are successful/advisory.
Feedback triage:
- Current-head review threads are resolved or triaged; no unresolved review debt remains.
- Earlier review fixes added verified base/head fetch guidance, temporary-ref cleanup behavior, cross-fork ref safety, Files API fallback guards, discovery-wave sequencing, shell quoting guidance, and prompt-size measurement corrections.
Labels: none. Documentation-only process update; path detector recommends no CI expansion.
Known residual risk: Low; this is internal docs/process guidance, with no runtime or release artifact changes.
Finalized by: GitHub `claude-review` / Claude Code Review check, completed SUCCESS for current head `4cc62859e39c42ef62381ba3d20ebaa252b5a74d` in run `27513994273`.

## Current Readiness

Merge-ready for current head `4cc62859e39c42ef62381ba3d20ebaa252b5a74d` after final live recheck: checks complete, merge state CLEAN, unresolved review-thread count 0, and no known blocker remains.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only internal agent skill update; no runtime, auth, or application code changes.
> 
> **Overview**
> **`plan-pr-batch` now requires a file-touch map before parallel fan-out**, with PR paths from verified-repo `git fetch` + three-dot rename-aware diffs (session-unique `refs/tmp/` refs, branch/OID validation, shallow deepen, cleanup) and a hardened paginated PR Files API fallback when git cannot run. Issues get paths from issue/design notes plus repo grep, with **`UNKNOWN` forcing serial discovery lanes** and collision-aware wave scheduling so only file-disjoint items run in parallel.
> 
> **Output and handoff tighten**: goal prompts use a **~4000-byte budget measured with `wc -c`**, measured template overhead, terse per-item fields, path evidence in the Batch Plan with compressed but collision-safe summaries in the prompt, and new **File-touch map** sections in the Batch Plan format and `pr-batch` goal template (owned paths only, disjoint waves). Common mistakes add no path guessing, no same-path parallel worktrees, and no eyeballing prompt length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc62859e39c42ef62381ba3d20ebaa252b5a74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

