### PR TITLE
Bump react-hooks lint to v6 and document RSC compiler boundary

### DIFF
--- a/docs/oss/building-features/react-compiler.md
+++ b/docs/oss/building-features/react-compiler.md
@@ -123,6 +123,7 @@ React Server Components do not change where you configure the Compiler: it still
 Client island compiled by the Babel `sources` predicate:
 
 ```tsx
+// Example path — adapt to your own project structure.
 // client/app/components/compiler-ready/RscQuantityPicker.client.tsx
 'use client';
 

--- a/docs/oss/building-features/react-compiler.md
+++ b/docs/oss/building-features/react-compiler.md
@@ -11,6 +11,7 @@ React on Rails delegates JavaScript/TypeScript transforms to your app's build to
 - **Babel path is canonical and verified.** Add `babel-plugin-react-compiler` to your `babel.config.js`, ordered **first**. The compiler-memoized output builds and server-renders correctly.
 - **SWC path is experimental — not recommended for production yet.** As of June 2026 there is no first-party SWC React Compiler plugin; only a brand-new, pre-1.0 third-party Wasm plugin exists. See [Rspack + SWC path](#rspack--swc-path-experimental).
 - **Scope it.** Both paths let you gate the compiler to specific files via the `sources` option. Start scoped to a few components, verify SSR, then widen.
+- **RSC boundaries are opt-in from the client side.** Compile the `'use client'` components that hydrate or manage state, keep Server Components directive-free, and verify the RSC payload path separately.
 
 ## Prerequisites
 
@@ -115,6 +116,64 @@ This was verified end-to-end: a compiler-memoized example component (`ReactCompi
 
 If you adopt the compiler, keep verifying SSR for your own components — especially any that read browser-only globals at render time, which is a Rules-of-React violation independent of the compiler.
 
+## RSC boundary example
+
+React Server Components do not change where you configure the Compiler: it still runs in the JavaScript transform pipeline. What changes is the scope you choose. Start with a small `'use client'` island that sits at the RSC boundary, then leave the Server Component itself without a directive so React on Rails can register it as a Server Component.
+
+Client island compiled by the Babel `sources` predicate:
+
+```tsx
+// client/app/components/compiler-ready/RscQuantityPicker.client.tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function RscQuantityPicker({ initialQuantity }: { initialQuantity: number }) {
+  const [quantity, setQuantity] = useState(initialQuantity);
+
+  return (
+    <button type="button" onClick={() => setQuantity((value) => value + 1)}>
+      Quantity: {quantity}
+    </button>
+  );
+}
+```
+
+Server Component that streams data and renders the compiled client island:
+
+```tsx
+// client/app/ror-auto-load-components/CompilerReadyRscProduct.tsx
+import RscQuantityPicker from '../components/compiler-ready/RscQuantityPicker.client';
+
+export default async function CompilerReadyRscProduct({ productId }: { productId: string }) {
+  const product = await loadProduct(productId);
+
+  return (
+    <section>
+      <h2>{product.name}</h2>
+      <RscQuantityPicker initialQuantity={1} />
+    </section>
+  );
+}
+```
+
+Scope the Compiler to the client island, not to every RSC file at once:
+
+```js
+resultConfig.plugins = [
+  [
+    'babel-plugin-react-compiler',
+    {
+      sources: (filename) =>
+        typeof filename === 'string' && filename.includes('client/app/components/compiler-ready/'),
+    },
+  ],
+  ...resultConfig.plugins,
+];
+```
+
+That keeps the first RSC rollout focused on the browser component that benefits from automatic memoization. The Server Component remains a normal RSC entry point: no `'use client'` directive, no browser-only hooks, and registration through `registerServerComponent()` / auto-registration as usual.
+
 ## Rspack + SWC path (experimental)
 
 Many React on Rails teams use Rspack with SWC for build speed (see the [Babel → SWC migration guide](../migrating/babel-to-swc-migration.md)). Unfortunately, the SWC React Compiler story is **not production-viable as of June 2026**:
@@ -133,6 +192,7 @@ The standard dummy app (`react_on_rails/spec/dummy`) ships a scoped, runnable re
 - **Component:** `client/app/startup/ReactCompilerExample.tsx` — a non-RSC component written with **no** manual memoization.
 - **Babel wiring:** `babel.config.js` adds `babel-plugin-react-compiler` **first**, gated behind `REACT_COMPILER=1` and scoped via `sources` to just `ReactCompilerExample`, so the default build (which uses SWC) and the existing test suite are unaffected.
 - **View / route:** `app/views/pages/react_compiler_example.html.erb` + the `react_compiler_example` route render it with `prerender: true` (SSR + hydration).
+- **Lint wiring:** the root flat ESLint config uses `eslint-plugin-react-hooks` v6 and enables the compiler Rules-of-React checks for this scoped compiler example.
 
 Build it with the compiler on (Babel path):
 
@@ -148,8 +208,6 @@ The compiler is **off by default**, so nothing changes for the normal SWC build.
 
 These are intentionally deferred and tracked separately:
 
-- **ESLint v6 / compiler lint rules.** The Compiler's "Rules of React" lint rules ship in `eslint-plugin-react-hooks` **v6**; this repo is on `^5.2.0`. Bumping ESLint and wiring the rules is a separate change (it has flat-config implications) and is not part of this recipe.
-- **RSC (React Server Components).** Auto-memoization across the `'use client'` / `'use server'` boundary is the highest-risk surface and needs a real RSC dummy build, not extrapolation. A non-RSC recipe ships first; the RSC example/verification is a follow-up.
 - **Performance benchmark.** A concrete before/after re-render / interaction-latency benchmark to quantify the win is a follow-up.
 
 ## References

--- a/docs/oss/building-features/react-compiler.md
+++ b/docs/oss/building-features/react-compiler.md
@@ -143,6 +143,7 @@ Server Component that streams data and renders the compiled client island:
 
 ```tsx
 // client/app/ror-auto-load-components/CompilerReadyRscProduct.tsx
+import { loadProduct } from '../lib/products'; // replace with your own data-fetching helper
 import RscQuantityPicker from '../components/compiler-ready/RscQuantityPicker.client';
 
 export default async function CompilerReadyRscProduct({ productId }: { productId: string }) {

--- a/docs/oss/building-features/react-compiler.md
+++ b/docs/oss/building-features/react-compiler.md
@@ -1,6 +1,6 @@
 # React Compiler with React on Rails
 
-[React Compiler](https://react.dev/learn/react-compiler) (stable **v1.0**, shipped 2025-10-07) is a build-time tool that adds **automatic memoization** to your components. It removes most hand-written `useMemo` / `useCallback` / `React.memo` boilerplate and cuts unnecessary re-renders — a free runtime-performance and DX win that costs you only a build-config change.
+[React Compiler](https://react.dev/learn/react-compiler) (stable **v1.0**, shipped 2025-10-07) is a build-time tool that adds **automatic memoization** to your components. It cuts unnecessary re-renders and much of the hand-written `useMemo` / `useCallback` / `React.memo` boilerplate.
 
 Because the Compiler is versioned independently of React itself, it works on React on Rails' current `react`/`react-dom` `~19.0.x` pin. You do **not** need to wait for a React 19.2 bump to adopt it.
 
@@ -11,7 +11,7 @@ React on Rails delegates JavaScript/TypeScript transforms to your app's build to
 - **Babel path is canonical and verified.** Add `babel-plugin-react-compiler` to your `babel.config.js`, ordered **first**. The compiler-memoized output builds and server-renders correctly.
 - **SWC path is experimental — not recommended for production yet.** As of June 2026 there is no first-party SWC React Compiler plugin; only a brand-new, pre-1.0 third-party Wasm plugin exists. See [Rspack + SWC path](#rspack--swc-path-experimental).
 - **Scope it.** Both paths let you gate the compiler to specific files via the `sources` option. Start scoped to a few components, verify SSR, then widen.
-- **RSC boundaries are opt-in from the client side.** Compile the `'use client'` components that hydrate or manage state, keep Server Components directive-free, and verify the RSC payload path separately.
+- **RSC boundaries are opt-in from the client side.** Compile `'use client'` islands, keep Server Components directive-free, and verify the RSC payload path separately.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ yarn add --dev babel-plugin-react-compiler@^1.0.0
 
 ### 2. Add the plugin to `babel.config.js`, ordered FIRST
 
-The React Compiler **must run before every other Babel plugin and preset** so it sees your original source before any other transform rewrites it (per the [React docs](https://react.dev/learn/react-compiler/installation)). In Babel, plugins run before presets, and within the `plugins` array they run in order — so the compiler must be the **first entry in `plugins`**.
+The React Compiler **must run before every other Babel plugin and preset** so it sees your original source before another transform rewrites it (per the [React docs](https://react.dev/learn/react-compiler/installation)). In Babel, make it the **first entry in `plugins`**.
 
 A typical React on Rails `babel.config.js` builds on Shakapacker's preset. Prepend the compiler:
 
@@ -65,9 +65,9 @@ module.exports = function createBabelConfig(api) {
 
 ### 3. (Recommended) Scope the compiler with `sources`
 
-You usually do not want to flip the compiler on for your entire app in one step — it changes the output of every component and can surface latent Rules-of-React violations. The plugin's `sources` option accepts **either an array of strings or a predicate `(filename) => boolean`**.
+Avoid enabling the compiler for the whole app in one step: it changes every component's output and can surface latent Rules-of-React violations. The `sources` option accepts **either an array of strings or a predicate `(filename) => boolean`**.
 
-The array form is **not glob-based**: each entry is matched as a plain filename **substring** (the plugin checks whether the absolute filename _contains_ the string), so a literal `**` glob like `client/app/**/*.tsx` matches no real path and would silently skip every component. Use the predicate form when you want precise control — it receives the absolute filename and returns `true` to opt a file in:
+The array form is **not glob-based**: each entry is matched as a filename **substring**, so a literal `**` glob like `client/app/**/*.tsx` matches no real path and silently skips every component. Use the predicate form for precise control:
 
 ```js
 resultConfig.plugins = [
@@ -83,7 +83,7 @@ resultConfig.plugins = [
 ];
 ```
 
-Start scoped, verify SSR and your tests, then widen the predicate (or drop `sources` to compile everything).
+Start scoped, verify SSR and tests, then widen the predicate (or drop `sources`).
 
 ### 4. Build and verify
 
@@ -118,63 +118,28 @@ If you adopt the compiler, keep verifying SSR for your own components — especi
 
 ## RSC boundary example
 
-React Server Components do not change where you configure the Compiler: it still runs in the JavaScript transform pipeline. What changes is the scope you choose. Start with a small `'use client'` island that sits at the RSC boundary, then leave the Server Component itself without a directive so React on Rails can register it as a Server Component.
-
-Client island compiled by the Babel `sources` predicate:
+React Server Components still use the same transform pipeline. Compile the client island and leave the Server Component directive-free:
 
 ```tsx
-// Example path — adapt to your own project structure.
-// client/app/components/compiler-ready/RscQuantityPicker.client.tsx
+// components/compiler-ready/Picker.client.tsx
 'use client';
 
 import { useState } from 'react';
 
-export default function RscQuantityPicker({ initialQuantity }: { initialQuantity: number }) {
-  const [quantity, setQuantity] = useState(initialQuantity);
+export function Picker() {
+  const [quantity, setQuantity] = useState(1);
+  return <button onClick={() => setQuantity((value) => value + 1)}>{quantity}</button>;
+}
 
-  return (
-    <button type="button" onClick={() => setQuantity((value) => value + 1)}>
-      Quantity: {quantity}
-    </button>
-  );
+// ror-auto-load-components/RscProduct.tsx
+import { Picker } from '../components/compiler-ready/Picker.client';
+
+export default function RscProduct() {
+  return <Picker />;
 }
 ```
 
-Server Component that streams data and renders the compiled client island:
-
-```tsx
-// client/app/ror-auto-load-components/CompilerReadyRscProduct.tsx
-import { loadProduct } from '../lib/products'; // replace with your own data-fetching helper
-import RscQuantityPicker from '../components/compiler-ready/RscQuantityPicker.client';
-
-export default async function CompilerReadyRscProduct({ productId }: { productId: string }) {
-  const product = await loadProduct(productId);
-
-  return (
-    <section>
-      <h2>{product.name}</h2>
-      <RscQuantityPicker initialQuantity={1} />
-    </section>
-  );
-}
-```
-
-Scope the Compiler to the client island, not to every RSC file at once:
-
-```js
-resultConfig.plugins = [
-  [
-    'babel-plugin-react-compiler',
-    {
-      sources: (filename) =>
-        typeof filename === 'string' && filename.includes('client/app/components/compiler-ready/'),
-    },
-  ],
-  ...resultConfig.plugins,
-];
-```
-
-That keeps the first RSC rollout focused on the browser component that benefits from automatic memoization. The Server Component remains a normal RSC entry point: no `'use client'` directive, no browser-only hooks, and registration through `registerServerComponent()` / auto-registration as usual.
+Scope `sources` to `components/compiler-ready/` before widening it.
 
 ## Rspack + SWC path (experimental)
 

--- a/docs/oss/building-features/react-compiler.md
+++ b/docs/oss/building-features/react-compiler.md
@@ -118,7 +118,7 @@ If you adopt the compiler, keep verifying SSR for your own components — especi
 
 ## RSC boundary example
 
-React Server Components still use the same transform pipeline. Compile the client island and leave the Server Component directive-free:
+The React Compiler applies only to Client Components (`'use client'`). Keep Server Components directive-free and outside the `sources` predicate:
 
 ```tsx
 // components/compiler-ready/Picker.client.tsx

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -32,6 +32,7 @@ const reactCompilerRulesOfReact = {
   'react-hooks/purity': 'error',
   'react-hooks/set-state-in-render': 'error',
   'react-hooks/unsupported-syntax': 'warn',
+  // Included from the v6.1.1 compiler-era recommended-latest rule set.
   'react-hooks/config': 'error',
   'react-hooks/gating': 'error',
 } as const;
@@ -388,6 +389,8 @@ const config = defineConfig([
     },
   },
   {
+    // Mirrors the Babel `sources` predicate in react_on_rails/spec/dummy/babel.config.js.
+    // Keep these two in sync if the component is renamed or moved.
     files: ['react_on_rails/spec/dummy/client/app/startup/ReactCompilerExample.tsx'],
     rules: reactCompilerRulesOfReact,
   },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -16,8 +16,8 @@ const compat = new FlatCompat({
   allConfig: js.configs.all,
 });
 
-// v6.1.1 does not expose a flat preset for just these compiler-era
-// Rules-of-React checks. Revisit this list when bumping eslint-plugin-react-hooks.
+// v6.1.1 does not expose a flat preset for these compiler-era Rules-of-React
+// checks. Revisit this explicit list when bumping eslint-plugin-react-hooks.
 const reactCompilerRulesOfReact = {
   'react-hooks/static-components': 'error',
   'react-hooks/use-memo': 'error',
@@ -32,7 +32,6 @@ const reactCompilerRulesOfReact = {
   'react-hooks/purity': 'error',
   'react-hooks/set-state-in-render': 'error',
   'react-hooks/unsupported-syntax': 'warn',
-  // Included from the v6.1.1 compiler-era recommended-latest rule set.
   'react-hooks/config': 'error',
   'react-hooks/gating': 'error',
 } as const;

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -92,10 +92,6 @@ const config = defineConfig([
   js.configs.recommended,
   compat.extends('eslint-config-shakacode'),
   {
-    files: ['react_on_rails/spec/dummy/client/app/startup/ReactCompilerExample.tsx'],
-    rules: reactCompilerRulesOfReact,
-  },
-  {
     languageOptions: {
       globals: {
         ...globals.browser,
@@ -390,6 +386,10 @@ const config = defineConfig([
       // Some tests validate error conditions without explicit assertions
       'jest/expect-expect': 'off',
     },
+  },
+  {
+    files: ['react_on_rails/spec/dummy/client/app/startup/ReactCompilerExample.tsx'],
+    rules: reactCompilerRulesOfReact,
   },
   // must be the last config in the array
   // https://github.com/prettier/eslint-plugin-prettier?tab=readme-ov-file#configuration-new-eslintconfigjs

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,6 +15,9 @@ const compat = new FlatCompat({
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 });
+
+// v6.1.1 does not expose a flat preset for just these compiler-era
+// Rules-of-React checks. Revisit this list when bumping eslint-plugin-react-hooks.
 const reactCompilerRulesOfReact = {
   'react-hooks/static-components': 'error',
   'react-hooks/use-memo': 'error',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,6 +15,23 @@ const compat = new FlatCompat({
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 });
+const reactCompilerRulesOfReact = {
+  'react-hooks/static-components': 'error',
+  'react-hooks/use-memo': 'error',
+  'react-hooks/component-hook-factories': 'error',
+  'react-hooks/preserve-manual-memoization': 'error',
+  'react-hooks/incompatible-library': 'warn',
+  'react-hooks/immutability': 'error',
+  'react-hooks/globals': 'error',
+  'react-hooks/refs': 'error',
+  'react-hooks/set-state-in-effect': 'error',
+  'react-hooks/error-boundaries': 'error',
+  'react-hooks/purity': 'error',
+  'react-hooks/set-state-in-render': 'error',
+  'react-hooks/unsupported-syntax': 'warn',
+  'react-hooks/config': 'error',
+  'react-hooks/gating': 'error',
+} as const;
 
 const config = defineConfig([
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
@@ -71,6 +88,10 @@ const config = defineConfig([
   },
   js.configs.recommended,
   compat.extends('eslint-config-shakacode'),
+  {
+    files: ['react_on_rails/spec/dummy/client/app/startup/ReactCompilerExample.tsx'],
+    rules: reactCompilerRulesOfReact,
+  },
   {
     languageOptions: {
       globals: {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6066,6 +6066,7 @@ React Server Components do not change where you configure the Compiler: it still
 Client island compiled by the Babel `sources` predicate:
 
 ```tsx
+// Example path — adapt to your own project structure.
 // client/app/components/compiler-ready/RscQuantityPicker.client.tsx
 'use client';
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6061,7 +6061,7 @@ If you adopt the compiler, keep verifying SSR for your own components — especi
 
 ## RSC boundary example
 
-React Server Components still use the same transform pipeline. Compile the client island and leave the Server Component directive-free:
+The React Compiler applies only to Client Components (`'use client'`). Keep Server Components directive-free and outside the `sources` predicate:
 
 ```tsx
 // components/compiler-ready/Picker.client.tsx

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6086,6 +6086,7 @@ Server Component that streams data and renders the compiled client island:
 
 ```tsx
 // client/app/ror-auto-load-components/CompilerReadyRscProduct.tsx
+import { loadProduct } from '../lib/products'; // replace with your own data-fetching helper
 import RscQuantityPicker from '../components/compiler-ready/RscQuantityPicker.client';
 
 export default async function CompilerReadyRscProduct({ productId }: { productId: string }) {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5943,7 +5943,7 @@ SOURCE: docs/oss/building-features/react-compiler.md
 
 # React Compiler with React on Rails
 
-[React Compiler](https://react.dev/learn/react-compiler) (stable **v1.0**, shipped 2025-10-07) is a build-time tool that adds **automatic memoization** to your components. It removes most hand-written `useMemo` / `useCallback` / `React.memo` boilerplate and cuts unnecessary re-renders — a free runtime-performance and DX win that costs you only a build-config change.
+[React Compiler](https://react.dev/learn/react-compiler) (stable **v1.0**, shipped 2025-10-07) is a build-time tool that adds **automatic memoization** to your components. It cuts unnecessary re-renders and much of the hand-written `useMemo` / `useCallback` / `React.memo` boilerplate.
 
 Because the Compiler is versioned independently of React itself, it works on React on Rails' current `react`/`react-dom` `~19.0.x` pin. You do **not** need to wait for a React 19.2 bump to adopt it.
 
@@ -5954,7 +5954,7 @@ React on Rails delegates JavaScript/TypeScript transforms to your app's build to
 - **Babel path is canonical and verified.** Add `babel-plugin-react-compiler` to your `babel.config.js`, ordered **first**. The compiler-memoized output builds and server-renders correctly.
 - **SWC path is experimental — not recommended for production yet.** As of June 2026 there is no first-party SWC React Compiler plugin; only a brand-new, pre-1.0 third-party Wasm plugin exists. See [Rspack + SWC path](#rspack--swc-path-experimental).
 - **Scope it.** Both paths let you gate the compiler to specific files via the `sources` option. Start scoped to a few components, verify SSR, then widen.
-- **RSC boundaries are opt-in from the client side.** Compile the `'use client'` components that hydrate or manage state, keep Server Components directive-free, and verify the RSC payload path separately.
+- **RSC boundaries are opt-in from the client side.** Compile `'use client'` islands, keep Server Components directive-free, and verify the RSC payload path separately.
 
 ## Prerequisites
 
@@ -5979,7 +5979,7 @@ yarn add --dev babel-plugin-react-compiler@^1.0.0
 
 ### 2. Add the plugin to `babel.config.js`, ordered FIRST
 
-The React Compiler **must run before every other Babel plugin and preset** so it sees your original source before any other transform rewrites it (per the [React docs](https://react.dev/learn/react-compiler/installation)). In Babel, plugins run before presets, and within the `plugins` array they run in order — so the compiler must be the **first entry in `plugins`**.
+The React Compiler **must run before every other Babel plugin and preset** so it sees your original source before another transform rewrites it (per the [React docs](https://react.dev/learn/react-compiler/installation)). In Babel, make it the **first entry in `plugins`**.
 
 A typical React on Rails `babel.config.js` builds on Shakapacker's preset. Prepend the compiler:
 
@@ -6008,9 +6008,9 @@ module.exports = function createBabelConfig(api) {
 
 ### 3. (Recommended) Scope the compiler with `sources`
 
-You usually do not want to flip the compiler on for your entire app in one step — it changes the output of every component and can surface latent Rules-of-React violations. The plugin's `sources` option accepts **either an array of strings or a predicate `(filename) => boolean`**.
+Avoid enabling the compiler for the whole app in one step: it changes every component's output and can surface latent Rules-of-React violations. The `sources` option accepts **either an array of strings or a predicate `(filename) => boolean`**.
 
-The array form is **not glob-based**: each entry is matched as a plain filename **substring** (the plugin checks whether the absolute filename _contains_ the string), so a literal `**` glob like `client/app/**/*.tsx` matches no real path and would silently skip every component. Use the predicate form when you want precise control — it receives the absolute filename and returns `true` to opt a file in:
+The array form is **not glob-based**: each entry is matched as a filename **substring**, so a literal `**` glob like `client/app/**/*.tsx` matches no real path and silently skips every component. Use the predicate form for precise control:
 
 ```js
 resultConfig.plugins = [
@@ -6026,7 +6026,7 @@ resultConfig.plugins = [
 ];
 ```
 
-Start scoped, verify SSR and your tests, then widen the predicate (or drop `sources` to compile everything).
+Start scoped, verify SSR and tests, then widen the predicate (or drop `sources`).
 
 ### 4. Build and verify
 
@@ -6061,63 +6061,28 @@ If you adopt the compiler, keep verifying SSR for your own components — especi
 
 ## RSC boundary example
 
-React Server Components do not change where you configure the Compiler: it still runs in the JavaScript transform pipeline. What changes is the scope you choose. Start with a small `'use client'` island that sits at the RSC boundary, then leave the Server Component itself without a directive so React on Rails can register it as a Server Component.
-
-Client island compiled by the Babel `sources` predicate:
+React Server Components still use the same transform pipeline. Compile the client island and leave the Server Component directive-free:
 
 ```tsx
-// Example path — adapt to your own project structure.
-// client/app/components/compiler-ready/RscQuantityPicker.client.tsx
+// components/compiler-ready/Picker.client.tsx
 'use client';
 
 import { useState } from 'react';
 
-export default function RscQuantityPicker({ initialQuantity }: { initialQuantity: number }) {
-  const [quantity, setQuantity] = useState(initialQuantity);
+export function Picker() {
+  const [quantity, setQuantity] = useState(1);
+  return <button onClick={() => setQuantity((value) => value + 1)}>{quantity}</button>;
+}
 
-  return (
-    <button type="button" onClick={() => setQuantity((value) => value + 1)}>
-      Quantity: {quantity}
-    </button>
-  );
+// ror-auto-load-components/RscProduct.tsx
+import { Picker } from '../components/compiler-ready/Picker.client';
+
+export default function RscProduct() {
+  return <Picker />;
 }
 ```
 
-Server Component that streams data and renders the compiled client island:
-
-```tsx
-// client/app/ror-auto-load-components/CompilerReadyRscProduct.tsx
-import { loadProduct } from '../lib/products'; // replace with your own data-fetching helper
-import RscQuantityPicker from '../components/compiler-ready/RscQuantityPicker.client';
-
-export default async function CompilerReadyRscProduct({ productId }: { productId: string }) {
-  const product = await loadProduct(productId);
-
-  return (
-    <section>
-      <h2>{product.name}</h2>
-      <RscQuantityPicker initialQuantity={1} />
-    </section>
-  );
-}
-```
-
-Scope the Compiler to the client island, not to every RSC file at once:
-
-```js
-resultConfig.plugins = [
-  [
-    'babel-plugin-react-compiler',
-    {
-      sources: (filename) =>
-        typeof filename === 'string' && filename.includes('client/app/components/compiler-ready/'),
-    },
-  ],
-  ...resultConfig.plugins,
-];
-```
-
-That keeps the first RSC rollout focused on the browser component that benefits from automatic memoization. The Server Component remains a normal RSC entry point: no `'use client'` directive, no browser-only hooks, and registration through `registerServerComponent()` / auto-registration as usual.
+Scope `sources` to `components/compiler-ready/` before widening it.
 
 ## Rspack + SWC path (experimental)
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5954,6 +5954,7 @@ React on Rails delegates JavaScript/TypeScript transforms to your app's build to
 - **Babel path is canonical and verified.** Add `babel-plugin-react-compiler` to your `babel.config.js`, ordered **first**. The compiler-memoized output builds and server-renders correctly.
 - **SWC path is experimental — not recommended for production yet.** As of June 2026 there is no first-party SWC React Compiler plugin; only a brand-new, pre-1.0 third-party Wasm plugin exists. See [Rspack + SWC path](#rspack--swc-path-experimental).
 - **Scope it.** Both paths let you gate the compiler to specific files via the `sources` option. Start scoped to a few components, verify SSR, then widen.
+- **RSC boundaries are opt-in from the client side.** Compile the `'use client'` components that hydrate or manage state, keep Server Components directive-free, and verify the RSC payload path separately.
 
 ## Prerequisites
 
@@ -6058,6 +6059,64 @@ This was verified end-to-end: a compiler-memoized example component (`ReactCompi
 
 If you adopt the compiler, keep verifying SSR for your own components — especially any that read browser-only globals at render time, which is a Rules-of-React violation independent of the compiler.
 
+## RSC boundary example
+
+React Server Components do not change where you configure the Compiler: it still runs in the JavaScript transform pipeline. What changes is the scope you choose. Start with a small `'use client'` island that sits at the RSC boundary, then leave the Server Component itself without a directive so React on Rails can register it as a Server Component.
+
+Client island compiled by the Babel `sources` predicate:
+
+```tsx
+// client/app/components/compiler-ready/RscQuantityPicker.client.tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function RscQuantityPicker({ initialQuantity }: { initialQuantity: number }) {
+  const [quantity, setQuantity] = useState(initialQuantity);
+
+  return (
+    <button type="button" onClick={() => setQuantity((value) => value + 1)}>
+      Quantity: {quantity}
+    </button>
+  );
+}
+```
+
+Server Component that streams data and renders the compiled client island:
+
+```tsx
+// client/app/ror-auto-load-components/CompilerReadyRscProduct.tsx
+import RscQuantityPicker from '../components/compiler-ready/RscQuantityPicker.client';
+
+export default async function CompilerReadyRscProduct({ productId }: { productId: string }) {
+  const product = await loadProduct(productId);
+
+  return (
+    <section>
+      <h2>{product.name}</h2>
+      <RscQuantityPicker initialQuantity={1} />
+    </section>
+  );
+}
+```
+
+Scope the Compiler to the client island, not to every RSC file at once:
+
+```js
+resultConfig.plugins = [
+  [
+    'babel-plugin-react-compiler',
+    {
+      sources: (filename) =>
+        typeof filename === 'string' && filename.includes('client/app/components/compiler-ready/'),
+    },
+  ],
+  ...resultConfig.plugins,
+];
+```
+
+That keeps the first RSC rollout focused on the browser component that benefits from automatic memoization. The Server Component remains a normal RSC entry point: no `'use client'` directive, no browser-only hooks, and registration through `registerServerComponent()` / auto-registration as usual.
+
 ## Rspack + SWC path (experimental)
 
 Many React on Rails teams use Rspack with SWC for build speed (see the [Babel → SWC migration guide](../migrating/babel-to-swc-migration.md)). Unfortunately, the SWC React Compiler story is **not production-viable as of June 2026**:
@@ -6076,6 +6135,7 @@ The standard dummy app (`react_on_rails/spec/dummy`) ships a scoped, runnable re
 - **Component:** `client/app/startup/ReactCompilerExample.tsx` — a non-RSC component written with **no** manual memoization.
 - **Babel wiring:** `babel.config.js` adds `babel-plugin-react-compiler` **first**, gated behind `REACT_COMPILER=1` and scoped via `sources` to just `ReactCompilerExample`, so the default build (which uses SWC) and the existing test suite are unaffected.
 - **View / route:** `app/views/pages/react_compiler_example.html.erb` + the `react_compiler_example` route render it with `prerender: true` (SSR + hydration).
+- **Lint wiring:** the root flat ESLint config uses `eslint-plugin-react-hooks` v6 and enables the compiler Rules-of-React checks for this scoped compiler example.
 
 Build it with the compiler on (Babel path):
 
@@ -6091,8 +6151,6 @@ The compiler is **off by default**, so nothing changes for the normal SWC build.
 
 These are intentionally deferred and tracked separately:
 
-- **ESLint v6 / compiler lint rules.** The Compiler's "Rules of React" lint rules ship in `eslint-plugin-react-hooks` **v6**; this repo is on `^5.2.0`. Bumping ESLint and wiring the rules is a separate change (it has flat-config implications) and is not part of this recipe.
-- **RSC (React Server Components).** Auto-memoization across the `'use client'` / `'use server'` boundary is the highest-risk surface and needs a real RSC dummy build, not extrapolation. A non-RSC recipe ships first; the RSC example/verification is a follow-up.
 - **Performance benchmark.** A concrete before/after re-render / interaction-latency benchmark to quantify the win is a follow-up.
 
 ## References

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^6.1.1",
     "eslint-plugin-testing-library": "^7.1.1",
     "globals": "^16.2.0",
     "jest": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-config-shakacode:
         specifier: ^19.0.0
-        version: 19.0.0(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+        version: 19.0.0(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-import-resolver-alias:
         specifier: ^1.1.2
         version: 1.1.2(eslint-plugin-import@2.32.0)
@@ -137,8 +137,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks:
-        specifier: ^5.2.0
-        version: 5.2.0(eslint@9.39.1(jiti@2.6.1))
+        specifier: ^6.1.1
+        version: 6.1.1(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-testing-library:
         specifier: ^7.1.1
         version: 7.13.5(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
@@ -5616,9 +5616,9 @@ packages:
       eslint-config-prettier:
         optional: true
 
-  eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@6.1.1:
+    resolution: {integrity: sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
@@ -10339,6 +10339,12 @@ packages:
 
   zlibjs@0.3.1:
     resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -15508,14 +15514,14 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-react-hooks: 6.1.1(eslint@9.39.1(jiti@2.6.1))
       object.assign: 4.1.7
       object.entries: 1.1.9
 
@@ -15523,10 +15529,10 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
 
-  eslint-config-shakacode@19.0.0(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-config-shakacode@19.0.0(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@2.6.1)))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
@@ -15648,9 +15654,15 @@ snapshots:
       '@types/eslint': 9.6.1
       eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@2.6.1))
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-react-hooks@6.1.1(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
+      '@babel/core': 7.28.5
+      '@babel/parser': 7.28.5
       eslint: 9.39.1(jiti@2.6.1)
+      zod: 4.1.13
+      zod-validation-error: 4.0.2(zod@4.1.13)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
@@ -21564,6 +21576,10 @@ snapshots:
       readable-stream: 4.7.0
 
   zlibjs@0.3.1: {}
+
+  zod-validation-error@4.0.2(zod@4.1.13):
+    dependencies:
+      zod: 4.1.13
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Part of #3920. This is the cheap slice only; the benchmark item remains deferred.

- bumps root `eslint-plugin-react-hooks` to v6 with pnpm
- scopes the React Compiler Rules-of-React lint rules to the existing compiler example
- adds an RSC boundary example to the React Compiler docs
- regenerates `llms-full.txt`

## Dependabot / Lockfile Compatibility

- `.github/dependabot.yml` has root npm coverage via `package-ecosystem: "npm"` and `directories: ["/", ...]`.
- The file comment notes the root pnpm workspace `/` covers workspace packages.
- No new lockfile was added; the existing root `pnpm-lock.yaml` was updated.

## Codex Decision Log

- **Non-blocking:** benchmark item from #3920.
  - **Decision:** deferred; not implemented in this branch.
  - **Why:** user requested cheap slice only.
  - **Review later:** run existing benchmark harness for before/after re-render or interaction-latency numbers, then update docs with concrete results.

## Test plan

- `pnpm add -D -w eslint-plugin-react-hooks@^6.1.1` -> pass
- `pnpm install` -> pass
- `pnpm run build` -> pass
- `pnpm run lint` -> pass
- `pnpm start format.listDifferent` -> pass
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> pass
- `script/check-docs-sidebar` -> pass
- `node script/generate-llms-full.mjs` -> pass
- `node script/generate-llms-full.mjs --check` -> pass
- `git diff --check origin/main...HEAD` -> pass
- `script/ci-changes-detector origin/main` -> recommends lint, JS tests, dummy integration, generator tests, E2E, and benchmarks
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings

Labels: full-ci — dependency/lockfile update plus lint behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The react-hooks major bump can change lint behavior for the one scoped file; repo-wide rules are unchanged, but CI lint must stay green on that example.
> 
> **Overview**
> Upgrades **`eslint-plugin-react-hooks`** to **v6** and turns on the compiler-era **Rules of React** lint rules only for `ReactCompilerExample.tsx`, aligned with the dummy app’s Babel `sources` scope so the rest of the repo is unchanged.
> 
> The **React Compiler** docs gain an **RSC boundary** example (compile `'use client'` islands, keep server components directive-free), a TL;DR note on that pattern, tighter `sources` guidance, and updated reference text for the new lint wiring. Deferred follow-ups for ESLint v6 and RSC docs are removed; **`llms-full.txt`** is regenerated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe02b891e742be489beb418f7e054fa4bdba1d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified RSC rollout TL;DR; added an RSC boundary example showing a client-island consumed by a directive-free server component; added guidance to scope compilation sources, prefer predicate-style matching, warn against glob-like arrays, and advise “start scoped, verify, then widen”; emphasized compiler-first plugin ordering; simplified follow-ups (only performance benchmark remains).
  * Added a note about wiring lint checks for the scoped compiler example.

* **Chores**
  * Added a targeted ESLint override to validate compiler-related rules.
  * Updated the ESLint React Hooks plugin to v6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: fe02b891e742be489beb418f7e054fa4bdba1d44
Score: 8/10
Auto-merge recommendation: yes
Affected areas: eslint dependency/lockfile, root ESLint flat config, React Compiler docs, llms-full generated reference
CI detector: `script/ci-changes-detector origin/main` -> JavaScript/TypeScript code + lint/format configuration; recommends lint, JS unit tests, dummy app integration tests, generator tests, Playwright E2E tests, core benchmarks, and React on Rails Pro benchmarks
Validation run:
- `pnpm run lint` -> pass
- `pnpm start format.listDifferent` -> pass
- `node script/generate-llms-full.mjs` -> generated; 146 pages, 2048 KiB, split threshold 2048 KiB; 73 docs URLs and 8 sidebar top-level sections validated
- `node script/generate-llms-full.mjs --check` -> current
- Pre-commit/pre-push hooks: eslint/prettier/markdown links/trailing newlines/branch lint -> pass
Review/check gate:
- GitHub checks: complete for `fe02b891e742be489beb418f7e054fa4bdba1d44`; 52 passed, 5 skipped, 0 failed, 0 pending
- Expected skips: benchmark confirmation/reporting jobs skipped because the benchmark suites completed without a manual confirmation path; secondary `claude` job skipped while `claude-review` passed; `docs-format-check` skipped by workflow selection while local formatter and markdown checks passed
- Review threads: GraphQL unresolved count is 0
- Current-head reviewer verdicts:
  - Claude review: `claude-review` check passed for current head; optional clarity comments were triaged and resolved without a wording-only CI churn push
  - CodeRabbit: check succeeded with review skipped
  - Cursor Bugbot: check passed
Known residual risk: Low-to-moderate; dependency/lockfile plus lint behavior changed, full-CI/benchmark surfaces were exercised, and `llms-full.txt` remains at the documented 2048 KiB threshold. The benchmark work item from #3920 remains deliberately deferred.
Finalized by: `claude-review` GitHub check / Claude Code Review workflow for current head, run https://github.com/shakacode/react_on_rails/actions/runs/27465025557/job/81185745350
