### PR TITLE
Fix precompile hook crash under non-UTF-8 locale (C/POSIX)

### DIFF
--- a/react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb
+++ b/react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe "Shakapacker precompile hook shared script" do
     end
   end
 
+  def with_default_external(encoding)
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+    original = Encoding.default_external
+    Encoding.default_external = encoding
+    yield
+  ensure
+    Encoding.default_external = original
+    $VERBOSE = original_verbose
+  end
+
   it "preserves setup failures while cleaning any captured env keys" do
     bad_overrides = Object.new
 
@@ -41,6 +52,55 @@ RSpec.describe "Shakapacker precompile hook shared script" do
     expect(self).to have_received(:build_rescript_if_needed)
     expect(self).to have_received(:generate_packs_if_needed)
     expect(self).to have_received(:generate_rsc_manifest_client_references_if_needed)
+  end
+
+  # Without LANG/LC_ALL (C/POSIX locale), Encoding.default_external is US-ASCII, and File.read
+  # of files containing non-ASCII characters returns strings that raise on regex match or encode.
+  describe "non-UTF-8 default external encoding" do
+    it "generates packs when the initializer contains non-ASCII characters" do
+      Dir.mktmpdir(nil, "/tmp") do |rails_root|
+        initializer_path = File.join(rails_root, "config", "initializers", "react_on_rails.rb")
+        FileUtils.mkdir_p(File.dirname(initializer_path))
+        File.write(initializer_path, <<~RUBY)
+          # ⚠️ auto bundling enabled
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+          end
+        RUBY
+
+        allow(self).to receive_messages(find_rails_root: rails_root, puts: nil)
+        allow(Dir).to receive(:chdir)
+
+        # The buggy behavior is warn + exit 1, so guard against SystemExit explicitly —
+        # otherwise the exit would abort the whole RSpec process instead of failing the example.
+        with_default_external(Encoding::US_ASCII) do
+          expect { generate_packs_if_needed }.not_to raise_error
+        end
+
+        expect(Dir).to have_received(:chdir).with(rails_root)
+      end
+    end
+
+    it "builds ReScript when package.json contains non-ASCII characters" do
+      Dir.mktmpdir(nil, "/tmp") do |rails_root|
+        File.write(File.join(rails_root, "rescript.json"), "{}\n")
+        File.write(File.join(rails_root, "package.json"), <<~JSON)
+          {
+            "description": "ReScript app — non-ASCII description",
+            "scripts": { "build:rescript": "rescript build" }
+          }
+        JSON
+
+        allow(self).to receive_messages(find_rails_root: rails_root, puts: nil)
+        allow(Dir).to receive(:chdir)
+
+        with_default_external(Encoding::US_ASCII) do
+          expect { build_rescript_if_needed }.not_to raise_error
+        end
+
+        expect(Dir).to have_received(:chdir).with(rails_root)
+      end
+    end
   end
 
   describe "valid_rsc_registration_entry_path?" do

--- a/react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb
+++ b/react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb
@@ -74,7 +74,9 @@ def build_rescript_if_needed
     exit 1
   end
 
-  package_json = JSON.parse(File.read(package_json_path))
+  # Read as UTF-8 explicitly: under a C/POSIX locale (no LANG/LC_ALL), Encoding.default_external
+  # is US-ASCII and non-ASCII content would raise when parsed or regex-matched.
+  package_json = JSON.parse(File.read(package_json_path, mode: "r:bom|utf-8"))
   unless package_json.dig("scripts", "build:rescript")
     warn "❌ Error: ReScript config found but no build:rescript script in package.json"
     warn "    Add this to your package.json scripts section:"
@@ -111,8 +113,10 @@ def generate_packs_if_needed
   return unless File.exist?(initializer_path)
 
   # Check if auto-pack generation is configured
-  # Match config lines that aren't commented out and allow flexible spacing
-  initializer_content = File.read(initializer_path)
+  # Match config lines that aren't commented out and allow flexible spacing.
+  # Read as UTF-8 explicitly: under a C/POSIX locale (no LANG/LC_ALL), Encoding.default_external
+  # is US-ASCII and non-ASCII content would raise when regex-matched.
+  initializer_content = File.read(initializer_path, mode: "r:bom|utf-8")
   return unless initializer_content.match?(/^\s*(?!#).*config\.auto_load_bundle\s*=/) ||
                 initializer_content.match?(/^\s*(?!#).*config\.components_subdirectory\s*=/)
 


### PR DESCRIPTION
## Summary

`react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb` crashed with `Pack generation failed: invalid byte sequence in US-ASCII` when the shell had no UTF-8 locale (LANG/LC_ALL unset, i.e. C/POSIX locale).

**Repro (on main):** from `react_on_rails/spec/dummy`:

```sh
env -u LANG -u LC_ALL RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook
```

exits 1 from the `StandardError` rescue in `generate_packs_if_needed`.

**Root cause:** `File.read` uses `Encoding.default_external`, which is US-ASCII under the C locale. The dummy app's `config/initializers/react_on_rails.rb` contains a non-ASCII character (`⚠️`), so the returned string has an invalid encoding and raises `ArgumentError` when regex-matched. The `package.json` read in `build_rescript_if_needed` has the same failure mode via `JSON.parse` (`Encoding::InvalidByteSequenceError`).

## Changes

- Read the initializer and `package.json` with an explicit UTF-8 encoding (`mode: "r:bom|utf-8"`).
- Add specs covering a US-ASCII default external encoding for both read paths (verified red before the fix: both raised `SystemExit` from the encoding crash).

## Not affected

The generator template hook (`lib/generators/react_on_rails/templates/base/base/bin/shakapacker-precompile-hook`) does not have this bug — it never reads and regex-matches files; it loads the Rails environment and delegates to `PacksGenerator`.

The Pro dummy app's hook (`react_on_rails_pro/spec/dummy/bin/shakapacker-precompile-hook`) loads this shared script, so it's fixed by this change as well.

## Verification

- `bundle exec rspec spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb` — 16 examples, 0 failures
- Real pack generation under the C locale from `spec/dummy` now succeeds (`generate_packs_if_needed` completes, exit 0)
- RuboCop clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to file read encoding in the shared precompile script plus regression specs; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **shakapacker precompile hook** failures when the process runs under a **C/POSIX locale** (no `LANG`/`LC_ALL`), where `Encoding.default_external` is US-ASCII and `File.read` on UTF-8 files with non-ASCII text caused encoding errors during pack detection and ReScript `package.json` parsing.
> 
> `generate_packs_if_needed` and `build_rescript_if_needed` now read `config/initializers/react_on_rails.rb` and `package.json` with **`mode: "r:bom|utf-8"`** so regex matching and `JSON.parse` work regardless of locale. Specs add **`with_default_external(Encoding::US_ASCII)`** and examples that use non-ASCII content in those files to lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615819970449493ce7f5f1f5f0027e42ad673d8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include non-UTF-8 default external encoding scenarios, including US-ASCII configurations
  * Enhanced file reading for React configuration and package files to explicitly handle UTF-8 encoding with byte order mark support
  * Added comprehensive test cases for pack generation and build operations under alternative system character encodings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->