### PR TITLE
Add verify-pr-fix skill for manual before/after fix verification

### DIFF
--- a/.agents/skills/verify-pr-fix/SKILL.md
+++ b/.agents/skills/verify-pr-fix/SKILL.md
@@ -88,6 +88,19 @@ Memorable invocation: `$verify-pr-fix <PR>` or "manually verify this fix and rep
 - **Types-only changes**: usually covered by `pnpm run type-check`; behavioral reproduction is normally not
   warranted — say so rather than staging a fake one.
 
+## Environment notes
+
+- **Pro RSpec encoding**: `react_on_rails_pro`'s `Gemfile.loader` can die with
+  `invalid byte sequence in US-ASCII`. Run Pro specs with a UTF-8 locale:
+  `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 RUBYOPT="-EUTF-8" bundle exec rspec <file>`.
+- **Pre-fix-on-one-file tactic** (cheap before/after for an already-merged PR): when the fix is in a single
+  file and the PR added regression specs, run the post-fix spec against the pre-fix file —
+  `git checkout <fix-commit>~1 -- <file>`, run the spec (it should fail on exactly the new tests), then
+  **always restore** with `git checkout HEAD -- <file>` and confirm `git status` is clean before moving on.
+- **Read the changed function from git, not from memory**: when a harness needs the exact pre/post logic
+  (a regex, a digest, a key format), extract it verbatim with `git show <rev>:<file>` so the reproduction
+  can't drift from the real code.
+
 ## When NOT to use this skill
 
 - Docs, comments, CHANGELOG, CI/workflow plumbing, benchmark tooling, refactors with no behavioral change,

--- a/.agents/skills/verify-pr-fix/SKILL.md
+++ b/.agents/skills/verify-pr-fix/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: verify-pr-fix
+description: >-
+  Manually verify that a bug-fix PR actually works by reproducing the failure before the fix and confirming it is gone after, with captured evidence, then posting findings to the PR (and optionally the linked issue). Use when asked to manually verify a PR/fix, reproduce an issue and its fix, confirm a fix works end to end, or take screenshots proving a change.
+argument-hint: '[PR URL or number]'
+---
+
+# Verify PR Fix
+
+Prove a bug-fix PR works by **reproducing the failure first, then showing the fix removes it**, with
+evidence a reader can check. A fix that "passes" means nothing unless you first showed the bug.
+
+This is behavioral verification, distinct from the local lint/test loop in `.agents/skills/verify/SKILL.md`
+(`$verify`) and from review skills (`$adversarial-pr-review`, `$post-merge-audit`). Use this when the
+question is "does the fix actually fix the reported problem?", not "does it lint and pass CI?".
+
+Memorable invocation: `$verify-pr-fix <PR>` or "manually verify this fix and reproduce the issue".
+
+## Core principles
+
+- **Show the bug before the fix.** Always capture a failing "before" and a passing "after" of the _same_
+  reproduction. Skipping the "before" is the most common way a verification lies.
+- **Faithful over convenient.** Reproduce through the same code path / API the product uses. If you must
+  build a harness, build it on the real mechanism (the actual module, the real `cluster`/HTTP/render path),
+  not a paraphrase of it.
+- **Evidence before assertions.** Never claim "verified" without captured output, a state check
+  (`ps`/`pgrep`, HTTP status, DOM, exit code), or a screenshot. Paste the real output, including PIDs,
+  codes, and timings. Never fabricate or assume output (see `AGENTS.md`).
+- **State what you did NOT exercise.** If the reproduction is mechanism-level rather than the full app, say
+  so plainly and name the residual-risk path. Honesty about scope is part of the deliverable.
+- **Reproduce the actual condition.** Many bugs are intermittent or race-dependent. Recreate the triggering
+  condition deterministically (the right input, a settle delay, the blocking state, the concurrency) before
+  concluding "no repro". A clean run can mean you never triggered the bug, not that it is absent.
+- **Leave the machine clean.** Kill every process you spawned and remove scratch files. Verify with
+  `pgrep`/`ps` that nothing leaked.
+
+## Instructions
+
+1. **Read the PR and the linked issue.** `gh pr view <n> --json title,body,files,commits,url,state` and
+   `gh issue view <linked> --json title,body,url`. Extract: the claimed bug, the expected vs actual
+   behavior, the reproduction the reporter described, and the validation the author already ran (look for a
+   "Manual / Residual Risk" or "Validation" section — verify what they left UNKNOWN).
+2. **Locate the changed surface.** Read the diff (`gh pr diff <n>` or the files in the worktree). Identify
+   the exact behavioral change and the smallest observable signal that distinguishes broken from fixed
+   (an orphaned process, an HTTP 500 vs 200, a hydration mismatch, a cache key collision, an exit code).
+3. **Choose the cheapest faithful reproduction**, in this order:
+   - **Full app run** when feasible — highest fidelity. For this repo that often means the dummy apps:
+     `cd react_on_rails/spec/dummy` (OSS) or the Pro dummy under `react_on_rails_pro/`, plus
+     `pnpm test:e2e` / Playwright for browser-visible behavior (see
+     `.claude/docs/playwright-e2e-testing.md` and `.claude/docs/manual-dev-environment-testing.md`).
+   - **Minimal faithful harness** when the full app is too heavy to stand up quickly (needs a license,
+     real bundles, a renderer, external services). Build it on the **same real API** the product uses and
+     label it mechanism-level. Example from PR #3882: driving Node's real `cluster` module the
+     node-renderer uses, rather than booting the whole renderer.
+   - For renderer/process changes, see `.claude/docs/validating-node-renderer-changes.md`.
+4. **Reproduce the bug (the "before").** Run the reproduction against pre-fix behavior. Get pre-fix code by
+   the least invasive means: check out the parent commit in a scratch worktree, or `git stash` the change,
+   or (for a harness) model the pre-fix path explicitly. Capture the failure. If it does not fail, you have
+   not reproduced it — recreate the triggering condition (input, timing, blocking, concurrency) and retry
+   before concluding anything.
+5. **Verify the fix (the "after").** Run the identical reproduction against the post-fix code. Capture the
+   now-passing result. Confirm the specific signal flipped (orphans 6/6 -> 0/6, exit code, status, DOM).
+6. **Capture evidence.** Save real terminal output. For UI/browser changes take screenshots via the
+   `/browse` skill or Playwright MCP. For a shareable visual of terminal results you may render the
+   captured output with the visualize tool, but the render must reproduce real output verbatim — never
+   stage numbers.
+7. **Clean up.** Kill spawned processes, remove scratch dirs/worktrees, and confirm nothing leaked
+   (`pgrep -fl <marker>` should report none).
+8. **Report to the PR.** Post a comment with the structured format below. Before posting to GitHub (an
+   outward-facing action), confirm with the user unless they already told you to post. Write the body to a
+   temp file and use `gh pr comment <n> --body-file` (avoids inline-formatting issues; see global Git
+   workflow rules).
+9. **Cross-link the issue (optional).** If asked, comment on the linked issue with a 2-3 sentence summary
+   and a link to the PR comment URL returned by step 8: `gh issue comment <n> --body-file`.
+
+## Reproduction tactics by change type
+
+- **Process / renderer lifecycle** (signals, workers, teardown, ports): drive the real `cluster`/child
+  process API; assert with `ps`/`pgrep`/`kill -0` on captured PIDs and on the master's exit code. Emulate
+  the real supervisor (e.g. Foreman: signal only the master PID, SIGKILL after its ~5s window).
+- **SSR / hydration / RSC** (render output, FOUC, streaming, cache keys): boot the relevant dummy app,
+  hit the affected route, compare server HTML vs hydrated DOM, watch the renderer log, diff cache keys.
+  Browser-visible? Screenshot before/after with `/browse` or Playwright.
+- **Generators / installers / scaffolding**: run the generator into a temp app and diff the produced files
+  against expectation; for behavioral output, boot the generated app.
+- **Caching / dedupe / digests**: construct the colliding or repeated inputs and assert hit/miss and that
+  failed renders are not cached.
+- **Types-only changes**: usually covered by `pnpm run type-check`; behavioral reproduction is normally not
+  warranted — say so rather than staging a fake one.
+
+## When NOT to use this skill
+
+- Docs, comments, CHANGELOG, CI/workflow plumbing, benchmark tooling, refactors with no behavioral change,
+  license-header enforcement, and pure type narrowing rarely have a user-observable runtime symptom to
+  reproduce. Route those to `$verify` (local checks) or a review skill instead, and say why a behavioral
+  repro adds nothing.
+
+## Output format (PR comment)
+
+````markdown
+## Manual verification: reproduced the bug and confirmed the fix ✅ / ❌
+
+<one line on what was verified and how (full app vs mechanism-level harness)>
+
+### Reproduction
+
+<how the bug was triggered; the key condition that makes it deterministic>
+
+### Results
+
+| Scenario              | Behavior   | Result          |
+| --------------------- | ---------- | --------------- |
+| Pre-fix, <condition>  | <observed> | <BROKEN signal> |
+| Post-fix, <condition> | <observed> | <FIXED signal>  |
+
+```text
+<real captured output, before and after>
+```
+````
+
+### Caveat
+
+<what was NOT exercised; the residual-risk path that remains UNKNOWN>
+
+```
+
+Keep the comment evidence-first and honest about scope. End behavioral claims with the captured proof, not
+adjectives.
+```

--- a/.agents/skills/verify-pr-fix/SKILL.md
+++ b/.agents/skills/verify-pr-fix/SKILL.md
@@ -54,16 +54,19 @@ Memorable invocation: `$verify-pr-fix <PR>` or "manually verify this fix and rep
      node-renderer uses, rather than booting the whole renderer.
    - For renderer/process changes, see `.claude/docs/validating-node-renderer-changes.md`.
 4. **Reproduce the bug (the "before").** Run the reproduction against pre-fix behavior. Get pre-fix code by
-   the least invasive means: check out the parent commit in a scratch worktree, or `git stash` the change,
-   or (for a harness) model the pre-fix path explicitly. Capture the failure. If it does not fail, you have
-   not reproduced it — recreate the triggering condition (input, timing, blocking, concurrency) and retry
+   the least invasive means: check out the parent commit in a scratch worktree, `git stash` an uncommitted
+   change, check out one file at its pre-fix revision (`git checkout <fix-commit>~1 -- <file>`), or (for a
+   harness) model the pre-fix path explicitly. Capture the failure. If it does not fail, you have not
+   reproduced it — recreate the triggering condition (input, timing, blocking, concurrency) and retry
    before concluding anything.
-5. **Verify the fix (the "after").** Run the identical reproduction against the post-fix code. Capture the
-   now-passing result. Confirm the specific signal flipped (orphans 6/6 -> 0/6, exit code, status, DOM).
-6. **Capture evidence.** Save real terminal output. For UI/browser changes take screenshots via the
-   `/browse` skill or Playwright MCP. For a shareable visual of terminal results you may render the
-   captured output with the visualize tool, but the render must reproduce real output verbatim — never
-   stage numbers.
+5. **Verify the fix (the "after").** Restore the post-fix code first (`git stash pop`,
+   `git checkout HEAD -- <file>`, or leave the worktree), then run the identical reproduction. Capture the
+   now-passing result and confirm the specific signal flipped (orphans 6/6 -> 0/6, exit code, status, DOM).
+   Confirm `git status` is clean so the "after" really ran against post-fix code.
+6. **Capture evidence.** Save real terminal output. For UI/browser changes take screenshots via Playwright
+   MCP (see `.claude/docs/playwright-e2e-testing.md`). For a shareable visual of terminal results you may
+   render the captured output with the visualize tool, but the render must reproduce real output verbatim —
+   never stage numbers.
 7. **Clean up.** Kill spawned processes, remove scratch dirs/worktrees, and confirm nothing leaked
    (`pgrep -fl <marker>` should report none).
 8. **Report to the PR.** Post a comment with the structured format below. Before posting to GitHub (an
@@ -80,7 +83,7 @@ Memorable invocation: `$verify-pr-fix <PR>` or "manually verify this fix and rep
   the real supervisor (e.g. Foreman: signal only the master PID, SIGKILL after its ~5s window).
 - **SSR / hydration / RSC** (render output, FOUC, streaming, cache keys): boot the relevant dummy app,
   hit the affected route, compare server HTML vs hydrated DOM, watch the renderer log, diff cache keys.
-  Browser-visible? Screenshot before/after with `/browse` or Playwright.
+  Browser-visible? Screenshot before/after with Playwright MCP.
 - **Generators / installers / scaffolding**: run the generator into a temp app and diff the produced files
   against expectation; for behavioral output, boot the generated app.
 - **Caching / dedupe / digests**: construct the colliding or repeated inputs and assert hit/miss and that
@@ -129,14 +132,11 @@ Memorable invocation: `$verify-pr-fix <PR>` or "manually verify this fix and rep
 ```text
 <real captured output, before and after>
 ```
-````
 
 ### Caveat
 
 <what was NOT exercised; the residual-risk path that remains UNKNOWN>
-
-```
+````
 
 Keep the comment evidence-first and honest about scope. End behavioral claims with the captured proof, not
 adjectives.
-```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 - When the user wants an adversarial PR review, red-team review, Claude/Codex comparison review, or a stricter pre-merge gate, use `.agents/skills/adversarial-pr-review/SKILL.md`; reusable prompts live in `.agents/workflows/adversarial-pr-review.md`
 - When the user assigns an issue, PR, review-fix pass, or merge queue to an agent, follow `.agents/workflows/pr-processing.md`
 - When the user asks to address PR review comments, use `.agents/skills/address-review/SKILL.md`; `.agents/workflows/address-review.md` remains a copy/paste prompt for assistants without skill support
+- When the user wants to manually verify a bug-fix PR by reproducing the failure before the fix and confirming it is gone after (with captured evidence or screenshots, optionally posted to the PR and issue), use `.agents/skills/verify-pr-fix/SKILL.md`; a short invocation is `$verify-pr-fix` or "manually verify this fix"
 - Default simplify model: `claude-opus-4-8`
 
 ## Canonical Agent Policy


### PR DESCRIPTION
## Summary

Adds a `verify-pr-fix` agent skill that codifies the manual before/after verification process used on #3882: reproduce a bug-fix's failure **before** the fix, confirm it is gone **after**, with captured evidence, then post findings to the PR (and optionally the linked issue).

It is distinct from the existing `$verify` (local lint/test loop) and the review skills (`$adversarial-pr-review`, `$post-merge-audit`) — those answer "does it pass CI?", this answers "does the fix actually fix the reported problem?".

## What it captures

Generalizable lessons from the #3882 verification session, as core principles:

- **Show the bug before the fix** — a passing "after" alone proves nothing.
- **Faithful over convenient** — build harnesses on the real API/mechanism (e.g. Node's real `cluster` module the node-renderer uses) when the full app is too heavy, and label them mechanism-level.
- **Reproduce the actual condition** — recreate the triggering timing/blocking/concurrency before concluding "no repro" (a clean run can mean you never triggered the bug).
- **Evidence before assertions**, **state what you did NOT exercise**, **leave the machine clean** (no orphaned processes).

Plus reproduction tactics by change type, a "when NOT to use this" gate (docs/CI/benchmark/refactor/type-only), and a standard PR-comment output format.

## Changes

- `.agents/skills/verify-pr-fix/SKILL.md` — the new skill (prettier-clean; auto-exposed as `/verify-pr-fix` via the `.claude/skills` symlink).
- `AGENTS.md` — registration line alongside the other skill entries.

## Validation

- `npx prettier --check` on the new skill and `AGENTS.md` → clean.
- `git diff --check` → no whitespace/conflict issues.
- Docs/skill-only change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent workflow only; no application runtime or CI behavior changes.
> 
> **Overview**
> Adds **`$verify-pr-fix`**, an agent skill for **manual behavioral verification** of bug-fix PRs: reproduce the failure on pre-fix code, confirm the same steps pass post-fix, capture real evidence, and optionally post a structured PR (and issue) comment.
> 
> The skill is positioned **apart from `$verify`** (lint/tests/CI) and review skills—it targets “does this fix the reported problem?” It encodes principles (mandatory before/after, faithful reproduction, evidence, scope caveats, cleanup), a nine-step workflow (`gh` PR/issue read, diff surface, reproduction choice, git tactics for pre/post), change-type tactics (renderer lifecycle, SSR, generators, caching), environment notes, a **when not to use** gate, and a PR comment template.
> 
> **`AGENTS.md`** gains one discovery line next to the other skill entries so agents route manual fix verification to `.agents/skills/verify-pr-fix/SKILL.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0bca1c873520976527bda0b5cf366c00fc7d39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidelines for manually verifying bug-fix pull requests: verification principles, step-by-step workflow, reproduction tactics for common change types, environment notes, cleanup practices, and a PR comment template with scenario/result tables and caveats.
  * Added an agent workflow entry with a short invocation hint to surface the manual verification procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->