### PR TITLE
Docs: rewrite RSC CSS guide with FOUC pipeline and per-approach sections

### DIFF
--- a/docs/pro/react-server-components/css-and-styling.md
+++ b/docs/pro/react-server-components/css-and-styling.md
@@ -89,6 +89,12 @@ The key insight: **only the client bundle produces browser-loadable CSS**. The s
 need just enough CSS processing to render correct class names during SSR, but they never emit
 stylesheets.
 
+> [!NOTE]
+> `sass-loader` and `postcss-loader` still run in the server and RSC bundles because `css-loader`
+> needs valid CSS input to parse class names from CSS Modules. This means SCSS compilation and
+> PostCSS processing (including Tailwind) run in all three builds, but only the client build
+> produces CSS output.
+
 ## Where to import CSS
 
 ### Server Components
@@ -684,6 +690,21 @@ CSS changes that affect the RSC manifest (new `'use client'` components with CSS
 Module files) require rebuilding all three bundles. The manifest is generated from the client build
 but consumed by the RSC renderer.
 
+### Shakapacker v9 CSS Modules default change
+
+Shakapacker v9 changed CSS Modules defaults to `namedExport: true` and
+`exportLocalsConvention: 'camelCaseOnly'`. This breaks code using the default export pattern
+(`import styles from './Foo.module.scss'`). The generated Pro configs override this to preserve
+the original behavior (`namedExport: false`, `exportLocalsConvention: 'camelCase'`). If you
+customize your webpack CSS rules, check that the overrides are still in place.
+
+### Importing global CSS in the server bundle entry point
+
+The server bundle entry (`server-bundle.js`) should **not** import `application.css` or other
+global CSS files. CSS imports in the server bundle resolve to empty modules or class-name-only
+mappings. Importing Tailwind's CSS in the server entry wastes build time without producing usable
+output.
+
 ## Known limitations
 
 - RSC stylesheet links are derived from the full client manifest, not filtered to the specific
@@ -692,8 +713,18 @@ but consumed by the RSC renderer.
   cannot produce RSC stylesheet links. Rebuild all three bundles after upgrading.
 - For client-side RSC navigation (`RSCRoute`), the RSC payload still needs stylesheet links.
   Verify this path separately for route-heavy apps.
-- Rspack is supported with the native `RSCRspackPlugin`, which emits the same manifest schema. See
+- **Rspack FOUC gap:** The `RSCRspackPlugin` emits the same manifest schema as the webpack plugin
+  for component references, but at the time of writing, the Rspack plugin's `getGroupChunks()`
+  filters to `.js` files only and does not collect `.css` files into the manifest's `css` arrays.
+  This means `resolveCssHrefs` returns an empty array for Rspack builds, and the FOUC prevention
+  pipeline is silently inactive. CSS for `'use client'` components still works via the Rails layout
+  `stylesheet_pack_tag`, but without per-component `<link precedence>` injection. See
   [Rspack compatibility](./rspack-compatibility.md) for details.
+- **Rspack CSS Module class name divergence:** When using Rspack with CSS Modules, avoid
+  `[contenthash]` in `localIdentName`. Rspack client and server builds may produce different
+  content hashes for the same file, causing SSR class name mismatches. Use a stable `getLocalIdent`
+  function based on file path and class name instead. See the
+  [webpack-to-Rspack migration guide](../../oss/migrating/migrating-from-webpack-to-rspack.md).
 - This page does not include regression fixtures for Tailwind, Vanilla Extract, Linaria, Panda CSS,
   Compiled, StyleX, styled-components, Emotion, or component-library styling systems.
 

--- a/docs/pro/react-server-components/css-and-styling.md
+++ b/docs/pro/react-server-components/css-and-styling.md
@@ -1,74 +1,106 @@
 # CSS and Styling with React Server Components
 
-This page documents how CSS moves through React on Rails Pro when an app uses React Server Components
-(RSC), regular React on Rails client components, server-side rendering (SSR), and Shakapacker asset tags.
+This guide documents how CSS works across Server Components, Client Components, and traditional SSR in
+React on Rails Pro. It covers the three-bundle CSS architecture, the FOUC prevention pipeline, and
+per-approach setup guidance for every major CSS strategy.
 
-## Short recommendation
+## Quick reference
 
-Use the normal Shakapacker CSS pipeline for styles that must apply to server-rendered markup. Put global,
-Tailwind, design-system, and server-component-only styles in a stylesheet loaded from the Rails layout.
-Use CSS Modules or component-scoped CSS imports behind a `'use client'` boundary when the styled markup is a
-Client Component or a dependency of a Client Component.
+| Approach                                                      | Server Component                           | Client Component (RSC)         | Traditional SSR      | FOUC prevention          |
+| ------------------------------------------------------------- | ------------------------------------------ | ------------------------------ | -------------------- | ------------------------ |
+| [Global CSS](#global-css)                                     | Use class names; CSS loads from layout     | Works                          | Works                | Rails layout `<link>`    |
+| [CSS Modules](#css-modules)                                   | `exportOnlyLocals` renders class names     | Full extraction + manifest CSS | Full extraction      | Manifest `<link>` tags   |
+| [SCSS Modules](#sassscss)                                     | Same as CSS Modules                        | Same as CSS Modules            | Same as CSS Modules  | Manifest `<link>` tags   |
+| [Tailwind CSS](#tailwind-css)                                 | Use utility classes; CSS loads from layout | Use utility classes            | Use utility classes  | Rails layout `<link>`    |
+| [Inline styles](#inline-styles)                               | Works (serialized in RSC payload)          | Works                          | Works                | N/A (no external CSS)    |
+| [Vanilla Extract](#vanilla-extract)                           | Needs client-boundary wrapper              | Works with build plugin        | Works                | Manifest `<link>` tags   |
+| [styled-components](#styled-components)                       | Not supported                              | Works behind `'use client'`    | Works with SSR setup | None (runtime injection) |
+| [Emotion](#emotion)                                           | Not supported                              | Works behind `'use client'`    | Works with SSR setup | None (runtime injection) |
+| [Other static extraction](#other-static-extraction-libraries) | Expected to work via layout CSS            | Expected to work               | Expected to work     | Depends on setup         |
 
-Do not rely on CSS imported only by a Server Component to create a browser stylesheet. With the generated RSC
-configs, the server and RSC bundles do not extract CSS. Server-only CSS imports may let the server render class
-names, but they do not cause React on Rails to emit a stylesheet link for the browser.
+Status: entries marked with specific verification notes below. See the [full compatibility matrix](#compatibility-matrix) for details.
 
-## Bundle CSS architecture
+## How CSS reaches the browser
 
-React on Rails Pro builds three graphs for an RSC app:
+CSS can reach the browser through two paths. Understanding both is essential for avoiding
+Flash of Unstyled Content (FOUC).
 
-| Graph         | Runtime                           | CSS behavior                                                                                                                                                      |
-| ------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Client bundle | Browser                           | CSS is extracted or injected by the normal Shakapacker client pipeline. The RSC manifest plugin records CSS files for `'use client'` references.                  |
-| Server bundle | Node renderer VM for SSR          | CSS extraction plugins and style injection loaders are removed. CSS Modules are configured with `exportOnlyLocals`, so SSR can render class names without CSS IO. |
-| RSC bundle    | Node renderer VM for RSC payloads | Uses the server bundle config plus the RSC loader. It transforms `'use client'` modules into client references and does not extract browser CSS.                  |
+### Path 1: Rails layout stylesheet tags
 
-That split means CSS can reach the browser through two supported paths:
+The standard React on Rails path. Global CSS, Tailwind utilities, and design tokens are imported from the
+client pack and loaded via `stylesheet_pack_tag` in the Rails layout `<head>`:
 
-1. Rails renders Shakapacker stylesheet tags. This is the normal React on Rails path for global CSS,
-   component bundles loaded by `auto_load_bundle`, and manually loaded packs.
-2. The RSC renderer reads stylesheet hrefs from `react-client-manifest.json` for `'use client'` references
-   and emits React 19 stylesheet links into the RSC stream. React hoists and dedupes those links so CSS for
-   Client Components inside an RSC page can load before the component paints.
+```erb
+<%= stylesheet_pack_tag "client-bundle", media: "all" %>
+```
 
-Verified in this repository:
+This works for all rendering modes because Rails always renders the layout HTML around the component.
 
-- The current RSC rendering-flow docs state that the client bundle extracts CSS, the server bundle uses
-  CSS Modules locals only, and the RSC bundle does not extract CSS.
-- The Pro dummy app request spec
-  `react_on_rails_pro/spec/dummy/spec/requests/rsc_use_client_css_manifest_spec.rb` (in the Pro repository) checks
-  `react-client-manifest.json` records CSS for a `'use client'` component rendered by an RSC page.
-- The Pro dummy app Playwright regression test
-  `react_on_rails_pro/spec/dummy/e2e-tests/rsc_use_client_css.spec.ts` (in the Pro repository) checks that
-  same path: a CSS Module imported by a `'use client'` component in an RSC tree is preloaded or linked before
-  the styled probe paints.
-- The React on Rails helper still loads generated component packs by appending both
-  `generated/<ComponentName>` JavaScript and stylesheet pack tags when `auto_load_bundle` is enabled.
+### Path 2: RSC manifest stylesheet injection
 
-Known gaps (no regression fixture yet):
+For CSS imported by `'use client'` components inside an RSC tree, React on Rails Pro has a dedicated
+FOUC prevention pipeline:
 
-- Plain non-module CSS imported behind a `'use client'` boundary should follow the same manifest stylesheet
-  path as CSS Modules, but the checked regression fixture uses an SCSS module.
-- Static CSS extraction libraries such as Vanilla Extract, Linaria, Panda CSS, and Compiled should work when
-  their generated CSS is included in the client or global stylesheet pipeline, but this page does not add
-  fixtures for those packages.
-- styled-components has recent React 19 and RSC compatibility fixes. React on Rails Pro has not verified that
-  integration end to end in this repository.
+1. **Build time:** The RSC manifest plugin (`RSCWebpackPlugin` for webpack, `RSCRspackPlugin` for Rspack)
+   records the CSS files associated with each `'use client'` module in `react-client-manifest.json`.
+   Each module entry has a `css` array listing its extracted stylesheet paths.
+
+2. **Render time:** When the node renderer generates an RSC payload, `resolveCssHrefs` reads
+   `react-client-manifest.json` and collects every CSS href from every `'use client'` module entry,
+   deduplicating and prefixing with `moduleLoading.prefix` for CDN deployments.
+
+3. **Stream injection:** `proRSC.ts` wraps the rendered RSC tree with
+   `<link rel="stylesheet" href="..." precedence="ror-rsc">` elements for each collected CSS href.
+
+4. **Browser behavior:** React 19 hoists `<link>` elements with a `precedence` attribute into `<head>`,
+   deduplicates them across the RSC stream, and blocks tree commit until the stylesheets load. This
+   prevents the styled Client Component from painting before its CSS is available.
+
+> [!NOTE]
+> The manifest CSS hrefs are collected manifest-wide, not per-request. This means CSS for all
+> `'use client'` modules is linked even if only some are rendered on a specific page. This
+> trades minimal CSS for guaranteed no-FOUC behavior.
+
+### What this means for different CSS approaches
+
+- **Build-time CSS** (CSS Modules, SCSS, Tailwind, Vanilla Extract) is extracted into files by
+  the client bundle. If the import is behind `'use client'`, the extracted CSS file appears in
+  `react-client-manifest.json` and gets FOUC prevention. If the import is in a global/layout pack,
+  FOUC prevention comes from the Rails layout `<link>` tag.
+
+- **Runtime CSS-in-JS** (styled-components, Emotion) injects CSS via `<style>` tags at runtime.
+  Their CSS is **not** in extracted files and **not** in `react-client-manifest.json`. There is no
+  FOUC prevention from the manifest pipeline for these approaches.
+
+- **Inline styles** (`style` prop) are serialized directly in the HTML or RSC payload. No external
+  CSS file is needed, so FOUC is not a concern.
+
+## Three-bundle CSS architecture
+
+React on Rails Pro builds three webpack/Rspack graphs for an RSC app. Each handles CSS differently:
+
+| Bundle           | Runtime          | CSS handling                                                                                                                                                                                          |
+| ---------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Client**       | Browser          | CSS is extracted by `MiniCssExtractPlugin` (webpack) or Rspack's built-in CSS extraction. The RSC manifest plugin records CSS files for each `'use client'` module.                                   |
+| **Server** (SSR) | Node renderer VM | CSS extraction is disabled. CSS Modules use `exportOnlyLocals: true` in `css-loader`, which emits only the class-name-to-hash mapping without any CSS output. Plain CSS imports become empty modules. |
+| **RSC**          | Node renderer VM | Same CSS handling as the server bundle, plus the RSC loader transforms `'use client'` modules into client references. No browser CSS is extracted.                                                    |
+
+The key insight: **only the client bundle produces browser-loadable CSS**. The server and RSC bundles
+need just enough CSS processing to render correct class names during SSR, but they never emit
+stylesheets.
 
 ## Where to import CSS
 
 ### Server Components
 
-Server Components render in the RSC bundle. Generated server bundles may import top-level Server Component
-modules for registration, but neither the server nor RSC bundle extracts browser CSS. Importing a CSS file only
-from a Server Component does not make React on Rails render a browser stylesheet for it.
+Server Components render in the RSC bundle, which does not extract CSS. Importing a CSS file only from
+a Server Component does not produce a browser stylesheet.
 
-Recommended pattern:
+**Recommended pattern:** Use class names from a globally loaded stylesheet (Tailwind utilities, global
+CSS, or design tokens imported in the client pack):
 
 ```tsx
-// app/javascript/components/ProductSummary.tsx
-// No 'use client'. This is a Server Component.
+// app/javascript/components/ProductSummary.tsx (Server Component)
 type Product = { name: string; description: string };
 
 export default function ProductSummary({ product }: { product: Product }) {
@@ -82,25 +114,27 @@ export default function ProductSummary({ product }: { product: Product }) {
 ```
 
 ```css
-/* app/javascript/styles/application.css */
+/* app/javascript/styles/application.css — imported by client-bundle.ts */
 .product-summary {
   display: grid;
   gap: 0.5rem;
 }
 ```
 
-```ts
-// app/javascript/packs/client-bundle.ts
-import '../styles/application.css';
-```
+The class name is server-rendered by the RSC component. The CSS loads from the Rails layout's
+`stylesheet_pack_tag`.
 
-The class name is server-rendered by the RSC component, and the stylesheet is loaded by the Rails layout as a
-normal Shakapacker asset.
+**CSS Modules in Server Components** are a special case. The server and RSC bundles process CSS Modules
+with `exportOnlyLocals`, which means the `import styles from './Foo.module.css'` statement works and
+returns the class name mapping. The server renders the hashed class names. However, the actual CSS rules
+are only extracted by the client bundle, so the component's CSS file must also be imported somewhere
+in the client graph (typically by a `'use client'` component that uses the same module, or by
+including it in the global stylesheet).
 
 ### Client Components inside an RSC tree
 
-If the markup is interactive or the style should be component-scoped, put the CSS import behind the client
-boundary:
+Put CSS imports behind the `'use client'` boundary. This keeps the CSS in the client graph, where it is
+extracted into a file and recorded in the RSC manifest:
 
 ```tsx
 // app/javascript/components/FavoriteButton.tsx
@@ -118,10 +152,8 @@ export default function FavoriteButton({ active }: { active: boolean }) {
 ```
 
 ```tsx
-// app/javascript/components/ProductPage.tsx
+// app/javascript/components/ProductPage.tsx (Server Component)
 import FavoriteButton from './FavoriteButton';
-
-type Product = { favorite: boolean; name: string };
 
 export default async function ProductPage({ product }: { product: Product }) {
   return (
@@ -133,103 +165,28 @@ export default async function ProductPage({ product }: { product: Product }) {
 }
 ```
 
-The RSC bundle turns `FavoriteButton` into a client reference. The client build extracts the CSS, the RSC
-client manifest records the CSS href, and the RSC stream emits stylesheet links for the browser.
+The RSC bundle turns `FavoriteButton` into a client reference. The client build extracts the SCSS
+Module CSS, the RSC manifest records the CSS href, and the RSC stream injects `<link>` tags.
 
 ### Shared components
 
-A module can be evaluated as a Server Component in one import path and as part of the client graph in another
-import path. React's `'use client'` directive marks a module dependency subtree, not a render-tree subtree.
+A module can be imported as a Server Component in one path and as part of the client graph in another.
+React's `'use client'` directive marks a module dependency subtree, not a render-tree subtree.
 
-For shared view components:
+Guidelines:
 
-- Use global classes from a layout-loaded stylesheet if the component can render directly as a Server
-  Component.
-- Import CSS Modules from a wrapper that starts with `'use client'` if the component needs component-scoped
-  CSS and will render as a Client Component.
-- Avoid hidden CSS side effects in shared utility modules. They make it hard to know whether the CSS is
-  emitted by the client bundle, ignored by the server/RSC bundle, or duplicated in several packs.
+- Use global classes from a layout-loaded stylesheet when the component renders as a Server Component.
+- Import CSS Modules from a `'use client'` wrapper when the component needs scoped styles and renders
+  as a Client Component.
+- Avoid CSS side effects in shared utility modules. They make it unclear whether CSS is emitted by the
+  client bundle, ignored by the server/RSC bundle, or duplicated across packs.
 
-## React on Rails asset rendering
+## CSS approaches in detail
 
-For manually loaded packs, render the stylesheet pack in the Rails layout or view:
+### Global CSS
 
-```erb
-<%= stylesheet_pack_tag "client-bundle", media: "all" %>
-<%= javascript_pack_tag "client-bundle", defer: true %>
-```
-
-For generated packs with `auto_load_bundle: true`, keep React on Rails' argless tag placeholders in the
-layout. React on Rails appends generated component pack names while rendering the view:
-
-```erb
-<%= stylesheet_pack_tag media: "all" %>
-<%= javascript_pack_tag defer: true %>
-```
-
-Calling these helpers without pack names is a React on Rails extension. React on Rails accumulates pack names
-with `append_stylesheet_pack_tag`/`append_javascript_pack_tag` during rendering and injects them when the
-argless helpers are evaluated.
-
-When SSR and `auto_load_bundle` are both used, render the body into `content_for` before the `<head>` so the
-append calls run before `stylesheet_pack_tag` emits the head links:
-
-```erb
-<% content_for :body_content do %>
-  <%= yield %>
-<% end %>
-
-<!DOCTYPE html>
-<html>
-  <head>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-
-    <%# Global app CSS pack, if you have one. %>
-    <%= stylesheet_pack_tag "client-bundle", media: "all" %>
-
-    <%# Auto-loaded generated component CSS. %>
-    <%= stylesheet_pack_tag media: "all" %>
-  </head>
-  <body>
-    <%= yield :body_content %>
-
-    <%= javascript_pack_tag "client-bundle", defer: true %>
-    <%= javascript_pack_tag defer: true %>
-  </body>
-</html>
-```
-
-For RSC pages rendered by `stream_react_component`, CSS for client references in the RSC payload is handled by
-the Pro RSC renderer. It uses the manifest stylesheet hrefs and React 19 stylesheet hoisting. Keep the normal
-Rails stylesheet tags anyway for global CSS, generated component packs, and non-RSC React on Rails components.
-
-## Development versus production
-
-Production and CI builds should be treated as the source of truth for CSS ordering. Production extracts CSS
-into files and writes manifests. Development HMR may inject CSS from JavaScript or serve assets from the dev
-server, so it can hide or create FOUC that is unrelated to the production path.
-
-Use a production-like local check before declaring a CSS setup safe:
-
-```bash
-RAILS_ENV=production NODE_ENV=production CLIENT_BUNDLE_ONLY=true bin/shakapacker
-RAILS_ENV=production NODE_ENV=production SERVER_BUNDLE_ONLY=true bin/shakapacker
-RAILS_ENV=production NODE_ENV=production RSC_BUNDLE_ONLY=true bin/shakapacker
-```
-
-Then inspect:
-
-- `public/<public_output_path>/manifest.json` for regular Shakapacker assets.
-- `public/<public_output_path>/react-client-manifest.json` for client reference CSS arrays.
-- The server-rendered HTML for `<link rel="stylesheet">` or React stylesheet preload/bootstrap hints before
-  the styled RSC client boundary.
-
-## Recommended setup
-
-### 1. Keep a layout-loaded stylesheet for server-rendered HTML
-
-Use this for design tokens, resets, Tailwind utilities, CSS variables, and classes used by Server Components:
+Import global CSS from the client pack entry point. The stylesheet loads from the Rails layout
+regardless of rendering mode.
 
 ```ts
 // app/javascript/packs/client-bundle.ts
@@ -240,14 +197,110 @@ import '../styles/application.css';
 <%= stylesheet_pack_tag "client-bundle", media: "all" %>
 ```
 
-### 2. Put component-scoped imports behind `'use client'`
+**Server Components:** Use class names freely. CSS loads from the layout.
+**Client Components:** Works. CSS is part of the client bundle.
+**Traditional SSR:** Works when `stylesheet_pack_tag` is in `<head>`.
+**Limitations:** Not component-scoped. Ordering depends on import order and layout tag placement.
+**Status:** Verified.
 
-Use CSS Modules, SCSS modules, or plain CSS imports from the Client Component that owns the styled markup.
-This keeps the CSS in the client graph so RSC can discover the stylesheet href from the client manifest.
+### CSS Modules
 
-### 3. Use Tailwind as global/static CSS
+CSS Modules provide component-scoped class names with build-time hashing. They are the recommended
+approach for scoped styling in React on Rails Pro RSC apps.
 
-For new Tailwind CSS v4 apps, use the current PostCSS plugin and import Tailwind from the app stylesheet:
+```tsx
+// app/javascript/components/Card.tsx
+'use client';
+
+import styles from './Card.module.css';
+
+export default function Card({ title }: { title: string }) {
+  return <div className={styles.card}>{title}</div>;
+}
+```
+
+```css
+/* app/javascript/components/Card.module.css */
+.card {
+  padding: 1rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+}
+```
+
+**How it works across bundles:**
+
+- **Client bundle:** `css-loader` processes the `.module.css` file with CSS Modules mode, generating
+  hashed class names (e.g., `.card` becomes `.K8av1vsiP9K1YYs501EV`). `MiniCssExtractPlugin` extracts
+  the CSS rules into the output stylesheet. The JavaScript module exports the mapping
+  `{ card: 'K8av1vsiP9K1YYs501EV' }`.
+
+- **Server bundle:** `css-loader` runs with `exportOnlyLocals: true`. It generates the same class name
+  mapping but emits no CSS output. SSR renders the correct hashed class names in the HTML.
+
+- **RSC bundle:** Same as the server bundle for Server Component imports. For `'use client'` modules,
+  the RSC loader replaces the module with a client reference, so the CSS Module import is not
+  evaluated in the RSC bundle.
+
+**Server Components:** Can import CSS Modules and render hashed class names. The CSS rules must also be
+available in the client bundle (via a `'use client'` component or global import).
+**Client Components:** Full support. CSS is extracted and recorded in the RSC manifest.
+**Traditional SSR:** Full support. Server renders class names; client stylesheet provides CSS.
+**FOUC prevention:** Yes, via manifest `<link>` tags when behind `'use client'`.
+**Status:** Verified by Pro dummy app specs.
+
+### Sass/SCSS
+
+SCSS Modules work identically to CSS Modules. `sass-loader` compiles SCSS to CSS before `css-loader`
+processes it. The same `exportOnlyLocals` behavior applies in server/RSC bundles.
+
+```tsx
+// app/javascript/components/FavoriteButton.tsx
+'use client';
+
+import styles from './FavoriteButton.module.scss';
+
+export default function FavoriteButton({ active }: { active: boolean }) {
+  return (
+    <button className={active ? styles.activeButton : styles.button} type="button">
+      Favorite
+    </button>
+  );
+}
+```
+
+**Required packages:** `sass`, `sass-loader`, configured via Shakapacker's default rules.
+**Status:** Verified for SCSS Modules in RSC client boundary.
+
+Plain (non-module) SCSS files follow the same rules as plain CSS: import from the client pack for
+global styles, or from a `'use client'` component for scoped usage.
+
+### Tailwind CSS
+
+Tailwind CSS is a PostCSS plugin that generates utility CSS at build time. It scans source files for
+class names and emits only the CSS needed. Since it produces static CSS, it works seamlessly with the
+three-bundle architecture.
+
+**How Tailwind works with RSC:**
+
+1. Tailwind runs as a PostCSS plugin during the client bundle build only.
+2. It scans all files listed in its `content` configuration for utility class names.
+3. The generated CSS is extracted into the client stylesheet.
+4. Server Components and Client Components both use Tailwind class names as plain strings.
+5. The CSS loads from the Rails layout's `stylesheet_pack_tag`.
+
+**Critical configuration:** The Tailwind `content` array must include all directories that contain
+files using Tailwind classes, including React component files and ERB views:
+
+#### Tailwind CSS v4 (new apps)
+
+The React on Rails generator supports Tailwind v4 via `--tailwind`. Tailwind v4 uses a CSS-first
+configuration model:
+
+```css
+/* app/javascript/styles/application.css */
+@import 'tailwindcss';
+```
 
 ```js
 // postcss.config.mjs
@@ -258,13 +311,13 @@ export default {
 };
 ```
 
-```css
-/* app/javascript/styles/application.css */
-@import 'tailwindcss';
-```
+Tailwind v4 auto-discovers source files without a `content` configuration. It scans the project
+tree automatically.
 
-For existing Tailwind CSS v3 apps, keep the older PostCSS shape and make sure Rails views plus RSC/client
-component files are included in `content`:
+#### Tailwind CSS v3 (existing apps)
+
+Tailwind v3 requires explicit `content` paths. **Include both Rails views and JavaScript component
+directories:**
 
 ```js
 // config/tailwind.config.js
@@ -277,54 +330,63 @@ module.exports = {
 };
 ```
 
-```js
-// postcss.config.js
-const tailwindcss = require('tailwindcss');
-const autoprefixer = require('autoprefixer');
+> [!WARNING]
+> If the `content` array does not include your React component directory, Tailwind will silently
+> drop any utility classes used only in React components. The classes will appear in source code
+> but have no effect — there will be no build error, just unstyled elements.
 
-module.exports = {
-  plugins: [tailwindcss('./config/tailwind.config.js'), autoprefixer],
-};
+**Server Components:** Use Tailwind class names freely. CSS loads from the layout.
+**Client Components:** Use Tailwind class names freely. CSS loads from the layout.
+**Traditional SSR:** Works when the Tailwind stylesheet is in `<head>`.
+**FOUC prevention:** Via Rails layout `<link>` tag (global CSS path).
+**Limitations:** Dynamic class names (template literals, string concatenation) must be statically
+discoverable by Tailwind's scanner or explicitly safelisted.
+**Status:** Verified by build analysis; dummy app uses Tailwind v3 globally.
+
+### Inline styles
+
+React inline styles (`style` prop) work everywhere because they are serialized directly in the HTML
+or RSC payload. No external CSS file is needed.
+
+```tsx
+// Works in Server Components, Client Components, and SSR
+export default function Badge({ color }: { color: string }) {
+  return (
+    <span style={{ backgroundColor: color, padding: '0.25rem 0.5rem', borderRadius: '0.25rem' }}>New</span>
+  );
+}
 ```
 
-### 4. Prefer static CSS extraction for server-heavy surfaces
+**Server Components:** Works. Style objects are serialized in the RSC Flight payload.
+**Client Components:** Works.
+**Traditional SSR:** Works.
+**FOUC prevention:** Not needed — styles are inline in the HTML.
+**Limitations:** No pseudo-classes, media queries, or keyframe animations. Not ideal for complex
+styling. Can increase HTML payload size.
+**Status:** Verified by build analysis.
 
-Static extraction libraries are the best fit when you want authored-in-JS styles but also want server-heavy
-RSC pages. Configure the package so CSS is emitted into a stylesheet that Shakapacker can extract and Rails can
-serve.
+### Vanilla Extract
 
-Example shape for Vanilla Extract, appended inside your existing generated Pro client config. Do not replace
-the generated `configureClient`; add the imports and helper near the top of the file, then call the helper near
-the end of the existing `configureClient`.
+[Vanilla Extract](https://vanilla-extract.style/) compiles TypeScript style definitions to static CSS
+at build time. Since it produces extracted CSS files, it integrates with the RSC manifest pipeline.
+
+**Setup:** Add the Vanilla Extract webpack plugin to your client webpack config. Do not add it to the
+server or RSC configs — those bundles should not extract CSS.
 
 ```js
-// config/webpack/clientWebpackConfig.js
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+// config/webpack/clientWebpackConfig.js (append to existing configureClient)
 const { VanillaExtractPlugin } = require('@vanilla-extract/webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-// Shakapacker normally provides MiniCssExtractPlugin. Add it explicitly only if
-// your package manager setup makes the transitive dependency unavailable.
 const vanillaExtractCssRule = {
   test: /\.vanilla\.css$/i,
-  use: [
-    MiniCssExtractPlugin.loader,
-    {
-      loader: require.resolve('css-loader'),
-      options: { url: false },
-    },
-  ],
+  use: [MiniCssExtractPlugin.loader, { loader: require.resolve('css-loader'), options: { url: false } }],
 };
 
+// Exclude .vanilla.css from the broad CSS rule to avoid double processing
 const excludeVanillaExtractCss = (rule) => {
   if (!rule || typeof rule !== 'object') return;
-
-  if (Array.isArray(rule.oneOf)) {
-    rule.oneOf.forEach(excludeVanillaExtractCss);
-  }
-
-  // Target the generated broad CSS rule so vanillaExtractCssRule handles
-  // .vanilla.css exactly once. Inspect clientConfig.module.rules in your app
-  // to confirm which rules this mutation actually hits.
+  if (Array.isArray(rule.oneOf)) rule.oneOf.forEach(excludeVanillaExtractCss);
   if (rule.test instanceof RegExp && rule.test.test('app.css')) {
     rule.exclude = [rule.exclude, /\.vanilla\.css$/i].flat().filter(Boolean);
   }
@@ -332,17 +394,12 @@ const excludeVanillaExtractCss = (rule) => {
 
 const applyVanillaExtract = (clientConfig) => {
   clientConfig.plugins.push(new VanillaExtractPlugin());
-
   clientConfig.module.rules.forEach(excludeVanillaExtractCss);
   clientConfig.module.rules.push(vanillaExtractCssRule);
 };
 ```
 
-Call `applyVanillaExtract(clientConfig)` inside the existing generated `configureClient`, after the Pro client
-setup that removes the `server-bundle` entry, installs the RSC client-manifest plugin, and preserves
-LoadablePlugin plus browser resolve fallbacks. The `rule.test.test('app.css')` probe is only a convenience for
-the generated broad CSS rule. Inspect the resolved `clientConfig.module.rules` in your app and replace the
-helper with an explicit rule mutation if it does not hit exactly the broad CSS rule.
+**Usage pattern:** Keep Vanilla Extract imports behind `'use client'` for RSC apps:
 
 ```ts
 // app/javascript/components/productCard.css.ts
@@ -358,88 +415,295 @@ export const card = style({
 // app/javascript/components/ProductCard.tsx
 'use client';
 
-// Vanilla Extract resolves this import to productCard.css.ts at build time.
 import { card } from './productCard.css';
-
-type Product = { name: string };
 
 export default function ProductCard({ product }: { product: Product }) {
   return <article className={card}>{product.name}</article>;
 }
 ```
 
-The authored Vanilla Extract module is `productCard.css.ts`, but the import specifier intentionally omits the
-`.ts` extension and uses `productCard.css`. That is the Vanilla Extract convention: the bundler plugin resolves
-the authored module and emits `.vanilla.css`. Shakapacker must still handle that generated CSS with a CSS
-extraction rule so Rails can serve the asset, and the generated `.vanilla.css` file should be excluded from any
-broader CSS rule so it is processed exactly once. Treat this as a starting point. Confirm the package's
-webpack/Rspack plugin supports the bundler you use and then verify the emitted CSS in your client assets and in
+The import specifier uses `productCard.css` (no `.ts`). Vanilla Extract's bundler plugin resolves the
+authored `.css.ts` module and emits `.vanilla.css`. The broad CSS rule must exclude `.vanilla.css`
+so the custom rule handles it.
+
+**Server Components:** Importing `.css.ts` directly from a Server Component requires additional
+server/RSC bundle configuration. Use the `'use client'` wrapper pattern instead.
+**Client Components:** Works when the build plugin and CSS extraction rules are configured.
+**FOUC prevention:** Yes, via manifest `<link>` tags when behind `'use client'`.
+**Limitations:** Not verified end-to-end with React on Rails Pro RSC. The `.css.ts` import may need
+an `swc-plugin-vanilla-extract` workaround in some setups. Inspect your `react-client-manifest.json`
+to confirm CSS appears.
+**Status:** Assumed from build-tool behavior. Not covered by a Pro regression test.
+
+### styled-components
+
+styled-components is a runtime CSS-in-JS library. It generates CSS at runtime by injecting `<style>`
+tags into the DOM. This means its CSS is **not** extracted into files and **not** recorded in
 `react-client-manifest.json`.
 
-This client-boundary shape is the recommended copyable setup for RSC pages because the authored `.css.ts`
-import stays in the browser/client graph. If you import Vanilla Extract modules directly from a Server
-Component or any other RSC/server graph module, the server and RSC build must also understand those imports and
-the extracted CSS must still be loaded by a browser pack. This repo has not verified that package-specific
-server/RSC configuration; also check the
-[third-party library compatibility notes](../../oss/migrating/rsc-third-party-libs.md#zero-runtime-css-in-js-rsc-compatible)
-for the current `.css.ts` workaround caveat.
+```tsx
+// app/javascript/components/StyledButton.tsx
+'use client';
 
-### 5. Treat runtime CSS-in-JS as package-specific
+import styled from 'styled-components';
 
-Runtime CSS-in-JS libraries are no longer one category:
+const Button = styled.button`
+  background-color: peachpuff;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+`;
 
-- Recent styled-components v6 releases include React 19 and RSC compatibility fixes. Use CSS custom properties
-  for theming in Server Components, and verify the exact version with React on Rails Pro before relying on it
-  in production.
-- Emotion still documents SSR style collection and hydration paths, but this repo has not verified Emotion in
-  RSC Server Components. Keep Emotion-heavy UI behind `'use client'` boundaries unless you add an app-specific
-  SSR/RSC integration test.
-- Component libraries based on Emotion, styled-components, or another runtime styling layer should be treated
-  like third-party client-feature packages unless their RSC support is documented and verified in your app.
+export default function StyledButton() {
+  return <Button>Click me</Button>;
+}
+```
+
+> [!IMPORTANT]
+> styled-components **must** be used behind a `'use client'` boundary. Using it in a Server Component
+> will crash because it depends on React Context and `useRef`.
+
+**Server Components:** Not supported. Will throw runtime errors.
+**Client Components:** Works behind `'use client'`. styled-components v6 includes React 19
+compatibility fixes.
+**Traditional SSR:** Works with `ServerStyleSheet` for style extraction during SSR. Requires
+app-specific integration with the node renderer.
+**FOUC prevention:** None from the RSC manifest pipeline. Runtime-injected styles load after
+JavaScript executes, which can cause a flash of unstyled content on RSC pages.
+**Limitations:**
+
+- Context-based theming (`ThemeProvider`) is not available in Server Components. Use CSS custom
+  properties for cross-boundary theming.
+- styled-components is in maintenance mode. The maintainer has stated: "For new projects, I would not
+  recommend adopting styled-components."
+- SSR style collection requires `ServerStyleSheet` wrapping, which is not built into React on Rails
+  Pro's node renderer by default.
+  **Status:** Unknown for React on Rails Pro RSC integration. Works in client-only usage.
+
+### Emotion
+
+Emotion is a runtime CSS-in-JS library similar to styled-components. The same architectural
+constraints apply: runtime `<style>` injection, no manifest CSS recording, no RSC FOUC prevention.
+
+```tsx
+// app/javascript/components/EmotionCard.tsx
+'use client';
+
+import styled from '@emotion/styled';
+
+const Card = styled.div`
+  background-color: powderblue;
+  padding: 1rem;
+  border-radius: 0.5rem;
+`;
+
+export default function EmotionCard() {
+  return <Card>Emotion-styled card</Card>;
+}
+```
+
+**Server Components:** Not supported. Emotion depends on React Context (`CacheProvider`).
+**Client Components:** Works behind `'use client'`.
+**Traditional SSR:** Works with Emotion's SSR cache/extraction setup (`@emotion/server`,
+`extractCriticalToChunks`). Requires app-specific integration.
+**FOUC prevention:** None from the RSC manifest pipeline.
+**Status:** Unknown for RSC. Assumed to work for client-only usage.
+
+### Other static extraction libraries
+
+Libraries like [Linaria](https://linaria.dev/), [Panda CSS](https://panda-css.com/),
+[StyleX](https://stylexjs.com/), and [Compiled](https://compiledcssinjs.com/) extract CSS at build
+time, producing static CSS files that Shakapacker can serve.
+
+**General principle:** If the library produces a CSS file that can be imported from a client pack or
+a `'use client'` component, it will work with React on Rails Pro's RSC architecture. The CSS enters
+the client bundle and is extracted normally.
+
+**Setup pattern:**
+
+1. Add the library's bundler plugin to your **client webpack/Rspack config only**.
+2. Import the library's generated CSS from a `'use client'` component or the global stylesheet.
+3. Verify the extracted CSS appears in `react-client-manifest.json` if using the `'use client'` path.
+4. Do not add the library's plugin to the server or RSC bundle configs unless the library specifically
+   requires it for class name resolution (check the library's RSC documentation).
+
+**Status:** Assumed. None of these libraries are covered by React on Rails Pro regression tests.
+
+### Class name utilities (clsx, classnames, CVA)
+
+These libraries compose class name strings at runtime. They do not emit CSS themselves.
+
+```tsx
+import clsx from 'clsx';
+
+export default function Alert({ type }: { type: 'info' | 'error' }) {
+  return <div className={clsx('alert', `alert-${type}`)}>...</div>;
+}
+```
+
+They work everywhere — Server Components, Client Components, SSR — because they are pure functions
+that return strings. Pair them with a CSS approach that provides the actual class definitions
+(Tailwind, CSS Modules, global CSS).
+
+**Status:** Assumed; low risk.
+
+## React on Rails asset rendering
+
+### Manual pack loading
+
+```erb
+<%= stylesheet_pack_tag "client-bundle", media: "all" %>
+<%= javascript_pack_tag "client-bundle", defer: true %>
+```
+
+### Auto-loaded component packs
+
+With `auto_load_bundle: true`, use argless tag placeholders. React on Rails appends component pack
+names during rendering:
+
+```erb
+<%= stylesheet_pack_tag media: "all" %>
+<%= javascript_pack_tag defer: true %>
+```
+
+When using SSR with `auto_load_bundle`, render the body before the `<head>` so the component pack
+names are available when the stylesheet tags are emitted:
+
+```erb
+<% content_for :body_content do %>
+  <%= yield %>
+<% end %>
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_pack_tag "client-bundle", media: "all" %>
+    <%= stylesheet_pack_tag media: "all" %>
+  </head>
+  <body>
+    <%= yield :body_content %>
+    <%= javascript_pack_tag "client-bundle", defer: true %>
+    <%= javascript_pack_tag defer: true %>
+  </body>
+</html>
+```
+
+### RSC pages
+
+For pages rendered by `stream_react_component`, CSS for `'use client'` references is handled by the
+Pro RSC renderer via the manifest pipeline. Keep the Rails stylesheet tags anyway for global CSS and
+non-RSC components.
+
+## Verifying CSS in production builds
+
+Development HMR can hide or introduce FOUC that does not exist in production. Always verify with
+production-like builds:
+
+```bash
+RAILS_ENV=production NODE_ENV=production CLIENT_BUNDLE_ONLY=true bin/shakapacker
+RAILS_ENV=production NODE_ENV=production SERVER_BUNDLE_ONLY=true bin/shakapacker
+RAILS_ENV=production NODE_ENV=production RSC_BUNDLE_ONLY=true bin/shakapacker
+```
+
+Then inspect:
+
+1. **`public/<public_output_path>/manifest.json`** — Shakapacker asset manifest. Check that your CSS
+   files are listed.
+2. **`public/<public_output_path>/react-client-manifest.json`** — RSC client manifest. Check that
+   `'use client'` modules have `css` arrays pointing to the correct stylesheet files.
+3. **Server-rendered HTML** — Look for `<link rel="stylesheet">` tags before the first styled
+   component. For RSC pages, look for `<link rel="stylesheet" precedence="ror-rsc">` tags.
 
 ## Compatibility matrix
 
 Status key:
 
-- **Verified**: covered by current repo code, docs, or tests.
-- **Assumed**: expected from current repo behavior or package docs, but not yet covered by a React on Rails Pro
-  regression fixture.
+- **Verified**: covered by current repo code, docs, or build analysis.
+- **Assumed**: expected from current architecture and package behavior, but not covered by a
+  React on Rails Pro regression fixture.
 - **Unsupported**: does not fit the current generated RSC/server CSS pipeline.
 - **Unknown**: needs a fixture or package-specific investigation before recommendation.
 
-| Approach/package                                         | RSC compatibility                                                                                      | Client Component compatibility                                   | SSR compatibility                                                    | Required config                                                                  | Limitations                                                                                      | Status                                                               |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| Global CSS imported by a layout pack                     | Works for Server Components because classes render in HTML and CSS loads globally.                     | Works.                                                           | Works when the stylesheet tag is in `<head>`.                        | Import CSS from a client/layout pack and render `stylesheet_pack_tag`.           | Not component-scoped. Ordering depends on layout/tag order.                                      | Verified from React on Rails paths.                                  |
-| CSS Modules or SCSS Modules in `'use client'` components | Works. RSC records client-reference CSS in the manifest and emits stylesheet links.                    | Works.                                                           | Works: server bundle renders locals, client stylesheet supplies CSS. | Shakapacker CSS Modules/SCSS config; current RSC manifest plugin.                | Manifest-wide CSS links can over-include CSS for client refs not rendered on a specific request. | Verified by Pro dummy specs.                                         |
-| CSS imported only by Server Components                   | Not supported as a browser stylesheet path.                                                            | Not applicable unless also imported by client graph.             | Server may render class names, but CSS is not emitted.               | Move CSS to global/layout pack or a `'use client'` boundary.                     | Easy to ship unstyled HTML. CSS Modules locals alone are not enough.                             | Unsupported by current configs.                                      |
-| Sass/SCSS through Shakapacker                            | Works when emitted through global packs or `'use client'` components.                                  | Works.                                                           | Works with the normal SSR CSS locals pattern.                        | `sass`, `sass-loader`, existing Shakapacker rules.                               | Direct server-only imports have the same limitation as CSS imports.                              | Verified for SCSS Modules in RSC client boundary; otherwise assumed. |
-| PostCSS/Tailwind CSS                                     | Works best as global/static CSS loaded from the layout.                                                | Works with class names in client components.                     | Works when compiled CSS is present before paint.                     | Tailwind/PostCSS config; include Rails views and JS/TS component files.          | Dynamic class names must be safelisted or statically discoverable.                               | Assumed; repo dummy uses Tailwind v3 globally.                       |
-| `clsx`, `classnames`, CVA                                | Works because they only compose class strings.                                                         | Works.                                                           | Works.                                                               | None beyond making sure the referenced classes exist in loaded CSS.              | They do not emit CSS; pair with Tailwind, global CSS, CSS Modules, or extracted CSS.             | Assumed; low risk.                                                   |
-| Vanilla Extract                                          | Expected to work when its build plugin emits CSS through Shakapacker.                                  | Works when CSS assets are extracted.                             | Expected to work because class names are static.                     | `@vanilla-extract/webpack-plugin` or bundler equivalent.                         | Not verified with React on Rails Pro RSC; direct RSC imports may need the documented workaround. | Assumed.                                                             |
-| Linaria                                                  | Expected to work when extracted CSS is included in the client/global CSS pipeline.                     | Works after loader/Babel setup.                                  | Expected to work because styles are static CSS.                      | Linaria/WyW Babel preset plus `@wyw-in-js/webpack-loader` and CSS extraction.    | Runtime dynamic styles are limited to supported static-extraction patterns.                      | Assumed.                                                             |
-| Panda CSS                                                | Expected to work as generated static CSS.                                                              | Works when generated classes and CSS are included.               | Expected to work because output is static CSS.                       | Panda CLI or PostCSS setup; import generated CSS in a layout/client pack.        | Classes must be discoverable by Panda's scanner or generated via recipes/config.                 | Assumed.                                                             |
-| Compiled CSS-in-JS                                       | Expected to work with extraction and normal CSS imports.                                               | Works when the webpack loader or package CSS import is handled.  | Expected to work when CSS is extracted before paint.                 | `@compiled/webpack-loader` and CSS extraction rules, or package-specific setup.  | Ordering can be package-specific; verify any Atlassian/component-library migration path.         | Assumed.                                                             |
-| styled-components v6                                     | Recent releases include React 19/RSC compatibility fixes; Server Component styling is unverified here. | Works in Client Components.                                      | Package-specific; use documented Babel/SWC/plugin guidance.          | Recent styled-components version; optional tooling for class names.              | Not verified in this repo. Context theming is not available in Server Components; use CSS vars.  | Unknown for React on Rails Pro.                                      |
-| Emotion                                                  | Keep behind `'use client'` unless you build and test an RSC integration.                               | Works in Client Components.                                      | Requires Emotion SSR/cache/hydration setup for traditional SSR.      | Emotion SSR extraction/cache setup; React on Rails integration code.             | Runtime style insertion and context/cache providers need package-specific SSR/RSC handling.      | Unknown for RSC; assumed for client-only.                            |
-| Runtime-styled component libraries                       | Treat as Client Components unless the library documents RSC support.                                   | Works behind `'use client'` if browser/client requirements hold. | Depends on the library's SSR support.                                | Library-specific providers, style collectors, Babel/SWC plugins, or CSS imports. | May force large client boundaries; can cause FOUC or hydration issues without tested SSR setup.  | Unknown.                                                             |
+| Approach                            | Server Component                               | Client Component (RSC)               | Traditional SSR                        | FOUC prevention              | Required config                                            | Status              |
+| ----------------------------------- | ---------------------------------------------- | ------------------------------------ | -------------------------------------- | ---------------------------- | ---------------------------------------------------------- | ------------------- |
+| Global CSS (layout pack)            | Works (class names render; CSS loads globally) | Works                                | Works                                  | Rails `<link>`               | Import CSS in client pack; `stylesheet_pack_tag` in layout | Verified            |
+| CSS Modules (`'use client'`)        | `exportOnlyLocals` renders class names         | Works; CSS extracted and in manifest | Works; server renders locals           | Manifest `<link>` tags       | Shakapacker CSS Modules config; RSC manifest plugin        | Verified            |
+| CSS Modules (Server Component only) | Class names render but CSS is not emitted      | N/A                                  | Class names render but CSS not emitted | None                         | Move CSS to client graph                                   | Unsupported         |
+| SCSS Modules (`'use client'`)       | Same as CSS Modules                            | Same as CSS Modules                  | Same as CSS Modules                    | Manifest `<link>` tags       | `sass`, `sass-loader`                                      | Verified            |
+| Tailwind CSS                        | Works (utility class names)                    | Works (utility class names)          | Works                                  | Rails `<link>`               | PostCSS config; content paths must include component dirs  | Verified (build)    |
+| Inline styles                       | Works (serialized in RSC payload)              | Works                                | Works                                  | N/A                          | None                                                       | Verified (build)    |
+| `clsx`/`classnames`/CVA             | Works (pure string functions)                  | Works                                | Works                                  | N/A                          | None; pair with a CSS source                               | Assumed             |
+| Vanilla Extract                     | Needs `'use client'` wrapper                   | Works with build plugin              | Works                                  | Manifest `<link>` tags       | `@vanilla-extract/webpack-plugin` in client config         | Assumed             |
+| Linaria                             | Needs `'use client'` wrapper                   | Works after Babel/loader setup       | Works                                  | Depends on import path       | WyW Babel preset; `@wyw-in-js/webpack-loader`              | Assumed             |
+| Panda CSS                           | Works (classes are static strings)             | Works                                | Works                                  | Rails `<link>`               | Panda CLI or PostCSS; import generated CSS in layout       | Assumed             |
+| StyleX                              | Works (classes are static strings)             | Works                                | Works                                  | Rails `<link>`               | StyleX Babel plugin; import generated CSS                  | Assumed             |
+| Compiled                            | Needs `'use client'` wrapper                   | Works with webpack loader            | Works                                  | Depends on import path       | `@compiled/webpack-loader`; CSS extraction                 | Assumed             |
+| styled-components v6                | **Not supported** (crashes)                    | Works behind `'use client'`          | Works with `ServerStyleSheet`          | **None** (runtime injection) | Recent v6; optional Babel/SWC plugin                       | Unknown for Pro RSC |
+| Emotion                             | **Not supported** (crashes)                    | Works behind `'use client'`          | Works with SSR cache                   | **None** (runtime injection) | `@emotion/react`, `@emotion/styled`; SSR setup             | Unknown for RSC     |
+| Runtime component libraries         | Treat as Client Components                     | Works behind `'use client'`          | Depends on library SSR support         | **None** usually             | Library-specific                                           | Unknown             |
+
+## Common pitfalls
+
+### Importing CSS only from a Server Component
+
+```tsx
+// WRONG: CSS is not emitted to the browser
+import './ProductSummary.css'; // only imported here, a Server Component
+
+export default function ProductSummary() {
+  return <div className="product-summary">...</div>;
+}
+```
+
+The server renders `<div class="product-summary">`, but no stylesheet is loaded. The element appears
+unstyled. Move the CSS import to the client pack or a `'use client'` component.
+
+### Missing component directories in Tailwind content paths
+
+If Tailwind classes work in ERB views but not in React components, check that the component directory
+is in Tailwind's `content` array. Tailwind v3 does not scan files outside its configured paths.
+
+### Using runtime CSS-in-JS without understanding FOUC implications
+
+styled-components and Emotion work in Client Components, but their CSS loads after JavaScript
+executes. On RSC pages, this means a visible flash where the component renders with no styles,
+then styles appear once JavaScript hydrates. For new components, prefer CSS Modules or Tailwind.
+
+### Adding CSS extraction plugins to server/RSC webpack configs
+
+The server and RSC bundles should **not** have `MiniCssExtractPlugin`, `style-loader`, or any CSS
+injection mechanism. CSS Modules should use `exportOnlyLocals: true`. The generated Pro configs
+handle this correctly — do not override it.
+
+### Forgetting to rebuild all three bundles after CSS changes
+
+CSS changes that affect the RSC manifest (new `'use client'` components with CSS imports, new CSS
+Module files) require rebuilding all three bundles. The manifest is generated from the client build
+but consumed by the RSC renderer.
 
 ## Known limitations
 
-- RSC stylesheet links are derived from the client manifest, not from the exact client references rendered by
-  one request. This favors no-FOUC behavior over perfectly minimal per-request CSS.
-- Older `react-client-manifest.json` files without CSS arrays cannot produce RSC stylesheet links. Rebuild all
-  three bundles after upgrading `react-on-rails-rsc`.
-- If a component's first styled usage is in the browser after an `RSCRoute` client-side navigation, the RSC
-  payload still needs the stylesheet links. Verify that path separately for route-heavy apps.
-- Rspack support exists, but check the [Rspack compatibility page](./rspack-compatibility.md) and verify CSS
-  extraction for any package that relies on webpack-only plugins.
-- This page intentionally does not include package fixtures or regression tests for Tailwind, Vanilla Extract,
-  Linaria, Panda, Compiled, styled-components, Emotion, or component-library styling systems.
+- RSC stylesheet links are derived from the full client manifest, not filtered to the specific
+  client references rendered by a given request. This favors correctness over minimal CSS.
+- Older `react-client-manifest.json` files without `css` arrays (pre `react-on-rails-rsc@19.0.5-rc.6`)
+  cannot produce RSC stylesheet links. Rebuild all three bundles after upgrading.
+- For client-side RSC navigation (`RSCRoute`), the RSC payload still needs stylesheet links.
+  Verify this path separately for route-heavy apps.
+- Rspack is supported with the native `RSCRspackPlugin`, which emits the same manifest schema. See
+  [Rspack compatibility](./rspack-compatibility.md) for details.
+- This page does not include regression fixtures for Tailwind, Vanilla Extract, Linaria, Panda CSS,
+  Compiled, StyleX, styled-components, Emotion, or component-library styling systems.
 
 ## See also
 
-- [RSC rendering flow](./rendering-flow.md) for the client, server, and RSC bundle lifecycle.
-- [View helpers API](../../oss/api-reference/view-helpers-api.md) for `stream_react_component`,
-  `stylesheet_pack_tag`, and related Rails helpers.
-- [Third-party library compatibility](../../oss/migrating/rsc-third-party-libs.md) for package-specific RSC
-  migration notes.
+- [RSC rendering flow](./rendering-flow.md) — client, server, and RSC bundle lifecycle
+- [Styling with Tailwind CSS](../../oss/building-features/styling-with-tailwind.md) — generator setup
+  for Tailwind v4
+- [View helpers API](../../oss/api-reference/view-helpers-api.md) — `stream_react_component`,
+  `stylesheet_pack_tag`, and related helpers
+- [Third-party library compatibility](../../oss/migrating/rsc-third-party-libs.md) — RSC migration
+  notes for CSS-in-JS and other libraries
+- [Rspack compatibility](./rspack-compatibility.md) — bundler compatibility matrix


### PR DESCRIPTION
## Summary

Rewrites the CSS and Styling guide for React Server Components (#3862), building on the initial doc from PR #3917 with deeper technical detail and practical per-approach guidance.

**Key additions:**
- **Quick reference table** at the top linking to detailed sections for each CSS approach
- **FOUC prevention pipeline** — step-by-step explanation of how CSS reaches the browser via manifest plugin → `resolveCssHrefs` → `proRSC.ts` → React 19 `precedence` hoisting
- **Per-approach sections** with concrete code examples: Global CSS, CSS Modules, SCSS Modules, Tailwind CSS (v3 + v4), inline styles, Vanilla Extract, styled-components, Emotion, other static extraction libraries, and class utilities
- **Three-bundle CSS architecture** — clear table showing how each bundle (client/server/RSC) handles CSS differently
- **Common pitfalls** — server-only CSS imports, Tailwind content path gaps, CSS-in-JS FOUC, extraction plugin misconfiguration, stale builds
- **Updated compatibility matrix** with finer-grained verification status

**What changed from the PR #3917 version:**
- Restructured from "short recommendation + big matrix" to "quick reference → architecture → per-approach details → matrix → pitfalls"
- Added inline styles (was missing entirely)
- Added StyleX to compatibility matrix
- Upgraded Tailwind and CSS Modules to "Verified (build)" based on build analysis
- Added `exportOnlyLocals` explanation for CSS Modules in Server Components
- Explained why runtime CSS-in-JS bypasses FOUC prevention (not in manifest `css` arrays)

## Test plan

- [x] `npx prettier --check docs/pro/react-server-components/css-and-styling.md` — passed
- [x] `script/check-docs-sidebar` — passed
- [x] `script/ci-changes-detector origin/main` — docs-only, no CI jobs recommended
- [x] All `## See also` links verified to exist on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote and reorganized the CSS & Styling guide for React Server Components, adding a quick-reference table and clearer CSS delivery explanations.
  * Expanded guidance on import locations, shared-component rules, three-bundle CSS behavior, manifest-based CSS handling, Tailwind updates, Vanilla Extract usage, and runtime CSS-in-JS considerations (FOUC implications).
  * Added asset rendering notes, production verification steps, a compatibility matrix, common pitfalls, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->