### PR TITLE
Docs: recommended ESLint flat config with react-hooks v6 + useEffectEvent guidance (#3884)

### DIFF
--- a/docs/oss/building-features/eslint-configuration.md
+++ b/docs/oss/building-features/eslint-configuration.md
@@ -109,13 +109,13 @@ extends: [
 
 ### Ignore generated files
 
-If you use [auto-bundling](https://www.shakacode.com/react-on-rails/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation/), React on Rails writes generated entry points to `<source_entry_path>/generated/` (typically `app/javascript/packs/generated/`) and a generated server bundle under a `generated/` directory. These files are machine-written and regenerated on every build — linting them produces noise and CI churn. The `globalIgnores` block above excludes them, along with Shakapacker's compiled output in `public/packs/` and `public/packs-test/`.
+If you use [auto-bundling](../core-concepts/auto-bundling-file-system-based-automated-bundle-generation.md), React on Rails writes generated entry points to `<source_entry_path>/generated/` (typically `app/javascript/packs/generated/`) and a generated server bundle under a `generated/` directory. These files are machine-written and regenerated on every build — linting them produces noise and CI churn. The `globalIgnores` block above excludes them, along with Shakapacker's compiled output in `public/packs/` and `public/packs-test/`.
 
 ### Globals for server-side rendering
 
 With server-side rendering, the same component code executes in two environments: the browser, and a JavaScript runtime on the server (Node renderer or ExecJS). Code guarded by environment checks (e.g., `typeof window === 'undefined'`) legitimately references both browser globals (`window`, `document`) and Node globals (`process`, `global`). Enabling both `globals.browser` and `globals.node` for `app/javascript` avoids false `no-undef` errors in either direction.
 
-If you keep [separate client and server entry files](https://www.shakacode.com/react-on-rails/docs/building-features/how-to-use-different-files-for-client-and-server-rendering/) (e.g., `*.client.jsx` / `*.server.jsx`), you can tighten this with per-pattern overrides — browser globals only for `**/*.client.*`, Node globals only for `**/*.server.*`.
+If you keep [separate client and server entry files](./how-to-use-different-files-for-client-and-server-rendering.md) (e.g., `*.client.jsx` / `*.server.jsx`), you can tighten this with per-pattern overrides — browser globals only for `**/*.client.*`, Node globals only for `**/*.server.*`.
 
 ## `useEffectEvent` and the linter
 

--- a/docs/oss/building-features/eslint-configuration.md
+++ b/docs/oss/building-features/eslint-configuration.md
@@ -1,0 +1,182 @@
+# ESLint Configuration
+
+React on Rails does not scaffold an ESLint config into your app — linting is your app's concern, and the right setup depends on your stack. This page gives a **recommended, verified flat-config setup** for a React on Rails app, including the pieces that are specific to React on Rails (ignoring generated bundles, globals for server-side rendering) and the React 19.2-era rules that protect `useEffectEvent`.
+
+## TL;DR
+
+- Use **flat config** (`eslint.config.mjs`) — the default since ESLint 9; the legacy `.eslintrc` format is deprecated and removed in ESLint 10.
+- Use **`eslint-plugin-react-hooks` v6 or later**. Version 6 is the first version whose `recommended` preset is flat-config native, and the first whose `exhaustive-deps` rule understands React's `useEffectEvent` — v5 actively gives **wrong guidance** for it (details [below](#useeffectevent-and-the-linter)).
+- Ignore React on Rails' **auto-generated packs** (`**/generated/**`) and Shakapacker build output (`public/packs*/`).
+- Enable **both browser and Node globals** for `app/javascript` — your components run in the browser _and_ in Node/ExecJS during server-side rendering.
+
+## Installation
+
+```bash
+npm install --save-dev eslint @eslint/js eslint-plugin-react eslint-plugin-react-hooks eslint-config-prettier globals
+# or: yarn add --dev / pnpm add -D
+```
+
+Notes:
+
+- Keep `@eslint/js` on the same major version as `eslint` (e.g., both `^9` or both `^10`); npm fails resolution if they diverge.
+- `eslint-plugin-react-hooks` must be `^6.0.0` or later. v7 (current) also works with this config and drops the legacy-format presets entirely.
+- `eslint-config-prettier` is only needed if you format with Prettier (recommended).
+
+## Recommended `eslint.config.mjs`
+
+This exact config was verified against `eslint` 9.x, `eslint-plugin-react-hooks` 6.1.1, and `eslint-plugin-react` 7.37:
+
+```js
+// eslint.config.mjs
+import js from '@eslint/js';
+import { defineConfig, globalIgnores } from 'eslint/config';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import prettier from 'eslint-config-prettier';
+import globals from 'globals';
+
+export default defineConfig([
+  // Never lint build output or React on Rails' auto-generated packs.
+  globalIgnores([
+    'public/packs/**',
+    'public/packs-test/**',
+    'app/javascript/**/generated/**',
+    'node_modules/**',
+  ]),
+
+  {
+    files: ['app/javascript/**/*.{js,jsx,ts,tsx}'],
+    extends: [js.configs.recommended, react.configs.flat.recommended, reactHooks.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      // React on Rails code runs in the browser AND in Node/ExecJS during
+      // server-side rendering, so enable both sets of globals.
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      // With the automatic JSX runtime (React 17+), importing React is unnecessary.
+      'react/react-in-jsx-scope': 'off',
+      // Most apps use TypeScript or skip PropTypes; remove if you use prop-types.
+      'react/prop-types': 'off',
+    },
+  },
+
+  // Webpack/Shakapacker config files are plain Node scripts.
+  {
+    files: ['config/webpack/**/*.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: { ...globals.node },
+    },
+  },
+
+  // Turn off stylistic rules that conflict with Prettier. Keep this last.
+  prettier,
+]);
+```
+
+### TypeScript
+
+For TypeScript apps, add [typescript-eslint](https://typescript-eslint.io/getting-started/) and extend its recommended config alongside the ones above:
+
+```bash
+npm install --save-dev typescript-eslint
+```
+
+```js
+import tseslint from 'typescript-eslint';
+
+// In the app/javascript block:
+extends: [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  react.configs.flat.recommended,
+  reactHooks.configs.recommended,
+],
+```
+
+## React on Rails specifics
+
+### Ignore generated files
+
+If you use [auto-bundling](https://www.shakacode.com/react-on-rails/docs/core-concepts/auto-bundling-file-system-based-automated-bundle-generation/), React on Rails writes generated entry points to `<source_entry_path>/generated/` (typically `app/javascript/packs/generated/`) and a generated server bundle under a `generated/` directory. These files are machine-written and regenerated on every build — linting them produces noise and CI churn. The `globalIgnores` block above excludes them, along with Shakapacker's compiled output in `public/packs/` and `public/packs-test/`.
+
+### Globals for server-side rendering
+
+With server-side rendering, the same component code executes in two environments: the browser, and a JavaScript runtime on the server (Node renderer or ExecJS). Code guarded by environment checks (e.g., `typeof window === 'undefined'`) legitimately references both browser globals (`window`, `document`) and Node globals (`process`, `global`). Enabling both `globals.browser` and `globals.node` for `app/javascript` avoids false `no-undef` errors in either direction.
+
+If you keep [separate client and server entry files](https://www.shakacode.com/react-on-rails/docs/building-features/how-to-use-different-files-for-client-and-server-rendering/) (e.g., `*.client.jsx` / `*.server.jsx`), you can tighten this with per-pattern overrides — browser globals only for `**/*.client.*`, Node globals only for `**/*.server.*`.
+
+## `useEffectEvent` and the linter
+
+### What `useEffectEvent` is for
+
+React 19.2 added [`useEffectEvent`](https://react.dev/reference/react/useEffectEvent): it extracts the "event" part of an Effect's logic so the Effect doesn't re-run when values used only inside that event change. Effect Events always see the latest props and state, but they are **not reactive** — they never appear in dependency arrays.
+
+The canonical example: a chat room should reconnect when `roomId` changes, but not when the notification `theme` changes:
+
+```jsx
+import { useEffect, useEffectEvent } from 'react';
+
+const serverUrl = 'https://localhost:1234';
+
+function ChatRoom({ roomId, theme }) {
+  const onConnected = useEffectEvent(() => {
+    // Always sees the latest theme — without making the Effect depend on it.
+    showNotification('Connected!', theme);
+  });
+
+  useEffect(() => {
+    const connection = createConnection(serverUrl, roomId);
+    connection.on('connected', () => {
+      onConnected();
+    });
+    connection.connect();
+    return () => connection.disconnect();
+  }, [roomId]); // ✅ theme changes do NOT reconnect the chat
+  // ...
+}
+```
+
+`useEffectEvent` requires **React 19.2 or later** at runtime. (React on Rails supports React 16+, so check your app's React version before adopting it.)
+
+### Why the hooks plugin version matters
+
+`useEffectEvent` only works if effect events are kept **out** of dependency arrays — that is its entire semantic. Only `eslint-plugin-react-hooks` v6+ knows this. Verified behavior on the example above:
+
+| Plugin version              | Behavior on the code above                                                                                                                                                                                                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **v5** (`exhaustive-deps`)  | ❌ Wrong guidance: `React Hook useEffect has a missing dependency: 'onConnected'. Either include it or remove the dependency array.` Following it breaks effect-event semantics (the Effect re-runs on every render, or you wrap things in `useCallback` and reintroduce the staleness problem). |
+| **v6+** (`exhaustive-deps`) | ✅ Clean pass. And if you _do_ add the effect event to the array, it flags it: `Functions returned from 'useEffectEvent' must not be included in the dependency array. Remove 'onConnected' from the list.`                                                                                      |
+
+v6 also enforces the other `useEffectEvent` restrictions from the React docs — effect events may only be called from inside Effects in the same component or Hook, not passed around or called during render.
+
+One more v6 difference worth knowing: in v5, `configs.recommended` was the **legacy** (eslintrc) format and fails outright inside flat config (flat config users needed `recommended-latest`). In v6, `configs.recommended` is flat-config native, and `recommended-legacy` exists for eslintrc holdouts. In v7, the legacy presets are gone.
+
+### Opting into the React Compiler rules
+
+v6+ also ships the React Compiler-powered diagnostics (purity, immutability, set-state-in-render, and friends). To enable them, swap the preset:
+
+```js
+extends: [js.configs.recommended, react.configs.flat.recommended, reactHooks.configs['recommended-latest']],
+```
+
+`recommended-latest` includes everything in `recommended` plus the compiler rules. These diagnostics are useful even if you have not adopted the compiler itself; if you have, see [React Compiler with React on Rails](https://www.shakacode.com/react-on-rails/docs/building-features/react-compiler/) for build-side setup.
+
+## References
+
+- [React 19.2 release post](https://react.dev/blog/2025/10/01/react-19-2) — `useEffectEvent` and `eslint-plugin-react-hooks` v6
+- [`useEffectEvent` API reference](https://react.dev/reference/react/useEffectEvent)
+- [Separating Events from Effects](https://react.dev/learn/separating-events-from-effects)
+- [ESLint flat config migration guide](https://eslint.org/docs/latest/use/configure/migration-guide)
+- [`eslint-plugin-react-hooks` on npm](https://www.npmjs.com/package/eslint-plugin-react-hooks)

--- a/docs/oss/building-features/eslint-configuration.md
+++ b/docs/oss/building-features/eslint-configuration.md
@@ -171,7 +171,7 @@ v6+ also ships the React Compiler-powered diagnostics (purity, immutability, set
 extends: [js.configs.recommended, react.configs.flat.recommended, reactHooks.configs['recommended-latest']],
 ```
 
-`recommended-latest` includes everything in `recommended` plus the compiler rules. These diagnostics are useful even if you have not adopted the compiler itself; if you have, see [React Compiler with React on Rails](https://www.shakacode.com/react-on-rails/docs/building-features/react-compiler/) for build-side setup.
+`recommended-latest` includes everything in `recommended` plus the compiler rules. These diagnostics are useful even if you have not adopted the compiler itself; if you have, see [React Compiler with React on Rails](./react-compiler.md) for build-side setup.
 
 ## References
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'building-features/dev-server-and-testing',
             'building-features/testing-configuration',
+            'building-features/eslint-configuration',
             'building-features/extensible-precompile-pattern',
             'building-features/process-managers',
             'building-features/debugging',


### PR DESCRIPTION
Addresses #3884 (docs deliverable of the reframed scope; see close-out note below).

## Summary

New docs page `docs/oss/building-features/eslint-configuration.md`: a recommended **ESLint flat config** for React on Rails apps with **eslint-plugin-react-hooks v6** (flat-config native) and **`useEffectEvent`** guidance, plus React-on-Rails-specific notes (ignoring generated packs/bundle output, browser+node globals for SSR code, per-pattern overrides for `*.client.*`/`*.server.*` files).

Per the 2026-06-11 triage correction on the issue (verified): **the install generator scaffolds no ESLint config into host apps at all** — `templates/.eslintrc` is only copied by the internal `dev_tests` generator. So there is nothing to "modernize" in generated output; this PR deliberately adds **no installer scaffolding** (that is a separate RFC-level maintainer decision per the triage).

## Codex Decision Log

- **Non-blocking:** dev_tests `.eslintrc` template modernization (optional item)
  - **Decision:** explicitly **deferred**
  - **Why:** PR #3937 (Tailwind generator option, issue #3895) is open on adjacent generator/template territory; the triage says to rebase template work after it merges. The template is internal-only (dev/test apps), so there is no user-facing urgency.
  - **Review later:** modernize `react_on_rails/lib/generators/react_on_rails/templates/.eslintrc` to flat config after #3937 merges, or fold into the scaffolding RFC.
- **Non-blocking:** codex review found two internal links hard-coded to published URLs for pages with custom slugs — fixed to relative `.md` links in a follow-up commit.

## Close-out recommendation

The docs page satisfies the reframed scope's main deliverable. Suggest closing #3884 after merge with a note splitting out (a) the deferred dev_tests template touch-up and (b) the "should the installer scaffold lint config at all?" RFC, which the triage explicitly excluded from this task.

## Test plan

- `pnpm start format.listDifferent` (Prettier): clean
- `script/check-docs-sidebar`: new doc has a sidebar entry
- `lychee --offline --include-fragments` on the page: 0 errors
- `codex review --base origin/main`: one P2 (slugged-page links), fixed
- Recommended config verified against eslint-plugin-react-hooks v6 flat-config docs (`reactHooks.configs['recommended-latest']`, `useEffectEvent` rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and sidebar navigation only; no runtime, generator, or lint config changes in the gem or sample apps.
> 
> **Overview**
> Adds a new **Development & Ops** doc page that recommends an **ESLint 9 flat config** (`eslint.config.mjs`) for React on Rails apps, with install steps, a copy-paste config, and optional **TypeScript** / **React Compiler** (`recommended-latest`) notes.
> 
> The guide is tailored to RoR: **ignore** Shakapacker output and `**/generated/**` packs, and use **browser + Node globals** for `app/javascript` because the same code runs in the browser and during SSR.
> 
> It also documents why **`eslint-plugin-react-hooks` v6+** matters for React 19.2 **`useEffectEvent`** (v5 `exhaustive-deps` gives incorrect dependency advice). The page is wired into the docs sidebar after **testing-configuration**; there is **no** installer or generator ESLint scaffolding in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be00aecde1e1c84fe662862dc58dfb008fe13294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive ESLint configuration docs for React on Rails: installation, flat-config setup, TypeScript integration, React/React Hooks guidance, handling generated build artifacts and SSR, and guidance on useEffectEvent and plugin behavior.
* **Chores**
  * Added the new ESLint documentation page to the site navigation/sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->