### PR TITLE
Add experimental View Transitions recipe, Turbo interplay doc, and flagged dummy demo

### DIFF
--- a/docs/oss/building-features/view-transitions.md
+++ b/docs/oss/building-features/view-transitions.md
@@ -1,0 +1,214 @@
+# View Transitions with React on Rails (Experimental)
+
+> **⚠️ Experimental — not officially supported.** This entire page is a canary recipe. The browser
+> [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) is still
+> evolving, React's component-level `<ViewTransition>` API is canary-only, and this recipe may change or
+> break without notice. Nothing on this page is covered by React on Rails' support policy or semver
+> guarantees. React Server Components are explicitly out of scope here. Tracked in
+> [#3888](https://github.com/shakacode/react_on_rails/issues/3888).
+
+This page shows how to use the **browser-native** `document.startViewTransition()` API with components
+rendered by `react_component` — first client-side-only (CSR), then with server rendering plus hydration
+(SSR-hydrate) — and how it interacts with Turbo Drive's own view-transition support.
+
+## What this covers (Experimental)
+
+- Wrapping React state updates (and client-side route updates) in `document.startViewTransition()`.
+- What does and does not work when the component is server-rendered and hydrated.
+- The Turbo Drive interplay: Turbo's cross-page transitions vs React-driven in-page transitions.
+- A tiny flagged demo in the gem's dummy app.
+
+It deliberately does **not** cover React's canary `<ViewTransition>` component / `addTransitionType`
+API beyond a status note (see below), and it does not cover React Server Components.
+
+## Browser support and feature detection (Experimental)
+
+Same-document view transitions (`document.startViewTransition`) ship in Chrome/Edge 111+, Safari 18+,
+and recent Firefox releases, but you must always feature-detect — unsupported browsers simply apply the
+DOM update without animation:
+
+```js
+function withViewTransition(applyUpdate) {
+  if (typeof document.startViewTransition === 'function') {
+    document.startViewTransition(applyUpdate);
+  } else {
+    applyUpdate(); // graceful fallback: same update, no animation
+  }
+}
+```
+
+## CSR recipe (Experimental)
+
+`document.startViewTransition(callback)` snapshots the current page, runs your `callback` to mutate the
+DOM, snapshots the result, and animates between the two snapshots.
+
+The catch for React: React 18/19 **batches state updates and commits asynchronously**, but the browser
+expects the DOM to be fully updated when your callback returns. Wrap the state update in
+[`flushSync`](https://react.dev/reference/react-dom/flushSync) so React commits synchronously inside
+the callback:
+
+```tsx
+import React, { useState } from 'react';
+import { flushSync } from 'react-dom';
+
+const Panel = () => {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggle = () => {
+    const applyUpdate = () => {
+      flushSync(() => {
+        setExpanded((prev) => !prev);
+      });
+    };
+
+    if (typeof document.startViewTransition === 'function') {
+      document.startViewTransition(applyUpdate);
+    } else {
+      applyUpdate();
+    }
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={toggle}>
+        Toggle
+      </button>
+      <div id="vt-panel" className={expanded ? 'panel panel--expanded' : 'panel'}>
+        …
+      </div>
+    </div>
+  );
+};
+```
+
+Give the animated element a `view-transition-name` so the browser can pair its old/new snapshots, and
+optionally style the transition pseudo-elements:
+
+```css
+#vt-panel {
+  view-transition-name: vt-panel;
+}
+
+::view-transition-old(vt-panel),
+::view-transition-new(vt-panel) {
+  animation-duration: 300ms;
+}
+```
+
+This works with plain `react_component("Panel", prerender: false)` — no React on Rails configuration is
+involved; the recipe is entirely inside your component and CSS.
+
+### Client-side route changes (Experimental)
+
+The same pattern wraps client-side navigation inside a React root: call your router's navigate function
+inside the `startViewTransition` callback (with `flushSync` if the router commits asynchronously). If
+you use React Router, prefer its built-in integration (`<Link viewTransition>` /
+`useViewTransitionState`) instead of hand-rolling — see [React Router](./react-router.md). These
+router-level integrations are experimental in the same sense as the rest of this page.
+
+### CSR pitfalls (Experimental)
+
+- **`flushSync` is a forced synchronous render.** Keep the transitioned update small; large trees will
+  jank inside the transition callback.
+- **One transition at a time.** Starting a new same-document transition skips any transition already
+  running. Rapid clicks fall back to the final state — that is by design, but don't queue your own.
+- **Duplicate `view-transition-name`s abort the transition.** Each name must be unique on the page at
+  snapshot time (watch out for lists; derive names from item ids if you animate list items).
+
+## SSR-hydrate recipe (Experimental)
+
+The same component works with `prerender: true` (server rendering + client hydration) as long as you
+follow these rules:
+
+- **Only touch the API in event handlers or effects.** `document` does not exist in the server-side
+  rendering environment (ExecJS or the Pro Node renderer). Never call or feature-detect
+  `document.startViewTransition` at module scope or during render of a server-rendered component.
+- **Don't branch markup on feature support during the initial render.** The server cannot know what the
+  browser supports, so support-dependent markup causes hydration mismatches. Feature-detect inside the
+  handler (as above), or stash support in state from a `useEffect` after mount.
+- **`view-transition-name` in server-rendered HTML is safe.** It is plain CSS — it has no effect until
+  a transition starts, and it does not affect hydration.
+- **The initial paint is not transitioned.** View transitions animate _updates_; server-rendered HTML
+  appearing and React hydrating it produce no transition (and hydration itself must not be wrapped in
+  one). Only post-hydration interactions animate.
+
+In short: SSR-hydrate works today with the browser API because the transition only ever runs on the
+client, after hydration, inside user-triggered handlers.
+
+## React canary `<ViewTransition>` status (Experimental)
+
+React's component-level API (`<ViewTransition>`, `addTransitionType`) is **canary-only** and is not
+part of this recipe. React 19.2 shipped groundwork that matters for the future here — SSR Suspense
+reveal batching, and the `useId` prefix change to `_r_` so generated ids are valid
+`view-transition-name` values — but running a canary React build under React on Rails is untested and
+unsupported. This page intentionally uses only the browser API, which works on stable React 19.
+
+## Turbo Drive interplay (Experimental)
+
+> **⚠️ Turbo claims pending maintainer review.** The claims in this section follow Turbo's documented
+> behavior and React on Rails' Turbo event wiring, but they have not yet been verified end-to-end in
+> the dummy app. Treat them as provisional until a maintainer confirms them.
+
+Rails apps using [Turbo Drive](https://turbo.hotwired.dev) have a second, independent view-transition
+system: Turbo can wrap its **cross-page** (page-to-page) renders in `document.startViewTransition` when
+the page opts in via:
+
+```html
+<meta name="view-transition" content="same-origin" />
+```
+
+How this relates to React-driven transitions:
+
+- **Two different scopes.** Turbo Drive transitions animate whole-page navigations (Turbo replaces the
+  `<body>`); React-driven transitions (this page's recipe) animate state/route updates **inside** a
+  mounted React root. Use Turbo's mechanism for cross-page continuity and the React recipe for in-page
+  interactions — they solve different problems.
+- **React state does not survive a Turbo visit.** React on Rails listens to `turbo:before-render` /
+  `turbo:render` and unmounts components before Turbo swaps the body, then re-mounts them on the new
+  page (see `packages/react-on-rails/src/pageLifecycle.ts`). Any cross-page visual continuity must come
+  from Turbo's transition (matching `view-transition-name`s in the old and new HTML), not from React.
+- **They must not run simultaneously.** Browsers allow only one active same-document transition;
+  starting another skips the one in progress. Avoid triggering a React `startViewTransition` from code
+  that runs during a Turbo visit (e.g., in `turbo:before-render`/`turbo:render` handlers or unmount
+  paths). In practice this is easy to satisfy: trigger React transitions only from user interactions.
+- **Turbo's preview cache can confuse pairing.** Turbo may first render a cached preview of the next
+  page and then the fresh response. Elements with `view-transition-name` that appear in both the old
+  page and the preview can pair unexpectedly or abort (duplicate names). Test with the cache in play
+  before shipping, or disable preview for transitioned pages (`<meta name="turbo-cache-control"
+content="no-preview">`).
+
+## In-repo demo (Experimental)
+
+The gem's dummy app contains a minimal CSR demo of this recipe, inert unless you opt in with an
+environment flag:
+
+- Component: `react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx`
+- View: `react_on_rails/spec/dummy/app/views/pages/view_transitions_demo.html.erb`
+- Route: defined in `react_on_rails/spec/dummy/config/routes.rb` only when `VIEW_TRANSITIONS_DEMO=true`
+
+Run it from a React on Rails checkout:
+
+```bash
+cd react_on_rails/spec/dummy
+VIEW_TRANSITIONS_DEMO=true bin/dev
+# then open http://localhost:3000/view_transitions_demo
+```
+
+With the flag unset, the route does not exist and the demo page is unreachable.
+
+## Promote-to-supported checklist (Experimental)
+
+This page graduates from experimental to supported only when all of the following are true:
+
+- [ ] React's `<ViewTransition>` / `addTransitionType` ship in a **stable** React release, and React on
+      Rails' supported React range includes that release.
+- [ ] The Turbo-interplay claims above are verified end-to-end in the dummy app (Turbo is enabled
+      there) by a maintainer, and the "pending maintainer review" banner is removed.
+- [ ] The CSR and SSR-hydrate recipes are re-validated against the then-current React on Rails major,
+      and the dummy demo is either covered by a spec/E2E test or promoted out of its env flag.
+- [ ] Browser support is re-confirmed as Baseline for same-document transitions across the browsers the
+      docs target (re-check Firefox).
+- [ ] Experimental banners are removed from this page and the change is announced in the CHANGELOG.
+
+**Owner:** maintainers — tracked in [#3888](https://github.com/shakacode/react_on_rails/issues/3888).
+Re-check cadence: each React minor release (or quarterly, whichever comes first).

--- a/docs/oss/building-features/view-transitions.md
+++ b/docs/oss/building-features/view-transitions.md
@@ -114,6 +114,9 @@ router-level integrations are experimental in the same sense as the rest of this
   running. Rapid clicks fall back to the final state — that is by design, but don't queue your own.
 - **Duplicate `view-transition-name`s abort the transition.** Each name must be unique on the page at
   snapshot time (watch out for lists; derive names from item ids if you animate list items).
+- **Names must be valid CSS custom identifiers.** A `view-transition-name` cannot start with a digit
+  and cannot be a CSS-wide keyword (`none`, `inherit`, …) — prefix derived names, e.g. `item-42`, not
+  `42`.
 
 ## SSR-hydrate recipe (Experimental)
 

--- a/docs/oss/building-features/view-transitions.md
+++ b/docs/oss/building-features/view-transitions.md
@@ -174,8 +174,8 @@ How this relates to React-driven transitions:
 - **Turbo's preview cache can confuse pairing.** Turbo may first render a cached preview of the next
   page and then the fresh response. Elements with `view-transition-name` that appear in both the old
   page and the preview can pair unexpectedly or abort (duplicate names). Test with the cache in play
-  before shipping, or disable preview for transitioned pages (`<meta name="turbo-cache-control"
-content="no-preview">`).
+  before shipping, or disable preview for transitioned pages
+  (`<meta name="turbo-cache-control" content="no-preview">`).
 
 ## In-repo demo (Experimental)
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -73,6 +73,7 @@ const sidebars: SidebarsConfig = {
             'building-features/react-helmet',
             'building-features/react-19-native-metadata',
             'building-features/react-compiler',
+            'building-features/view-transitions',
             'building-features/streaming-server-rendering',
             'building-features/how-to-conditionally-server-render-based-on-device-type',
             'building-features/how-to-use-different-files-for-client-and-server-rendering',

--- a/llms.txt
+++ b/llms.txt
@@ -46,6 +46,8 @@ Use this file as the short machine-readable route map. Use `./llms-full.txt` for
   - Pro configuration: https://reactonrails.com/docs/configuration/configuration-pro
   - Deployment: https://reactonrails.com/docs/deployment
   - Troubleshooting: https://reactonrails.com/docs/deployment/troubleshooting
+- View transitions (experimental, unsupported):
+  - View Transitions recipe + Turbo interplay: https://reactonrails.com/docs/building-features/view-transitions
 - Upgrading and migration:
   - Upgrading: https://reactonrails.com/docs/upgrading/upgrading-react-on-rails
   - Pro coupled upgrade checklist (gem + npm + lockfiles, RC version formats, RSC manifest verification): https://reactonrails.com/docs/pro/updating#coupled-pro-upgrade-checklist

--- a/llms.txt
+++ b/llms.txt
@@ -41,13 +41,13 @@ Use this file as the short machine-readable route map. Use `./llms-full.txt` for
   - Pro overview: https://reactonrails.com/docs/pro/node-renderer
   - Technical basics: https://reactonrails.com/docs/building-features/node-renderer/basics
   - JS configuration: https://reactonrails.com/docs/building-features/node-renderer/js-configuration
+- View transitions (experimental, unsupported):
+  - View Transitions recipe + Turbo interplay: https://reactonrails.com/docs/building-features/view-transitions
 - Configuration and deployment:
   - Configuration overview: https://reactonrails.com/docs/configuration
   - Pro configuration: https://reactonrails.com/docs/configuration/configuration-pro
   - Deployment: https://reactonrails.com/docs/deployment
   - Troubleshooting: https://reactonrails.com/docs/deployment/troubleshooting
-- View transitions (experimental, unsupported):
-  - View Transitions recipe + Turbo interplay: https://reactonrails.com/docs/building-features/view-transitions
 - Upgrading and migration:
   - Upgrading: https://reactonrails.com/docs/upgrading/upgrading-react-on-rails
   - Pro coupled upgrade checklist (gem + npm + lockfiles, RC version formats, RSC manifest verification): https://reactonrails.com/docs/pro/updating#coupled-pro-upgrade-checklist

--- a/react_on_rails/spec/dummy/app/views/pages/view_transitions_demo.html.erb
+++ b/react_on_rails/spec/dummy/app/views/pages/view_transitions_demo.html.erb
@@ -1,0 +1,31 @@
+<%#
+  EXPERIMENTAL / UNSUPPORTED View Transitions demo (issue #3888).
+
+  This page demonstrates the CSR recipe from
+  docs/oss/building-features/view-transitions.md. It is inert by default: the
+  route only exists when the dummy app is booted with VIEW_TRANSITIONS_DEMO=true
+  (see config/routes.rb).
+%>
+<% content_for :head do %>
+  <style>
+    /* Pair the demo box's old/new snapshots and slow the animation enough to see it. */
+    #vt-demo-box {
+      view-transition-name: vt-demo-box;
+    }
+
+    ::view-transition-old(vt-demo-box),
+    ::view-transition-new(vt-demo-box) {
+      animation-duration: 300ms;
+    }
+  </style>
+<% end %>
+
+<h1>View Transitions demo (experimental — unsupported)</h1>
+
+<p>
+  Client-side-only rendering of <code>ViewTransitionsDemo</code>. The toggle wraps a React state update
+  in <code>document.startViewTransition()</code> (with a non-animated fallback when the browser lacks
+  the API). See <code>docs/oss/building-features/view-transitions.md</code>.
+</p>
+
+<%= react_component("ViewTransitionsDemo", prerender: false) %>

--- a/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
@@ -43,8 +43,12 @@ const ViewTransitionsDemo = (): React.ReactElement => {
       });
     };
 
-    if (supportsViewTransitions) {
-      (document as DocumentWithViewTransition).startViewTransition?.(applyUpdate);
+    // Inline detection (the doc's withViewTransition pattern): the fallback
+    // always fires, so the toggle never silently no-ops. The state above is
+    // only for the display text.
+    const doc = document as DocumentWithViewTransition;
+    if (typeof doc.startViewTransition === 'function') {
+      doc.startViewTransition(applyUpdate);
     } else {
       applyUpdate();
     }

--- a/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
@@ -1,0 +1,75 @@
+// View Transitions demo component (issue #3888).
+//
+// EXPERIMENTAL / UNSUPPORTED. Demonstrates the CSR recipe from
+// docs/oss/building-features/view-transitions.md: wrapping a React state
+// update in document.startViewTransition() (when available) so the browser
+// animates between the before/after DOM states. Unsupported browsers apply
+// the same update without animation.
+//
+// This demo is inert by default: its route only exists when the dummy app is
+// booted with VIEW_TRANSITIONS_DEMO=true (see config/routes.rb). The page
+// renders client-side only (prerender: false), so it is safe to feature-detect
+// the browser API during render here; server-rendered components must only
+// touch the API inside event handlers or effects.
+import React, { useState } from 'react';
+import { flushSync } from 'react-dom';
+
+// document.startViewTransition may be missing from older TS DOM libs and from
+// older browsers, so type and feature-detect it defensively.
+type DocumentWithViewTransition = Document & {
+  startViewTransition?: (updateCallback: () => void) => unknown;
+};
+
+const ViewTransitionsDemo = (): React.ReactElement => {
+  const [expanded, setExpanded] = useState(false);
+
+  const supportsViewTransitions =
+    typeof (document as DocumentWithViewTransition).startViewTransition === 'function';
+
+  const toggle = () => {
+    const applyUpdate = () => {
+      // flushSync forces React to commit the update synchronously inside the
+      // startViewTransition callback, where the browser snapshots the "new"
+      // page state.
+      flushSync(() => {
+        setExpanded((prev) => !prev);
+      });
+    };
+
+    const doc = document as DocumentWithViewTransition;
+    if (typeof doc.startViewTransition === 'function') {
+      doc.startViewTransition(applyUpdate);
+    } else {
+      applyUpdate();
+    }
+  };
+
+  return (
+    <div>
+      <p data-testid="vt-demo-support">
+        {supportsViewTransitions
+          ? 'This browser supports document.startViewTransition — toggling below animates.'
+          : 'This browser lacks document.startViewTransition — toggling below updates without animation.'}
+      </p>
+      <button type="button" onClick={toggle}>
+        Toggle panel
+      </button>
+      <div
+        id="vt-demo-box"
+        data-testid="vt-demo-box"
+        style={{
+          marginTop: 12,
+          padding: expanded ? 24 : 8,
+          width: expanded ? 320 : 160,
+          background: expanded ? '#2563eb' : '#9ca3af',
+          color: '#fff',
+          borderRadius: 8,
+        }}
+      >
+        {expanded ? 'Expanded' : 'Collapsed'}
+      </div>
+    </div>
+  );
+};
+
+export default ViewTransitionsDemo;

--- a/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
@@ -61,7 +61,7 @@ const ViewTransitionsDemo = (): React.ReactElement => {
           ? 'This browser supports document.startViewTransition — toggling below animates.'
           : 'This browser lacks document.startViewTransition — toggling below updates without animation.'}
       </p>
-      <button type="button" onClick={toggle}>
+      <button type="button" onClick={toggle} aria-expanded={expanded} aria-controls="vt-demo-box">
         Toggle panel
       </button>
       <div

--- a/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
+++ b/react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx
@@ -7,11 +7,11 @@
 // the same update without animation.
 //
 // This demo is inert by default: its route only exists when the dummy app is
-// booted with VIEW_TRANSITIONS_DEMO=true (see config/routes.rb). The page
-// renders client-side only (prerender: false), so it is safe to feature-detect
-// the browser API during render here; server-rendered components must only
-// touch the API inside event handlers or effects.
-import React, { useState } from 'react';
+// booted with VIEW_TRANSITIONS_DEMO=true (see config/routes.rb). Feature
+// detection happens in a useEffect after mount, so the pattern is also safe to
+// copy into SSR-hydrated components (document does not exist during server
+// render).
+import React, { useEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
 
 // document.startViewTransition may be missing from older TS DOM libs and from
@@ -22,9 +22,16 @@ type DocumentWithViewTransition = Document & {
 
 const ViewTransitionsDemo = (): React.ReactElement => {
   const [expanded, setExpanded] = useState(false);
+  const [supportsViewTransitions, setSupportsViewTransitions] = useState(false);
 
-  const supportsViewTransitions =
-    typeof (document as DocumentWithViewTransition).startViewTransition === 'function';
+  // Detect after mount so this pattern is safe to copy for SSR-hydrated
+  // components too. The handler below only runs post-mount, so branching on
+  // the state value is reliable; the initial false value is harmless.
+  useEffect(() => {
+    setSupportsViewTransitions(
+      typeof (document as DocumentWithViewTransition).startViewTransition === 'function',
+    );
+  }, []);
 
   const toggle = () => {
     const applyUpdate = () => {
@@ -36,9 +43,8 @@ const ViewTransitionsDemo = (): React.ReactElement => {
       });
     };
 
-    const doc = document as DocumentWithViewTransition;
-    if (typeof doc.startViewTransition === 'function') {
-      doc.startViewTransition(applyUpdate);
+    if (supportsViewTransitions) {
+      (document as DocumentWithViewTransition).startViewTransition?.(applyUpdate);
     } else {
       applyUpdate();
     }

--- a/react_on_rails/spec/dummy/config/routes.rb
+++ b/react_on_rails/spec/dummy/config/routes.rb
@@ -46,4 +46,9 @@ Rails.application.routes.draw do
   get "turbo_frame_tag_hello_world" => "pages#turbo_frame_tag_hello_world"
   post "turbo_stream_send_hello_world" => "pages#turbo_stream_send_hello_world"
   get "manual_render_test" => "pages#manual_render_test"
+
+  # EXPERIMENTAL View Transitions demo (issue #3888). Inert by default: the
+  # route only exists when the dummy app is booted with VIEW_TRANSITIONS_DEMO=true.
+  # See docs/oss/building-features/view-transitions.md.
+  get "view_transitions_demo" => "pages#view_transitions_demo" if ENV["VIEW_TRANSITIONS_DEMO"] == "true"
 end


### PR DESCRIPTION
Fixes #3888

## Summary

Establishes **View Transitions readiness** (explicitly *not* support) for React on Rails, per the issue's 2026-06-11 triage note:

- **New experimental recipe doc** — `docs/oss/building-features/view-transitions.md`:
  - CSR recipe: wrapping React state/route updates in `document.startViewTransition()` with `flushSync`, feature detection, `view-transition-name` CSS, and pitfalls.
  - SSR-hydrate recipe: what works with hydration (handler-only API access, no support-dependent markup in initial render, `view-transition-name` is hydration-safe, initial paint is never transitioned).
  - Turbo Drive interplay: Turbo's cross-page transitions vs React-driven in-root transitions, why they must not run simultaneously, and Turbo preview-cache pitfalls.
  - Short React canary `<ViewTransition>` status note (canary-only, untested/unsupported with React on Rails).
  - **Promote-to-supported checklist** with owner line: "Owner: maintainers — tracked in #3888" and a re-check cadence.
  - Banner at top + every section marked **(Experimental)**; page states it is not officially supported and APIs may change.
  - The RSC-path spike was **dropped entirely** per the triage note — no RSC View Transitions content.
- **Flagged in-repo dummy demo** (inert by default):
  - `react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx` — minimal CSR component demonstrating the recipe (auto-bundled via the existing `startup` components subdirectory).
  - `react_on_rails/spec/dummy/app/views/pages/view_transitions_demo.html.erb` — demo page with the transition CSS.
  - `react_on_rails/spec/dummy/config/routes.rb` — `/view_transitions_demo` route exists **only** when the dummy app boots with `VIEW_TRANSITIONS_DEMO=true`.
- **Registration**: doc ID `building-features/view-transitions` added to `docs/sidebars.ts` (one line, under Building Features → Rendering) and a task entry added to `llms.txt`. `llms-full.txt` intentionally untouched.

⚠️ Turbo-interplay claims flagged for maintainer review (per triage) — the doc's Turbo section carries a visible "⚠️ Turbo claims pending maintainer review" banner until a maintainer verifies them end-to-end in the dummy app.

No CHANGELOG entry: docs + flag-gated dummy-app demo only; no user-visible gem/package behavior change.

Labels: none — docs plus an env-gated dummy-app demo that is inert by default; standard path-based CI selection is sufficient.

## Validation

- `script/check-docs-sidebar origin/main` → `✓ All 1 new doc(s) have sidebar entries`
- `pnpm exec eslint react_on_rails/spec/dummy/client/app/startup/ViewTransitionsDemo.client.tsx` → clean
- `pnpm exec prettier --check` on the doc, `sidebars.ts`, and the component → clean
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` → 217 files inspected, no offenses detected
- Flag **off**: dummy app boots, `/view_transitions_demo` route **absent** (`rails runner` route check)
- Flag **on**: route present; integration-session smoke test renders the page with status 200, component div, transition CSS, and the generated pack
- Flag **off** dummy specs after `pnpm run build:test`: `bundle exec rspec spec/helpers spec/requests` → **133 examples, 0 failures**
- Pack generation regenerates cleanly including the new `generated/ViewTransitionsDemo.js`

Note: a pre-existing (unrelated) environment quirk was observed — `spec/support/shakapacker_precompile_hook_shared.rb` fails with `invalid byte sequence in US-ASCII` when run under a C/POSIX locale; it reproduces on clean `origin/main` and is not introduced by this PR.

## Codex Decision Log

- `codex review --base origin/main` (codex-cli 0.136.0) run after commit: "I did not identify any actionable correctness, build, or documentation-link issues in the diff. The new doc is in the sidebar, and the added TypeScript demo type-checks and lints cleanly in the dummy app." → no findings to address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and env-gated dummy-app demo only; no production gem or npm behavior changes.
> 
> **Overview**
> Adds an **experimental, unsupported** View Transitions guide for React on Rails ([#3888](https://github.com/shakacode/react_on_rails/issues/3888)): browser-native `document.startViewTransition()` with `flushSync` for CSR, SSR-hydrate constraints, pitfalls, React canary API status, Turbo Drive interplay (marked pending maintainer review), a promote-to-supported checklist, and how to run an opt-in dummy demo.
> 
> **Docs discovery:** new page under Building Features → Rendering in `docs/sidebars.ts` and a link in `llms.txt`.
> 
> **Dummy app (inert by default):** `ViewTransitionsDemo.client.tsx`, `view_transitions_demo.html.erb`, and `/view_transitions_demo` only when `VIEW_TRANSITIONS_DEMO=true`. No gem or package behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 762c81dca4faeeeefb06f248127e383d79a2609e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive experimental guide for browser-native view transitions with React on Rails, covering feature detection, CSR/SSR patterns, CSS styling, Turbo interplay, and a promotion checklist.

* **New Features**
  * Experimental view transitions demo and routing added (gated behind an environment flag) to showcase animated state transitions.

* **Navigation**
  * Docs sidebar and machine-readable route map updated to include the new guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->