### PR TITLE
Pin prerelease gems in create-react-on-rails-app

### DIFF
--- a/packages/create-react-on-rails-app/src/create-app.ts
+++ b/packages/create-react-on-rails-app/src/create-app.ts
@@ -136,11 +136,26 @@ function localGemPath(envVarName: string): string | null {
   return resolvedPath;
 }
 
-function bundleAddArgs(gemName: string, localPath: string | null, strict: boolean = true): string[] {
+function rubygemsPrereleaseVersion(cliVersion?: string): string | null {
+  if (!cliVersion || !cliVersion.includes('-')) {
+    return null;
+  }
+
+  return cliVersion.replace('-', '.');
+}
+
+function bundleAddArgs(
+  gemName: string,
+  localPath: string | null,
+  strict: boolean = true,
+  version: string | null = null,
+): string[] {
   const args = ['add', gemName];
 
   if (localPath) {
     args.push('--path', localPath);
+  } else if (version) {
+    args.push('--version', `= ${version}`);
   } else if (strict) {
     args.push('--strict');
   }
@@ -487,6 +502,7 @@ export function createApp(appName: string, options: CliOptions): void {
   let currentStep = 1;
   const reactOnRailsGemPath = localGemPath('REACT_ON_RAILS_GEM_PATH');
   const reactOnRailsProGemPath = proRequested ? localGemPath('REACT_ON_RAILS_PRO_GEM_PATH') : null;
+  const prereleaseGemVersion = rubygemsPrereleaseVersion(options.cliVersion);
 
   function educationalGitEnvForCommits(): NodeJS.ProcessEnv {
     if (!cachedEducationalGitEnv) {
@@ -544,7 +560,7 @@ export function createApp(appName: string, options: CliOptions): void {
   currentStep += 1;
   logStep(currentStep, totalSteps, 'Adding react_on_rails gem...');
   try {
-    const reactOnRailsArgs = bundleAddArgs('react_on_rails', reactOnRailsGemPath);
+    const reactOnRailsArgs = bundleAddArgs('react_on_rails', reactOnRailsGemPath, true, prereleaseGemVersion);
     if (reactOnRailsGemPath) {
       logInfo(`Using local react_on_rails gem path: ${reactOnRailsGemPath}`);
     }
@@ -570,7 +586,12 @@ export function createApp(appName: string, options: CliOptions): void {
     currentStep += 1;
     logStep(currentStep, totalSteps, `Adding react_on_rails_pro gem (${proModeLabel})...`);
     try {
-      const reactOnRailsProArgs = bundleAddArgs('react_on_rails_pro', reactOnRailsProGemPath, false);
+      const reactOnRailsProArgs = bundleAddArgs(
+        'react_on_rails_pro',
+        reactOnRailsProGemPath,
+        false,
+        prereleaseGemVersion,
+      );
       if (reactOnRailsProGemPath) {
         logInfo(`Using local react_on_rails_pro gem path: ${reactOnRailsProGemPath}`);
       }

--- a/packages/create-react-on-rails-app/src/index.ts
+++ b/packages/create-react-on-rails-app/src/index.ts
@@ -87,6 +87,7 @@ async function run(appName: string, rawOpts: Record<string, unknown>, command?: 
     rspack: webpackRequested ? false : (rawOpts.rspack ?? true) === true,
     pro,
     rsc,
+    cliVersion: packageJson.version,
   };
 
   if (options.rsc && options.pro) {

--- a/packages/create-react-on-rails-app/src/types.ts
+++ b/packages/create-react-on-rails-app/src/types.ts
@@ -4,6 +4,7 @@ export interface CliOptions {
   rspack: boolean;
   pro: boolean;
   rsc: boolean;
+  cliVersion?: string;
 }
 
 export interface ValidationResult {

--- a/packages/create-react-on-rails-app/tests/create-app.test.ts
+++ b/packages/create-react-on-rails-app/tests/create-app.test.ts
@@ -585,6 +585,35 @@ describe('createApp', () => {
     expect(processExitSpy).not.toHaveBeenCalled();
   });
 
+  it('pins react_on_rails to the matching RubyGems prerelease when create-app is a prerelease', () => {
+    const appPath = path.resolve(process.cwd(), 'my-app');
+
+    createApp('my-app', { ...baseOptions, cliVersion: '17.0.0-rc.2' });
+
+    expect(mockedExecLiveArgs).toHaveBeenCalledWith(
+      'bundle',
+      ['add', 'react_on_rails', '--version', '= 17.0.0.rc.2'],
+      appPath,
+    );
+  });
+
+  it('pins react_on_rails_pro to the matching RubyGems prerelease when create-app is a prerelease', () => {
+    const appPath = path.resolve(process.cwd(), 'my-app');
+
+    createApp('my-app', { ...baseOptions, rsc: true, cliVersion: '17.0.0-rc.2' });
+
+    expect(mockedExecLiveArgs).toHaveBeenCalledWith(
+      'bundle',
+      ['add', 'react_on_rails', '--version', '= 17.0.0.rc.2'],
+      appPath,
+    );
+    expect(mockedExecLiveArgs).toHaveBeenCalledWith(
+      'bundle',
+      ['add', 'react_on_rails_pro', '--version', '= 17.0.0.rc.2'],
+      appPath,
+    );
+  });
+
   it('creates a standard app without rsc', () => {
     const appPath = path.resolve(process.cwd(), 'my-app');
 


### PR DESCRIPTION
## Summary
- pass the create-react-on-rails-app package version into the scaffold flow
- pin Ruby gems to the matching RubyGems prerelease when the CLI itself is a prerelease
- keep stable releases on the existing behavior and keep local gem path overrides ahead of version pins

This fixes the rc.2 release-gate failure where `create-react-on-rails-app@17.0.0-rc.2` generated apps locked to stable `16.6.0` gems.

## Verification
- `pnpm --filter create-react-on-rails-app test`
- `pnpm --filter create-react-on-rails-app type-check`
- `pnpm --filter create-react-on-rails-app build`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `pnpm exec eslint --no-warn-ignored packages/create-react-on-rails-app/src/create-app.ts packages/create-react-on-rails-app/src/index.ts packages/create-react-on-rails-app/src/types.ts packages/create-react-on-rails-app/tests/create-app.test.ts`
- `bundle add react_on_rails --version "= 17.0.0.rc.2" --skip-install` in a temp Gemfile
- `bundle add react_on_rails_pro --version "= 17.0.0.rc.2" --skip-install` in a temp Gemfile
- local standard generated-app smoke from built CLI: Gemfile/Gemfile.lock/package.json pinned to rc.2
- local RSC generated-app smoke from built CLI: react_on_rails, react_on_rails_pro, react-on-rails-pro, and node renderer pinned to rc.2
- autoreview: clean, no actionable findings

## Notes
- `bundle exec rubocop` was attempted and is blocked by pre-existing offenses under `react_on_rails/spike/3313_prism_gemfile_rewriter/*`, unrelated to this TypeScript-only change.

Refs shakacode/react_on_rails#3823
Refs shakacode/react_on_rails#3898

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to create-app gem install args and version mapping; stable releases and local gem path overrides behave as before.
> 
> **Overview**
> When **create-react-on-rails-app** is a prerelease (version contains `-`), scaffold now passes the CLI version into `createApp` and runs `bundle add` with an explicit RubyGems version (npm `17.0.0-rc.2` → `= 17.0.0.rc.2`) for **react_on_rails** and **react_on_rails_pro**, so generated apps match the CLI instead of resolving to the latest stable gem.
> 
> Stable releases keep **`--strict`** on the OSS gem; **`REACT_ON_RAILS_*_GEM_PATH`** still uses **`--path`** and overrides version pins. Tests cover prerelease pinning for standard and RSC flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dad7d121fb3ea26761e114530ec241f2170c2a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now automatically installs matching prerelease versions of React on Rails gems when using a prerelease CLI version.

* **Tests**
  * Added test coverage for prerelease gem version pinning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->