### PR TITLE
Docs: record decided Server Functions stance in RSC mutations section

### DIFF
--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -810,6 +810,16 @@ For most React on Rails applications, you won't need `React.cache()` for data fe
 
 > **Important:** React on Rails does **not** support Server Actions (`'use server'`). Server Actions run on the Node renderer, which is a rendering server -- it has no access to Rails models, sessions, cookies, or CSRF protection. Do not use `'use server'` in React on Rails applications.
 
+This is a deliberate, settled design decision, not a temporary gap (see the decision record in
+[#3867](https://github.com/shakacode/react_on_rails/issues/3867)): Rails controllers are the mutation
+layer, and the ergonomics gap with Next.js Server Actions is being closed by a first-class Rails-native
+bridge -- a `useRailsForm` hook paired with controller conveniences -- tracked in
+[#3872](https://github.com/shakacode/react_on_rails/issues/3872) and **in development, not yet shipped**.
+Until it ships, the `fetch` + CSRF pattern below is the supported approach. An optional
+`'use server'`-shaped authoring syntax that compiles down to the Rails bridge (for Next.js-migration
+familiarity only) is a deferred follow-up RFC, tracked in
+[#3956](https://github.com/shakacode/react_on_rails/issues/3956).
+
 All mutations in React on Rails should go through Rails controllers via standard forms or API endpoints:
 
 ```jsx


### PR DESCRIPTION
Updates the Mutations section of docs/oss/migrating/rsc-data-fetching.md to reflect the decision recorded on #3867 (maintainer-approved): the 'use server' prohibition is a deliberate settled design choice; the Rails-native bridge (useRailsForm, #3872 / PR #3942) is the chosen v1 path and is explicitly labeled in development, not shipped; the deferred 'use server'-shaped sugar follow-up is linked as #3956.

Single-paragraph docs-only change; the existing fetch + CSRF guidance remains the documented supported approach until #3872 ships.

Closes #3867.

## Codex Decision Log

- **Non-blocking:** whether to close #3867 via this PR.
  - **Decision:** yes — the issue's acceptance criteria are otherwise complete (decision recorded, CSRF story specified, implementation issues #3872 + #3956 filed); this docs update is the last open criterion.
  - **Why:** acceptance-criteria checklist on the issue's decision comment.
  - **Review later:** None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with issue links; no runtime, auth, or mutation code changes.
> 
> **Overview**
> The **Mutations** section in `rsc-data-fetching.md` now states that banning `'use server'` is a **settled design choice** (decision [#3867](https://github.com/shakacode/react_on_rails/issues/3867)), not a temporary limitation.
> 
> The new text names **Rails controllers** as the mutation layer and points to the in-progress **`useRailsForm`** bridge ([#3872](https://github.com/shakacode/react_on_rails/issues/3872)), explicitly marked **not yet shipped**. Until that lands, the doc keeps **`fetch` + CSRF** as the supported path. A deferred optional `'use server'`-style authoring layer that would compile to the Rails bridge is linked as [#3956](https://github.com/shakacode/react_on_rails/issues/3956).
> 
> No behavior or API changes—only documentation aligned with the recorded Server Functions stance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399e4b7114cc4f350edf33e3984ff2ff0aa805ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration documentation with clarification on supported mutation patterns in React on Rails, including Rails controller usage, Server Actions limitations, and the current fetch + CSRF approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->