### PR TITLE
Docs: modernize the getting-started tutorial

### DIFF
--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -35,8 +35,9 @@ bundle add react_on_rails --strict
 # Run the installer for TypeScript
 bin/rails generate react_on_rails:install --typescript
 
-# Optional: Use Rspack for faster builds
-# bin/rails generate react_on_rails:install --typescript --rspack
+# Fresh installs use Rspack by default when supported.
+# To force Webpack instead, pass --no-rspack:
+# bin/rails generate react_on_rails:install --typescript --no-rspack
 
 # For JavaScript instead of TypeScript, omit --typescript
 # bin/rails generate react_on_rails:install

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -13,7 +13,7 @@ Before starting, make sure you have:
 
 - **🚨 React on Rails 17.0.0+** (this guide)
 - **🚨 Shakapacker 6+** (7+ recommended for React on Rails 17)
-- **Rails 7+** application (Rails 5.2+ supported)
+- **Rails 7+** application
 - **Ruby 3.3+** (required)
 - **Node.js 18+** and a package manager (**npm**, **pnpm**, **Yarn**, or **bun**)
 - **Foreman or Overmind** (for running `bin/dev`)
@@ -196,7 +196,7 @@ Now that you have React on Rails working, here's what to explore next:
 
 ### Dive Deeper
 
-1. **[Complete Tutorial](../getting-started/tutorial.md)** - Build a full app with Redux
+1. **[Complete Tutorial](../getting-started/tutorial.md)** - Build a TypeScript component with hooks and auto-bundling
 2. **[Server-Side Rendering](../core-concepts/react-server-rendering.md)** - Optimize for SEO and performance
 3. **[Production Deployment](../deployment/README.md)** - Deploy to production
 

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -58,7 +58,7 @@ Take a look at the files created by the generator.
 
 - Component files (`.tsx` for TypeScript, `.jsx` for JavaScript)
 - Shakapacker install
-- React component files in `client/`
+- React component files in `app/javascript/src/`
 - A sample controller and view
 - Bundler configuration
 

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -12,7 +12,7 @@ This guide will have you rendering React components in your Rails app as quickly
 Before starting, make sure you have:
 
 - **🚨 React on Rails 17.0.0+** (this guide)
-- **🚨 Shakapacker 6+** (7+ recommended for React on Rails 17)
+- **Shakapacker 6+** — installed automatically by the React on Rails generator (7+ recommended for React on Rails 17)
 - **Rails 7+** application
 - **Ruby 3.3+** (required)
 - **Node.js 18+** and a package manager (**npm**, **pnpm**, **Yarn**, or **bun**)
@@ -60,9 +60,9 @@ Take a look at the files created by the generator.
 - Shakapacker install
 - React component files in `client/`
 - A sample controller and view
-- Webpack configuration
+- Bundler configuration
 
-> 💡 **Performance Tip:** Add the `--rspack` flag for significantly faster builds (~20x improvement). You can also switch bundlers later with `bin/switch-bundler rspack`.
+> 💡 **Performance Tip:** Fresh installs use Rspack by default when supported for significantly faster builds. To compare or temporarily force Webpack, run the installer with `--no-rspack`; you can also switch bundlers later with `bin/switch-bundler`.
 >
 > **Note on `bin/switch-bundler`:** This utility safely switches between webpack and rspack by updating `shakapacker.yml` and managing dependencies. However, it does not modify custom webpack configuration code. If you have custom webpack plugins or loaders, you may need to update those manually to work with rspack. See [Rspack documentation](../api-reference/generator-details.md#rspack-support) for details on unified configuration patterns.
 
@@ -73,7 +73,7 @@ Take a look at the files created by the generator.
 > - **overmind**: `brew install overmind` (macOS) or see [installation guide](https://github.com/DarthSim/overmind#installation)
 > - **foreman**: `gem install foreman` (install globally, not in your project bundle - [details](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman))
 
-Start both Rails and the Webpack dev server:
+Start both Rails and the bundler dev server:
 
 ```bash
 ./bin/dev
@@ -82,7 +82,7 @@ Start both Rails and the Webpack dev server:
 This starts both:
 
 - Rails server on `http://localhost:3000`
-- Webpack dev server for hot reloading
+- Bundler dev server for hot reloading
 
 ## 🎨 Step 3: See Your Component (2 minutes)
 

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -62,7 +62,7 @@ Take a look at the files created by the generator.
 - A sample controller and view
 - Bundler configuration
 
-> 💡 **Performance Tip:** Fresh installs use Rspack by default when supported for significantly faster builds. To compare or temporarily force Webpack, run the installer with `--no-rspack`; you can also switch bundlers later with `bin/switch-bundler`.
+> 💡 **Performance Tip:** Fresh installs use Rspack by default when supported for significantly faster builds. To compare or temporarily force Webpack, run the installer with `--no-rspack`; you can also switch bundlers later with `bin/switch-bundler webpack` or `bin/switch-bundler rspack`.
 >
 > **Note on `bin/switch-bundler`:** This utility safely switches between webpack and rspack by updating `shakapacker.yml` and managing dependencies. However, it does not modify custom webpack configuration code. If you have custom webpack plugins or loaders, you may need to update those manually to work with rspack. See [Rspack documentation](../api-reference/generator-details.md#rspack-support) for details on unified configuration patterns.
 

--- a/docs/oss/getting-started/quick-start.md
+++ b/docs/oss/getting-started/quick-start.md
@@ -35,7 +35,7 @@ bundle add react_on_rails --strict
 # Run the installer for TypeScript
 bin/rails generate react_on_rails:install --typescript
 
-# Fresh installs use Rspack by default when supported.
+# Fresh installs use Rspack by default when supported (Shakapacker 9+).
 # To force Webpack instead, pass --no-rspack:
 # bin/rails generate react_on_rails:install --typescript --no-rspack
 
@@ -62,7 +62,7 @@ Take a look at the files created by the generator.
 - A sample controller and view
 - Bundler configuration
 
-> 💡 **Performance Tip:** Fresh installs use Rspack by default when supported for significantly faster builds. To compare or temporarily force Webpack, run the installer with `--no-rspack`; you can also switch bundlers later with `bin/switch-bundler webpack` or `bin/switch-bundler rspack`.
+> 💡 **Performance Tip:** Fresh installs use Rspack by default when supported by your Shakapacker version (9+) for significantly faster builds. To compare or temporarily force Webpack, run the installer with `--no-rspack`; you can also switch bundlers later with `bin/switch-bundler webpack` or `bin/switch-bundler rspack`.
 >
 > **Note on `bin/switch-bundler`:** This utility safely switches between webpack and rspack by updating `shakapacker.yml` and managing dependencies. However, it does not modify custom webpack configuration code. If you have custom webpack plugins or loaders, you may need to update those manually to work with rspack. See [Rspack documentation](../api-reference/generator-details.md#rspack-support) for details on unified configuration patterns.
 

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -228,7 +228,6 @@ Then add `prerender: true` in the Rails view:
 
 > [!NOTE]
 > `prerender: true` needs a server bundle. For a first local SSR check, use `./bin/dev static` or run a production precompile. If you want the dev server to serve the prerender bundle, follow the [HMR guide](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) and set `config.same_bundle_for_client_and_server = true` for that mode.
-
 > [!WARNING]
 > Server rendering runs in Node or ExecJS, which has no browser globals (`window`, `document`, `localStorage`). Guard browser-only access inside a `useEffect` hook or a conditional on `typeof window !== 'undefined'`.
 

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -160,7 +160,12 @@ If your app sets `config.auto_load_bundle = true` in `config/initializers/react_
 <%= react_component("Counter", props: @counter_props) %>
 ```
 
-The generated `react_on_rails_default` layout includes the Shakapacker tags that auto-bundling needs. If you render from your application's default layout instead, add the same `stylesheet_pack_tag` and `javascript_pack_tag` placeholders there.
+The generated `react_on_rails_default` layout includes the Shakapacker tags that auto-bundling needs. If you render from your application's default layout instead, add the same argless pack-tag calls there:
+
+```erb
+<%= stylesheet_pack_tag %>
+<%= javascript_pack_tag %>
+```
 
 If `app/views/layouts/react_on_rails_default.html.erb` is not present (for example, you added React on Rails manually to an existing app without running the installer), remove the `layout` line from the controller and add the pack-tag placeholders to the layout that renders this view.
 
@@ -281,7 +286,11 @@ Run `./bin/dev`, not only `bin/rails server`. The dev command starts both Rails 
 
 ### Server Rendering Fails
 
-Temporarily set `prerender: false` to confirm the browser render works, then remove browser-only APIs from the server render path. You can also enable `trace: true` on `react_component` while debugging.
+Temporarily set `prerender: false` to confirm the browser render works, then remove browser-only APIs from the server render path. You can also enable `trace: true` on `react_component` while debugging:
+
+```erb
+<%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true, trace: true) %>
+```
 
 ## Appendix: Redux Integration
 
@@ -300,6 +309,8 @@ When rendering a Redux-backed component, the Rails side still uses the same view
 ```erb
 <%= react_component("HelloWorldApp", props: @hello_world_props, auto_load_bundle: true) %>
 ```
+
+The component is named `HelloWorldApp` because that is what the Redux installer generates. Adjust the component name and props key to match your app's controller setup.
 
 For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [Redux integration guide](../building-features/react-and-redux.md).
 

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -130,7 +130,7 @@ Add a controller action if you do not already have one:
 bin/rails generate controller Dashboard show
 ```
 
-In `app/controllers/dashboard_controller.rb`, set props for React. The Quick Start installer creates `react_on_rails_default`, which includes the generated bundle placeholders:
+In `app/controllers/dashboard_controller.rb`, set props for React. The Quick Start installer creates `react_on_rails_default`, which includes the generated bundle placeholders. If that layout is missing, use the fallback note below before copying this controller:
 
 ```ruby
 class DashboardController < ApplicationController
@@ -166,6 +166,8 @@ The generated `react_on_rails_default` layout includes the Shakapacker tags that
 <%= stylesheet_pack_tag %>
 <%= javascript_pack_tag %>
 ```
+
+With no pack name, Shakapacker renders every bundle accumulated by `append_javascript_pack_tag` and `append_stylesheet_pack_tag`, which lets auto-bundling load per-component packs without hardcoding generated pack names in the layout.
 
 If `app/views/layouts/react_on_rails_default.html.erb` is not present (for example, you added React on Rails manually to an existing app without running the installer), remove the `layout` line from the controller and add the pack-tag placeholders to your `application.html.erb` or whichever layout renders this view.
 
@@ -217,6 +219,8 @@ The server file can re-export the same component when no special server behavior
 ```tsx
 export { default } from './Counter.client';
 ```
+
+The generated TypeScript config uses bundler module resolution, so the extensionless re-export matches the installer defaults. If your app uses a stricter custom Node ESM TypeScript setup, use the relative import extension style required by that config.
 
 Auto-bundling discovers `Counter.server.tsx` and includes it in the generated server bundle. You do not need to change `config.server_bundle_js_file` when the generated `server-bundle.js` entrypoint is already in place.
 

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -9,7 +9,7 @@ This tutorial starts from the [Quick Start](./quick-start.md) app and builds a s
 - `bin/dev` with HMR during development
 - Optional server rendering with `prerender: true`
 
-Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux integration](#appendix-redux-integration) when you need a shared client store or you are maintaining an existing Redux setup.
+Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux Integration](#appendix-redux-integration) when you need a shared client store or you are maintaining an existing Redux setup.
 
 ## Table of Contents
 
@@ -93,7 +93,7 @@ mkdir -p app/javascript/src/Counter/ror_components
 Add `app/javascript/src/Counter/ror_components/Counter.client.tsx`:
 
 ```tsx
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 type CounterProps = {
   initialCount?: number;
@@ -102,7 +102,7 @@ type CounterProps = {
 
 export default function Counter({ initialCount = 0, label = 'Counter' }: CounterProps) {
   const [count, setCount] = useState(initialCount);
-  const doubled = useMemo(() => count * 2, [count]);
+  const doubled = count * 2;
 
   return (
     <section>
@@ -132,7 +132,7 @@ Add a controller action if you do not already have one:
 bin/rails generate controller Dashboard show
 ```
 
-In `app/controllers/dashboard_controller.rb`, set props for React:
+In `app/controllers/dashboard_controller.rb`, set props for React. The Quick Start installer creates `react_on_rails_default`, which includes the generated bundle placeholders:
 
 ```ruby
 class DashboardController < ApplicationController
@@ -162,6 +162,8 @@ If your app sets `config.auto_load_bundle = true` in `config/initializers/react_
 ```
 
 The generated `react_on_rails_default` layout includes the Shakapacker tags that auto-bundling needs. If you render from your application's default layout instead, add the same `stylesheet_pack_tag` and `javascript_pack_tag` placeholders there.
+
+If `app/views/layouts/react_on_rails_default.html.erb` is not present in your app, remove the `layout` line from the controller and add the pack-tag placeholders to the layout that renders this view.
 
 ## Run The App With HMR
 
@@ -218,7 +220,7 @@ Then add `prerender: true` in the Rails view:
 <%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true) %>
 ```
 
-Server rendering runs in Node or ExecJS, so browser globals such as `window`, `document`, and `localStorage` must stay inside effects or client-only branches:
+Server rendering runs in Node or ExecJS, so browser globals such as `window`, `document`, and `localStorage` must stay inside effects or client-only branches. This standalone example shows the pattern; you do not need to add it for the Counter tutorial:
 
 ```tsx
 import React, { useEffect, useState } from 'react';

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -102,7 +102,6 @@ type CounterProps = {
 
 export default function Counter({ initialCount = 0, label = 'Counter' }: CounterProps) {
   const [count, setCount] = useState(initialCount);
-  const doubled = count * 2;
 
   return (
     <section>
@@ -110,7 +109,6 @@ export default function Counter({ initialCount = 0, label = 'Counter' }: Counter
       <p>
         Count: <strong>{count}</strong>
       </p>
-      <p>Double: {doubled}</p>
       <button type="button" onClick={() => setCount((current) => current + 1)}>
         Increment
       </button>
@@ -140,6 +138,7 @@ class DashboardController < ApplicationController
 
   def show
     @counter_props = {
+      # React props use camelCase; react_component serializes this hash to JSON.
       initialCount: 3,
       label: "Orders ready"
     }
@@ -163,7 +162,7 @@ If your app sets `config.auto_load_bundle = true` in `config/initializers/react_
 
 The generated `react_on_rails_default` layout includes the Shakapacker tags that auto-bundling needs. If you render from your application's default layout instead, add the same `stylesheet_pack_tag` and `javascript_pack_tag` placeholders there.
 
-If `app/views/layouts/react_on_rails_default.html.erb` is not present in your app, remove the `layout` line from the controller and add the pack-tag placeholders to the layout that renders this view.
+If `app/views/layouts/react_on_rails_default.html.erb` is not present (for example, you added React on Rails manually to an existing app without running the installer), remove the `layout` line from the controller and add the pack-tag placeholders to the layout that renders this view.
 
 ## Run The App With HMR
 
@@ -214,27 +213,19 @@ The server file can re-export the same component when no special server behavior
 export { default } from './Counter.client';
 ```
 
+Auto-bundling discovers `Counter.server.tsx` and includes it in the generated server bundle. You do not need to change `config.server_bundle_js_file` when the generated `server-bundle.js` entrypoint is already in place.
+
 Then add `prerender: true` in the Rails view:
 
 ```erb
 <%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true) %>
 ```
 
-Server rendering runs in Node or ExecJS, so browser globals such as `window`, `document`, and `localStorage` must stay inside effects or client-only branches. This standalone example shows the pattern; you do not need to add it for the Counter tutorial:
+> [!NOTE]
+> `prerender: true` needs a server bundle. For a first local SSR check, use `./bin/dev static` or run a production precompile. If you want the dev server to serve the prerender bundle, follow the [HMR guide](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) and set `config.same_bundle_for_client_and_server = true` for that mode.
 
-```tsx
-import React, { useEffect, useState } from 'react';
-
-export default function BrowserTime() {
-  const [timeZone, setTimeZone] = useState('UTC');
-
-  useEffect(() => {
-    setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
-  }, []);
-
-  return <p>Your browser time zone is {timeZone}.</p>;
-}
-```
+> [!WARNING]
+> Server rendering runs in Node or ExecJS, which has no browser globals (`window`, `document`, `localStorage`). Guard browser-only access inside a `useEffect` hook or a conditional on `typeof window !== 'undefined'`.
 
 For deeper SSR guidance, see [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md) and [React Server Rendering](../core-concepts/react-server-rendering.md).
 
@@ -244,6 +235,12 @@ Before deploying, run the production asset pipeline locally once:
 
 ```bash
 RAILS_ENV=production NODE_ENV=production bin/rails assets:precompile
+```
+
+After verifying the production build locally, remove compiled assets before returning to development:
+
+```bash
+bin/rails assets:clobber
 ```
 
 For deployment details, see:
@@ -311,6 +308,6 @@ For manually wired stores or advanced store sharing, use the [`redux_store` help
 - [Using React on Rails](./using-react-on-rails.md)
 - [Auto-Bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
 - [View Helpers API](../api-reference/view-helpers-api.md)
-- [Hot Module Replacement](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md)
+- [Hot Module Replacement (HMR)](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md)
 - [Server Rendering](../core-concepts/react-server-rendering.md)
 - [Production Deployment](../deployment/README.md)

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -228,7 +228,6 @@ Then add `prerender: true` in the Rails view:
 
 > [!NOTE]
 > `prerender: true` needs a server bundle. For a first local SSR check, use `./bin/dev static` or run a production precompile. If you want the dev server to serve the prerender bundle, follow the [HMR guide](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) and set `config.same_bundle_for_client_and_server = true` for that mode.
-> [!WARNING]
 > Server rendering runs in Node or ExecJS, which has no browser globals (`window`, `document`, `localStorage`). Guard browser-only access inside a `useEffect` hook or a conditional on `typeof window !== 'undefined'`.
 
 For deeper SSR guidance, see [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md) and [React Server Rendering](../core-concepts/react-server-rendering.md).

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -167,7 +167,7 @@ The generated `react_on_rails_default` layout includes the Shakapacker tags that
 <%= javascript_pack_tag %>
 ```
 
-If `app/views/layouts/react_on_rails_default.html.erb` is not present (for example, you added React on Rails manually to an existing app without running the installer), remove the `layout` line from the controller and add the pack-tag placeholders to the layout that renders this view.
+If `app/views/layouts/react_on_rails_default.html.erb` is not present (for example, you added React on Rails manually to an existing app without running the installer), remove the `layout` line from the controller and add the pack-tag placeholders to your `application.html.erb` or whichever layout renders this view.
 
 ## Run The App With HMR
 
@@ -228,6 +228,7 @@ Then add `prerender: true` in the Rails view:
 
 > [!NOTE]
 > `prerender: true` needs a server bundle. For a first local SSR check, use `./bin/dev static` or run a production precompile. If you want the dev server to serve the prerender bundle, follow the [HMR guide](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) and set `config.same_bundle_for_client_and_server = true` for that mode.
+>
 > Server rendering runs in Node or ExecJS, which has no browser globals (`window`, `document`, `localStorage`). Guard browser-only access inside a `useEffect` hook or a conditional on `typeof window !== 'undefined'`.
 
 For deeper SSR guidance, see [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md) and [React Server Rendering](../core-concepts/react-server-rendering.md).

--- a/docs/oss/getting-started/tutorial.md
+++ b/docs/oss/getting-started/tutorial.md
@@ -1,267 +1,314 @@
-# React on Rails Basic Tutorial
+# React on Rails Tutorial
 
-_See also [Examples and migration references](./examples-and-references.md) for the maintained tutorial demo, migration references, and current React on Rails Pro + RSC demos._
+_See also [Examples and migration references](./examples-and-references.md) for maintained demo apps, migration references, and current React on Rails Pro + RSC demos._
 
----
+This tutorial starts from the [Quick Start](./quick-start.md) app and builds a small TypeScript component using the modern React on Rails workflow:
 
-_Updated for Ruby 3.3+, Rails 7, React on Rails v17, and Shakapacker v7_
+- TypeScript function components and React Hooks
+- Auto-bundling from files in `ror_components`
+- `bin/dev` with HMR during development
+- Optional server rendering with `prerender: true`
 
-This tutorial guides you through setting up a new or existing Rails app with **React on Rails**, demonstrating Rails + React + Redux + Server Rendering.
-
-After finishing this tutorial you will get an application that can do the following (live on Heroku):
-
-![example](https://cloud.githubusercontent.com/assets/371302/17368567/111cc722-596b-11e6-9b72-ac5967a60e42.gif)
-
-You can find it here:
-
-- [Source code for this app in PR, using the --redux option](https://github.com/shakacode/react_on_rails-test-new-redux-generation/pull/17) and [for Heroku](https://github.com/shakacode/react_on_rails-test-new-redux-generation/pull/18).
-- [Live on Heroku](https://www.reactrails.com/)
-
-By the time you read this, the latest may have changed. Be sure to check the versions here:
-
-- [https://rubygems.org/gems/react_on_rails](https://rubygems.org/gems/react_on_rails)
-- [https://www.npmjs.com/package/react-on-rails](https://www.npmjs.com/package/react-on-rails)
+Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux integration](#appendix-redux-integration) when you need a shared client store or you are maintaining an existing Redux setup.
 
 ## Table of Contents
 
-- [Installation](#installation)
-  - [Setting up your environment](#setting-up-your-environment)
-  - [Create a new Ruby on Rails App](#create-a-new-ruby-on-rails-app)
-  - [Add the Shakapacker and react_on_rails gems](#add-the-shakapacker-and-react_on_rails-gems)
-  - [Run the Shakapacker generator](#run-the-shakapacker-generator)
-  - [Run the React on Rails Generator](#run-the-react-on-rails-generator)
-  - [Setting up your environment variables](#setting-up-your-environment-variables)
-  - [Running the app](#running-the-app)
-- [HMR vs. React Hot Reloading](#hmr-vs-react-hot-reloading)
-- [Deployment](#deployment)
-- [Going Further](#going-further)
-  - [Turning on Server Rendering](#turning-on-server-rendering)
-  - [Optional Configuration](#optional-configuration)
-    - [Moving from the Rails default `/app/javascript` to the recommended `/client` structure](#moving-from-the-rails-default-appjavascript-to-the-recommended-client-structure)
-    - [Custom IP & PORT setup (Cloud9 example)](#custom-ip--port-setup-cloud9-example)
-    - [RubyMine performance tip](#rubymine-performance-tip)
+- [Prerequisites](#prerequisites)
+- [Start From The Quick-Start App](#start-from-the-quick-start-app)
+- [Understand The Generated Files](#understand-the-generated-files)
+- [Create A TypeScript Counter Component](#create-a-typescript-counter-component)
+- [Render The Component From Rails](#render-the-component-from-rails)
+- [Run The App With HMR](#run-the-app-with-hmr)
+- [Pass Props From Rails](#pass-props-from-rails)
+- [Optional: Turn On Server Rendering](#optional-turn-on-server-rendering)
+- [Production Build And Deployment](#production-build-and-deployment)
+- [Troubleshooting](#troubleshooting)
+- [Appendix: Redux Integration](#appendix-redux-integration)
 - [What's Next?](#whats-next)
 
-## Installation
+## Prerequisites
 
-### Setting up your environment
+Use current, maintained versions for new apps:
 
-Trying out **React on Rails** is super easy, so long as you have the basic prerequisites.
+- Ruby 3.3+
+- Rails 7+
+- Node.js 18+ and your preferred package manager
+- Foreman or Overmind for `bin/dev`
 
-- **Ruby:** We support Ruby 3.3+ and recommend using the latest stable Ruby version. Solutions like [rvm](https://rvm.io) or [rbenv](https://github.com/rbenv/rbenv) make it easy to have multiple Ruby versions on your machine.
-- **Rails:** React on Rails supports Rails 5.2 and later. This tutorial targets Rails 7.0+ for new apps, so some steps may differ for older existing apps.
-- **Node.js:** We support all [active Node versions](https://github.com/nodejs/release#release-schedule) but recommend using the latest LTS release of Nodejs for the longest support. Older inactive node versions might still work but is not guaranteed. We also recommend using [nvm](https://github.com/nvm-sh/nvm/) to ease using different node versions in different projects.
-- **Node Package manager:** You can use [npm](https://npmjs.com/), Yarn ([Classic](https://classic.yarnpkg.com/) or [Berry](https://yarnpkg.com/)), or [pnpm](https://pnpm.io/).
-- You need to have either [Overmind](https://github.com/DarthSim/overmind) or [Foreman](https://rubygems.org/gems/foreman) as a process manager.
+React on Rails is published as both a Ruby gem and an npm package. For exact current versions, check:
 
-### Create a new Ruby on Rails App
+- [react_on_rails on RubyGems](https://rubygems.org/gems/react_on_rails)
+- [react-on-rails on npm](https://www.npmjs.com/package/react-on-rails)
 
-Then we need to create a fresh Rails application as follows.
+## Start From The Quick-Start App
 
-First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app.
-Pass `--skip-javascript` so React on Rails can install Shakapacker for the JavaScript setup.
-
-> [!NOTE]
-> **Rails 5.2 / 6.x users:** Rails 6.x uses the same `--skip-javascript` flag. Rails 5.2 is outside
-> the scope of this Rails 7+ tutorial. For Webpacker-era setup guidance, see the
-> [legacy Webpacker migration shims](../building-features/rails-webpacker-react-integration-options.md#legacy-webpacker--webpack-4-migration-shims)
-> and [migrating from react-rails](../migrating/migrating-from-react-rails.md).
+If you already completed the [Quick Start](./quick-start.md), keep using that app. Otherwise, create a Rails app and run the TypeScript installer:
 
 ```bash
 rails new test-react-on-rails --skip-javascript
-
 cd test-react-on-rails
-```
 
-Note: You can use `--database=postgresql` option to use Postgresql for the database.
-
-### Add the Shakapacker and react_on_rails gems
-
-We recommend using the latest version of these gems. Otherwise, specify the
-exact versions of both the gem and npm packages. In other words, don't use
-the `^` or `~` in the version specifications.
-
-```bash
 bundle add react_on_rails --strict
-bundle add shakapacker --strict
+bin/rails generate react_on_rails:install --typescript
 ```
 
-Note: The latest released React On Rails version is considered stable. Please use the latest
-version to ensure you get all the security patches and the best support.
+The installer sets up Shakapacker, React, TypeScript, the React on Rails initializer, a sample controller, and a `bin/dev` process file. Fresh installs use Rspack by default when the installed Shakapacker version supports it. To force Webpack instead, pass `--no-rspack`.
 
-### Run the Shakapacker generator
+> [!TIP]
+> Commit or stash your app before running generators. The diff is much easier to review when generated changes are isolated.
 
-```bash
-bundle exec rails shakapacker:install
-```
+There is no `react_on_rails:component` generator. For new components, create the files manually under the configured `ror_components` directory and let auto-bundling discover them.
 
-Commit all the changes so far to avoid getting errors in the next step.
+## Understand The Generated Files
 
-```bash
-git add . && git commit -m "Initial commit"
-```
-
-Alternatively, you can use `--ignore-warnings` in the next step.
-
-### Run the React on Rails Generator
-
-```bash
-rails generate react_on_rails:install
-```
-
-You will be prompted to approve changes in certain files. Press `enter` to proceed
-one by one or enter `a` to replace all configuration files required by the project.
-You can check the diffs before you commit to see what changed.
-
-**Note on Redux:** The basic installer uses React Hooks for state management. However, this tutorial demonstrates Redux integration (as used in the [live example](https://www.reactrails.com/)). To follow this tutorial with Redux, run:
-
-```bash
-rails generate react_on_rails:install --redux
-```
-
-If you prefer to use React Hooks instead of Redux, run the basic installer without the `--redux` flag.
-
-### Setting up your environment variables
-
-Add the following variable to your environment:
+The TypeScript installer creates a structure like this:
 
 ```text
-EXECJS_RUNTIME=Node
+app/javascript/
+└── src/
+    └── HelloWorld/
+        └── ror_components/
+            ├── HelloWorld.client.tsx
+            ├── HelloWorld.module.css
+            └── HelloWorld.server.tsx
 ```
 
-Then run the server with one of the following options:
+The important pieces are:
 
-### Running the app
+- `config/initializers/react_on_rails.rb` configures React on Rails.
+- `config/shakapacker.yml` configures the bundler and enables nested entries for generated packs.
+- `app/javascript/src/**/ror_components/*` contains components that React on Rails can auto-register.
+- Rails views call `react_component` to render those components.
+
+Auto-bundling means you do not manually create a pack for every component and you do not manually call `ReactOnRails.register` for the basic component case. React on Rails generates the per-component bundles and loads the right bundle when the view helper asks for it.
+
+## Create A TypeScript Counter Component
+
+Create a new component directory:
 
 ```bash
-./bin/dev # For HMR
-# or
-./bin/dev static # Without HMR, statically creating the bundles
+mkdir -p app/javascript/src/Counter/ror_components
 ```
 
-Visit [http://localhost:3000/hello_world](http://localhost:3000/hello_world) and see your **React On Rails** app running!
+Add `app/javascript/src/Counter/ror_components/Counter.client.tsx`:
 
-## HMR vs. React Hot Reloading
+```tsx
+import React, { useMemo, useState } from 'react';
 
-First, check that the `hmr` and the `inline` options are `true` in your `config/shakapacker.yml` file.
+type CounterProps = {
+  initialCount?: number;
+  label?: string;
+};
 
-The basic setup will have HMR working with the default Shakapacker setup. When you run `./bin/dev` and change a JSX file, the browser will automatically refresh!
+export default function Counter({ initialCount = 0, label = 'Counter' }: CounterProps) {
+  const [count, setCount] = useState(initialCount);
+  const doubled = useMemo(() => count * 2, [count]);
 
-The basic [HMR](https://webpack.js.org/concepts/hot-module-replacement/), without a special React setup, will cause a full page refresh each time you save a file.
-
-If you want to go further with HMR, take a look at these links:
-
-- [webpack-dev-server](https://github.com/rails/webpacker/blob/5-x-stable/docs/webpack-dev-server.md)
-- [DevServer](https://webpack.js.org/configuration/dev-server/)
-- [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/)
-
-React on Rails will automatically handle disabling server rendering if there is only one bundle file created by the Webpack development server by `shakapacker`.
-
-## Deployment
-
-Now that you have React on Rails working locally, you're ready to deploy to production!
-
-For detailed deployment instructions, see:
-
-- **[Heroku Deployment Guide](../deployment/heroku-deployment.md)** - Step-by-step Heroku deployment
-- **[General Deployment Guide](../deployment/README.md)** - Production deployment strategies for any platform
-
-These guides cover:
-
-- Configuring buildpacks
-- Database setup (PostgreSQL)
-- Asset compilation
-- Environment variables
-- Troubleshooting common deployment issues
-
-## Going Further
-
-### Turning on Server Rendering
-
-You can turn on server rendering by simply changing the `prerender` option to `true`:
-
-```erb
-<%= react_component("HelloWorld", props: @hello_world_props, prerender: true) %>
+  return (
+    <section>
+      <h2>{label}</h2>
+      <p>
+        Count: <strong>{count}</strong>
+      </p>
+      <p>Double: {doubled}</p>
+      <button type="button" onClick={() => setCount((current) => current + 1)}>
+        Increment
+      </button>
+      <button type="button" onClick={() => setCount(initialCount)}>
+        Reset
+      </button>
+    </section>
+  );
+}
 ```
 
-If you want to test this out with HMR, then you also need to add this line to your
-`config/intializers/react_on_rails.rb`
+The file name controls the component name. `Counter.client.tsx` is rendered from Rails as `"Counter"`. The `.client` suffix tells auto-bundling this is the browser entry point.
+
+## Render The Component From Rails
+
+Add a controller action if you do not already have one:
+
+```bash
+bin/rails generate controller Dashboard show
+```
+
+In `app/controllers/dashboard_controller.rb`, set props for React:
 
 ```ruby
-  config.same_bundle_for_client_and_server = true
+class DashboardController < ApplicationController
+  layout "react_on_rails_default"
+
+  def show
+    @counter_props = {
+      initialCount: 3,
+      label: "Orders ready"
+    }
+  end
+end
 ```
 
-More likely, you will create a different build file for server rendering. However, if you want to
-use the same file from the shakapacker-dev-server, you'll need to add that line.
+In `app/views/dashboard/show.html.erb`, render the component:
 
-When you look at the source code for the page (right click, view source in Chrome), you can see the difference between non-server rendering, where your DIV containing your React looks like this:
+```erb
+<h1>Dashboard</h1>
 
-```html
-<div id="HelloWorld-react-component-b7ae1dc6-396c-411d-886a-269633b3f604"></div>
+<%= react_component("Counter", props: @counter_props, auto_load_bundle: true) %>
 ```
 
-versus with server rendering:
+If your app sets `config.auto_load_bundle = true` in `config/initializers/react_on_rails.rb`, you can omit `auto_load_bundle: true` from individual helper calls:
 
-```html
-<div id="HelloWorld-react-component-d846ce53-3b82-4c4a-8f32-ffc347c8444a">
-  <div data-reactroot="">
-    <h3>
-      Hello,
-      <!-- -->Stranger<!-- -->!
-    </h3>
-    <hr />
-    <form><label for="name">Say hello to:</label><input type="text" id="name" value="Stranger" /></form>
-  </div>
-</div>
+```erb
+<%= react_component("Counter", props: @counter_props) %>
 ```
 
-For more details on server rendering, see:
+The generated `react_on_rails_default` layout includes the Shakapacker tags that auto-bundling needs. If you render from your application's default layout instead, add the same `stylesheet_pack_tag` and `javascript_pack_tag` placeholders there.
 
-- [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md)
-- [React Server Rendering](../core-concepts/react-server-rendering.md)
+## Run The App With HMR
 
-### Optional Configuration
-
-#### Moving from the Rails default `/app/javascript` to the recommended `/client` structure
-
-ShakaCode recommends that you use `/client` for your client side app. This way a non-Rails, front-end developer can be at home just by opening up the `/client` directory.
-
-1. Move the directory:
+Start Rails and the bundler dev server together:
 
 ```bash
-mv app/javascript client
+./bin/dev
 ```
 
-2. Edit your `/config/shakapacker.yml` file. Change the `default/source_path`:
+Visit the route for your controller, such as [http://localhost:3000/dashboard/show](http://localhost:3000/dashboard/show). Edit `Counter.client.tsx`, save, and the page should update through HMR.
 
-```yml
-source_path: client
+Use static bundling when you want to test the production-style compiled assets locally:
+
+```bash
+./bin/dev static
 ```
 
-#### Custom IP & PORT setup (Cloud9 example)
+## Pass Props From Rails
 
-In case you are running some custom setup with different IP or PORT you should also edit Procfile.dev. For example, to be able to run on free Cloud9 IDE we are putting IP 0.0.0.0 and PORT 8080. The default generated file `Procfile.dev` uses `-p 3000`.
+`props:` accepts a Ruby hash or a JSON string. Prefer hashes in normal Rails views so the code stays readable:
 
-```Procfile.dev
-web: rails s -p 8080 -b 0.0.0.0
+```erb
+<%= react_component(
+      "Counter",
+      props: {
+        initialCount: current_user.notifications.unread.count,
+        label: "Unread notifications"
+      },
+      auto_load_bundle: true
+    ) %>
 ```
 
-Then visit https://your-shared-addr.c9users.io:8080/hello_world
+Keep props serializable. Pass IDs, strings, numbers, booleans, arrays, and hashes; fetch richer client-side data through your usual Rails JSON endpoints or GraphQL layer.
 
-#### RubyMine performance tip
+## Optional: Turn On Server Rendering
 
-It's super important to exclude certain directories from RubyMine or else it will slow to a crawl as it tries to parse all the npm files.
+For a component that can render without browser-only APIs, add a server entry before you enable prerendering. Keep both files in the same `ror_components` directory:
 
-- Generated files, per the settings in your `config/shakapacker.yml`, which default to `public/packs` and `public/packs-test` (kept separate so test and development manifests do not overwrite each other)
-- `node_modules`
+```text
+app/javascript/src/Counter/ror_components/
+├── Counter.client.tsx
+└── Counter.server.tsx
+```
+
+The server file can re-export the same component when no special server behavior is needed:
+
+```tsx
+export { default } from './Counter.client';
+```
+
+Then add `prerender: true` in the Rails view:
+
+```erb
+<%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true) %>
+```
+
+Server rendering runs in Node or ExecJS, so browser globals such as `window`, `document`, and `localStorage` must stay inside effects or client-only branches:
+
+```tsx
+import React, { useEffect, useState } from 'react';
+
+export default function BrowserTime() {
+  const [timeZone, setTimeZone] = useState('UTC');
+
+  useEffect(() => {
+    setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  }, []);
+
+  return <p>Your browser time zone is {timeZone}.</p>;
+}
+```
+
+For deeper SSR guidance, see [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md) and [React Server Rendering](../core-concepts/react-server-rendering.md).
+
+## Production Build And Deployment
+
+Before deploying, run the production asset pipeline locally once:
+
+```bash
+RAILS_ENV=production NODE_ENV=production bin/rails assets:precompile
+```
+
+For deployment details, see:
+
+- [Heroku Deployment Guide](../deployment/heroku-deployment.md)
+- [General Deployment Guide](../deployment/README.md)
+
+## Troubleshooting
+
+### The Component Is Not Found
+
+Check that the component lives under a directory matching `config.components_subdirectory`, which is usually `ror_components`:
+
+```text
+app/javascript/src/Counter/ror_components/Counter.client.tsx
+```
+
+Then make sure the view uses the component name without the `.client` or `.tsx` suffix:
+
+```erb
+<%= react_component("Counter", props: @counter_props, auto_load_bundle: true) %>
+```
+
+### The Bundle Is Not Loaded
+
+Use `auto_load_bundle: true` on the helper call or set it globally:
+
+```ruby
+# config/initializers/react_on_rails.rb
+config.auto_load_bundle = true
+```
+
+Also confirm that `nested_entries: true` remains enabled in `config/shakapacker.yml`.
+
+### HMR Does Not Update The Page
+
+Run `./bin/dev`, not only `bin/rails server`. The dev command starts both Rails and the bundler dev server.
+
+### Server Rendering Fails
+
+Temporarily set `prerender: false` to confirm the browser render works, then remove browser-only APIs from the server render path. You can also enable `trace: true` on `react_component` while debugging.
+
+## Appendix: Redux Integration
+
+Use Redux when your app already has Redux conventions, needs a shared client store across many React islands, or benefits from Redux middleware and DevTools. For local UI state, React Hooks are usually simpler.
+
+To generate the Redux example for a new app, run the installer with both TypeScript and Redux:
+
+```bash
+bin/rails generate react_on_rails:install --typescript --redux
+```
+
+The Redux installer creates a larger structure with actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
+
+When rendering a Redux-backed component, the Rails side still uses the same view helper style:
+
+```erb
+<%= react_component("HelloWorldApp", props: @hello_world_props, auto_load_bundle: true) %>
+```
+
+For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [Redux integration guide](../building-features/react-and-redux.md).
 
 ## What's Next?
 
-Now that you have React on Rails running, here are ways to level up:
-
-- **Add server-side rendering** — [SSR guide](../core-concepts/react-server-rendering.md)
-- **See the feature comparison** — [OSS vs Pro](./oss-vs-pro.md)
-- **Upgrade to Pro** for React Server Components, streaming SSR, and 3-10x faster SSR — [3-step upgrade guide](../../pro/upgrading-to-pro.md)
-- **Explore the full docs** — [Documentation index](../../README.md)
-
-Feedback is greatly appreciated! As are stars on GitHub. If you want personalized help, don't hesitate to get in touch with us at [contact@shakacode.com](mailto:contact@shakacode.com).
+- [Using React on Rails](./using-react-on-rails.md)
+- [Auto-Bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
+- [View Helpers API](../api-reference/view-helpers-api.md)
+- [Hot Module Replacement](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md)
+- [Server Rendering](../core-concepts/react-server-rendering.md)
+- [Production Deployment](../deployment/README.md)

--- a/docs/oss/getting-started/using-react-on-rails.md
+++ b/docs/oss/getting-started/using-react-on-rails.md
@@ -26,7 +26,7 @@ The generator sets up:
 
 - **[Quick Start Guide](./quick-start.md)** - Fastest path (15 minutes)
 - **[Installation Guide](./installation-into-an-existing-rails-app.md)** - For existing Rails apps
-- **[Complete Tutorial](./tutorial.md)** - Step-by-step with Redux and routing
+- **[Complete Tutorial](./tutorial.md)** - Step-by-step with TypeScript, hooks, and auto-bundling
 
 ---
 
@@ -263,4 +263,4 @@ Now that you understand the core concepts, here are recommended paths forward:
 
 ---
 
-**Ready to build something?** The [Tutorial](./tutorial.md) walks you through building a complete app with Redux, routing, and testing.
+**Ready to build something?** The [Tutorial](./tutorial.md) walks you through building a TypeScript component with hooks, Rails props, auto-bundling, and optional server rendering.

--- a/docs/oss/getting-started/using-react-on-rails.md
+++ b/docs/oss/getting-started/using-react-on-rails.md
@@ -140,7 +140,7 @@ app/javascript/
 
 - Shakapacker handles Rspack or Webpack setup
 - Config in `config/shakapacker.yml`
-- For custom webpack needs, see [Webpack Configuration Guide](../core-concepts/webpack-configuration.md)
+- For custom bundler needs, see [Webpack/Rspack Configuration Guide](../core-concepts/webpack-configuration.md)
 
 ### Development Workflow
 

--- a/docs/oss/getting-started/using-react-on-rails.md
+++ b/docs/oss/getting-started/using-react-on-rails.md
@@ -12,14 +12,14 @@ When you install React on Rails, several things happen:
 
 1. **Ruby gem installed** - Provides Rails integration, view helpers, and SSR support
 2. **NPM package installed** - Client-side JavaScript library for registering components
-3. **Generator creates files** - Component structure, webpack config, sample code
-4. **Shakapacker configured** - Webpack integration for Rails (required dependency)
+3. **Generator creates files** - Component structure, bundler config, sample code
+4. **Shakapacker configured** - Bundler integration for Rails (required dependency)
 
 The generator sets up:
 
 - Component directories (typically `app/javascript/bundles/` or with auto-bundling in `app/javascript/src/*/ror_components/`)
 - Rails integration (controllers, views, initializer)
-- Webpack configuration for building JavaScript bundles
+- Bundler configuration for building JavaScript bundles
 - Development workflow with hot module replacement
 
 **For detailed installation instructions, see:**
@@ -83,7 +83,7 @@ import HelloWorld from '../components/HelloWorld';
 ReactOnRails.register({ HelloWorld });
 ```
 
-You must configure webpack entry points and manually register each component.
+You must configure bundler entry points and manually register each component.
 
 ### Modern Auto-Bundling (Recommended)
 
@@ -95,7 +95,7 @@ With auto-bundling enabled:
 
 1. Place components in designated directories (e.g., `app/javascript/src/*/ror_components/`)
 2. React on Rails automatically finds and bundles them
-3. No manual webpack configuration needed
+3. No manual bundler configuration needed
 4. No manual `ReactOnRails.register()` calls
 5. Components are loaded on-demand per page
 
@@ -136,9 +136,9 @@ app/javascript/
 - **Route**: Added to `config/routes.rb`
 - **Initializer**: `config/initializers/react_on_rails.rb` - Configuration
 
-### Webpack Configuration
+### Bundler Configuration
 
-- Shakapacker handles webpack setup
+- Shakapacker handles Rspack or Webpack setup
 - Config in `config/shakapacker.yml`
 - For custom webpack needs, see [Webpack Configuration Guide](../core-concepts/webpack-configuration.md)
 
@@ -147,7 +147,7 @@ app/javascript/
 The generator creates `bin/dev` for starting both:
 
 - Rails server (port 3000)
-- Webpack dev server (for hot reloading)
+- Bundler dev server (for hot reloading)
 
 > **Note:** You need `overmind` or `foreman` installed to run `bin/dev`. Install with `brew install overmind` (macOS) or `gem install foreman` (globally). See the [Quick Start Guide](./quick-start.md#-step-2-start-the-development-server-1-minute) for detailed installation instructions.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -363,8 +363,8 @@ This guide will have you rendering React components in your Rails app as quickly
 Before starting, make sure you have:
 
 - **🚨 React on Rails 17.0.0+** (this guide)
-- **🚨 Shakapacker 6+** (7+ recommended for React on Rails 17)
-- **Rails 7+** application (Rails 5.2+ supported)
+- **Shakapacker 6+** — installed automatically by the React on Rails generator (7+ recommended for React on Rails 17)
+- **Rails 7+** application
 - **Ruby 3.3+** (required)
 - **Node.js 18+** and a package manager (**npm**, **pnpm**, **Yarn**, or **bun**)
 - **Foreman or Overmind** (for running `bin/dev`)
@@ -386,8 +386,9 @@ bundle add react_on_rails --strict
 # Run the installer for TypeScript
 bin/rails generate react_on_rails:install --typescript
 
-# Optional: Use Rspack for faster builds
-# bin/rails generate react_on_rails:install --typescript --rspack
+# Fresh installs use Rspack by default when supported (Shakapacker 9+).
+# To force Webpack instead, pass --no-rspack:
+# bin/rails generate react_on_rails:install --typescript --no-rspack
 
 # For JavaScript instead of TypeScript, omit --typescript
 # bin/rails generate react_on_rails:install
@@ -408,11 +409,11 @@ Take a look at the files created by the generator.
 
 - Component files (`.tsx` for TypeScript, `.jsx` for JavaScript)
 - Shakapacker install
-- React component files in `client/`
+- React component files in `app/javascript/src/`
 - A sample controller and view
-- Webpack configuration
+- Bundler configuration
 
-> 💡 **Performance Tip:** Add the `--rspack` flag for significantly faster builds (~20x improvement). You can also switch bundlers later with `bin/switch-bundler rspack`.
+> 💡 **Performance Tip:** Fresh installs use Rspack by default when supported by your Shakapacker version (9+) for significantly faster builds. To compare or temporarily force Webpack, run the installer with `--no-rspack`; you can also switch bundlers later with `bin/switch-bundler webpack` or `bin/switch-bundler rspack`.
 >
 > **Note on `bin/switch-bundler`:** This utility safely switches between webpack and rspack by updating `shakapacker.yml` and managing dependencies. However, it does not modify custom webpack configuration code. If you have custom webpack plugins or loaders, you may need to update those manually to work with rspack. See [Rspack documentation](../api-reference/generator-details.md#rspack-support) for details on unified configuration patterns.
 
@@ -423,7 +424,7 @@ Take a look at the files created by the generator.
 > - **overmind**: `brew install overmind` (macOS) or see [installation guide](https://github.com/DarthSim/overmind#installation)
 > - **foreman**: `gem install foreman` (install globally, not in your project bundle - [details](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman))
 
-Start both Rails and the Webpack dev server:
+Start both Rails and the bundler dev server:
 
 ```bash
 ./bin/dev
@@ -432,7 +433,7 @@ Start both Rails and the Webpack dev server:
 This starts both:
 
 - Rails server on `http://localhost:3000`
-- Webpack dev server for hot reloading
+- Bundler dev server for hot reloading
 
 ## 🎨 Step 3: See Your Component (2 minutes)
 
@@ -547,7 +548,7 @@ Now that you have React on Rails working, here's what to explore next:
 
 ### Dive Deeper
 
-1. **[Complete Tutorial](../getting-started/tutorial.md)** - Build a full app with Redux
+1. **[Complete Tutorial](../getting-started/tutorial.md)** - Build a TypeScript component with hooks and auto-bundling
 2. **[Server-Side Rendering](../core-concepts/react-server-rendering.md)** - Optimize for SEO and performance
 3. **[Production Deployment](../deployment/README.md)** - Deploy to production
 
@@ -747,6 +748,7 @@ When no `--pro` or `--rsc` flag is given, the CLI prompts you to choose a setup 
 
 The default choice is RSC. Press Enter to accept it, or type `1` or `2` to pick a different mode.
 In non-interactive environments (CI, pipes), standard mode is used automatically.
+When the mode prompt is shown, the CLI also asks whether to add Tailwind CSS v4 to the generated SSR example.
 
 To skip the prompt, pass `--standard`, `--pro`, or `--rsc` explicitly.
 All mode flags support JavaScript (`.jsx`) and TypeScript (`.tsx`) templates.
@@ -771,6 +773,9 @@ npx create-react-on-rails-app my-app --standard
 # JavaScript instead of TypeScript
 npx create-react-on-rails-app my-app --template javascript
 
+# Add Tailwind CSS v4 to the generated SSR example
+npx create-react-on-rails-app my-app --tailwind
+
 # Use Rspack for ~20x faster builds
 npx create-react-on-rails-app my-app --rspack
 
@@ -783,16 +788,18 @@ npx create-react-on-rails-app my-app --rspack --rsc
 
 ### All Options
 
-| Option                       | Description                                                    | Default       |
-| ---------------------------- | -------------------------------------------------------------- | ------------- |
-| `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`  |
-| `--rspack`                   | Use Rspack instead of Webpack (~20x faster)                    | `false`       |
-| `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`       |
-| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`       |
-| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`       |
-| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                | auto-detected |
+| Option                       | Description                                                    | Default                  |
+| ---------------------------- | -------------------------------------------------------------- | ------------------------ |
+| `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
+| `--rspack`                   | Use Rspack instead of Webpack (~20x faster)                    | `false`                  |
+| `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
+| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
+| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
+| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example               | prompt with mode/`false` |
+| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                | auto-detected            |
 
 When none of `--standard`, `--pro`, or `--rsc` is given, the CLI prompts interactively in TTY environments (default: RSC). In non-TTY environments (CI, pipes, redirected output), standard mode is used automatically.
+When `--tailwind` is omitted, Tailwind is prompted only alongside the mode prompt and disabled otherwise.
 
 ## What It Does
 
@@ -813,6 +820,7 @@ After completion, you get:
 - Standard Rails git scaffold files (`.gitignore` and `.gitattributes`) preserved in the generated app
 - Optional Pro setup (`--pro`) with Pro Node renderer wiring and the generated `/hello_world` example
 - Optional RSC setup (`--rsc`) with HelloServer route and Pro Node renderer wiring
+- Optional Tailwind CSS v4 setup (`--tailwind`) for the generated SSR example
 - Server-side rendering ready
 - Development scripts (`bin/dev` with hot reloading and first-run browser open)
 
@@ -855,273 +863,333 @@ PAGE: https://reactonrails.com/docs/getting-started/tutorial
 SOURCE: docs/oss/getting-started/tutorial.md
 ================================================================================
 
-# React on Rails Basic Tutorial
+# React on Rails Tutorial
 
-_See also [Examples and migration references](./examples-and-references.md) for the maintained tutorial demo, migration references, and current React on Rails Pro + RSC demos._
+_See also [Examples and migration references](./examples-and-references.md) for maintained demo apps, migration references, and current React on Rails Pro + RSC demos._
 
----
+This tutorial starts from the [Quick Start](./quick-start.md) app and builds a small TypeScript component using the modern React on Rails workflow:
 
-_Updated for Ruby 3.3+, Rails 7, React on Rails v17, and Shakapacker v7_
+- TypeScript function components and React Hooks
+- Auto-bundling from files in `ror_components`
+- `bin/dev` with HMR during development
+- Optional server rendering with `prerender: true`
 
-This tutorial guides you through setting up a new or existing Rails app with **React on Rails**, demonstrating Rails + React + Redux + Server Rendering.
-
-After finishing this tutorial you will get an application that can do the following (live on Heroku):
-
-![example](https://cloud.githubusercontent.com/assets/371302/17368567/111cc722-596b-11e6-9b72-ac5967a60e42.gif)
-
-You can find it here:
-
-- [Source code for this app in PR, using the --redux option](https://github.com/shakacode/react_on_rails-test-new-redux-generation/pull/17) and [for Heroku](https://github.com/shakacode/react_on_rails-test-new-redux-generation/pull/18).
-- [Live on Heroku](https://www.reactrails.com/)
-
-By the time you read this, the latest may have changed. Be sure to check the versions here:
-
-- [https://rubygems.org/gems/react_on_rails](https://rubygems.org/gems/react_on_rails)
-- [https://www.npmjs.com/package/react-on-rails](https://www.npmjs.com/package/react-on-rails)
+Redux is still supported, but it is no longer the main path for a first React on Rails app. See [Appendix: Redux Integration](#appendix-redux-integration) when you need a shared client store or you are maintaining an existing Redux setup.
 
 ## Table of Contents
 
-- [Installation](#installation)
-  - [Setting up your environment](#setting-up-your-environment)
-  - [Create a new Ruby on Rails App](#create-a-new-ruby-on-rails-app)
-  - [Add the Shakapacker and react_on_rails gems](#add-the-shakapacker-and-react_on_rails-gems)
-  - [Run the Shakapacker generator](#run-the-shakapacker-generator)
-  - [Run the React on Rails Generator](#run-the-react-on-rails-generator)
-  - [Setting up your environment variables](#setting-up-your-environment-variables)
-  - [Running the app](#running-the-app)
-- [HMR vs. React Hot Reloading](#hmr-vs-react-hot-reloading)
-- [Deployment](#deployment)
-- [Going Further](#going-further)
-  - [Turning on Server Rendering](#turning-on-server-rendering)
-  - [Optional Configuration](#optional-configuration)
-    - [Moving from the Rails default `/app/javascript` to the recommended `/client` structure](#moving-from-the-rails-default-appjavascript-to-the-recommended-client-structure)
-    - [Custom IP & PORT setup (Cloud9 example)](#custom-ip--port-setup-cloud9-example)
-    - [RubyMine performance tip](#rubymine-performance-tip)
+- [Prerequisites](#prerequisites)
+- [Start From The Quick-Start App](#start-from-the-quick-start-app)
+- [Understand The Generated Files](#understand-the-generated-files)
+- [Create A TypeScript Counter Component](#create-a-typescript-counter-component)
+- [Render The Component From Rails](#render-the-component-from-rails)
+- [Run The App With HMR](#run-the-app-with-hmr)
+- [Pass Props From Rails](#pass-props-from-rails)
+- [Optional: Turn On Server Rendering](#optional-turn-on-server-rendering)
+- [Production Build And Deployment](#production-build-and-deployment)
+- [Troubleshooting](#troubleshooting)
+- [Appendix: Redux Integration](#appendix-redux-integration)
 - [What's Next?](#whats-next)
 
-## Installation
+## Prerequisites
 
-### Setting up your environment
+Use current, maintained versions for new apps:
 
-Trying out **React on Rails** is super easy, so long as you have the basic prerequisites.
+- Ruby 3.3+
+- Rails 7+
+- Node.js 18+ and your preferred package manager
+- Foreman or Overmind for `bin/dev`
 
-- **Ruby:** We support Ruby 3.3+ and recommend using the latest stable Ruby version. Solutions like [rvm](https://rvm.io) or [rbenv](https://github.com/rbenv/rbenv) make it easy to have multiple Ruby versions on your machine.
-- **Rails:** React on Rails supports Rails 5.2 and later. This tutorial targets Rails 7.0+ for new apps, so some steps may differ for older existing apps.
-- **Node.js:** We support all [active Node versions](https://github.com/nodejs/release#release-schedule) but recommend using the latest LTS release of Nodejs for the longest support. Older inactive node versions might still work but is not guaranteed. We also recommend using [nvm](https://github.com/nvm-sh/nvm/) to ease using different node versions in different projects.
-- **Node Package manager:** You can use [npm](https://npmjs.com/), Yarn ([Classic](https://classic.yarnpkg.com/) or [Berry](https://yarnpkg.com/)), or [pnpm](https://pnpm.io/).
-- You need to have either [Overmind](https://github.com/DarthSim/overmind) or [Foreman](https://rubygems.org/gems/foreman) as a process manager.
+React on Rails is published as both a Ruby gem and an npm package. For exact current versions, check:
 
-### Create a new Ruby on Rails App
+- [react_on_rails on RubyGems](https://rubygems.org/gems/react_on_rails)
+- [react-on-rails on npm](https://www.npmjs.com/package/react-on-rails)
 
-Then we need to create a fresh Rails application as follows.
+## Start From The Quick-Start App
 
-First, be sure to run `rails -v` and check you are using Rails 7.0 or above for this new tutorial app.
-Pass `--skip-javascript` so React on Rails can install Shakapacker for the JavaScript setup.
-
-> [!NOTE]
-> **Rails 5.2 / 6.x users:** Rails 6.x uses the same `--skip-javascript` flag. Rails 5.2 is outside
-> the scope of this Rails 7+ tutorial. For Webpacker-era setup guidance, see the
-> [legacy Webpacker migration shims](../building-features/rails-webpacker-react-integration-options.md#legacy-webpacker--webpack-4-migration-shims)
-> and [migrating from react-rails](../migrating/migrating-from-react-rails.md).
+If you already completed the [Quick Start](./quick-start.md), keep using that app. Otherwise, create a Rails app and run the TypeScript installer:
 
 ```bash
 rails new test-react-on-rails --skip-javascript
-
 cd test-react-on-rails
-```
 
-Note: You can use `--database=postgresql` option to use Postgresql for the database.
-
-### Add the Shakapacker and react_on_rails gems
-
-We recommend using the latest version of these gems. Otherwise, specify the
-exact versions of both the gem and npm packages. In other words, don't use
-the `^` or `~` in the version specifications.
-
-```bash
 bundle add react_on_rails --strict
-bundle add shakapacker --strict
+bin/rails generate react_on_rails:install --typescript
 ```
 
-Note: The latest released React On Rails version is considered stable. Please use the latest
-version to ensure you get all the security patches and the best support.
+The installer sets up Shakapacker, React, TypeScript, the React on Rails initializer, a sample controller, and a `bin/dev` process file. Fresh installs use Rspack by default when the installed Shakapacker version supports it. To force Webpack instead, pass `--no-rspack`.
 
-### Run the Shakapacker generator
+> [!TIP]
+> Commit or stash your app before running generators. The diff is much easier to review when generated changes are isolated.
 
-```bash
-bundle exec rails shakapacker:install
-```
+There is no `react_on_rails:component` generator. For new components, create the files manually under the configured `ror_components` directory and let auto-bundling discover them.
 
-Commit all the changes so far to avoid getting errors in the next step.
+## Understand The Generated Files
 
-```bash
-git add . && git commit -m "Initial commit"
-```
-
-Alternatively, you can use `--ignore-warnings` in the next step.
-
-### Run the React on Rails Generator
-
-```bash
-rails generate react_on_rails:install
-```
-
-You will be prompted to approve changes in certain files. Press `enter` to proceed
-one by one or enter `a` to replace all configuration files required by the project.
-You can check the diffs before you commit to see what changed.
-
-**Note on Redux:** The basic installer uses React Hooks for state management. However, this tutorial demonstrates Redux integration (as used in the [live example](https://www.reactrails.com/)). To follow this tutorial with Redux, run:
-
-```bash
-rails generate react_on_rails:install --redux
-```
-
-If you prefer to use React Hooks instead of Redux, run the basic installer without the `--redux` flag.
-
-### Setting up your environment variables
-
-Add the following variable to your environment:
+The TypeScript installer creates a structure like this:
 
 ```text
-EXECJS_RUNTIME=Node
+app/javascript/
+└── src/
+    └── HelloWorld/
+        └── ror_components/
+            ├── HelloWorld.client.tsx
+            ├── HelloWorld.module.css
+            └── HelloWorld.server.tsx
 ```
 
-Then run the server with one of the following options:
+The important pieces are:
 
-### Running the app
+- `config/initializers/react_on_rails.rb` configures React on Rails.
+- `config/shakapacker.yml` configures the bundler and enables nested entries for generated packs.
+- `app/javascript/src/**/ror_components/*` contains components that React on Rails can auto-register.
+- Rails views call `react_component` to render those components.
+
+Auto-bundling means you do not manually create a pack for every component and you do not manually call `ReactOnRails.register` for the basic component case. React on Rails generates the per-component bundles and loads the right bundle when the view helper asks for it.
+
+## Create A TypeScript Counter Component
+
+Create a new component directory:
 
 ```bash
-./bin/dev # For HMR
-# or
-./bin/dev static # Without HMR, statically creating the bundles
+mkdir -p app/javascript/src/Counter/ror_components
 ```
 
-Visit [http://localhost:3000/hello_world](http://localhost:3000/hello_world) and see your **React On Rails** app running!
+Add `app/javascript/src/Counter/ror_components/Counter.client.tsx`:
 
-## HMR vs. React Hot Reloading
+```tsx
+import React, { useState } from 'react';
 
-First, check that the `hmr` and the `inline` options are `true` in your `config/shakapacker.yml` file.
+type CounterProps = {
+  initialCount?: number;
+  label?: string;
+};
 
-The basic setup will have HMR working with the default Shakapacker setup. When you run `./bin/dev` and change a JSX file, the browser will automatically refresh!
+export default function Counter({ initialCount = 0, label = 'Counter' }: CounterProps) {
+  const [count, setCount] = useState(initialCount);
 
-The basic [HMR](https://webpack.js.org/concepts/hot-module-replacement/), without a special React setup, will cause a full page refresh each time you save a file.
-
-If you want to go further with HMR, take a look at these links:
-
-- [webpack-dev-server](https://github.com/rails/webpacker/blob/5-x-stable/docs/webpack-dev-server.md)
-- [DevServer](https://webpack.js.org/configuration/dev-server/)
-- [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/)
-
-React on Rails will automatically handle disabling server rendering if there is only one bundle file created by the Webpack development server by `shakapacker`.
-
-## Deployment
-
-Now that you have React on Rails working locally, you're ready to deploy to production!
-
-For detailed deployment instructions, see:
-
-- **[Heroku Deployment Guide](../deployment/heroku-deployment.md)** - Step-by-step Heroku deployment
-- **[General Deployment Guide](../deployment/README.md)** - Production deployment strategies for any platform
-
-These guides cover:
-
-- Configuring buildpacks
-- Database setup (PostgreSQL)
-- Asset compilation
-- Environment variables
-- Troubleshooting common deployment issues
-
-## Going Further
-
-### Turning on Server Rendering
-
-You can turn on server rendering by simply changing the `prerender` option to `true`:
-
-```erb
-<%= react_component("HelloWorld", props: @hello_world_props, prerender: true) %>
+  return (
+    <section>
+      <h2>{label}</h2>
+      <p>
+        Count: <strong>{count}</strong>
+      </p>
+      <button type="button" onClick={() => setCount((current) => current + 1)}>
+        Increment
+      </button>
+      <button type="button" onClick={() => setCount(initialCount)}>
+        Reset
+      </button>
+    </section>
+  );
+}
 ```
 
-If you want to test this out with HMR, then you also need to add this line to your
-`config/intializers/react_on_rails.rb`
+The file name controls the component name. `Counter.client.tsx` is rendered from Rails as `"Counter"`. The `.client` suffix tells auto-bundling this is the browser entry point.
+
+## Render The Component From Rails
+
+Add a controller action if you do not already have one:
+
+```bash
+bin/rails generate controller Dashboard show
+```
+
+In `app/controllers/dashboard_controller.rb`, set props for React. The Quick Start installer creates `react_on_rails_default`, which includes the generated bundle placeholders. If that layout is missing, use the fallback note below before copying this controller:
 
 ```ruby
-  config.same_bundle_for_client_and_server = true
+class DashboardController < ApplicationController
+  layout "react_on_rails_default"
+
+  def show
+    @counter_props = {
+      # React props use camelCase; react_component serializes this hash to JSON.
+      initialCount: 3,
+      label: "Orders ready"
+    }
+  end
+end
 ```
 
-More likely, you will create a different build file for server rendering. However, if you want to
-use the same file from the shakapacker-dev-server, you'll need to add that line.
+In `app/views/dashboard/show.html.erb`, render the component:
 
-When you look at the source code for the page (right click, view source in Chrome), you can see the difference between non-server rendering, where your DIV containing your React looks like this:
+```erb
+<h1>Dashboard</h1>
 
-```html
-<div id="HelloWorld-react-component-b7ae1dc6-396c-411d-886a-269633b3f604"></div>
+<%= react_component("Counter", props: @counter_props, auto_load_bundle: true) %>
 ```
 
-versus with server rendering:
+If your app sets `config.auto_load_bundle = true` in `config/initializers/react_on_rails.rb`, you can omit `auto_load_bundle: true` from individual helper calls:
 
-```html
-<div id="HelloWorld-react-component-d846ce53-3b82-4c4a-8f32-ffc347c8444a">
-  <div data-reactroot="">
-    <h3>
-      Hello,
-      <!-- -->Stranger<!-- -->!
-    </h3>
-    <hr />
-    <form><label for="name">Say hello to:</label><input type="text" id="name" value="Stranger" /></form>
-  </div>
-</div>
+```erb
+<%= react_component("Counter", props: @counter_props) %>
 ```
 
-For more details on server rendering, see:
+The generated `react_on_rails_default` layout includes the Shakapacker tags that auto-bundling needs. If you render from your application's default layout instead, add the same argless pack-tag calls there:
 
-- [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md)
-- [React Server Rendering](../core-concepts/react-server-rendering.md)
+```erb
+<%= stylesheet_pack_tag %>
+<%= javascript_pack_tag %>
+```
 
-### Optional Configuration
+With no pack name, Shakapacker renders every bundle accumulated by `append_javascript_pack_tag` and `append_stylesheet_pack_tag`, which lets auto-bundling load per-component packs without hardcoding generated pack names in the layout.
 
-#### Moving from the Rails default `/app/javascript` to the recommended `/client` structure
+If `app/views/layouts/react_on_rails_default.html.erb` is not present (for example, you added React on Rails manually to an existing app without running the installer), remove the `layout` line from the controller and add the pack-tag placeholders to your `application.html.erb` or whichever layout renders this view.
 
-ShakaCode recommends that you use `/client` for your client side app. This way a non-Rails, front-end developer can be at home just by opening up the `/client` directory.
+## Run The App With HMR
 
-1. Move the directory:
+Start Rails and the bundler dev server together:
 
 ```bash
-mv app/javascript client
+./bin/dev
 ```
 
-2. Edit your `/config/shakapacker.yml` file. Change the `default/source_path`:
+Visit the route for your controller, such as [http://localhost:3000/dashboard/show](http://localhost:3000/dashboard/show). Edit `Counter.client.tsx`, save, and the page should update through HMR.
 
-```yml
-source_path: client
+Use static bundling when you want to test the production-style compiled assets locally:
+
+```bash
+./bin/dev static
 ```
 
-#### Custom IP & PORT setup (Cloud9 example)
+## Pass Props From Rails
 
-In case you are running some custom setup with different IP or PORT you should also edit Procfile.dev. For example, to be able to run on free Cloud9 IDE we are putting IP 0.0.0.0 and PORT 8080. The default generated file `Procfile.dev` uses `-p 3000`.
+`props:` accepts a Ruby hash or a JSON string. Prefer hashes in normal Rails views so the code stays readable:
 
-```Procfile.dev
-web: rails s -p 8080 -b 0.0.0.0
+```erb
+<%= react_component(
+      "Counter",
+      props: {
+        initialCount: current_user.notifications.unread.count,
+        label: "Unread notifications"
+      },
+      auto_load_bundle: true
+    ) %>
 ```
 
-Then visit https://your-shared-addr.c9users.io:8080/hello_world
+Keep props serializable. Pass IDs, strings, numbers, booleans, arrays, and hashes; fetch richer client-side data through your usual Rails JSON endpoints or GraphQL layer.
 
-#### RubyMine performance tip
+## Optional: Turn On Server Rendering
 
-It's super important to exclude certain directories from RubyMine or else it will slow to a crawl as it tries to parse all the npm files.
+For a component that can render without browser-only APIs, add a server entry before you enable prerendering. Keep both files in the same `ror_components` directory:
 
-- Generated files, per the settings in your `config/shakapacker.yml`, which default to `public/packs` and `public/packs-test` (kept separate so test and development manifests do not overwrite each other)
-- `node_modules`
+```text
+app/javascript/src/Counter/ror_components/
+├── Counter.client.tsx
+└── Counter.server.tsx
+```
+
+The server file can re-export the same component when no special server behavior is needed:
+
+```tsx
+export { default } from './Counter.client';
+```
+
+The generated TypeScript config uses bundler module resolution, so the extensionless re-export matches the installer defaults. If your app uses a stricter custom Node ESM TypeScript setup, use the relative import extension style required by that config.
+
+Auto-bundling discovers `Counter.server.tsx` and includes it in the generated server bundle. You do not need to change `config.server_bundle_js_file` when the generated `server-bundle.js` entrypoint is already in place.
+
+Then add `prerender: true` in the Rails view:
+
+```erb
+<%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true) %>
+```
+
+> [!NOTE]
+> `prerender: true` needs a server bundle. For a first local SSR check, use `./bin/dev static` or run a production precompile. If you want the dev server to serve the prerender bundle, follow the [HMR guide](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md) and set `config.same_bundle_for_client_and_server = true` for that mode.
+>
+> Server rendering runs in Node or ExecJS, which has no browser globals (`window`, `document`, `localStorage`). Guard browser-only access inside a `useEffect` hook or a conditional on `typeof window !== 'undefined'`.
+
+For deeper SSR guidance, see [Client vs. Server Rendering](../core-concepts/client-vs-server-rendering.md) and [React Server Rendering](../core-concepts/react-server-rendering.md).
+
+## Production Build And Deployment
+
+Before deploying, run the production asset pipeline locally once:
+
+```bash
+RAILS_ENV=production NODE_ENV=production bin/rails assets:precompile
+```
+
+After verifying the production build locally, remove compiled assets before returning to development:
+
+```bash
+bin/rails assets:clobber
+```
+
+For deployment details, see:
+
+- [Heroku Deployment Guide](../deployment/heroku-deployment.md)
+- [General Deployment Guide](../deployment/README.md)
+
+## Troubleshooting
+
+### The Component Is Not Found
+
+Check that the component lives under a directory matching `config.components_subdirectory`, which is usually `ror_components`:
+
+```text
+app/javascript/src/Counter/ror_components/Counter.client.tsx
+```
+
+Then make sure the view uses the component name without the `.client` or `.tsx` suffix:
+
+```erb
+<%= react_component("Counter", props: @counter_props, auto_load_bundle: true) %>
+```
+
+### The Bundle Is Not Loaded
+
+Use `auto_load_bundle: true` on the helper call or set it globally:
+
+```ruby
+# config/initializers/react_on_rails.rb
+config.auto_load_bundle = true
+```
+
+Also confirm that `nested_entries: true` remains enabled in `config/shakapacker.yml`.
+
+### HMR Does Not Update The Page
+
+Run `./bin/dev`, not only `bin/rails server`. The dev command starts both Rails and the bundler dev server.
+
+### Server Rendering Fails
+
+Temporarily set `prerender: false` to confirm the browser render works, then remove browser-only APIs from the server render path. You can also enable `trace: true` on `react_component` while debugging:
+
+```erb
+<%= react_component("Counter", props: @counter_props, prerender: true, auto_load_bundle: true, trace: true) %>
+```
+
+## Appendix: Redux Integration
+
+Use Redux when your app already has Redux conventions, needs a shared client store across many React islands, or benefits from Redux middleware and DevTools. For local UI state, React Hooks are usually simpler.
+
+To generate the Redux example for a new app, run the installer with both TypeScript and Redux:
+
+```bash
+bin/rails generate react_on_rails:install --typescript --redux
+```
+
+The Redux installer creates a larger structure with actions, reducers, store setup, presentational components, containers, and auto-registered entry points under `ror_components`.
+
+When rendering a Redux-backed component, the Rails side still uses the same view helper style:
+
+```erb
+<%= react_component("HelloWorldApp", props: @hello_world_props, auto_load_bundle: true) %>
+```
+
+The component is named `HelloWorldApp` because that is what the Redux installer generates. Adjust the component name and props key to match your app's controller setup.
+
+For manually wired stores or advanced store sharing, use the [`redux_store` helper](../api-reference/redux-store-api.md) and the [Redux integration guide](../building-features/react-and-redux.md).
 
 ## What's Next?
 
-Now that you have React on Rails running, here are ways to level up:
-
-- **Add server-side rendering** — [SSR guide](../core-concepts/react-server-rendering.md)
-- **See the feature comparison** — [OSS vs Pro](./oss-vs-pro.md)
-- **Upgrade to Pro** for React Server Components, streaming SSR, and 3-10x faster SSR — [3-step upgrade guide](../../pro/upgrading-to-pro.md)
-- **Explore the full docs** — [Documentation index](../../README.md)
-
-Feedback is greatly appreciated! As are stars on GitHub. If you want personalized help, don't hesitate to get in touch with us at [contact@shakacode.com](mailto:contact@shakacode.com).
+- [Using React on Rails](./using-react-on-rails.md)
+- [Auto-Bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)
+- [View Helpers API](../api-reference/view-helpers-api.md)
+- [Hot Module Replacement (HMR)](../building-features/hmr-and-hot-reloading-with-the-webpack-dev-server.md)
+- [Server Rendering](../core-concepts/react-server-rendering.md)
+- [Production Deployment](../deployment/README.md)
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/getting-started/existing-rails-app
@@ -1405,21 +1473,21 @@ When you install React on Rails, several things happen:
 
 1. **Ruby gem installed** - Provides Rails integration, view helpers, and SSR support
 2. **NPM package installed** - Client-side JavaScript library for registering components
-3. **Generator creates files** - Component structure, webpack config, sample code
-4. **Shakapacker configured** - Webpack integration for Rails (required dependency)
+3. **Generator creates files** - Component structure, bundler config, sample code
+4. **Shakapacker configured** - Bundler integration for Rails (required dependency)
 
 The generator sets up:
 
 - Component directories (typically `app/javascript/bundles/` or with auto-bundling in `app/javascript/src/*/ror_components/`)
 - Rails integration (controllers, views, initializer)
-- Webpack configuration for building JavaScript bundles
+- Bundler configuration for building JavaScript bundles
 - Development workflow with hot module replacement
 
 **For detailed installation instructions, see:**
 
 - **[Quick Start Guide](./quick-start.md)** - Fastest path (15 minutes)
 - **[Installation Guide](./installation-into-an-existing-rails-app.md)** - For existing Rails apps
-- **[Complete Tutorial](./tutorial.md)** - Step-by-step with Redux and routing
+- **[Complete Tutorial](./tutorial.md)** - Step-by-step with TypeScript, hooks, and auto-bundling
 
 ---
 
@@ -1476,7 +1544,7 @@ import HelloWorld from '../components/HelloWorld';
 ReactOnRails.register({ HelloWorld });
 ```
 
-You must configure webpack entry points and manually register each component.
+You must configure bundler entry points and manually register each component.
 
 ### Modern Auto-Bundling (Recommended)
 
@@ -1488,7 +1556,7 @@ With auto-bundling enabled:
 
 1. Place components in designated directories (e.g., `app/javascript/src/*/ror_components/`)
 2. React on Rails automatically finds and bundles them
-3. No manual webpack configuration needed
+3. No manual bundler configuration needed
 4. No manual `ReactOnRails.register()` calls
 5. Components are loaded on-demand per page
 
@@ -1529,18 +1597,18 @@ app/javascript/
 - **Route**: Added to `config/routes.rb`
 - **Initializer**: `config/initializers/react_on_rails.rb` - Configuration
 
-### Webpack Configuration
+### Bundler Configuration
 
-- Shakapacker handles webpack setup
+- Shakapacker handles Rspack or Webpack setup
 - Config in `config/shakapacker.yml`
-- For custom webpack needs, see [Webpack Configuration Guide](../core-concepts/webpack-configuration.md)
+- For custom bundler needs, see [Webpack/Rspack Configuration Guide](../core-concepts/webpack-configuration.md)
 
 ### Development Workflow
 
 The generator creates `bin/dev` for starting both:
 
 - Rails server (port 3000)
-- Webpack dev server (for hot reloading)
+- Bundler dev server (for hot reloading)
 
 > **Note:** You need `overmind` or `foreman` installed to run `bin/dev`. Install with `brew install overmind` (macOS) or `gem install foreman` (globally). See the [Quick Start Guide](./quick-start.md#-step-2-start-the-development-server-1-minute) for detailed installation instructions.
 
@@ -1656,7 +1724,7 @@ Now that you understand the core concepts, here are recommended paths forward:
 
 ---
 
-**Ready to build something?** The [Tutorial](./tutorial.md) walks you through building a complete app with Redux, routing, and testing.
+**Ready to build something?** The [Tutorial](./tutorial.md) walks you through building a TypeScript component with hooks, Rails props, auto-bundling, and optional server rendering.
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/getting-started/oss-vs-pro
@@ -1823,6 +1891,8 @@ With React on Rails and a client-side router (for example TanStack Router in Pro
 Choose Inertia Rails if you are building a new app from scratch, want SPA-style page transitions, and are comfortable replacing the Rails view layer entirely.
 
 Choose React on Rails if you want to integrate React into existing Rails views incrementally, need server rendering with code splitting or streaming, or want the upgrade path to React on Rails Pro features like React Server Components.
+
+Ready to switch? See the [Inertia Rails migration guide](../migrating/migrating-from-inertia-rails.md) — both gems can coexist in one app, so you can migrate route by route.
 
 Official docs:
 
@@ -5863,6 +5933,396 @@ Use this matrix to decide which approach to use:
 - [Using React Helmet](react-helmet.md) — legacy react-helmet documentation
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/building-features/react-compiler
+SOURCE: docs/oss/building-features/react-compiler.md
+================================================================================
+
+# React Compiler with React on Rails
+
+[React Compiler](https://react.dev/learn/react-compiler) (stable **v1.0**, shipped 2025-10-07) is a build-time tool that adds **automatic memoization** to your components. It removes most hand-written `useMemo` / `useCallback` / `React.memo` boilerplate and cuts unnecessary re-renders — a free runtime-performance and DX win that costs you only a build-config change.
+
+Because the Compiler is versioned independently of React itself, it works on React on Rails' current `react`/`react-dom` `~19.0.x` pin. You do **not** need to wait for a React 19.2 bump to adopt it.
+
+React on Rails delegates JavaScript/TypeScript transforms to your app's build tool (Shakapacker → webpack or Rspack, with Babel or SWC). The Compiler is therefore configured in **your app's Babel or SWC config**, not inside React on Rails. This page documents both transform paths.
+
+## TL;DR
+
+- **Babel path is canonical and verified.** Add `babel-plugin-react-compiler` to your `babel.config.js`, ordered **first**. The compiler-memoized output builds and server-renders correctly.
+- **SWC path is experimental — not recommended for production yet.** As of June 2026 there is no first-party SWC React Compiler plugin; only a brand-new, pre-1.0 third-party Wasm plugin exists. See [Rspack + SWC path](#rspack--swc-path-experimental).
+- **Scope it.** Both paths let you gate the compiler to specific files via the `sources` option. Start scoped to a few components, verify SSR, then widen.
+
+## Prerequisites
+
+- **React ≥ 19** runtime (React on Rails' dummy apps and the Pro runtime already pin `~19.0.x`).
+- **Shakapacker** (any bundler/transpiler combination it supports).
+- Components that follow the [Rules of React](https://react.dev/reference/rules). The Compiler skips (bails out of) components it cannot safely optimize; it does not crash the build for them.
+
+## Shakapacker + Babel path (canonical)
+
+This is the verified, recommended path.
+
+### 1. Install the plugin
+
+```bash
+# pnpm
+pnpm add -D babel-plugin-react-compiler@^1.0.0
+# npm
+npm install --save-dev babel-plugin-react-compiler@^1.0.0
+# yarn
+yarn add --dev babel-plugin-react-compiler@^1.0.0
+```
+
+### 2. Add the plugin to `babel.config.js`, ordered FIRST
+
+The React Compiler **must run before every other Babel plugin and preset** so it sees your original source before any other transform rewrites it (per the [React docs](https://react.dev/learn/react-compiler/installation)). In Babel, plugins run before presets, and within the `plugins` array they run in order — so the compiler must be the **first entry in `plugins`**.
+
+A typical React on Rails `babel.config.js` builds on Shakapacker's preset. Prepend the compiler:
+
+```js
+// babel.config.js
+const defaultConfigFunc = require('shakapacker/package/babel/preset.js');
+
+module.exports = function createBabelConfig(api) {
+  const resultConfig = defaultConfigFunc(api);
+  const isProductionEnv = api.env('production');
+
+  resultConfig.presets = [
+    ...resultConfig.presets,
+    ['@babel/preset-react', { runtime: 'automatic', development: !isProductionEnv }],
+  ];
+
+  // React Compiler MUST be first.
+  resultConfig.plugins = [
+    'babel-plugin-react-compiler', // ← first, ahead of everything else
+    ...resultConfig.plugins,
+  ];
+
+  return resultConfig;
+};
+```
+
+### 3. (Recommended) Scope the compiler with `sources`
+
+You usually do not want to flip the compiler on for your entire app in one step — it changes the output of every component and can surface latent Rules-of-React violations. The plugin's `sources` option accepts **either an array of strings or a predicate `(filename) => boolean`**.
+
+The array form is **not glob-based**: each entry is matched as a plain filename **substring** (the plugin checks whether the absolute filename _contains_ the string), so a literal `**` glob like `client/app/**/*.tsx` matches no real path and would silently skip every component. Use the predicate form when you want precise control — it receives the absolute filename and returns `true` to opt a file in:
+
+```js
+resultConfig.plugins = [
+  [
+    'babel-plugin-react-compiler',
+    {
+      // Compile only files under client/app/startup/compiler-ready/
+      sources: (filename) =>
+        typeof filename === 'string' && filename.includes('client/app/startup/compiler-ready'),
+    },
+  ],
+  ...resultConfig.plugins,
+];
+```
+
+Start scoped, verify SSR and your tests, then widen the predicate (or drop `sources` to compile everything).
+
+### 4. Build and verify
+
+```bash
+# Your normal Shakapacker build, e.g.:
+RAILS_ENV=test NODE_ENV=test bin/shakapacker
+```
+
+The compiler injects a memoization cache into each compiled component. In the emitted bundle, a compiled component contains memo-cache slot accesses (`$[0]`, `$[1]`, …) and `useMemoCache` calls — components it skipped do not. That is how you can confirm, against a real build, that the compiler ran and that your `sources` scope is correct.
+
+> **Note:** `Symbol.for("react.memo_cache_sentinel")` appears in every React 19 bundle — it is part of React's runtime, not proof that the compiler ran. Look for `$[n]` memo-slot accesses **inside your component** instead.
+
+## No double-application risk (verified)
+
+A common worry is that Shakapacker's default Babel preset might already include the React Compiler (or `@babel/preset-react`), causing a double transform. **It does not.**
+
+Inspecting the resolved `shakapacker/package/babel/preset.js` (Shakapacker 10.1) shows its full transform set is:
+
+- `@babel/preset-env`
+- `@babel/preset-typescript` (when present)
+- `@babel/plugin-transform-runtime`
+
+It contains **no** `@babel/preset-react` and **no** `babel-plugin-react-compiler`. Apps add `@babel/preset-react` themselves in `babel.config.js`, and the React Compiler is only present if you add it explicitly. So there is **no double-application** — the compiler runs exactly once, and only where you place it.
+
+## SSR compatibility (verified)
+
+React on Rails server-renders your components through the Node renderer / ExecJS server bundle (`renderToString` / `renderToPipeableStream`). The Compiler's output is plain React — auto-memoization is a render-time optimization that does not change the SSR contract.
+
+This was verified end-to-end: a compiler-memoized example component (`ReactCompilerExample`) was built with the Babel path and server-rendered through the dummy app's server bundle, producing correct HTML with `hasErrors: false`. SSR works unchanged with the compiler enabled.
+
+If you adopt the compiler, keep verifying SSR for your own components — especially any that read browser-only globals at render time, which is a Rules-of-React violation independent of the compiler.
+
+## Rspack + SWC path (experimental)
+
+Many React on Rails teams use Rspack with SWC for build speed (see the [Babel → SWC migration guide](../migrating/babel-to-swc-migration.md)). Unfortunately, the SWC React Compiler story is **not production-viable as of June 2026**:
+
+- There is **no first-party SWC plugin**. `@swc/plugin-react-compiler` does not exist on npm (404), and `@swc/core` has no native React Compiler support.
+- The only candidate, `swc-plugin-react-compiler`, is a **brand-new third-party Wasm plugin** (first published 2026-06-09, currently `0.1.1`) with no published `@swc/core` peer-version constraints. SWC Wasm plugins do not follow semver for ABI compatibility with the `@swc/core` host, so a plugin built against one `@swc/core` can fail to load against another.
+
+**Recommendation: the Babel path is canonical; the SWC path is experimental.** If you are on SWC/Rspack and want the React Compiler today, the most reliable option is to run the **Babel compiler plugin scoped to your compiler-ready components** while keeping SWC for the rest of the build, or to stay on SWC without the compiler until a first-party `@swc/core` integration ships. Track the React Compiler [working group](https://github.com/reactwg/react-compiler) and `@swc/core` releases before wiring the experimental SWC plugin into a production Rspack build.
+
+If you do experiment with the SWC plugin, do it behind an env flag and scoped to a throwaway component first, exactly as with the Babel `sources` example above — and treat any build that succeeds as unverified until you have an SSR smoke test.
+
+## Reference example in this repo
+
+The standard dummy app (`react_on_rails/spec/dummy`) ships a scoped, runnable reference:
+
+- **Component:** `client/app/startup/ReactCompilerExample.tsx` — a non-RSC component written with **no** manual memoization.
+- **Babel wiring:** `babel.config.js` adds `babel-plugin-react-compiler` **first**, gated behind `REACT_COMPILER=1` and scoped via `sources` to just `ReactCompilerExample`, so the default build (which uses SWC) and the existing test suite are unaffected.
+- **View / route:** `app/views/pages/react_compiler_example.html.erb` + the `react_compiler_example` route render it with `prerender: true` (SSR + hydration).
+
+Build it with the compiler on (Babel path):
+
+```bash
+cd react_on_rails/spec/dummy
+REACT_COMPILER=1 SHAKAPACKER_JAVASCRIPT_TRANSPILER=babel \
+  RAILS_ENV=test NODE_ENV=test bin/shakapacker
+```
+
+The compiler is **off by default**, so nothing changes for the normal SWC build.
+
+## Follow-ups (not yet covered here)
+
+These are intentionally deferred and tracked separately:
+
+- **ESLint v6 / compiler lint rules.** The Compiler's "Rules of React" lint rules ship in `eslint-plugin-react-hooks` **v6**; this repo is on `^5.2.0`. Bumping ESLint and wiring the rules is a separate change (it has flat-config implications) and is not part of this recipe.
+- **RSC (React Server Components).** Auto-memoization across the `'use client'` / `'use server'` boundary is the highest-risk surface and needs a real RSC dummy build, not extrapolation. A non-RSC recipe ships first; the RSC example/verification is a follow-up.
+- **Performance benchmark.** A concrete before/after re-render / interaction-latency benchmark to quantify the win is a follow-up.
+
+## References
+
+- [React Compiler (v1.0)](https://react.dev/learn/react-compiler)
+- [React Compiler installation](https://react.dev/learn/react-compiler/installation)
+- [Rules of React](https://react.dev/reference/rules)
+- [Babel → SWC migration guide](../migrating/babel-to-swc-migration.md)
+- [React Compiler working group](https://github.com/reactwg/react-compiler)
+
+================================================================================
+PAGE: https://reactonrails.com/docs/building-features/view-transitions
+SOURCE: docs/oss/building-features/view-transitions.md
+================================================================================
+
+# View Transitions with React on Rails (Experimental)
+
+> **⚠️ Experimental — not officially supported.** This entire page is a canary recipe. The browser
+> [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) is still
+> evolving, React's component-level `<ViewTransition>` API is canary-only, and this recipe may change or
+> break without notice. Nothing on this page is covered by React on Rails' support policy or semver
+> guarantees. React Server Components are explicitly out of scope here. Tracked in
+> [#3888](https://github.com/shakacode/react_on_rails/issues/3888).
+
+This page shows how to use the **browser-native** `document.startViewTransition()` API with components
+rendered by `react_component` — first client-side-only (CSR), then with server rendering plus hydration
+(SSR-hydrate) — and how it interacts with Turbo Drive's own view-transition support.
+
+## What this covers (Experimental)
+
+- Wrapping React state updates (and client-side route updates) in `document.startViewTransition()`.
+- What does and does not work when the component is server-rendered and hydrated.
+- The Turbo Drive interplay: Turbo's cross-page transitions vs React-driven in-page transitions.
+- A tiny flagged demo in the gem's dummy app.
+
+It deliberately does **not** cover React's canary `<ViewTransition>` component / `addTransitionType`
+API beyond a status note (see below), and it does not cover React Server Components.
+
+## Browser support and feature detection (Experimental)
+
+Same-document view transitions (`document.startViewTransition`) ship in Chrome/Edge 111+, Safari 18+,
+and recent Firefox releases, but you must always feature-detect — unsupported browsers simply apply the
+DOM update without animation:
+
+```js
+function withViewTransition(applyUpdate) {
+  if (typeof document.startViewTransition === 'function') {
+    document.startViewTransition(applyUpdate);
+  } else {
+    applyUpdate(); // graceful fallback: same update, no animation
+  }
+}
+```
+
+## CSR recipe (Experimental)
+
+`document.startViewTransition(callback)` snapshots the current page, runs your `callback` to mutate the
+DOM, snapshots the result, and animates between the two snapshots.
+
+The catch for React: React 18/19 **batches state updates and commits asynchronously**, but the browser
+expects the DOM to be fully updated when your callback returns. Wrap the state update in
+[`flushSync`](https://react.dev/reference/react-dom/flushSync) so React commits synchronously inside
+the callback:
+
+```tsx
+import React, { useState } from 'react';
+import { flushSync } from 'react-dom';
+
+const Panel = () => {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggle = () => {
+    const applyUpdate = () => {
+      flushSync(() => {
+        setExpanded((prev) => !prev);
+      });
+    };
+
+    if (typeof document.startViewTransition === 'function') {
+      document.startViewTransition(applyUpdate);
+    } else {
+      applyUpdate();
+    }
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={toggle}>
+        Toggle
+      </button>
+      <div id="vt-panel" className={expanded ? 'panel panel--expanded' : 'panel'}>
+        …
+      </div>
+    </div>
+  );
+};
+```
+
+Give the animated element a `view-transition-name` so the browser can pair its old/new snapshots, and
+optionally style the transition pseudo-elements:
+
+```css
+#vt-panel {
+  view-transition-name: vt-panel;
+}
+
+::view-transition-old(vt-panel),
+::view-transition-new(vt-panel) {
+  animation-duration: 300ms;
+}
+```
+
+This works with plain `react_component("Panel", prerender: false)` — no React on Rails configuration is
+involved; the recipe is entirely inside your component and CSS.
+
+### Client-side route changes (Experimental)
+
+The same pattern wraps client-side navigation inside a React root: call your router's navigate function
+inside the `startViewTransition` callback (with `flushSync` if the router commits asynchronously). If
+you use React Router, prefer its built-in integration (`<Link viewTransition>` /
+`useViewTransitionState`) instead of hand-rolling — see [React Router](./react-router.md). These
+router-level integrations are experimental in the same sense as the rest of this page.
+
+### CSR pitfalls (Experimental)
+
+- **`flushSync` is a forced synchronous render.** Keep the transitioned update small; large trees will
+  jank inside the transition callback.
+- **One transition at a time.** Starting a new same-document transition skips any transition already
+  running. Rapid clicks fall back to the final state — that is by design, but don't queue your own.
+- **Duplicate `view-transition-name`s abort the transition.** Each name must be unique on the page at
+  snapshot time (watch out for lists; derive names from item ids if you animate list items).
+- **Names must be valid CSS custom identifiers.** A `view-transition-name` cannot start with a digit
+  and cannot be a CSS-wide keyword (`none`, `inherit`, …) — prefix derived names, e.g. `item-42`, not
+  `42`.
+
+## SSR-hydrate recipe (Experimental)
+
+The same component works with `prerender: true` (server rendering + client hydration) as long as you
+follow these rules:
+
+- **Only touch the API in event handlers or effects.** `document` does not exist in the server-side
+  rendering environment (ExecJS or the Pro Node renderer). Never call or feature-detect
+  `document.startViewTransition` at module scope or during render of a server-rendered component.
+- **Don't branch markup on feature support during the initial render.** The server cannot know what the
+  browser supports, so support-dependent markup causes hydration mismatches. Feature-detect inside the
+  handler (as above), or stash support in state from a `useEffect` after mount.
+- **`view-transition-name` in server-rendered HTML is safe.** It is plain CSS — it has no effect until
+  a transition starts, and it does not affect hydration.
+- **The initial paint is not transitioned.** View transitions animate _updates_; server-rendered HTML
+  appearing and React hydrating it produce no transition (and hydration itself must not be wrapped in
+  one). Only post-hydration interactions animate.
+
+In short: SSR-hydrate works today with the browser API because the transition only ever runs on the
+client, after hydration, inside user-triggered handlers.
+
+## React canary `<ViewTransition>` status (Experimental)
+
+React's component-level API (`<ViewTransition>`, `addTransitionType`) is **canary-only** and is not
+part of this recipe. React 19.2 shipped groundwork that matters for the future here — SSR Suspense
+reveal batching, and the `useId` prefix change to `_r_` so generated ids are valid
+`view-transition-name` values — but running a canary React build under React on Rails is untested and
+unsupported. This page intentionally uses only the browser API, which works on stable React 19.
+
+## Turbo Drive interplay (Experimental)
+
+> **⚠️ Turbo claims pending maintainer review.** The claims in this section follow Turbo's documented
+> behavior and React on Rails' Turbo event wiring, but they have not yet been verified end-to-end in
+> the dummy app. Treat them as provisional until a maintainer confirms them.
+
+Rails apps using [Turbo Drive](https://turbo.hotwired.dev) have a second, independent view-transition
+system: Turbo can wrap its **cross-page** (page-to-page) renders in `document.startViewTransition` when
+the page opts in via:
+
+```html
+<meta name="view-transition" content="same-origin" />
+```
+
+How this relates to React-driven transitions:
+
+- **Two different scopes.** Turbo Drive transitions animate whole-page navigations (Turbo replaces the
+  `<body>`); React-driven transitions (this page's recipe) animate state/route updates **inside** a
+  mounted React root. Use Turbo's mechanism for cross-page continuity and the React recipe for in-page
+  interactions — they solve different problems.
+- **React state does not survive a Turbo visit.** React on Rails listens to `turbo:before-render` /
+  `turbo:render` and unmounts components before Turbo swaps the body, then re-mounts them on the new
+  page (see `packages/react-on-rails/src/pageLifecycle.ts`). Any cross-page visual continuity must come
+  from Turbo's transition (matching `view-transition-name`s in the old and new HTML), not from React.
+- **They must not run simultaneously.** Browsers allow only one active same-document transition;
+  starting another skips the one in progress. Avoid triggering a React `startViewTransition` from code
+  that runs during a Turbo visit (e.g., in `turbo:before-render`/`turbo:render` handlers or unmount
+  paths). In practice this is easy to satisfy: trigger React transitions only from user interactions.
+- **Turbo's preview cache can confuse pairing.** Turbo may first render a cached preview of the next
+  page and then the fresh response. Elements with `view-transition-name` that appear in both the old
+  page and the preview can pair unexpectedly or abort (duplicate names). Test with the cache in play
+  before shipping, or disable preview for transitioned pages
+  (`<meta name="turbo-cache-control" content="no-preview">`).
+
+## In-repo demo (Experimental)
+
+The gem's dummy app contains a minimal CSR demo of this recipe, inert unless you opt in with an
+environment flag:
+
+- Component: `react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx`
+- View: `react_on_rails/spec/dummy/app/views/pages/view_transitions_demo.html.erb`
+- Route: defined in `react_on_rails/spec/dummy/config/routes.rb` only when `VIEW_TRANSITIONS_DEMO=true`
+
+Run it from a React on Rails checkout:
+
+```bash
+cd react_on_rails/spec/dummy
+VIEW_TRANSITIONS_DEMO=true bin/dev
+# then open http://localhost:3000/view_transitions_demo
+```
+
+With the flag unset, the route does not exist and the demo page is unreachable.
+
+## Promote-to-supported checklist (Experimental)
+
+This page graduates from experimental to supported only when all of the following are true:
+
+- [ ] React's `<ViewTransition>` / `addTransitionType` ship in a **stable** React release, and React on
+      Rails' supported React range includes that release.
+- [ ] The Turbo-interplay claims above are verified end-to-end in the dummy app (Turbo is enabled
+      there) by a maintainer, and the "pending maintainer review" banner is removed.
+- [ ] The CSR and SSR-hydrate recipes are re-validated against the then-current React on Rails major,
+      and the dummy demo is either covered by a spec/E2E test or promoted out of its env flag.
+- [ ] Browser support is re-confirmed as Baseline for same-document transitions across the browsers the
+      docs target (re-check Firefox).
+- [ ] Experimental banners are removed from this page and the change is announced in the CHANGELOG.
+
+**Owner:** maintainers — tracked in [#3888](https://github.com/shakacode/react_on_rails/issues/3888).
+Re-check cadence: each React minor release (or quarterly, whichever comes first).
+
+================================================================================
 PAGE: https://reactonrails.com/docs/building-features/streaming-server-rendering
 SOURCE: docs/oss/building-features/streaming-server-rendering.md
 ================================================================================
@@ -6679,6 +7139,109 @@ export const initialStates = {
 ```
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/building-features/styling-with-tailwind
+SOURCE: docs/oss/building-features/styling-with-tailwind.md
+================================================================================
+
+# Styling with Tailwind CSS v4
+
+React on Rails can generate a Tailwind CSS v4 setup for the server-rendered
+HelloWorld example. The generator uses Tailwind's CSS-first setup, the
+`@tailwindcss/postcss` plugin, and the same shared bundler template for Webpack
+and Rspack.
+
+## New Apps
+
+For a fresh Rails app, pass `--tailwind` to `create-react-on-rails-app`:
+
+```bash
+npx create-react-on-rails-app my-app --tailwind
+cd my-app
+bin/rails db:prepare
+bin/dev
+```
+
+The CLI forwards `--tailwind` to `rails generate react_on_rails:install`, so the
+generated `/hello_world` page is server-rendered and styled by Tailwind CSS v4.
+
+## Existing Apps
+
+For an existing Rails app, pass the generator flag directly:
+
+```bash
+bundle exec rails generate react_on_rails:install --tailwind
+```
+
+The generator installs these published packages:
+
+```bash
+pnpm add tailwindcss@^4.3.0 @tailwindcss/postcss@^4.3.0 postcss@^8.5.15 postcss-loader@^8.2.1
+npm install tailwindcss@^4.3.0 @tailwindcss/postcss@^4.3.0 postcss@^8.5.15 postcss-loader@^8.2.1
+yarn add tailwindcss@^4.3.0 @tailwindcss/postcss@^4.3.0 postcss@^8.5.15 postcss-loader@^8.2.1
+```
+
+It also creates `app/javascript/stylesheets/application.css`:
+
+<!-- prettier-ignore -->
+```css
+@import "tailwindcss";
+```
+
+The generated `HelloWorld.client.jsx` or `HelloWorld.client.tsx` imports that CSS
+file and uses Tailwind utility classes. The shared `commonWebpackConfig.js`
+template inserts `postcss-loader` after `css-loader` and configures
+`@tailwindcss/postcss`, regardless of whether the project uses Webpack or Rspack.
+
+## Server Rendering Without a Flash of Unstyled Content
+
+The generated example keeps two pieces together:
+
+1. `app/views/hello_world/index.html.erb` renders the component with
+   `prerender: true`.
+2. `app/views/layouts/react_on_rails_default.html.erb` keeps
+   `<%= stylesheet_pack_tag %>` in the document head before
+   `<%= javascript_pack_tag %>`.
+
+When React on Rails auto-loads the generated component pack, it appends the
+generated component stylesheet pack. In a production build, Shakapacker emits
+that stylesheet as an extracted CSS `<link>` in the SSR HTML. Do not remove the
+empty `stylesheet_pack_tag`; it is the placeholder React on Rails uses to insert
+component CSS and avoid a Tailwind flash of unstyled content.
+
+In development, CSS can be injected by the dev server instead of extracted as a
+static link. Use a production build when validating the no-FOUC path.
+
+## Adding Tailwind Manually
+
+If you are not rerunning the generator, add the packages yourself:
+
+```bash
+pnpm add tailwindcss@^4.3.0 @tailwindcss/postcss@^4.3.0 postcss@^8.5.15 postcss-loader@^8.2.1
+npm install tailwindcss@^4.3.0 @tailwindcss/postcss@^4.3.0 postcss@^8.5.15 postcss-loader@^8.2.1
+yarn add tailwindcss@^4.3.0 @tailwindcss/postcss@^4.3.0 postcss@^8.5.15 postcss-loader@^8.2.1
+```
+
+Then create a CSS entry, import it from your client component or client pack,
+and add `postcss-loader` after `css-loader` in your shared bundler config:
+
+```javascript
+{
+  loader: 'postcss-loader',
+  options: {
+    postcssOptions: {
+      plugins: [require('@tailwindcss/postcss')],
+    },
+  },
+}
+```
+
+Keep the SSR view prerendered and keep `stylesheet_pack_tag` in the layout head
+so the generated component CSS can be emitted before the JavaScript runs.
+
+Tailwind v3 projects should use Tailwind's v3 PostCSS setup instead of this v4
+recipe.
+
+================================================================================
 PAGE: https://reactonrails.com/docs/building-features/i18n
 SOURCE: docs/oss/building-features/i18n.md
 ================================================================================
@@ -6894,6 +7457,11 @@ SOURCE: docs/oss/building-features/images.md
 
 # Configuring Images and Assets with Webpack
 
+This page covers the **bundling** side of images: configuring webpack so images
+imported from your JavaScript/SCSS resolve correctly. For the **performance**
+side — responsive `srcset`, lazy loading, CLS prevention, LCP preloading, and
+AVIF/WebP — see [Fast Images in React on Rails](./fast-images.md).
+
 A leading slash is necessary on the `name` option for file-loader/url-loader and the `publicPath` option for output.
 
 ```javascript
@@ -6939,6 +7507,635 @@ to `app/javascript/images/foobar.jpg` with a custom alias like this:
     },
   },
 ```
+
+## See also
+
+- [Fast Images in React on Rails](./fast-images.md) — responsive `srcset`,
+  lazy loading, CLS prevention, LCP preloading, and modern formats using Rails
+  primitives.
+- [Font Optimization](./fonts.md) — self-hosting and optimizing web fonts
+  (preload, `font-display`, and a `size-adjust` metric-matched fallback to
+  eliminate layout shift).
+
+================================================================================
+PAGE: https://reactonrails.com/docs/building-features/fast-images
+SOURCE: docs/oss/building-features/fast-images.md
+================================================================================
+
+# Fast Images in React on Rails
+
+Next.js markets `next/image` as a single component that solves responsive
+images, lazy loading, modern formats, layout-shift (CLS) prevention, and LCP
+prioritization. Rails already ships the primitives for every one of those
+concerns — no hosted image service, no Vercel lock-in. This recipe shows how to
+combine them in a React on Rails app, both in ERB views and in React components
+rendered with `react_component`.
+
+> **A first-party `<Image>` component is under consideration** for React on
+> Rails (see [issue #3874](https://github.com/shakacode/react_on_rails/issues/3874)).
+> Everything on this page works today with stock Rails — the proposed component
+> would only package these defaults, not replace them.
+
+For configuring webpack to _bundle_ images imported from your JavaScript (the
+asset-loading side), see
+[Configuring Images and Assets with Webpack](./images.md). This page is about
+the _markup and serving_ side: what the browser receives.
+
+## The checklist
+
+A "fast image" means:
+
+1. **Responsive `srcset` + `sizes`** — the browser downloads a size appropriate
+   for the layout, not a 2400px original on a phone.
+2. **Intrinsic `width`/`height` (+ CSS `aspect-ratio`)** — layout space is
+   reserved before the image loads, so there is no CLS.
+3. **`loading="lazy"` + `decoding="async"`** on everything below the fold.
+4. **`fetchpriority="high"` + `loading="eager"` + a preload** on the LCP/hero
+   image only.
+5. **AVIF/WebP with a fallback** via `<picture>`.
+
+## Responsive `srcset` from the asset pipeline
+
+For images that ship with your app (Sprockets/Propshaft), commit the size
+variants and let `image_tag` build the `srcset`. Hash keys are resolved through
+the asset pipeline just like the main `src`, so fingerprinting works:
+
+```erb
+<%= image_tag("team-photo-800.jpg",
+      srcset: {
+        "team-photo-400.jpg" => "400w",
+        "team-photo-800.jpg" => "800w",
+        "team-photo-1600.jpg" => "1600w"
+      },
+      sizes: "(max-width: 600px) 100vw, 600px",
+      width: 800,
+      height: 533,
+      loading: "lazy",
+      decoding: "async",
+      alt: "The team at launch") %>
+```
+
+`sizes` tells the browser how wide the image will render at each viewport
+width; without it the browser assumes `100vw` and over-downloads.
+
+## Responsive `srcset` from Active Storage variants
+
+For user-uploaded images, generate the width set with
+[Active Storage variants](https://guides.rubyonrails.org/active_storage_overview.html#transforming-images).
+You need the `image_processing` gem (libvips recommended):
+
+```ruby
+# Gemfile
+gem "image_processing", "~> 1.2"
+```
+
+```erb
+<%# app/views/products/show.html.erb %>
+<% widths = [400, 800, 1600] %>
+<% variants = widths.index_with { |w| @product.photo.variant(resize_to_limit: [w, nil]) } %>
+<%= image_tag url_for(variants[800].processed),
+      srcset: widths.map { |w| "#{url_for(variants[w].processed)} #{w}w" }.join(", "),
+      sizes: "(max-width: 600px) 100vw, 600px",
+      width: 800,
+      height: (800 * @product.photo_aspect_ratio).round,
+      loading: "lazy",
+      decoding: "async",
+      alt: @product.name %>
+```
+
+:::warning Request-time variant generation is a performance footgun
+
+`variant(...)` does **not** resize anything until the variant is first served.
+With the default redirect mode, the first visitor to hit each width pays the
+transformation cost (or times out on large images), and a cold cache after a
+storage migration pays it again for every image on the page — multiplied by
+every width in your `srcset`.
+
+Treat request-time generation as a fallback, not the plan:
+
+- **Pre-generate variants** when the upload happens, in a background job, by
+  calling `.processed` (which transforms and uploads the variant if missing):
+
+  ```ruby
+  class Product < ApplicationRecord
+    has_one_attached :photo do |attachable|
+      attachable.variant :w400, resize_to_limit: [400, nil], preprocessed: true
+      attachable.variant :w800, resize_to_limit: [800, nil], preprocessed: true
+      attachable.variant :w1600, resize_to_limit: [1600, nil], preprocessed: true
+    end
+  end
+  ```
+
+  Named variants with `preprocessed: true` (Rails 7.1+) enqueue transformation
+  right after upload instead of on first request. Reference them as
+  `@product.photo.variant(:w800)`.
+
+- **Run `analyze` on attach** (Active Storage does this by default via a job)
+  so `metadata[:width]`/`metadata[:height]` are available for CLS attributes
+  without downloading the blob. Until that job has run, `attachment.analyzed?`
+  is `false` and the dimensions are missing — guard for it and fall back to a
+  default aspect ratio, as the snippets below do.
+
+- **Serve through a CDN.** Put a CDN in front of your storage service (or use
+  [proxy mode](https://guides.rubyonrails.org/active_storage_overview.html#putting-a-cdn-in-front-of-active-storage)
+  plus a CDN in front of the app) so each generated variant is transformed
+  once and cached at the edge — not re-served by your Rails dynos.
+
+:::
+
+To get intrinsic dimensions for the `width`/`height` attributes, read the
+analyzed metadata instead of hardcoding:
+
+```ruby
+# app/models/product.rb
+# Height ÷ width (≈0.667 for a 3:2 landscape photo) — the multiplier that
+# turns a display width into the matching height attribute. Note that CSS
+# `aspect-ratio` is the inverse: width / height.
+def photo_aspect_ratio
+  meta = photo.metadata
+  return 2.0 / 3 unless meta["width"].to_i.positive? && meta["height"].to_i.positive?
+
+  meta["height"].to_f / meta["width"]
+end
+```
+
+Guard on **both** dimensions: until the analyzer job has run
+(`photo.analyzed?` is `false`), either value can be missing, and a zero height
+would emit `height="0"` and an `aspect-ratio` of 0.
+
+## Passing image props to a React component
+
+When the `<img>` lives inside a React component, keep the URL math in Rails —
+where the asset pipeline and Active Storage live — and hand React a plain props
+hash via `react_component`. Compute the props in a helper:
+
+```ruby
+# app/helpers/images_helper.rb
+module ImagesHelper
+  # Must match the named variants on the model (:w400, :w800, :w1600),
+  # pre-generated at upload time with preprocessed: true — see the
+  # variant-generation warning above.
+  RESPONSIVE_WIDTHS = [400, 800, 1600].freeze
+
+  # Returns {src:, srcSet:, sizes:, width:, height:} for an Active Storage attachment.
+  def responsive_image_props(attachment, sizes: "100vw", display_width: 800)
+    # Snap to the closest generated width so an unlisted value can't produce
+    # a nil variant lookup.
+    display_width = RESPONSIVE_WIDTHS.min_by { |w| (w - display_width).abs }
+    meta = attachment.metadata
+    aspect_ratio =
+      if meta["width"].to_i.positive? && meta["height"].to_i.positive?
+        meta["height"].to_f / meta["width"]
+      else
+        2.0 / 3 # analysis hasn't run yet — see the warning above
+      end
+    srcset = RESPONSIVE_WIDTHS.map { |w| "#{url_for(attachment.variant(:"w#{w}"))} #{w}w" }
+
+    {
+      src: url_for(attachment.variant(:"w#{display_width}")),
+      srcSet: srcset.join(", "),
+      sizes: sizes,
+      width: display_width,
+      height: (display_width * aspect_ratio).round
+    }
+  end
+end
+```
+
+If you cannot define named variants (or are on Rails < 7.1), the request-time
+form — `attachment.variant(resize_to_limit: [w, nil]).processed` — is a drop-in
+replacement for `attachment.variant(:"w#{w}")`. But it transforms on first
+request, which is exactly the footgun the warning above describes: acceptable
+for a low-traffic admin page, not for anything user-facing.
+
+```erb
+<%# app/views/products/show.html.erb %>
+<%= react_component("ProductHero", props: {
+      name: @product.name,
+      image: responsive_image_props(@product.photo, sizes: "(max-width: 600px) 100vw, 600px")
+    }) %>
+```
+
+The React side is just an `<img>` spreading those attributes — it renders
+identically on the server and client, so there is nothing to hydrate
+incorrectly:
+
+```jsx
+// app/javascript/src/ProductHero/ror_components/ProductHero.jsx
+export default function ProductHero({ name, image }) {
+  return (
+    <figure>
+      <img
+        src={image.src}
+        srcSet={image.srcSet}
+        sizes={image.sizes}
+        width={image.width}
+        height={image.height}
+        loading="lazy"
+        decoding="async"
+        alt={name}
+      />
+      <figcaption>{name}</figcaption>
+    </figure>
+  );
+}
+```
+
+For asset-pipeline images the same pattern applies — build the hash with
+`image_path`/`image_url` instead of `url_for(variant)`.
+
+## CLS prevention: intrinsic size + `aspect-ratio`
+
+Always emit `width` and `height` attributes (the intrinsic pixel dimensions,
+not the display size). Browsers use them to reserve the correct box before the
+bytes arrive, which is what keeps CLS at zero. Then let CSS control the actual
+display size:
+
+```css
+img {
+  max-width: 100%;
+  height: auto; /* keep the reserved aspect ratio when width is constrained */
+}
+```
+
+If you size an image with CSS alone (e.g. a `background-size: cover`-style
+crop), reserve the space explicitly:
+
+```css
+.card-thumb {
+  aspect-ratio: 3 / 2;
+  width: 100%;
+  object-fit: cover;
+}
+```
+
+## Defaults for non-hero images
+
+Every image that can start below the fold should opt out of competing with
+critical resources:
+
+- `loading="lazy"` — the browser defers the download until the image nears the
+  viewport.
+- `decoding="async"` — decode off the main thread instead of blocking paint.
+
+These are plain attributes in both ERB (`loading: "lazy", decoding: "async"`)
+and JSX (`loading="lazy" decoding="async"`). They are the right default for
+everything **except** the LCP image — lazy-loading the hero is one of the most
+common LCP regressions.
+
+## The LCP/hero image: prioritize and preload
+
+For the one image that is your [Largest Contentful Paint](https://web.dev/articles/optimize-lcp)
+element, invert the defaults:
+
+```erb
+<%= image_tag("hero-1600.jpg",
+      srcset: { "hero-800.jpg" => "800w", "hero-1600.jpg" => "1600w" },
+      sizes: "100vw",
+      width: 1600,
+      height: 900,
+      loading: "eager",
+      fetchpriority: "high",
+      alt: "Hand-thrown ceramic mugs lined up on a workbench") %>
+```
+
+- `fetchpriority="high"` tells the browser to fight for bandwidth for this
+  request.
+- `loading="eager"` (the default, but explicit beats accidental `lazy`).
+- Give the hero real `alt` text — it is usually meaningful content. Reserve
+  `alt: ""` for purely decorative images.
+
+Additionally, preload it from your **layout's `<head>`**, so the fetch starts
+before the browser has parsed down to the `<img>` (or, for client-rendered
+components, before React renders at all):
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+<head>
+  <%= yield :preloads %>
+  <%# ... %>
+</head>
+```
+
+If the hero has a single source,
+[`preload_link_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-preload_link_tag)
+is the right tool:
+
+```erb
+<%# app/views/home/index.html.erb %>
+<% content_for :preloads do %>
+  <%= preload_link_tag image_path("hero-1600.jpg"), as: "image", fetchpriority: "high" %>
+<% end %>
+```
+
+For a **responsive** hero (the `srcset` case above), the preload must carry
+`imagesrcset`/`imagesizes` so the browser preloads the same candidate the
+`<img>` will pick. Use a plain `<link>` here — **not** `preload_link_tag`:
+besides the tag, `preload_link_tag` also sends an HTTP `Link: rel=preload`
+header built only from the fixed `href` (it does not include
+`imagesrcset`/`imagesizes`), so browsers that honor the header would fetch the
+full-size image on every viewport, duplicating the download the responsive
+preload was supposed to avoid.
+
+```erb
+<%# app/views/home/index.html.erb %>
+<% content_for :preloads do %>
+  <link
+    rel="preload"
+    as="image"
+    fetchpriority="high"
+    imagesrcset="<%= image_path('hero-800.jpg') %> 800w, <%= image_path('hero-1600.jpg') %> 1600w"
+    imagesizes="100vw"
+  />
+<% end %>
+```
+
+This is deliberately a **layout-level** concern: the preload belongs in the
+document `<head>` your layout owns, declared by the page that knows its hero.
+You do not need (and React on Rails does not currently provide) a
+head-injection helper for it. Preload at most one or two images per page —
+preloading more steals bandwidth from the things you actually wanted to
+prioritize.
+
+## Modern formats: AVIF/WebP with fallback
+
+AVIF and WebP are typically 30–50% smaller than JPEG at equivalent quality.
+Active Storage variants can transcode formats too (libvips must be built with
+AVIF support for `:avif`). Define them as named, pre-generated variants, like
+the width variants earlier:
+
+```ruby
+# app/models/product.rb — add format variants next to the width variants
+attachable.variant :w800_avif, resize_to_limit: [800, nil], format: :avif, preprocessed: true
+attachable.variant :w800_webp, resize_to_limit: [800, nil], format: :webp, preprocessed: true
+```
+
+```erb
+<picture>
+  <source srcset="<%= url_for(@product.photo.variant(:w800_avif)) %>" type="image/avif" />
+  <source srcset="<%= url_for(@product.photo.variant(:w800_webp)) %>" type="image/webp" />
+  <%= image_tag url_for(@product.photo.variant(:w800)),
+        width: 800, height: 533, loading: "lazy", decoding: "async",
+        alt: @product.name %>
+</picture>
+```
+
+The browser picks the first `<source>` it supports and falls back to the
+`<img>` otherwise — older browsers never download the modern formats. On
+Rails 7.1+ you can also use the
+[`picture_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-picture_tag)
+helper. In JSX the same markup is `<picture>` + `<source>` elements with
+`srcSet`/`type` props.
+
+For brevity this example is **fixed-width** — one 800px candidate per format.
+In production, make each `<source>` responsive exactly like
+[the plain `<img>` above](#responsive-srcset-from-active-storage-variants):
+define the format variants at every width (`:w400_avif`, `:w800_avif`,
+`:w1600_avif`, …) and give each `<source>` the multi-width `srcset` plus the
+same `sizes` value. Otherwise the browser always downloads the one listed
+candidate and you lose the responsive savings. Note the multiplication — two
+formats × three widths is six variants per image — which is why these are
+defined with `preprocessed: true` rather than transformed at request time.
+
+## Putting it together
+
+| Concern          | Non-hero image            | LCP/hero image                          |
+| ---------------- | ------------------------- | --------------------------------------- |
+| `srcset`/`sizes` | yes                       | yes                                     |
+| `width`/`height` | always                    | always                                  |
+| `loading`        | `lazy`                    | `eager`                                 |
+| `decoding`       | `async`                   | (default)                               |
+| `fetchpriority`  | (default)                 | `high`                                  |
+| Preload          | no                        | preload `<link>` in the layout `<head>` |
+| Formats          | AVIF/WebP via `<picture>` | AVIF/WebP via `<picture>`               |
+
+To verify the result, check LCP and CLS in Chrome DevTools (Performance panel)
+or with the [web-vitals](https://github.com/GoogleChrome/web-vitals) library:
+the hero should be discovered in the preload scanner's first pass, and CLS from
+images should be ~0.
+
+## See also
+
+- [Configuring Images and Assets with Webpack](./images.md) — bundling images
+  imported from JavaScript/SCSS.
+- [Font Optimization](./fonts.md) — the companion recipe for the other classic
+  CLS source.
+- [web.dev: Optimize LCP](https://web.dev/articles/optimize-lcp) and
+  [web.dev: CLS](https://web.dev/articles/cls).
+
+================================================================================
+PAGE: https://reactonrails.com/docs/building-features/fonts
+SOURCE: docs/oss/building-features/fonts.md
+================================================================================
+
+# Font Optimization (a `next/font/local` analog)
+
+Web fonts are a classic source of two performance problems:
+
+1. **Render-blocking external requests** when you load fonts from a third-party
+   host (e.g. the Google Fonts CDN) — an extra origin connection plus a
+   privacy/GDPR consideration.
+2. **Cumulative Layout Shift (CLS)** when the browser re-renders text after the
+   web font replaces the fallback font, because the two fonts have different
+   metrics.
+
+`next/font` solves both by self-hosting the font, preloading it, setting
+`font-display`, and generating a metric-matched fallback face. React on Rails
+ships a small first-party helper that does the same thing on Rails — no
+third-party dependency, no build plugin. You self-host (commit + fingerprint) a
+`.woff2` through your asset pipeline and the helper emits the correct `<head>`
+markup.
+
+> This is the OSS v1: the **`next/font/local`** path (you commit the font file).
+> Build-time Google-Fonts fetching (`next/font/google`) and automatic per-font
+> metric derivation are tracked as follow-ups.
+
+See also: [Configuring Images and Assets with Webpack](./images.md).
+
+## The helper
+
+`ReactOnRails::FontHelper#react_on_rails_font_face` is mixed into the standard
+view helpers. It returns markup for the document `<head>`:
+
+1. `<link rel="preload" as="font" type="font/woff2" crossorigin>` so the browser
+   fetches the font in parallel with first paint;
+2. an `@font-face` rule with `font-display: swap`;
+3. an optional **metric-matched fallback** `@font-face` (`size-adjust` plus
+   `ascent-override` / `descent-override` / `line-gap-override`) so the system
+   fallback occupies the same space as the web font.
+
+It uses the same `<head>`-injection convention as
+[`react_component_hash`](./react-helmet.md): wrap the return value in
+`content_for :head`, and yield it from your layout's `<head>`.
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+<head>
+  <%= yield :head %>
+  <%# ... %>
+</head>
+```
+
+```erb
+<%# your view %>
+<% content_for :head do %>
+  <%= react_on_rails_font_face(
+        family: "Inter",
+        src: asset_path("inter-latin-400-normal.woff2"),
+        weight: 400,
+        fallback: {
+          family: "Arial",
+          size_adjust: "107.12%",
+          ascent_override: "90.44%",
+          descent_override: "22.52%",
+          line_gap_override: "0.0%"
+        }
+      ) %>
+<% end %>
+```
+
+Then set your CSS font stack to the web font, then the generated fallback face,
+then a generic family:
+
+```css
+body {
+  font-family: 'Inter', 'Inter Fallback', Arial, sans-serif;
+}
+```
+
+### Options
+
+| Option           | Default    | Notes                                                          |
+| ---------------- | ---------- | -------------------------------------------------------------- |
+| `family:`        | (required) | CSS `font-family` name for the web font.                       |
+| `src:`           | (required) | URL to the `.woff2`. Use `asset_path(...)` for fingerprinting. |
+| `weight:`        | `400`      | A range like `"100 900"` is valid for variable fonts.          |
+| `style:`         | `"normal"` | `font-style`.                                                  |
+| `display:`       | `"swap"`   | `font-display`. `swap` shows fallback text immediately.        |
+| `unicode_range:` | `nil`      | Emit a `unicode-range` to subset the face (see below).         |
+| `preload:`       | `true`     | Emit the preload `<link>`.                                     |
+| `fallback:`      | `nil`      | Metric-matched fallback face (see below).                      |
+
+> **Trusted input only.** Every argument is interpolated verbatim into the CSS/HTML this helper emits into `<head>`, and the result is marked HTML-safe. Pass developer-controlled values (font names, asset paths) — never end-user input. Values containing `<`, `>`, `"`, or a newline raise `ArgumentError`.
+
+## Self-hosting through the asset pipeline
+
+Commit the `.woff2` file into your asset pipeline so it is fingerprinted and
+served with a far-future cache header. With Sprockets/Propshaft, place it under
+`app/assets/fonts/` (or `vendor/assets`) and reference it with
+`asset_path("inter-latin-400-normal.woff2")`. With Shakapacker, import the font
+from your pack and pass the resolved URL. Either way the font is served from your
+own origin — there is no runtime request to a third-party font host.
+
+## `font-display: swap`
+
+`swap` tells the browser to render text immediately with the fallback font and
+swap in the web font when it arrives. This avoids invisible text (the "FOIT"
+flash of invisible text) at the cost of a "FOUT" flash of unstyled text — which
+the fallback-metrics technique below makes nearly invisible.
+
+## The `size-adjust` fallback (eliminating CLS)
+
+`font-display: swap` shows fallback text first, then swaps in the web font. If
+the fallback and the web font have different metrics, text **reflows** on the
+swap — that reflow is CLS. The fix (the same one `next/font` uses) is a second
+`@font-face` that takes a **local** system font and adjusts its metrics with
+`size-adjust`, `ascent-override`, `descent-override`, and `line-gap-override` so
+it occupies exactly the space the real web font will. The helper also emits
+`font-weight` and `font-style` on this fallback face matching the primary face,
+so the browser applies it to the same elements (without this, the size-adjust
+protection silently fails for non-`400` weights or non-`normal` styles — just as
+`next/font` generates a weight-matched fallback). See
+[web.dev: font best practices](https://web.dev/articles/font-best-practices) and
+[Chrome: improved font fallbacks](https://developer.chrome.com/blog/font-fallbacks/).
+
+### Deriving the numbers (worked example: Inter over Arial)
+
+These values must be derived from the actual font metrics — do not guess. The
+example below uses metrics from
+[`@capsizecss/metrics`](https://github.com/seek-oss/capsize) `v4.0.0` (the same
+data source `next/font` and `fontaine` use). All values share `unitsPerEm: 2048`.
+
+| Metric       | Inter (web font) | Arial (fallback) |
+| ------------ | ---------------- | ---------------- |
+| `xWidthAvg`  | 978              | 913              |
+| `ascent`     | 1984             | 1854             |
+| `descent`    | -494             | -434             |
+| `lineGap`    | 0                | 67               |
+| `unitsPerEm` | 2048             | 2048             |
+
+`size-adjust` scales the fallback so its average character width matches the web
+font:
+
+```
+size-adjust = (inter.xWidthAvg / inter.unitsPerEm) / (arial.xWidthAvg / arial.unitsPerEm)
+            = (978 / 2048) / (913 / 2048)
+            = 1.0712  ->  107.12%
+```
+
+The overrides describe the **web font's** vertical metrics, scaled by
+`size-adjust` so the adjusted fallback's line box matches:
+
+```
+ascent-override   = (inter.ascent  / inter.unitsPerEm) / size-adjust = 0.9044 -> 90.44%
+descent-override  = (|inter.descent| / inter.unitsPerEm) / size-adjust = 0.2252 -> 22.52%
+line-gap-override = (inter.lineGap / inter.unitsPerEm) / size-adjust = 0.0    -> 0.0%
+```
+
+These match the values `next/font/local` generates for Inter with an Arial
+fallback. For other fonts, plug the font's own metrics into the same formulas,
+or read the generated numbers from your `next/font` setup if you are migrating.
+
+## Subsetting guidance
+
+Ship only the glyphs you need. A full font can be hundreds of KB; a `latin`
+subset is typically 15–30 KB. Sensible default: **start with the `latin`
+subset** for English-language sites, then add `latin-ext` if you need accented
+European characters. Declare the covered range with `unicode_range:` so the
+browser can skip the download when a page has no matching glyphs:
+
+```erb
+<%= react_on_rails_font_face(
+      family: "Inter",
+      src: asset_path("inter-latin-400-normal.woff2"),
+      unicode_range: "U+0000-00FF, U+0131, U+0152-0153, U+2000-206F"
+    ) %>
+```
+
+Most font distributions (e.g. [Fontsource](https://fontsource.org)) ship
+per-subset `.woff2` files plus the matching `unicode-range` for each — commit the
+subset you need and copy its range.
+
+## Core Web Vitals (CLS) note
+
+Self-hosting + preload removes the render-blocking third-party request; the
+`size-adjust` fallback removes the layout shift on swap. Together they target two
+Core Web Vitals at once (LCP/render time and CLS). To verify, record CLS in
+Chrome DevTools (Performance panel) or the
+[web-vitals](https://github.com/GoogleChrome/web-vitals) library before and after
+adding the fallback face: the font-swap layout shift should drop to ~0.
+
+## Runnable example
+
+A working example lives in the dummy app:
+
+- View: `react_on_rails/spec/dummy/app/views/pages/font_optimization_example.html.erb`
+- Vendored font: `react_on_rails/spec/dummy/public/fonts/inter-latin-400-normal.woff2`
+  (Inter, OFL-1.1 — see `public/fonts/LICENSE-Inter.txt`)
+- Unit spec: `react_on_rails/spec/react_on_rails/font_helper_spec.rb`
+- Request spec: `react_on_rails/spec/dummy/spec/requests/font_optimization_spec.rb`
+
+## Known follow-ups (not in v1)
+
+- **Build-time Google-Fonts fetching** (the `next/font/google` path): fetch and
+  vendor a Google font at build time instead of committing the file.
+- **Automatic per-font metric derivation**: compute the `size-adjust` and
+  override values programmatically from the font binary instead of hardcoding
+  documented numbers.
+- **Pro streaming-shell coverage**: ensure the preload `<link>` lands in the
+  streaming shell before the first body flush (see
+  `react_on_rails_pro/lib/react_on_rails_pro/concerns/stream.rb`). v1 covers the
+  non-streaming `react_component_hash` head-injection path only.
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/building-features/rails-engine-integration
@@ -10034,6 +11231,393 @@ If you're using the React on Rails Pro Node Renderer, the renderer process has i
 - [Testing Configuration](./testing-configuration.md) — setting up test environments
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/building-features/web-vitals-and-rum
+SOURCE: docs/oss/building-features/web-vitals-and-rum.md
+================================================================================
+
+# Web Vitals and Real User Monitoring (RUM)
+
+React on Rails instruments **server-side** render performance — the repo's
+`benchmarks/` suite feeds a Bencher-based regression dashboard, and
+[Performance Benchmarks](../core-concepts/performance-benchmarks.md) covers
+ExecJS vs Node Renderer throughput. What that does not tell you is how your app
+performs **for real users in real browsers**: Largest Contentful Paint (LCP),
+Cumulative Layout Shift (CLS), Interaction to Next Paint (INP), Time to First
+Byte (TTFB), and First Contentful Paint (FCP). This page closes that loop with a
+**first-party** Real User Monitoring setup: the browser collects Web Vitals with
+the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) library and
+beacons them to **your own Rails endpoint** — no third-party analytics vendor,
+no Vercel, no extra SaaS bill, and the data never leaves your app
+(privacy/GDPR friendly).
+
+For comparison: Next.js ships
+[`useReportWebVitals`](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals),
+a thin hook over the same `web-vitals` library, and pairs it with Vercel Speed
+Insights for turnkey field RUM — a path that effectively assumes you deploy on
+Vercel and send your traffic data there. On Rails, the equivalent is just
+another controller action: POST the vitals to your app and aggregate them with
+ActiveRecord or your existing APM.
+
+> **Scope note:** This page covers wiring the framework-agnostic `web-vitals`
+> metrics. Framework-level hydration-timing instrumentation (`performance.mark`
+> entries emitted from the React on Rails client runtime — "time to hydrate",
+> "first interaction after hydration") is a planned follow-up, tracked in
+> [issue #3877](https://github.com/shakacode/react_on_rails/issues/3877). It has
+> not shipped yet; nothing on this page depends on it.
+
+## How the pieces fit
+
+1. **Client**: a small script in your client bundle subscribes to the five Core
+   Web Vitals via `web-vitals`, queues them, and flushes the queue with
+   `navigator.sendBeacon` when the page is hidden or unloaded.
+2. **Sampling**: only a configurable fraction of page views report (default
+   below: 10%), so high-traffic apps don't write a row per page view.
+3. **Server**: a Rails route + controller accepts the JSON beacon, validates it
+   with strong parameters, and stores it (or forwards it to your APM).
+4. **Aggregation**: you query percentiles (p75 is the Core Web Vitals
+   threshold standard) from your own database.
+
+## Client: collecting and beaconing vitals
+
+Add the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) package:
+
+```bash
+npm install web-vitals
+# or: yarn add web-vitals
+# or: pnpm add web-vitals
+```
+
+Then add the following to a Shakapacker entry — either a dedicated pack or your
+existing client bundle entry. It is intentionally plain JavaScript with no React
+on Rails API dependency, so it works in any client bundle:
+
+```js
+// app/javascript/packs/web-vitals-reporter.js
+// (or import it from your existing client bundle entry)
+import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals';
+
+const VITALS_ENDPOINT = '/web_vitals';
+
+// Report only a fraction of page views. Decide once per page load so a sampled
+// page view reports its full set of metrics (you can also read the rate from a
+// <meta> tag to configure it from Rails without rebuilding the bundle).
+const SAMPLE_RATE = 0.1; // 10%
+const isSampled = Math.random() < SAMPLE_RATE;
+
+const queue = [];
+
+function addToQueue({ name, value, id, rating, delta, navigationType }) {
+  queue.push({
+    name,
+    value,
+    id,
+    rating,
+    delta,
+    navigation_type: navigationType,
+    // Capture the path when the metric is observed, not when the queue is
+    // flushed -- with Turbo Drive one flush can carry metrics from several
+    // routes. Send the pathname only: query strings can contain tokens or PII.
+    page: window.location.pathname,
+  });
+}
+
+function flushQueue() {
+  if (!isSampled || queue.length === 0) {
+    return;
+  }
+
+  // splice(0) drains the queue and returns its contents in one step.
+  const body = JSON.stringify({ metrics: queue.splice(0) });
+
+  // sendBeacon queues delivery even while the page unloads. Wrap the payload in
+  // a Blob so the request carries a JSON content type and Rails parses the
+  // params (a bare string would be sent as text/plain).
+  const blob = new Blob([body], { type: 'application/json' });
+  if (!(navigator.sendBeacon && navigator.sendBeacon(VITALS_ENDPOINT, blob))) {
+    // Fallback for browsers without sendBeacon: keepalive lets the request
+    // outlive the page. Telemetry is fire-and-forget -- swallow delivery
+    // errors instead of surfacing them.
+    fetch(VITALS_ENDPOINT, {
+      method: 'POST',
+      body,
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+    }).catch(() => {});
+  }
+}
+
+onCLS(addToQueue);
+onFCP(addToQueue);
+onINP(addToQueue);
+onLCP(addToQueue);
+onTTFB(addToQueue);
+
+// CLS, LCP, and INP only settle when the page is hidden or unloaded, so flush
+// on visibility change rather than on a timer.
+addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    flushQueue();
+  }
+});
+// pagehide covers older Safari, which does not reliably fire visibilitychange
+// on unload.
+addEventListener('pagehide', flushQueue);
+// Turbo Drive swaps the page without firing visibilitychange or pagehide, so
+// also flush before each Turbo visit. Harmless no-op in apps without Turbo.
+addEventListener('turbo:before-visit', flushQueue);
+```
+
+Why this shape:
+
+- **Queue + flush on `visibilitychange`/`pagehide`** — CLS, LCP, and INP are
+  not final until the user leaves the page, so per-metric immediate POSTs would
+  both undercount and multiply requests. Batching into one beacon per page view
+  is the pattern the `web-vitals` documentation recommends.
+- **`navigator.sendBeacon`** — a normal `fetch`/XHR issued during unload is
+  routinely cancelled by the browser; `sendBeacon` hands the payload to the
+  browser to deliver asynchronously even after the page is gone. The
+  `keepalive: true` fetch is the fallback for the rare browser without it.
+- **Turbo Drive** — Turbo navigations swap the `<body>` without firing
+  `visibilitychange` or `pagehide`, so several routes can share one flush.
+  That is why the snippet stamps each metric with the pathname **at
+  observation time** (one `page` per metric, not per POST) and also flushes on
+  `turbo:before-visit`. Registering that listener in a non-Turbo app is a
+  harmless no-op — the event simply never fires.
+- **Back/forward cache** — `web-vitals` treats a
+  [bfcache](https://web.dev/articles/bfcache) restore as a separate page view
+  and reports all metrics again with new `id`s (and
+  `navigationType: 'back-forward-cache'`). The listeners and queue survive the
+  restore, so those metrics are delivered on the next hide — no extra code
+  needed.
+- **Payload fields** mirror the `web-vitals`
+  [`Metric` type](https://github.com/GoogleChrome/web-vitals#metric): `name`
+  (`'CLS' | 'FCP' | 'INP' | 'LCP' | 'TTFB'`), `value`, `id` (unique per metric
+  per page load — use it to deduplicate), `rating`
+  (`'good' | 'needs-improvement' | 'poor'`), `delta` (change since the last
+  report of this metric), and `navigationType` (e.g. `'navigate'`,
+  `'reload'`, `'back-forward'`, `'prerender'`) — plus the `page` pathname the
+  snippet captures per metric.
+
+## Server: a first-party ingestion endpoint
+
+Add a route:
+
+```ruby
+# config/routes.rb
+post "/web_vitals", to: "web_vitals#create"
+```
+
+And a controller:
+
+```ruby
+# app/controllers/web_vitals_controller.rb
+class WebVitalsController < ApplicationController
+  # sendBeacon cannot set custom request headers, so the beacon arrives without
+  # the X-CSRF-Token header Rails expects. Skipping forgery protection on this
+  # one write-only, anonymous endpoint is the standard trade-off -- see the
+  # CSRF section below before copying this.
+  skip_forgery_protection
+
+  VALID_NAMES = %w[CLS FCP INP LCP TTFB].freeze
+  VALID_RATINGS = %w[good needs-improvement poor].freeze
+
+  def create
+    rows = coerced_rows
+    return head :unprocessable_entity if rows.nil?
+
+    # insert_all! (Rails 6+) writes every row in one all-or-nothing statement,
+    # skipping per-row callbacks/validations -- fine for telemetry. On older
+    # Rails, wrap per-row creates in a single transaction instead.
+    WebVitalMetric.insert_all!(rows) if rows.any?
+    head :no_content
+  end
+
+  private
+
+  # Coerce and validate every metric before persisting anything. Metrics with
+  # an unknown name or rating are silently dropped (skipped, not an error);
+  # any non-numeric value rejects the whole beacon by returning nil. Either
+  # way, nothing half-persists. String fields are length-clamped because this
+  # endpoint skips CSRF protection -- never trust client-supplied sizes.
+  def coerced_rows
+    now = Time.current
+    vitals_params[:metrics].to_a.filter_map do |metric|
+      next unless VALID_NAMES.include?(metric[:name])
+      next unless VALID_RATINGS.include?(metric[:rating])
+
+      {
+        name: metric[:name],
+        value: Float(metric[:value]),
+        delta: Float(metric[:delta]),
+        metric_id: metric[:id].to_s.byteslice(0, 64),
+        rating: metric[:rating],
+        navigation_type: metric[:navigation_type].to_s.byteslice(0, 32),
+        page: metric[:page].to_s.byteslice(0, 255),
+        created_at: now
+      }
+    end
+  rescue ArgumentError, TypeError
+    # Float() raises on non-numeric values.
+    nil
+  end
+
+  def vitals_params
+    params.permit(metrics: %i[name value id rating delta navigation_type page])
+  end
+end
+```
+
+The strong-params schema matches the client payload (and the `web-vitals`
+`Metric` type): `name`, `value`, `id`, `rating`, `delta`, `navigation_type`,
+plus the per-metric page path. Everything else in the request is dropped, and
+all metrics are coerced up front and written in a single atomic insert — a
+malformed beacon never half-persists.
+
+### CSRF and abuse considerations
+
+`skip_forgery_protection` is what makes the `sendBeacon` path work, and it is a
+real trade-off:
+
+- **Why it is usually acceptable here**: the endpoint is write-only, stores
+  anonymous numeric metrics, returns no data, and performs no action on behalf
+  of a user — there is nothing for a classic CSRF attack to gain.
+- **What you give up**: anyone can POST junk metrics. Mitigate with the strict
+  schema validation above (unknown names/ratings are dropped, non-numeric
+  values are rejected) and rate limiting (e.g. a
+  [Rack::Attack](https://github.com/rack/rack-attack) throttle on
+  `POST /web_vitals` per IP). Treat the data as untrusted telemetry, not as an
+  audit log.
+- **Alternative that keeps CSRF protection**: skip `sendBeacon` entirely and
+  always use `fetch(..., { keepalive: true })` with the `X-CSRF-Token` header
+  read from the `csrf-token` meta tag (emitted by `csrf_meta_tags`). `keepalive` requests survive unload in
+  modern browsers, though delivery is somewhat less reliable than `sendBeacon`
+  (keepalive requests share a small per-origin in-flight budget). Pick this if
+  your security posture rules out any unprotected endpoint.
+
+### Sampling
+
+The `SAMPLE_RATE` constant in the client snippet controls what fraction of page
+views report. 10% is a sensible default for most apps: Core Web Vitals are
+percentile statistics, so you need volume, not completeness. Guidance:
+
+- **Low-traffic apps** (under ~10k page views/day): sample 100% (`1`) — you
+  need every data point to compute a stable p75.
+- **High-traffic apps**: 1–10% is typically plenty. At 1M page views/day, a 1%
+  sample still yields 10k measurements.
+- Decide **once per page view** (as the snippet does), never per metric —
+  otherwise a page view contributes CLS but not LCP and your per-page
+  correlations break.
+- To tune the rate without rebuilding the bundle, emit it from Rails (e.g.
+  `<meta name="web-vitals-sample-rate" content="<%= ENV.fetch('WEB_VITALS_SAMPLE_RATE', '0.1') %>">`)
+  and read it in the snippet instead of hardcoding the constant.
+
+## Storage and aggregation
+
+This is guidance, not a product — storage and visualization are your app's
+choice. Two common paths:
+
+### Option 1: ActiveRecord table
+
+```ruby
+# Generate with `bin/rails generate migration CreateWebVitalMetrics` so the
+# migration version matches your app's Rails version.
+class CreateWebVitalMetrics < ActiveRecord::Migration[7.1]
+  def change
+    create_table :web_vital_metrics do |t|
+      t.string :name, null: false
+      t.float :value, null: false
+      t.float :delta
+      t.string :metric_id
+      t.string :rating
+      t.string :navigation_type
+      t.string :page
+      t.datetime :created_at, null: false
+    end
+
+    add_index :web_vital_metrics, %i[name created_at]
+    add_index :web_vital_metrics, %i[page name]
+  end
+end
+```
+
+Core Web Vitals thresholds are defined at the **75th percentile**, so query p75
+rather than averages (averages hide the slow tail that ratings are based on):
+
+```sql
+-- p75 LCP per page over the last 7 days (PostgreSQL)
+SELECT page,
+       percentile_cont(0.75) WITHIN GROUP (ORDER BY value) AS p75_lcp_ms,
+       count(*) AS samples
+FROM web_vital_metrics
+WHERE name = 'LCP'
+  AND created_at > now() - interval '7 days'
+GROUP BY page
+ORDER BY p75_lcp_ms DESC;
+```
+
+`percentile_cont` is PostgreSQL-specific — on MySQL or SQLite, compute the
+percentile with a window function (`PERCENT_RANK()`/`NTILE`) or load the sorted
+values and pick the p75 index in Ruby.
+
+Prune old rows on a schedule (a nightly
+`WebVitalMetric.where("created_at < ?", 90.days.ago).delete_all` job) or roll
+daily percentiles up into a summary table if volume grows.
+
+### Option 2: forward to your existing APM
+
+If you already run an APM or metrics stack (New Relic, Datadog, Sentry,
+Prometheus/StatsD, Scout, Skylight…), skip the table and forward from the
+controller instead — e.g. emit a custom event or a distribution/histogram
+metric tagged with `name`, `rating`, and `page`. You keep the same first-party
+beacon and endpoint; only the sink changes. This is usually the right call when
+the APM already owns your dashboards and alerting.
+
+## Privacy
+
+This setup is deliberately privacy-friendly, but keep it that way:
+
+- **No PII in beacons.** The payload is metric names and numbers plus a page
+  path. Do not add user IDs, emails, session tokens, or full URLs — the snippet
+  sends `location.pathname` precisely because query strings can carry tokens or
+  personal data. If a path itself embeds an identifier (e.g. `/users/123`),
+  normalize it before storing (`/users/:id`).
+- **First-party only.** Data goes from the user's browser to your own origin
+  and stays in your database. There is no third-party analytics script, no
+  cross-site cookie, and no data-processing agreement with an analytics vendor
+  to manage — which substantially simplifies the GDPR story compared with
+  shipping field data to an external RUM service.
+- **No fingerprinting.** Resist the temptation to add user-agent strings,
+  precise geolocation, or device fingerprints "for segmentation." Coarse
+  dimensions (`navigation_type`, `rating`, page path) answer almost every
+  performance question.
+
+## How this complements server-side benchmarks
+
+The `benchmarks/` suite and [Performance
+Benchmarks](../core-concepts/performance-benchmarks.md) answer "did this change
+make server rendering slower?" under controlled load. Field Web Vitals answer
+"what do real users experience?" across real devices, networks, and cache
+states — including everything the server-side numbers cannot see: asset
+delivery, font loading (see [Font Optimization](./fonts.md), which targets LCP
+and CLS directly), hydration cost, and third-party scripts. Use both: Bencher
+to catch server-render regressions in CI, and your vitals table to verify that
+optimizations actually move p75 LCP/CLS/INP for users.
+
+## Related
+
+- [Performance Benchmarks](../core-concepts/performance-benchmarks.md) — the
+  server-side measurement story this complements
+- [Font Optimization](./fonts.md) — a direct LCP/CLS lever, verifiable with
+  this setup
+- [Caching](./caching.md) — server-side render caching, a common TTFB lever
+- [web.dev: Web Vitals](https://web.dev/articles/vitals) — metric definitions
+  and thresholds
+- [GoogleChrome/web-vitals](https://github.com/GoogleChrome/web-vitals) — the
+  collection library
+- [Issue #3877](https://github.com/shakacode/react_on_rails/issues/3877) —
+  tracking for the planned framework-level hydration-timing instrumentation
+
+================================================================================
 PAGE: https://reactonrails.com/docs/building-features/node-renderer/basics
 SOURCE: docs/oss/building-features/node-renderer/basics.md
 ================================================================================
@@ -11957,6 +13541,409 @@ SOURCE: docs/oss/building-features/node-renderer/troubleshooting.md
 For node renderer troubleshooting (connection refused, memory issues, worker restarts), see the [Node Renderer section in the main troubleshooting guide](../../../pro/troubleshooting.md#node-renderer).
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/reference/error-reference
+SOURCE: docs/oss/reference/error-reference.md
+================================================================================
+
+<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. -->
+<!-- Regenerate with: BUNDLE_GEMFILE=react_on_rails/Gemfile bundle exec ruby script/generate_error_reference.rb -->
+<!-- Source: react_on_rails/lib/react_on_rails/smart_error.rb -->
+
+# Error Reference
+
+React on Rails SmartError messages include stable `ROR###` codes and canonical URLs. Use this page to look up a code from a terminal error, server log, or support request.
+
+Error codes are append-only once published: do not reuse a removed code for a different failure.
+
+## Code Index
+
+| Code              | Error                            | SmartError type                     |
+| ----------------- | -------------------------------- | ----------------------------------- |
+| [ROR001](#ror001) | Component Not Registered         | `:component_not_registered`         |
+| [ROR002](#ror002) | Auto-loaded Bundle Missing       | `:missing_auto_loaded_bundle`       |
+| [ROR003](#ror003) | Auto-loaded Store Bundle Missing | `:missing_auto_loaded_store_bundle` |
+| [ROR004](#ror004) | Hydration Mismatch               | `:hydration_mismatch`               |
+| [ROR005](#ror005) | Server Rendering Failed          | `:server_rendering_error`           |
+| [ROR006](#ror006) | Redux Store Not Found            | `:redux_store_not_found`            |
+| [ROR007](#ror007) | Configuration Error              | `:configuration_error`              |
+
+<a id="ror001"></a>
+
+## ROR001: Component Not Registered
+
+**SmartError type:** `:component_not_registered`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror001
+
+React on Rails could not find the component in the client-side component registry.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR001]: Component 'ProductCard' Not Registered
+
+Component 'ProductCard' was not found in the component registry.
+
+React on Rails offers two approaches:
+• Auto-bundling (recommended): Components load automatically, no registration needed
+• Manual registration: Traditional approach requiring explicit registration
+
+
+Code: ROR001
+Docs: https://reactonrails.com/docs/reference/error-reference#ror001
+
+💡 Suggested Solution:
+🚀 Recommended: Use Auto-Bundling (No Registration Required!)
+
+1. Enable auto-bundling in your view:
+   <%= react_component("ProductCard", props: {}, auto_load_bundle: true) %>
+
+2. Place your component in the components directory:
+   app/javascript/components/ProductCard/ProductCard.jsx
+
+   Component structure:
+   components/
+   └── ProductCard/
+       └── ProductCard.jsx (must export default)
+
+3. Generate the bundle:
+   bundle exec rake react_on_rails:generate_packs
+
+✨ That's it! No manual registration needed.
+
+─────────────────────────────────────────────
+
+Alternative: Manual Registration
+
+If you prefer manual registration:
+1. Register in your entry file:
+   ReactOnRails.register({ ProductCard: ProductCard });
+
+2. Import the component:
+   import ProductCard from './components/ProductCard';
+
+
+
+📋 Context:
+Component: ProductCard
+Registered components: ProductList, ProductDetails, UserProfile
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+<a id="ror002"></a>
+
+## ROR002: Auto-loaded Bundle Missing
+
+**SmartError type:** `:missing_auto_loaded_bundle`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror002
+
+A component is configured for auto-loading, but its generated bundle is missing.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR002]: Auto-loaded Bundle Missing
+
+Component 'Dashboard' is configured for auto-loading but its bundle is missing.
+Expected location: app/javascript/packs/generated/Dashboard.js
+
+
+Code: ROR002
+Docs: https://reactonrails.com/docs/reference/error-reference#ror002
+
+💡 Suggested Solution:
+1. Run the pack generation task:
+   bundle exec rake react_on_rails:generate_packs
+
+2. Ensure your component is in the correct directory:
+   app/javascript/components/Dashboard/
+
+3. Check that the component file follows naming conventions:
+   - Component file: Dashboard.jsx or Dashboard.tsx
+   - Must export default
+
+4. Verify webpack/shakapacker is configured for nested entries:
+   config.nested_entries_dir = 'components'
+
+
+
+📋 Context:
+Component: Dashboard
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+<a id="ror003"></a>
+
+## ROR003: Auto-loaded Store Bundle Missing
+
+**SmartError type:** `:missing_auto_loaded_store_bundle`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror003
+
+A Redux store is configured for auto-loading, but its generated store bundle is missing.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR003]: Auto-loaded Store Bundle Missing
+
+Redux store 'AppStore' is configured for auto-loading but its bundle is missing.
+Expected location: app/javascript/packs/generated/AppStore.js
+
+
+Code: ROR003
+Docs: https://reactonrails.com/docs/reference/error-reference#ror003
+
+💡 Suggested Solution:
+1. Run the pack generation task:
+   bundle exec rake react_on_rails:generate_packs
+
+2. Ensure your store is in a directory matching stores_subdirectory under packer_source_path:
+   app/javascript/**/ror_stores/AppStore.js
+
+3. Check that the store file follows naming conventions:
+   - Store file: AppStore.js or AppStore.ts
+   - Must export default a store generator function
+
+4. Verify stores_subdirectory is configured:
+   config.stores_subdirectory = 'ror_stores'
+
+
+
+📋 Context:
+Component: AppStore
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+<a id="ror004"></a>
+
+## ROR004: Hydration Mismatch
+
+**SmartError type:** `:hydration_mismatch`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror004
+
+The server-rendered HTML does not match the React tree rendered in the browser.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR004]: Hydration Mismatch
+
+The server-rendered HTML doesn't match what React rendered on the client.
+Component: UserProfile
+
+
+Code: ROR004
+Docs: https://reactonrails.com/docs/reference/error-reference#ror004
+
+💡 Suggested Solution:
+Common causes and solutions:
+
+1. **Random IDs or timestamps**: Use consistent values between server and client
+   // Bad: Math.random() or Date.now()
+   // Good: Use props or deterministic values
+
+2. **Browser-only APIs**: Check for client-side before using:
+   if (typeof window !== 'undefined') { ... }
+
+3. **Different data**: Ensure props are identical on server and client
+   - Check your redux store initialization
+   - Verify railsContext is consistent
+
+4. **Conditional rendering**: Avoid using user agent or viewport checks
+
+Debug tips:
+- Set prerender: false temporarily to isolate the issue
+- Check browser console for hydration warnings
+- Compare server HTML with client render
+
+
+
+📋 Context:
+Component: UserProfile
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+<a id="ror005"></a>
+
+## ROR005: Server Rendering Failed
+
+**SmartError type:** `:server_rendering_error`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror005
+
+Server-side rendering failed while rendering a React component.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR005]: Server Rendering Failed
+
+An error occurred while server-side rendering component 'ComplexComponent'.
+window is not defined
+
+
+Code: ROR005
+Docs: https://reactonrails.com/docs/reference/error-reference#ror005
+
+💡 Suggested Solution:
+1. Check your JavaScript console output:
+   tail -f log/development.log | grep 'React on Rails'
+
+2. Common issues:
+   - Missing Node.js dependencies: cd client && npm install
+   - Syntax errors in component code
+   - Using browser-only APIs without checks
+
+3. Debug server rendering:
+   - Set config.trace = true in your configuration
+   - Set config.development_mode = true for better errors
+   - Check config.server_bundle_js_file points to correct file
+
+4. Verify your server bundle:
+   bin/shakapacker or bin/webpack
+
+
+
+📋 Context:
+Component: ComplexComponent
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+<a id="ror006"></a>
+
+## ROR006: Redux Store Not Found
+
+**SmartError type:** `:redux_store_not_found`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror006
+
+A component requested a Redux store that was not registered.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR006]: Redux Store Not Found
+
+Redux store 'AppStore' was not found.
+Available stores: UserStore, ProductStore
+
+
+Code: ROR006
+Docs: https://reactonrails.com/docs/reference/error-reference#ror006
+
+💡 Suggested Solution:
+1. Register your Redux store:
+   ReactOnRails.registerStore({ AppStore: AppStore });
+
+2. Ensure the store is imported:
+   import AppStore from './store/AppStore';
+
+3. Initialize the store before rendering components that depend on it:
+   <%= redux_store('AppStore', props: {}) %>
+
+4. Check store dependencies in your component:
+   store_dependencies: ['AppStore']
+
+
+
+📋 Context:
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+<a id="ror007"></a>
+
+## ROR007: Configuration Error
+
+**SmartError type:** `:configuration_error`
+
+**Canonical URL:** https://reactonrails.com/docs/reference/error-reference#ror007
+
+React on Rails detected invalid or incomplete configuration.
+
+### Example SmartError Output
+
+```text
+❌ React on Rails Error [ROR007]: Configuration Error
+
+Invalid configuration detected.
+config.server_bundle_js_file points to a missing file
+
+
+Code: ROR007
+Docs: https://reactonrails.com/docs/reference/error-reference#ror007
+
+💡 Suggested Solution:
+Review your React on Rails configuration:
+
+1. Check config/initializers/react_on_rails.rb
+
+2. Common configuration issues:
+   - Invalid bundle paths
+   - Missing Node modules location
+   - Incorrect component subdirectory
+
+3. Run configuration doctor:
+   rake react_on_rails:doctor
+
+
+
+📋 Context:
+Rails Environment: development (detailed errors enabled)
+
+🔧 Need More Help?
+📞 Get Help & Support:
+   • 🚀 Professional Support: react_on_rails@shakacode.com (fastest resolution)
+   • 💬 React + Rails Slack: https://invite.reactrails.com
+   • 🆓 GitHub Issues: https://github.com/shakacode/react_on_rails/issues
+   • 📖 Discussions: https://github.com/shakacode/react_on_rails/discussions
+```
+
+================================================================================
 PAGE: https://reactonrails.com/docs/configuration
 SOURCE: docs/oss/configuration/README.md
 ================================================================================
@@ -13257,6 +15244,35 @@ Uncommonly used options:
 
 ---
 
+### react_on_rails_preload_links
+
+```erb
+<%= react_on_rails_preload_links("HelloWorld", "comments_list") %>
+```
+
+Use `react_on_rails_preload_links` in a layout or view `<head>` when you know which auto-bundled React components the page will render. The helper resolves each component to its generated Shakapacker pack (`generated/ComponentName`) and emits preload link tags for the manifest assets. Pass component names as PascalCase, camelCase, or snake_case strings; hyphenated names are rejected because they cannot be normalized reliably.
+
+For JavaScript chunks, plain script assets render as `<link rel="preload" as="script">`. Module assets render as `<link rel="modulepreload">` when the manifest marks the asset as a module or the emitted file has an `.mjs` extension. CSS chunks render as `<link rel="preload" as="style">`. Component packs without CSS assets simply skip the stylesheet preload.
+
+```erb
+<head>
+  <%= react_on_rails_preload_links("ProductPage") %>
+  <%= stylesheet_pack_tag "application" %>
+</head>
+<body>
+  <%= react_component("ProductPage", props: @product_props, auto_load_bundle: true) %>
+  <%= javascript_pack_tag "application" %>
+</body>
+```
+
+Because preload hints belong in `<head>`, pass component names that are known before the component renders.
+
+This helper only emits HTML link tags. Keep the normal `stylesheet_pack_tag` and `javascript_pack_tag` calls in the layout so the browser still applies and executes the assets.
+
+When using a CDN asset host, keep Shakapacker's Subresource Integrity and `crossorigin` settings consistent between preload tags and the final script/style tags so the browser can reuse the preloaded response.
+
+---
+
 ### react_component_hash
 
 > **React 19 Alternative:** For metadata use cases (page titles, meta tags, canonical URLs), consider using [React 19 Native Metadata](../building-features/react-19-native-metadata.md) with `react_component` or `stream_react_component` instead. React 19 natively hoists `<title>`, `<meta>`, and `<link>` tags to `<head>`, eliminating the need for a render-function and `react_component_hash`. See the [migration guide](../building-features/react-19-native-metadata.md#migration-guide) for step-by-step instructions.
@@ -13907,6 +15923,7 @@ Options:
   -T, [--typescript], [--no-typescript]            # Generate TypeScript files and install TypeScript dependencies. Default: false
       [--rspack], [--no-rspack]                    # Use Rspack (default) as the bundler; pass --no-rspack to use Webpack
       [--webpack], [--no-webpack]                  # Use Webpack as the bundler (alias for --no-rspack)
+      [--tailwind], [--no-tailwind]                # Install Tailwind CSS v4 and style the generated SSR example. Default: false
       [--pro], [--no-pro]                          # Install React on Rails Pro with Node Renderer. Default: false
       [--rsc], [--no-rsc]                          # Install React Server Components support (includes Pro). Default: false
       [--ignore-warnings], [--no-ignore-warnings]  # Skip warnings. Default: false
@@ -13932,6 +15949,13 @@ can pass the redux option if you'd like to have redux setup for you automaticall
 
     Passing the --typescript generator option generates TypeScript files (.tsx)
     instead of JavaScript files (.jsx) and sets up TypeScript configuration.
+
+* Tailwind CSS v4
+
+    Passing the --tailwind generator option installs Tailwind CSS v4,
+    configures `@tailwindcss/postcss` for Webpack or Rspack, and styles the
+    generated SSR HelloWorld page. See
+    [Styling with Tailwind CSS v4](../building-features/styling-with-tailwind.md).
 
 * Rspack (default)
 
@@ -14280,6 +16304,7 @@ SOURCE: docs/oss/deployment/README.md
 - [Docker Deployment](./docker-deployment.md) — Containerized deployments with Kamal, Kubernetes, and Control Plane
 - [Heroku Deployment](./heroku-deployment.md) — PaaS deployment on Heroku
 - [Review App Security](./review-app-security.md) — Safe review-app defaults for public repositories and fork PRs
+- [Security Model and Hardening](./security-model-and-hardening.md) — Props escaping contract, Node renderer threat model, RSC advisory posture
 
 ## Troubleshooting
 
@@ -15036,6 +17061,287 @@ For fork pull requests, the safest operational model is:
 2. Let a maintainer review the change.
 3. Deploy only with a review-app credential that cannot access staging or production secrets.
 4. Destroy the review app after review.
+
+================================================================================
+PAGE: https://reactonrails.com/docs/deployment/security-model-and-hardening
+SOURCE: docs/oss/deployment/security-model-and-hardening.md
+================================================================================
+
+# Security Model and Hardening
+
+> [!NOTE]
+> **Summary for AI agents:** This page documents the React on Rails security model: how component props are escaped into HTML, the trust boundary and hardening options for the Pro Node renderer, and the React Server Components (RSC) advisory posture. For review-app-specific guidance, see [Review App Security](./review-app-security.md). To report a vulnerability, see [SECURITY.md](https://github.com/shakacode/react_on_rails/blob/main/SECURITY.md).
+
+This guide is written for security reviewers. Every claim is tied to specific code in the
+[shakacode/react_on_rails](https://github.com/shakacode/react_on_rails) repository so you can verify it
+yourself; where a guarantee does **not** exist, that is stated explicitly.
+
+Scope:
+
+- [Props escaping contract](#props-escaping-contract) — applies to all React on Rails apps (OSS and Pro).
+- [Node renderer threat model](#node-renderer-threat-model-pro) — applies to React on Rails Pro apps using the
+  standalone Node renderer.
+- [React Server Components advisory posture](#react-server-components-advisory-posture-pro) — applies to Pro
+  apps using RSC.
+- [Reporting vulnerabilities](#reporting-vulnerabilities).
+
+Out of scope here: the general security of your own React components and Rails app (authentication,
+authorization, CSRF, etc. remain standard Rails concerns — React on Rails does not add a separate
+authentication or authorization layer in front of your Rails app).
+
+## Props escaping contract
+
+### How props reach the page
+
+`react_component` and `redux_store` embed your props as JSON inside
+`<script type="application/json">` data tags — not as executable JavaScript:
+
+- Component props: `generate_component_script` in `react_on_rails/lib/react_on_rails/pro_helper.rb`
+  (part of the OSS gem despite the file name) builds
+  `content_tag(:script, json_safe_and_pretty(render_options.client_props).html_safe, type: "application/json", ...)`.
+- Store props: `generate_store_script` in the same file does the same for Redux store hydration data.
+- Rails context: `rails_context_if_not_already_rendered` in `react_on_rails/lib/react_on_rails/helper.rb`
+  embeds the rails context the same way.
+
+The client-side package reads these tags back with `JSON.parse` and passes the result to your components.
+
+### What is escaped, and by what
+
+All three paths above escape the JSON through one function:
+`ReactOnRails::JsonOutput.escape`, which delegates to Rails'
+`ERB::Util.json_escape` (`react_on_rails/lib/react_on_rails/json_output.rb`, line 8).
+
+`ERB::Util.json_escape` replaces the HTML-significant characters `<`, `>`, and `&` with their Unicode
+escape sequences (`\u003c`, `\u003e`, `\u0026`) and escapes the U+2028/U+2029 line separators. Because no
+literal `<` can survive, a props value containing `</script><script>alert('xss')</script>` cannot terminate
+the surrounding `<script>` tag — it is emitted as
+`\u003c/script\u003e\u003cscript\u003ealert('xss')\u003c/script\u003e`, which `JSON.parse` later restores
+to the original string for your component as plain data.
+
+The helper entry points that apply this escaping:
+
+- `sanitized_props_string` (`react_on_rails/lib/react_on_rails/helper.rb`) — escapes props whether passed
+  as a `Hash` (serialized via `to_json` first) or as a pre-serialized JSON `String`.
+- `json_safe_and_pretty` (`react_on_rails/lib/react_on_rails/helper.rb`) — same contract, used by the
+  script-tag generators above.
+
+### Test coverage
+
+This contract is covered by specs in the repository:
+
+- `react_on_rails/spec/react_on_rails/json_output_spec.rb` — unit specs for `JsonOutput.escape`, including
+  an explicit `</script><script>...` payload.
+- `react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb` (`#sanitized_props_string`
+  examples) — asserts that a props hash containing `</script><script>alert('foo')</script>` is escaped in
+  the rendered output, for both hash and string-typed props.
+
+### What this does and does not guarantee
+
+**Guaranteed (by the code above):**
+
+- Props values cannot break out of the JSON `<script type="application/json">` data tags, because `<`,
+  `>`, and `&` never appear literally in the emitted JSON.
+- Props are delivered to React as data. React's normal JSX text rendering then escapes them again on
+  output, as in any React app.
+
+**Not guaranteed — your responsibility:**
+
+- **What your components do with props.** If a component passes a props value to
+  `dangerouslySetInnerHTML`, interpolates it into a URL (`javascript:` schemes), or otherwise treats it as
+  markup, the embedding-layer escaping above does not protect you. Escaping happens at the HTML-embedding
+  boundary, not inside your component tree.
+- **Pre-serialized string props are trusted as JSON.** If you pass props as a `String` instead of a
+  `Hash`, React on Rails HTML-escapes it for the client-side script tag but does **not** validate that it
+  is well-formed JSON. On the server-rendering path, the string is interpolated directly into the
+  JavaScript evaluated by the SSR runtime (`var props = #{props_string};` in
+  `react_on_rails/lib/react_on_rails/server_rendering_js_code.rb`; see also the comment above the
+  `js_code` construction in `server_rendered_react_component` in
+  `react_on_rails/lib/react_on_rails/helper.rb`, which only escapes U+2028/U+2029 there). A string built
+  by concatenating untrusted input is therefore JavaScript injection into your own SSR context. **Build
+  props from Ruby data structures (`Hash`); never concatenate user input into a JSON string yourself.**
+- **Server-rendered HTML is inserted as-is.** The HTML your server-rendered components produce is marked
+  `html_safe` and inserted without further sanitization — the output of your own bundle is trusted by
+  design. The escaping contract covers props going _in_, not component HTML coming _out_.
+
+## Node renderer threat model (Pro)
+
+This section applies to React on Rails Pro deployments using the standalone Node renderer
+(`react-on-rails-pro-node-renderer`). If you use ExecJS-based SSR (the OSS default), there is no separate
+renderer process or network hop, and this section does not apply.
+
+### Trust model: the renderer executes your app's code
+
+The Node renderer is a service that accepts JavaScript bundles uploaded by your Rails app and executes
+them to render components. This is its purpose, not a flaw — but it has a direct consequence:
+
+> **Anyone who can reach the renderer's port and authenticate can execute arbitrary JavaScript with the
+> renderer process's privileges** (by uploading a bundle, or by sending a rendering request that the
+> bundle evaluates). The renderer is **not** a sandbox for untrusted code and must be treated as an
+> internal service with the same trust level as your Rails app servers.
+
+Concretely, the worker exposes these HTTP endpoints
+(`packages/react-on-rails-pro-node-renderer/src/worker.ts`):
+
+| Endpoint                                                                 | Auth                                                     | Purpose                                                     |
+| ------------------------------------------------------------------------ | -------------------------------------------------------- | ----------------------------------------------------------- |
+| `POST /bundles/:bundleTimestamp/render/:renderRequestDigest`             | password (via `performRequestPrechecks`)                 | Evaluate a rendering request; may also carry bundle uploads |
+| `POST /bundles/:bundleTimestamp/incremental-render/:renderRequestDigest` | password (via `performRequestPrechecks`)                 | Streaming/incremental rendering                             |
+| `POST /upload-assets`                                                    | password (via `performRequestPrechecks`)                 | Upload server bundles and assets                            |
+| `POST /asset-exists`                                                     | password (via `authenticate`, no protocol-version check) | Check whether an uploaded asset exists                      |
+| `GET /info`                                                              | **none**                                                 | Returns `node_version` and `renderer_version`               |
+
+Note for reviewers: unlike the other authenticated endpoints, `/asset-exists` calls `authenticate`
+directly rather than through `performRequestPrechecks`, so it skips the protocol-version check — a
+compatibility control, not a security control.
+
+Known limitation: `GET /info` is unauthenticated and discloses the Node and renderer versions
+(`worker.ts`, the `app.get('/info', ...)` route). This is harmless on a private network but is version
+disclosure if you expose the port publicly — one more reason never to do so.
+
+### Network exposure
+
+- The renderer binds to `localhost` by default (`host: env.RENDERER_HOST || 'localhost'` in
+  `packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts`). Setting `RENDERER_HOST=0.0.0.0`
+  is needed for containerized deployments; if you do, network access control must come from your
+  infrastructure (security groups, network policies, private VPC subnets).
+- The renderer listens for **cleartext HTTP/2 (h2c)** and does not terminate TLS itself (see the server
+  construction in `run()` in `worker.ts`). The shared password travels in the request body. Treat the
+  Rails-to-renderer link as plaintext: keep it on a private network, or place TLS-terminating
+  infrastructure in front of the renderer and use an `https://` value for `config.renderer_url` on the
+  Rails side.
+- **Never expose the renderer port to the public internet.** There is no rate limiting, no TLS, and the
+  authenticated surface is "execute JavaScript".
+
+### Authentication between Rails and the renderer
+
+Authentication is a single shared secret:
+
+- The renderer checks the password from the request body
+  (`authenticate` in `packages/react-on-rails-pro-node-renderer/src/worker/authHandler.ts`). A
+  submitted password whose byte length differs from the configured secret is rejected with `401`
+  _before_ any comparison; only same-length candidates are then compared with
+  `crypto.timingSafeEqual`. The comparison is therefore timing-safe for same-length guesses, but the
+  early length check means the secret's length is not protected — use a long random secret, not a
+  short passphrase. Comparison errors are also rejected with `401`.
+- **Production-like environments fail closed on both sides.** If neither `RAILS_ENV` nor `NODE_ENV` is a
+  development/test value, the renderer refuses to start without a password
+  (`validatePasswordForProduction` in `configBuilder.ts`), and the Rails side raises at configuration time
+  (`validate_renderer_password_for_production` in
+  `react_on_rails_pro/lib/react_on_rails_pro/configuration.rb`). When both environments are unset, the
+  code treats the environment as production-like and still requires a password.
+- Both sides warn at startup if the password matches a known-default value or is shorter than 16
+  characters (`KNOWN_WEAK_PASSWORDS` / `MIN_PASSWORD_LENGTH` in `configBuilder.ts`;
+  `warn_if_renderer_password_weak` in the Pro gem's `configuration.rb`). In these audited paths the
+  literal password value is not logged: the weak-password warnings report only length/known-default
+  status, and the renderer masks the password in its config diagnostics. Other logging or
+  error-reporting paths in your app (e.g. exception trackers capturing config objects) are outside
+  this guarantee — audit them yourself.
+- Rails resolves the password in this order: `config.renderer_password`, then a password embedded in
+  `config.renderer_url` (`https://:password@host:3800`), then `ENV["RENDERER_PASSWORD"]`
+  (documented in the error message in `configuration.rb`).
+
+Known limitations of this model (by design — plan your network accordingly):
+
+- One shared secret, not per-client credentials; there is no second factor and no built-in rotation
+  mechanism. Rotate by deploying a new `RENDERER_PASSWORD` to both sides.
+- In `development`/`test` environments the password is optional, and with no password set the renderer
+  accepts unauthenticated requests (`authenticate` returns success when no password is configured). Do not
+  run a password-less renderer outside an isolated development machine.
+- Authentication grants access to all endpoints equally; there is no per-endpoint authorization.
+
+### Code execution and the VM context
+
+The renderer evaluates bundles inside a Node `vm` context. Two configuration options control how much of
+the host the bundle can reach, and their security semantics are documented in the config source
+(`packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts`, `Config` interface):
+
+- `supportModules: true` injects a default set of Node globals **and wraps the bundle so it receives the
+  host `require`**, granting access to Node built-ins such as `fs` and `child_process`. This is required
+  for loadable-components and most real-world SSR bundles.
+- `additionalContext`: any plain-object value (even `{}`) also switches the bundle into CommonJS mode with
+  the host's unrestricted `require`.
+- The most restricted mode is `supportModules: false` **and** `additionalContext: null`.
+
+Even in the most restricted mode, do not treat the `vm` context as a security boundary: Node's `vm` module
+is explicitly [not a security mechanism](https://nodejs.org/api/vm.html) and the renderer makes no
+sandboxing claim beyond it. The security boundary is **who can reach the port and authenticate**, plus the
+OS-level privileges of the renderer process.
+
+### Hardening checklist
+
+Every item below maps to a configuration option or behavior verified in this repository:
+
+1. **Set a strong `RENDERER_PASSWORD`** (random, ≥ 16 characters) on both Rails and the renderer.
+   Production-like environments refuse to start without one; the length/known-default checks only warn.
+2. **Keep the renderer on a private network.** Default bind is `localhost`; if you set
+   `RENDERER_HOST=0.0.0.0` for containers, restrict ingress to your Rails app servers and your health
+   checker.
+3. **Treat the link as plaintext.** The renderer speaks cleartext h2c; use a private network or external
+   TLS termination, and prefer an `https://` `config.renderer_url` when a TLS hop exists.
+4. **Run the renderer as an unprivileged OS user / minimal container, with resource limits.** The
+   bundle typically runs with host `require` (see above), so the renderer process's OS privileges and
+   resource ceiling are the effective blast radius. Set `--max-old-space-size` on the Node process and
+   enforce container `memory` + `cpu` limits to bound the impact of a rogue or compromised bundle.
+5. **Don't expose `GET /info`** beyond your monitoring network; it is unauthenticated version disclosure.
+6. **Rotate the shared secret on a schedule** by redeploying both sides with a new value; there is no
+   built-in rotation.
+7. **Keep `NODE_ENV`/`RAILS_ENV` set correctly.** The fail-closed password requirement keys off these; an
+   unset environment is treated as production-like (strict), but a mistakenly set `development` value
+   disables the requirement.
+
+## React Server Components advisory posture (Pro)
+
+RSC support in React on Rails Pro is built directly on React's Flight packages: the
+`react-on-rails-rsc` package wraps React's `react-server-dom-webpack`. Vulnerabilities in those upstream
+packages therefore apply to this stack, and the project's response is enforced in code:
+
+- **December 2025 React RSC advisories.** The React team published critical advisories affecting React
+  Server Components, including a remote code execution issue
+  ([CVE-2025-55182](https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components))
+  and follow-on
+  [denial-of-service and source-code exposure fixes](https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components).
+  React on Rails Pro shipped corresponding dependency floors; see the `CHANGELOG.md` security entries for
+  CVE-2025-55182 ([PR 2175](https://github.com/shakacode/react_on_rails/pull/2175)) and
+  CVE-2025-55183/55184/67779 ([PR 2233](https://github.com/shakacode/react_on_rails/pull/2233)).
+- **The patched-version requirement is checked, not just documented.** For RSC, the supported React range
+  is `19.0.x` with patch `>= 19.0.4` (`~19.0.4`) — not an open-ended `>= 19.0.4` floor; newer minors such
+  as 19.1.x are flagged as unverified by the doctor and rejected by the renderer's startup check:
+  - `rake react_on_rails:doctor` warns when the installed React is 19.0.x below 19.0.4, citing the known
+    security vulnerabilities (`check_rsc_react_version` in `react_on_rails/lib/react_on_rails/doctor.rb`).
+  - The RSC generator emits the same warning at setup time, naming CVE-2025-55182, CVE-2025-67779, and
+    CVE-2026-23864 (`react_on_rails/lib/generators/react_on_rails/rsc_setup.rb`).
+  - The Node renderer runs an RSC peer-compatibility check at startup (`runRscPeerCompatibilityCheck`,
+    called from the renderer's master, worker, and wrapper entry points in
+    `packages/react-on-rails-pro-node-renderer/src/`). Incompatible `react`, `react-dom`, or
+    `react-on-rails-rsc` versions **fail startup**; an older-but-compatible `react-on-rails-rsc` only
+    logs a warning. Setting `REACT_ON_RAILS_PRO_DISABLE_VERSION_CHECK=1` downgrades the hard startup
+    failure to a warning — **do not set this in production: it allows the renderer to boot on React
+    versions with known critical vulnerabilities (CVE-2025-55182 and related).**
+
+### How to verify your own status
+
+```bash
+# Reports your React/RSC versions and flags the security floor:
+bundle exec rake react_on_rails:doctor
+```
+
+Also subscribe to [React's blog](https://react.dev/blog) for upstream advisories, and watch this
+repository's `CHANGELOG.md` security entries for the corresponding React on Rails releases.
+
+## Reporting vulnerabilities
+
+The supported-version policy, triage commitments, and private reporting process live in
+[SECURITY.md](https://github.com/shakacode/react_on_rails/blob/main/SECURITY.md) at the repository root.
+Formalizing the public advisory process (security contact alias, GitHub Security Advisories policy) is
+tracked in [issue #3266](https://github.com/shakacode/react_on_rails/issues/3266).
+
+## Related documentation
+
+- [Review App Security](./review-app-security.md) — running untrusted PR code in review apps
+- [Node Renderer Basics](../building-features/node-renderer/basics.md) — renderer architecture
+- [Node Renderer JS Configuration](../building-features/node-renderer/js-configuration.md) — all renderer
+  configuration options, including the `supportModules` / `additionalContext` runtime-globals notes
+- [Docker Deployment](./docker-deployment.md) — containerized deployment patterns
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/deployment/server-rendering-tips
@@ -17529,6 +19835,203 @@ React Server Components migration content lives under **React on Rails Pro** in 
 The migration guides explain the mechanics. This page shows what those mechanics look like in real repos.
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/migrating/migrating-from-nextjs
+SOURCE: docs/oss/migrating/migrating-from-nextjs.md
+================================================================================
+
+# Migrate from Next.js
+
+This guide is for teams running a **Next.js frontend against a Rails backend** (or evaluating that split) who want to collapse the two apps into a single Rails application with React on Rails — keeping modern React (server components, streaming, `'use client'`) while deleting the duplicated auth, API, and deployment layers.
+
+It has two parts:
+
+1. A [capability mapping](#capability-mapping-nextjs--react-on-rails-pro) from Next.js App Router concepts to their React on Rails (and React on Rails Pro) equivalents — restricted to what is shipped today, with a short, explicit roadmap list for the rest.
+2. An [incremental migration strategy](#collapse-the-two-app-stack-incremental-migration-behind-a-reverse-proxy) for moving a Next.js app into Rails route-by-route behind a reverse proxy, with no big-bang cutover.
+
+For the architectural decision itself (one app vs. two), see [Next.js with a Separate Rails Backend: Pros and Drawbacks](../getting-started/nextjs-with-separate-rails-backend.md) and [Comparing React on Rails to Alternatives](../getting-started/comparing-react-on-rails-to-alternatives.md).
+
+## When this migration makes sense
+
+- You run (or are about to run) **two apps** — a Next.js frontend and a Rails API — and are paying for it twice: two deploys, two runtimes to monitor and patch, duplicated session/CSRF/auth handling, and an API contract whose only consumer is your own frontend.
+- Your team is **Rails-strong** and the API exists mostly to feed the Next.js app, not external clients.
+- You want React Server Components, streaming SSR, and component caching, and would rather get them inside Rails than maintain a second framework's mental model. These are [React on Rails Pro](../../pro/react-on-rails-pro.md) features.
+
+## When to stay on Next.js
+
+Be honest about the cases where this migration is the wrong move:
+
+- **No Rails team.** If Rails is not already a first-class part of your stack, adopting it to host React is a bigger change than this guide covers.
+- **Your API has many external consumers.** If mobile apps and partners consume the same API, the two-app split is carrying real architectural weight (see the [decision checklist](../getting-started/nextjs-with-separate-rails-backend.md#decision-checklist)).
+- **You depend on Vercel-specific edge features** (edge middleware/functions at the CDN, ISR served from Vercel's CDN). React on Rails runs on any Rack host; it does not replicate Vercel's edge network.
+
+## Capability mapping: Next.js → React on Rails (Pro)
+
+Every row in this table maps to a feature that is **shipped and documented today**. Rows marked **[Pro]** require [React on Rails Pro](../../pro/react-on-rails-pro.md); RSC and streaming additionally require the [Node renderer](../../pro/node-renderer.md).
+
+| Next.js (App Router)                                         | React on Rails (Pro)                                                                                                                       | Docs                                                                                                                                                      |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| React Server Components (server-first pages)                 | **[Pro]** `registerServerComponent` to register, `RSCRoute` to embed server components inside client trees                                 | [RSC hub](../../pro/react-server-components/index.md), [RSC inside client components](../../pro/react-server-components/inside-client-components.md)      |
+| `'use client'` directive                                     | Same directive, unchanged. **[Pro]** auto-bundling reads it to choose between `ReactOnRails.register` and `registerServerComponent`        | [Auto-bundling with RSC](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md#auto-bundling-with-react-server-components)      |
+| Streaming SSR + `<Suspense>` (`loading.tsx`)                 | **[Pro]** `stream_react_component` and `stream_react_component_with_async_props`                                                           | [Streaming SSR](../../pro/streaming-ssr.md)                                                                                                               |
+| Data fetching in server components (`fetch` to your own API) | **In-process data access** — ActiveRecord in the controller or in async-props blocks; no HTTP hop, no API layer to maintain                | [RSC data fetching](./rsc-data-fetching.md), **[Pro]** [DB queries in async props](../../pro/async-props-database-queries.md)                             |
+| Full Route Cache / component caching                         | **[Pro]** `cached_react_component` (fragment caching) and one-line prerender caching                                                       | [Caching](../building-features/caching.md), [Fragment caching](../../pro/fragment-caching.md)                                                             |
+| Metadata API (`metadata` export, `generateMetadata`)         | React 19 native metadata — `<title>`/`<meta>`/`<link>` rendered in components are hoisted to `<head>`; works with SSR, streaming, and RSC  | [React 19 Native Metadata](../building-features/react-19-native-metadata.md)                                                                              |
+| `next/font/local`                                            | `react_on_rails_font_face` view helper — self-hosted `.woff2` preload, `@font-face` with `font-display`, metric-matched fallback           | [Font Optimization](../building-features/fonts.md)                                                                                                        |
+| `next/link` + client-side routing                            | React Router or TanStack Router integration (your routes, SSR-compatible)                                                                  | [React Router](../building-features/react-router.md), [TanStack Router](../building-features/tanstack-router.md)                                          |
+| `middleware.ts` (auth gating, redirects, headers)            | Rack middleware and Rails controller filters — auth runs in the same process as the data it protects (Devise/Warden and friends)           | [Rails on Rack](https://guides.rubyonrails.org/rails_on_rack.html)                                                                                        |
+| `next dev` (HMR dev server)                                  | `bin/dev` — Rails plus webpack-dev-server with HMR by default                                                                              | [HMR and dev server modes](../building-features/dev-server-and-testing.md)                                                                                |
+| Vercel deploy / self-hosted `next start`                     | Any Rack host: one Rails deploy, standard Rails 7.1+ Dockerfile; **[Pro]** Node renderer ships as a sidecar container when you use SSR/RSC | [Docker deployment](../deployment/docker-deployment.md), [Node renderer container deployment](../building-features/node-renderer/container-deployment.md) |
+
+The headline row is data access. In the two-app stack, a "server component" in Next.js still fetches from your Rails API over HTTP, with auth forwarded across the boundary. After the migration the same component's data comes from ActiveRecord in-process — the API endpoints that existed only to feed the frontend get deleted, not rewritten.
+
+### On the roadmap (not shipped yet)
+
+These Next.js capabilities do not have a first-party React on Rails equivalent today. Each is tracked in an open issue; the table lists the interim approach.
+
+| Next.js capability                            | Status                                                                                                                                                |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Server Actions (`'use server'`)               | Tracked in [#3867](https://github.com/shakacode/react_on_rails/issues/3867). Today: Rails controller actions receiving regular form posts             |
+| `use cache` tags / `revalidateTag`            | Tracked in [#3871](https://github.com/shakacode/react_on_rails/issues/3871). Today: key-based cache expiry via the `cache_key` option                 |
+| `useForm`-style form/mutation helpers         | Tracked in [#3872](https://github.com/shakacode/react_on_rails/issues/3872). Today: standard `fetch`/form submission to Rails controllers             |
+| File-system routing, nested layouts, prefetch | Tracked in [#3873](https://github.com/shakacode/react_on_rails/issues/3873). Today: Rails routes + React Router/TanStack Router                       |
+| `next/image` optimization analog              | Tracked in [#3874](https://github.com/shakacode/react_on_rails/issues/3874). Today: webpack asset pipeline ([images](../building-features/images.md)) |
+
+## Collapse the two-app stack: incremental migration behind a reverse proxy
+
+You do not need a big-bang rewrite. Because the two-app stack already routes browser traffic through a reverse proxy (or can trivially be put behind one), you can migrate **one route group at a time**: Rails takes over a path prefix, Next.js keeps serving everything else, and users never notice the seam.
+
+### Step 0: Prerequisites
+
+- Your Rails app (today's API backend) gets React on Rails installed: [Installation into an Existing Rails App](../getting-started/installation-into-an-existing-rails-app.md). For RSC/streaming parity with Next.js, add [React on Rails Pro](../../pro/installation.md) and the Node renderer.
+- Both apps must be reachable from one reverse proxy you control: nginx, Caddy, HAProxy, an ALB, or your CDN's origin routing all work. If Next.js and Rails are on separate subdomains (`app.example.com` + `api.example.com`), plan to serve the migrated routes from the main domain — same-origin is what lets you delete the cross-origin auth plumbing later.
+
+### Step 1: One domain, one proxy
+
+Route all browser traffic through the proxy, with Next.js as the default upstream and Rails opted in per path:
+
+```nginx
+upstream nextjs { server 127.0.0.1:3000; }
+upstream rails  { server 127.0.0.1:3001; }
+
+server {
+  listen 443 ssl;
+  ssl_certificate     /etc/ssl/certs/example.com.pem;   # replace with your cert path
+  ssl_certificate_key /etc/ssl/private/example.com.key; # replace with your key path
+  server_name example.com;
+  # Terminate TLS at the proxy so both upstreams speak plain HTTP internally.
+
+  # nginx proxies upstream over HTTP/1.0 by default, which lacks chunked
+  # transfer encoding (required for streaming SSR) and disables keep-alive.
+  # Use HTTP/1.1 and clear the Connection header.
+  proxy_http_version 1.1;
+  proxy_set_header Connection "";
+
+  # Disabled globally because BOTH stacks stream during the migration:
+  # Next.js (loading.tsx, async server components) and Rails
+  # (stream_react_component, RSC async props). nginx buffers the full
+  # response by default, defeating streaming. Alternatively, keep buffering
+  # on and have each app send `X-Accel-Buffering: no` on streaming responses.
+  proxy_buffering off;
+
+  # Streaming SSR and RSC async-props responses can hold connections open
+  # longer than nginx's default 60s proxy_read_timeout. Tune to match your
+  # slowest expected stream.
+  # proxy_read_timeout 120s;
+
+  # Forward the browser-facing origin so both apps generate correct URLs
+  # and the shared session cookie stays on example.com.
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+  # Migrated route groups go to Rails (grows over time). Match the exact
+  # path plus its subpaths — a bare prefix like `location /account` would
+  # also capture /accounting.
+  location = /account  { proxy_pass http://rails; }
+  location /account/   { proxy_pass http://rails; }
+  location = /settings { proxy_pass http://rails; }
+  location /settings/  { proxy_pass http://rails; }
+
+  # Rails also keeps serving the existing API for not-yet-migrated pages
+  location /api/ { proxy_pass http://rails; }
+
+  # Everything else stays on Next.js until migrated
+  location / { proxy_pass http://nextjs; }
+}
+```
+
+Each migrated route group is a two-line proxy change — and a two-line rollback if something goes wrong.
+
+:::caution proxy_set_header inheritance
+nginx only inherits `server`-level `proxy_set_header` directives into `location` blocks that define **none** of their own. If you later add a `proxy_set_header` inside a `location`, repeat all of the headers above in that block.
+:::
+
+### Step 2: Share the session
+
+Pick the Rails session as the source of truth for authentication:
+
+- Set the Rails session cookie on the shared domain. Since the proxy serves both apps from one origin, the browser sends the same cookie to both upstreams. If the cookie was previously scoped to an API subdomain, set the domain explicitly:
+
+  ```ruby
+  # config/initializers/session_store.rb
+  Rails.application.config.session_store :cookie_store,
+                                          key: "_example_session",
+                                          domain: "example.com", # the shared, browser-facing domain
+                                          secure: true, # HTTPS only — TLS terminates at the proxy
+                                          same_site: :lax
+  ```
+
+- Next.js pages that need auth state already forward cookies to the Rails API for data fetching; that keeps working unchanged.
+- Avoid migrating _half_ of an auth flow. Move login/logout/signup to Rails early (they are usually plain forms — the easiest pages to port), so there is exactly one place that writes the session.
+
+### Step 3: Migrate one route group at a time
+
+Pick a self-contained route group (start with a low-risk one). For each:
+
+1. **Add the Rails route and controller.** The controller loads data with ActiveRecord directly — this replaces the API call the Next.js page was making.
+2. **Port the page component.** Your React components move largely as-is (see [porting notes](#porting-component-code) below). Render with `react_component` in the view, or `stream_react_component` / `RSCRoute` with Pro for streaming and server components.
+3. **Verify behind the proxy locally**, then flip the `location` block for that path prefix from the Next.js upstream to Rails.
+4. **Watch error rates and Core Web Vitals** for the migrated paths; roll back by reverting the proxy line if needed.
+
+### Step 4: Retire redundant API endpoints
+
+After each route group moves, the API endpoints that existed only to feed those Next.js pages have no callers left. Delete them (or log access first to confirm). This is where the maintenance win compounds: every migrated route shrinks the API surface you version, document, and secure.
+
+### Step 5: Final cutover checklist
+
+When the last route group flips to Rails:
+
+- [ ] All `location` blocks point at Rails; the Next.js upstream receives no traffic (verify with proxy access logs).
+- [ ] Remove the Next.js app from CI/CD and infrastructure; archive the repo or directory.
+- [ ] Delete frontend-only API endpoints, CORS configuration, and token-exchange/refresh plumbing that existed for the cross-app split.
+- [ ] Move redirects that lived in `next.config.js` / `middleware.ts` into the proxy config or Rails routes.
+- [ ] Re-point sitemap/robots generation, health checks, and uptime monitoring at the Rails app.
+- [ ] Collapse the two deploy pipelines into one.
+
+## Porting component code
+
+Most of your React code is framework-agnostic and moves unchanged. The Next.js-specific imports are the work:
+
+- **`'use client'`** — keep it. With Pro RSC auto-bundling, the directive determines registration (client component vs. server component) exactly as it determines the boundary in Next.js. Without RSC, every component is a client component and the directive is inert but harmless.
+- **`next/link`, `useRouter`, `usePathname`** — replace with plain `<a>` tags (Rails-routed pages) or your client router's equivalents ([React Router](../building-features/react-router.md), [TanStack Router](../building-features/tanstack-router.md)).
+- **`next/head` / Metadata API** — replace with React 19 native `<title>`/`<meta>`/`<link>` tags rendered directly in components ([guide](../building-features/react-19-native-metadata.md)).
+- **`next/image`** — replace with `<img>` plus webpack-pipeline assets ([images](../building-features/images.md)); a first-party optimization helper is tracked in [#3874](https://github.com/shakacode/react_on_rails/issues/3874).
+- **`next/font`** — replace with the [`react_on_rails_font_face` helper](../building-features/fonts.md) for the `next/font/local` use case (self-hosted `.woff2`, preload, metric-matched fallback).
+- **`fetch` in server components** — delete the HTTP hop: pass props from the controller, or query ActiveRecord in async-props blocks ([RSC data fetching](./rsc-data-fetching.md)).
+- **`process.env.NEXT_PUBLIC_*`** — pass values as props from Rails, or configure them in your webpack build (e.g., `EnvironmentPlugin`/`DefinePlugin`).
+- **CSS Modules / global CSS** — supported via Shakapacker's webpack setup; for server components see [CSS and styling with RSC](../../pro/react-server-components/css-and-styling.md).
+
+If you are adopting server components as part of the move, the [RSC migration series](./migrating-to-rsc.md) covers component restructuring, context/state, and data-fetching patterns in depth — it applies directly to components arriving from Next.js.
+
+## Related reading
+
+- [Next.js with a Separate Rails Backend: Pros and Drawbacks](../getting-started/nextjs-with-separate-rails-backend.md) — the architecture decision this guide assumes you've made
+- [Comparing React on Rails to Alternatives](../getting-started/comparing-react-on-rails-to-alternatives.md)
+- [React on Rails Pro](../../pro/react-on-rails-pro.md) — RSC, streaming SSR, caching, Node renderer
+- [RSC Migration Series](./migrating-to-rsc.md)
+- [Example Migrations](./example-migrations.md)
+
+================================================================================
 PAGE: https://reactonrails.com/docs/migrating/migrating-from-react-rails
 SOURCE: docs/oss/migrating/migrating-from-react-rails.md
 ================================================================================
@@ -17817,6 +20320,88 @@ then treat the migration as:
 6. Review `bin/dev`, `config/shakapacker.yml`, and webpack config diffs before committing.
 
 Current React on Rails does not support `gem "webpacker"`; Shakapacker is the recommended baseline. The install generator adds Shakapacker rather than enforcing a hard install-time block, and `react_on_rails doctor` flags Webpacker as a removed/breaking-change issue when it detects `config/webpacker.yml` or `bin/webpacker`. Migrate to Shakapacker first (step 1 above) when you can; use the [Legacy Webpacker / Webpack 4 migration shims](../building-features/rails-webpacker-react-integration-options.md#legacy-webpacker--webpack-4-migration-shims) only as a narrow temporary bridge when the bundler migration cannot happen first.
+
+================================================================================
+PAGE: https://reactonrails.com/docs/migrating/migrating-from-inertia-rails
+SOURCE: docs/oss/migrating/migrating-from-inertia-rails.md
+================================================================================
+
+# Migrate from Inertia Rails
+
+This guide is for Rails apps that currently use [Inertia Rails](https://inertia-rails.dev/) with React and are evaluating a move to React on Rails. It covers three things:
+
+1. A concept-mapping table from Inertia idioms to their React on Rails equivalents.
+2. A **verified** coexistence setup: both gems in one app, so you can migrate route by route instead of all at once.
+3. An honest "when to stay on Inertia" section.
+
+For the "why" comparison (architecture, SSR, streaming, RSC tradeoffs), see [Comparing React on Rails to Alternatives](../getting-started/comparing-react-on-rails-to-alternatives.md#react-on-rails-vs-inertia-rails). This page is the "how."
+
+> **Scope note:** This is the v1 of the migration guide. A full step-by-step playbook (forms, shared state, SSR cutover, removing Inertia) and a worked example app are planned as follow-ups, tracked in [#3899](https://github.com/shakacode/react_on_rails/issues/3899). Two parity features that affect the mapping table — a first-class `useForm`-style helper ([#3872](https://github.com/shakacode/react_on_rails/issues/3872)) and an opinionated routing/prefetch starter ([#3873](https://github.com/shakacode/react_on_rails/issues/3873)) — are **not shipped as of this writing**; check those issues for current status. The table gives you the interim answer for each.
+
+## Concept mapping
+
+| Inertia concept                                                     | React on Rails equivalent                                                                                                                                                                                                                                                                                                                                                                                                                                  | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `render inertia: 'Page', props: {...}` in a controller              | A normal Rails view that calls [`react_component("Page", props: {...})`](../api-reference/view-helpers-api.md#react_component) (or [`react_component_hash`](../api-reference/view-helpers-api.md#react_component_hash) when SSR returns multiple regions — though for head tags on React 19, prefer [native metadata hoisting](../building-features/react-19-native-metadata.md) over `react_component_hash`)                                              | Your controller stays a conventional Rails action rendering a view. Props are any JSON-serializable Ruby hash, same as Inertia page props.                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Page components resolved by name (`resolve:` in `createInertiaApp`) | Components registered with `ReactOnRails.register({ Page })`, or discovered automatically with [auto-bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md)                                                                                                                                                                                                                                                            | With auto-bundling you skip both manual registration and manual pack tags.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `useForm` (form state, submit, errors, processing)                  | **Interim:** `fetch` (or your HTTP client) with [`ReactOnRails.authenticityHeaders()`](../api-reference/javascript-api.md) for Rails CSRF, plus your own form state. **Planned:** a first-class `useForm`-style hook is tracked in [#3872](https://github.com/shakacode/react_on_rails/issues/3872) (implementation in flight in [PR #3942](https://github.com/shakacode/react_on_rails/pull/3942) at the time of writing; #3872 is the durable reference) | This is currently Inertia's strongest ergonomic advantage; see [When to stay on Inertia](#when-to-stay-on-inertia). Do not plan a migration assuming the helper has shipped — check #3872 first.                                                                                                                                                                                                                                                                                                                                                                  |
+| `<Link>` (SPA navigation), `prefetch`                               | **Interim:** plain `<a>` full-page navigation between Rails routes, or client-side routing within a section via [React Router](../building-features/react-router.md) or [TanStack Router](../building-features/tanstack-router.md). **Planned:** an opinionated SSR-friendly routing + prefetch starter is tracked in [#3873](https://github.com/shakacode/react_on_rails/issues/3873)                                                                     | React on Rails does not impose a router. Full-page navigation is also how you cross the Inertia↔React on Rails boundary during an incremental migration (verified below).                                                                                                                                                                                                                                                                                                                                                                                        |
+| Shared data (`inertia_share`)                                       | [`railsContext`](../core-concepts/render-functions-and-railscontext.md) for request/app-wide context (extend it via [`config.rendering_extension`](../configuration/README.md#rendering_extension)), plus per-page props from your view                                                                                                                                                                                                                    | `railsContext` is only passed to [render functions](../core-concepts/render-functions-and-railscontext.md) — a plain registered component receives just its props, so register the page as a render function (or copy shared values into per-page props). There is no `usePage()` equivalent for nested components: pass shared values down via props/React Context from the render function, or use the Redux store. For shared _client state_ across multiple components on one page, there is also the [Redux store API](../api-reference/redux-store-api.md). |
+| Deferred / lazy / merge props                                       | **OSS:** fetch from the component after mount (standard React data fetching). **Pro:** [async props with streaming SSR](../../pro/streaming-ssr.md) (`stream_react_component_with_async_props`) stream slow data into a server-rendered page; [RSC](../../pro/react-server-components/index.md) moves data fetching into server components                                                                                                                 | Inertia's deferred props resolve client-side after the page visit. Pro streaming starts HTML immediately and streams the slow parts — same goal, stronger SSR story.                                                                                                                                                                                                                                                                                                                                                                                              |
+| Partial reloads                                                     | Component-local data refetching (the component owns its data refresh; no protocol-level partial visit needed). With Pro RSC, navigation can refetch only the [RSC payload](../../pro/react-server-components/rsc-payload-route-data.md) instead of a full page                                                                                                                                                                                             | There is no direct protocol equivalent in React on Rails; data refresh is ordinary React, not a framework visit.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| SSR via the Inertia/Vite SSR server (sidecar Node process)          | **OSS:** `react_component(..., prerender: true)` using [ExecJS server rendering](../core-concepts/react-server-rendering.md) — no separate process to deploy. **Pro:** the [Node renderer](../../pro/node-renderer.md) (dedicated Node process) and [streaming SSR](../../pro/streaming-ssr.md)                                                                                                                                                            | Inertia SSR is a single `renderToString` pass. ExecJS rendering (pooled JS contexts inside the Ruby process) is typically slower than a dedicated Node SSR process for large pages — measure before relying on it; the Pro Node renderer is the performance path. Pro can also stream (`renderToPipeableStream`) and supports RSC; see the comparison page for details.                                                                                                                                                                                           |
+| Persistent layouts (`Page.layout = ...`)                            | Ordinary React composition inside your registered component; the Rails layout (ERB) owns the document shell                                                                                                                                                                                                                                                                                                                                                | During coexistence, both stacks share the same Rails layout conventions (see below).                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| CSRF handling (Inertia's automatic XSRF cookie/axios integration)   | Rails `csrf_meta_tags` + [`ReactOnRails.authenticityHeaders()`](../api-reference/javascript-api.md) on mutating requests                                                                                                                                                                                                                                                                                                                                   | Standard Rails forms (`form_with`) also keep working — Rails owns the page.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+
+## Coexistence: run both gems during the migration (verified)
+
+The migration-enabling claim is that `inertia_rails` and `react_on_rails` can live in the same app while you move route by route. We verified this in a minimal scratch app (2026-06-11), with one page rendered by each stack and full-page navigation across the boundary in a real browser.
+
+**Verified versions:**
+
+| Component                                   | Version                                   |
+| ------------------------------------------- | ----------------------------------------- |
+| Ruby / Rails                                | 3.4.6 / 8.1.3                             |
+| `react_on_rails` gem / `react-on-rails` npm | 16.6.0 / 16.6.0                           |
+| `inertia_rails` gem                         | 3.21.2                                    |
+| `@inertiajs/react` npm                      | 2.3.26 (see version-pairing gotcha below) |
+| `shakapacker` gem / npm                     | 9.7.0 / 9.7.0                             |
+| React / ReactDOM                            | 19.2.7                                    |
+
+**The setup:**
+
+- One Gemfile with both gems: `gem "react_on_rails"`, `gem "inertia_rails"`, `gem "shakapacker"`.
+- One Shakapacker install compiles packs for both stacks. The Inertia entry point is just another pack (`createInertiaApp` bootstrapping `@inertiajs/react`); the React on Rails entry point registers components with `ReactOnRails.register`.
+- An Inertia route: a controller action with `render inertia: "InertiaPage", props: {...}`, using a Rails layout that loads the Inertia pack.
+- A React on Rails route: a conventional controller action whose ERB view calls `react_component("HelloFromReactOnRails", props: {...}, prerender: false)`, using a layout that loads the React on Rails pack.
+- Each page contains a plain `<a>` link to the other.
+
+**What was verified (in a real browser, via Playwright):**
+
+- Both gems boot together; no initializer or engine conflicts.
+- The React on Rails page mounts client-side with the props passed from the view helper.
+- The Inertia page mounts client-side from the `data-page` payload emitted by `inertia_rails`, with the props passed from the controller.
+- Full-page navigation across the boundary works in both directions (React on Rails page → Inertia page → back).
+- Both layouts emit `csrf_meta_tags` from the same Rails session — the two stacks share Rails session and CSRF infrastructure.
+
+**Gotchas found during verification:**
+
+- **Pin `@inertiajs/react` to the major version your `inertia_rails` gem supports.** With `inertia_rails` 3.21.2, `@inertiajs/react` 3.4.0 failed to boot (`TypeError: Cannot read properties of null (reading 'component')` inside `createInertiaApp`); pinning to `@inertiajs/react` ^2 (2.3.26) worked. If your existing app already runs, keep its existing client version during the migration.
+- This was verified with full-page (`<a>`) navigation across the boundary. Inertia's `<Link>` SPA visits only work between Inertia pages; links that leave the Inertia section of the app should be regular anchors.
+- The scratch app used webpack-bundled Inertia via Shakapacker. If your Inertia app uses Vite, you can run Vite and Shakapacker side by side during the migration, but that combination was **not** part of this verification.
+
+**The resulting migration strategy** is route-by-route: keep `render inertia:` actions as they are, and convert one low-risk route at a time to a conventional Rails view + `react_component`. Page components are plain React in both stacks, so most component code moves unchanged — what changes is how props arrive (view helper instead of the Inertia page object) and how navigation/forms talk to Rails (see the mapping table).
+
+## When to stay on Inertia
+
+React on Rails is not the right answer for every Inertia app. Staying put is reasonable when:
+
+- **You're a small CRUD app with no SSR, SEO, or streaming needs.** Inertia's client-rendered model with controller-provided props is a great fit there, and the migration buys you little.
+- **`useForm` is load-bearing for your team.** Inertia's form helper (state + submit + validation errors + processing flags in one hook) is genuinely smoother today than the interim `fetch` + `authenticityHeaders` pattern. If your app is mostly forms, consider waiting until [#3872](https://github.com/shakacode/react_on_rails/issues/3872) ships and re-evaluating.
+- **You rely heavily on Inertia's navigation conveniences** — `<Link>` visits, prefetching, scroll restoration, and flash-message-over-redirect conventions. React on Rails leaves routing choices to you; until [#3873](https://github.com/shakacode/react_on_rails/issues/3873) ships an opinionated starter, replicating that polish is your code.
+- **You use Inertia's multi-framework support** (Vue or Svelte pages). React on Rails is React-only.
+
+The reasons to move are the ones Inertia architecturally can't offer: streaming SSR, React Server Components, component-level code splitting with SSR, fragment caching, and incremental React adoption inside existing ERB views — see the [comparison page](../getting-started/comparing-react-on-rails-to-alternatives.md#react-on-rails-vs-inertia-rails) for that side of the decision.
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/migrating/migrating-from-vite-rails
@@ -23340,6 +25925,457 @@ sequenceDiagram
 ## Next Steps
 
 To learn more about how to render React Server Components inside client components, see [React Server Components Inside Client Components](./inside-client-components.md).
+
+================================================================================
+PAGE: https://reactonrails.com/docs/pro/react-server-components/css-and-styling
+SOURCE: docs/pro/react-server-components/css-and-styling.md
+================================================================================
+
+# CSS and Styling with React Server Components
+
+This page documents how CSS moves through React on Rails Pro when an app uses React Server Components
+(RSC), regular React on Rails client components, server-side rendering (SSR), and Shakapacker asset tags.
+
+## Short recommendation
+
+Use the normal Shakapacker CSS pipeline for styles that must apply to server-rendered markup. Put global,
+Tailwind, design-system, and server-component-only styles in a stylesheet loaded from the Rails layout.
+Use CSS Modules or component-scoped CSS imports behind a `'use client'` boundary when the styled markup is a
+Client Component or a dependency of a Client Component.
+
+Do not rely on CSS imported only by a Server Component to create a browser stylesheet. With the generated RSC
+configs, the server and RSC bundles do not extract CSS. Server-only CSS imports may let the server render class
+names, but they do not cause React on Rails to emit a stylesheet link for the browser.
+
+## Bundle CSS architecture
+
+React on Rails Pro builds three graphs for an RSC app:
+
+| Graph         | Runtime                           | CSS behavior                                                                                                                                                      |
+| ------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Client bundle | Browser                           | CSS is extracted or injected by the normal Shakapacker client pipeline. The RSC manifest plugin records CSS files for `'use client'` references.                  |
+| Server bundle | Node renderer VM for SSR          | CSS extraction plugins and style injection loaders are removed. CSS Modules are configured with `exportOnlyLocals`, so SSR can render class names without CSS IO. |
+| RSC bundle    | Node renderer VM for RSC payloads | Uses the server bundle config plus the RSC loader. It transforms `'use client'` modules into client references and does not extract browser CSS.                  |
+
+That split means CSS can reach the browser through two supported paths:
+
+1. Rails renders Shakapacker stylesheet tags. This is the normal React on Rails path for global CSS,
+   component bundles loaded by `auto_load_bundle`, and manually loaded packs.
+2. The RSC renderer reads stylesheet hrefs from `react-client-manifest.json` for `'use client'` references
+   and emits React 19 stylesheet links into the RSC stream. React hoists and dedupes those links so CSS for
+   Client Components inside an RSC page can load before the component paints.
+
+Verified in this repository:
+
+- The current RSC rendering-flow docs state that the client bundle extracts CSS, the server bundle uses
+  CSS Modules locals only, and the RSC bundle does not extract CSS.
+- The Pro dummy app request spec
+  `react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb` (in the Pro repository) checks
+  `react-client-manifest.json` records CSS for a `'use client'` component rendered by an RSC page.
+- The Pro dummy app Playwright regression test
+  `react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts` (in the Pro repository) checks that
+  same path: a CSS Module imported by a `'use client'` component in an RSC tree is preloaded or linked before
+  the styled probe paints.
+- The React on Rails helper still loads generated component packs by appending both
+  `generated/<ComponentName>` JavaScript and stylesheet pack tags when `auto_load_bundle` is enabled.
+
+Known gaps (no regression fixture yet):
+
+- Plain non-module CSS imported behind a `'use client'` boundary should follow the same manifest stylesheet
+  path as CSS Modules, but the checked regression fixture uses an SCSS module.
+- Static CSS extraction libraries such as Vanilla Extract, Linaria, Panda CSS, and Compiled should work when
+  their generated CSS is included in the client or global stylesheet pipeline, but this page does not add
+  fixtures for those packages.
+- styled-components has recent React 19 and RSC compatibility fixes. React on Rails Pro has not verified that
+  integration end to end in this repository.
+
+## Where to import CSS
+
+### Server Components
+
+Server Components render in the RSC bundle. Generated server bundles may import top-level Server Component
+modules for registration, but neither the server nor RSC bundle extracts browser CSS. Importing a CSS file only
+from a Server Component does not make React on Rails render a browser stylesheet for it.
+
+Recommended pattern:
+
+```tsx
+// app/javascript/components/ProductSummary.tsx
+// No 'use client'. This is a Server Component.
+type Product = { name: string; description: string };
+
+export default function ProductSummary({ product }: { product: Product }) {
+  return (
+    <article className="product-summary">
+      <h2>{product.name}</h2>
+      <p>{product.description}</p>
+    </article>
+  );
+}
+```
+
+```css
+/* app/javascript/styles/application.css */
+.product-summary {
+  display: grid;
+  gap: 0.5rem;
+}
+```
+
+```ts
+// app/javascript/packs/client-bundle.ts
+import '../styles/application.css';
+```
+
+The class name is server-rendered by the RSC component, and the stylesheet is loaded by the Rails layout as a
+normal Shakapacker asset.
+
+### Client Components inside an RSC tree
+
+If the markup is interactive or the style should be component-scoped, put the CSS import behind the client
+boundary:
+
+```tsx
+// app/javascript/components/FavoriteButton.tsx
+'use client';
+
+import styles from './FavoriteButton.module.scss';
+
+export default function FavoriteButton({ active }: { active: boolean }) {
+  return (
+    <button className={active ? styles.activeButton : styles.button} type="button">
+      Favorite
+    </button>
+  );
+}
+```
+
+```tsx
+// app/javascript/components/ProductPage.tsx
+import FavoriteButton from './FavoriteButton';
+
+type Product = { favorite: boolean; name: string };
+
+export default async function ProductPage({ product }: { product: Product }) {
+  return (
+    <section>
+      <h1>{product.name}</h1>
+      <FavoriteButton active={product.favorite} />
+    </section>
+  );
+}
+```
+
+The RSC bundle turns `FavoriteButton` into a client reference. The client build extracts the CSS, the RSC
+client manifest records the CSS href, and the RSC stream emits stylesheet links for the browser.
+
+### Shared components
+
+A module can be evaluated as a Server Component in one import path and as part of the client graph in another
+import path. React's `'use client'` directive marks a module dependency subtree, not a render-tree subtree.
+
+For shared view components:
+
+- Use global classes from a layout-loaded stylesheet if the component can render directly as a Server
+  Component.
+- Import CSS Modules from a wrapper that starts with `'use client'` if the component needs component-scoped
+  CSS and will render as a Client Component.
+- Avoid hidden CSS side effects in shared utility modules. They make it hard to know whether the CSS is
+  emitted by the client bundle, ignored by the server/RSC bundle, or duplicated in several packs.
+
+## React on Rails asset rendering
+
+For manually loaded packs, render the stylesheet pack in the Rails layout or view:
+
+```erb
+<%= stylesheet_pack_tag "client-bundle", media: "all" %>
+<%= javascript_pack_tag "client-bundle", defer: true %>
+```
+
+For generated packs with `auto_load_bundle: true`, keep React on Rails' argless tag placeholders in the
+layout. React on Rails appends generated component pack names while rendering the view:
+
+```erb
+<%= stylesheet_pack_tag media: "all" %>
+<%= javascript_pack_tag defer: true %>
+```
+
+Calling these helpers without pack names is a React on Rails extension. React on Rails accumulates pack names
+with `append_stylesheet_pack_tag`/`append_javascript_pack_tag` during rendering and injects them when the
+argless helpers are evaluated.
+
+When SSR and `auto_load_bundle` are both used, render the body into `content_for` before the `<head>` so the
+append calls run before `stylesheet_pack_tag` emits the head links:
+
+```erb
+<% content_for :body_content do %>
+  <%= yield %>
+<% end %>
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%# Global app CSS pack, if you have one. %>
+    <%= stylesheet_pack_tag "client-bundle", media: "all" %>
+
+    <%# Auto-loaded generated component CSS. %>
+    <%= stylesheet_pack_tag media: "all" %>
+  </head>
+  <body>
+    <%= yield :body_content %>
+
+    <%= javascript_pack_tag "client-bundle", defer: true %>
+    <%= javascript_pack_tag defer: true %>
+  </body>
+</html>
+```
+
+For RSC pages rendered by `stream_react_component`, CSS for client references in the RSC payload is handled by
+the Pro RSC renderer. It uses the manifest stylesheet hrefs and React 19 stylesheet hoisting. Keep the normal
+Rails stylesheet tags anyway for global CSS, generated component packs, and non-RSC React on Rails components.
+
+## Development versus production
+
+Production and CI builds should be treated as the source of truth for CSS ordering. Production extracts CSS
+into files and writes manifests. Development HMR may inject CSS from JavaScript or serve assets from the dev
+server, so it can hide or create FOUC that is unrelated to the production path.
+
+Use a production-like local check before declaring a CSS setup safe:
+
+```bash
+RAILS_ENV=production NODE_ENV=production CLIENT_BUNDLE_ONLY=true bin/shakapacker
+RAILS_ENV=production NODE_ENV=production SERVER_BUNDLE_ONLY=true bin/shakapacker
+RAILS_ENV=production NODE_ENV=production RSC_BUNDLE_ONLY=true bin/shakapacker
+```
+
+Then inspect:
+
+- `public/<public_output_path>/manifest.json` for regular Shakapacker assets.
+- `public/<public_output_path>/react-client-manifest.json` for client reference CSS arrays.
+- The server-rendered HTML for `<link rel="stylesheet">` or React stylesheet preload/bootstrap hints before
+  the styled RSC client boundary.
+
+## Recommended setup
+
+### 1. Keep a layout-loaded stylesheet for server-rendered HTML
+
+Use this for design tokens, resets, Tailwind utilities, CSS variables, and classes used by Server Components:
+
+```ts
+// app/javascript/packs/client-bundle.ts
+import '../styles/application.css';
+```
+
+```erb
+<%= stylesheet_pack_tag "client-bundle", media: "all" %>
+```
+
+### 2. Put component-scoped imports behind `'use client'`
+
+Use CSS Modules, SCSS modules, or plain CSS imports from the Client Component that owns the styled markup.
+This keeps the CSS in the client graph so RSC can discover the stylesheet href from the client manifest.
+
+### 3. Use Tailwind as global/static CSS
+
+For new Tailwind CSS v4 apps, use the current PostCSS plugin and import Tailwind from the app stylesheet:
+
+```js
+// postcss.config.mjs
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+```
+
+```css
+/* app/javascript/styles/application.css */
+@import 'tailwindcss';
+```
+
+For existing Tailwind CSS v3 apps, keep the older PostCSS shape and make sure Rails views plus RSC/client
+component files are included in `content`:
+
+```js
+// config/tailwind.config.js
+module.exports = {
+  content: ['./app/views/**/*.{erb,haml,slim}', './app/javascript/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+```js
+// postcss.config.js
+const tailwindcss = require('tailwindcss');
+const autoprefixer = require('autoprefixer');
+
+module.exports = {
+  plugins: [tailwindcss('./config/tailwind.config.js'), autoprefixer],
+};
+```
+
+### 4. Prefer static CSS extraction for server-heavy surfaces
+
+Static extraction libraries are the best fit when you want authored-in-JS styles but also want server-heavy
+RSC pages. Configure the package so CSS is emitted into a stylesheet that Shakapacker can extract and Rails can
+serve.
+
+Example shape for Vanilla Extract, appended inside your existing generated Pro client config. Do not replace
+the generated `configureClient`; add the imports and helper near the top of the file, then call the helper near
+the end of the existing `configureClient`.
+
+```js
+// config/webpack/clientWebpackConfig.js
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { VanillaExtractPlugin } = require('@vanilla-extract/webpack-plugin');
+
+// Shakapacker normally provides MiniCssExtractPlugin. Add it explicitly only if
+// your package manager setup makes the transitive dependency unavailable.
+const vanillaExtractCssRule = {
+  test: /\.vanilla\.css$/i,
+  use: [
+    MiniCssExtractPlugin.loader,
+    {
+      loader: require.resolve('css-loader'),
+      options: { url: false },
+    },
+  ],
+};
+
+const excludeVanillaExtractCss = (rule) => {
+  if (!rule || typeof rule !== 'object') return;
+
+  if (Array.isArray(rule.oneOf)) {
+    rule.oneOf.forEach(excludeVanillaExtractCss);
+  }
+
+  // Target the generated broad CSS rule so vanillaExtractCssRule handles
+  // .vanilla.css exactly once. Inspect clientConfig.module.rules in your app
+  // to confirm which rules this mutation actually hits.
+  if (rule.test instanceof RegExp && rule.test.test('app.css')) {
+    rule.exclude = [rule.exclude, /\.vanilla\.css$/i].flat().filter(Boolean);
+  }
+};
+
+const applyVanillaExtract = (clientConfig) => {
+  clientConfig.plugins.push(new VanillaExtractPlugin());
+
+  clientConfig.module.rules.forEach(excludeVanillaExtractCss);
+  clientConfig.module.rules.push(vanillaExtractCssRule);
+};
+```
+
+Call `applyVanillaExtract(clientConfig)` inside the existing generated `configureClient`, after the Pro client
+setup that removes the `server-bundle` entry, installs the RSC client-manifest plugin, and preserves
+LoadablePlugin plus browser resolve fallbacks. The `rule.test.test('app.css')` probe is only a convenience for
+the generated broad CSS rule. Inspect the resolved `clientConfig.module.rules` in your app and replace the
+helper with an explicit rule mutation if it does not hit exactly the broad CSS rule.
+
+```ts
+// app/javascript/components/productCard.css.ts
+import { style } from '@vanilla-extract/css';
+
+export const card = style({
+  display: 'grid',
+  gap: '0.75rem',
+});
+```
+
+```tsx
+// app/javascript/components/ProductCard.tsx
+'use client';
+
+// Vanilla Extract resolves this import to productCard.css.ts at build time.
+import { card } from './productCard.css';
+
+type Product = { name: string };
+
+export default function ProductCard({ product }: { product: Product }) {
+  return <article className={card}>{product.name}</article>;
+}
+```
+
+The authored Vanilla Extract module is `productCard.css.ts`, but the import specifier intentionally omits the
+`.ts` extension and uses `productCard.css`. That is the Vanilla Extract convention: the bundler plugin resolves
+the authored module and emits `.vanilla.css`. Shakapacker must still handle that generated CSS with a CSS
+extraction rule so Rails can serve the asset, and the generated `.vanilla.css` file should be excluded from any
+broader CSS rule so it is processed exactly once. Treat this as a starting point. Confirm the package's
+webpack/Rspack plugin supports the bundler you use and then verify the emitted CSS in your client assets and in
+`react-client-manifest.json`.
+
+This client-boundary shape is the recommended copyable setup for RSC pages because the authored `.css.ts`
+import stays in the browser/client graph. If you import Vanilla Extract modules directly from a Server
+Component or any other RSC/server graph module, the server and RSC build must also understand those imports and
+the extracted CSS must still be loaded by a browser pack. This repo has not verified that package-specific
+server/RSC configuration; also check the
+[third-party library compatibility notes](../../oss/migrating/rsc-third-party-libs.md#zero-runtime-css-in-js-rsc-compatible)
+for the current `.css.ts` workaround caveat.
+
+### 5. Treat runtime CSS-in-JS as package-specific
+
+Runtime CSS-in-JS libraries are no longer one category:
+
+- Recent styled-components v6 releases include React 19 and RSC compatibility fixes. Use CSS custom properties
+  for theming in Server Components, and verify the exact version with React on Rails Pro before relying on it
+  in production.
+- Emotion still documents SSR style collection and hydration paths, but this repo has not verified Emotion in
+  RSC Server Components. Keep Emotion-heavy UI behind `'use client'` boundaries unless you add an app-specific
+  SSR/RSC integration test.
+- Component libraries based on Emotion, styled-components, or another runtime styling layer should be treated
+  like third-party client-feature packages unless their RSC support is documented and verified in your app.
+
+## Compatibility matrix
+
+Status key:
+
+- **Verified**: covered by current repo code, docs, or tests.
+- **Assumed**: expected from current repo behavior or package docs, but not yet covered by a React on Rails Pro
+  regression fixture.
+- **Unsupported**: does not fit the current generated RSC/server CSS pipeline.
+- **Unknown**: needs a fixture or package-specific investigation before recommendation.
+
+| Approach/package                                         | RSC compatibility                                                                                      | Client Component compatibility                                   | SSR compatibility                                                    | Required config                                                                  | Limitations                                                                                      | Status                                                               |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| Global CSS imported by a layout pack                     | Works for Server Components because classes render in HTML and CSS loads globally.                     | Works.                                                           | Works when the stylesheet tag is in `<head>`.                        | Import CSS from a client/layout pack and render `stylesheet_pack_tag`.           | Not component-scoped. Ordering depends on layout/tag order.                                      | Verified from React on Rails paths.                                  |
+| CSS Modules or SCSS Modules in `'use client'` components | Works. RSC records client-reference CSS in the manifest and emits stylesheet links.                    | Works.                                                           | Works: server bundle renders locals, client stylesheet supplies CSS. | Shakapacker CSS Modules/SCSS config; current RSC manifest plugin.                | Manifest-wide CSS links can over-include CSS for client refs not rendered on a specific request. | Verified by Pro dummy specs.                                         |
+| CSS imported only by Server Components                   | Not supported as a browser stylesheet path.                                                            | Not applicable unless also imported by client graph.             | Server may render class names, but CSS is not emitted.               | Move CSS to global/layout pack or a `'use client'` boundary.                     | Easy to ship unstyled HTML. CSS Modules locals alone are not enough.                             | Unsupported by current configs.                                      |
+| Sass/SCSS through Shakapacker                            | Works when emitted through global packs or `'use client'` components.                                  | Works.                                                           | Works with the normal SSR CSS locals pattern.                        | `sass`, `sass-loader`, existing Shakapacker rules.                               | Direct server-only imports have the same limitation as CSS imports.                              | Verified for SCSS Modules in RSC client boundary; otherwise assumed. |
+| PostCSS/Tailwind CSS                                     | Works best as global/static CSS loaded from the layout.                                                | Works with class names in client components.                     | Works when compiled CSS is present before paint.                     | Tailwind/PostCSS config; include Rails views and JS/TS component files.          | Dynamic class names must be safelisted or statically discoverable.                               | Assumed; repo dummy uses Tailwind v3 globally.                       |
+| `clsx`, `classnames`, CVA                                | Works because they only compose class strings.                                                         | Works.                                                           | Works.                                                               | None beyond making sure the referenced classes exist in loaded CSS.              | They do not emit CSS; pair with Tailwind, global CSS, CSS Modules, or extracted CSS.             | Assumed; low risk.                                                   |
+| Vanilla Extract                                          | Expected to work when its build plugin emits CSS through Shakapacker.                                  | Works when CSS assets are extracted.                             | Expected to work because class names are static.                     | `@vanilla-extract/webpack-plugin` or bundler equivalent.                         | Not verified with React on Rails Pro RSC; direct RSC imports may need the documented workaround. | Assumed.                                                             |
+| Linaria                                                  | Expected to work when extracted CSS is included in the client/global CSS pipeline.                     | Works after loader/Babel setup.                                  | Expected to work because styles are static CSS.                      | Linaria/WyW Babel preset plus `@wyw-in-js/webpack-loader` and CSS extraction.    | Runtime dynamic styles are limited to supported static-extraction patterns.                      | Assumed.                                                             |
+| Panda CSS                                                | Expected to work as generated static CSS.                                                              | Works when generated classes and CSS are included.               | Expected to work because output is static CSS.                       | Panda CLI or PostCSS setup; import generated CSS in a layout/client pack.        | Classes must be discoverable by Panda's scanner or generated via recipes/config.                 | Assumed.                                                             |
+| Compiled CSS-in-JS                                       | Expected to work with extraction and normal CSS imports.                                               | Works when the webpack loader or package CSS import is handled.  | Expected to work when CSS is extracted before paint.                 | `@compiled/webpack-loader` and CSS extraction rules, or package-specific setup.  | Ordering can be package-specific; verify any Atlassian/component-library migration path.         | Assumed.                                                             |
+| styled-components v6                                     | Recent releases include React 19/RSC compatibility fixes; Server Component styling is unverified here. | Works in Client Components.                                      | Package-specific; use documented Babel/SWC/plugin guidance.          | Recent styled-components version; optional tooling for class names.              | Not verified in this repo. Context theming is not available in Server Components; use CSS vars.  | Unknown for React on Rails Pro.                                      |
+| Emotion                                                  | Keep behind `'use client'` unless you build and test an RSC integration.                               | Works in Client Components.                                      | Requires Emotion SSR/cache/hydration setup for traditional SSR.      | Emotion SSR extraction/cache setup; React on Rails integration code.             | Runtime style insertion and context/cache providers need package-specific SSR/RSC handling.      | Unknown for RSC; assumed for client-only.                            |
+| Runtime-styled component libraries                       | Treat as Client Components unless the library documents RSC support.                                   | Works behind `'use client'` if browser/client requirements hold. | Depends on the library's SSR support.                                | Library-specific providers, style collectors, Babel/SWC plugins, or CSS imports. | May force large client boundaries; can cause FOUC or hydration issues without tested SSR setup.  | Unknown.                                                             |
+
+## Known limitations
+
+- RSC stylesheet links are derived from the client manifest, not from the exact client references rendered by
+  one request. This favors no-FOUC behavior over perfectly minimal per-request CSS.
+- Older `react-client-manifest.json` files without CSS arrays cannot produce RSC stylesheet links. Rebuild all
+  three bundles after upgrading `react-on-rails-rsc`.
+- If a component's first styled usage is in the browser after an `RSCRoute` client-side navigation, the RSC
+  payload still needs the stylesheet links. Verify that path separately for route-heavy apps.
+- Rspack support exists, but check the [Rspack compatibility page](./rspack-compatibility.md) and verify CSS
+  extraction for any package that relies on webpack-only plugins.
+- This page intentionally does not include package fixtures or regression tests for Tailwind, Vanilla Extract,
+  Linaria, Panda, Compiled, styled-components, Emotion, or component-library styling systems.
+
+## See also
+
+- [RSC rendering flow](./rendering-flow.md) for the client, server, and RSC bundle lifecycle.
+- [View helpers API](../../oss/api-reference/view-helpers-api.md) for `stream_react_component`,
+  `stylesheet_pack_tag`, and related Rails helpers.
+- [Third-party library compatibility](../../oss/migrating/rsc-third-party-libs.md) for package-specific RSC
+  migration notes.
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/pro/react-server-components/tutorial
@@ -29370,6 +32406,16 @@ For most React on Rails applications, you won't need `React.cache()` for data fe
 
 > **Important:** React on Rails does **not** support Server Actions (`'use server'`). Server Actions run on the Node renderer, which is a rendering server -- it has no access to Rails models, sessions, cookies, or CSRF protection. Do not use `'use server'` in React on Rails applications.
 
+This is a deliberate, settled design decision, not a temporary gap (see the decision record in
+[#3867](https://github.com/shakacode/react_on_rails/issues/3867)): Rails controllers are the mutation
+layer, and the ergonomics gap with Next.js Server Actions is being closed by a first-class Rails-native
+bridge -- a `useRailsForm` hook paired with controller conveniences -- tracked in
+[#3872](https://github.com/shakacode/react_on_rails/issues/3872) and **in development, not yet shipped**.
+Until it ships, the `fetch` + CSRF pattern below is the supported approach. An optional
+`'use server'`-shaped authoring syntax that compiles down to the Rails bridge (for Next.js-migration
+familiarity only) is a deferred follow-up RFC, tracked in
+[#3956](https://github.com/shakacode/react_on_rails/issues/3956).
+
 All mutations in React on Rails should go through Rails controllers via standard forms or API endpoints:
 
 ```jsx
@@ -30194,6 +33240,8 @@ export default function QueryProvider({ children }) {
 ## CSS-in-JS Libraries
 
 CSS-in-JS is the most impactful compatibility challenge for RSC migration. Runtime CSS-in-JS libraries depend on React Context and re-rendering, which Server Components fundamentally lack.
+
+For React on Rails Pro bundle and asset-loading patterns, see [CSS and Styling with React Server Components](../../pro/react-server-components/css-and-styling.md).
 
 ### Runtime CSS-in-JS (Problematic)
 
@@ -32748,6 +35796,15 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 ## Versions
 
 ### [Unreleased]
+
+#### Added
+
+- **Machine-readable doctor output (`FORMAT=json`)**: `bin/rails react_on_rails:doctor FORMAT=json` (and `ReactOnRails::Doctor.new(format: :json)`) now emits a stable, versioned JSON report — `schema_version`, `ror_version`, overall `status`, per-check entries with stable snake_case ids (`pass`/`warn`/`fail` status, most-severe `message`, full `details`), and a `summary` of check counts — so coding agents and tooling can consume diagnosis results without parsing the human-formatted text. Stray check output is routed to stderr so stdout stays valid JSON; the default human-readable output and exit-code semantics are unchanged. Split out from the MCP-server RFC in [Issue 3870](https://github.com/shakacode/react_on_rails/issues/3870). Closes [Issue 3943](https://github.com/shakacode/react_on_rails/issues/3943). [PR 3948](https://github.com/shakacode/react_on_rails/pull/3948) by [justin808](https://github.com/justin808).
+- **Consumer-facing AI-agent guidance scaffolded into generated and installed apps**: `rails generate react_on_rails:install` (and therefore `create-react-on-rails-app`, which delegates to it) now writes a concise, app-scoped `AGENTS.md` plus thin editor-pointer files (`CLAUDE.md`, `.cursor/rules/react-on-rails.mdc`, `.github/copilot-instructions.md`) so an AI coding agent dropped into a fresh app already knows how to register a component, use the `react_component` view helper, choose `.client`/`.server` bundles, recover from the top runtime errors (sourced from `SmartError`), and run `bin/rails react_on_rails:doctor`. The errors section tracks the live `SmartError` messages, and the editor files are pointers (not copies). Emission is gated by `--agent-files`/`--no-agent-files` (default on) in both paths and never overwrites an existing file. Cross-links the eval-harness work in [Issue 3832](https://github.com/shakacode/react_on_rails/issues/3832). Closes [Issue 3868](https://github.com/shakacode/react_on_rails/issues/3868). [PR 3924](https://github.com/shakacode/react_on_rails/pull/3924) by [justin808](https://github.com/justin808).
+- **First-party font optimization helper (a `next/font/local` analog)**: New `ReactOnRails::FontHelper#react_on_rails_font_face` view helper returns `<head>` markup for a committed, self-hosted `.woff2` font: a `<link rel="preload" as="font" type="font/woff2" crossorigin>`, an `@font-face` with `font-display: swap`, and an optional metric-matched fallback `@font-face` (`size-adjust` plus `ascent-override` / `descent-override` / `line-gap-override`) so the system fallback occupies the same space as the web font and the swap produces no layout shift (CLS). Self-hosting through the asset pipeline avoids any third-party font-host request. Includes a new [Font Optimization](docs/oss/building-features/fonts.md) docs page (self-hosting, preload, `font-display`, the `size-adjust` fallback technique with a worked Inter-over-Arial derivation, subsetting guidance, and a CLS note) and a runnable dummy-app example. v1 covers the `next/font/local` committed-file path and the non-streaming `react_component_hash` head-injection path. Closes [Issue 3875](https://github.com/shakacode/react_on_rails/issues/3875) (partial). Deferred sub-tasks tracked in [Issue 3921](https://github.com/shakacode/react_on_rails/issues/3921). [PR 3923](https://github.com/shakacode/react_on_rails/pull/3923) by [justin808](https://github.com/justin808).
+- **Stable SmartError codes and generated error reference**: SmartError messages now include stable `ROR###` codes and canonical documentation URLs, and `docs/oss/reference/error-reference.md` is generated from the SmartError definitions with a drift check. Fixes [Issue 3894](https://github.com/shakacode/react_on_rails/issues/3894). [PR 3936](https://github.com/shakacode/react_on_rails/pull/3936) by [justin808](https://github.com/justin808).
+- **Preload link helper for generated component packs**: Added `react_on_rails_preload_links` so layouts can emit preload, modulepreload, and stylesheet preload tags for auto-bundled component packs from the Shakapacker manifest. Fixes [Issue 3889](https://github.com/shakacode/react_on_rails/issues/3889). [PR 3935](https://github.com/shakacode/react_on_rails/pull/3935) by [justin808](https://github.com/justin808).
+- **Tailwind CSS v4 generator option**: `rails generate react_on_rails:install --tailwind` and `create-react-on-rails-app --tailwind` now install Tailwind CSS v4, wire `@tailwindcss/postcss` for Webpack or Rspack, and style the generated server-rendered HelloWorld example with extracted component CSS support. Interactive `create-react-on-rails-app` runs recommend Tailwind by default while still allowing users to opt out. Fixes [Issue 3895](https://github.com/shakacode/react_on_rails/issues/3895). [PR 3937](https://github.com/shakacode/react_on_rails/pull/3937) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.2] - 2026-06-09
 


### PR DESCRIPTION
## Summary

- Rewrite the getting-started tutorial around TypeScript, React hooks, auto-bundling, `bin/dev`, Rails props, and optional SSR.
- Move Redux out of the primary path into an appendix, with the current Redux helper/API docs linked from there.
- Update nearby getting-started link labels so the tutorial is no longer advertised as Redux-first.
- Remove stale tutorial material called out by triage: Shakapacker v7 update framing, Rails 5.2+ tutorial claims, the 2016 GIF, and dead `reactrails.com` / `react_on_rails-test-new-redux-generation` links.

Closes #3901.

## Decision log

- Kept Redux as an appendix in the same page rather than splitting a new page; the issue triage allowed either path, and this avoids sidebar churn for the docs slice.
- Updated `quick-start.md` and `using-react-on-rails.md` link text because both pages still framed the tutorial as Redux-first.
- Rebased once after #3924 landed. That main change adds generated-app agent files and does not change the tutorial workflow or auto-bundling behavior.

## Validation

- `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none.
- `script/check-docs-sidebar` -> pass.
- `pnpm start format.listDifferent` -> pass.
- `git diff --check origin/main...HEAD` -> pass.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> pass, 214 files inspected, no offenses detected.
- Pre-push `markdown-links` online lychee on changed Markdown files -> pass.
- Targeted stale-content scan -> no matches for old Redux-first labels, Shakapacker v7, Rails 5.2, 2016 GIF, `reactrails.com`, old test-new-redux repo links, or the stale Redux helper anchor.
- `codex review --base origin/main` -> final clean after accepting fixes for layout guidance, SSR server file ordering, Redux API anchor, and production precompile guidance.

## Labels

Labels: none. This is docs-only and the CI detector recommends no CI expansion.

## Release mode note

Release tracker #3823 is currently `accelerated-rc`. This PR is ready for normal review/check routing, but auto-merge still requires the live accelerated-RC merge gate from `AGENTS.md` before merge: current-head checks/review state, unresolved thread sweep, and an independent finalizer if auto-merge is used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to onboarding documentation; no runtime, auth, or application code is modified.
> 
> **Overview**
> **Getting-started docs** are aligned with the current install path: **TypeScript, hooks, auto-bundling, `bin/dev`, and optional SSR**, with **Redux demoted to an appendix** instead of the main tutorial.
> 
> **`quick-start.md`** tightens prerequisites (**Rails 7+**, Shakapacker via the generator), documents **Rspack-by-default** installs (**`--no-rspack`** for Webpack), points generated components at **`app/javascript/src/`**, and replaces **Webpack-specific** wording with **bundler** language.
> 
> **`tutorial.md`** is largely rewritten: a **Counter** walkthrough (`ror_components`, `react_component`, layouts/pack tags, props, SSR, troubleshooting, production precompile) replaces the old Redux/Heroku-era flow; stale links and legacy version claims are removed.
> 
> **`using-react-on-rails.md`** updates cross-links and the same **bundler / non-Redux-first** framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b1c013c6cfb837a70fe4184a90272329a2d548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Getting Started and tutorial rewritten for a TypeScript + Hooks workflow; now require Rails 7+, Ruby 3.3+, and Node 18+.
  * Fresh installs default to Rspack; use --no-rspack to force Webpack. Updated created-files and performance-tip wording.
  * Dev server/HMR references use the bundler dev server (./bin/dev). Auto-bundling, props/SSR guidance, and troubleshooting updated.
  * New step-by-step TypeScript Counter example; Redux moved to an appendix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: 91b1c013c6cfb837a70fe4184a90272329a2d548
Score: 9/10
Auto-merge recommendation: yes
Affected areas: OSS getting-started docs, llms-full aggregate docs
CI detector: `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none
Validation run:
- `node script/generate-llms-full.mjs` -> regenerated `llms-full.txt` after #3903 merged
- `node script/generate-llms-full.mjs --check` -> pass, 145 pages, 2034 KiB, 72 docs URLs validated
- `script/check-docs-sidebar` -> pass
- `pnpm start format.listDifferent` -> pass
- `git diff --check origin/main...HEAD` -> pass
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> pass, 218 files inspected, no offenses detected
- Pre-push `markdown-links` online lychee on changed Markdown files -> pass
Review/check gate:
- GitHub checks: complete for `91b1c013c6cfb837a70fe4184a90272329a2d548`; `build` skipped by docs-only `detect-changes`; all other current-head checks passing
- Markdown link check: initial current-head run hit an unrelated TLS handshake failure for `https://vite.dev/guide/` in an untouched file; failed job rerun passed for the same head
- Review threads: GraphQL unresolved count is 0
- Current-head reviewer verdicts:
  - Claude review: complete for `91b1c013c6cfb837a70fe4184a90272329a2d548`, no confirmed blocker; check `claude-review` SUCCESS at https://github.com/shakacode/react_on_rails/actions/runs/27404994998/job/80991808489
  - Cursor Bugbot: SUCCESS for current head
  - CodeRabbit: SUCCESS
Known residual risk: none beyond docs wording risk; no runtime behavior changed
Finalized by: `claude-review` check SUCCESS for current head SHA, GitHub Actions job https://github.com/shakacode/react_on_rails/actions/runs/27404994998/job/80991808489
