### PR TITLE
Fix CI rerun mapping for split dummy app tests (#3909)

### DIFF
--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -214,10 +214,21 @@ fi
 
 # Map CI job names to identifiers
 # NOTE: Version numbers below must match .github/workflows/main.yml matrix configuration
+job_name_matches() {
+  local check="$1"
+  local job_pattern="$2"
+
+  [[ "$check" == $job_pattern ]] || [[ "$check" == $job_pattern* ]]
+}
+
 declare -A JOB_MAP
 JOB_MAP["lint-js-and-ruby"]="lint-js-and-ruby"
 JOB_MAP["rspec-package-tests"]="rspec-package-tests"
 JOB_MAP["package-js-tests"]="package-js-tests"
+# Split dummy app callers include build jobs too, so only match the reusable integration job.
+JOB_MAP["webpack-dummy-app-tests / dummy-app-integration-tests*"]="dummy-app-integration-tests"
+JOB_MAP["webpack-minimum-dummy-app-tests / dummy-app-integration-tests*"]="dummy-app-integration-tests"
+JOB_MAP["rspack-dummy-app-tests / dummy-app-integration-tests*"]="dummy-app-integration-tests"
 JOB_MAP["dummy-app-integration-tests (4.0, 22, latest)"]="dummy-app-integration-tests"
 JOB_MAP["dummy-app-integration-tests (3.3, 20, minimum)"]="dummy-app-integration-tests"
 JOB_MAP["examples"]="examples"
@@ -256,6 +267,9 @@ run_command() {
 # Map CI job names to human-readable versions.
 # Keep Shakapacker versions in sync with bin/ci-switch-config and SWITCHING_CI_CONFIGS.md.
 declare -A JOB_VERSION_MAP
+JOB_VERSION_MAP["webpack-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 4.0, Node 22, Shakapacker 10.1.0, React 19"
+JOB_VERSION_MAP["webpack-minimum-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 3.3, Node 20, Shakapacker 8.2.0, React 18"
+JOB_VERSION_MAP["rspack-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 4.0, Node 22, Shakapacker 10.1.0, React 19"
 JOB_VERSION_MAP["dummy-app-integration-tests (4.0, 22, latest)"]="Ruby 4.0, Node 22, Shakapacker 10.1.0, React 19"
 JOB_VERSION_MAP["dummy-app-integration-tests (3.3, 20, minimum)"]="Ruby 3.3, Node 20, Shakapacker 8.2.0, React 18"
 
@@ -263,7 +277,7 @@ JOB_VERSION_MAP["dummy-app-integration-tests (3.3, 20, minimum)"]="Ruby 3.3, Nod
 get_version_info() {
   local job_name="$1"
   for mapped_job_name in "${!JOB_VERSION_MAP[@]}"; do
-    if [[ "$job_name" == "$mapped_job_name"* ]]; then
+    if job_name_matches "$job_name" "$mapped_job_name"; then
       echo " (${JOB_VERSION_MAP[$mapped_job_name]})"
       return
     fi
@@ -283,8 +297,8 @@ declare -A COMMANDS_TO_RUN
 
 while IFS= read -r check; do
   for job_name in "${!JOB_MAP[@]}"; do
-    if [[ "$check" == "$job_name"* ]]; then
-      COMMANDS_TO_RUN["${JOB_MAP[$job_name]}"]="$job_name"
+    if job_name_matches "$check" "$job_name"; then
+      COMMANDS_TO_RUN["${JOB_MAP[$job_name]}"]="$check"
       break
     fi
   done

--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -218,6 +218,8 @@ job_name_matches() {
   local check="$1"
   local job_pattern="$2"
 
+  # Preserve historical prefix matching for exact keys; glob keys that already
+  # end in * match through the first condition.
   [[ "$check" == $job_pattern ]] || [[ "$check" == $job_pattern* ]]
 }
 
@@ -269,7 +271,7 @@ run_command() {
 declare -A JOB_VERSION_MAP
 JOB_VERSION_MAP["webpack-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 4.0, Node 22, Shakapacker 10.1.0, React 19"
 JOB_VERSION_MAP["webpack-minimum-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 3.3, Node 20, Shakapacker 8.2.0, React 18"
-JOB_VERSION_MAP["rspack-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 4.0, Node 22, Shakapacker 10.1.0, React 19"
+JOB_VERSION_MAP["rspack-dummy-app-tests / dummy-app-integration-tests*"]="Ruby 4.0, Node 22, React 19 (rspack)"
 JOB_VERSION_MAP["dummy-app-integration-tests (4.0, 22, latest)"]="Ruby 4.0, Node 22, Shakapacker 10.1.0, React 19"
 JOB_VERSION_MAP["dummy-app-integration-tests (3.3, 20, minimum)"]="Ruby 3.3, Node 20, Shakapacker 8.2.0, React 18"
 


### PR DESCRIPTION
Closes #3909

## Summary

- Updates `bin/ci-rerun-failures` so split webpack/rspack dummy app integration checks map back to the existing local dummy-app rerun command.
- Matches the stable `*-dummy-app-tests / dummy-app-integration-tests*` check prefix instead of the old single `dummy-app-integration-tests (...)` naming shape.
- Keeps build-bundle checks and bare caller names out of the integration rerun mapping.
- Defers the AGENTS/pr-processing CI-name-impact checklist gate text per batch scope.

## Validation

- `bash -n bin/ci-rerun-failures` -> passed
- `/opt/homebrew/bin/bash -n bin/ci-rerun-failures` -> passed
- mapping harness -> webpack, webpack-minimum, and rspack split dummy integration names map to `dummy-app-integration-tests` / `bundle exec rake run_rspec:all_dummy`; build jobs and bare caller names do not match
- `git diff --check -- bin/ci-rerun-failures` -> passed
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> passed
- pre-commit hook -> passed
- `codex review --base origin/main` -> clean, no actionable findings
- `script/ci-changes-detector origin/main` -> CI infrastructure; recommends full test suite, no benchmarks

Labels: full-ci. This changes CI tooling that maps GitHub check names to local reruns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI developer-tooling only; no runtime app, auth, or production behavior changes.
> 
> **Overview**
> Updates **`bin/ci-rerun-failures`** so failed GitHub checks from the **split webpack / webpack-minimum / rspack dummy-app workflows** map to the existing local **`dummy-app-integration-tests`** rerun (`run_rspec:all_dummy`), using stable check names like `webpack-dummy-app-tests / dummy-app-integration-tests*`.
> 
> Introduces **`job_name_matches`** for consistent prefix/glob matching across **`JOB_MAP`**, **`JOB_VERSION_MAP`**, and command deduplication. Patterns are scoped to the reusable integration job so **build-bundle** checks and bare caller names are not pulled into the integration mapping. When building the rerun list, the script now keeps the **actual failed check name** for display instead of the map key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98451b52499abbf72ac3bd1fd2db484cfd95bc26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI job-name matching to handle wildcard/prefix variants, ensuring failed checks map more accurately to local rerun commands.
  * Updated logic for selecting and displaying version info for failed CI checks so variant-specific Ruby/Node/packager/React versions show correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->