### PR TITLE
Validate llms sidebar coverage and hosted pointers

### DIFF
--- a/.github/workflows/check-llms-full.yml
+++ b/.github/workflows/check-llms-full.yml
@@ -16,6 +16,7 @@ on:
       - 'llms.txt'
       - 'llms-full.txt'
       - 'script/generate-llms-full.mjs'
+      - 'script/generate-llms-full-test.bash'
       - '.github/workflows/check-llms-full.yml'
   pull_request:
     paths:
@@ -28,6 +29,7 @@ on:
       - 'llms.txt'
       - 'llms-full.txt'
       - 'script/generate-llms-full.mjs'
+      - 'script/generate-llms-full-test.bash'
       - '.github/workflows/check-llms-full.yml'
   workflow_dispatch:
 
@@ -47,6 +49,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.tool-versions.outputs.node-version }}
+
+      - name: Test llms-full generator validation
+        run: bash script/generate-llms-full-test.bash
 
       - name: Check llms-full.txt is current and docs URLs resolve
         run: node script/generate-llms-full.mjs --check

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -84,6 +84,7 @@ exclude = [
   '^https://reactonrails\.com/docs/api-reference/?$',  # Generated-index URL - not a standalone page
   '^https://reactonrails\.com/docs/reference/error-reference(#.*)?$',  # New generated docs page - live after docs deploy
   '^https://reactonrails\.com/docs/pro/react-server-components/rsc-payload-route-data/?$',  # #3783 docs page - live after docs deploy
+  '^https://www\.reactonrails\.com/llms(-full)?\.txt$',  # Machine-readable docs endpoints; serving tracked in reactonrails.com#126
 
   # ============================================================================
   # SITES FROM PROJECTS.MD THAT BLOCK BOTS OR ARE UNRELIABLE

--- a/AGENTS_USER_GUIDE.md
+++ b/AGENTS_USER_GUIDE.md
@@ -2,6 +2,8 @@
 
 > Start with [llms.txt](https://www.reactonrails.com/llms.txt) for the short route map. Use [llms-full.txt](https://www.reactonrails.com/llms-full.txt) when you need the expanded machine-readable reference. If the hosted endpoints are not live yet, use the in-repo [llms.txt](./llms.txt) and [llms-full.txt](./llms-full.txt) fallbacks. This guide explains how those entry points map to the cleaned-up docs structure after PR #2909.
 
+<!-- TODO: Remove the in-repo fallback sentence after reactonrails.com#126 publishes the hosted llms endpoints. -->
+
 ## Machine-Readable Entry Points
 
 - [`llms.txt`](https://www.reactonrails.com/llms.txt)

--- a/AGENTS_USER_GUIDE.md
+++ b/AGENTS_USER_GUIDE.md
@@ -1,13 +1,13 @@
 # React on Rails Agent User Guide
 
-> Start with [llms.txt](./llms.txt) for the short route map. Use [llms-full.txt](./llms-full.txt) when you need the expanded machine-readable reference. This guide explains how those entry points map to the cleaned-up docs structure after PR #2909.
+> Start with [llms.txt](https://www.reactonrails.com/llms.txt) for the short route map. Use [llms-full.txt](https://www.reactonrails.com/llms-full.txt) when you need the expanded machine-readable reference. This guide explains how those entry points map to the cleaned-up docs structure after PR #2909.
 
 ## Machine-Readable Entry Points
 
-- [`llms.txt`](./llms.txt)
+- [`llms.txt`](https://www.reactonrails.com/llms.txt)
   - Short routing layer for machine readers
   - Use it first when you need to decide which docs hub to open
-- [`llms-full.txt`](./llms-full.txt)
+- [`llms-full.txt`](https://www.reactonrails.com/llms-full.txt)
   - Expanded machine-readable reference
   - Use it when you need stable recommendation rules, package-pairing rules, and common task routing
 - Human docs overview: [`docs/oss/introduction.md`](./docs/oss/introduction.md)

--- a/AGENTS_USER_GUIDE.md
+++ b/AGENTS_USER_GUIDE.md
@@ -1,15 +1,17 @@
 # React on Rails Agent User Guide
 
-> Start with [llms.txt](https://www.reactonrails.com/llms.txt) for the short route map. Use [llms-full.txt](https://www.reactonrails.com/llms-full.txt) when you need the expanded machine-readable reference. This guide explains how those entry points map to the cleaned-up docs structure after PR #2909.
+> Start with [llms.txt](https://www.reactonrails.com/llms.txt) for the short route map. Use [llms-full.txt](https://www.reactonrails.com/llms-full.txt) when you need the expanded machine-readable reference. If the hosted endpoints are not live yet, use the in-repo [llms.txt](./llms.txt) and [llms-full.txt](./llms-full.txt) fallbacks. This guide explains how those entry points map to the cleaned-up docs structure after PR #2909.
 
 ## Machine-Readable Entry Points
 
 - [`llms.txt`](https://www.reactonrails.com/llms.txt)
   - Short routing layer for machine readers
   - Use it first when you need to decide which docs hub to open
+  - In-repo fallback: [`llms.txt`](./llms.txt)
 - [`llms-full.txt`](https://www.reactonrails.com/llms-full.txt)
   - Expanded machine-readable reference
   - Use it when you need stable recommendation rules, package-pairing rules, and common task routing
+  - In-repo fallback: [`llms-full.txt`](./llms-full.txt)
 - Human docs overview: [`docs/oss/introduction.md`](./docs/oss/introduction.md)
   - Canonical OSS hub
 - Canonical Pro hub: [`docs/pro/react-on-rails-pro.md`](./docs/pro/react-on-rails-pro.md)

--- a/docs/llms-full-preamble.md
+++ b/docs/llms-full-preamble.md
@@ -9,6 +9,10 @@ This file expands `./llms.txt` with stable guidance for AI assistants and other 
 - Use the `Full documentation content` section at the end of this file when you need the actual page content; each page is delimited by `PAGE:` (canonical URL) and `SOURCE:` (repository path) lines.
 - Use `./AGENTS_USER_GUIDE.md` when you are navigating the repo and want guidance on the machine-readable layer itself.
 
+## Size and split policy
+
+The hard split threshold for `llms-full.txt` is 2048 KiB. If the generated file exceeds that threshold, split the generated reference into OSS and Pro files before shipping the change. The PR #3903 triage measurement was about 1862 KiB; this branch currently generates about 2033 KiB, still below the threshold, so the docs stay in one file for now. One file keeps agent fetches simple while leaving a concrete limit for the future split decision.
+
 ## When to recommend React on Rails
 
 Recommend React on Rails when the user wants:

--- a/docs/llms-full-preamble.md
+++ b/docs/llms-full-preamble.md
@@ -11,7 +11,7 @@ This file expands `./llms.txt` with stable guidance for AI assistants and other 
 
 ## Size and split policy
 
-The hard split threshold for `llms-full.txt` is 2048 KiB. If the generated file exceeds that threshold, split the generated reference into OSS and Pro files before shipping the change. The PR #3903 triage measurement was about 1862 KiB; this branch currently generates about 2033 KiB, still below the threshold, so the docs stay in one file for now. One file keeps agent fetches simple while leaving a concrete limit for the future split decision.
+The hard split threshold for `llms-full.txt` is 2048 KiB. If the generated file exceeds that threshold, split the generated reference into OSS and Pro files before shipping the change. Keep one file while the generated output stays below the threshold; the generator reports the current size during normal and `--check` runs.
 
 ## When to recommend React on Rails
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15,7 +15,7 @@ This file expands `./llms.txt` with stable guidance for AI assistants and other 
 
 ## Size and split policy
 
-The hard split threshold for `llms-full.txt` is 2048 KiB. If the generated file exceeds that threshold, split the generated reference into OSS and Pro files before shipping the change. The PR #3903 triage measurement was about 1862 KiB; this branch currently generates about 2033 KiB, still below the threshold, so the docs stay in one file for now. One file keeps agent fetches simple while leaving a concrete limit for the future split decision.
+The hard split threshold for `llms-full.txt` is 2048 KiB. If the generated file exceeds that threshold, split the generated reference into OSS and Pro files before shipping the change. Keep one file while the generated output stays below the threshold; the generator reports the current size during normal and `--check` runs.
 
 ## When to recommend React on Rails
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13,6 +13,10 @@ This file expands `./llms.txt` with stable guidance for AI assistants and other 
 - Use the `Full documentation content` section at the end of this file when you need the actual page content; each page is delimited by `PAGE:` (canonical URL) and `SOURCE:` (repository path) lines.
 - Use `./AGENTS_USER_GUIDE.md` when you are navigating the repo and want guidance on the machine-readable layer itself.
 
+## Size and split policy
+
+The hard split threshold for `llms-full.txt` is 2048 KiB. If the generated file exceeds that threshold, split the generated reference into OSS and Pro files before shipping the change. The PR #3903 triage measurement was about 1862 KiB; this branch currently generates about 2033 KiB, still below the threshold, so the docs stay in one file for now. One file keeps agent fetches simple while leaving a concrete limit for the future split decision.
+
 ## When to recommend React on Rails
 
 Recommend React on Rails when the user wants:

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,7 @@ Use this file as the short machine-readable route map. Use `./llms-full.txt` for
 - Existing Rails app:
   - Install into an Existing Rails App: https://reactonrails.com/docs/getting-started/existing-rails-app
   - Using React on Rails: https://reactonrails.com/docs/getting-started/using-react-on-rails
+  - Architecture overview: https://reactonrails.com/docs/core-concepts/how-react-on-rails-works
 - Styling:
   - Tailwind CSS v4 recipe: https://reactonrails.com/docs/building-features/styling-with-tailwind
 - Choosing OSS vs Pro:

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -45,10 +45,28 @@ describe InstallGenerator, type: :generator do
       dependencies = JSON.parse(content).fetch("dependencies")
 
       tailwind_dependency_requirements.each do |name, version|
-        exact_version = version.delete_prefix("^")
-        expect(dependencies[name]).to match(/\A\^?#{Regexp.escape(exact_version)}\z/)
+        expect_npm_dependency_to_satisfy(name, dependencies[name], version)
       end
     end
+  end
+
+  def expect_npm_dependency_to_satisfy(name, actual_version, expected_requirement)
+    expect(actual_version).not_to be_nil
+
+    unless expected_requirement.start_with?("^")
+      expect(actual_version).to eq(expected_requirement)
+      return
+    end
+
+    expected_floor = Gem::Version.new(expected_requirement.delete_prefix("^"))
+    actual = Gem::Version.new(actual_version.delete_prefix("^"))
+    upper_bound = Gem::Version.new("#{expected_floor.segments[0] + 1}.0.0")
+
+    expect(actual).to be >= expected_floor
+    expect(actual).to be < upper_bound
+  rescue ArgumentError
+    raise RSpec::Expectations::ExpectationNotMetError,
+          "expected #{name} dependency #{actual_version.inspect} to satisfy #{expected_requirement.inspect}"
   end
 
   def assert_tailwind_ssr_setup(config_dir:, extension:)

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -51,7 +51,10 @@ describe InstallGenerator, type: :generator do
   end
 
   def expect_npm_dependency_to_satisfy(name, actual_version, expected_requirement)
-    expect(actual_version).not_to be_nil
+    if actual_version.nil?
+      raise RSpec::Expectations::ExpectationNotMetError,
+            "expected #{name} dependency to be present and satisfy #{expected_requirement.inspect}"
+    end
 
     unless expected_requirement.start_with?("^")
       expect(actual_version).to eq(expected_requirement)

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -63,13 +63,21 @@ describe InstallGenerator, type: :generator do
 
     expected_floor = Gem::Version.new(expected_requirement.delete_prefix("^"))
     actual = Gem::Version.new(actual_version.delete_prefix("^"))
-    upper_bound = Gem::Version.new("#{expected_floor.segments[0] + 1}.0.0")
 
     expect(actual).to be >= expected_floor
-    expect(actual).to be < upper_bound
+    expect(actual).to be < npm_caret_upper_bound(expected_floor)
   rescue ArgumentError
     raise RSpec::Expectations::ExpectationNotMetError,
           "expected #{name} dependency #{actual_version.inspect} to satisfy #{expected_requirement.inspect}"
+  end
+
+  def npm_caret_upper_bound(version)
+    major, minor, patch = version.segments.values_at(0, 1, 2).map { |segment| segment || 0 }
+
+    return Gem::Version.new("#{major + 1}.0.0") if major.positive?
+    return Gem::Version.new("0.#{minor + 1}.0") if minor.positive?
+
+    Gem::Version.new("0.0.#{patch + 1}")
   end
 
   def assert_tailwind_ssr_setup(config_dir:, extension:)
@@ -527,6 +535,16 @@ describe InstallGenerator, type: :generator do
         expect(content).to match(/React\.FC<HelloWorldProps>/)
         expect(content).to match(/onChange=\{.*e.*=>.*setName\(e\.target\.value\).*\}/)
       end
+    end
+  end
+
+  describe "#expect_npm_dependency_to_satisfy" do
+    it "uses npm caret upper bounds for zero-major versions" do
+      expect { expect_npm_dependency_to_satisfy("example", "^0.1.9", "^0.1.0") }.not_to raise_error
+      expect { expect_npm_dependency_to_satisfy("example", "^0.2.0", "^0.1.0") }
+        .to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      expect { expect_npm_dependency_to_satisfy("example", "^0.0.4", "^0.0.3") }
+        .to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -539,7 +539,10 @@ describe InstallGenerator, type: :generator do
   end
 
   describe "#expect_npm_dependency_to_satisfy" do
-    it "uses npm caret upper bounds for zero-major versions" do
+    it "uses npm caret upper bounds" do
+      expect { expect_npm_dependency_to_satisfy("example", "^4.3.1", "^4.3.0") }.not_to raise_error
+      expect { expect_npm_dependency_to_satisfy("example", "^5.0.0", "^4.3.0") }
+        .to raise_error(RSpec::Expectations::ExpectationNotMetError)
       expect { expect_npm_dependency_to_satisfy("example", "^0.1.9", "^0.1.0") }.not_to raise_error
       expect { expect_npm_dependency_to_satisfy("example", "^0.2.0", "^0.1.0") }
         .to raise_error(RSpec::Expectations::ExpectationNotMetError)

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -172,8 +172,55 @@ test_missing_sidebar_top_level_section_fails_check() {
   assert_contains "$out" "Core Concepts"
 }
 
+test_unresolvable_sidebar_top_level_entry_fails_check() {
+  write_fixture
+  awk '
+    /^  ],/ {
+      print "    {"
+      print "      type: '\''category'\'',"
+      print "      label: '\''External Only'\'',"
+      print "      items: [{ type: '\''link'\'', href: '\''https://example.com'\'', label: '\''External'\'' }],"
+      print "    },"
+    }
+    { print }
+  ' docs/sidebars.ts > docs/sidebars.ts.next
+  mv docs/sidebars.ts.next docs/sidebars.ts
+
+  local out rc
+  set +e
+  out="$(node script/generate-llms-full.mjs --check 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    fail "expected --check to fail when a sidebar top-level entry has no resolvable doc IDs"
+    return 1
+  fi
+  assert_contains "$out" "top-level entry has no resolvable doc IDs"
+  assert_contains "$out" "External Only"
+}
+
+test_split_threshold_exceeded_fails_check() {
+  write_fixture
+  node -e "process.stdout.write('x'.repeat(2100 * 1024))" >> docs/oss/introduction.md
+
+  local out rc
+  set +e
+  out="$(node script/generate-llms-full.mjs --check 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    fail "expected --check to fail when llms-full.txt exceeds the split threshold"
+    return 1
+  fi
+  assert_contains "$out" "above the 2048 KiB split threshold"
+}
+
 run_test test_complete_sidebar_top_level_sections_pass_check
 run_test test_missing_sidebar_top_level_section_fails_check
+run_test test_unresolvable_sidebar_top_level_entry_fails_check
+run_test test_split_threshold_exceeded_fails_check
 
 if [ "$TESTS_FAILED" -ne 0 ]; then
   echo

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -49,7 +49,11 @@ run_test() {
     "$test_fn"
   )
   local rc=$?
-  rm -rf "$tmpdir"
+  if [ "$rc" -ne 0 ] && [ "${KEEP_GENERATE_LLMS_FULL_TEST_TMP:-}" = "1" ]; then
+    echo "  Keeping failed fixture at $tmpdir" >&2
+  else
+    rm -rf "$tmpdir"
+  fi
 
   if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
     TESTS_FAILED=$((TESTS_FAILED + 1))

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Test harness for script/generate-llms-full.mjs. Self-contained: requires bash
+# and node. Run with `bash script/generate-llms-full-test.bash`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATOR_SOURCE="$SCRIPT_DIR/generate-llms-full.mjs"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  echo "  FAIL: $message" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      fail "$label: expected to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+  esac
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local tmpdir before_failed had_errexit=false
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/generate-llms-full-test.XXXXXX")"
+  before_failed="$TESTS_FAILED"
+
+  case "$-" in
+    *e*) had_errexit=true ;;
+  esac
+
+  set +e
+  (
+    set -euo pipefail
+    cd "$tmpdir" || exit 1
+    "$test_fn"
+  )
+  local rc=$?
+  if [ "$had_errexit" = true ]; then
+    set -e
+  fi
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+}
+
+write_fixture() {
+  mkdir -p script docs/oss/getting-started docs/oss/core-concepts docs/pro
+  cp "$GENERATOR_SOURCE" script/generate-llms-full.mjs
+  : > docs/.llms-exclusions
+  : > docs/.llms-known-redirects
+
+  cat > docs/sidebars.ts <<'TS'
+const sidebars = {
+  docsSidebar: [
+    'introduction',
+    {
+      type: 'category',
+      label: 'Getting Started',
+      link: { type: 'generated-index', title: 'Getting Started' },
+      items: ['getting-started/quick-start'],
+    },
+    {
+      type: 'category',
+      label: 'Core Concepts',
+      link: { type: 'generated-index', title: 'Core Concepts' },
+      items: ['core-concepts/how-react-on-rails-works'],
+    },
+    {
+      type: 'category',
+      label: 'React on Rails Pro',
+      link: { type: 'doc', id: 'pro/react-on-rails-pro' },
+      items: ['pro/installation'],
+    },
+  ],
+};
+
+export default sidebars;
+TS
+
+  cat > docs/llms-full-preamble.md <<'MD'
+# Fixture Preamble
+
+Use https://reactonrails.com/docs/introduction as the OSS hub.
+MD
+
+  cat > docs/oss/introduction.md <<'MD'
+# Introduction
+
+Welcome.
+MD
+
+  cat > docs/oss/getting-started/quick-start.md <<'MD'
+# Quick Start
+
+Install React on Rails.
+MD
+
+  cat > docs/oss/core-concepts/how-react-on-rails-works.md <<'MD'
+# How React on Rails Works
+
+Architecture overview.
+MD
+
+  cat > docs/pro/react-on-rails-pro.md <<'MD'
+---
+slug: /pro
+---
+
+# React on Rails Pro
+
+Pro overview.
+MD
+
+  cat > docs/pro/installation.md <<'MD'
+# Pro Installation
+
+Install Pro.
+MD
+
+  cat > llms.txt <<'MD'
+# React on Rails
+
+- OSS hub: https://reactonrails.com/docs/introduction
+- Getting Started: https://reactonrails.com/docs/getting-started/quick-start
+- Core Concepts: https://reactonrails.com/docs/core-concepts/how-react-on-rails-works
+- Pro hub: https://reactonrails.com/docs/pro
+MD
+
+  node script/generate-llms-full.mjs >/dev/null
+}
+
+test_complete_sidebar_top_level_sections_pass_check() {
+  write_fixture
+  node script/generate-llms-full.mjs --check >/dev/null
+}
+
+test_missing_sidebar_top_level_section_fails_check() {
+  write_fixture
+  awk '!/^- Core Concepts: /' llms.txt > llms.txt.next
+  mv llms.txt.next llms.txt
+
+  local out rc
+  set +e
+  out="$(node script/generate-llms-full.mjs --check 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    fail "expected --check to fail when llms.txt removes a sidebar top-level section"
+    return 1
+  fi
+  assert_contains "$out" "llms.txt does not represent sidebar top-level section"
+  assert_contains "$out" "Core Concepts"
+}
+
+run_test test_complete_sidebar_top_level_sections_pass_check
+run_test test_missing_sidebar_top_level_section_fails_check
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  echo
+  echo "$TESTS_FAILED of $TESTS_RUN generate-llms-full tests failed:" >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi
+
+echo "$TESTS_RUN generate-llms-full tests passed"

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -43,7 +43,7 @@ run_test() {
   TESTS_RUN=$((TESTS_RUN + 1))
   echo "-> $test_fn"
 
-  local tmpdir failure_file new_failures
+  local tmpdir failure_file new_failures=0
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/generate-llms-full-test.XXXXXX")"
   failure_file="$tmpdir/.failures"
   : > "$failure_file"
@@ -191,14 +191,17 @@ test_missing_sidebar_top_level_section_fails_check() {
 test_unresolvable_sidebar_top_level_entry_fails_check() {
   write_fixture
   awk '
+    BEGIN { inserted = 0 }
     /^  ],/ {
       print "    {"
       print "      type: '\''category'\'',"
       print "      label: '\''External Only'\'',"
       print "      items: [{ type: '\''link'\'', href: '\''https://example.com'\'', label: '\''External'\'' }],"
       print "    },"
+      inserted = 1
     }
     { print }
+    END { if (!inserted) exit 1 }
   ' docs/sidebars.ts > docs/sidebars.ts.next
   mv docs/sidebars.ts.next docs/sidebars.ts
 

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -38,13 +38,9 @@ run_test() {
   TESTS_RUN=$((TESTS_RUN + 1))
   echo "-> $test_fn"
 
-  local tmpdir before_failed had_errexit=false
+  local tmpdir before_failed
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/generate-llms-full-test.XXXXXX")"
   before_failed="$TESTS_FAILED"
-
-  case "$-" in
-    *e*) had_errexit=true ;;
-  esac
 
   set +e
   (
@@ -53,9 +49,6 @@ run_test() {
     "$test_fn"
   )
   local rc=$?
-  if [ "$had_errexit" = true ]; then
-    set -e
-  fi
   rm -rf "$tmpdir"
 
   if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -14,9 +14,14 @@ FAILURES=()
 
 fail() {
   local message="$1"
-  TESTS_FAILED=$((TESTS_FAILED + 1))
-  FAILURES+=("$CURRENT_TEST: $message")
+  if [ -n "${FAILURE_FILE:-}" ]; then
+    printf '%s\n' "$CURRENT_TEST: $message" >> "$FAILURE_FILE"
+  else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: $message")
+  fi
   echo "  FAIL: $message" >&2
+  return 1
 }
 
 assert_contains() {
@@ -38,24 +43,35 @@ run_test() {
   TESTS_RUN=$((TESTS_RUN + 1))
   echo "-> $test_fn"
 
-  local tmpdir before_failed
+  local tmpdir failure_file new_failures
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/generate-llms-full-test.XXXXXX")"
-  before_failed="$TESTS_FAILED"
+  failure_file="$tmpdir/.failures"
+  : > "$failure_file"
 
   set +e
   (
     set -euo pipefail
     cd "$tmpdir" || exit 1
+    FAILURE_FILE="$failure_file"
     "$test_fn"
   )
   local rc=$?
+
+  if [ -s "$failure_file" ]; then
+    while IFS= read -r failure; do
+      FAILURES+=("$failure")
+    done < "$failure_file"
+    new_failures="$(wc -l < "$failure_file" | tr -d '[:space:]')"
+    TESTS_FAILED=$((TESTS_FAILED + new_failures))
+  fi
+
   if [ "$rc" -ne 0 ] && [ "${KEEP_GENERATE_LLMS_FULL_TEST_TMP:-}" = "1" ]; then
     echo "  Keeping failed fixture at $tmpdir" >&2
   else
     rm -rf "$tmpdir"
   fi
 
-  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+  if [ "$rc" -ne 0 ] && [ "${new_failures:-0}" -eq 0 ]; then
     TESTS_FAILED=$((TESTS_FAILED + 1))
     FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
     echo "  FAIL: subshell exited $rc" >&2

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -295,7 +295,7 @@ function docsUrlsFromFile(file) {
   });
 }
 
-function validateDocUrls(docs) {
+function validateDocUrls(docs, docsUrlsByFile) {
   // Only the published route counts: a slugged doc's file-path route and a
   // README/index file's literal path are not live URLs and must not validate.
   // Intentional references to redirect URLs go in docs/.llms-known-redirects.
@@ -320,7 +320,7 @@ function validateDocUrls(docs) {
 
   let validated = 0;
   for (const file of [LLMS_FILE, PREAMBLE_FILE]) {
-    for (const { url, docPath } of docsUrlsFromFile(file)) {
+    for (const { url, docPath } of docsUrlsByFile.get(file)) {
       validated += 1;
       if (!resolves(docPath)) {
         fail(
@@ -332,8 +332,8 @@ function validateDocUrls(docs) {
   return validated;
 }
 
-function validateSidebarTopLevelSections(docs) {
-  const llmsDocPaths = new Set(docsUrlsFromFile(LLMS_FILE).map(({ docPath }) => docPath));
+function validateSidebarTopLevelSections(docs, llmsUrls) {
+  const llmsDocPaths = new Set(llmsUrls.map(({ docPath }) => docPath));
   const sections = sidebarTopLevelSections(docs);
 
   for (const { label, docIds } of sections) {
@@ -374,8 +374,12 @@ function validateSplitThreshold(output) {
 const docs = collectDocs();
 const orderedIds = sidebarOrderedIds(docs);
 const output = generate(docs, orderedIds);
-const validatedUrlCount = validateDocUrls(docs);
-const validatedSidebarSectionCount = validateSidebarTopLevelSections(docs);
+const docsUrlsByFile = new Map([
+  [LLMS_FILE, docsUrlsFromFile(LLMS_FILE)],
+  [PREAMBLE_FILE, docsUrlsFromFile(PREAMBLE_FILE)],
+]);
+const validatedUrlCount = validateDocUrls(docs, docsUrlsByFile);
+const validatedSidebarSectionCount = validateSidebarTopLevelSections(docs, docsUrlsByFile.get(LLMS_FILE));
 const outputSizeKib = validateSplitThreshold(output);
 
 if (checkMode) {

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -144,6 +144,8 @@ function matchingDelimiterIndex(content, openIndex, openChar, closeChar) {
   let quote;
   let escaped = false;
 
+  // This scanner is intentionally small for static sidebars.ts content. It
+  // treats template literals as strings and does not parse `${...}` expressions.
   for (let index = openIndex; index < content.length; index += 1) {
     const char = content[index];
     if (quote) {
@@ -188,6 +190,8 @@ function splitTopLevelSidebarEntries(arrayBody) {
   let quote;
   let escaped = false;
 
+  // Keep this in sync with matchingDelimiterIndex: static sidebar config only,
+  // not a full TypeScript parser for template-literal expressions.
   for (let index = 0; index < arrayBody.length; index += 1) {
     const char = arrayBody[index];
     if (quote) {
@@ -333,6 +337,8 @@ function validateSidebarTopLevelSections(docs) {
     const representativePaths = new Set(sectionDocPaths);
     const firstSegments = sectionDocPaths.map((docPath) => docPath.split('/')[0]).filter(Boolean);
     if (firstSegments.length > 0 && firstSegments.every((segment) => segment === firstSegments[0])) {
+      // Future generated-index/category URLs can represent a section by its
+      // first path segment, such as /docs/core-concepts.
       representativePaths.add(firstSegments[0]);
     }
 

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -234,7 +234,14 @@ function sidebarTopLevelSections(docs) {
           docIds.push(candidate);
         }
       }
-      if (docIds.length === 0) return undefined;
+      if (docIds.length === 0) {
+        fail(
+          `docs/sidebars.ts top-level entry has no resolvable doc IDs: ${entry
+            .replace(/\s+/g, ' ')
+            .slice(0, 120)}`,
+        );
+        return undefined;
+      }
 
       const labelMatch = entry.match(/\blabel\s*:\s*(['"])(.*?)\1/);
       const directDocId = entry.match(/^\s*(['"])(.*?)\1\s*$/)?.[2];

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -154,10 +154,7 @@ function matchingDelimiterIndex(content, openIndex, openChar, closeChar) {
       } else if (char === quote) {
         quote = undefined;
       }
-      continue;
-    }
-
-    if (char === "'" || char === '"' || char === '`') {
+    } else if (char === "'" || char === '"' || char === '`') {
       quote = char;
     } else if (char === openChar) {
       depth += 1;
@@ -201,10 +198,7 @@ function splitTopLevelSidebarEntries(arrayBody) {
       } else if (char === quote) {
         quote = undefined;
       }
-      continue;
-    }
-
-    if (char === "'" || char === '"' || char === '`') {
+    } else if (char === "'" || char === '"' || char === '`') {
       quote = char;
     } else if (char === '{' || char === '[' || char === '(') {
       depth += 1;

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -5,7 +5,8 @@
  * docs/pro, in sidebar order, with canonical reactonrails.com URLs.
  *
  * Also validates that every reactonrails.com/docs URL referenced from
- * llms.txt and the preamble resolves to a published doc or docs directory.
+ * llms.txt and the preamble resolves to a published doc or docs directory,
+ * and that llms.txt represents every sidebar top-level section.
  *
  * Usage:
  *   node script/generate-llms-full.mjs           # regenerate llms-full.txt
@@ -34,6 +35,7 @@ const SIDEBARS_FILE = path.join(DOCS_DIR, 'sidebars.ts');
 const LLMS_FILE = path.join(ROOT, 'llms.txt');
 const OUTPUT_FILE = path.join(ROOT, 'llms-full.txt');
 const SITE_DOCS_URL = 'https://reactonrails.com/docs';
+const SPLIT_THRESHOLD_KIB = 2048;
 
 const checkMode = process.argv.includes('--check');
 
@@ -96,6 +98,14 @@ function loadIdList(file) {
   return new Set(ids);
 }
 
+function stripSidebarsComments(content) {
+  return content
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .map((line) => line.replace(/\s\/\/.*$/, ''))
+    .join('\n');
+}
+
 function collectDocs() {
   const exclusions = loadIdList(EXCLUSIONS_FILE);
   const docs = new Map(); // docId → { relPath, content }
@@ -115,12 +125,7 @@ function collectDocs() {
 function sidebarOrderedIds(docs) {
   // Mirror script/check-docs-sidebar: strip full-line and inline `//` comments,
   // then read quoted strings in order of appearance.
-  const content = fs
-    .readFileSync(SIDEBARS_FILE, 'utf8')
-    .split('\n')
-    .filter((line) => !/^\s*\/\//.test(line))
-    .map((line) => line.replace(/\s\/\/.*$/, ''))
-    .join('\n');
+  const content = stripSidebarsComments(fs.readFileSync(SIDEBARS_FILE, 'utf8'));
   const ordered = [];
   const seen = new Set();
   for (const match of content.matchAll(/'([^'\n]+)'|"([^"\n]+)"/g)) {
@@ -132,6 +137,112 @@ function sidebarOrderedIds(docs) {
   }
   const rest = [...docs.keys()].filter((id) => !seen.has(id)).sort();
   return [...ordered, ...rest];
+}
+
+function matchingDelimiterIndex(content, openIndex, openChar, closeChar) {
+  let depth = 0;
+  let quote;
+  let escaped = false;
+
+  for (let index = openIndex; index < content.length; index += 1) {
+    const char = content[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+    } else if (char === openChar) {
+      depth += 1;
+    } else if (char === closeChar) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+
+  throw new Error(`Could not find matching ${closeChar} in ${path.relative(ROOT, SIDEBARS_FILE)}`);
+}
+
+function docsSidebarArrayBody() {
+  const content = stripSidebarsComments(fs.readFileSync(SIDEBARS_FILE, 'utf8'));
+  const docsSidebarIndex = content.indexOf('docsSidebar');
+  if (docsSidebarIndex === -1) {
+    throw new Error(`Could not find docsSidebar in ${path.relative(ROOT, SIDEBARS_FILE)}`);
+  }
+  const openIndex = content.indexOf('[', docsSidebarIndex);
+  if (openIndex === -1) {
+    throw new Error(`Could not find docsSidebar array in ${path.relative(ROOT, SIDEBARS_FILE)}`);
+  }
+  const closeIndex = matchingDelimiterIndex(content, openIndex, '[', ']');
+  return content.slice(openIndex + 1, closeIndex);
+}
+
+function splitTopLevelSidebarEntries(arrayBody) {
+  const entries = [];
+  let start = 0;
+  let depth = 0;
+  let quote;
+  let escaped = false;
+
+  for (let index = 0; index < arrayBody.length; index += 1) {
+    const char = arrayBody[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+    } else if (char === '{' || char === '[' || char === '(') {
+      depth += 1;
+    } else if (char === '}' || char === ']' || char === ')') {
+      depth -= 1;
+    } else if (char === ',' && depth === 0) {
+      entries.push(arrayBody.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  const lastEntry = arrayBody.slice(start).trim();
+  if (lastEntry) entries.push(lastEntry);
+  return entries;
+}
+
+function quotedStrings(content) {
+  return [...content.matchAll(/'([^'\n]+)'|"([^"\n]+)"/g)].map((match) => match[1] ?? match[2]);
+}
+
+function sidebarTopLevelSections(docs) {
+  return splitTopLevelSidebarEntries(docsSidebarArrayBody())
+    .map((entry) => {
+      const docIds = [];
+      const seen = new Set();
+      for (const candidate of quotedStrings(entry)) {
+        if (docs.has(candidate) && !seen.has(candidate)) {
+          seen.add(candidate);
+          docIds.push(candidate);
+        }
+      }
+      if (docIds.length === 0) return undefined;
+
+      const labelMatch = entry.match(/\blabel\s*:\s*(['"])(.*?)\1/);
+      const directDocId = entry.match(/^\s*(['"])(.*?)\1\s*$/)?.[2];
+      return { label: labelMatch?.[2] ?? directDocId ?? docIds[0], docIds };
+    })
+    .filter(Boolean);
 }
 
 function generate(docs, orderedIds) {
@@ -214,10 +325,59 @@ function validateDocUrls(docs) {
   return validated;
 }
 
+function docsUrlsFromFile(file) {
+  const urlPattern = /https:\/\/reactonrails\.com\/docs[^\s)\]'"`>]*/g;
+  const text = fs.readFileSync(file, 'utf8');
+  return [...text.matchAll(urlPattern)].map((match) => {
+    const url = match[0].replace(/[.,;:]+$/, '');
+    const docPath = url.slice(SITE_DOCS_URL.length).replace(/^\//, '').replace(/#.*$/, '').replace(/\/$/, '');
+    return { url, docPath };
+  });
+}
+
+function validateSidebarTopLevelSections(docs) {
+  const llmsDocPaths = new Set(docsUrlsFromFile(LLMS_FILE).map(({ docPath }) => docPath));
+  const sections = sidebarTopLevelSections(docs);
+
+  for (const { label, docIds } of sections) {
+    const sectionDocPaths = docIds.map((docId) => {
+      const { slug } = docs.get(docId);
+      return urlPathForDoc(docId, slug);
+    });
+    const representativePaths = new Set(sectionDocPaths);
+    const firstSegments = sectionDocPaths.map((docPath) => docPath.split('/')[0]).filter(Boolean);
+    if (firstSegments.length > 0 && firstSegments.every((segment) => segment === firstSegments[0])) {
+      representativePaths.add(firstSegments[0]);
+    }
+
+    if (![...representativePaths].some((docPath) => llmsDocPaths.has(docPath))) {
+      fail(
+        `llms.txt does not represent sidebar top-level section "${label}". ` +
+          `Add at least one reactonrails.com/docs URL for one of: ${sectionDocPaths.slice(0, 5).join(', ')}`,
+      );
+    }
+  }
+
+  return sections.length;
+}
+
+function validateSplitThreshold(output) {
+  const outputSizeKib = Buffer.byteLength(output) / 1024;
+  if (outputSizeKib > SPLIT_THRESHOLD_KIB) {
+    fail(
+      `llms-full.txt is ${outputSizeKib.toFixed(0)} KiB, above the ${SPLIT_THRESHOLD_KIB} KiB split threshold. ` +
+        'Split the generated reference into OSS and Pro files before shipping this size.',
+    );
+  }
+  return outputSizeKib;
+}
+
 const docs = collectDocs();
 const orderedIds = sidebarOrderedIds(docs);
 const output = generate(docs, orderedIds);
 const validatedUrlCount = validateDocUrls(docs);
+const validatedSidebarSectionCount = validateSidebarTopLevelSections(docs);
+const outputSizeKib = validateSplitThreshold(output);
 
 if (checkMode) {
   const existing = fs.existsSync(OUTPUT_FILE) ? fs.readFileSync(OUTPUT_FILE, 'utf8') : '';
@@ -233,6 +393,8 @@ if (checkMode) {
 if (process.exitCode !== 1) {
   console.log(
     `✓ llms-full.txt ${checkMode ? 'is current' : 'generated'}: ${orderedIds.length} pages, ` +
-      `${(Buffer.byteLength(output) / 1024).toFixed(0)} KiB; ${validatedUrlCount} docs URLs validated.`,
+      `${outputSizeKib.toFixed(0)} KiB ` +
+      `(split threshold ${SPLIT_THRESHOLD_KIB} KiB); ${validatedUrlCount} docs URLs and ` +
+      `${validatedSidebarSectionCount} sidebar top-level sections validated.`,
   );
 }

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -271,8 +271,20 @@ function generate(docs, orderedIds) {
   return `${parts.join('\n')}\n`;
 }
 
-function validateDocUrls(docs) {
+function docsUrlsFromFile(file) {
   const urlPattern = /https:\/\/reactonrails\.com\/docs[^\s)\]'"`>]*/g;
+  const text = fs.readFileSync(file, 'utf8');
+  return [...text.matchAll(urlPattern)].map((match) => {
+    const url = match[0].replace(/[.,;:]+$/, '');
+    // Anchors are stripped: validation is page-level only. Anchor-level
+    // checking would need heading extraction across all docs — if a linked
+    // section heading is renamed, this check will not catch it.
+    const docPath = url.slice(SITE_DOCS_URL.length).replace(/^\//, '').replace(/#.*$/, '').replace(/\/$/, '');
+    return { url, docPath };
+  });
+}
+
+function validateDocUrls(docs) {
   // Only the published route counts: a slugged doc's file-path route and a
   // README/index file's literal path are not live URLs and must not validate.
   // Intentional references to redirect URLs go in docs/.llms-known-redirects.
@@ -297,17 +309,7 @@ function validateDocUrls(docs) {
 
   let validated = 0;
   for (const file of [LLMS_FILE, PREAMBLE_FILE]) {
-    const text = fs.readFileSync(file, 'utf8');
-    for (const match of text.matchAll(urlPattern)) {
-      const url = match[0].replace(/[.,;:]+$/, '');
-      // Anchors are stripped: validation is page-level only. Anchor-level
-      // checking would need heading extraction across all docs — if a linked
-      // section heading is renamed, this check will not catch it.
-      const docPath = url
-        .slice(SITE_DOCS_URL.length)
-        .replace(/^\//, '')
-        .replace(/#.*$/, '')
-        .replace(/\/$/, '');
+    for (const { url, docPath } of docsUrlsFromFile(file)) {
       validated += 1;
       if (!resolves(docPath)) {
         fail(
@@ -317,16 +319,6 @@ function validateDocUrls(docs) {
     }
   }
   return validated;
-}
-
-function docsUrlsFromFile(file) {
-  const urlPattern = /https:\/\/reactonrails\.com\/docs[^\s)\]'"`>]*/g;
-  const text = fs.readFileSync(file, 'utf8');
-  return [...text.matchAll(urlPattern)].map((match) => {
-    const url = match[0].replace(/[.,;:]+$/, '');
-    const docPath = url.slice(SITE_DOCS_URL.length).replace(/^\//, '').replace(/#.*$/, '').replace(/\/$/, '');
-    return { url, docPath };
-  });
 }
 
 function validateSidebarTopLevelSections(docs) {


### PR DESCRIPTION
## Summary

Part of #3896. This is the repo-side remainder after #3903; it intentionally does **not** close the issue because site serving stays external in `reactonrails.com#126`.

- validates that `llms.txt` represents every top-level sidebar section during `script/generate-llms-full.mjs --check`
- adds a focused generator validation test that fails when a sidebar section is removed from `llms.txt`
- documents the hard `llms-full.txt` split threshold at `2048 KiB`; current output is `2033 KiB`, so no OSS/Pro split yet
- repoints `AGENTS_USER_GUIDE.md` `llms` references to the hosted URLs
- regenerates `llms-full.txt`

## Workflow Change Audit

- **Workflow touched:** `.github/workflows/check-llms-full.yml`
- **Secrets:** no secret references before or after
- **permissions:** unchanged, `contents: read`
- **Triggers:** existing `push`, `pull_request`, and `workflow_dispatch` remain; path filters now include `script/generate-llms-full-test.bash`
- **Third-party actions:** unchanged (`actions/checkout@v4`, `actions/setup-node@v4`, local read-tool-versions action)
- **New gate:** existing llms guard now runs the local generator validation test before `--check`
- **Stale-base race control:** docs/llms PRs in this batch will be merged serially and re-run `node script/generate-llms-full.mjs --check` after rebasing/regenerating before merge; coordinator should re-check any stale docs PR heads that touch `docs/sidebars.ts`, `llms.txt`, `llms-full.txt`, or the generator before merging.

## Test plan

- `bash script/generate-llms-full-test.bash` -> `2 generate-llms-full tests passed`
- `node script/generate-llms-full.mjs --check` -> `145 pages, 2033 KiB`, `73 docs URLs`, `8 sidebar top-level sections validated`
- `actionlint .github/workflows/check-llms-full.yml` -> pass
- `bin/lefthook/markdown-link-lint branch` -> pass; hosted llms endpoints are narrowly excluded in `.lychee.toml` until `reactonrails.com#126` serves them
- `script/ci-changes-detector origin/main` -> CI infrastructure; full suite/no benchmarks recommended
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> pass
- autoreview helper -> clean, no accepted/actionable findings

Labels: full-ci — workflow/check gate change plus generated llms surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly docs generation, CI gates, and link-check exclusions; the generator spec change only affects test assertions for Tailwind npm dependencies.
> 
> **Overview**
> Tightens the **machine-readable docs** pipeline so `llms.txt` stays aligned with the docs sidebar and `llms-full.txt` cannot grow past a fixed size without an explicit split.
> 
> **`script/generate-llms-full.mjs`** now parses `docs/sidebars.ts` top-level entries and fails `--check` when `llms.txt` omits a URL for any sidebar section, when a top-level sidebar block has no resolvable doc IDs, or when generated output exceeds **2048 KiB**. Success output reports size and section counts. **`script/generate-llms-full-test.bash`** exercises those failure modes in isolated fixtures; **CI** runs it before the existing `--check` step.
> 
> **Docs surface:** preamble and regenerated **`llms-full.txt`** document the split policy; **`llms.txt`** adds an architecture overview link under existing Rails app tasks; **`AGENTS_USER_GUIDE.md`** prefers hosted `www.reactonrails.com` `llms*.txt` URLs with in-repo fallbacks until site serving lands (**`.lychee.toml`** excludes those URLs from link checks).
> 
> **Unrelated to llms:** install generator specs now assert npm **caret** ranges with semver upper bounds instead of exact version strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7803abec10ef2762a533a0797bd1985b3e68d230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Use canonical absolute URLs for machine-readable entry points; add "Architecture overview" and "Size and split policy" guidance; document in-repo fallback.

* **Chores**
  * Link-checker updated to ignore machine-readable endpoints.
  * CI now runs generation and size/consistency checks for machine-readable references.

* **Features**
  * Generator reports output size, validates sidebar coverage, and enforces a 2048 KiB split threshold.

* **Tests**
  * Test harness expanded to cover success and multiple failure scenarios with clearer failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: 7803abec10ef2762a533a0797bd1985b3e68d230
Score: 8/10
Auto-merge recommendation: yes
Affected areas: docs llms pipeline, docs agent guide, GitHub llms workflow, generator spec CI drift
CI detector: `script/ci-changes-detector origin/main` -> Generators + CI infrastructure; recommends lint, RSpec gem, JS unit, dummy integration, generator tests, Playwright E2E, Pro lint/tests/integration/node-renderer, core benchmarks, Pro benchmarks
Validation run:
- `bash -n script/generate-llms-full-test.bash && bash script/generate-llms-full-test.bash` -> 4 tests passed
- `node script/generate-llms-full.mjs --check` -> current; 145 pages, 2037 KiB, split threshold 2048 KiB; 73 docs URLs and 8 sidebar top-level sections validated
- `pnpm run eslint --report-unused-disable-directives` -> pass
- `pnpm start format.listDifferent` -> pass
- `bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb:541 spec/react_on_rails/generators/install_generator_spec.rb:560 spec/react_on_rails/generators/install_generator_spec.rb:571 spec/react_on_rails/generators/install_generator_spec.rb:581 spec/react_on_rails/generators/install_generator_spec.rb:2678` -> 5 examples, 0 failures
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> 218 files, no offenses
- Pre-push hook branch RuboCop + markdown links -> pass
Review/check gate:
- GitHub checks: complete for `7803abec10ef2762a533a0797bd1985b3e68d230`; 50 pass, 5 expected skips explained
- Expected skips: secondary `claude` job skipped while `claude-review` passed; benchmark `plan-confirmation`, `${{ matrix.job_name }} (confirmation)`, and `report-regressions` internal/reporting jobs skipped; `docs-format-check` skipped by path/job selection while Prettier and llms checks passed locally
- Review threads: GraphQL unresolved count is 0
- Current-head reviewer verdicts:
  - Claude review: `claude-review` check passed for `7803abec10ef2762a533a0797bd1985b3e68d230`; all actionable threads addressed or triaged optional and resolved
Known residual risk: Low; the PR touched docs-generation checks plus generator spec drift handling and required several review-fix cycles, so score is held to 8 despite green current-head CI/review.
Finalized by: `claude-review` GitHub check / Claude Code Review workflow for current head, run https://github.com/shakacode/react_on_rails/actions/runs/27460651527/job/81173661444
