### PR TITLE
Add cross-agent coordination backend workflow

### DIFF
--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -51,6 +51,7 @@ Plan a PR batch
 - Excluded or deferred:
 - Dependencies and sequencing:
 - Subagent split:
+- Coordination hooks:
 - Verification expectations:
 - Open questions:
 
@@ -80,6 +81,7 @@ Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
+- For concurrent or dependency-sensitive batches, assign a stable agent id per lane and use `agent-coord heartbeat` / `agent-coord status` when the private coordination backend is available.
 - Final handoff must include links, tests, blockers, next action, and merged/ready/blocked/deferred/UNKNOWN sections.
 ```
 

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -111,6 +111,8 @@ Execution rules:
   heartbeat status. If a lane declares `depends_on` but `agent-coord status`
   shows no matching private batch state, treat dependency state as `UNKNOWN` and
   stop to report the missing private batch file.
+  If status cannot be checked for a declared dependency lane, stop with
+  dependency state `UNKNOWN` instead of using advisory fallback for that lane.
 - Final handoff must include links, tests, blockers, next action, and merged/ready/blocked/deferred/UNKNOWN sections.
 ```
 

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -31,13 +31,18 @@ Plan a PR batch
      live or stale private claims, including holder and heartbeat liveness.
      Report dead or fallback-expired claims as recoverable before assigning
      takeover work. If backend state cannot be checked, write `UNKNOWN`; public
-     claim comments are advisory only.
+     claim comments are advisory only. Include active batches, lane
+     `depends_on` refs, and current `blocked_on` refs in the plan so workers can
+     see cross-batch status before they start.
 
 3. Shape
    - Exclude issues labeled `needs-customer-feedback` from implementation batches unless the user explicitly provides customer evidence or maintainer approval for that issue; list them under "Excluded or deferred" with `needs-customer-feedback` as the reason.
    - For any issue that is speculative, AI/code-analysis-only, over-scoped, or unclear in value, priority, or fix scope, route through `.agents/skills/evaluate-issue/SKILL.md` before assigning it to implementation work.
    - Exclude closed or merged items unless the user explicitly asked to audit them.
-   - Separate independent work from dependency-ordered work.
+   - Separate independent work from dependency-ordered work. Give every planned
+     lane a stable agent id and a lane name; for dependency-ordered work, define
+     explicit `depends_on` refs in the form `<batch-id>:<lane-name>` so
+     `agent-coord status` can show whether the lane is blocked.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
@@ -57,6 +62,7 @@ Plan a PR batch
 - Excluded or deferred:
 - Dependencies and sequencing:
 - Subagent split:
+- Concurrent activity and dependency status:
 - Coordination hooks, including backend claim exclusions:
 - Verification expectations:
 - Open questions:
@@ -87,7 +93,14 @@ Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
-- For concurrent or dependency-sensitive batches, assign a stable agent id per lane. When the private coordination backend is available, use `agent-coord claim` before creating worktrees/branches, `agent-coord heartbeat` at phase transitions, and `agent-coord status` before dependency-sensitive work.
+- For concurrent or dependency-sensitive batches, assign a stable agent id and
+  lane name per lane. Declare lane dependencies with `depends_on` refs such as
+  `<batch-id>:<lane-name>`. When the private coordination backend is available,
+  use `agent-coord claim` before creating worktrees/branches,
+  `agent-coord heartbeat` at phase transitions, and `agent-coord status` at
+  lane start and before rebase or push. If the lane shows unmet `blocked_on`
+  refs, set heartbeat `--status blocked`, report the blocked refs, and move to
+  another independent lane until dependencies report terminal status.
 - Final handoff must include links, tests, blockers, next action, and merged/ready/blocked/deferred/UNKNOWN sections.
 ```
 

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -26,14 +26,16 @@ Plan a PR batch
    - For every bare number, run both `gh pr view N` and `gh issue view N` when type is ambiguous.
    - For filters, run focused `gh pr list` or `gh issue list` commands and keep the query in the report.
    - Record title, URL, state, branch/author for PRs, labels, linked PR/issue refs, and blockers. If a fact cannot be verified, write `UNKNOWN`.
-   - If the private `shakacode/agent-coordination` backend is available, run
-     `agent-coord status` and exclude/report targets that already have active
-     live or stale private claims, including holder and heartbeat liveness.
-     Report dead or fallback-expired claims as recoverable before assigning
-     takeover work. If backend state cannot be checked, write `UNKNOWN`; public
-     claim comments are advisory only. Include active batches, lane
-     `depends_on` refs, and current `blocked_on` refs in the plan so workers can
-     see cross-batch status before they start.
+   - Treat the private `shakacode/agent-coordination` backend as available when
+     `agent-coord status` exits 0. If available, run `agent-coord status` and
+     exclude/report targets that already have active live or stale private
+     claims, including holder and heartbeat liveness. Report dead or
+     fallback-expired claims as recoverable before assigning takeover work. If
+     backend state cannot be checked, write `UNKNOWN`; public claim comments are
+     advisory only. `UNKNOWN` applies to unavailable status checks, not live
+     claim refusals during `$pr-batch`, which remain hard stops. Include active
+     batches, lane `depends_on` refs, and current `blocked_on` refs in the plan
+     so workers can see cross-batch status before they start.
 
 3. Shape
    - Exclude issues labeled `needs-customer-feedback` from implementation batches unless the user explicitly provides customer evidence or maintainer approval for that issue; list them under "Excluded or deferred" with `needs-customer-feedback` as the reason.

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -108,7 +108,9 @@ Execution rules:
   lane start and before rebase or push. If the lane shows unmet `blocked_on`
   refs, set heartbeat `--status blocked`, report the blocked refs, and move to
   another independent lane until dependencies report a backend terminal
-  heartbeat status.
+  heartbeat status. If a lane declares `depends_on` but `agent-coord status`
+  shows no matching private batch state, treat dependency state as `UNKNOWN` and
+  stop to report the missing private batch file.
 - Final handoff must include links, tests, blockers, next action, and merged/ready/blocked/deferred/UNKNOWN sections.
 ```
 

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -45,6 +45,9 @@ Plan a PR batch
      lane a stable agent id and a lane name; for dependency-ordered work, define
      explicit `depends_on` refs in the form `<batch-id>:<lane-name>` so
      `agent-coord status` can show whether the lane is blocked.
+     Coordinators must create or update the private backend
+     `batches/<batch-id>.json` with those lane refs before dependent workers
+     start; otherwise `agent-coord status` cannot report `blocked_on` lanes.
    - Cap at 8 with shared/risky files, else 10 independent items; propose a smaller first batch.
    - For PRs with review feedback, route the worker to use the repo review workflow before code changes.
    - For issues, define the expected deliverable: fix, investigation, reproduction, docs update, or no-PR audit.
@@ -97,7 +100,8 @@ Execution rules:
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
   lane name per lane. Declare lane dependencies with `depends_on` refs such as
-  `<batch-id>:<lane-name>`. When the private coordination backend is available,
+  `<batch-id>:<lane-name>`, and create or update the private backend
+  `batches/<batch-id>.json` before dispatching dependent workers. When the private coordination backend is available,
   use `agent-coord claim` before creating worktrees/branches,
   `agent-coord heartbeat` at phase transitions, and `agent-coord status` at
   lane start and before rebase or push. If the lane shows unmet `blocked_on`

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -26,6 +26,12 @@ Plan a PR batch
    - For every bare number, run both `gh pr view N` and `gh issue view N` when type is ambiguous.
    - For filters, run focused `gh pr list` or `gh issue list` commands and keep the query in the report.
    - Record title, URL, state, branch/author for PRs, labels, linked PR/issue refs, and blockers. If a fact cannot be verified, write `UNKNOWN`.
+   - If the private `shakacode/agent-coordination` backend is available, run
+     `agent-coord status` and exclude/report targets that already have active
+     live or stale private claims, including holder and heartbeat liveness.
+     Report dead or fallback-expired claims as recoverable before assigning
+     takeover work. If backend state cannot be checked, write `UNKNOWN`; public
+     claim comments are advisory only.
 
 3. Shape
    - Exclude issues labeled `needs-customer-feedback` from implementation batches unless the user explicitly provides customer evidence or maintainer approval for that issue; list them under "Excluded or deferred" with `needs-customer-feedback` as the reason.
@@ -51,7 +57,7 @@ Plan a PR batch
 - Excluded or deferred:
 - Dependencies and sequencing:
 - Subagent split:
-- Coordination hooks:
+- Coordination hooks, including backend claim exclusions:
 - Verification expectations:
 - Open questions:
 
@@ -81,7 +87,7 @@ Execution rules:
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
-- For concurrent or dependency-sensitive batches, assign a stable agent id per lane and use `agent-coord heartbeat` / `agent-coord status` when the private coordination backend is available.
+- For concurrent or dependency-sensitive batches, assign a stable agent id per lane. When the private coordination backend is available, use `agent-coord claim` before creating worktrees/branches, `agent-coord heartbeat` at phase transitions, and `agent-coord status` before dependency-sensitive work.
 - Final handoff must include links, tests, blockers, next action, and merged/ready/blocked/deferred/UNKNOWN sections.
 ```
 

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -102,7 +102,8 @@ Execution rules:
   `agent-coord heartbeat` at phase transitions, and `agent-coord status` at
   lane start and before rebase or push. If the lane shows unmet `blocked_on`
   refs, set heartbeat `--status blocked`, report the blocked refs, and move to
-  another independent lane until dependencies report terminal status.
+  another independent lane until dependencies report a backend terminal
+  heartbeat status.
 - Final handoff must include links, tests, blockers, next action, and merged/ready/blocked/deferred/UNKNOWN sections.
 ```
 

--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -101,7 +101,8 @@ Execution rules:
 - For concurrent or dependency-sensitive batches, assign a stable agent id and
   lane name per lane. Declare lane dependencies with `depends_on` refs such as
   `<batch-id>:<lane-name>`, and create or update the private backend
-  `batches/<batch-id>.json` before dispatching dependent workers. When the private coordination backend is available,
+  `batches/<batch-id>.json` before dispatching dependent workers.
+  When the private coordination backend is available,
   use `agent-coord claim` before creating worktrees/branches,
   `agent-coord heartbeat` at phase transitions, and `agent-coord status` at
   lane start and before rebase or push. If the lane shows unmet `blocked_on`

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -94,18 +94,22 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
+<!-- Keep this Coordination block in sync with .agents/workflows/pr-processing.md. -->
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
-is available, acquire `agent-coord claim` for each issue/PR lane before creating
-that lane's worktree or branch; hard-stop if refused and report the holder plus
-heartbeat liveness. Run `agent-coord heartbeat` at every phase transition. For
-lanes declared in `batches/<batch-id>.json` with `depends_on`, run
-`agent-coord status` at lane start and before rebase or push; if unmet
-`blocked_on` refs remain, set that lane heartbeat `--status blocked`, report the
-blocked refs, and move to another independent lane until the dependency reports
-a terminal status such as `done`, `complete`, `merged`, `ready`, or `released`.
-Also use `agent-coord status` before dependency-sensitive readiness or closeout
-decisions. Structured public claim comments are fallback/advisory only; the
-private claim is the coordination source of truth.
+is available (`agent-coord status` exits 0), acquire `agent-coord claim` for
+each issue/PR lane before creating that lane's worktree or branch; hard-stop if
+refused and report the holder plus heartbeat liveness. Run `agent-coord
+heartbeat` at every phase transition. For lanes declared in
+`batches/<batch-id>.json` with `depends_on`, run `agent-coord status` at lane
+start and before rebase or push; if unmet `blocked_on` refs remain, set that
+lane heartbeat `--status blocked`, report the blocked refs, and move to another
+independent lane until the dependency reports a terminal status such as `done`,
+`complete`, `completed`, `merged`, or `ready`. Also use `agent-coord status`
+before dependency-sensitive readiness or closeout decisions. If `agent-coord
+status` cannot be checked, report `UNKNOWN` private state and use structured
+public claim comments as an advisory fallback. Structured public claim comments
+are fallback/advisory only; the private claim is the coordination source of
+truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -234,6 +238,10 @@ Use exact lane assignments as the primary coordination mechanism. Labels are hel
 - For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
   backend when available. Each lane gets a stable agent id such as
   `m5-codex-batch2` or `m1-claude-fable-lane1`.
+- Treat the backend as available when `agent-coord status` exits 0. If the
+  command is missing, auth fails, or status exits non-zero, report private state
+  as `UNKNOWN` and use advisory public claim comments. A refused
+  `agent-coord claim` after a successful status check remains a hard stop.
 - Acquire an `agent-coord claim` for each issue/PR lane before creating that
   lane's worktree or branch. A refused claim is a hard stop for machine agents:
   report the holder, heartbeat liveness, and target instead of creating a
@@ -241,8 +249,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are hel
 - Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
   start, branch or PR update, review pass, blocked state, and done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
-  `stale` until 4x TTL, and `dead` after that. Do not model liveness with
-  sticky labels.
+  `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
+  minutes; do not model liveness with sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
 - For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -81,7 +81,8 @@ If the user is in `/plan` or asks for a plan-to-goal handoff, stop after the `/g
 
 Keep this template aligned with the matching plan-to-goal prompt in
 `.agents/workflows/pr-processing.md`, including the review/audit gate
-paragraphs.
+paragraphs. Keep the `Coordination:` paragraph in sync with the same paragraph
+there.
 
 Use this template when creating the `/goal` text:
 
@@ -103,6 +104,8 @@ private `batches/<batch-id>.json` files for dependency lanes, and check
 readiness, or closeout decisions. Treat non-empty `blocked_on` refs as unmet
 dependencies; if a lane declares `depends_on` but status shows no matching
 private batch state, report dependency state as `UNKNOWN` and stop that lane.
+If status cannot be checked for a declared dependency lane, stop with dependency
+state `UNKNOWN` instead of using advisory fallback for that lane.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -94,6 +94,9 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
+Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
+is available, run `agent-coord heartbeat` at every phase transition and use
+`agent-coord status` before dependency-sensitive work.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -219,6 +222,16 @@ Use exact lane assignments as the primary coordination mechanism. Labels are hel
 
 - Use a maintainer-applied eligibility label such as `codex-ready` only if the repo has adopted it.
 - Use a temporary `codex-wip` label only as a visible dashboard hint; do not treat it as the durable lock.
+- For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
+  backend when available. Each lane gets a stable agent id such as
+  `m5-codex-batch2` or `m1-claude-fable-lane1`.
+- Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
+  start, branch or PR update, review pass, blocked state, and done state.
+  Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
+  `stale` until 4x TTL, and `dead` after that. Do not model liveness with
+  sticky labels.
+- Use `agent-coord status` before starting dependency-sensitive lanes and before
+  rebase, push, readiness, or closeout decisions that depend on another lane.
 - Prefer a structured claim comment for resumable coordination:
 
 ```markdown
@@ -248,6 +261,8 @@ When worker subagents are explicitly authorized:
 - Give each worker a separate worktree and branch.
 - Tell workers they are not alone in the codebase and must not revert others' edits.
 - Keep write scopes disjoint unless the main agent serializes integration.
+- Refresh that worker's heartbeat whenever it starts an item, pushes or updates a
+  PR, completes a review pass, becomes blocked, resumes, or finishes the lane.
 - The main agent owns final PR creation, status reporting, full-CI decisions, and merge sequencing.
 
 ## Coordinator Closeout Lane

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -81,10 +81,8 @@ If the user is in `/plan` or asks for a plan-to-goal handoff, stop after the `/g
 
 Keep this template aligned with the matching plan-to-goal prompt in
 `.agents/workflows/pr-processing.md`, including the review/audit gate
-paragraphs. Keep the `Coordination:` paragraph in sync with the same paragraph
-there.
-
-<!-- Keep the Coordination paragraph inside the prompt below in sync with `.agents/workflows/pr-processing.md`. -->
+paragraphs. The `Coordination:` line below intentionally points at the canonical
+workflow rules instead of duplicating them.
 
 Use this template when creating the `/goal` text:
 
@@ -97,17 +95,10 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
-Coordination: follow the canonical coordination protocol in
-`.agents/workflows/pr-processing.md` under Coordination State and Worker Rules
-before creating worktrees or branches. Assign stable agent ids, claim before
-branching when the backend is available, heartbeat at phase transitions, create
-private `batches/<batch-id>.json` files for dependency lanes, and check
-`agent-coord status` at lane start and before dependency-sensitive rebase, push,
-readiness, or closeout decisions. Treat non-empty `blocked_on` refs as unmet
-dependencies; if a lane declares `depends_on` but status shows no matching
-private batch state, report dependency state as `UNKNOWN` and stop that lane.
-If status cannot be checked for a declared dependency lane, stop with dependency
-state `UNKNOWN` instead of using advisory fallback for that lane.
+Coordination: follow `.agents/workflows/pr-processing.md` under Coordination
+State and Worker Rules before creating worktrees or branches. Include stable
+agent ids, `agent-coord status` / claim outcomes, batch ids, dependency refs,
+and any `UNKNOWN` state in every worker lane and handoff.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -95,8 +95,12 @@ Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
-is available, run `agent-coord heartbeat` at every phase transition and use
-`agent-coord status` before dependency-sensitive work.
+is available, acquire `agent-coord claim` for each issue/PR lane before creating
+that lane's worktree or branch; hard-stop if refused and report the holder plus
+heartbeat liveness. Run `agent-coord heartbeat` at every phase transition and use
+`agent-coord status` before dependency-sensitive work. Structured public claim
+comments are fallback/advisory only; the private claim is the coordination source
+of truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -225,6 +229,10 @@ Use exact lane assignments as the primary coordination mechanism. Labels are hel
 - For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
   backend when available. Each lane gets a stable agent id such as
   `m5-codex-batch2` or `m1-claude-fable-lane1`.
+- Acquire an `agent-coord claim` for each issue/PR lane before creating that
+  lane's worktree or branch. A refused claim is a hard stop for machine agents:
+  report the holder, heartbeat liveness, and target instead of creating a
+  competing branch.
 - Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
   start, branch or PR update, review pass, blocked state, and done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
@@ -232,7 +240,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are hel
   sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
-- Prefer a structured claim comment for resumable coordination:
+- Use a structured public claim comment only as an advisory fallback or human
+  hint when the private backend is unavailable or explicitly mirrored:
 
 ```markdown
 <!-- codex-claim v1
@@ -248,16 +257,21 @@ expires_at: <ISO8601_UTC>
 Use any stable session, thread, or machine identifier that lets a restarted
 coordinator recognize its own work; if none exists, use `thread: unavailable`
 and rely on the machine, branch, and batch fields. Set `expires_at` to a short
-bounded lease, usually 2-4 hours for an active batch or no later than the known
-batch window. Refresh the claim when continuing beyond that window.
+bounded advisory lease, usually 2-4 hours for an active batch or no later than
+the known batch window. Refresh the comment when continuing beyond that window.
+Do not use the public comment to override or bypass a private claim refusal.
 
-On restart, search for existing claim comments. Resume your own live claim, skip another live claim, or treat expired claims as recoverable after reporting the takeover.
+On restart, prefer `agent-coord status` and the private claim/heartbeat state.
+Use claim comments only to recover context when the backend is unavailable.
 
 ## Worker Rules
 
 When worker subagents are explicitly authorized:
 
 - Assign one target or one disjoint lane per worker.
+- Acquire the lane's `agent-coord claim` before creating the worker worktree or
+  branch when the backend is available. If the claim is refused, the worker
+  reports the holder and heartbeat liveness, then stops that lane.
 - Give each worker a separate worktree and branch.
 - Tell workers they are not alone in the codebase and must not revert others' edits.
 - Keep write scopes disjoint unless the main agent serializes integration.

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -222,75 +222,22 @@ requests already handled, and no-PR rationales.
 
 ## Coordination State
 
-Use exact lane assignments as the primary coordination mechanism. Labels are helpful but not sufficient.
+Use [.agents/workflows/pr-processing.md](../../workflows/pr-processing.md) as the
+canonical source for coordination state and worker rules. Keep this skill as a
+routing entry point; do not duplicate the full protocol here.
 
-- Use a maintainer-applied eligibility label such as `codex-ready` only if the repo has adopted it.
-- Use a temporary `codex-wip` label only as a visible dashboard hint; do not treat it as the durable lock.
-- For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
-  backend when available. Each lane gets a stable agent id such as
-  `m5-codex-batch2` or `m1-claude-fable-lane1`.
-- Treat the backend as available when `agent-coord status` exits 0. If the
-  command is missing, auth fails, or status exits non-zero, report private state
-  as `UNKNOWN` and use advisory public claim comments. A refused
-  `agent-coord claim` after a successful status check remains a hard stop.
-- Acquire an `agent-coord claim` for each issue/PR lane before creating that
-  lane's worktree or branch. A refused claim is a hard stop for machine agents:
-  report the holder, heartbeat liveness, and target instead of creating a
-  competing branch.
-- Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
-  start, branch or PR update, review pass, blocked state, and done state.
-  Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
-  `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
-  minutes; do not model liveness with sticky labels.
-- Use `agent-coord status` before starting dependency-sensitive lanes and before
-  rebase, push, readiness, or closeout decisions that depend on another lane.
-- For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat
-  non-empty `blocked_on` refs as an unmet dependency. The worker should refresh
-  its own heartbeat with `--status blocked`, switch to another independent lane
-  when one exists, and re-check `agent-coord status` before resuming, rebasing,
-  or pushing the blocked lane.
-- Use a structured public claim comment only as an advisory fallback or human
-  hint when the private backend is unavailable or explicitly mirrored:
-
-```markdown
-<!-- codex-claim v1
-batch: <BATCH_ID>
-machine: <MACHINE_ID>
-thread: <codex-thread-id>
-branch: <BRANCH_NAME>
-status: in_progress
-expires_at: <ISO8601_UTC>
--->
-```
-
-Use any stable session, thread, or machine identifier that lets a restarted
-coordinator recognize its own work; if none exists, use `thread: unavailable`
-and rely on the machine, branch, and batch fields. Set `expires_at` to a short
-bounded advisory lease, usually 2-4 hours for an active batch or no later than
-the known batch window. Refresh the comment when continuing beyond that window.
-Do not use the public comment to override or bypass a private claim refusal.
-
-On restart, prefer `agent-coord status` and the private claim/heartbeat state.
-Use claim comments only to recover context when the backend is unavailable.
+In short: exact lane assignments beat labels; private `agent-coord` state is the
+source of truth when `agent-coord status` exits 0; refused claims hard-stop
+machine agents; workers heartbeat at phase transitions; dependency-sensitive
+lanes run `agent-coord status` before rebase, push, readiness, and closeout; and
+structured public claim comments are only advisory fallback state.
 
 ## Worker Rules
 
-When worker subagents are explicitly authorized:
-
-- Assign one target or one disjoint lane per worker.
-- Acquire the lane's `agent-coord claim` before creating the worker worktree or
-  branch when the backend is available. If the claim is refused, the worker
-  reports the holder and heartbeat liveness, then stops that lane.
-- Give each worker a separate worktree and branch.
-- Tell workers they are not alone in the codebase and must not revert others' edits.
-- Keep write scopes disjoint unless the main agent serializes integration.
-- Refresh that worker's heartbeat whenever it starts an item, pushes or updates a
-  PR, completes a review pass, becomes blocked, resumes, or finishes the lane.
-- For a worker lane with `depends_on`, check `agent-coord status` at lane start
-  and before rebase or push. If dependencies are unmet, the worker reports the
-  `blocked_on` refs, sets heartbeat `--status blocked`, and moves to another
-  independent lane instead of pushing dependent work.
-- The main agent owns final PR creation, status reporting, full-CI decisions, and merge sequencing.
+Follow the canonical
+[Worker Rules](../../workflows/pr-processing.md#worker-rules) and keep one target
+or one disjoint lane per worker. The main agent owns final PR creation, status
+reporting, full-CI decisions, and merge sequencing.
 
 ## Coordinator Closeout Lane
 

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -84,6 +84,8 @@ Keep this template aligned with the matching plan-to-goal prompt in
 paragraphs. Keep the `Coordination:` paragraph in sync with the same paragraph
 there.
 
+<!-- Keep the Coordination paragraph inside the prompt below in sync with `.agents/workflows/pr-processing.md`. -->
+
 Use this template when creating the `/goal` text:
 
 ```text

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -95,12 +95,14 @@ Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
 Coordination: follow the canonical coordination protocol in
-`.agents/workflows/pr-processing.md`: assign stable agent ids, run
-`agent-coord claim` before creating worktrees or branches when
-`agent-coord status` exits 0, hard-stop on refused claims, heartbeat at phase
-transitions, run `agent-coord status` before dependency-sensitive rebase, push,
-readiness, or closeout decisions, and use structured public claim comments only
-as an advisory fallback when private status cannot be checked.
+`.agents/workflows/pr-processing.md` under Coordination State and Worker Rules
+before creating worktrees or branches. Assign stable agent ids, claim before
+branching when the backend is available, heartbeat at phase transitions, create
+private `batches/<batch-id>.json` files for dependency lanes, and check
+`agent-coord status` at lane start and before dependency-sensitive rebase, push,
+readiness, or closeout decisions. Treat non-empty `blocked_on` refs as unmet
+dependencies; if a lane declares `depends_on` but status shows no matching
+private batch state, report dependency state as `UNKNOWN` and stop that lane.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -228,9 +230,10 @@ routing entry point; do not duplicate the full protocol here.
 
 In short: exact lane assignments beat labels; private `agent-coord` state is the
 source of truth when `agent-coord status` exits 0; refused claims hard-stop
-machine agents; workers heartbeat at phase transitions; dependency-sensitive
-lanes run `agent-coord status` before rebase, push, readiness, and closeout; and
-structured public claim comments are only advisory fallback state.
+machine agents; workers heartbeat at phase transitions; coordinators create
+private batch files before dependency lanes start; dependency-sensitive lanes run
+`agent-coord status` before rebase, push, readiness, and closeout; and structured
+public claim comments are only advisory fallback state.
 
 ## Worker Rules
 

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -94,22 +94,13 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
-<!-- Keep this Coordination block in sync with .agents/workflows/pr-processing.md. -->
-Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
-is available (`agent-coord status` exits 0), acquire `agent-coord claim` for
-each issue/PR lane before creating that lane's worktree or branch; hard-stop if
-refused and report the holder plus heartbeat liveness. Run `agent-coord
-heartbeat` at every phase transition. For lanes declared in
-`batches/<batch-id>.json` with `depends_on`, run `agent-coord status` at lane
-start and before rebase or push; if unmet `blocked_on` refs remain, set that
-lane heartbeat `--status blocked`, report the blocked refs, and move to another
-independent lane until the dependency reports a terminal status such as `done`,
-`complete`, `completed`, `merged`, or `ready`. Also use `agent-coord status`
-before dependency-sensitive readiness or closeout decisions. If `agent-coord
-status` cannot be checked, report `UNKNOWN` private state and use structured
-public claim comments as an advisory fallback. Structured public claim comments
-are fallback/advisory only; the private claim is the coordination source of
-truth.
+Coordination: follow the canonical coordination protocol in
+`.agents/workflows/pr-processing.md`: assign stable agent ids, run
+`agent-coord claim` before creating worktrees or branches when
+`agent-coord status` exits 0, hard-stop on refused claims, heartbeat at phase
+transitions, run `agent-coord status` before dependency-sensitive rebase, push,
+readiness, or closeout decisions, and use structured public claim comments only
+as an advisory fallback when private status cannot be checked.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -97,10 +97,15 @@ Mode: spawn worker subagents only after the target list and lane split are confi
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
 is available, acquire `agent-coord claim` for each issue/PR lane before creating
 that lane's worktree or branch; hard-stop if refused and report the holder plus
-heartbeat liveness. Run `agent-coord heartbeat` at every phase transition and use
-`agent-coord status` before dependency-sensitive work. Structured public claim
-comments are fallback/advisory only; the private claim is the coordination source
-of truth.
+heartbeat liveness. Run `agent-coord heartbeat` at every phase transition. For
+lanes declared in `batches/<batch-id>.json` with `depends_on`, run
+`agent-coord status` at lane start and before rebase or push; if unmet
+`blocked_on` refs remain, set that lane heartbeat `--status blocked`, report the
+blocked refs, and move to another independent lane until the dependency reports
+a terminal status such as `done`, `complete`, `merged`, `ready`, or `released`.
+Also use `agent-coord status` before dependency-sensitive readiness or closeout
+decisions. Structured public claim comments are fallback/advisory only; the
+private claim is the coordination source of truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -240,6 +245,11 @@ Use exact lane assignments as the primary coordination mechanism. Labels are hel
   sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
+- For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat
+  non-empty `blocked_on` refs as an unmet dependency. The worker should refresh
+  its own heartbeat with `--status blocked`, switch to another independent lane
+  when one exists, and re-check `agent-coord status` before resuming, rebasing,
+  or pushing the blocked lane.
 - Use a structured public claim comment only as an advisory fallback or human
   hint when the private backend is unavailable or explicitly mirrored:
 
@@ -277,6 +287,10 @@ When worker subagents are explicitly authorized:
 - Keep write scopes disjoint unless the main agent serializes integration.
 - Refresh that worker's heartbeat whenever it starts an item, pushes or updates a
   PR, completes a review pass, becomes blocked, resumes, or finishes the lane.
+- For a worker lane with `depends_on`, check `agent-coord status` at lane start
+  and before rebase or push. If dependencies are unmet, the worker reports the
+  `blocked_on` refs, sets heartbeat `--status blocked`, and moves to another
+  independent lane instead of pushing dependent work.
 - The main agent owns final PR creation, status reporting, full-CI decisions, and merge sequencing.
 
 ## Coordinator Closeout Lane

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -37,10 +37,11 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      advisory fallback.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
-     shows unmet `blocked_on` refs, set that lane's heartbeat to `--status
-blocked`, report the blocked refs in the handoff, and move to another
-     independent lane until the dependency reports a terminal status such as
-     `done`, `complete`, `completed`, `merged`, or `ready`.
+     shows unmet `blocked_on` refs, set that lane's heartbeat status to
+     `blocked`, report the blocked refs in the handoff, and move to another
+     independent lane until the dependency reports a backend terminal heartbeat
+     status. The current public summary lives in
+     [agent-coordination-backend.md](../../internal/contributor-info/agent-coordination-backend.md).
    - Use the current checkout for one focused task.
    - For multiple independent PRs or lanes (independent work streams with separate branch/worktree ownership), use one worktree per PR branch so agents do not overlap edits.
 4. Make a local batch:
@@ -289,7 +290,6 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
-<!-- Keep this Coordination block in sync with .agents/skills/pr-batch/SKILL.md. -->
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
 is available (`agent-coord status` exits 0), acquire `agent-coord claim` for
 each issue/PR lane before creating that lane's worktree or branch; hard-stop if
@@ -298,13 +298,12 @@ heartbeat` at every phase transition. For lanes declared in
 `batches/<batch-id>.json` with `depends_on`, run `agent-coord status` at lane
 start and before rebase or push; if unmet `blocked_on` refs remain, set that
 lane heartbeat `--status blocked`, report the blocked refs, and move to another
-independent lane until the dependency reports a terminal status such as `done`,
-`complete`, `completed`, `merged`, or `ready`. Also use `agent-coord status`
-before dependency-sensitive readiness or closeout decisions. If `agent-coord
-status` cannot be checked, report `UNKNOWN` private state and use structured
-public claim comments as an advisory fallback. Structured public claim comments
-are fallback/advisory only; the private claim is the coordination source of
-truth.
+independent lane until the dependency reports a backend terminal heartbeat
+status. Also use `agent-coord status` before dependency-sensitive readiness or
+closeout decisions. If `agent-coord status` cannot be checked, report `UNKNOWN`
+private state and use structured public claim comments as an advisory fallback.
+Structured public claim comments are fallback/advisory only; the private claim
+is the coordination source of truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -44,7 +44,9 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      independent lane until the dependency reports a backend terminal heartbeat
      status. If the lane declares `depends_on` but `agent-coord status` shows no
      matching private batch state for that lane, treat dependency state as
-     `UNKNOWN` and stop to report the missing private batch file. The current
+     `UNKNOWN` and stop to report the missing private batch file. If the status
+     command itself fails for a declared dependency lane, also stop with
+     dependency state `UNKNOWN` instead of using advisory fallback. The current
      public summary lives in
      [agent-coordination-backend.md](../../internal/contributor-info/agent-coordination-backend.md).
    - Use the current checkout for one focused task.
@@ -304,6 +306,8 @@ private `batches/<batch-id>.json` files for dependency lanes, and check
 readiness, or closeout decisions. Treat non-empty `blocked_on` refs as unmet
 dependencies; if a lane declares `depends_on` but status shows no matching
 private batch state, report dependency state as `UNKNOWN` and stop that lane.
+If status cannot be checked for a declared dependency lane, stop with dependency
+state `UNKNOWN` instead of using advisory fallback for that lane.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -459,7 +463,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
 - Coordinators create or update private backend `batches/<batch-id>.json` files
-  before dispatching workers for dependency-sensitive lanes; declared
+  before dispatching workers for dependency-sensitive lanes, following the
+  private backend README/schema rather than public examples; declared
   `depends_on` refs are only enforceable after that state exists.
 - For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat
   non-empty `blocked_on` refs as an unmet dependency. The worker should refresh

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -290,20 +290,12 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
-Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
-is available (`agent-coord status` exits 0), acquire `agent-coord claim` for
-each issue/PR lane before creating that lane's worktree or branch; hard-stop if
-refused and report the holder plus heartbeat liveness. Run `agent-coord
-heartbeat` at every phase transition. For lanes declared in
-`batches/<batch-id>.json` with `depends_on`, run `agent-coord status` at lane
-start and before rebase or push; if unmet `blocked_on` refs remain, set that
-lane heartbeat `--status blocked`, report the blocked refs, and move to another
-independent lane until the dependency reports a backend terminal heartbeat
-status. Also use `agent-coord status` before dependency-sensitive readiness or
-closeout decisions. If `agent-coord status` cannot be checked, report `UNKNOWN`
-private state and use structured public claim comments as an advisory fallback.
-Structured public claim comments are fallback/advisory only; the private claim
-is the coordination source of truth.
+Coordination: follow the canonical coordination protocol in
+`.agents/workflows/pr-processing.md` under Coordination State and Worker Rules
+before creating worktrees or branches. Assign stable agent ids, claim before
+branching when the backend is available, heartbeat at phase transitions, create
+private `batches/<batch-id>.json` files for dependency lanes, and check status
+before dependency-sensitive rebase, push, readiness, or closeout decisions.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -439,7 +431,7 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 - Use a temporary `codex-wip` label only as a visible hint; do not treat it as the durable lock.
 - For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
   backend when available. Each lane gets a stable agent id such as
-  `m5-codex-batch2` or `m1-claude-fable-lane1`.
+  `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 - Treat the backend as available when `agent-coord status` exits 0. If the
   command is missing, auth fails, or status exits non-zero, report private state
   as `UNKNOWN` and use advisory public claim comments. A refused
@@ -455,6 +447,9 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   minutes; do not model liveness with sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
+- Coordinators create or update private backend `batches/<batch-id>.json` files
+  before dispatching workers for dependency-sensitive lanes; declared
+  `depends_on` refs are only enforceable after that state exists.
 - For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat
   non-empty `blocked_on` refs as an unmet dependency. The worker should refresh
   its own heartbeat with `--status blocked`, switch to another independent lane

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -28,18 +28,19 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
    - When the value, priority, or proposed fix scope is unclear, use `.agents/skills/evaluate-issue/SKILL.md` before implementation (or `.agents/workflows/evaluate-issue.md` for agents without skill support).
 3. Isolate the work:
    - Fetch/prune `main`, confirm the expected repository root, and verify nested repo paths before assigning work.
-   - When the private `shakacode/agent-coordination` backend is available, acquire
-     an `agent-coord claim` for each issue/PR lane before creating that lane's
-     worktree or branch. Machine agents must hard-stop when the claim is refused
-     and report the holder plus heartbeat liveness. Structured public claim
-     comments are fallback/advisory only; the private claim is the coordination
-     source of truth.
+   - When the private `shakacode/agent-coordination` backend is available
+     (`agent-coord status` exits 0), acquire an `agent-coord claim` for each
+     issue/PR lane before creating that lane's worktree or branch. Machine
+     agents must hard-stop when the claim is refused and report the holder plus
+     heartbeat liveness. If `agent-coord status` cannot be checked, report
+     private state as `UNKNOWN` and use structured public claim comments as an
+     advisory fallback.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
-     `agent-coord status` at lane start. If the lane shows unmet `blocked_on`
-     refs, set that lane's heartbeat to `--status blocked`, report the blocked
-     refs in the handoff, and move to another independent lane until the
-     dependency reports a terminal status such as `done`, `complete`, `merged`,
-     `ready`, or `released`.
+     `agent-coord status` at lane start and before rebase or push. If the lane
+     shows unmet `blocked_on` refs, set that lane's heartbeat to `--status
+blocked`, report the blocked refs in the handoff, and move to another
+     independent lane until the dependency reports a terminal status such as
+     `done`, `complete`, `completed`, `merged`, or `ready`.
    - Use the current checkout for one focused task.
    - For multiple independent PRs or lanes (independent work streams with separate branch/worktree ownership), use one worktree per PR branch so agents do not overlap edits.
 4. Make a local batch:
@@ -288,18 +289,22 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
+<!-- Keep this Coordination block in sync with .agents/skills/pr-batch/SKILL.md. -->
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
-is available, acquire `agent-coord claim` for each issue/PR lane before creating
-that lane's worktree or branch; hard-stop if refused and report the holder plus
-heartbeat liveness. Run `agent-coord heartbeat` at every phase transition. For
-lanes declared in `batches/<batch-id>.json` with `depends_on`, run
-`agent-coord status` at lane start and before rebase or push; if unmet
-`blocked_on` refs remain, set that lane heartbeat `--status blocked`, report the
-blocked refs, and move to another independent lane until the dependency reports
-a terminal status such as `done`, `complete`, `merged`, `ready`, or `released`.
-Also use `agent-coord status` before dependency-sensitive readiness or closeout
-decisions. Structured public claim comments are fallback/advisory only; the
-private claim is the coordination source of truth.
+is available (`agent-coord status` exits 0), acquire `agent-coord claim` for
+each issue/PR lane before creating that lane's worktree or branch; hard-stop if
+refused and report the holder plus heartbeat liveness. Run `agent-coord
+heartbeat` at every phase transition. For lanes declared in
+`batches/<batch-id>.json` with `depends_on`, run `agent-coord status` at lane
+start and before rebase or push; if unmet `blocked_on` refs remain, set that
+lane heartbeat `--status blocked`, report the blocked refs, and move to another
+independent lane until the dependency reports a terminal status such as `done`,
+`complete`, `completed`, `merged`, or `ready`. Also use `agent-coord status`
+before dependency-sensitive readiness or closeout decisions. If `agent-coord
+status` cannot be checked, report `UNKNOWN` private state and use structured
+public claim comments as an advisory fallback. Structured public claim comments
+are fallback/advisory only; the private claim is the coordination source of
+truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -436,6 +441,10 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 - For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
   backend when available. Each lane gets a stable agent id such as
   `m5-codex-batch2` or `m1-claude-fable-lane1`.
+- Treat the backend as available when `agent-coord status` exits 0. If the
+  command is missing, auth fails, or status exits non-zero, report private state
+  as `UNKNOWN` and use advisory public claim comments. A refused
+  `agent-coord claim` after a successful status check remains a hard stop.
 - Acquire an `agent-coord claim` for each issue/PR lane before creating that
   lane's worktree or branch. A refused claim is a hard stop for machine agents:
   report the holder, heartbeat liveness, and target instead of creating a
@@ -443,8 +452,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 - Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
   start, branch or PR update, review pass, blocked state, and done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
-  `stale` until 4x TTL, and `dead` after that. Do not model liveness with
-  sticky labels.
+  `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
+  minutes; do not model liveness with sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
 - For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -32,9 +32,11 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      (`agent-coord status` exits 0), acquire an `agent-coord claim` for each
      issue/PR lane before creating that lane's worktree or branch. Machine
      agents must hard-stop when the claim is refused and report the holder plus
-     heartbeat liveness. If `agent-coord status` cannot be checked, report
-     private state as `UNKNOWN` and use structured public claim comments as an
-     advisory fallback.
+     heartbeat liveness. `agent-coord status` is a preflight view; the claim
+     operation is the backend's compare-and-swap gate, so the claim result is the
+     source of truth for races. If `agent-coord status` cannot be checked,
+     report private state as `UNKNOWN` and use structured public claim comments
+     as an advisory fallback.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
@@ -446,6 +448,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   lane's worktree or branch. A refused claim is a hard stop for machine agents:
   report the holder, heartbeat liveness, and target instead of creating a
   competing branch.
+  `agent-coord status` is advisory preflight, while `agent-coord claim` is the
+  backend's compare-and-swap gate for concurrent claim races.
 - Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
   start, branch or PR update, review pass, blocked state, resumed state, and
   done state.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -297,8 +297,11 @@ Coordination: follow the canonical coordination protocol in
 `.agents/workflows/pr-processing.md` under Coordination State and Worker Rules
 before creating worktrees or branches. Assign stable agent ids, claim before
 branching when the backend is available, heartbeat at phase transitions, create
-private `batches/<batch-id>.json` files for dependency lanes, and check status
-before dependency-sensitive rebase, push, readiness, or closeout decisions.
+private `batches/<batch-id>.json` files for dependency lanes, and check
+`agent-coord status` at lane start and before dependency-sensitive rebase, push,
+readiness, or closeout decisions. Treat non-empty `blocked_on` refs as unmet
+dependencies; if a lane declares `depends_on` but status shows no matching
+private batch state, report dependency state as `UNKNOWN` and stop that lane.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -444,7 +447,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   report the holder, heartbeat liveness, and target instead of creating a
   competing branch.
 - Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
-  start, branch or PR update, review pass, blocked state, and done state.
+  start, branch or PR update, review pass, blocked state, resumed state, and
+  done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
   `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
   minutes; do not model liveness with sticky labels.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -286,7 +286,8 @@ If the user is using `/plan`, or asks to prepare a `/goal`, stop after producing
 Keep this goal prompt aligned with `.agents/skills/pr-batch/SKILL.md`,
 including the review/audit gate paragraphs.
 
-<!-- Keep the Coordination paragraph inside the prompt below in sync with `.agents/skills/pr-batch/SKILL.md`. -->
+The `$pr-batch` skill links to this canonical `Coordination:` paragraph instead
+of duplicating it.
 
 Use this goal prompt shape:
 

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -34,6 +34,12 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      and report the holder plus heartbeat liveness. Structured public claim
      comments are fallback/advisory only; the private claim is the coordination
      source of truth.
+   - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
+     `agent-coord status` at lane start. If the lane shows unmet `blocked_on`
+     refs, set that lane's heartbeat to `--status blocked`, report the blocked
+     refs in the handoff, and move to another independent lane until the
+     dependency reports a terminal status such as `done`, `complete`, `merged`,
+     `ready`, or `released`.
    - Use the current checkout for one focused task.
    - For multiple independent PRs or lanes (independent work streams with separate branch/worktree ownership), use one worktree per PR branch so agents do not overlap edits.
 4. Make a local batch:
@@ -285,10 +291,15 @@ Mode: spawn worker subagents only after the target list and lane split are confi
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
 is available, acquire `agent-coord claim` for each issue/PR lane before creating
 that lane's worktree or branch; hard-stop if refused and report the holder plus
-heartbeat liveness. Run `agent-coord heartbeat` at every phase transition and use
-`agent-coord status` before dependency-sensitive work. Structured public claim
-comments are fallback/advisory only; the private claim is the coordination source
-of truth.
+heartbeat liveness. Run `agent-coord heartbeat` at every phase transition. For
+lanes declared in `batches/<batch-id>.json` with `depends_on`, run
+`agent-coord status` at lane start and before rebase or push; if unmet
+`blocked_on` refs remain, set that lane heartbeat `--status blocked`, report the
+blocked refs, and move to another independent lane until the dependency reports
+a terminal status such as `done`, `complete`, `merged`, `ready`, or `released`.
+Also use `agent-coord status` before dependency-sensitive readiness or closeout
+decisions. Structured public claim comments are fallback/advisory only; the
+private claim is the coordination source of truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -436,6 +447,11 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
+- For lanes declared in `batches/<batch-id>.json` with `depends_on`, treat
+  non-empty `blocked_on` refs as an unmet dependency. The worker should refresh
+  its own heartbeat with `--status blocked`, switch to another independent lane
+  when one exists, and re-check `agent-coord status` before resuming, rebasing,
+  or pushing the blocked lane.
 - Use a structured public claim comment only as an advisory fallback or human
   hint when the private backend is unavailable or explicitly mirrored:
 
@@ -473,6 +489,10 @@ When worker subagents are explicitly authorized:
 - Keep write scopes disjoint unless the main agent serializes integration.
 - Refresh that worker's heartbeat whenever it starts an item, pushes or updates a
   PR, completes a review pass, becomes blocked, resumes, or finishes the lane.
+- For a worker lane with `depends_on`, check `agent-coord status` at lane start
+  and before rebase or push. If dependencies are unmet, the worker reports the
+  `blocked_on` refs, sets heartbeat `--status blocked`, and moves to another
+  independent lane instead of pushing dependent work.
 - The main agent owns final PR creation, status reporting, full-CI decisions, and merge sequencing.
 
 ### Coordinator Closeout Lane

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -461,8 +461,9 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   start, branch or PR update, review pass, blocked state, resumed state, and
   done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
-  `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
-  minutes; do not model liveness with sticky labels.
+  `stale` until the backend dead threshold, and `dead` after that. Check the
+  private backend README and CLI help for current TTL defaults and threshold
+  calculations; do not model liveness with sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
   If `agent-coord status` cannot be checked for a declared dependency lane, stop

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -462,6 +462,9 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   minutes; do not model liveness with sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
+  If `agent-coord status` cannot be checked for a declared dependency lane, stop
+  with dependency state `UNKNOWN` instead of using advisory fallback for that
+  lane.
 - Coordinators create or update private backend `batches/<batch-id>.json` files
   before dispatching workers for dependency-sensitive lanes, following the
   private backend README/schema rather than public examples; declared
@@ -512,6 +515,9 @@ When worker subagents are explicitly authorized:
   and before rebase or push. If dependencies are unmet, the worker reports the
   `blocked_on` refs, sets heartbeat `--status blocked`, and moves to another
   independent lane instead of pushing dependent work.
+- If `agent-coord status` cannot be checked for a worker lane with `depends_on`,
+  treat dependency state as `UNKNOWN` and stop that lane instead of using
+  advisory fallback.
 - If a worker lane declares `depends_on` but `agent-coord status` shows no
   matching batch state for that lane, treat dependency state as `UNKNOWN` and
   stop to report the missing private batch file.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -28,6 +28,12 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
    - When the value, priority, or proposed fix scope is unclear, use `.agents/skills/evaluate-issue/SKILL.md` before implementation (or `.agents/workflows/evaluate-issue.md` for agents without skill support).
 3. Isolate the work:
    - Fetch/prune `main`, confirm the expected repository root, and verify nested repo paths before assigning work.
+   - When the private `shakacode/agent-coordination` backend is available, acquire
+     an `agent-coord claim` for each issue/PR lane before creating that lane's
+     worktree or branch. Machine agents must hard-stop when the claim is refused
+     and report the holder plus heartbeat liveness. Structured public claim
+     comments are fallback/advisory only; the private claim is the coordination
+     source of truth.
    - Use the current checkout for one focused task.
    - For multiple independent PRs or lanes (independent work streams with separate branch/worktree ownership), use one worktree per PR branch so agents do not overlap edits.
 4. Make a local batch:
@@ -277,8 +283,12 @@ Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
 Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
-is available, run `agent-coord heartbeat` at every phase transition and use
-`agent-coord status` before dependency-sensitive work.
+is available, acquire `agent-coord claim` for each issue/PR lane before creating
+that lane's worktree or branch; hard-stop if refused and report the holder plus
+heartbeat liveness. Run `agent-coord heartbeat` at every phase transition and use
+`agent-coord status` before dependency-sensitive work. Structured public claim
+comments are fallback/advisory only; the private claim is the coordination source
+of truth.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -415,6 +425,10 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 - For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
   backend when available. Each lane gets a stable agent id such as
   `m5-codex-batch2` or `m1-claude-fable-lane1`.
+- Acquire an `agent-coord claim` for each issue/PR lane before creating that
+  lane's worktree or branch. A refused claim is a hard stop for machine agents:
+  report the holder, heartbeat liveness, and target instead of creating a
+  competing branch.
 - Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
   start, branch or PR update, review pass, blocked state, and done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
@@ -422,7 +436,8 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
-- Prefer a structured claim comment for resumable coordination:
+- Use a structured public claim comment only as an advisory fallback or human
+  hint when the private backend is unavailable or explicitly mirrored:
 
 ```markdown
 <!-- codex-claim v1
@@ -438,16 +453,21 @@ expires_at: <ISO8601_UTC>
 Use any stable session, thread, or machine identifier that lets a restarted
 coordinator recognize its own work; if none exists, use `thread: unavailable`
 and rely on the machine, branch, and batch fields. Set `expires_at` to a short
-bounded lease, usually 2-4 hours for an active batch or no later than the known
-batch window. Refresh the claim when continuing beyond that window.
+bounded advisory lease, usually 2-4 hours for an active batch or no later than
+the known batch window. Refresh the comment when continuing beyond that window.
+Do not use the public comment to override or bypass a private claim refusal.
 
-On restart, search for existing claim comments. Resume your own live claim, skip another live claim, or treat expired claims as recoverable after reporting the takeover.
+On restart, prefer `agent-coord status` and the private claim/heartbeat state.
+Use claim comments only to recover context when the backend is unavailable.
 
 ### Worker Rules
 
 When worker subagents are explicitly authorized:
 
 - Assign one target or one disjoint lane per worker.
+- Acquire the lane's `agent-coord claim` before creating the worker worktree or
+  branch when the backend is available. If the claim is refused, the worker
+  reports the holder and heartbeat liveness, then stops that lane.
 - Give each worker a separate worktree and branch.
 - Tell workers they are not alone in the codebase and must not revert others' edits.
 - Keep write scopes disjoint unless the main agent serializes integration.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -496,6 +496,9 @@ When worker subagents are explicitly authorized:
   and before rebase or push. If dependencies are unmet, the worker reports the
   `blocked_on` refs, sets heartbeat `--status blocked`, and moves to another
   independent lane instead of pushing dependent work.
+- If a worker lane declares `depends_on` but `agent-coord status` shows no
+  matching batch state for that lane, treat dependency state as `UNKNOWN` and
+  stop to report the missing private batch file.
 - The main agent owns final PR creation, status reporting, full-CI decisions, and merge sequencing.
 
 ### Coordinator Closeout Lane

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -40,7 +40,10 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
      `blocked`, report the blocked refs in the handoff, and move to another
      independent lane until the dependency reports a backend terminal heartbeat
-     status. The current public summary lives in
+     status. If the lane declares `depends_on` but `agent-coord status` shows no
+     matching private batch state for that lane, treat dependency state as
+     `UNKNOWN` and stop to report the missing private batch file. The current
+     public summary lives in
      [agent-coordination-backend.md](../../internal/contributor-info/agent-coordination-backend.md).
    - Use the current checkout for one focused task.
    - For multiple independent PRs or lanes (independent work streams with separate branch/worktree ownership), use one worktree per PR branch so agents do not overlap edits.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -286,6 +286,8 @@ If the user is using `/plan`, or asks to prepare a `/goal`, stop after producing
 Keep this goal prompt aligned with `.agents/skills/pr-batch/SKILL.md`,
 including the review/audit gate paragraphs.
 
+<!-- Keep the Coordination paragraph inside the prompt below in sync with `.agents/skills/pr-batch/SKILL.md`. -->
+
 Use this goal prompt shape:
 
 ```text

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -276,6 +276,9 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
+Coordination: assign a stable agent id per lane. When `shakacode/agent-coordination`
+is available, run `agent-coord heartbeat` at every phase transition and use
+`agent-coord status` before dependency-sensitive work.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
@@ -409,6 +412,16 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 
 - Use a maintainer-applied eligibility label such as `codex-ready` only if the repo has adopted it.
 - Use a temporary `codex-wip` label only as a visible hint; do not treat it as the durable lock.
+- For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
+  backend when available. Each lane gets a stable agent id such as
+  `m5-codex-batch2` or `m1-claude-fable-lane1`.
+- Refresh heartbeats with `agent-coord heartbeat` at phase transitions: item
+  start, branch or PR update, review pass, blocked state, and done state.
+  Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
+  `stale` until 4x TTL, and `dead` after that. Do not model liveness with
+  sticky labels.
+- Use `agent-coord status` before starting dependency-sensitive lanes and before
+  rebase, push, readiness, or closeout decisions that depend on another lane.
 - Prefer a structured claim comment for resumable coordination:
 
 ```markdown
@@ -438,6 +451,8 @@ When worker subagents are explicitly authorized:
 - Give each worker a separate worktree and branch.
 - Tell workers they are not alone in the codebase and must not revert others' edits.
 - Keep write scopes disjoint unless the main agent serializes integration.
+- Refresh that worker's heartbeat whenever it starts an item, pushes or updates a
+  PR, completes a review pass, becomes blocked, resumes, or finishes the lane.
 - The main agent owns final PR creation, status reporting, full-CI decisions, and merge sequencing.
 
 ### Coordinator Closeout Lane
@@ -449,23 +464,25 @@ PR-only output.
 The closeout lane is:
 
 1. Re-fetch every worker PR and issue state from GitHub.
-2. Wait for current-head checks and configured review agents, using bounded
+2. Run `agent-coord status` when available and reconcile blocked or stale lanes
+   before making readiness decisions.
+3. Wait for current-head checks and configured review agents, using bounded
    polling.
-3. Fetch current unresolved review threads and triage them as fixed, waived, or
+4. Fetch current unresolved review threads and triage them as fixed, waived, or
    still blocking.
-4. Refresh stale release-mode classification from the release tracker when
+5. Refresh stale release-mode classification from the release tracker when
    needed. For accelerated-RC merge readiness, refresh the latest finalized
    PR-body `Agent Merge Confidence` block required by `AGENTS.md`; keep this
    distinct from tracker mode/classification updates.
-5. After the final push, if local validation passed and the only uncertainty is
+6. After the final push, if local validation passed and the only uncertainty is
    whether full CI is needed, request full CI with `+ci-run-full` and record the
    reason as FYI, then loop back to re-fetch and wait for the newly requested
    current-head checks before readiness or merge.
-6. Under the current release mode, mark ready or merge PRs that satisfy the
+7. Under the current release mode, mark ready or merge PRs that satisfy the
    merge qualification rules, including the merge-endgame debounce and
    waiver-soak rules before merge; report only remaining blockers, questions,
    or `UNKNOWN` live state.
-7. After any closeout-lane merge action, run a lightweight sweep for late
+8. After any closeout-lane merge action, run a lightweight sweep for late
    post-merge bot findings before the final batch handoff: confirm the PR landed,
    check `main` status, and inspect late review/check comments that arrived
    around or after merge. Route release-relevant findings into the next

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 - `.agents/workflows/`: shared prompt templates and reusable workflows for Codex, GPT, and other non-Claude tools
 - `internal/contributor-info/agent-workflow-adoption.md`: guide for copying these agent workflows into other repositories
 - `internal/contributor-info/agent-pr-batch-skills.md`: contributor guide for choosing and sequencing `$plan-pr-batch` and `$pr-batch`
+- `internal/contributor-info/multi-batch-operations.md`: operator guide for running multiple batches across machines, launch surfaces, and repos
 - `internal/contributor-info/issue-evaluation.md`: principles for deciding whether issues and proposed fixes are worth implementing
 - When deciding whether an issue or proposed fix is worth doing, use `.agents/skills/evaluate-issue/SKILL.md`; a short invocation is `$evaluate-issue` or "Is this issue worth fixing?"
 - When the user wants to choose issues or PRs for a future Codex batch, use `.agents/skills/plan-pr-batch/SKILL.md` to produce a ready `$pr-batch` goal; a short invocation is `$plan-pr-batch` or "Plan a Codex batch"

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -9,11 +9,10 @@ rules in [AGENTS.md](../../AGENTS.md), [.agents/skills/pr-batch/SKILL.md](../../
 and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md).
 
 Until the private repo has tagged releases, pull the private repo and rerun the
-smoke checks below after backend CLI or schema changes. The command examples and
-default TTL values in this page were verified against private backend commit
-`ed339f2000d3639eca03298a22d7c600a04e20f7`; update that anchor when the private
-CLI contract changes. The private README and `bin/agent-coord --help` output are
-authoritative if they differ from this public pointer.
+smoke checks below after backend CLI or schema changes. The command examples in
+this page were verified at the initial backend rollout; the private README and
+`bin/agent-coord --help` output are authoritative if they differ from this
+public pointer.
 
 ## Setup
 
@@ -84,10 +83,12 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
-BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$$-coord-layer"
+BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)-coord-layer"
+BATCH_ID_FILE="${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer"
 # Set once at kickoff, include a short batch slug plus a unique suffix, and reuse for this batch.
-printf '%s\n' "$BATCH_ID" > .agent-coord-batch-id
-# In a fresh shell, restore with: BATCH_ID=$(cat .agent-coord-batch-id)
+printf '%s\n' "$BATCH_ID" > "$BATCH_ID_FILE"
+# In a fresh shell, restore with: BATCH_ID=$(cat "$BATCH_ID_FILE")
+# At batch closeout, remove the temporary pointer: rm -f "$BATCH_ID_FILE"
 
 bin/agent-coord heartbeat \
   --agent-id mobile-codex-batch2 \
@@ -99,25 +100,22 @@ bin/agent-coord status
 ```
 
 Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
-`stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
-minutes, so the default dead threshold is 60 minutes after the heartbeat update.
-Verify these defaults against the private README or CLI help when updating the
-private backend; the values above were current at private commit
-`ed339f2000d3639eca03298a22d7c600a04e20f7`.
-Dependent lanes blocked on a dead-heartbeat takeover should expect up to that
-60-minute window before takeover is safe under default TTL settings.
-The default claim lease TTL is 4 hours, used only as a fallback when heartbeat
-liveness is missing or invalid. Use the private repo's launchd template for
-desktop sessions that need out-of-band renewal while an agent is between tool
-calls.
+`stale` until 4x TTL, and `dead` after that. See the private backend README and
+CLI help for current default TTL values and the dead-threshold calculation.
+Dependent lanes blocked on a dead-heartbeat takeover should wait until current
+backend liveness marks the holder `dead` before takeover is safe. The default
+claim lease TTL is only a fallback when heartbeat liveness is missing or invalid.
+Use the private repo's launchd template for desktop sessions that need
+out-of-band renewal while an agent is between tool calls.
 
 For dependency-sensitive lanes, coordinators create or update
 `batches/<batch-id>.json` in the private backend before dispatching dependent
-workers. Use the private backend README and schema files for that JSON layout;
-this public pointer intentionally omits the batch-state schema. The private
-backend README and CLI are authoritative for the terminal heartbeat statuses
-that unblock `depends_on` refs. A released claim is audit state and does not
-unblock dependent lanes by itself.
+workers. Batch files are edited as JSON in the private repo in v1. Use the
+private backend README and schema files for that JSON layout; this public pointer
+intentionally omits the batch-state schema. The private backend README and CLI
+are authoritative for the terminal heartbeat statuses that unblock `depends_on`
+refs, currently `complete`, `completed`, `done`, `merged`, and `ready`. A
+released claim is audit state and does not unblock dependent lanes by itself.
 
 If a worker lane declares `depends_on` but `agent-coord status` shows no matching
 batch file or lane state, the worker must treat dependency state as `UNKNOWN` and

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -30,5 +30,33 @@ AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord heartbeat \
 AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord status
 ```
 
+## Heartbeats
+
+Workers refresh heartbeats at every phase transition:
+
+- item start
+- branch or PR update
+- review pass
+- blocked state
+- done state
+
+Use stable agent ids that identify machine, tool, and lane, for example
+`m5-codex-batch2` or `m1-claude-fable-lane1`.
+
+```bash
+bin/agent-coord heartbeat \
+  --agent-id m5-codex-batch2 \
+  --repo shakacode/react_on_rails \
+  --target 3970 \
+  --batch-id agent-coord-2026-06-13 \
+  --branch jg-codex/3970-agent-heartbeats
+bin/agent-coord status
+```
+
+Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
+`stale` until 4x TTL, and `dead` after that. Use the private repo's launchd
+template for desktop sessions that need out-of-band renewal while an agent is
+between tool calls.
+
 Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
 source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -9,9 +9,11 @@ rules in [AGENTS.md](../../AGENTS.md), [.agents/skills/pr-batch/SKILL.md](../../
 and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md).
 
 Until the private repo has tagged releases, pull the private repo and rerun the
-smoke checks below after backend CLI or schema changes. Record the validated
-private backend commit in the PR body or batch handoff, not in this stable
-public pointer.
+smoke checks below after backend CLI or schema changes. The command examples and
+default TTL values in this page were verified against private backend commit
+`ed339f2000d3639eca03298a22d7c600a04e20f7`; update that anchor when the private
+CLI contract changes. The private README and `bin/agent-coord --help` output are
+authoritative if they differ from this public pointer.
 
 ## Setup
 
@@ -36,14 +38,19 @@ non-zero, report private state as `UNKNOWN` and use structured public claim
 comments as an advisory fallback. A successful status check followed by a
 refused `agent-coord claim` is not unavailability; it is a hard stop.
 
+Do not use an unverified private clone for hard-stop gates. If the local private
+CLI or README no longer matches this public pointer and the operator cannot
+validate the current private backend version, report private state as `UNKNOWN`
+and stay in advisory fallback mode until a coordinator validates the backend.
+
 Machine agents must not override a refused private claim on their own. A human
 coordinator may authorize a one-off manual override only after running
 `agent-coord status`, recording why the private state is wrong or degraded in
-the batch handoff as the authoritative incident note, and either repairing the
-private state or posting a structured public claim comment that names the
-override. Mirror the same note to the issue or PR when that is the active lane
-discussion, but do not use an override to bypass a live or stale holder that can
-be contacted.
+the batch handoff as the authoritative incident note, and repairing the private
+state so later machine agents can observe the override through `agent-coord
+status`. Mirror the same note to the issue or PR when that is the active lane
+discussion, but do not use a public claim comment as the machine-readable
+override channel or to bypass a live or stale holder that can be contacted.
 
 Use a temporary local state directory for smoke checks that should not write to
 GitHub. `AGENT_COORD_STATE_ROOT` sets the directory where `agent-coord` reads
@@ -91,6 +98,9 @@ bin/agent-coord status
 Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
 `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
 minutes, so the default dead threshold is 60 minutes after the heartbeat update.
+Verify these defaults against the private README or CLI help when updating the
+private backend; the values above were current at private commit
+`ed339f2000d3639eca03298a22d7c600a04e20f7`.
 Dependent lanes blocked on a dead-heartbeat takeover should expect up to that
 60-minute window before takeover is safe under default TTL settings.
 The default claim lease TTL is 4 hours, used only as a fallback when heartbeat

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -16,6 +16,10 @@ public pointer.
 
 ## Setup
 
+For a fresh machine joining an active multi-machine batch, start with
+[Multi-Batch Operations](multi-batch-operations.md#fresh-machine-quick-start)
+and then run the backend setup below.
+
 ```bash
 gh auth status
 gh repo clone shakacode/agent-coordination

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -84,8 +84,8 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
-BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M)-coord-layer"
-# Set once at kickoff, include a short batch slug, and reuse for this batch.
+BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$$-coord-layer"
+# Set once at kickoff, include a short batch slug plus a unique suffix, and reuse for this batch.
 printf '%s\n' "$BATCH_ID" > .agent-coord-batch-id
 # In a fresh shell, restore with: BATCH_ID=$(cat .agent-coord-batch-id)
 
@@ -113,9 +113,11 @@ calls.
 
 For dependency-sensitive lanes, coordinators create or update
 `batches/<batch-id>.json` in the private backend before dispatching dependent
-workers. The private backend README and CLI are authoritative for the terminal
-heartbeat statuses that unblock `depends_on` refs. A released claim is audit
-state and does not unblock dependent lanes by itself.
+workers. Use the private backend README and schema files for that JSON layout;
+this public pointer intentionally omits the batch-state schema. The private
+backend README and CLI are authoritative for the terminal heartbeat statuses
+that unblock `depends_on` refs. A released claim is audit state and does not
+unblock dependent lanes by itself.
 
 If a worker lane declares `depends_on` but `agent-coord status` shows no matching
 batch file or lane state, the worker must treat dependency state as `UNKNOWN` and

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -16,7 +16,14 @@ gh repo clone shakacode/agent-coordination
 cd agent-coordination
 ruby -Itest test/agent_coord_test.rb
 bin/agent-coord --help
+mkdir -p "$HOME/.local/bin"
+ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
+agent-coord --help
 ```
+
+The workflow docs assume `agent-coord` is available on `PATH`. Add
+`$HOME/.local/bin` to the shell `PATH` if needed, or run the command by its full
+path inside the private clone.
 
 Use a temporary local state directory for smoke checks that should not write to
 GitHub:

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -78,5 +78,10 @@ liveness is missing or invalid. Use the private repo's launchd template for
 desktop sessions that need out-of-band renewal while an agent is between tool
 calls.
 
+For `batches/<batch-id>.json`, the dependency-complete heartbeat statuses at
+private backend commit `ed339f2` are `complete`, `completed`, `done`, `merged`,
+and `ready`. A released claim is audit state and does not unblock dependent
+lanes by itself.
+
 Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
 source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -10,7 +10,8 @@ and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.m
 
 This pointer was validated against private backend commit `ed339f2`. Until the
 private repo has tagged releases, pull the private repo and rerun the smoke
-checks below after backend CLI or schema changes.
+checks below after backend CLI or schema changes. Update this hash in the same
+PR whenever the private CLI interface, schema, or smoke-check procedure changes.
 
 ## Setup
 

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -83,7 +83,7 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
-BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)-coord-layer"
+BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(python3 -c 'import uuid; print(uuid.uuid4().hex[:8])')-coord-layer"
 BATCH_ID_FILE=$(mktemp "${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer.XXXXXX")
 # Set once at kickoff, include a short batch slug plus a unique suffix, and reuse for this batch.
 printf '%s\n' "$BATCH_ID" > "$BATCH_ID_FILE"
@@ -118,7 +118,8 @@ workers. Batch files are edited as JSON in the private repo in v1. Use the
 private backend README and schema files for that JSON layout; this public pointer
 intentionally omits the batch-state schema. The private backend README and CLI
 are authoritative for the terminal heartbeat statuses that unblock `depends_on`
-refs, currently `complete`, `completed`, `done`, `merged`, and `ready`. A
+refs. At the initial backend rollout those statuses were `complete`, `completed`,
+`done`, `merged`, and `ready`; re-check the private CLI after backend updates. A
 released claim is audit state and does not unblock dependent lanes by itself.
 
 If a worker lane declares `depends_on` but `agent-coord status` shows no matching

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -36,6 +36,13 @@ non-zero, report private state as `UNKNOWN` and use structured public claim
 comments as an advisory fallback. A successful status check followed by a
 refused `agent-coord claim` is not unavailability; it is a hard stop.
 
+Machine agents must not override a refused private claim on their own. A human
+coordinator may authorize a one-off manual override only after running
+`agent-coord status`, recording why the private state is wrong or degraded in
+the issue, PR, or batch handoff, and either repairing the private state or
+posting a structured public claim comment that names the override. Do not use an
+override to bypass a live or stale holder that can be contacted.
+
 Use a temporary local state directory for smoke checks that should not write to
 GitHub:
 
@@ -82,7 +89,9 @@ calls.
 For `batches/<batch-id>.json`, the dependency-complete heartbeat statuses at
 private backend commit `ed339f2` are `complete`, `completed`, `done`, `merged`,
 and `ready`. A released claim is audit state and does not unblock dependent
-lanes by itself.
+lanes by itself. The `complete` and `completed` aliases are both accepted in v1
+so humans and older agents can use either wording while the operating model
+settles.
 
 Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
 source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -89,7 +89,9 @@ BATCH_ID_FILE=$(mktemp "${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer.XXXXXX"
 printf '%s\n' "$BATCH_ID" > "$BATCH_ID_FILE"
 # Record the printed file path in the batch handoff.
 printf 'Batch id file: %s\n' "$BATCH_ID_FILE"
-# In a fresh shell, restore with: BATCH_ID=$(cat /tmp/agent-coord-batch-id.coord-layer.XXXXXX)
+# In a fresh shell, set BATCH_ID_FILE to the recorded path, then restore:
+# BATCH_ID_FILE=/tmp/agent-coord-batch-id.coord-layer.abc123
+# BATCH_ID=$(cat "$BATCH_ID_FILE")
 # At batch closeout, remove the temporary pointer: rm -f "$BATCH_ID_FILE"
 
 bin/agent-coord heartbeat \

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -28,7 +28,8 @@ ruby -Itest test/agent_coord_test.rb
 bin/agent-coord --help
 mkdir -p "$HOME/.local/bin"
 ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
-"$HOME/.local/bin/agent-coord" --help
+export PATH="$HOME/.local/bin:$PATH"
+agent-coord --help
 ```
 
 The workflow docs assume `agent-coord` is available on `PATH`. Add
@@ -87,7 +88,7 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
-BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')-coord-layer"
+BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(openssl rand -hex 4)-coord-layer"
 BATCH_ID_FILE=$(mktemp "${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer.XXXXXX")
 # Set once at kickoff, include a short batch slug plus a unique suffix, and reuse for this batch.
 printf '%s\n' "$BATCH_ID" > "$BATCH_ID_FILE"

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -8,10 +8,10 @@ React on Rails repository should only carry this pointer and the public workflow
 rules in [AGENTS.md](../../AGENTS.md), [.agents/skills/pr-batch/SKILL.md](../../.agents/skills/pr-batch/SKILL.md),
 and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md).
 
-This pointer was validated against private backend commit `ed339f2`. Until the
-private repo has tagged releases, pull the private repo and rerun the smoke
-checks below after backend CLI or schema changes. Update this hash in the same
-PR whenever the private CLI interface, schema, or smoke-check procedure changes.
+Until the private repo has tagged releases, pull the private repo and rerun the
+smoke checks below after backend CLI or schema changes. Record the validated
+private backend commit in the PR body or batch handoff, not in this stable
+public pointer.
 
 ## Setup
 
@@ -44,7 +44,9 @@ posting a structured public claim comment that names the override. Do not use an
 override to bypass a live or stale holder that can be contacted.
 
 Use a temporary local state directory for smoke checks that should not write to
-GitHub:
+GitHub. `AGENT_COORD_STATE_ROOT` sets the directory where `agent-coord` reads
+and writes JSON state; override it here so dry runs stay local instead of using
+the default state root documented in the private repo README.
 
 ```bash
 STATE_ROOT=$(mktemp -d)
@@ -65,15 +67,17 @@ Workers refresh heartbeats at every phase transition:
 - blocked state
 - done state
 
-Use stable agent ids that identify machine, tool, and lane, for example
-`m5-codex-batch2` or `m1-claude-fable-lane1`.
+Use stable agent ids that identify machine role, tool, and lane, for example
+`mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
+BATCH_ID=agent-coord-YYYY-MM-DD # Set once at kickoff and reuse for this batch.
+
 bin/agent-coord heartbeat \
-  --agent-id m5-codex-batch2 \
+  --agent-id mobile-codex-batch2 \
   --repo shakacode/react_on_rails \
   --target 3970 \
-  --batch-id "agent-coord-$(date +%Y-%m-%d)" \
+  --batch-id "$BATCH_ID" \
   --branch jg-codex/3970-agent-heartbeats
 bin/agent-coord status
 ```
@@ -86,12 +90,11 @@ liveness is missing or invalid. Use the private repo's launchd template for
 desktop sessions that need out-of-band renewal while an agent is between tool
 calls.
 
-For `batches/<batch-id>.json`, the dependency-complete heartbeat statuses at
-private backend commit `ed339f2` are `complete`, `completed`, `done`, `merged`,
-and `ready`. A released claim is audit state and does not unblock dependent
-lanes by itself. The `complete` and `completed` aliases are both accepted in v1
-so humans and older agents can use either wording while the operating model
-settles.
+For dependency-sensitive lanes, coordinators create or update
+`batches/<batch-id>.json` in the private backend before dispatching dependent
+workers. The private backend README and CLI are authoritative for the terminal
+heartbeat statuses that unblock `depends_on` refs. A released claim is audit
+state and does not unblock dependent lanes by itself.
 
 Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
 source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -8,6 +8,10 @@ React on Rails repository should only carry this pointer and the public workflow
 rules in [AGENTS.md](../../AGENTS.md), [.agents/skills/pr-batch/SKILL.md](../../.agents/skills/pr-batch/SKILL.md),
 and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md).
 
+This pointer was validated against private backend commit `ed339f2`. Until the
+private repo has tagged releases, pull the private repo and rerun the smoke
+checks below after backend CLI or schema changes.
+
 ## Setup
 
 ```bash
@@ -24,6 +28,12 @@ agent-coord --help
 The workflow docs assume `agent-coord` is available on `PATH`. Add
 `$HOME/.local/bin` to the shell `PATH` if needed, or run the command by its full
 path inside the private clone.
+
+Treat the backend as available when `agent-coord status` exits 0. If the command
+is missing, auth fails, the private repo cannot be read, or `status` exits
+non-zero, report private state as `UNKNOWN` and use structured public claim
+comments as an advisory fallback. A successful status check followed by a
+refused `agent-coord claim` is not unavailability; it is a hard stop.
 
 Use a temporary local state directory for smoke checks that should not write to
 GitHub:
@@ -55,15 +65,18 @@ bin/agent-coord heartbeat \
   --agent-id m5-codex-batch2 \
   --repo shakacode/react_on_rails \
   --target 3970 \
-  --batch-id agent-coord-2026-06-13 \
+  --batch-id "agent-coord-$(date +%Y-%m-%d)" \
   --branch jg-codex/3970-agent-heartbeats
 bin/agent-coord status
 ```
 
 Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
-`stale` until 4x TTL, and `dead` after that. Use the private repo's launchd
-template for desktop sessions that need out-of-band renewal while an agent is
-between tool calls.
+`stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
+minutes, so the default dead threshold is 60 minutes after the heartbeat update.
+The default claim lease TTL is 4 hours, used only as a fallback when heartbeat
+liveness is missing or invalid. Use the private repo's launchd template for
+desktop sessions that need out-of-band renewal while an agent is between tool
+calls.
 
 Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
 source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -37,6 +37,8 @@ is missing, auth fails, the private repo cannot be read, or `status` exits
 non-zero, report private state as `UNKNOWN` and use structured public claim
 comments as an advisory fallback. A successful status check followed by a
 refused `agent-coord claim` is not unavailability; it is a hard stop.
+`agent-coord status` is a preflight view; `agent-coord claim` is the backend's
+compare-and-swap gate for concurrent claim races.
 
 Do not use an unverified private clone for hard-stop gates. If the local private
 CLI or README no longer matches this public pointer and the operator cannot
@@ -60,10 +62,11 @@ the default state root documented in the private repo README.
 ```bash
 STATE_ROOT=$(mktemp -d)
 AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord heartbeat \
-  --agent-id worker-3969 \
+  --agent-id smoke-test-0 \
   --repo shakacode/react_on_rails \
-  --target 3969
+  --target 9999
 AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord status
+rm -rf "$STATE_ROOT"
 ```
 
 ## Heartbeats

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -1,0 +1,34 @@
+# Agent Coordination Backend
+
+Concurrent agent batches can use the private `shakacode/agent-coordination`
+repository for shared claim, heartbeat, and batch dependency state.
+
+Keep schema definitions and examples in the private backend repository. This
+React on Rails repository should only carry this pointer and the public workflow
+rules in [AGENTS.md](../../AGENTS.md), [.agents/skills/pr-batch/SKILL.md](../../.agents/skills/pr-batch/SKILL.md),
+and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md).
+
+## Setup
+
+```bash
+gh auth status
+gh repo clone shakacode/agent-coordination
+cd agent-coordination
+ruby -Itest test/agent_coord_test.rb
+bin/agent-coord --help
+```
+
+Use a temporary local state directory for smoke checks that should not write to
+GitHub:
+
+```bash
+STATE_ROOT=$(mktemp -d)
+AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord heartbeat \
+  --agent-id worker-3969 \
+  --repo shakacode/react_on_rails \
+  --target 3969
+AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord status
+```
+
+Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
+source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -23,7 +23,7 @@ ruby -Itest test/agent_coord_test.rb
 bin/agent-coord --help
 mkdir -p "$HOME/.local/bin"
 ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
-agent-coord --help
+"$HOME/.local/bin/agent-coord" --help
 ```
 
 The workflow docs assume `agent-coord` is available on `PATH`. Add
@@ -71,7 +71,8 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
-BATCH_ID=agent-coord-YYYY-MM-DD # Set once at kickoff and reuse for this batch.
+BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M)-coord-layer"
+# Set once at kickoff, include a short batch slug, and reuse for this batch.
 
 bin/agent-coord heartbeat \
   --agent-id mobile-codex-batch2 \
@@ -95,6 +96,11 @@ For dependency-sensitive lanes, coordinators create or update
 workers. The private backend README and CLI are authoritative for the terminal
 heartbeat statuses that unblock `depends_on` refs. A released claim is audit
 state and does not unblock dependent lanes by itself.
+
+If a worker lane declares `depends_on` but `agent-coord status` shows no matching
+batch file or lane state, the worker must treat dependency state as `UNKNOWN` and
+stop to report the missing private batch state instead of proceeding as
+independent.
 
 Do not store secrets, `.env` files, credentials, patches, customer data, or Pro
 source code in the coordination backend. It is only for minimal JSON state files.

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -84,10 +84,12 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 
 ```bash
 BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)-coord-layer"
-BATCH_ID_FILE="${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer"
+BATCH_ID_FILE=$(mktemp "${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer.XXXXXX")
 # Set once at kickoff, include a short batch slug plus a unique suffix, and reuse for this batch.
 printf '%s\n' "$BATCH_ID" > "$BATCH_ID_FILE"
-# In a fresh shell, restore with: BATCH_ID=$(cat "$BATCH_ID_FILE")
+# Record the printed file path in the batch handoff.
+printf 'Batch id file: %s\n' "$BATCH_ID_FILE"
+# In a fresh shell, restore with: BATCH_ID=$(cat /tmp/agent-coord-batch-id.coord-layer.XXXXXX)
 # At batch closeout, remove the temporary pointer: rm -f "$BATCH_ID_FILE"
 
 bin/agent-coord heartbeat \

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -64,11 +64,11 @@ the default state root documented in the private repo README.
 
 ```bash
 STATE_ROOT=$(mktemp -d)
-AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord heartbeat \
+AGENT_COORD_STATE_ROOT="$STATE_ROOT" agent-coord heartbeat \
   --agent-id smoke-test-0 \
   --repo shakacode/react_on_rails \
   --target 9999
-AGENT_COORD_STATE_ROOT="$STATE_ROOT" bin/agent-coord status
+AGENT_COORD_STATE_ROOT="$STATE_ROOT" agent-coord status
 rm -rf "$STATE_ROOT"
 ```
 
@@ -98,13 +98,13 @@ printf 'Batch id file: %s\n' "$BATCH_ID_FILE"
 # BATCH_ID=$(cat "$BATCH_ID_FILE")
 # At batch closeout, remove the temporary pointer: rm -f "$BATCH_ID_FILE"
 
-bin/agent-coord heartbeat \
+agent-coord heartbeat \
   --agent-id mobile-codex-batch2 \
   --repo shakacode/react_on_rails \
   --target 3970 \
   --batch-id "$BATCH_ID" \
   --branch jg-codex/3970-agent-heartbeats
-bin/agent-coord status
+agent-coord status
 ```
 
 Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
@@ -120,12 +120,10 @@ For dependency-sensitive lanes, coordinators create or update
 `batches/<batch-id>.json` in the private backend before dispatching dependent
 workers. Batch files are edited as JSON in the private repo in v1. Use the
 private backend README and schema files for that JSON layout; this public pointer
-intentionally omits the batch-state schema. The private backend README and CLI
-are authoritative for the terminal heartbeat statuses that unblock `depends_on`
-refs. At the initial backend rollout those statuses were `complete`, `completed`,
-`done`, `merged`, and `ready`; `complete` and `completed` are intentional aliases
-for the same terminal state. Re-check the private CLI after backend updates. A
-released claim is audit state and does not unblock dependent lanes by itself.
+intentionally omits the batch-state schema and terminal-status list. The private
+backend README and CLI are authoritative for the terminal heartbeat statuses that
+unblock `depends_on` refs; re-check them after backend updates. A released claim
+is audit state and does not unblock dependent lanes by itself.
 
 If a worker lane declares `depends_on` but `agent-coord status` shows no matching
 batch file or lane state, the worker must treat dependency state as `UNKNOWN` and

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -39,9 +39,11 @@ refused `agent-coord claim` is not unavailability; it is a hard stop.
 Machine agents must not override a refused private claim on their own. A human
 coordinator may authorize a one-off manual override only after running
 `agent-coord status`, recording why the private state is wrong or degraded in
-the issue, PR, or batch handoff, and either repairing the private state or
-posting a structured public claim comment that names the override. Do not use an
-override to bypass a live or stale holder that can be contacted.
+the batch handoff as the authoritative incident note, and either repairing the
+private state or posting a structured public claim comment that names the
+override. Mirror the same note to the issue or PR when that is the active lane
+discussion, but do not use an override to bypass a live or stale holder that can
+be contacted.
 
 Use a temporary local state directory for smoke checks that should not write to
 GitHub. `AGENT_COORD_STATE_ROOT` sets the directory where `agent-coord` reads
@@ -65,6 +67,7 @@ Workers refresh heartbeats at every phase transition:
 - branch or PR update
 - review pass
 - blocked state
+- resumed state
 - done state
 
 Use stable agent ids that identify machine role, tool, and lane, for example
@@ -73,6 +76,8 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 ```bash
 BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M)-coord-layer"
 # Set once at kickoff, include a short batch slug, and reuse for this batch.
+printf '%s\n' "$BATCH_ID" > .agent-coord-batch-id
+# In a fresh shell, restore with: BATCH_ID=$(cat .agent-coord-batch-id)
 
 bin/agent-coord heartbeat \
   --agent-id mobile-codex-batch2 \
@@ -86,6 +91,8 @@ bin/agent-coord status
 Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
 `stale` until 4x TTL, and `dead` after that. The default heartbeat TTL is 15
 minutes, so the default dead threshold is 60 minutes after the heartbeat update.
+Dependent lanes blocked on a dead-heartbeat takeover should expect up to that
+60-minute window before takeover is safe under default TTL settings.
 The default claim lease TTL is 4 hours, used only as a fallback when heartbeat
 liveness is missing or invalid. Use the private repo's launchd template for
 desktop sessions that need out-of-band renewal while an agent is between tool

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -87,7 +87,7 @@ Use stable agent ids that identify machine role, tool, and lane, for example
 `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
 
 ```bash
-BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(python3 -c 'import uuid; print(uuid.uuid4().hex[:8])')-coord-layer"
+BATCH_ID="agent-coord-$(date +%Y%m%d-%H%M%S)-$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')-coord-layer"
 BATCH_ID_FILE=$(mktemp "${TMPDIR:-/tmp}/agent-coord-batch-id.coord-layer.XXXXXX")
 # Set once at kickoff, include a short batch slug plus a unique suffix, and reuse for this batch.
 printf '%s\n' "$BATCH_ID" > "$BATCH_ID_FILE"
@@ -123,7 +123,8 @@ private backend README and schema files for that JSON layout; this public pointe
 intentionally omits the batch-state schema. The private backend README and CLI
 are authoritative for the terminal heartbeat statuses that unblock `depends_on`
 refs. At the initial backend rollout those statuses were `complete`, `completed`,
-`done`, `merged`, and `ready`; re-check the private CLI after backend updates. A
+`done`, `merged`, and `ready`; `complete` and `completed` are intentional aliases
+for the same terminal state. Re-check the private CLI after backend updates. A
 released claim is audit state and does not unblock dependent lanes by itself.
 
 If a worker lane declares `depends_on` but `agent-coord status` shows no matching

--- a/internal/contributor-info/agent-pr-batch-skills.md
+++ b/internal/contributor-info/agent-pr-batch-skills.md
@@ -2,6 +2,11 @@
 
 Use this guide when deciding between the planning and execution skills for Codex batch work.
 
+When one coordinator runs multiple batches across machines, desktop apps, or
+repositories, use [Multi-Batch Operations](multi-batch-operations.md) for the
+operator-level topology, launcher roles, cross-batch routing, and failure
+drills. This file stays focused on skill selection and per-batch sizing.
+
 ## Skill Roles
 
 | Skill             | Use when                                                                              | Output                                                                           |
@@ -18,7 +23,7 @@ The `.agents/skills/plan-pr-batch/agents/openai.yaml` file under a skill is opti
 2. If exact candidate issues are already known and may be hypothetical, AI/code-analysis-only, over-scoped, or better handled with a no-PR evidence comment, start with `$evaluate-issue` directly.
 3. Verify every candidate through GitHub. Use `UNKNOWN` for facts that cannot be checked.
 4. After `$plan-pr-batch` resolves exact candidates, use `$evaluate-issue` for speculative, AI/code-analysis-only, over-scoped, or unclear items before assigning implementation work.
-5. Shape the batch into independent worker lanes. Cap at 8 items when files or risk overlap, or 10 fully independent items; otherwise propose a smaller first batch.
+5. Shape the batch into independent worker lanes. Cap each batch at 8 items when files or risk overlap, or 10 fully independent items; otherwise propose a smaller first batch. For multiple concurrent batches, keep this as a per-batch cap and apply the cross-batch routing guidance in [Multi-Batch Operations](multi-batch-operations.md) before launching.
 6. Give the user the Batch Plan and fenced `$pr-batch` goal prompt. Do not launch workers yet.
 7. When the user says to run it, use `$pr-batch` with the fenced goal prompt.
 

--- a/internal/contributor-info/agent-workflow-adoption.md
+++ b/internal/contributor-info/agent-workflow-adoption.md
@@ -96,7 +96,7 @@ Do not copy the CI workflow files as a bundle unless the target repo has the sam
 
 5. Adopt cross-repo coordination when needed.
    - Copy `agent-coordination-backend.md` and `multi-batch-operations.md` only if the target repo will participate in multi-machine, multi-batch, or cross-repo work.
-   - Point operators at the same private shakacode/agent-coordination backend used by React on Rails.
+   - For ShakaCode-internal repos, point operators at the same private shakacode/agent-coordination backend used by React on Rails. External adopters should host their own private backend with the same schema or rely on public claim comments.
    - Use full repository names in every claim and heartbeat so `owner/repo#123` remains distinct from another repo's `#123`.
    - Keep private backend schema examples in the private coordination repo. Public/adopter repos should document only operator rules, setup pointers, and safe fallbacks.
    - Define which packages or directories must not be split across simultaneous batches, then add that routing rule to the target repo's copy of `multi-batch-operations.md`.

--- a/internal/contributor-info/agent-workflow-adoption.md
+++ b/internal/contributor-info/agent-workflow-adoption.md
@@ -30,9 +30,10 @@ ShakaCode-internal adopting repos should join the same private
 `shakacode/agent-coordination` repo instead of creating per-repo coordination
 stores. Claims and heartbeats are namespaced by full repo name, so one status
 table can safely include `shakacode/react_on_rails` and adopter repos such as
-`shakacode/react_on_rails_rsc`. External adopters should host their own private
-coordination backend with the same `agent-coord` schema, or skip this section and
-use the structured public claim comment fallback documented in
+`shakacode/react_on_rails_rsc`. External adopters should skip this section and
+use the structured public claim comment fallback until ShakaCode publishes a
+public backend spec or grants them access to the coordination backend spec.
+That fallback is documented in
 [AGENTS.md](../../AGENTS.md).
 
 ### Claude support
@@ -96,7 +97,7 @@ Do not copy the CI workflow files as a bundle unless the target repo has the sam
 
 5. Adopt cross-repo coordination when needed.
    - Copy `agent-coordination-backend.md` and `multi-batch-operations.md` only if the target repo will participate in multi-machine, multi-batch, or cross-repo work.
-   - For ShakaCode-internal repos, point operators at the same private shakacode/agent-coordination backend used by React on Rails. External adopters should host their own private backend with the same schema or rely on public claim comments.
+   - For ShakaCode-internal repos, point operators at the same private shakacode/agent-coordination backend used by React on Rails. External adopters should use public claim comments until a public backend spec is available or ShakaCode grants access to the private spec.
    - Use full repository names in every claim and heartbeat so `owner/repo#123` remains distinct from another repo's `#123`.
    - Keep private backend schema examples in the private coordination repo. Public/adopter repos should document only operator rules, setup pointers, and safe fallbacks.
    - Define which packages or directories must not be split across simultaneous batches, then add that routing rule to the target repo's copy of `multi-batch-operations.md`.

--- a/internal/contributor-info/agent-workflow-adoption.md
+++ b/internal/contributor-info/agent-workflow-adoption.md
@@ -18,6 +18,20 @@ The goal is not to copy React on Rails blindly. The goal is to copy the reusable
 - [.agents/workflows/address-review.md](../../.agents/workflows/address-review.md) - generic non-Claude review-comment triage and fixing workflow.
 - [.agents/skills/autoreview/SKILL.md](../../.agents/skills/autoreview/SKILL.md) - independent review skill used before commits, pushes, PRs, or merge readiness.
 
+### Multi-batch coordination support
+
+Copy these when the target repo participates in concurrent batches, cross-repo
+work, or the shared private coordination backend:
+
+- [internal/contributor-info/agent-coordination-backend.md](agent-coordination-backend.md) - pointer to the private coordination backend, heartbeat rules, and local smoke-check commands.
+- [internal/contributor-info/multi-batch-operations.md](multi-batch-operations.md) - operating model for multiple batches across machines, launch surfaces, and repos.
+
+Adopting repos should join the same private shakacode/agent-coordination repo
+instead of creating per-repo coordination stores. Claims and heartbeats are
+namespaced by full repo name, so one status table can safely include
+`shakacode/react_on_rails` and adopter repos such as
+`shakacode/react_on_rails_rsc`.
+
 ### Claude support
 
 Copy these when the target repo uses Claude Code:
@@ -77,19 +91,26 @@ Do not copy the CI workflow files as a bundle unless the target repo has the sam
    - Keep the post-merge audit checks for late reviews, untriaged `Must Fix` comments, missing changelog entries, and cross-PR interactions.
    - Keep the post-merge issue plan gate: Codex and Claude independent audits draft issue entries only; one coordinator dedupes fingerprints and creates issues only after user approval.
 
-5. Customize address-review behavior.
+5. Adopt cross-repo coordination when needed.
+   - Copy `agent-coordination-backend.md` and `multi-batch-operations.md` only if the target repo will participate in multi-machine, multi-batch, or cross-repo work.
+   - Point operators at the same private shakacode/agent-coordination backend used by React on Rails.
+   - Use full repository names in every claim and heartbeat so `owner/repo#123` remains distinct from another repo's `#123`.
+   - Keep private backend schema examples in the private coordination repo. Public/adopter repos should document only operator rules, setup pointers, and safe fallbacks.
+   - Define which packages or directories must not be split across simultaneous batches, then add that routing rule to the target repo's copy of `multi-batch-operations.md`.
+
+6. Customize address-review behavior.
    - Keep the summary marker `<!-- address-review-summary -->` unless the repo already has a different checkpoint marker.
    - Keep the tiers: `MUST-FIX`, `DISCUSS`, `OPTIONAL`, and `SKIPPED`.
    - Keep `autopilot` as an initiation mode and `a` as the post-triage apply action.
    - Update bot assumptions, reviewer names, and any repo-specific reply or resolution rules.
 
-6. Decide whether to adopt CI comment commands.
+7. Decide whether to adopt CI comment commands.
    - If adopted, create the labels the workflow expects, especially `full-ci`.
    - Update the workflow map in `ci-commands.yml` so it dispatches the target repo's actual expensive workflows.
    - Ensure each expensive workflow knows how to react to `full-ci` or manual dispatch.
    - If not adopted, remove `+ci-*` language from `AGENTS.md` and `pr-processing.md`, and replace it with the target repo's real full-CI trigger.
 
-7. Validate with a dry run.
+8. Validate with a dry run.
    - Ask an agent to process a low-risk issue and stop before opening a PR.
    - Ask an agent to run `$pr-batch` with a filter-based request and confirm it stops with an exact target list and `/goal` prompt before spawning workers.
    - Ask an agent to triage one PR review and stop at the quick-action menu.
@@ -109,6 +130,7 @@ Update these before considering the workflow adopted:
 - Manual developer-flow checks for app startup, generated apps, examples, or test fixtures.
 - PR labels such as `full-ci`, `benchmark`, and `ready-to-merge`.
 - Batch coordination labels such as `codex-ready`, `codex-wip`, or `codex-pending-question`, if adopted; otherwise remove or replace those examples and rely on exact lane assignments plus structured claim comments.
+- Cross-repo coordination backend, agent-id format, claim/heartbeat/status lifecycle, and package-routing rules if the repo will share multi-batch operations with other repos.
 - Full-CI trigger mechanism if `+ci-*` is not installed.
 - Follow-up issue title convention. React on Rails uses `Follow-up:`.
 - Documentation boundaries: public docs, internal docs, generated docs, changelog policy.

--- a/internal/contributor-info/agent-workflow-adoption.md
+++ b/internal/contributor-info/agent-workflow-adoption.md
@@ -34,7 +34,7 @@ table can safely include `shakacode/react_on_rails` and adopter repos such as
 use the structured public claim comment fallback until ShakaCode publishes a
 public backend spec or grants them access to the coordination backend spec.
 That fallback is documented in
-[AGENTS.md](../../AGENTS.md).
+[pr-processing.md](../../.agents/workflows/pr-processing.md#coordination-state).
 
 ### Claude support
 
@@ -97,7 +97,7 @@ Do not copy the CI workflow files as a bundle unless the target repo has the sam
 
 5. Adopt cross-repo coordination when needed.
    - Copy `agent-coordination-backend.md` and `multi-batch-operations.md` only if the target repo will participate in multi-machine, multi-batch, or cross-repo work.
-   - For ShakaCode-internal repos, point operators at the same private shakacode/agent-coordination backend used by React on Rails. External adopters should use public claim comments until a public backend spec is available or ShakaCode grants access to the private spec.
+   - For ShakaCode-internal repos, point operators at the same private shakacode/agent-coordination backend used by React on Rails. External adopters should use public claim comments from `.agents/workflows/pr-processing.md` until a public backend spec is available or ShakaCode grants access to the private spec.
    - Use full repository names in every claim and heartbeat so `owner/repo#123` remains distinct from another repo's `#123`.
    - Keep private backend schema examples in the private coordination repo. Public/adopter repos should document only operator rules, setup pointers, and safe fallbacks.
    - Define which packages or directories must not be split across simultaneous batches, then add that routing rule to the target repo's copy of `multi-batch-operations.md`.

--- a/internal/contributor-info/agent-workflow-adoption.md
+++ b/internal/contributor-info/agent-workflow-adoption.md
@@ -26,11 +26,14 @@ work, or the shared private coordination backend:
 - [internal/contributor-info/agent-coordination-backend.md](agent-coordination-backend.md) - pointer to the private coordination backend, heartbeat rules, and local smoke-check commands.
 - [internal/contributor-info/multi-batch-operations.md](multi-batch-operations.md) - operating model for multiple batches across machines, launch surfaces, and repos.
 
-Adopting repos should join the same private shakacode/agent-coordination repo
-instead of creating per-repo coordination stores. Claims and heartbeats are
-namespaced by full repo name, so one status table can safely include
-`shakacode/react_on_rails` and adopter repos such as
-`shakacode/react_on_rails_rsc`.
+ShakaCode-internal adopting repos should join the same private
+`shakacode/agent-coordination` repo instead of creating per-repo coordination
+stores. Claims and heartbeats are namespaced by full repo name, so one status
+table can safely include `shakacode/react_on_rails` and adopter repos such as
+`shakacode/react_on_rails_rsc`. External adopters should host their own private
+coordination backend with the same `agent-coord` schema, or skip this section and
+use the structured public claim comment fallback documented in
+[AGENTS.md](../../AGENTS.md).
 
 ### Claude support
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -43,9 +43,9 @@ should use this PR branch or `main` for the current workflow docs.
    agent-coord status
    ```
 
-   Keep that `PATH` entry in the active shell, or keep using the full path in
-   later commands. Add it to the shell profile if future shells should inherit
-   the same setup.
+   The remaining snippets assume that `PATH` entry is present in the active
+   shell. In another shell, add the export first or replace each `agent-coord`
+   command below with `"$HOME/.local/bin/agent-coord"`.
 
 4. If the status command exits non-zero, report private state as `UNKNOWN` and
    use the structured public claim comment fallback. Do not start a

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -11,7 +11,8 @@ reader without asking Justin which machine, tool, or repository owns a lane.
 
 ## Baseline Topology
 
-The current coordination model assumes:
+The current coordination model assumes this host map as of 2026-06-13; update
+the table when the active machine pool or launch surfaces change:
 
 | Surface or host              | Primary role                  | Notes                                                                                       |
 | ---------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -1,0 +1,209 @@
+# Multi-Batch Operations
+
+Use this playbook when one coordinator is running multiple agent batches across
+machines, launch surfaces, or repositories. It sits above the per-lane workflow
+rules in [AGENTS.md](../../AGENTS.md),
+[PR Batch Skills Usage](agent-pr-batch-skills.md), and
+[Agent Coordination Backend](agent-coordination-backend.md).
+
+The goal is to make the live operating model reconstructable by a cold-start
+reader without asking Justin which machine, tool, or repository owns a lane.
+
+## Baseline Topology
+
+The current coordination model assumes:
+
+| Surface or host              | Primary role                  | Notes                                                                                       |
+| ---------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| M5 128GB mobile laptop       | High-memory mobile batch host | Useful for heavy local context, but treat power, network, and travel as availability risks. |
+| M1 64GB wired desktop        | Stable wired batch host       | Prefer for long-running desktop sessions and lanes that benefit from steady network/power.  |
+| Claude Desktop               | Batch kickoff surface         | Best for long-running multi-lane work when Claude Fable should own the hardest items.       |
+| Codex Desktop                | Batch kickoff surface         | Best for long-running Codex batches, local validation, commits, and repo-aware finishing.   |
+| conductor.build              | Single-PR focus and finishing | Best when one PR needs concentrated Claude plus Codex chats on the same PR.                 |
+| shakacode/react_on_rails     | Main gem/npm/Pro monorepo     | Claims use this full repo name in the coordination backend.                                 |
+| shakacode/react_on_rails_rsc | RSC integration/adoption repo | Uses the same coordination backend, with claims namespaced by repo.                         |
+
+Run up to three concurrent batches only when their packages, branches, and risk
+surfaces are intentionally disjoint:
+
+- one Claude Fable batch for the hardest, most ambiguous, or highest-risk items;
+- two Codex batches for simpler, parallel-friendly, well-scoped items;
+- conductor.build sessions only for focused PR finishing or a single PR that
+  needs both Claude and Codex attention.
+
+Machine choice is an operational decision, not a policy label. Prefer the wired
+desktop when continuity matters more than local memory, and prefer the M5 laptop
+when mobility or local capacity is the better fit. If either machine is likely
+to disappear during a lane, route dependency-sensitive work elsewhere.
+
+## Launcher Roles
+
+Use Claude Desktop and Codex Desktop to kick off batches because they are the
+right surfaces for long-running lane splits, local worktrees, validation loops,
+and coordinator handoffs.
+
+Use conductor.build for one PR at a time. Its special value is focused finishing:
+Claude and Codex chats can work against the same PR context. A conductor session
+must take a normal coordination lease before editing or finishing that PR. Once
+the lease exists, batch workers must skip that PR unless the lease is released,
+dead, or explicitly transferred by the coordinator.
+
+Do not let conductor become an invisible side channel. If conductor takes a PR,
+record the claim in shakacode/agent-coordination with the same repo and target
+identity that batch workers use, then refresh heartbeats while conductor owns
+the lane.
+
+## Coordination Lifecycle
+
+The private shakacode/agent-coordination repository is the coordination source
+of truth for concurrent batches. Public issue or PR claim comments are human
+hints and recovery aids only.
+
+Use stable agent ids with the base format `<machine>-<tool>-<batch>`, for
+example `m5-codex-batch2`, `m1-claude-fable`, or `m1-conductor-finish`. If one
+batch runs multiple simultaneously-heartbeating lanes on the same machine and
+tool, add a short lane suffix after the batch id so each heartbeat remains
+distinguishable.
+
+Use this lifecycle for every lane:
+
+1. **Kickoff**: the coordinator runs `agent-coord status`, confirms the target
+   repo, and chooses non-overlapping lane owners.
+2. **Claim**: the lane owner takes an `agent-coord claim` for the repo and
+   issue/PR target before creating a branch, worktree, or conductor session.
+3. **Heartbeat**: the owner sends `agent-coord heartbeat` at every phase
+   transition: item start, branch update, PR update, review pass, blocked state,
+   resumed state, and done state.
+4. **Status**: the coordinator checks `agent-coord status` before starting
+   dependency-sensitive work, rebasing, pushing, finishing, or reassigning a
+   target.
+5. **Blocked**: the owner records the blocker in coordination state and stops
+   speculative work on that lane. The coordinator assigns exactly one owner for
+   the shared question or fix.
+6. **Closeout**: the owner marks the lane done, including final branch/PR state
+   and validation evidence, then releases or lets the claim expire according to
+   the backend policy.
+
+If the private backend is unavailable, use the structured public claim comment
+fallback from [AGENTS.md](../../AGENTS.md) and
+[pr-processing.md](../../.agents/workflows/pr-processing.md), but do not use a
+public comment to override a refused private claim.
+
+## Batch Sizing And Routing
+
+The per-batch cap remains in
+[PR Batch Skills Usage](agent-pr-batch-skills.md): 8 items when files or risk
+overlap, or 10 fully independent items. Treat that as a per-batch maximum, not a
+global promise that three batches can safely process 24 to 30 active items.
+
+Before launching multiple batches, route by package and risk:
+
+- Avoid running two batches against the same package or high-churn directory at
+  the same time. Examples include `react_on_rails/`,
+  `packages/react-on-rails/`, `react_on_rails_pro/`, and an adopter repo such
+  as `react_on_rails_rsc`.
+- Route all `react_on_rails_pro/` work to one batch unless the coordinator has
+  explicit disjoint file ownership and validation coverage for each lane.
+- Keep Pro/core boundary work in one batch when a change crosses OSS gem code,
+  Pro code, package build config, SSR, hydration, or release-sensitive behavior.
+- Route RSC-sensitive work intentionally. If work spans `react_on_rails` and
+  `react_on_rails_rsc`, either keep it in one coordinated batch or designate one
+  repo as the lead and make the other repo wait on a claim/status dependency.
+- Use conductor.build to remove one PR from the batch pool when finishing needs
+  concentrated review, conflict resolution, or Claude plus Codex context on the
+  same PR.
+
+Cross-batch safety should reduce concurrency before it reduces review quality.
+If two batches want the same package, move one target, shrink one batch, or make
+one batch wait for the other lane's done heartbeat.
+
+## Failure Drills
+
+### M5 Laptop Goes Offline
+
+1. Check `agent-coord status` for the affected lane.
+2. If the heartbeat is still live, do not take over. Wait or contact the
+   operator through the coordinator channel.
+3. If the heartbeat is stale, pause dependent work and avoid starting new lanes
+   in the same package.
+4. If the heartbeat is dead, a replacement worker may claim the target only
+   after checking the branch/PR state and recording the takeover in coordination
+   status.
+5. If local unpushed work may exist on the laptop, mark the lane blocked instead
+   of recreating a competing implementation.
+
+### M1 Desktop Session Dies
+
+1. Restart the desktop app or terminal on the same machine when practical.
+2. Reuse the same agent id for the same lane so the coordinator can connect the
+   resumed heartbeat to the prior work.
+3. Re-read `git status`, current branch, and remote branch state before editing.
+4. If the session cannot be recovered, mark the heartbeat stale/dead through the
+   normal TTL path and let a replacement worker take a fresh claim.
+
+### Conductor Takes A PR
+
+1. The conductor operator claims the PR target before editing.
+2. The active batch coordinator reruns status and removes that PR from worker
+   assignment.
+3. Any worker that already started the PR stops, reports its branch/worktree
+   state, and waits for an explicit handoff.
+4. When conductor finishes, it records validation evidence and either marks the
+   lane done or transfers ownership back to a batch worker.
+
+### Two Batches Find A Shared Blocker
+
+1. Stop speculative fixes in every affected lane.
+2. Record one shared blocker in coordination status with affected repo/target
+   ids.
+3. Assign one owner to investigate or ask the maintainer question.
+4. Keep unaffected lanes moving only if they do not touch the blocked package,
+   branch, or release gate.
+5. Resume affected lanes only after the blocker is answered, fixed, or
+   explicitly waived.
+
+## Cross-Repo Operation
+
+Adopting repos join the same private shakacode/agent-coordination backend.
+Claims and heartbeats are namespaced by full repo name, so
+`shakacode/react_on_rails#3973` and `shakacode/react_on_rails_rsc#3973` are
+different targets even if the issue numbers match.
+
+Use one status table for the whole operating window. That lets a coordinator see
+that a `react_on_rails_rsc` lane is waiting on a `react_on_rails` package
+release, or that a conductor session has removed a PR from the shared pool.
+
+When a cross-repo change needs sequencing, make the dependency explicit in the
+coordination state:
+
+- lead repo and target;
+- dependent repo and target;
+- current owner and heartbeat liveness;
+- unblock condition, such as merged PR, published package, released RC, or
+  maintainer decision.
+
+## Operator Checklist
+
+Before kickoff:
+
+- confirm exact issue/PR targets and trusted scope;
+- run `agent-coord status`;
+- assign agent ids using `<machine>-<tool>-<batch>`;
+- route packages so concurrent batches do not overlap;
+- reserve conductor.build only for single-PR focus or finishing;
+- document any cross-repo dependency before workers start.
+
+During execution:
+
+- refresh heartbeats at phase transitions;
+- check status before dependency-sensitive work, rebase, push, or closeout;
+- shrink or pause batches when package overlap appears;
+- treat public claim comments as advisory only.
+
+At closeout:
+
+- record final branch/PR state and validation evidence;
+- mark blocked lanes with exact blocker ownership;
+- check both `react_on_rails` and `react_on_rails_rsc` status when work crossed
+  repositories;
+- hand off remaining risks with `UNKNOWN` for anything not verified live.

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -27,8 +27,10 @@ machine names or an enforced scheduler policy:
 | shakacode/react_on_rails     | Main gem/npm/Pro monorepo     | Claims use this full repo name in the coordination backend.                                 |
 | shakacode/react_on_rails_rsc | RSC integration/adoption repo | Uses the same coordination backend, with claims namespaced by repo.                         |
 
-Prefer no more than three concurrent batches, and only when their packages,
-branches, and risk surfaces are intentionally disjoint:
+Prefer no more than three concurrent batches as a soft operating limit before
+backend enforcement exists. A fourth batch requires an explicit human decision
+with package and risk separation recorded in the batch handoff. Keep concurrent
+batch packages, branches, and risk surfaces intentionally disjoint:
 
 - one Claude Fable batch for the hardest, most ambiguous, or highest-risk items;
 - two Codex batches for simpler, parallel-friendly, well-scoped items;

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -105,10 +105,10 @@ machine names or an enforced scheduler policy:
 | shakacode/react_on_rails     | Main gem/npm/Pro monorepo     | Claims use this full repo name in the coordination backend.                                 |
 | shakacode/react_on_rails_rsc | RSC integration/adoption repo | Uses the same coordination backend, with claims namespaced by repo.                         |
 
-Prefer no more than three concurrent batches as a soft operating limit before
-backend enforcement exists. A fourth batch requires an explicit human decision
-with package and risk separation recorded in the batch handoff. Keep concurrent
-batch packages, branches, and risk surfaces intentionally disjoint:
+Prefer no more than three concurrent batches as a soft operating limit. A fourth
+batch requires an explicit human decision with package and risk separation
+recorded in the batch handoff. Keep concurrent batch packages, branches, and
+risk surfaces intentionally disjoint:
 
 - one Claude Fable batch for the hardest, most ambiguous, or highest-risk items;
 - two Codex batches for simpler, parallel-friendly, well-scoped items;
@@ -119,9 +119,9 @@ Machine choice is an operational decision, not a policy label. Prefer the wired
 host when continuity matters more than local memory, and prefer the mobile host
 when mobility or local capacity is the better fit. If either machine is likely
 to disappear during a lane, route dependency-sensitive work elsewhere.
-If a coordinator attempts a fourth batch before backend enforcement exists, treat
-that as an explicit human decision: record the package/risk separation in the
-batch handoff and downgrade any uncertain overlap to blocked or deferred work.
+If a coordinator attempts a fourth batch, treat that as an explicit human
+decision: record the package/risk separation in the batch handoff and downgrade
+any uncertain overlap to blocked or deferred work.
 
 ## Launcher Roles
 
@@ -215,8 +215,8 @@ one batch wait for the other lane's done heartbeat.
    in the same package.
 4. If the heartbeat is dead, a replacement worker may claim the target only
    after checking the branch/PR state and recording the takeover in coordination
-   status. With the default 15-minute TTL, expect up to 60 minutes from the last
-   heartbeat before liveness reaches `dead`.
+   status. Use the private backend README and CLI help for the current TTL and
+   dead-threshold calculation.
 5. If local unpushed work may exist on the laptop, mark the lane blocked instead
    of recreating a competing implementation.
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -28,7 +28,8 @@ should use this PR branch or `main` for the current workflow docs.
    ```
 
 2. Check out the public repo branch that contains the active workflow docs,
-   normally `main` after PR #3977 lands or the PR branch while it is still open.
+   normally `main` after the workflow docs land or the active PR branch while it
+   is still open.
 3. Clone or update the private backend and put `agent-coord` on `PATH`:
 
    ```bash
@@ -38,10 +39,13 @@ should use this PR branch or `main` for the current workflow docs.
    bin/agent-coord --help
    mkdir -p "$HOME/.local/bin"
    ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
-   agent-coord status
+   "$HOME/.local/bin/agent-coord" status
    ```
 
-4. If `agent-coord status` exits non-zero, report private state as `UNKNOWN` and
+   Add `$HOME/.local/bin` to the shell `PATH`, or keep using the full path in
+   later commands.
+
+4. If the status command exits non-zero, report private state as `UNKNOWN` and
    use the structured public claim comment fallback. Do not start a
    dependency-sensitive lane when the lane declares `depends_on` and private
    status cannot be checked.

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -39,11 +39,13 @@ should use this PR branch or `main` for the current workflow docs.
    bin/agent-coord --help
    mkdir -p "$HOME/.local/bin"
    ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
-   "$HOME/.local/bin/agent-coord" status
+   export PATH="$HOME/.local/bin:$PATH"
+   agent-coord status
    ```
 
-   Add `$HOME/.local/bin` to the shell `PATH`, or keep using the full path in
-   later commands.
+   Keep that `PATH` entry in the active shell, or keep using the full path in
+   later commands. Add it to the shell profile if future shells should inherit
+   the same setup.
 
 4. If the status command exits non-zero, report private state as `UNKNOWN` and
    use the structured public claim comment fallback. Do not start a

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -12,22 +12,23 @@ lane.
 
 ## Baseline Topology
 
-The current coordination model assumes these durable host and surface roles.
-Keep specific hardware inventory in the private operations runbook and update
-that inventory when the active machine pool or launch surfaces change:
+The current coordination model uses these role names for a two-machine,
+three-launcher operating window. Keep specific hardware inventory in the private
+operations runbook; this public table is role vocabulary, not a durable list of
+machine names or an enforced scheduler policy:
 
-| Surface or host              | Primary role                  | Notes                                                                                       |
+| Role                         | Primary use                   | Notes                                                                                       |
 | ---------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
-| Mobile high-memory host      | High-memory mobile batch host | Useful for heavy local context, but treat power, network, and travel as availability risks. |
-| Stable wired host            | Stable wired batch host       | Prefer for long-running desktop sessions and lanes that benefit from steady network/power.  |
+| Mobile high-memory host      | High-memory batch host        | Useful for heavy local context, but treat power, network, and travel as availability risks. |
+| Stable wired host            | Stable batch host             | Prefer for long-running desktop sessions and lanes that benefit from steady network/power.  |
 | Claude Desktop               | Batch kickoff surface         | Best for long-running multi-lane work when Claude Fable should own the hardest items.       |
 | Codex Desktop                | Batch kickoff surface         | Best for long-running Codex batches, local validation, commits, and repo-aware finishing.   |
 | conductor.build              | Single-PR focus and finishing | Best when one PR needs concentrated Claude plus Codex chats on the same PR.                 |
 | shakacode/react_on_rails     | Main gem/npm/Pro monorepo     | Claims use this full repo name in the coordination backend.                                 |
 | shakacode/react_on_rails_rsc | RSC integration/adoption repo | Uses the same coordination backend, with claims namespaced by repo.                         |
 
-Run up to three concurrent batches only when their packages, branches, and risk
-surfaces are intentionally disjoint:
+Prefer no more than three concurrent batches, and only when their packages,
+branches, and risk surfaces are intentionally disjoint:
 
 - one Claude Fable batch for the hardest, most ambiguous, or highest-risk items;
 - two Codex batches for simpler, parallel-friendly, well-scoped items;
@@ -38,6 +39,9 @@ Machine choice is an operational decision, not a policy label. Prefer the wired
 host when continuity matters more than local memory, and prefer the mobile host
 when mobility or local capacity is the better fit. If either machine is likely
 to disappear during a lane, route dependency-sensitive work elsewhere.
+If a coordinator attempts a fourth batch before backend enforcement exists, treat
+that as an explicit human decision: record the package/risk separation in the
+batch handoff and downgrade any uncertain overlap to blocked or deferred work.
 
 ## Launcher Roles
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -7,7 +7,8 @@ rules in [AGENTS.md](../../AGENTS.md),
 [Agent Coordination Backend](agent-coordination-backend.md).
 
 The goal is to make the live operating model reconstructable by a cold-start
-reader without asking Justin which machine, tool, or repository owns a lane.
+reader without asking the coordinator which machine, tool, or repository owns a
+lane.
 
 ## Baseline Topology
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -88,9 +88,9 @@ Use this lifecycle for every lane:
    the backend policy.
 
 If the private backend is unavailable, use the structured public claim comment
-fallback from [AGENTS.md](../../AGENTS.md) and
-[pr-processing.md](../../.agents/workflows/pr-processing.md), but do not use a
-public comment to override a refused private claim.
+fallback from
+[pr-processing.md](../../.agents/workflows/pr-processing.md#coordination-state),
+but do not use a public comment to override a refused private claim.
 
 ## Batch Sizing And Routing
 
@@ -122,7 +122,7 @@ one batch wait for the other lane's done heartbeat.
 
 ## Failure Drills
 
-### M5 Laptop Goes Offline
+### Mobile Batch Host Goes Offline
 
 1. Check `agent-coord status` for the affected lane.
 2. If the heartbeat is still live, do not take over. Wait or contact the
@@ -135,7 +135,7 @@ one batch wait for the other lane's done heartbeat.
 5. If local unpushed work may exist on the laptop, mark the lane blocked instead
    of recreating a competing implementation.
 
-### M1 Desktop Session Dies
+### Stable Desktop Session Dies
 
 1. Restart the desktop app or terminal on the same machine when practical.
 2. Reuse the same agent id for the same lane so the coordinator can connect the

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -131,7 +131,8 @@ one batch wait for the other lane's done heartbeat.
    in the same package.
 4. If the heartbeat is dead, a replacement worker may claim the target only
    after checking the branch/PR state and recording the takeover in coordination
-   status.
+   status. With the default 15-minute TTL, expect up to 60 minutes from the last
+   heartbeat before liveness reaches `dead`.
 5. If local unpushed work may exist on the laptop, mark the lane blocked instead
    of recreating a competing implementation.
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -67,10 +67,10 @@ of truth for concurrent batches. Public issue or PR claim comments are human
 hints and recovery aids only.
 
 Use stable agent ids with the base format `<machine>-<tool>-<batch>`, for
-example `mobile-codex-batch2`, `desktop-claude-fable`, or `desktop-conductor-finish`. If one
-batch runs multiple simultaneously-heartbeating lanes on the same machine and
-tool, add a short lane suffix after the batch id so each heartbeat remains
-distinguishable.
+example `mobile-codex-batch2`, `desktop-claude-fable`, or
+`desktop-conductor-finish`; if one batch runs multiple
+simultaneously-heartbeating lanes on the same machine and tool, add a short lane
+suffix after the batch id so each heartbeat remains distinguishable.
 
 Use this lifecycle for every lane:
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -10,6 +10,78 @@ The goal is to make the live operating model reconstructable by a cold-start
 reader without asking the coordinator which machine, tool, or repository owns a
 lane.
 
+## Fresh Machine Quick Start
+
+Use this when a coordinator asks Codex, Claude, or conductor.build to join a
+batch from another machine or fresh checkout.
+
+The coordinator should provide the batch objective, exact targets, stable
+`batch_id`, lane names, agent ids, any `depends_on` refs, and whether the worker
+should use this PR branch or `main` for the current workflow docs.
+
+1. Authenticate GitHub and confirm access:
+
+   ```bash
+   gh auth status
+   gh repo view shakacode/react_on_rails
+   gh repo view shakacode/agent-coordination
+   ```
+
+2. Check out the public repo branch that contains the active workflow docs,
+   normally `main` after PR #3977 lands or the PR branch while it is still open.
+3. Clone or update the private backend and put `agent-coord` on `PATH`:
+
+   ```bash
+   gh repo clone shakacode/agent-coordination
+   cd agent-coordination
+   ruby -Itest test/agent_coord_test.rb
+   bin/agent-coord --help
+   mkdir -p "$HOME/.local/bin"
+   ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
+   agent-coord status
+   ```
+
+4. If `agent-coord status` exits non-zero, report private state as `UNKNOWN` and
+   use the structured public claim comment fallback. Do not start a
+   dependency-sensitive lane when the lane declares `depends_on` and private
+   status cannot be checked.
+5. Before dependent lanes start, the coordinator creates or updates
+   `batches/<batch-id>.json` in the private backend so `agent-coord status` can
+   render `blocked_on` refs.
+6. Each worker claims before creating a worktree, branch, or conductor session:
+
+   ```bash
+   agent-coord claim \
+     --agent-id <agent-id> \
+     --repo shakacode/react_on_rails \
+     --target <issue-or-pr> \
+     --batch-id <batch-id> \
+     --branch <branch>
+   ```
+
+   A refused claim after successful status is a hard stop. Report the holder,
+   heartbeat liveness, and target instead of creating competing work.
+
+7. Each worker heartbeats at item start, branch/PR update, review pass, blocked
+   state, resumed state, and done state:
+
+   ```bash
+   agent-coord heartbeat \
+     --agent-id <agent-id> \
+     --repo shakacode/react_on_rails \
+     --target <issue-or-pr> \
+     --batch-id <batch-id> \
+     --branch <branch> \
+     --status in_progress
+   ```
+
+8. Before rebase, push, readiness, or closeout, rerun `agent-coord status`. If a
+   lane shows non-empty `blocked_on`, set the worker heartbeat to
+   `--status blocked`, report the blocked refs, and move to independent work.
+9. Final handoff from the second machine must include the agent id, batch id,
+   branch/PR URL, validation run, current `agent-coord status` summary, blockers,
+   and `UNKNOWN` for anything not verified live.
+
 ## Baseline Topology
 
 The current coordination model uses these role names for a two-machine,

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -12,13 +12,14 @@ lane.
 
 ## Baseline Topology
 
-The current coordination model assumes this host map as of 2026-06-13; update
-the table when the active machine pool or launch surfaces change:
+The current coordination model assumes these durable host and surface roles.
+Keep specific hardware inventory in the private operations runbook and update
+that inventory when the active machine pool or launch surfaces change:
 
 | Surface or host              | Primary role                  | Notes                                                                                       |
 | ---------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
-| M5 128GB mobile laptop       | High-memory mobile batch host | Useful for heavy local context, but treat power, network, and travel as availability risks. |
-| M1 64GB wired desktop        | Stable wired batch host       | Prefer for long-running desktop sessions and lanes that benefit from steady network/power.  |
+| Mobile high-memory host      | High-memory mobile batch host | Useful for heavy local context, but treat power, network, and travel as availability risks. |
+| Stable wired host            | Stable wired batch host       | Prefer for long-running desktop sessions and lanes that benefit from steady network/power.  |
 | Claude Desktop               | Batch kickoff surface         | Best for long-running multi-lane work when Claude Fable should own the hardest items.       |
 | Codex Desktop                | Batch kickoff surface         | Best for long-running Codex batches, local validation, commits, and repo-aware finishing.   |
 | conductor.build              | Single-PR focus and finishing | Best when one PR needs concentrated Claude plus Codex chats on the same PR.                 |
@@ -34,7 +35,7 @@ surfaces are intentionally disjoint:
   needs both Claude and Codex attention.
 
 Machine choice is an operational decision, not a policy label. Prefer the wired
-desktop when continuity matters more than local memory, and prefer the M5 laptop
+host when continuity matters more than local memory, and prefer the mobile host
 when mobility or local capacity is the better fit. If either machine is likely
 to disappear during a lane, route dependency-sensitive work elsewhere.
 
@@ -62,7 +63,7 @@ of truth for concurrent batches. Public issue or PR claim comments are human
 hints and recovery aids only.
 
 Use stable agent ids with the base format `<machine>-<tool>-<batch>`, for
-example `m5-codex-batch2`, `m1-claude-fable`, or `m1-conductor-finish`. If one
+example `mobile-codex-batch2`, `desktop-claude-fable`, or `desktop-conductor-finish`. If one
 batch runs multiple simultaneously-heartbeating lanes on the same machine and
 tool, add a short lane suffix after the batch id so each heartbeat remains
 distinguishable.


### PR DESCRIPTION
## Summary

- create the private `shakacode/agent-coordination` backend with `agent-coord` CLI support for claims, releases, heartbeats, status, and batch dependency rendering
- document React on Rails workflow hooks for backend claims, heartbeat phase transitions, dependency-aware lanes, missing/unknown dependency state, and multi-batch operation
- add internal multi-batch operating model docs for fresh-machine startup, two-machine/three-launcher roles, conductor.build handoffs, cross-repo coordination, and failure drills

## Issues

Closes #3969
Closes #3970
Closes #3971
Closes #3972
Closes #3973
Contributes to #3974

## Batch Outcomes

- #3969: done. Private backend repo, schemas, setup docs, and CLI skeleton exist.
- #3970: done. Heartbeat upsert/liveness, phase-transition hooks, launchd template, and stale/dead semantics are documented and locally demonstrated.
- #3971: done. Lease claim acquire/release uses CAS-safe writes, live/stale heartbeats block takeover, and dead-heartbeat takeover is locally tested.
- #3972: done. `agent-coord status` renders batch lanes, `depends_on`, and `blocked_on`; workflow prompts require dependency checks and `UNKNOWN` stops when state is missing.
- #3973: done. Multi-batch operating model is documented and linked from internal contributor docs / `AGENTS.md`, including fresh-machine setup for another host.
- #3974: umbrella. This PR is the implementation closeout vehicle; final issue closeout should summarize this PR, private backend head, and deferred items.

Deferred: #3975 remains a sibling unless a maintainer explicitly adds it. Optional follow-ups: a thin `$batch-status` wrapper, private state GC/tagging, versioned private backend releases, and stricter sync lint for duplicated prompt snippets.

## Coordination Backend Evidence

Private backend repo: `shakacode/agent-coordination` (private). Runtime schemas live there; this public repo only links setup/workflow rules.

Private backend latest validated head: `ed339f2000d3639eca03298a22d7c600a04e20f7`

Core private commits:
- `2be9496` Initialize agent coordination backend
- `cb19a05` Add heartbeat liveness protocol
- `1232a03` Use heartbeat liveness for claim takeover
- `e21b22d` Render batch dependency status
- `76f91f8` Document CLI PATH setup
- `ed339f2` Keep released claims from unblocking lanes

Runtime heartbeat-state commits from smoke/demo activity: `309a781`, `fa6fb08`, `f654694`, `6bc8d82`.

## Validation

Private `shakacode/agent-coordination`:
- `ruby -Itest test/agent_coord_test.rb` -> `12 runs, 86 assertions, 0 failures, 0 errors, 0 skips`
- `ruby -c bin/agent-coord` -> `Syntax OK`
- `plutil -lint launchd/com.shakacode.agent-coord-heartbeat.plist.example` -> OK
- `AGENT_COORD_STATE_ROOT=<tmp> agent-coord heartbeat/status` with the private CLI on `PATH` -> heartbeat/status smoke passed

React on Rails:
- `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none
- `git diff --check` / committed diff check -> passed
- `pnpm start format.listDifferent` -> passed
- `bin/check-links` -> passed (`2750 Total`, `1894 OK`, `856 Excluded`)
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> `218 files inspected, no offenses detected` (tsort future-default-gem warning only)
- pre-commit/pre-push hooks passed; online markdown link check -> `38 Total`, `38 OK`
- `codex review --commit HEAD` for `befec1ffd406157064c523bb53edb873fff507a0` -> no discrete correctness/security/maintainability issue
- Earlier `claude -p '/code-review origin/main'` and `/simplify` attempts produced no output for >5 minutes and were killed with exit 143; not counted as final review gates

## Review / Check State

Release mode: open release tracker #3823 declares `Mode: accelerated-rc`.

Current public head SHA: `befec1ffd406157064c523bb53edb873fff507a0`.

Current GitHub state at body refresh:
- Full `gh pr checks 3977` gate: all rows passed or explained-skipped.
- Passing: `build`, `detect-changes`, `markdown-format-check`, `markdown-link-check`, `CodeQL`, `Cursor Bugbot`, `claude-review`, Ruby/JS Analyze rows.
- Skipped: `docs-format-check` and `claude` rows are explained by docs-only/draft selection; CodeRabbit skipped review because draft.
- Review threads: GraphQL unresolved count was 0 after review triage/resolution for current head.
- Triage comments: https://github.com/shakacode/react_on_rails/pull/3977#issuecomment-4698057110, https://github.com/shakacode/react_on_rails/pull/3977#issuecomment-4698072130, https://github.com/shakacode/react_on_rails/pull/3977#issuecomment-4698077314, https://github.com/shakacode/react_on_rails/pull/3977#issuecomment-4698081624

## Codex Decision Log

- **Non-blocking:** Should claim release delete claim files or preserve them?
  - **Decision:** Preserve released claim records with `status: released` for auditability in v1.
  - **Why:** This keeps state history inspectable in the private repo and still allows takeover/reclaim behavior.
  - **Review later:** If the private repo becomes noisy, add garbage collection or switch release to deletion.

- **Non-blocking:** Should v1 add a separate `batch-status` skill wrapper?
  - **Decision:** Use `agent-coord status` directly in v1 and document the hook points.
  - **Why:** The CLI is the source of truth now; a wrapper can be added later once operator usage settles.
  - **Review later:** Add a thin skill if repeated operator requests prefer `$batch-status`.

- **Non-blocking:** Should public docs duplicate private backend schema/defaults?
  - **Decision:** Public docs give setup/operator pointers and the minimum status examples needed for safe operation; the private README/CLI remain authoritative.
  - **Why:** The coordination backend is private operational infrastructure and should own schemas/defaults.
  - **Review later:** Add versioned private backend releases or generated public pointer docs if the contract changes often.

## Labels

Labels: full-ci, full-ci-no-benchmarks. This is workflow/process tooling plus a private backend CLI, so broad CI/review coverage is useful; benchmarks are not meaningful. The public branch is docs-only by `script/ci-changes-detector origin/main`; private backend behavior is validated locally in the private repo.

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: `befec1ffd406157064c523bb53edb873fff507a0`
Score: 7/10
Auto-merge recommendation: no
Affected areas: agent workflows, private coordination backend, internal docs
CI detector: `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs none
Validation run:
- Private backend tests/syntax/plist lint and heartbeat/status smoke passed as listed above
- Public repo formatting, link checks, RuboCop, diff checks, and hooks passed as listed above
- Local `codex review --commit HEAD` passed for the current head commit
Review/check gate:
- GitHub checks: full list passed or explained-skipped for current head
- Review threads: GraphQL unresolved count 0 after triage/resolution for current head
- Current-head reviewer verdicts: `claude-review` passed, Cursor Bugbot passed, CodeRabbit skipped because draft
Known residual risk: private backend is new operational infrastructure; rollout should remain heartbeat/advisory before hard-stop gates are relied on broadly by maintainers.
Finalized by: not finalized; authoring agent cannot finalize its own accelerated-RC merge confidence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent coordination policy for concurrent batches; misapplied hard-stop/UNKNOWN rules could block work or allow overlap until operators validate the private backend, though this repo diff is documentation only.
> 
> **Overview**
> Documents how concurrent Codex/Claude batches should use the private **`shakacode/agent-coordination`** backend (`agent-coord claim`, `heartbeat`, `status`) instead of treating public claim comments as the durable lock.
> 
> **Canonical rules** land in `.agents/workflows/pr-processing.md`: claim before worktrees/branches, heartbeat at phase transitions, private `batches/<batch-id>.json` for `depends_on` / `blocked_on`, hard-stop on refused claims, and **`UNKNOWN`** when dependency state or status checks are missing. Coordinator closeout adds a **`agent-coord status`** reconciliation step.
> 
> **`$plan-pr-batch`** and **`$pr-batch`** are updated to reference that protocol (stable agent ids, lane deps, goal-prompt `Coordination:` line) while **`pr-batch`** stops duplicating the full claim-comment spec.
> 
> **New contributor docs**: `agent-coordination-backend.md` (setup/smoke checks pointer) and **`multi-batch-operations.md`** (multi-machine topology, routing, failure drills). **`AGENTS.md`** and adoption guides link these for cross-repo operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit befec1ffd406157064c523bb53edb873fff507a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-batch operations support for running concurrent agent batches across machines and repositories with enhanced coordination tracking.

* **Documentation**
  * Expanded coordination protocol guidance for dependency-sensitive batch workflows.
  * Added new operator playbook for multi-batch execution with state management and failure recovery procedures.
  * Updated adoption guidance to include cross-repo coordination setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->