### PR TITLE
Docs: fix Node Renderer Kubernetes probes

### DIFF
--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -425,14 +425,20 @@ containers:
       initialDelaySeconds: 10
       periodSeconds: 5
       failureThreshold: 6
+      timeoutSeconds: 1
     readinessProbe:
+      # tcpSocket is a shallow fallback: port reachability only, not application readiness.
       tcpSocket:
         port: 3800
       periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 1
     livenessProbe:
       tcpSocket:
         port: 3800
-      periodSeconds: 30
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 1
 ```
 
 > **Note:** `REACT_RENDERER_URL` must be read in your initializer for it to take effect:
@@ -452,7 +458,7 @@ When running the Node Renderer in containers:
 - On Control Plane, use `process.env.PORT` for the port — Control Plane assigns the port dynamically. See the [Control Plane port docs](https://docs.controlplane.com/reference/workload/containers#port-variable).
 - Set `workersCount` explicitly rather than relying on CPU auto-detection, which can over-allocate workers in constrained containers.
 - Use `tcpSocket` probes for shallow Kubernetes startup, readiness, and liveness checks. Kubernetes `httpGet` probes use HTTP/1.1 and cannot check the h2c-only Node Renderer listener directly.
-- For endpoint-style renderer checks, use an `exec` probe with an h2c-capable client packaged in the renderer image, or expose a separate HTTP/1.1 health endpoint in your own application code. See [Configuring Startup, Readiness, and Liveness Probes](../building-features/node-renderer/js-configuration.md#configuring-startup-readiness-and-liveness-probes) for timing values and `curl --http2-prior-knowledge` examples.
+- The manifest above uses portable `tcpSocket` checks. For application-level readiness, use an `exec` probe with an h2c-capable client packaged in the renderer image, or expose a separate HTTP/1.1 health endpoint in your own application code. See [Configuring Startup, Readiness, and Liveness Probes](../building-features/node-renderer/js-configuration.md#configuring-startup-readiness-and-liveness-probes) for timing values and `curl --http2-prior-knowledge` examples.
 
 ## Static assets and CDN
 

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -427,6 +427,8 @@ containers:
       failureThreshold: 6
       timeoutSeconds: 1
     readinessProbe:
+      # Omits initialDelaySeconds: startupProbe above defers readiness/liveness until boot succeeds (K8s 1.20+).
+      # If you skip startupProbe or run an older cluster, add initialDelaySeconds to cover the boot window.
       # tcpSocket is a shallow fallback: port reachability only, not application readiness.
       tcpSocket:
         port: 3800

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -420,9 +420,13 @@ containers:
       - name: RENDERER_PORT
         value: '3800'
     readinessProbe:
-      httpGet:
-        path: /health
+      tcpSocket:
         port: 3800
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 3800
+      periodSeconds: 30
 ```
 
 > **Note:** `REACT_RENDERER_URL` must be read in your initializer for it to take effect:
@@ -441,7 +445,8 @@ When running the Node Renderer in containers:
 - Set `host` to `0.0.0.0` so health checks and the Rails container can reach it. See [Node Renderer configuration](../building-features/node-renderer/js-configuration.md).
 - On Control Plane, use `process.env.PORT` for the port — Control Plane assigns the port dynamically. See the [Control Plane port docs](https://docs.controlplane.com/reference/workload/containers#port-variable).
 - Set `workersCount` explicitly rather than relying on CPU auto-detection, which can over-allocate workers in constrained containers.
-- Add a `/health` endpoint for container orchestrator probes. See [Adding a Health Check Endpoint](../building-features/node-renderer/js-configuration.md#adding-a-health-check-endpoint).
+- Use `tcpSocket` probes for shallow Kubernetes readiness and liveness checks. Kubernetes `httpGet` probes use HTTP/1.1 and cannot check the h2c-only Node Renderer listener directly.
+- For endpoint-style renderer checks, use an `exec` probe with an h2c-capable client packaged in the renderer image, or expose a separate HTTP/1.1 health endpoint in your own application code.
 
 ## Static assets and CDN
 

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -419,6 +419,12 @@ containers:
         value: '0.0.0.0'
       - name: RENDERER_PORT
         value: '3800'
+    startupProbe:
+      tcpSocket:
+        port: 3800
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      failureThreshold: 6
     readinessProbe:
       tcpSocket:
         port: 3800
@@ -445,8 +451,8 @@ When running the Node Renderer in containers:
 - Set `host` to `0.0.0.0` so health checks and the Rails container can reach it. See [Node Renderer configuration](../building-features/node-renderer/js-configuration.md).
 - On Control Plane, use `process.env.PORT` for the port — Control Plane assigns the port dynamically. See the [Control Plane port docs](https://docs.controlplane.com/reference/workload/containers#port-variable).
 - Set `workersCount` explicitly rather than relying on CPU auto-detection, which can over-allocate workers in constrained containers.
-- Use `tcpSocket` probes for shallow Kubernetes readiness and liveness checks. Kubernetes `httpGet` probes use HTTP/1.1 and cannot check the h2c-only Node Renderer listener directly.
-- For endpoint-style renderer checks, use an `exec` probe with an h2c-capable client packaged in the renderer image, or expose a separate HTTP/1.1 health endpoint in your own application code.
+- Use `tcpSocket` probes for shallow Kubernetes startup, readiness, and liveness checks. Kubernetes `httpGet` probes use HTTP/1.1 and cannot check the h2c-only Node Renderer listener directly.
+- For endpoint-style renderer checks, use an `exec` probe with an h2c-capable client packaged in the renderer image, or expose a separate HTTP/1.1 health endpoint in your own application code. See [Configuring Startup, Readiness, and Liveness Probes](../building-features/node-renderer/js-configuration.md#configuring-startup-readiness-and-liveness-probes) for timing values and `curl --http2-prior-knowledge` examples.
 
 ## Static assets and CDN
 

--- a/docs/oss/deployment/docker-deployment.md
+++ b/docs/oss/deployment/docker-deployment.md
@@ -434,6 +434,8 @@ containers:
       failureThreshold: 3
       timeoutSeconds: 1
     livenessProbe:
+      # tcpSocket is port-open only; a hung event loop can still pass. For stricter hung-process
+      # detection, use an exec probe with curl --http2-prior-knowledge and a short --max-time.
       tcpSocket:
         port: 3800
       periodSeconds: 10

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16762,6 +16762,8 @@ containers:
       failureThreshold: 3
       timeoutSeconds: 1
     livenessProbe:
+      # tcpSocket is port-open only; a hung event loop can still pass. For stricter hung-process
+      # detection, use an exec probe with curl --http2-prior-knowledge and a short --max-time.
       tcpSocket:
         port: 3800
       periodSeconds: 10

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16755,6 +16755,8 @@ containers:
       failureThreshold: 6
       timeoutSeconds: 1
     readinessProbe:
+      # Omits initialDelaySeconds: startupProbe above defers readiness/liveness until boot succeeds (K8s 1.20+).
+      # If you skip startupProbe or run an older cluster, add initialDelaySeconds to cover the boot window.
       # tcpSocket is a shallow fallback: port reachability only, not application readiness.
       tcpSocket:
         port: 3800

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16747,10 +16747,26 @@ containers:
         value: '0.0.0.0'
       - name: RENDERER_PORT
         value: '3800'
-    readinessProbe:
-      httpGet:
-        path: /health
+    startupProbe:
+      tcpSocket:
         port: 3800
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      failureThreshold: 6
+      timeoutSeconds: 1
+    readinessProbe:
+      # tcpSocket is a shallow fallback: port reachability only, not application readiness.
+      tcpSocket:
+        port: 3800
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 1
+    livenessProbe:
+      tcpSocket:
+        port: 3800
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 1
 ```
 
 > **Note:** `REACT_RENDERER_URL` must be read in your initializer for it to take effect:
@@ -16769,7 +16785,8 @@ When running the Node Renderer in containers:
 - Set `host` to `0.0.0.0` so health checks and the Rails container can reach it. See [Node Renderer configuration](../building-features/node-renderer/js-configuration.md).
 - On Control Plane, use `process.env.PORT` for the port — Control Plane assigns the port dynamically. See the [Control Plane port docs](https://docs.controlplane.com/reference/workload/containers#port-variable).
 - Set `workersCount` explicitly rather than relying on CPU auto-detection, which can over-allocate workers in constrained containers.
-- Add a `/health` endpoint for container orchestrator probes. See [Adding a Health Check Endpoint](../building-features/node-renderer/js-configuration.md#adding-a-health-check-endpoint).
+- Use `tcpSocket` probes for shallow Kubernetes startup, readiness, and liveness checks. Kubernetes `httpGet` probes use HTTP/1.1 and cannot check the h2c-only Node Renderer listener directly.
+- The manifest above uses portable `tcpSocket` checks. For application-level readiness, use an `exec` probe with an h2c-capable client packaged in the renderer image, or expose a separate HTTP/1.1 health endpoint in your own application code. See [Configuring Startup, Readiness, and Liveness Probes](../building-features/node-renderer/js-configuration.md#configuring-startup-readiness-and-liveness-probes) for timing values and `curl --http2-prior-knowledge` examples.
 
 ## Static assets and CDN
 


### PR DESCRIPTION
## Summary

- Replace the broken Node Renderer Kubernetes `httpGet /health` readiness probe example with `tcpSocket` readiness/liveness probes on port 3800.
- Document why Kubernetes `httpGet` probes cannot check the h2c-only Node Renderer listener directly.
- Point endpoint-style renderer checks at `exec` probes with an h2c-capable client, or a separate HTTP/1.1 health endpoint owned by application code.

Refs #3880. This is the docs-only split from the issue; it intentionally does not implement health endpoints and should leave #3880 open for feature work.

## Decision log

- Used `tcpSocket` in the copy-paste manifest because it works with the current h2c listener and requires no new endpoint.
- Kept endpoint guidance as prose instead of adding a fake `/health` route, per the issue triage.

## Validation

- `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none.
- `script/check-docs-sidebar` -> pass.
- `pnpm start format.listDifferent` -> pass.
- `git diff --check origin/main...HEAD` -> pass.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> pass, 214 files inspected, no offenses detected.
- Pre-push `markdown-links` online lychee on changed Markdown file -> pass.
- Targeted scan of `docs/oss/deployment/docker-deployment.md` -> no `path: /health` or “Add a `/health` endpoint” guidance remains.
- `codex review --base origin/main` -> clean: no actionable regression found in the h2c/probe docs change.

## Labels

Labels: none. This is docs-only and the CI detector recommends no CI expansion.

## Release mode note

Release tracker #3823 is currently `accelerated-rc`. This PR is ready for normal review/check routing, but auto-merge still requires the live accelerated-RC merge gate from `AGENTS.md` before merge: current-head checks/review state, unresolved thread sweep, and an independent finalizer if auto-merge is used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deployment examples; no application or runtime behavior is modified.
> 
> **Overview**
> Updates **Node Renderer in containers** Kubernetes guidance so the copy-paste sidecar example no longer uses `httpGet` on `/health`.
> 
> The manifest now defines **startup**, **readiness**, and **liveness** probes as `tcpSocket` checks on port **3800**, with timing/thresholds and inline notes on startup-probe deferral and the limits of port-only checks. Container configuration bullets explain that Kubernetes `httpGet` (HTTP/1.1) cannot probe the renderer’s **h2c-only** listener, and point to **exec** probes with `curl --http2-prior-knowledge` or a separate HTTP/1.1 health endpoint for stricter readiness. The prior “add a `/health` endpoint” instruction is removed. The same edits are reflected in the regenerated **`llms-full.txt`** aggregate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 770a9935c3c4646b227b3e3015591033658a94cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes deployment guidance for Node Renderer containers: health checks now recommend TCP socket probes on port 3800 with explicit startup, readiness and liveness timing/thresholds; prefer tcpSocket for lightweight checks; document alternatives for application-level readiness via an exec probe (using an h2c-capable client) or a separate HTTP/1.1 health endpoint; removed prior /health HTTP endpoint instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: 770a9935c3c4646b227b3e3015591033658a94cb
Score: 9/10
Auto-merge recommendation: yes
Affected areas: OSS deployment docs, llms-full aggregate docs
CI detector: `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none
Validation run:
- Rebased on current `origin/main` after #3903 and #3931 merged
- `node script/generate-llms-full.mjs` -> regenerated `llms-full.txt` on current main
- `node script/generate-llms-full.mjs --check` -> pass, 145 pages, 2036 KiB, 72 docs URLs validated
- `script/check-docs-sidebar` -> pass
- `pnpm start format.listDifferent` -> pass
- `git diff --check origin/main...HEAD` -> pass
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> pass, 218 files inspected, no offenses detected
- Pre-push `markdown-links` online lychee on changed Markdown file -> pass
Review/check gate:
- GitHub checks: complete for `770a9935c3c4646b227b3e3015591033658a94cb`; `build` skipped by docs-only `detect-changes`; all other current-head checks passing
- Review threads: GraphQL unresolved count is 0 after addressing the current-head Claude comments on shallow liveness checks and startupProbe timing
- Current-head reviewer verdicts:
  - Claude review: complete for `770a9935c3c4646b227b3e3015591033658a94cb`, no confirmed blocker; check `claude-review` SUCCESS at https://github.com/shakacode/react_on_rails/actions/runs/27405576438/job/80993791215
  - Cursor Bugbot: SUCCESS for current head
  - CodeRabbit: SUCCESS
Known residual risk: none beyond docs wording risk; no runtime behavior changed
Finalized by: `claude-review` check SUCCESS for current head SHA, GitHub Actions job https://github.com/shakacode/react_on_rails/actions/runs/27405576438/job/80993791215
