### PR TITLE
Docs: correct vm.Script caching analysis caveats

### DIFF
--- a/analysis/vm-script-caching-investigation-2026-06-07.md
+++ b/analysis/vm-script-caching-investigation-2026-06-07.md
@@ -4,19 +4,26 @@ Related issue: [#3282](https://github.com/shakacode/react_on_rails/issues/3282)
 
 ## Verdict
 
-| Area                      | Status         | Finding                                                                               |
-| ------------------------- | -------------- | ------------------------------------------------------------------------------------- |
-| vm.Script caching benefit | **Not needed** | Execution time dominates; compile overhead is negligible for real workloads           |
-| Hypothesis from #3282     | Refuted        | Expected ~3ms savings not achievable — real compile cost is <15μs even for 500KB code |
-| Implementation effort     | Not justified  | Adds complexity for <0.01% improvement on actual render paths                         |
+| Area                      | Status                                | Finding                                                                                                           |
+| ------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| vm.Script caching benefit | **Not supported by current evidence** | Exploratory microbenchmarks show same-source cache hits and colder unique-source compiles behave very differently |
+| Hypothesis from #3282     | Not demonstrated as raw compile cost  | The original ~3ms observation was not reproduced with its original harness                                        |
+| Implementation effort     | Not justified without stronger signal | Adds cache invalidation and memory-management complexity before a production-like win is proven                   |
 
 ## Executive Summary
 
-Issue #3282 proposed caching pre-compiled `vm.Script` objects to save the ~3ms "per-request JS-parse cost" observed in profiling. We ran controlled benchmarks isolating V8 compilation cost and found:
+Issue #3282 proposed caching pre-compiled `vm.Script` objects to save the ~3ms "per-request JS-parse cost" observed in profiling. This note measured isolated `vm.Script` compilation and cached-vs-uncached execution on macOS arm64. It did **not** reproduce the original #3282 profiling harness or a Linux x86_64 production-like environment.
 
-1. **V8 compilation is extremely fast**: ~26μs per MB of code
-2. **Execution time dominates**: Scripts with real computation show only 1.02-1.08x speedup from caching
-3. **The 3ms observed** was likely execution time, not parse time
+Directly measured in this investigation:
+
+1. **Isolated compile/setup medians need caveats**: original raw medians were 0.5-3.8μs, with a clearly noisy 650 KB row at 0.83μs; a 2026-06-13 reproduction separated hot same-source cache hits from colder unique-source compiles and measured much larger values for the unique-source path, including a 662 KB generated script around 8.8ms on Apple M5 Max.
+2. **Execution time dominated these synthetic scripts**: scripts with real computation showed roughly 1.00-1.08x speedup from caching, often within measurement noise.
+3. **No portable throughput constant was established**: the measurements are useful as exploratory evidence, not as a precise "μs per MB" claim.
+
+Inferred, not directly measured here:
+
+1. The original ~3ms #3282 observation likely included work other than raw `new vm.Script(...)` compilation, such as React execution, props handling, context setup, or profiler warmup effects.
+2. A production-like Linux x86_64 benchmark could still find a meaningful compile/cache signal, but this analysis did not produce that evidence.
 
 Caching `vm.Script` is only beneficial for scripts that:
 
@@ -24,27 +31,31 @@ Caching `vm.Script` is only beneficial for scripts that:
 - Run 100+ times with identical code
 - Have minimal actual computation
 
-The render template in react_on_rails_pro does real work (React rendering, props serialization, DOM diffing) — execution will always dominate, making compilation overhead irrelevant.
+The render template in react_on_rails_pro does real work (React rendering and props serialization). The available evidence says execution is likely to dominate; it does not prove that every production workload has zero measurable benefit from `vm.Script` caching.
 
-## Benchmark Environment
+## Original Benchmark Environment
 
 - **Runtime**: Node.js v22.12.0
 - **OS**: macOS Darwin (arm64)
 - **CPU**: Apple M1
 - **Methodology**: 5000 measurements per subject (1000 iterations × 5 trials, interleaved A/B)
 
+## Reproducibility Note
+
+The original local experiment bundle was an ephemeral `tmp/` path and was not retained. A narrow standalone reproduction script is now committed as [`analysis/vm-script-caching-repro-2026-06-13.mjs`](vm-script-caching-repro-2026-06-13.mjs). It is intended to reproduce the shape of the microbenchmark, not to establish portable production throughput.
+
 ## Key Results
 
 ### 1. Compilation Cost vs Code Size
 
-| Code Size | Compile Time | Cached Exec | Uncached Exec | Speedup   |
-| --------- | ------------ | ----------- | ------------- | --------- |
-| 60 chars  | 0.54μs       | 0.62μs      | 1.37μs        | **2.2x**  |
-| 8 KB      | 0.54μs       | 38.04μs     | 38.54μs       | **1.01x** |
-| 69 KB     | 2.75μs       | 400.12μs    | 404.00μs      | **1.01x** |
-| 650 KB    | 0.83μs       | 2016.46μs   | 2016.25μs     | **1.00x** |
+| Code Size | Compile Time | Cached Exec | Uncached Exec | Speedup   | Interpretation              |
+| --------- | ------------ | ----------- | ------------- | --------- | --------------------------- |
+| 60 chars  | 0.54μs       | 0.62μs      | 1.37μs        | **2.2x**  | Trivial script              |
+| 8 KB      | 0.54μs       | 38.04μs     | 38.54μs       | **1.01x** | Noise-band difference       |
+| 69 KB     | 2.75μs       | 400.12μs    | 404.00μs      | **1.01x** | Noise-band difference       |
+| 650 KB    | 0.83μs       | 2016.46μs   | 2016.25μs     | **1.00x** | Internally inconsistent row |
 
-**Observation**: For scripts with real execution time (38μs+), caching provides <1% improvement because compilation (0.5-3μs) is noise compared to execution.
+**Observation**: For scripts with real execution time (38μs+), cached-vs-uncached differences were mostly <1%. The 650 KB compile median is lower than the 69 KB median, so it should be treated as timer and benchmark noise. This table does not support a precise per-MB compilation-throughput claim.
 
 ### 2. Parse Complexity Analysis
 
@@ -58,7 +69,7 @@ Different AST patterns were tested to find maximum parse cost:
 | Regex literals    | 29 KB     | 1.8μs        | 15.4 MB                     |
 | String literals   | 111 KB    | 3.8μs        | 27.6 MB                     |
 
-**Observation**: Even the most expensive parsing pattern (deeply nested objects) requires 2.6 MB of code to reach 1ms compile time. This is unrealistic for render templates.
+**Observation**: These generated AST patterns also landed in the low-microsecond range. The "size needed for 1ms compile" column is a rough extrapolation from noisy microbench data, not a measured production threshold.
 
 ### 3. Execution Count Scaling
 
@@ -84,22 +95,22 @@ Scripts that do real work (object creation, loops, array operations):
 | Medium (100 sqrt calls) | 12.87μs     | 13.80μs       | **1.07x** |
 | Heavy (1000 objects)    | 39.15μs     | 39.99μs       | **1.02x** |
 
-**Observation**: The moment execution time exceeds ~5μs, caching benefit drops to noise levels.
+**Observation**: In these synthetic cases, once execution time exceeded a few microseconds, caching benefit dropped into measurement noise.
 
-## Why the Original 3ms Estimate Was Wrong
+## What the Original 3ms Estimate Did and Did Not Show
 
 Issue #3282 stated:
 
 > Per-request JS-parse cost: ~3 ms
 
-This measurement likely included:
+This investigation did not rerun the original profiling harness, so it cannot prove what the original number contained. Based on the isolated microbenchmarks above, the ~3ms "parse" attribution likely included one or more non-compile costs:
 
 1. **React component evaluation** (function execution, not parsing)
 2. **Props serialization** (JSON stringify/parse overhead)
 3. **Context creation** (`vm.createContext` cost, not `vm.Script` compile)
 4. **JIT warmup** artifacts in the profiling
 
-Our isolated benchmark shows V8 parses 1MB of JavaScript in ~26μs. A 200-byte template (post-#3281) would compile in <1μs.
+The corrected conclusion is narrower: the available isolated measurements did not reproduce a raw `vm.Script` compile cost anywhere near 3ms. They do not, by themselves, prove that a 200-byte post-#3281 render template would always compile in less than 1μs on every runtime and host.
 
 ## Scripts That Would Benefit (Not Our Use Case)
 
@@ -142,29 +153,55 @@ const render = new vm.Script(`
 
 ## Recommendation
 
-**Close issue #3282 as "won't implement".**
+**Keep issue #3282 closed unless new production-like evidence shows a material win.**
 
-The optimization targets the wrong layer. V8's JIT compiler is not the bottleneck — React rendering and props handling are. Any performance work should focus on:
+The current evidence does not justify adding `vm.Script` caching to the renderer. It points toward React rendering and props handling as better performance targets:
 
 1. Reducing props size (#3281)
 2. Streaming/chunked rendering
 3. Component-level caching
 4. Reducing React reconciliation work
 
-Adding `vm.Script` caching would:
+Adding `vm.Script` caching without stronger evidence would:
 
 - Add code complexity (cache invalidation, memory management)
-- Provide <0.01% improvement on real workloads
+- Risk providing no measurable improvement on real workloads
 - Create false confidence that "we optimized the VM layer"
 
 ## Artifacts
 
 Benchmark scripts and raw data are captured in this committed analysis note:
 
-- Raw benchmark output: see the two sections below.
+- Reproduction script: [`analysis/vm-script-caching-repro-2026-06-13.mjs`](vm-script-caching-repro-2026-06-13.mjs)
+- Example reproduction output: see the section below.
+- Original raw benchmark output: see the two later sections, with caveats.
 - Original local experiment bundle: intentionally not retained because it was an ephemeral `tmp/` path.
 
-### Raw Benchmark Output (Summary)
+### Example Reproduction Output (2026-06-13)
+
+Later runs on the same host varied with source shape, V8's compilation cache, and sampling noise; run the script above for current local values.
+
+```text
+vm.Script caching reproduction
+==============================
+Node: v22.12.0
+Platform: darwin arm64
+CPU: Apple M5 Max
+
+| Size | Code Len | Samples | Same-source Compile | Unique-source Compile | Cached Med | Uncached Med | Speedup |
+| ---- | -------- | ------- | ------------------- | --------------------- | ---------- | ------------ | ------- |
+| tiny   |       54 |    5000 |              0.46us |                2.62us |     0.88us |       1.17us | 1.33x |
+| small  |      379 |    3000 |              0.37us |                6.75us |     1.54us |       2.00us | 1.30x |
+| medium |     8323 |    1000 |              0.54us |              106.50us |    25.42us |      26.17us | 1.03x |
+| large  |    72453 |     300 |              1.58us |             1190.38us |   207.54us |     208.96us | 1.01x |
+| huge   |   662053 |      80 |              9.96us |             8834.42us |  1917.67us |    1958.00us | 1.02x |
+
+Note: Same-source compile uses V8/Node compilation-cache behavior by default.
+Unique-source compile varies the source text each sample to show a colder path.
+Run with `node --no-compilation-cache` to compare with V8 compilation caching disabled.
+```
+
+### Original Raw Benchmark Output (Exploratory)
 
 ```text
 vm.Script Caching Benchmark
@@ -198,6 +235,8 @@ Pattern                        |    Chars |  Compile
 
 ## Conclusion
 
-V8's compilation is too fast to be a bottleneck. The ~3ms attributed to "JS parsing" in the original issue was execution time, not parse time. Caching `vm.Script` objects provides meaningful speedup only for trivial expressions executed thousands of times — not for per-request React rendering.
+The available microbenchmarks do not support implementing `vm.Script` caching for the render path. They show cached-vs-uncached runtime differences near the measurement-noise band once scripts perform real work, while also showing that cold or unique-source compilation can be much more expensive than the original same-source compile medians implied.
 
-**Status: Investigation complete. Optimization not needed.**
+The stronger original wording was overconfident. The ~3ms attributed to "JS parsing" in #3282 was not reproduced here as raw `vm.Script` compile cost, but identifying it as execution time remains an inference until the original or an equivalent production-like harness is rerun.
+
+**Status: Investigation corrected. Optimization still not justified by current evidence.**

--- a/analysis/vm-script-caching-repro-2026-06-13.mjs
+++ b/analysis/vm-script-caching-repro-2026-06-13.mjs
@@ -1,0 +1,97 @@
+import os from 'node:os';
+import vm from 'node:vm';
+import { performance } from 'node:perf_hooks';
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+function measure(callback, samples) {
+  const values = [];
+
+  for (let index = 0; index < 100; index += 1) {
+    callback(-index - 1);
+  }
+
+  for (let index = 0; index < samples; index += 1) {
+    const startedAt = performance.now();
+    callback(index);
+    values.push((performance.now() - startedAt) * 1000);
+  }
+
+  return median(values);
+}
+
+function makeScript(statementCount) {
+  const statements = Array.from(
+    { length: statementCount },
+    (_, index) => `total += values[${index % 32}];`,
+  ).join('\n');
+
+  return `(() => {
+let total = 0;
+${statements}
+globalThis.sink = total;
+})()`;
+}
+
+const cases = [
+  { name: 'tiny', samples: 5000, source: '(() => { globalThis.sink = values[0] + values[1]; })()' },
+  { name: 'small', samples: 3000, source: makeScript(16) },
+  { name: 'medium', samples: 1000, source: makeScript(400) },
+  { name: 'large', samples: 300, source: makeScript(3500) },
+  { name: 'huge', samples: 80, source: makeScript(32000) },
+];
+
+const context = vm.createContext({
+  values: Array.from({ length: 32 }, (_, index) => index + 1),
+});
+
+console.log('vm.Script caching reproduction');
+console.log('==============================');
+console.log(`Node: ${process.version}`);
+console.log(`Platform: ${process.platform} ${process.arch}`);
+console.log(`CPU: ${os.cpus()[0]?.model ?? 'unknown'}`);
+console.log();
+console.log(
+  '| Size | Code Len | Samples | Same-source Compile | Unique-source Compile | Cached Med | Uncached Med | Speedup |',
+);
+console.log(
+  '| ---- | -------- | ------- | ------------------- | --------------------- | ---------- | ------------ | ------- |',
+);
+
+for (const benchmarkCase of cases) {
+  const { name, samples, source } = benchmarkCase;
+  const compiled = new vm.Script(source);
+
+  const sameSourceCompileMedian = measure(() => {
+    return new vm.Script(source);
+  }, samples);
+  const uniqueSourceCompileMedian = measure((index) => {
+    return new vm.Script(`${source}\n// unique compile ${index}`);
+  }, samples);
+  const cachedMedian = measure(() => {
+    compiled.runInContext(context);
+  }, samples);
+  const uncachedMedian = measure(() => {
+    vm.runInContext(source, context);
+  }, samples);
+
+  console.log(
+    `| ${name.padEnd(6)} | ${String(source.length).padStart(8)} | ${String(samples).padStart(
+      7,
+    )} | ${sameSourceCompileMedian.toFixed(2).padStart(17)}us | ${uniqueSourceCompileMedian
+      .toFixed(2)
+      .padStart(19)}us | ${cachedMedian
+      .toFixed(2)
+      .padStart(8)}us | ${uncachedMedian.toFixed(2).padStart(10)}us | ${(
+      uncachedMedian / cachedMedian
+    ).toFixed(2)}x |`,
+  );
+}
+
+console.log();
+console.log('Note: Same-source compile uses V8/Node compilation-cache behavior by default.');
+console.log('Unique-source compile varies the source text each sample to show a colder path.');
+console.log('Run with `node --no-compilation-cache` to compare with V8 compilation caching disabled.');


### PR DESCRIPTION
## Summary

- Corrects the vm.Script caching investigation so same-source V8 compilation-cache hits are not presented as production-like precompiled-template evidence.
- Adds a small reproduction script that separates hot same-source compile time, colder unique-source compile time, cached execution, and uncached execution.
- Keeps #3282 closed unless future production-like evidence shows a material runtime win, but removes the internally inconsistent throughput claim.

Closes #3980.

## Validation

- `node analysis/vm-script-caching-repro-2026-06-13.mjs` -> passed; huge source sample showed same-source compile ~10.92us, unique-source compile ~8852.33us, cached execution median ~1894.96us, uncached execution median ~1995.04us.
- `pnpm exec eslint analysis/vm-script-caching-repro-2026-06-13.mjs` -> passed; baseline-browser-mapping age warning only.
- `pnpm exec prettier --check analysis/vm-script-caching-investigation-2026-06-07.md analysis/vm-script-caching-repro-2026-06-13.mjs` -> passed.
- `git diff --check origin/main...HEAD && git diff --check` -> passed.
- `script/ci-changes-detector origin/main` -> uncategorized analysis changes; recommends full suite for safety.
- pre-push hook -> passed branch-lint and markdown link checks.
- `codex review --base origin/main` -> no discrete correctness, security, performance, or maintainability regressions found after review fixes.

Labels: full-ci, full-ci-no-benchmarks because the CI detector treats `analysis/` as uncategorized, while this documentation/reproduction-script correction cannot affect runtime benchmarks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and analysis-only changes under `analysis/`; no renderer or runtime behavior is modified.
> 
> **Overview**
> Revises the **vm.Script caching** investigation so it no longer treats hot same-source V8 compile times as proof against production `vm.Script` caching, and adds a committed microbenchmark repro.
> 
> The investigation doc now separates **directly measured** microbench results from **inferred** claims about the original ~3ms #3282 observation, drops the internally inconsistent “μs per MB” throughput framing, and reframes the verdict from “won’t implement / not needed” to **optimization not justified by current evidence** while keeping #3282 closed unless production-like data appears. It documents reproducibility limits (ephemeral original bundle, macOS arm64 only) and adds example output from the new repro.
> 
> **`analysis/vm-script-caching-repro-2026-06-13.mjs`** measures median times for same-source vs unique-source `new vm.Script(...)`, plus cached `runInContext` vs uncached `vm.runInContext`, across several generated script sizes, with notes on `--no-compilation-cache`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7399d36131df7c08d5c02c5025a810636869b7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->