### PR TITLE
Docs: fast images recipe with Rails primitives; reconcile images.md (#3874 docs slice)

### DIFF
--- a/docs/oss/building-features/fast-images.md
+++ b/docs/oss/building-features/fast-images.md
@@ -1,0 +1,363 @@
+# Fast Images in React on Rails
+
+Next.js markets `next/image` as a single component that solves responsive
+images, lazy loading, modern formats, layout-shift (CLS) prevention, and LCP
+prioritization. Rails already ships the primitives for every one of those
+concerns — no hosted image service, no Vercel lock-in. This recipe shows how to
+combine them in a React on Rails app, both in ERB views and in React components
+rendered with `react_component`.
+
+> **A first-party `<Image>` component is under consideration** for React on
+> Rails (see [issue #3874](https://github.com/shakacode/react_on_rails/issues/3874)).
+> Everything on this page works today with stock Rails — the proposed component
+> would only package these defaults, not replace them.
+
+For configuring webpack to _bundle_ images imported from your JavaScript (the
+asset-loading side), see
+[Configuring Images and Assets with Webpack](./images.md). This page is about
+the _markup and serving_ side: what the browser receives.
+
+## The checklist
+
+A "fast image" means:
+
+1. **Responsive `srcset` + `sizes`** — the browser downloads a size appropriate
+   for the layout, not a 2400px original on a phone.
+2. **Intrinsic `width`/`height` (+ CSS `aspect-ratio`)** — layout space is
+   reserved before the image loads, so there is no CLS.
+3. **`loading="lazy"` + `decoding="async"`** on everything below the fold.
+4. **`fetchpriority="high"` + `loading="eager"` + a preload** on the LCP/hero
+   image only.
+5. **AVIF/WebP with a fallback** via `<picture>`.
+
+## Responsive `srcset` from the asset pipeline
+
+For images that ship with your app (Sprockets/Propshaft), commit the size
+variants and let `image_tag` build the `srcset`. Hash keys are resolved through
+the asset pipeline just like the main `src`, so fingerprinting works:
+
+```erb
+<%= image_tag("team-photo-800.jpg",
+      srcset: {
+        "team-photo-400.jpg" => "400w",
+        "team-photo-800.jpg" => "800w",
+        "team-photo-1600.jpg" => "1600w"
+      },
+      sizes: "(max-width: 600px) 100vw, 600px",
+      width: 800,
+      height: 533,
+      loading: "lazy",
+      decoding: "async",
+      alt: "The team at launch") %>
+```
+
+`sizes` tells the browser how wide the image will render at each viewport
+width; without it the browser assumes `100vw` and over-downloads.
+
+## Responsive `srcset` from Active Storage variants
+
+For user-uploaded images, generate the width set with
+[Active Storage variants](https://guides.rubyonrails.org/active_storage_overview.html#transforming-images).
+You need the `image_processing` gem (libvips recommended):
+
+```ruby
+# Gemfile
+gem "image_processing", "~> 1.2"
+```
+
+```erb
+<%# app/views/products/show.html.erb %>
+<% widths = [400, 800, 1600] %>
+<% variants = widths.index_with { |w| @product.photo.variant(resize_to_limit: [w, nil]) } %>
+<%= image_tag url_for(variants[800].processed),
+      srcset: widths.map { |w| "#{url_for(variants[w].processed)} #{w}w" }.join(", "),
+      sizes: "(max-width: 600px) 100vw, 600px",
+      width: 800,
+      height: (800 * @product.photo_aspect_ratio).round,
+      loading: "lazy",
+      decoding: "async",
+      alt: @product.name %>
+```
+
+:::warning Request-time variant generation is a performance footgun
+
+`variant(...)` does **not** resize anything until the variant is first served.
+With the default redirect mode, the first visitor to hit each width pays the
+transformation cost (or times out on large images), and a cold cache after a
+storage migration pays it again for every image on the page — multiplied by
+every width in your `srcset`.
+
+Treat request-time generation as a fallback, not the plan:
+
+- **Pre-generate variants** when the upload happens, in a background job, by
+  calling `.processed` (which transforms and uploads the variant if missing):
+
+  ```ruby
+  class Product < ApplicationRecord
+    has_one_attached :photo do |attachable|
+      attachable.variant :w400, resize_to_limit: [400, nil], preprocessed: true
+      attachable.variant :w800, resize_to_limit: [800, nil], preprocessed: true
+      attachable.variant :w1600, resize_to_limit: [1600, nil], preprocessed: true
+    end
+  end
+  ```
+
+  Named variants with `preprocessed: true` (Rails 7.1+) enqueue transformation
+  right after upload instead of on first request. Reference them as
+  `@product.photo.variant(:w800)`.
+
+- **Run `analyze` on attach** (Active Storage does this by default via a job)
+  so `metadata[:width]`/`metadata[:height]` are available for CLS attributes
+  without downloading the blob.
+
+- **Serve through a CDN.** Put a CDN in front of your storage service (or use
+  [proxy mode](https://guides.rubyonrails.org/active_storage_overview.html#putting-a-cdn-in-front-of-active-storage)
+  plus a CDN in front of the app) so each generated variant is transformed
+  once and cached at the edge — not re-served by your Rails dynos.
+
+:::
+
+To get intrinsic dimensions for the `width`/`height` attributes, read the
+analyzed metadata instead of hardcoding:
+
+```ruby
+# app/models/product.rb
+def photo_aspect_ratio
+  meta = photo.metadata
+  return 2.0 / 3 unless meta["width"].to_i.positive?
+
+  meta["height"].to_f / meta["width"]
+end
+```
+
+## Passing image props to a React component
+
+When the `<img>` lives inside a React component, keep the URL math in Rails —
+where the asset pipeline and Active Storage live — and hand React a plain props
+hash via `react_component`. Compute the props in a helper:
+
+```ruby
+# app/helpers/images_helper.rb
+module ImagesHelper
+  RESPONSIVE_WIDTHS = [400, 800, 1600].freeze
+
+  # Returns {src:, srcSet:, sizes:, width:, height:} for an Active Storage attachment.
+  def responsive_image_props(attachment, sizes: "100vw", display_width: 800)
+    variants = RESPONSIVE_WIDTHS.index_with do |w|
+      attachment.variant(resize_to_limit: [w, nil]).processed
+    end
+    width = attachment.metadata["width"].to_i
+    height = attachment.metadata["height"].to_i
+    aspect_ratio = width.positive? ? height.to_f / width : 2.0 / 3
+
+    {
+      src: url_for(variants[display_width]),
+      srcSet: RESPONSIVE_WIDTHS.map { |w| "#{url_for(variants[w])} #{w}w" }.join(", "),
+      sizes: sizes,
+      width: display_width,
+      height: (display_width * aspect_ratio).round
+    }
+  end
+end
+```
+
+```erb
+<%# app/views/products/show.html.erb %>
+<%= react_component("ProductHero", props: {
+      name: @product.name,
+      image: responsive_image_props(@product.photo, sizes: "(max-width: 600px) 100vw, 600px")
+    }) %>
+```
+
+The React side is just an `<img>` spreading those attributes — it renders
+identically on the server and client, so there is nothing to hydrate
+incorrectly:
+
+```jsx
+// app/javascript/src/ProductHero/ror_components/ProductHero.jsx
+export default function ProductHero({ name, image }) {
+  return (
+    <figure>
+      <img
+        src={image.src}
+        srcSet={image.srcSet}
+        sizes={image.sizes}
+        width={image.width}
+        height={image.height}
+        loading="lazy"
+        decoding="async"
+        alt={name}
+      />
+      <figcaption>{name}</figcaption>
+    </figure>
+  );
+}
+```
+
+For asset-pipeline images the same pattern applies — build the hash with
+`image_path`/`image_url` instead of `url_for(variant)`.
+
+## CLS prevention: intrinsic size + `aspect-ratio`
+
+Always emit `width` and `height` attributes (the intrinsic pixel dimensions,
+not the display size). Browsers use them to reserve the correct box before the
+bytes arrive, which is what keeps CLS at zero. Then let CSS control the actual
+display size:
+
+```css
+img {
+  max-width: 100%;
+  height: auto; /* keep the reserved aspect ratio when width is constrained */
+}
+```
+
+If you size an image with CSS alone (e.g. a `background-size: cover`-style
+crop), reserve the space explicitly:
+
+```css
+.card-thumb {
+  aspect-ratio: 3 / 2;
+  width: 100%;
+  object-fit: cover;
+}
+```
+
+## Defaults for non-hero images
+
+Every image that can start below the fold should opt out of competing with
+critical resources:
+
+- `loading="lazy"` — the browser defers the download until the image nears the
+  viewport.
+- `decoding="async"` — decode off the main thread instead of blocking paint.
+
+These are plain attributes in both ERB (`loading: "lazy", decoding: "async"`)
+and JSX (`loading="lazy" decoding="async"`). They are the right default for
+everything **except** the LCP image — lazy-loading the hero is one of the most
+common LCP regressions.
+
+## The LCP/hero image: prioritize and preload
+
+For the one image that is your [Largest Contentful Paint](https://web.dev/articles/optimize-lcp)
+element, invert the defaults:
+
+```erb
+<%= image_tag("hero-1600.jpg",
+      srcset: { "hero-800.jpg" => "800w", "hero-1600.jpg" => "1600w" },
+      sizes: "100vw",
+      width: 1600,
+      height: 900,
+      loading: "eager",
+      fetchpriority: "high",
+      alt: "") %>
+```
+
+- `fetchpriority="high"` tells the browser to fight for bandwidth for this
+  request.
+- `loading="eager"` (the default, but explicit beats accidental `lazy`).
+
+Additionally, preload it from your **layout's `<head>`**, so the fetch starts
+before the browser has parsed down to the `<img>` (or, for client-rendered
+components, before React renders at all):
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+<head>
+  <%= yield :preloads %>
+  <%# ... %>
+</head>
+```
+
+If the hero has a single source,
+[`preload_link_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-preload_link_tag)
+is the right tool:
+
+```erb
+<%# app/views/home/index.html.erb %>
+<% content_for :preloads do %>
+  <%= preload_link_tag image_path("hero-1600.jpg"), as: "image", fetchpriority: "high" %>
+<% end %>
+```
+
+For a **responsive** hero (the `srcset` case above), the preload must carry
+`imagesrcset`/`imagesizes` so the browser preloads the same candidate the
+`<img>` will pick. Use a plain `<link>` here — **not** `preload_link_tag`:
+besides the tag, `preload_link_tag` also sends an HTTP `Link: rel=preload`
+header built only from the fixed `href` (it does not include
+`imagesrcset`/`imagesizes`), so browsers that honor the header would fetch the
+full-size image on every viewport, duplicating the download the responsive
+preload was supposed to avoid.
+
+```erb
+<%# app/views/home/index.html.erb %>
+<% content_for :preloads do %>
+  <link
+    rel="preload"
+    as="image"
+    fetchpriority="high"
+    imagesrcset="<%= image_path('hero-800.jpg') %> 800w, <%= image_path('hero-1600.jpg') %> 1600w"
+    imagesizes="100vw"
+  />
+<% end %>
+```
+
+This is deliberately a **layout-level** concern: the preload belongs in the
+document `<head>` your layout owns, declared by the page that knows its hero.
+You do not need (and React on Rails does not currently provide) a
+head-injection helper for it. Preload at most one or two images per page —
+preloading more steals bandwidth from the things you actually wanted to
+prioritize.
+
+## Modern formats: AVIF/WebP with fallback
+
+AVIF and WebP are typically 30–50% smaller than JPEG at equivalent quality.
+Active Storage variants can transcode on the fly (libvips must be built with
+AVIF support for `:avif`):
+
+```erb
+<% avif = @product.photo.variant(resize_to_limit: [800, nil], format: :avif) %>
+<% webp = @product.photo.variant(resize_to_limit: [800, nil], format: :webp) %>
+<picture>
+  <source srcset="<%= url_for(avif.processed) %>" type="image/avif" />
+  <source srcset="<%= url_for(webp.processed) %>" type="image/webp" />
+  <%= image_tag url_for(@product.photo.variant(resize_to_limit: [800, nil]).processed),
+        width: 800, height: 533, loading: "lazy", decoding: "async",
+        alt: @product.name %>
+</picture>
+```
+
+The browser picks the first `<source>` it supports and falls back to the
+`<img>` otherwise — older browsers never download the modern formats. On
+Rails 7.1+ you can also use the
+[`picture_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-picture_tag)
+helper. In JSX the same markup is `<picture>` + `<source>` elements with
+`srcSet`/`type` props.
+
+The same request-time-generation warning applies doubly here: a `<picture>`
+with two formats × three widths is six variants per image. Pre-generate them.
+
+## Putting it together
+
+| Concern          | Non-hero image            | LCP/hero image                          |
+| ---------------- | ------------------------- | --------------------------------------- |
+| `srcset`/`sizes` | yes                       | yes                                     |
+| `width`/`height` | always                    | always                                  |
+| `loading`        | `lazy`                    | `eager`                                 |
+| `decoding`       | `async`                   | (default)                               |
+| `fetchpriority`  | (default)                 | `high`                                  |
+| Preload          | no                        | preload `<link>` in the layout `<head>` |
+| Formats          | AVIF/WebP via `<picture>` | AVIF/WebP via `<picture>`               |
+
+To verify the result, check LCP and CLS in Chrome DevTools (Performance panel)
+or with the [web-vitals](https://github.com/GoogleChrome/web-vitals) library:
+the hero should be discovered in the preload scanner's first pass, and CLS from
+images should be ~0.
+
+## See also
+
+- [Configuring Images and Assets with Webpack](./images.md) — bundling images
+  imported from JavaScript/SCSS.
+- [Font Optimization](./fonts.md) — the companion recipe for the other classic
+  CLS source.
+- [web.dev: Optimize LCP](https://web.dev/articles/optimize-lcp) and
+  [web.dev: CLS](https://web.dev/articles/cls).

--- a/docs/oss/building-features/fast-images.md
+++ b/docs/oss/building-features/fast-images.md
@@ -108,7 +108,9 @@ Treat request-time generation as a fallback, not the plan:
 
 - **Run `analyze` on attach** (Active Storage does this by default via a job)
   so `metadata[:width]`/`metadata[:height]` are available for CLS attributes
-  without downloading the blob.
+  without downloading the blob. Until that job has run, `attachment.analyzed?`
+  is `false` and the dimensions are missing — guard for it and fall back to a
+  default aspect ratio, as the snippets below do.
 
 - **Serve through a CDN.** Put a CDN in front of your storage service (or use
   [proxy mode](https://guides.rubyonrails.org/active_storage_overview.html#putting-a-cdn-in-front-of-active-storage)
@@ -124,11 +126,15 @@ analyzed metadata instead of hardcoding:
 # app/models/product.rb
 def photo_aspect_ratio
   meta = photo.metadata
-  return 2.0 / 3 unless meta["width"].to_i.positive?
+  return 2.0 / 3 unless meta["width"].to_i.positive? && meta["height"].to_i.positive?
 
   meta["height"].to_f / meta["width"]
 end
 ```
+
+Guard on **both** dimensions: until the analyzer job has run
+(`photo.analyzed?` is `false`), either value can be missing, and a zero height
+would emit `height="0"` and an `aspect-ratio` of 0.
 
 ## Passing image props to a React component
 
@@ -139,20 +145,28 @@ hash via `react_component`. Compute the props in a helper:
 ```ruby
 # app/helpers/images_helper.rb
 module ImagesHelper
+  # Must match the named variants on the model (:w400, :w800, :w1600),
+  # pre-generated at upload time with preprocessed: true — see the
+  # variant-generation warning above.
   RESPONSIVE_WIDTHS = [400, 800, 1600].freeze
 
   # Returns {src:, srcSet:, sizes:, width:, height:} for an Active Storage attachment.
   def responsive_image_props(attachment, sizes: "100vw", display_width: 800)
-    variants = RESPONSIVE_WIDTHS.index_with do |w|
-      attachment.variant(resize_to_limit: [w, nil]).processed
-    end
-    width = attachment.metadata["width"].to_i
-    height = attachment.metadata["height"].to_i
-    aspect_ratio = width.positive? ? height.to_f / width : 2.0 / 3
+    # Snap to the closest generated width so an unlisted value can't produce
+    # a nil variant lookup.
+    display_width = RESPONSIVE_WIDTHS.min_by { |w| (w - display_width).abs }
+    meta = attachment.metadata
+    aspect_ratio =
+      if meta["width"].to_i.positive? && meta["height"].to_i.positive?
+        meta["height"].to_f / meta["width"]
+      else
+        2.0 / 3 # analysis hasn't run yet — see the warning above
+      end
+    srcset = RESPONSIVE_WIDTHS.map { |w| "#{url_for(attachment.variant(:"w#{w}"))} #{w}w" }
 
     {
-      src: url_for(variants[display_width]),
-      srcSet: RESPONSIVE_WIDTHS.map { |w| "#{url_for(variants[w])} #{w}w" }.join(", "),
+      src: url_for(attachment.variant(:"w#{display_width}")),
+      srcSet: srcset.join(", "),
       sizes: sizes,
       width: display_width,
       height: (display_width * aspect_ratio).round
@@ -160,6 +174,12 @@ module ImagesHelper
   end
 end
 ```
+
+If you cannot define named variants (or are on Rails < 7.1), the request-time
+form — `attachment.variant(resize_to_limit: [w, nil]).processed` — is a drop-in
+replacement for `attachment.variant(:"w#{w}")`. But it transforms on first
+request, which is exactly the footgun the warning above describes: acceptable
+for a low-traffic admin page, not for anything user-facing.
 
 ```erb
 <%# app/views/products/show.html.erb %>

--- a/docs/oss/building-features/fast-images.md
+++ b/docs/oss/building-features/fast-images.md
@@ -124,6 +124,9 @@ analyzed metadata instead of hardcoding:
 
 ```ruby
 # app/models/product.rb
+# Height ÷ width (≈0.667 for a 3:2 landscape photo) — the multiplier that
+# turns a display width into the matching height attribute. Note that CSS
+# `aspect-ratio` is the inverse: width / height.
 def photo_aspect_ratio
   meta = photo.metadata
   return 2.0 / 3 unless meta["width"].to_i.positive? && meta["height"].to_i.positive?
@@ -269,12 +272,14 @@ element, invert the defaults:
       height: 900,
       loading: "eager",
       fetchpriority: "high",
-      alt: "") %>
+      alt: "Hand-thrown ceramic mugs lined up on a workbench") %>
 ```
 
 - `fetchpriority="high"` tells the browser to fight for bandwidth for this
   request.
 - `loading="eager"` (the default, but explicit beats accidental `lazy`).
+- Give the hero real `alt` text — it is usually meaningful content. Reserve
+  `alt: ""` for purely decorative images.
 
 Additionally, preload it from your **layout's `<head>`**, so the fetch starts
 before the browser has parsed down to the `<img>` (or, for client-rendered
@@ -331,16 +336,21 @@ prioritize.
 ## Modern formats: AVIF/WebP with fallback
 
 AVIF and WebP are typically 30–50% smaller than JPEG at equivalent quality.
-Active Storage variants can transcode on the fly (libvips must be built with
-AVIF support for `:avif`):
+Active Storage variants can transcode formats too (libvips must be built with
+AVIF support for `:avif`). Define them as named, pre-generated variants, like
+the width variants earlier:
+
+```ruby
+# app/models/product.rb — add format variants next to the width variants
+attachable.variant :w800_avif, resize_to_limit: [800, nil], format: :avif, preprocessed: true
+attachable.variant :w800_webp, resize_to_limit: [800, nil], format: :webp, preprocessed: true
+```
 
 ```erb
-<% avif = @product.photo.variant(resize_to_limit: [800, nil], format: :avif) %>
-<% webp = @product.photo.variant(resize_to_limit: [800, nil], format: :webp) %>
 <picture>
-  <source srcset="<%= url_for(avif.processed) %>" type="image/avif" />
-  <source srcset="<%= url_for(webp.processed) %>" type="image/webp" />
-  <%= image_tag url_for(@product.photo.variant(resize_to_limit: [800, nil]).processed),
+  <source srcset="<%= url_for(@product.photo.variant(:w800_avif)) %>" type="image/avif" />
+  <source srcset="<%= url_for(@product.photo.variant(:w800_webp)) %>" type="image/webp" />
+  <%= image_tag url_for(@product.photo.variant(:w800)),
         width: 800, height: 533, loading: "lazy", decoding: "async",
         alt: @product.name %>
 </picture>
@@ -353,8 +363,15 @@ Rails 7.1+ you can also use the
 helper. In JSX the same markup is `<picture>` + `<source>` elements with
 `srcSet`/`type` props.
 
-The same request-time-generation warning applies doubly here: a `<picture>`
-with two formats × three widths is six variants per image. Pre-generate them.
+For brevity this example is **fixed-width** — one 800px candidate per format.
+In production, make each `<source>` responsive exactly like
+[the plain `<img>` above](#responsive-srcset-from-active-storage-variants):
+define the format variants at every width (`:w400_avif`, `:w800_avif`,
+`:w1600_avif`, …) and give each `<source>` the multi-width `srcset` plus the
+same `sizes` value. Otherwise the browser always downloads the one listed
+candidate and you lose the responsive savings. Note the multiplication — two
+formats × three widths is six variants per image — which is why these are
+defined with `preprocessed: true` rather than transformed at request time.
 
 ## Putting it together
 

--- a/docs/oss/building-features/images.md
+++ b/docs/oss/building-features/images.md
@@ -1,5 +1,10 @@
 # Configuring Images and Assets with Webpack
 
+This page covers the **bundling** side of images: configuring webpack so images
+imported from your JavaScript/SCSS resolve correctly. For the **performance**
+side — responsive `srcset`, lazy loading, CLS prevention, LCP preloading, and
+AVIF/WebP — see [Fast Images in React on Rails](./fast-images.md).
+
 A leading slash is necessary on the `name` option for file-loader/url-loader and the `publicPath` option for output.
 
 ```javascript
@@ -48,6 +53,9 @@ to `app/javascript/images/foobar.jpg` with a custom alias like this:
 
 ## See also
 
-For self-hosting and optimizing web fonts (preload, `font-display`, and a
-`size-adjust` metric-matched fallback to eliminate layout shift), see
-[Font Optimization](./fonts.md).
+- [Fast Images in React on Rails](./fast-images.md) — responsive `srcset`,
+  lazy loading, CLS prevention, LCP preloading, and modern formats using Rails
+  primitives.
+- [Font Optimization](./fonts.md) — self-hosting and optimizing web fonts
+  (preload, `font-display`, and a `size-adjust` metric-matched fallback to
+  eliminate layout shift).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -87,6 +87,7 @@ const sidebars: SidebarsConfig = {
             'building-features/react-and-redux',
             'building-features/i18n',
             'building-features/images',
+            'building-features/fast-images',
             'building-features/fonts',
             'building-features/rails-engine-integration',
             'building-features/turbolinks',


### PR DESCRIPTION
# Docs: Fast Images in React on Rails (recipe, Rails primitives only)

Part of #3874 (the first-party `<Image>` component/helper decision is still open — this PR intentionally does NOT close the issue).

## Summary

Adds the docs slice of issue #3874's "Descoped v1" (per the 2026-06-11 triage): a "fast images in React on Rails" recipe showing that stock Rails primitives already cover the `next/image` concern bundle — no helper, component, or dummy-app code in this PR.

New page `docs/oss/building-features/fast-images.md` covers:

- **Responsive `srcset`/`sizes`** via `image_tag srcset:` (asset pipeline) and via Active Storage variants (`image_processing`/libvips), with complete ERB snippets.
- **Rails-to-React props pattern**: a `responsive_image_props` helper computing `{src, srcSet, sizes, width, height}` in Rails and a JSX `<img>` consuming it via `react_component` props (SSR/hydration-safe by construction).
- **CLS prevention**: intrinsic `width`/`height` + CSS `aspect-ratio`.
- **Non-hero defaults**: `loading="lazy"`, `decoding="async"`.
- **LCP/hero**: `fetchpriority="high"`, `loading="eager"`, and layout-level preload via `content_for`/`yield` — explicitly the layout-level approach, no head-injection helper.
- **Modern formats**: AVIF/WebP Active Storage variants with `<picture>`/`<source>` fallback.
- **Prominent `:::warning` footgun callout**: request-time Active Storage variant generation (first-hit latency/cost, multiplied by srcset widths × formats); recommends pre-generating via named variants with `preprocessed: true` (Rails 7.1+) / `.processed`, `analyze` metadata for dimensions, and CDN serving.
- A note that a first-party `<Image>` component is under consideration (links #3874) and that the recipe works today without it.

## How `images.md` was reconciled

The triage said "extend or supersede `docs/oss/building-features/images.md`". That page (including the ~6 lines PR #3923 recently added) is about the **webpack bundling** side (url-loader/file-loader config, aliases) — a different concern from runtime image performance. So:

- **New page** `fast-images.md` for the markup/serving recipe, added to the same sidebar group (`Integrations`, right after `images`).
- **`images.md` refocused, not rewritten**: a scope sentence at the top ("this page covers bundling; for performance see Fast Images") and its "See also" converted to a list linking both `fast-images.md` and `fonts.md` (preserving the #3923 fonts cross-link). No content removed, no contradiction between the two pages.
- Exactly one new line in `docs/sidebars.ts`.
- `llms.txt`/`llms-full.txt` untouched (per batch instructions).

## Codex Decision Log

`codex review --base origin/main` (codex-cli 0.136.0), two passes:

1. **Pass 1 — 1 finding (P2, accepted & fixed):** the responsive hero preload example used `preload_link_tag` with `imagesrcset`/`imagesizes`. Verified against actionview 7.1.6 source (`asset_tag_helper.rb` L343–371): `preload_link_tag` unconditionally sends an HTTP `Link: rel=preload` header built only from the fixed `href`, so browsers honoring the header would fetch the full-size image on every viewport, defeating the responsive preload. Fixed: `preload_link_tag` kept for the single-source hero; responsive hero now uses a plain `<link rel="preload" imagesrcset=... imagesizes=...>` with the rationale documented inline.
2. **Pass 2 (post-fix) — clean:** "I did not find any discrete correctness or build issues in the diff."

Self-review per `.agents/workflows/pr-processing.md` Self-Review Gate also caught one factual issue pre-review: `preprocessed: true` is Rails 7.1+, not "Rails 7+" (fixed).

## Validation evidence

- `pnpm exec prettier --check docs/oss/building-features/fast-images.md docs/oss/building-features/images.md docs/sidebars.ts` → all files use Prettier code style.
- `script/check-docs-sidebar` → ✓ `building-features/fast-images` has a sidebar entry; all new docs accounted for.
- `pnpm exec eslint docs/sidebars.ts` → no errors.
- Snippet syntax checks: all 12 ` ```ruby `/` ```erb ` blocks in `fast-images.md` extracted and checked with `ruby -c` (ERB compiled via `ERB#src`, wrapped in a method body so view-context `yield :preloads` parses) → 12/12 OK.
- `lychee docs/oss/building-features/fast-images.md` → 10/10 links OK, 0 errors (after fixing two `AssetTagHelpers` → `AssetTagHelper` Rails API URLs; corrected URL + anchors verified live via curl, HTTP 200 with both method anchors present).

## Changelog

No entry — docs-only change; `.claude/docs/changelog-guidelines.md` explicitly excludes documentation fixes.

Labels: none — docs-only change; standard path-based CI selection suffices.

## Merge coordination

**This PR must merge SERIALLY with the other Batch-4 docs PRs** — they share `docs/sidebars.ts`, so concurrent merges will conflict. Coordinator should rebase/merge one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> Adds **`docs/oss/building-features/fast-images.md`**, a recipe for fast images in React on Rails using stock Rails (responsive `srcset`/`sizes` via `image_tag` and Active Storage, `responsive_image_props` → `react_component`, CLS sizing, lazy/async defaults, LCP hero + layout `content_for` preloads, AVIF/WebP `<picture>`), with a warning on request-time variant generation and a note that a first-party `<Image>` is tracked in #3874.
> 
> **`images.md`** now states it covers webpack **bundling** only and links to the new page; its **See also** lists Fast Images and Font Optimization. **`docs/sidebars.ts`** registers `building-features/fast-images` under Integrations after `images`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aa4eaccf8e9e40c4051621dd11b4f4e2f5197cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Fast Images" guide covering responsive srcset/sizes, pre-generated format variants, intrinsic sizing to prevent layout shifts, lazy/async defaults, and LCP/hero prioritization with a practical checklist.
  * Clarified the images doc to emphasize bundling (asset imports) and linked to the new Fast Images guide and Font Optimization.
  * Added the new guide to the Integrations sidebar for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->