### PR TITLE
Docs: Web Vitals / first-party RUM guide (#3877 docs leg)

### DIFF
--- a/docs/oss/building-features/web-vitals-and-rum.md
+++ b/docs/oss/building-features/web-vitals-and-rum.md
@@ -67,10 +67,10 @@ const VITALS_ENDPOINT = '/web_vitals';
 const SAMPLE_RATE = 0.1; // 10%
 const isSampled = Math.random() < SAMPLE_RATE;
 
-const queue = new Set();
+const queue = [];
 
 function addToQueue({ name, value, id, rating, delta, navigationType }) {
-  queue.add({
+  queue.push({
     name,
     value,
     id,
@@ -85,12 +85,12 @@ function addToQueue({ name, value, id, rating, delta, navigationType }) {
 }
 
 function flushQueue() {
-  if (!isSampled || queue.size === 0) {
+  if (!isSampled || queue.length === 0) {
     return;
   }
 
-  const body = JSON.stringify({ metrics: [...queue] });
-  queue.clear();
+  // splice(0) drains the queue and returns its contents in one step.
+  const body = JSON.stringify({ metrics: queue.splice(0) });
 
   // sendBeacon queues delivery even while the page unloads. Wrap the payload in
   // a Blob so the request carries a JSON content type and Rails parses the
@@ -197,9 +197,11 @@ class WebVitalsController < ApplicationController
 
   private
 
-  # Coerce and validate every metric BEFORE persisting anything, so a
-  # malformed beacon is rejected whole instead of half-persisted.
-  # Returns attribute hashes, or nil when any value is malformed.
+  # Coerce and validate every metric before persisting anything. Metrics with
+  # an unknown name or rating are silently dropped (skipped, not an error);
+  # any non-numeric value rejects the whole beacon by returning nil. Either
+  # way, nothing half-persists. String fields are length-clamped because this
+  # endpoint skips CSRF protection -- never trust client-supplied sizes.
   def coerced_rows
     now = Time.current
     vitals_params[:metrics].to_a.filter_map do |metric|
@@ -210,9 +212,9 @@ class WebVitalsController < ApplicationController
         name: metric[:name],
         value: Float(metric[:value]),
         delta: Float(metric[:delta]),
-        metric_id: metric[:id].to_s,
+        metric_id: metric[:id].to_s.byteslice(0, 64),
         rating: metric[:rating],
-        navigation_type: metric[:navigation_type].to_s,
+        navigation_type: metric[:navigation_type].to_s.byteslice(0, 32),
         page: metric[:page].to_s.byteslice(0, 255),
         created_at: now
       }
@@ -315,6 +317,10 @@ WHERE name = 'LCP'
 GROUP BY page
 ORDER BY p75_lcp_ms DESC;
 ```
+
+`percentile_cont` is PostgreSQL-specific — on MySQL or SQLite, compute the
+percentile with a window function (`PERCENT_RANK()`/`NTILE`) or load the sorted
+values and pick the p75 index in Ruby.
 
 Prune old rows on a schedule (a nightly
 `WebVitalMetric.where("created_at < ?", 90.days.ago).delete_all` job) or roll

--- a/docs/oss/building-features/web-vitals-and-rum.md
+++ b/docs/oss/building-features/web-vitals-and-rum.md
@@ -69,8 +69,19 @@ const isSampled = Math.random() < SAMPLE_RATE;
 
 const queue = new Set();
 
-function addToQueue(metric) {
-  queue.add(metric);
+function addToQueue({ name, value, id, rating, delta, navigationType }) {
+  queue.add({
+    name,
+    value,
+    id,
+    rating,
+    delta,
+    navigation_type: navigationType,
+    // Capture the path when the metric is observed, not when the queue is
+    // flushed -- with Turbo Drive one flush can carry metrics from several
+    // routes. Send the pathname only: query strings can contain tokens or PII.
+    page: window.location.pathname,
+  });
 }
 
 function flushQueue() {
@@ -78,18 +89,7 @@ function flushQueue() {
     return;
   }
 
-  const body = JSON.stringify({
-    // Send the pathname only — query strings can contain tokens or PII.
-    page: window.location.pathname,
-    metrics: [...queue].map(({ name, value, id, rating, delta, navigationType }) => ({
-      name,
-      value,
-      id,
-      rating,
-      delta,
-      navigation_type: navigationType,
-    })),
-  });
+  const body = JSON.stringify({ metrics: [...queue] });
   queue.clear();
 
   // sendBeacon queues delivery even while the page unloads. Wrap the payload in
@@ -98,13 +98,14 @@ function flushQueue() {
   const blob = new Blob([body], { type: 'application/json' });
   if (!(navigator.sendBeacon && navigator.sendBeacon(VITALS_ENDPOINT, blob))) {
     // Fallback for browsers without sendBeacon: keepalive lets the request
-    // outlive the page.
+    // outlive the page. Telemetry is fire-and-forget -- swallow delivery
+    // errors instead of surfacing them.
     fetch(VITALS_ENDPOINT, {
       method: 'POST',
       body,
       headers: { 'Content-Type': 'application/json' },
       keepalive: true,
-    });
+    }).catch(() => {});
   }
 }
 
@@ -124,6 +125,9 @@ addEventListener('visibilitychange', () => {
 // pagehide covers older Safari, which does not reliably fire visibilitychange
 // on unload.
 addEventListener('pagehide', flushQueue);
+// Turbo Drive swaps the page without firing visibilitychange or pagehide, so
+// also flush before each Turbo visit. Harmless no-op in apps without Turbo.
+addEventListener('turbo:before-visit', flushQueue);
 ```
 
 Why this shape:
@@ -136,13 +140,26 @@ Why this shape:
   routinely cancelled by the browser; `sendBeacon` hands the payload to the
   browser to deliver asynchronously even after the page is gone. The
   `keepalive: true` fetch is the fallback for the rare browser without it.
+- **Turbo Drive** — Turbo navigations swap the `<body>` without firing
+  `visibilitychange` or `pagehide`, so several routes can share one flush.
+  That is why the snippet stamps each metric with the pathname **at
+  observation time** (one `page` per metric, not per POST) and also flushes on
+  `turbo:before-visit`. Registering that listener in a non-Turbo app is a
+  harmless no-op — the event simply never fires.
+- **Back/forward cache** — `web-vitals` treats a
+  [bfcache](https://web.dev/articles/bfcache) restore as a separate page view
+  and reports all metrics again with new `id`s (and
+  `navigationType: 'back-forward-cache'`). The listeners and queue survive the
+  restore, so those metrics are delivered on the next hide — no extra code
+  needed.
 - **Payload fields** mirror the `web-vitals`
   [`Metric` type](https://github.com/GoogleChrome/web-vitals#metric): `name`
   (`'CLS' | 'FCP' | 'INP' | 'LCP' | 'TTFB'`), `value`, `id` (unique per metric
   per page load — use it to deduplicate), `rating`
   (`'good' | 'needs-improvement' | 'poor'`), `delta` (change since the last
   report of this metric), and `navigationType` (e.g. `'navigate'`,
-  `'reload'`, `'back-forward'`, `'prerender'`).
+  `'reload'`, `'back-forward'`, `'prerender'`) — plus the `page` pathname the
+  snippet captures per metric.
 
 ## Server: a first-party ingestion endpoint
 
@@ -168,38 +185,54 @@ class WebVitalsController < ApplicationController
   VALID_RATINGS = %w[good needs-improvement poor].freeze
 
   def create
-    vitals_params[:metrics].to_a.each do |metric|
+    rows = coerced_rows
+    return head :unprocessable_entity if rows.nil?
+
+    # insert_all! (Rails 6+) writes every row in one all-or-nothing statement,
+    # skipping per-row callbacks/validations -- fine for telemetry. On older
+    # Rails, wrap per-row creates in a single transaction instead.
+    WebVitalMetric.insert_all!(rows) if rows.any?
+    head :no_content
+  end
+
+  private
+
+  # Coerce and validate every metric BEFORE persisting anything, so a
+  # malformed beacon is rejected whole instead of half-persisted.
+  # Returns attribute hashes, or nil when any value is malformed.
+  def coerced_rows
+    now = Time.current
+    vitals_params[:metrics].to_a.filter_map do |metric|
       next unless VALID_NAMES.include?(metric[:name])
       next unless VALID_RATINGS.include?(metric[:rating])
 
-      WebVitalMetric.create!(
+      {
         name: metric[:name],
         value: Float(metric[:value]),
         delta: Float(metric[:delta]),
         metric_id: metric[:id].to_s,
         rating: metric[:rating],
         navigation_type: metric[:navigation_type].to_s,
-        page: vitals_params[:page].to_s.byteslice(0, 255)
-      )
+        page: metric[:page].to_s.byteslice(0, 255),
+        created_at: now
+      }
     end
-
-    head :no_content
   rescue ArgumentError, TypeError
-    # Float() raises on non-numeric values -- reject malformed beacons.
-    head :unprocessable_entity
+    # Float() raises on non-numeric values.
+    nil
   end
 
-  private
-
   def vitals_params
-    params.permit(:page, metrics: %i[name value id rating delta navigation_type])
+    params.permit(metrics: %i[name value id rating delta navigation_type page])
   end
 end
 ```
 
 The strong-params schema matches the client payload (and the `web-vitals`
 `Metric` type): `name`, `value`, `id`, `rating`, `delta`, `navigation_type`,
-plus the page path. Everything else in the request is dropped.
+plus the per-metric page path. Everything else in the request is dropped, and
+all metrics are coerced up front and written in a single atomic insert — a
+malformed beacon never half-persists.
 
 ### CSRF and abuse considerations
 

--- a/docs/oss/building-features/web-vitals-and-rum.md
+++ b/docs/oss/building-features/web-vitals-and-rum.md
@@ -46,6 +46,8 @@ Add the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) package:
 
 ```bash
 npm install web-vitals
+# or: yarn add web-vitals
+# or: pnpm add web-vitals
 ```
 
 Then add the following to a Shakapacker entry — either a dedicated pack or your
@@ -215,7 +217,7 @@ real trade-off:
   audit log.
 - **Alternative that keeps CSRF protection**: skip `sendBeacon` entirely and
   always use `fetch(..., { keepalive: true })` with the `X-CSRF-Token` header
-  read from the `csrf_token` meta tag. `keepalive` requests survive unload in
+  read from the `csrf-token` meta tag (emitted by `csrf_meta_tags`). `keepalive` requests survive unload in
   modern browsers, though delivery is somewhat less reliable than `sendBeacon`
   (keepalive requests share a small per-origin in-flight budget). Pick this if
   your security posture rules out any unprotected endpoint.
@@ -234,7 +236,7 @@ percentile statistics, so you need volume, not completeness. Guidance:
   otherwise a page view contributes CLS but not LCP and your per-page
   correlations break.
 - To tune the rate without rebuilding the bundle, emit it from Rails (e.g.
-  `<meta name="web-vitals-sample-rate" content="<%= ENV.fetch("WEB_VITALS_SAMPLE_RATE", "0.1") %>">`)
+  `<meta name="web-vitals-sample-rate" content="<%= ENV.fetch('WEB_VITALS_SAMPLE_RATE', '0.1') %>">`)
   and read it in the snippet instead of hardcoding the constant.
 
 ## Storage and aggregation

--- a/docs/oss/building-features/web-vitals-and-rum.md
+++ b/docs/oss/building-features/web-vitals-and-rum.md
@@ -1,0 +1,338 @@
+# Web Vitals and Real User Monitoring (RUM)
+
+React on Rails instruments **server-side** render performance — the repo's
+`benchmarks/` suite feeds a Bencher-based regression dashboard, and
+[Performance Benchmarks](../core-concepts/performance-benchmarks.md) covers
+ExecJS vs Node Renderer throughput. What that does not tell you is how your app
+performs **for real users in real browsers**: Largest Contentful Paint (LCP),
+Cumulative Layout Shift (CLS), Interaction to Next Paint (INP), Time to First
+Byte (TTFB), and First Contentful Paint (FCP). This page closes that loop with a
+**first-party** Real User Monitoring setup: the browser collects Web Vitals with
+the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) library and
+beacons them to **your own Rails endpoint** — no third-party analytics vendor,
+no Vercel, no extra SaaS bill, and the data never leaves your app
+(privacy/GDPR friendly).
+
+For comparison: Next.js ships
+[`useReportWebVitals`](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals),
+a thin hook over the same `web-vitals` library, and pairs it with Vercel Speed
+Insights for turnkey field RUM — a path that effectively assumes you deploy on
+Vercel and send your traffic data there. On Rails, the equivalent is just
+another controller action: POST the vitals to your app and aggregate them with
+ActiveRecord or your existing APM.
+
+> **Scope note:** This page covers wiring the framework-agnostic `web-vitals`
+> metrics. Framework-level hydration-timing instrumentation (`performance.mark`
+> entries emitted from the React on Rails client runtime — "time to hydrate",
+> "first interaction after hydration") is a planned follow-up, tracked in
+> [issue #3877](https://github.com/shakacode/react_on_rails/issues/3877). It has
+> not shipped yet; nothing on this page depends on it.
+
+## How the pieces fit
+
+1. **Client**: a small script in your client bundle subscribes to the five Core
+   Web Vitals via `web-vitals`, queues them, and flushes the queue with
+   `navigator.sendBeacon` when the page is hidden or unloaded.
+2. **Sampling**: only a configurable fraction of page views report (default
+   below: 10%), so high-traffic apps don't write a row per page view.
+3. **Server**: a Rails route + controller accepts the JSON beacon, validates it
+   with strong parameters, and stores it (or forwards it to your APM).
+4. **Aggregation**: you query percentiles (p75 is the Core Web Vitals
+   threshold standard) from your own database.
+
+## Client: collecting and beaconing vitals
+
+Add the [`web-vitals`](https://github.com/GoogleChrome/web-vitals) package:
+
+```bash
+npm install web-vitals
+```
+
+Then add the following to a Shakapacker entry — either a dedicated pack or your
+existing client bundle entry. It is intentionally plain JavaScript with no React
+on Rails API dependency, so it works in any client bundle:
+
+```js
+// app/javascript/packs/web-vitals-reporter.js
+// (or import it from your existing client bundle entry)
+import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals';
+
+const VITALS_ENDPOINT = '/web_vitals';
+
+// Report only a fraction of page views. Decide once per page load so a sampled
+// page view reports its full set of metrics (you can also read the rate from a
+// <meta> tag to configure it from Rails without rebuilding the bundle).
+const SAMPLE_RATE = 0.1; // 10%
+const isSampled = Math.random() < SAMPLE_RATE;
+
+const queue = new Set();
+
+function addToQueue(metric) {
+  queue.add(metric);
+}
+
+function flushQueue() {
+  if (!isSampled || queue.size === 0) {
+    return;
+  }
+
+  const body = JSON.stringify({
+    // Send the pathname only — query strings can contain tokens or PII.
+    page: window.location.pathname,
+    metrics: [...queue].map(({ name, value, id, rating, delta, navigationType }) => ({
+      name,
+      value,
+      id,
+      rating,
+      delta,
+      navigation_type: navigationType,
+    })),
+  });
+  queue.clear();
+
+  // sendBeacon queues delivery even while the page unloads. Wrap the payload in
+  // a Blob so the request carries a JSON content type and Rails parses the
+  // params (a bare string would be sent as text/plain).
+  const blob = new Blob([body], { type: 'application/json' });
+  if (!(navigator.sendBeacon && navigator.sendBeacon(VITALS_ENDPOINT, blob))) {
+    // Fallback for browsers without sendBeacon: keepalive lets the request
+    // outlive the page.
+    fetch(VITALS_ENDPOINT, {
+      method: 'POST',
+      body,
+      headers: { 'Content-Type': 'application/json' },
+      keepalive: true,
+    });
+  }
+}
+
+onCLS(addToQueue);
+onFCP(addToQueue);
+onINP(addToQueue);
+onLCP(addToQueue);
+onTTFB(addToQueue);
+
+// CLS, LCP, and INP only settle when the page is hidden or unloaded, so flush
+// on visibility change rather than on a timer.
+addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    flushQueue();
+  }
+});
+// pagehide covers older Safari, which does not reliably fire visibilitychange
+// on unload.
+addEventListener('pagehide', flushQueue);
+```
+
+Why this shape:
+
+- **Queue + flush on `visibilitychange`/`pagehide`** — CLS, LCP, and INP are
+  not final until the user leaves the page, so per-metric immediate POSTs would
+  both undercount and multiply requests. Batching into one beacon per page view
+  is the pattern the `web-vitals` documentation recommends.
+- **`navigator.sendBeacon`** — a normal `fetch`/XHR issued during unload is
+  routinely cancelled by the browser; `sendBeacon` hands the payload to the
+  browser to deliver asynchronously even after the page is gone. The
+  `keepalive: true` fetch is the fallback for the rare browser without it.
+- **Payload fields** mirror the `web-vitals`
+  [`Metric` type](https://github.com/GoogleChrome/web-vitals#metric): `name`
+  (`'CLS' | 'FCP' | 'INP' | 'LCP' | 'TTFB'`), `value`, `id` (unique per metric
+  per page load — use it to deduplicate), `rating`
+  (`'good' | 'needs-improvement' | 'poor'`), `delta` (change since the last
+  report of this metric), and `navigationType` (e.g. `'navigate'`,
+  `'reload'`, `'back-forward'`, `'prerender'`).
+
+## Server: a first-party ingestion endpoint
+
+Add a route:
+
+```ruby
+# config/routes.rb
+post "/web_vitals", to: "web_vitals#create"
+```
+
+And a controller:
+
+```ruby
+# app/controllers/web_vitals_controller.rb
+class WebVitalsController < ApplicationController
+  # sendBeacon cannot set custom request headers, so the beacon arrives without
+  # the X-CSRF-Token header Rails expects. Skipping forgery protection on this
+  # one write-only, anonymous endpoint is the standard trade-off -- see the
+  # CSRF section below before copying this.
+  skip_forgery_protection
+
+  VALID_NAMES = %w[CLS FCP INP LCP TTFB].freeze
+  VALID_RATINGS = %w[good needs-improvement poor].freeze
+
+  def create
+    vitals_params[:metrics].to_a.each do |metric|
+      next unless VALID_NAMES.include?(metric[:name])
+      next unless VALID_RATINGS.include?(metric[:rating])
+
+      WebVitalMetric.create!(
+        name: metric[:name],
+        value: Float(metric[:value]),
+        delta: Float(metric[:delta]),
+        metric_id: metric[:id].to_s,
+        rating: metric[:rating],
+        navigation_type: metric[:navigation_type].to_s,
+        page: vitals_params[:page].to_s.byteslice(0, 255)
+      )
+    end
+
+    head :no_content
+  rescue ArgumentError, TypeError
+    # Float() raises on non-numeric values -- reject malformed beacons.
+    head :unprocessable_entity
+  end
+
+  private
+
+  def vitals_params
+    params.permit(:page, metrics: %i[name value id rating delta navigation_type])
+  end
+end
+```
+
+The strong-params schema matches the client payload (and the `web-vitals`
+`Metric` type): `name`, `value`, `id`, `rating`, `delta`, `navigation_type`,
+plus the page path. Everything else in the request is dropped.
+
+### CSRF and abuse considerations
+
+`skip_forgery_protection` is what makes the `sendBeacon` path work, and it is a
+real trade-off:
+
+- **Why it is usually acceptable here**: the endpoint is write-only, stores
+  anonymous numeric metrics, returns no data, and performs no action on behalf
+  of a user — there is nothing for a classic CSRF attack to gain.
+- **What you give up**: anyone can POST junk metrics. Mitigate with the strict
+  schema validation above (unknown names/ratings are dropped, non-numeric
+  values are rejected) and rate limiting (e.g. a
+  [Rack::Attack](https://github.com/rack/rack-attack) throttle on
+  `POST /web_vitals` per IP). Treat the data as untrusted telemetry, not as an
+  audit log.
+- **Alternative that keeps CSRF protection**: skip `sendBeacon` entirely and
+  always use `fetch(..., { keepalive: true })` with the `X-CSRF-Token` header
+  read from the `csrf_token` meta tag. `keepalive` requests survive unload in
+  modern browsers, though delivery is somewhat less reliable than `sendBeacon`
+  (keepalive requests share a small per-origin in-flight budget). Pick this if
+  your security posture rules out any unprotected endpoint.
+
+### Sampling
+
+The `SAMPLE_RATE` constant in the client snippet controls what fraction of page
+views report. 10% is a sensible default for most apps: Core Web Vitals are
+percentile statistics, so you need volume, not completeness. Guidance:
+
+- **Low-traffic apps** (under ~10k page views/day): sample 100% (`1`) — you
+  need every data point to compute a stable p75.
+- **High-traffic apps**: 1–10% is typically plenty. At 1M page views/day, a 1%
+  sample still yields 10k measurements.
+- Decide **once per page view** (as the snippet does), never per metric —
+  otherwise a page view contributes CLS but not LCP and your per-page
+  correlations break.
+- To tune the rate without rebuilding the bundle, emit it from Rails (e.g.
+  `<meta name="web-vitals-sample-rate" content="<%= ENV.fetch("WEB_VITALS_SAMPLE_RATE", "0.1") %>">`)
+  and read it in the snippet instead of hardcoding the constant.
+
+## Storage and aggregation
+
+This is guidance, not a product — storage and visualization are your app's
+choice. Two common paths:
+
+### Option 1: ActiveRecord table
+
+```ruby
+class CreateWebVitalMetrics < ActiveRecord::Migration[8.0]
+  def change
+    create_table :web_vital_metrics do |t|
+      t.string :name, null: false
+      t.float :value, null: false
+      t.float :delta
+      t.string :metric_id
+      t.string :rating
+      t.string :navigation_type
+      t.string :page
+      t.datetime :created_at, null: false
+    end
+
+    add_index :web_vital_metrics, %i[name created_at]
+    add_index :web_vital_metrics, %i[page name]
+  end
+end
+```
+
+Core Web Vitals thresholds are defined at the **75th percentile**, so query p75
+rather than averages (averages hide the slow tail that ratings are based on):
+
+```sql
+-- p75 LCP per page over the last 7 days (PostgreSQL)
+SELECT page,
+       percentile_cont(0.75) WITHIN GROUP (ORDER BY value) AS p75_lcp_ms,
+       count(*) AS samples
+FROM web_vital_metrics
+WHERE name = 'LCP'
+  AND created_at > now() - interval '7 days'
+GROUP BY page
+ORDER BY p75_lcp_ms DESC;
+```
+
+Prune old rows on a schedule (a nightly
+`WebVitalMetric.where("created_at < ?", 90.days.ago).delete_all` job) or roll
+daily percentiles up into a summary table if volume grows.
+
+### Option 2: forward to your existing APM
+
+If you already run an APM or metrics stack (New Relic, Datadog, Sentry,
+Prometheus/StatsD, Scout, Skylight…), skip the table and forward from the
+controller instead — e.g. emit a custom event or a distribution/histogram
+metric tagged with `name`, `rating`, and `page`. You keep the same first-party
+beacon and endpoint; only the sink changes. This is usually the right call when
+the APM already owns your dashboards and alerting.
+
+## Privacy
+
+This setup is deliberately privacy-friendly, but keep it that way:
+
+- **No PII in beacons.** The payload is metric names and numbers plus a page
+  path. Do not add user IDs, emails, session tokens, or full URLs — the snippet
+  sends `location.pathname` precisely because query strings can carry tokens or
+  personal data. If a path itself embeds an identifier (e.g. `/users/123`),
+  normalize it before storing (`/users/:id`).
+- **First-party only.** Data goes from the user's browser to your own origin
+  and stays in your database. There is no third-party analytics script, no
+  cross-site cookie, and no data-processing agreement with an analytics vendor
+  to manage — which substantially simplifies the GDPR story compared with
+  shipping field data to an external RUM service.
+- **No fingerprinting.** Resist the temptation to add user-agent strings,
+  precise geolocation, or device fingerprints "for segmentation." Coarse
+  dimensions (`navigation_type`, `rating`, page path) answer almost every
+  performance question.
+
+## How this complements server-side benchmarks
+
+The `benchmarks/` suite and [Performance
+Benchmarks](../core-concepts/performance-benchmarks.md) answer "did this change
+make server rendering slower?" under controlled load. Field Web Vitals answer
+"what do real users experience?" across real devices, networks, and cache
+states — including everything the server-side numbers cannot see: asset
+delivery, font loading (see [Font Optimization](./fonts.md), which targets LCP
+and CLS directly), hydration cost, and third-party scripts. Use both: Bencher
+to catch server-render regressions in CI, and your vitals table to verify that
+optimizations actually move p75 LCP/CLS/INP for users.
+
+## Related
+
+- [Performance Benchmarks](../core-concepts/performance-benchmarks.md) — the
+  server-side measurement story this complements
+- [Font Optimization](./fonts.md) — a direct LCP/CLS lever, verifiable with
+  this setup
+- [Caching](./caching.md) — server-side render caching, a common TTFB lever
+- [web.dev: Web Vitals](https://web.dev/articles/vitals) — metric definitions
+  and thresholds
+- [GoogleChrome/web-vitals](https://github.com/GoogleChrome/web-vitals) — the
+  collection library
+- [Issue #3877](https://github.com/shakacode/react_on_rails/issues/3877) —
+  tracking for the planned framework-level hydration-timing instrumentation

--- a/docs/oss/building-features/web-vitals-and-rum.md
+++ b/docs/oss/building-features/web-vitals-and-rum.md
@@ -247,7 +247,9 @@ choice. Two common paths:
 ### Option 1: ActiveRecord table
 
 ```ruby
-class CreateWebVitalMetrics < ActiveRecord::Migration[8.0]
+# Generate with `bin/rails generate migration CreateWebVitalMetrics` so the
+# migration version matches your app's Rails version.
+class CreateWebVitalMetrics < ActiveRecord::Migration[7.1]
   def change
     create_table :web_vital_metrics do |t|
       t.string :name, null: false

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -101,6 +101,7 @@ const sidebars: SidebarsConfig = {
             'building-features/extensible-precompile-pattern',
             'building-features/process-managers',
             'building-features/debugging',
+            'building-features/web-vitals-and-rum',
           ],
         },
         {


### PR DESCRIPTION
# Docs: Web Vitals / first-party RUM guide (#3877, docs leg)

## Summary

Adds one new docs page, `docs/oss/building-features/web-vitals-and-rum.md`, plus its `docs/sidebars.ts` entry (under **Building Features → Development & Ops**). This is the docs-first deliverable from the issue's "Triage — 2026-06-11 / Descoped v1" plan.

The page covers:

- **Positioning**: React on Rails already instruments server-side render performance (`benchmarks/` + Bencher, linked to `core-concepts/performance-benchmarks`); this closes the client-side real-user loop with a **first-party** setup — vitals POST to your own Rails endpoint, no third-party analytics/Vercel, data stays in the app. Brief contrast with Next.js `useReportWebVitals` + Vercel Speed Insights.
- **Client wiring**: complete copy-pasteable Shakapacker entry using the `web-vitals` package (LCP, CLS, INP, TTFB, FCP), with a queue flushed via `navigator.sendBeacon` on `visibilitychange`/`pagehide` and a `fetch keepalive` fallback. Uses a JSON `Blob` so Rails parses the beacon params.
- **Rails ingestion**: route + controller with strong params whose schema mirrors the `web-vitals` `Metric` type (`name`/`value`/`id`/`rating`/`delta`/`navigationType`), value-type validation, and a CSRF section explaining the `skip_forgery_protection` trade-off for beacon endpoints plus the `fetch` + `X-CSRF-Token` alternative.
- **Sampling**: once-per-page-view sampling in the snippet, 10% default, with tuning guidance and a meta-tag pattern for configuring the rate from Rails.
- **Storage/aggregation guidance only** (no product): ActiveRecord table sketch + p75 SQL query, or forward to an existing APM.
- **Privacy note**: no PII in beacons, pathname-only pages, first-party/GDPR-friendly, no fingerprinting.
- **Scope note in the page**: framework-level hydration-timing instrumentation (`performance.mark` from the RoR client runtime) is a planned follow-up tracked in #3877 — no unshipped APIs are promised.

## Scope

Part of #3877 — do **not** close the issue on merge. The instrumentation leg (`performance.mark` from `ClientRenderer`/`pageLifecycle`) and the eventual shipped hook/Rails concern remain open per the triage plan. This PR touches only the new docs page and one `docs/sidebars.ts` line; no source code, no `packages/`, no `llms*.txt`.

**Labels: none** — docs-only change; standard path-based CI selection suffices.

## Merge sequencing

⚠️ This PR must merge **serially** with the other Batch-4 docs PRs (shared `docs/sidebars.ts`), after the Batch-3 docs queue drains. Expect a trivial one-line sidebar conflict if merged out of order.

## Codex Decision Log

`codex review --base origin/main` (codex-cli 0.136.0) was run after the initial commit. Findings:

1. **[P2] `ActiveRecord::Migration[8.0]` fails on Rails < 8** — **Accepted and fixed** (commit `b7b7e828f`): the migration example now uses `[7.1]` (matching the dummy app) with a comment telling readers to generate the migration so the version matches their app.

No other findings. Pre-Codex self-review fixes: corrected the Rails CSRF meta tag name (`csrf-token`, not `csrf_token`) and matched the sibling-docs multi-package-manager install convention.

## Validation

- `script/check-docs-sidebar origin/main` → ✓ `building-features/web-vitals-and-rum` has a sidebar entry (1/1)
- `node_modules/.bin/prettier --check docs/oss/building-features/web-vitals-and-rum.md docs/sidebars.ts` → all files use Prettier code style
- `lychee --config .lychee.toml docs/oss/building-features/web-vitals-and-rum.md` → 9/9 links OK, 0 errors (lychee 0.23.0, matching CI)
- Snippet syntax checks on extracted fenced blocks:
  - JS reporter snippet → `node --check` → OK
  - All 3 Ruby snippets (routes, controller, migration) → `ruby -c` → Syntax OK
- Changelog: **no entry** — docs-only change; `.claude/docs/changelog-guidelines.md` excludes documentation fixes/additions from CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no application or package code changes.
> 
> **Overview**
> Adds a new **Building Features → Development & Ops** doc, `web-vitals-and-rum.md`, that walks through **first-party** browser RUM: collect Core Web Vitals with `web-vitals`, batch and send via `sendBeacon` (with Turbo Drive and sampling notes), and ingest on a dedicated Rails `POST /web_vitals` action with validation, CSRF trade-offs, optional ActiveRecord storage or APM forwarding, and privacy guidance. It positions this alongside existing server-side benchmarks and explicitly scopes out unshipped RoR hydration `performance.mark` work (#3877).
> 
> `docs/sidebars.ts` gains one entry so the page appears in the OSS docs nav.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51946344c4071eb3e5456ca9d9c933c5ccbd8127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New comprehensive guide for implementing first‑party Real User Monitoring (RUM) with web‑vitals and a Rails ingestion endpoint
  * Covers client-side metrics collection, sampling, batching, and reliable delivery strategies
  * Describes server-side ingestion, validation, bulk persistence or forwarding, aggregation, percentile querying, and pruning
  * Discusses CSRF/abuse trade-offs, sampling configuration, and privacy best practices
<!-- end of auto-generated comment: release notes by coderabbit.ai -->