### PR TITLE
Docs: add OSS flagship demo to examples gallery (closes #3876)

### DIFF
--- a/docs/oss/getting-started/examples-and-references.md
+++ b/docs/oss/getting-started/examples-and-references.md
@@ -13,6 +13,16 @@ starting from.
 Check each entry's note before evaluating — some starters are fully open
 source, while others require React on Rails Pro.
 
+### OSS Flagship Demo (open source)
+
+- Repo: [shakacode/react-on-rails-demo-flagship](https://github.com/shakacode/react-on-rails-demo-flagship)
+- Use it when you want the canonical clone-and-run open-source demo: a real
+  ActiveRecord-backed CRUD task board with server-side rendering, React 19,
+  TypeScript, Redux Toolkit, and Shakapacker + Rspack — no Pro, no RSC.
+- Two run modes: `bin/dev` for local development and `docker compose up` for a
+  deterministic container boot; `bin/smoke` verifies the server-rendered HTML
+  and exits non-zero if SSR fails.
+
 ### SSR + HMR Tutorial Demo (open source)
 
 - Repo: [shakacode/react-on-rails-demo-ssr-hmr](https://github.com/shakacode/react-on-rails-demo-ssr-hmr)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -624,6 +624,16 @@ starting from.
 Check each entry's note before evaluating — some starters are fully open
 source, while others require React on Rails Pro.
 
+### OSS Flagship Demo (open source)
+
+- Repo: [shakacode/react-on-rails-demo-flagship](https://github.com/shakacode/react-on-rails-demo-flagship)
+- Use it when you want the canonical clone-and-run open-source demo: a real
+  ActiveRecord-backed CRUD task board with server-side rendering, React 19,
+  TypeScript, Redux Toolkit, and Shakapacker + Rspack — no Pro, no RSC.
+- Two run modes: `bin/dev` for local development and `docker compose up` for a
+  deterministic container boot; `bin/smoke` verifies the server-rendered HTML
+  and exits non-zero if SSR fails.
+
 ### SSR + HMR Tutorial Demo (open source)
 
 - Repo: [shakacode/react-on-rails-demo-ssr-hmr](https://github.com/shakacode/react-on-rails-demo-ssr-hmr)


### PR DESCRIPTION
## Summary

Adds **[shakacode/react-on-rails-demo-flagship](https://github.com/shakacode/react-on-rails-demo-flagship)** as the first Starter Repo entry in `docs/oss/getting-started/examples-and-references.md`, per the maintainer decision recorded on the issue (standalone repo, one repo / two run modes).

The demo (built and verified in this batch):
- OSS React on Rails 16.6.0, React **19.0.7** (19.0.x line), TypeScript, Shakapacker 10 + **Rspack**, **Redux Toolkit**
- Styled SSR'd CRUD task board, seeded data, visible error states (422 validation + network-failure banner)
- Two run modes: clone-and-run `bin/dev`, and deterministic `docker compose up` with `bin/smoke` exiting non-zero on SSR failure (negative-tested)
- CI smoke on PR + push + weekly cron: [green run](https://github.com/shakacode/react-on-rails-demo-flagship/actions/runs/27402170014)
- SSR proven via curl: raw HTML response contains rendered task-card markup, not just the mount node

Regenerates `llms-full.txt` (drift guard is live).

## Note on PR #3958 overlap

The `llms-full.txt` regeneration here includes the same staleness fix as #3958 (verified byte-identical apart from this PR's new entry). **If #3958 merges first, this branch needs a rebase + regenerate; either merge order converges.**

Closes #3876

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime, auth, or data-handling changes.
> 
> **Overview**
> Documents **[shakacode/react-on-rails-demo-flagship](https://github.com/shakacode/react-on-rails-demo-flagship)** as the **first** Starter Repo in the OSS examples index, positioned as the canonical open-source clone-and-run demo (SSR CRUD task board, React 19, TypeScript, Redux Toolkit, Shakapacker + Rspack; `bin/dev`, Docker, and `bin/smoke` SSR checks).
> 
> The same block is added to **`llms-full.txt`** so the aggregated LLM doc stays in sync with the drift guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab7a9f5fdc4d6aa3c12af823832927ded89bb732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "OSS Flagship Demo (open source)" entry to examples and references, including repository link and brief tech-stack description.
  * Documented supported run modes (local dev and containerized) and a smoke SSR verification step that fails on SSR errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge qualifications

Documented at merge time (maintainer-authorized merge, 2026-06-12):

- **Decision authority:** implements the maintainer decision recorded on #3876 (standalone repo `shakacode/react-on-rails-demo-flagship`, one repo / two run modes).
- **Acceptance criteria met:** demo repo live with green smoke CI on PR + push + weekly cron (run 27402170014); SSR proven via curl (rendered task-card markup in raw HTML, not just the mount node); negative test confirms `bin/smoke` exits non-zero when SSR breaks; clone-and-run `bin/dev` and deterministic `docker compose up` both verified locally end-to-end.
- **Scope:** docs-only in this repo — a 10-line gallery entry in `docs/oss/getting-started/examples-and-references.md` plus its regenerated `llms-full.txt` mirror (20 inserted lines total vs main after rebase).
- **Review state:** all checks green on the pre-rebase head; the single review suggestion (optional version-requirement note) was declined per its own consistency rationale and the thread resolved. Rebase onto post-rc.3 main was mechanical (llms-full regeneration only).
- **Merge sequencing:** lands after PR #3964 (shared llms-full.txt regeneration), with a final rebase + regen + green current-head checks before merge.

## Codex Merge Readiness (2026-06-13)

- **Release mode:** `accelerated-rc` from release gate #3823. This coordinator is not treating the PR as auto-mergeable because the accelerated-RC independent-finalizer requirement is not satisfied by this `justin808` update.
- **Current head SHA:** `ab7a9f5fdc4d6aa3c12af823832927ded89bb732`.
- **CI/check status:** `gh pr checks 3959` refreshed by the coordinator; all current-head checks are passing or path-selected/skipped for this docs-only change (`check-llms-full`, `check-sidebar`, markdown checks, CodeQL, Claude review, CodeRabbit, Cursor Bugbot all complete).
- **Review-thread status:** GraphQL review-thread fetch returned 0 unresolved threads.
- **Review feedback triage:** CodeRabbit approved; Claude review completed; no unresolved current review threads remain. Prior optional version-requirement feedback is already documented as declined/resolved in the existing merge qualifications.
- **Validation run:** Existing PR evidence covers the external flagship demo green smoke run, SSR curl proof, negative smoke proof, and local demo run modes. Coordinator live validation: `gh pr checks 3959` and unresolved review-thread GraphQL fetch on 2026-06-13.
- **Label/CI decision:** Labels: none. This repo diff is docs-only (`docs/oss/getting-started/examples-and-references.md`, `llms-full.txt`); path-selected docs/llms checks are sufficient. No `full-ci` or `benchmark` label recommended.
- **Known residual risk:** Depends on the external demo evidence already linked in the PR body. No repo-code residual risk found. Auto-merge remains blocked only by accelerated-RC finalizer mechanics.
- **Merge recommendation:** Ready for maintainer/finalizer review. Do not auto-merge from this coordinator lane unless a valid independent finalizer/confidence gate is added or a maintainer explicitly chooses the merge path.

## Final Maintainer-Authorized Merge Evidence (2026-06-13)

- **Release mode:** `accelerated-rc` from release gate #3823 (`Mode: accelerated-rc`). This is a maintainer-directed merge after explicit Codex-thread authorization, not unattended auto-merge.
- **Current head SHA:** `ab7a9f5fdc4d6aa3c12af823832927ded89bb732`.
- **CI/check status:** Current-head `gh pr checks 3959` has 14 passing checks and 1 path-selected skip; no failures or pending checks.
- **Review-thread status:** GraphQL review-thread fetch returned 0 unresolved threads.
- **Review feedback triage:** CodeRabbit approved; Claude review completed; no unresolved current-head review threads remain.
- **Fresh demo repository validation:** cloned `shakacode/react-on-rails-demo-flagship` at `9f87298204e2cd8f273f5201a7651c78fa41dcd5`; confirmed public `main` and green GitHub `SSR Smoke` run 27402170014, whose workflow is `docker compose up -d --build && bin/smoke`; ran `bin/ci` locally; ran `SECRET_KEY_BASE_DUMMY=1 bin/rails assets:precompile`; booted Rails locally on port 3030; ran `SMOKE_URL=http://127.0.0.1:3030 bin/smoke` successfully; confirmed raw HTML has 6 `data-testid="task-card"` markers and the seeded SSR title; verified JSON error paths with session CSRF cookie (`422` for blank title, `404` for missing task); verified `bin/smoke` exits non-zero against a healthy fake server with no SSR markers. Local Docker daemon was unavailable due Docker API 500s, so local Docker was not rerun; the demo repo CI covers that exact Docker smoke path.
- **Label/CI decision:** Labels: none. This repo diff is docs-only (`docs/oss/getting-started/examples-and-references.md`, `llms-full.txt`); docs/llms checks are sufficient. No `full-ci` or `benchmark` label needed.
- **Known residual risk:** External demo Docker path relies on the green upstream demo CI rather than this local Docker daemon, which is unhealthy in this desktop session. No repo-code residual risk found.
- **Merge recommendation:** Merge now under maintainer authorization.