### PR TITLE
Update CHANGELOG.md for 17.0.0.rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.0.0.rc.3] - 2026-06-11
+
 #### Added
 
 - **Machine-readable doctor output (`FORMAT=json`)**: `bin/rails react_on_rails:doctor FORMAT=json` (and `ReactOnRails::Doctor.new(format: :json)`) now emits a stable, versioned JSON report — `schema_version`, `ror_version`, overall `status`, per-check entries with stable snake_case ids (`pass`/`warn`/`fail` status, most-severe `message`, full `details`), and a `summary` of check counts — so coding agents and tooling can consume diagnosis results without parsing the human-formatted text. Stray check output is routed to stderr so stdout stays valid JSON; the default human-readable output and exit-code semantics are unchanged. Split out from the MCP-server RFC in [Issue 3870](https://github.com/shakacode/react_on_rails/issues/3870). Closes [Issue 3943](https://github.com/shakacode/react_on_rails/issues/3943). [PR 3948](https://github.com/shakacode/react_on_rails/pull/3948) by [justin808](https://github.com/justin808).
@@ -32,6 +34,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 - **Stable SmartError codes and generated error reference**: SmartError messages now include stable `ROR###` codes and canonical documentation URLs, and `docs/oss/reference/error-reference.md` is generated from the SmartError definitions with a drift check. Fixes [Issue 3894](https://github.com/shakacode/react_on_rails/issues/3894). [PR 3936](https://github.com/shakacode/react_on_rails/pull/3936) by [justin808](https://github.com/justin808).
 - **Preload link helper for generated component packs**: Added `react_on_rails_preload_links` so layouts can emit preload, modulepreload, and stylesheet preload tags for auto-bundled component packs from the Shakapacker manifest. Fixes [Issue 3889](https://github.com/shakacode/react_on_rails/issues/3889). [PR 3935](https://github.com/shakacode/react_on_rails/pull/3935) by [justin808](https://github.com/justin808).
 - **Tailwind CSS v4 generator option**: `rails generate react_on_rails:install --tailwind` and `create-react-on-rails-app --tailwind` now install Tailwind CSS v4, wire `@tailwindcss/postcss` for Webpack or Rspack, and style the generated server-rendered HelloWorld example with extracted component CSS support. Interactive `create-react-on-rails-app` runs recommend Tailwind by default while still allowing users to opt out. Fixes [Issue 3895](https://github.com/shakacode/react_on_rails/issues/3895). [PR 3937](https://github.com/shakacode/react_on_rails/pull/3937) by [justin808](https://github.com/justin808).
+
+#### Fixed
+
+- **[Pro]** **Node renderer drains workers on `SIGTERM`/`SIGINT` instead of orphaning them**: The Pro Node renderer master now installs `SIGTERM` and `SIGINT` handlers before forking workers, so supervisors (Foreman, local dev, process managers) that signal the master gracefully drain workers — sending the shutdown message, waiting a short grace period, calling `cluster.disconnect()`, then awaiting each worker's `exit` event — instead of killing only the master and leaving orphaned worker processes behind. Shutdown uses signal-style exit codes (`SIGINT` → 130, `SIGTERM` → 143), reuses a shutdown-time worker snapshot for the hard `SIGKILL` fallback so disconnected-but-still-running workers are not missed, and suppresses reforks while a shutdown is in progress. Fixes [Issue 3863](https://github.com/shakacode/react_on_rails/issues/3863). [PR 3882](https://github.com/shakacode/react_on_rails/pull/3882) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.2] - 2026-06-09
 
@@ -2291,7 +2297,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.2...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.3...main
+[17.0.0.rc.3]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.2...v17.0.0.rc.3
 [17.0.0.rc.2]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.1...v17.0.0.rc.2
 [17.0.0.rc.1]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.0...v17.0.0.rc.1
 [17.0.0.rc.0]: https://github.com/shakacode/react_on_rails/compare/v16.6.0...v17.0.0.rc.0


### PR DESCRIPTION
Stamps the `17.0.0.rc.3` changelog header (dated 2026-06-11) and moves the accumulated `[Unreleased]` entries under it. Generated with `/update-changelog rc.3` after a mechanical classification sweep of every PR merged since `v17.0.0.rc.2`.

## Entries added to rc.3

### Added
- Machine-readable doctor output (`FORMAT=json`) — [PR 3948](https://github.com/shakacode/react_on_rails/pull/3948)
- Consumer-facing `AGENTS.md` scaffolded into generated/installed apps — [PR 3924](https://github.com/shakacode/react_on_rails/pull/3924)
- First-party font optimization helper (`react_on_rails_font_face`) — [PR 3923](https://github.com/shakacode/react_on_rails/pull/3923)
- Stable `SmartError` codes + generated error reference — [PR 3936](https://github.com/shakacode/react_on_rails/pull/3936)
- Preload link helper for component packs (`react_on_rails_preload_links`) — [PR 3935](https://github.com/shakacode/react_on_rails/pull/3935)
- Tailwind CSS v4 generator option (`--tailwind`) — [PR 3937](https://github.com/shakacode/react_on_rails/pull/3937)

### Fixed
- **[Pro]** Node renderer drains workers on `SIGTERM`/`SIGINT` instead of orphaning them — [PR 3882](https://github.com/shakacode/react_on_rails/pull/3882)

## Classification notes (excluded PRs)

- **[PR 3860](https://github.com/shakacode/react_on_rails/pull/3860)** (revert of the Pro-side RSC FOUC CSS wrapping from [#3587](https://github.com/shakacode/react_on_rails/pull/3587)) — **no entry.** #3587 shipped in rc.2 but was redundant with the native FOUC fix delivered via `react-on-rails-rsc@19.0.5-rc.7` ([#3857](https://github.com/shakacode/react_on_rails/pull/3857), already in the rc.2 section). The user-visible FOUC behavior is unchanged rc.2 → rc.3, so a "reverted the FOUC fix" line would mislead. The revert PR itself already removed the #3587 entry.
- **[PR 3915](https://github.com/shakacode/react_on_rails/pull/3915)** (pin prerelease gems in `create-react-on-rails-app`) — **no entry**, release-process: fixes the rc.2 release-gate so the prerelease CLI pins prerelease gems; prerelease tooling only.
- All remaining PRs in the range were docs-only, CI/release-process, or contributor tooling.

Prior RC sections (rc.0/rc.1/rc.2) are left intact; compare links updated. After merge, run `rake release` (no args) to publish and auto-create the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CHANGELOG edits with no runtime or build behavior changes.
> 
> **Overview**
> **Prepares the `17.0.0.rc.3` (2026-06-11) release notes** by stamping a new version section and moving everything that was under `[Unreleased]` into it, leaving `[Unreleased]` empty for the next cycle.
> 
> The **Added** block documents six shipped features: JSON doctor output, install-time AI agent files (`AGENTS.md` and editor pointers), `react_on_rails_font_face`, stable `ROR###` SmartError codes with a generated error reference, `react_on_rails_preload_links`, and a `--tailwind` install option for Tailwind v4. A new **Fixed** subsection records **[Pro]** graceful Node renderer shutdown on `SIGTERM`/`SIGINT` (no orphaned workers).
> 
> At the bottom, **compare links** are updated so `[unreleased]` points at `v17.0.0.rc.3...main` and `[17.0.0.rc.3]` compares `rc.2` to `rc.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3200361a478473ab2d1c92bf2624e2684a01c3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pro Node renderer graceful shutdown to properly drain workers instead of orphaning them during shutdown, with automatic hard shutdown fallback when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->