### PR TITLE
Tools: add PR batch merge ledger

### DIFF
--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -170,7 +170,7 @@ At merge readiness and batch closeout, run the machine-checkable per-PR merge
 ledger with `script/pr-merge-ledger <PR> --strict`, supplying explicit changelog
 classification and any P0/P1/P2/Must-Fix disposition evidence. Do not report a
 target `complete` while the ledger has any `UNKNOWN` field, unresolved
-current-head review thread, `CHANGES_REQUESTED` review object, or
+current-head review thread, active `review_objects.changes_requested` entry, or
 `complete_allowed: false`. Include the ledger JSON artifact path or table in the
 final handoff.
 

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -166,6 +166,14 @@ next paragraph; an empty full check list is `UNKNOWN` / not ready. Treat untriag
 regression, compatibility, and missing-changelog findings as merge blockers
 unless a maintainer explicitly waives them.
 
+At merge readiness and batch closeout, run the machine-checkable per-PR merge
+ledger with `script/pr-merge-ledger <PR> --strict`, supplying explicit changelog
+classification and any P0/P1/P2/Must-Fix disposition evidence. Do not report a
+target `complete` while the ledger has any `UNKNOWN` field, unresolved
+current-head review thread, `CHANGES_REQUESTED` review object, or
+`complete_allowed: false`. Include the ledger JSON artifact path or table in the
+final handoff.
+
 If `gh pr checks <PR> --required` reports no required checks, do NOT treat that
 as CI-ready. Instead treat the full `gh pr checks <PR>` list as the readiness
 gate and require each current-head check to pass or be skipped with CI selector
@@ -231,7 +239,9 @@ Use the canonical Batch Handoff Format in
 **Immediate maintainer attention** for true blockers and questions only, and
 **FYI / decisions made** for decisions, validations, review state, full-CI
 requests already handled, no-PR rationales, autonomous nit outcomes,
-confidence notes, and decision-point counts per PR.
+confidence notes, decision-point counts per PR, and per-PR merge-ledger summaries.
+Do not call a target `complete` while its ledger has `UNKNOWN` fields or
+`complete_allowed: false`.
 
 ## Coordination State
 
@@ -259,7 +269,7 @@ reporting, full-CI decisions, and merge sequencing.
 For the complete numbered sequence, follow the canonical closeout lane in
 `.agents/workflows/pr-processing.md` instead of stopping at PR creation. The
 coordinator owns the live re-fetch, current-head checks and review-thread triage,
-stale release-mode classification updates and the finalized PR-body
+per-PR merge-ledger run, stale release-mode classification updates and the finalized PR-body
 `Agent Merge Confidence` block refresh required for accelerated-RC readiness (kept
 distinct), full-CI request and waitback when uncertainty remains, and any
 authorized ready/merge action, and the late post-merge bot-finding sweep before

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -586,7 +586,8 @@ The closeout lane is:
    explicit changelog classification and any P0/P1/P2/Must-Fix disposition
    evidence. Store the JSON artifact or table for the final handoff. Do not
    mark a target complete while the ledger has `UNKNOWN` fields, unresolved
-   current-head review threads, `CHANGES_REQUESTED` review objects, or
+   current-head review threads, active `review_objects.changes_requested`
+   entries, or
    `complete_allowed: false`.
 6. Refresh stale release-mode classification from the release tracker when
    needed. For accelerated-RC merge readiness, refresh the latest finalized

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -93,6 +93,22 @@ gh api graphql --paginate -f owner="${OWNER}" -f name="${NAME}" -F pr="${PR_NUMB
 
 Use `-F pr=...` intentionally here: `gh api graphql` needs a JSON integer for `$pr:Int!`, and raw `-f pr=...` sends a string.
 
+At merge readiness or batch closeout, build the machine-checkable per-PR merge
+ledger. The command uses GitHub GraphQL/API reviewThreads, reviews, and PR
+comments, then emits JSON against `script/pr-merge-ledger.schema.json`:
+
+```bash
+script/pr-merge-ledger <PR> --repo "${REPO}" \
+  --changelog-classification <changelog_present|changelog_missing|deferred_to_update_changelog|not_user_visible> \
+  --finding-dispositions <optional-dispositions.json> \
+  --strict --pretty > "/tmp/pr-<PR>-merge-ledger.json"
+script/pr-merge-ledger --schema
+```
+
+If changelog classification or P0/P1/P2/Must-Fix dispositions are not supplied,
+the ledger records those fields as `UNKNOWN`. `--strict` exits non-zero when any
+ledger violation exists or any field is `UNKNOWN`.
+
 For an issue, gather enough context to avoid duplicate work:
 
 ```bash
@@ -394,11 +410,11 @@ it as an immediate maintainer question. Also apply the merge-endgame debounce
 and waiver-soak rule under **Merge Endgame Debounce And Waiver Soak** before
 the final merge/readiness decision.
 
-After workers finish, the coordinator must keep working through the Coordinator Closeout Lane instead of stopping at PR creation: re-fetch live PR status, wait for current-head checks and reviews, triage/resolve or explicitly waive current unresolved review threads, update stale release-mode classification, refresh the finalized PR-body `Agent Merge Confidence` block when accelerated-RC readiness requires it, request full CI when uncertainty remains, re-fetch and wait for the newly requested current-head checks, and merge eligible ready PRs when authorized under the current release mode.
+After workers finish, the coordinator must keep working through the Coordinator Closeout Lane instead of stopping at PR creation: re-fetch live PR status, wait for current-head checks and reviews, triage/resolve or explicitly waive current unresolved review threads, run `script/pr-merge-ledger <PR> --strict` with explicit changelog classification and P0/P1/P2/Must-Fix dispositions, update stale release-mode classification, refresh the finalized PR-body `Agent Merge Confidence` block when accelerated-RC readiness requires it, request full CI when uncertainty remains, re-fetch and wait for the newly requested current-head checks, and merge eligible ready PRs when authorized under the current release mode.
 
 For blocking questions, stop work on that target, surface a structured question to the coordinator or maintainer, and mark the issue/PR with the agreed pending-question state. Report the question/comment URL as `blocked needing user input`; do not open a speculative PR. For non-blocking questions where you make a decision and continue, record the decision in the PR description before review or merge.
 
-Before final handoff, kill or confirm no stray GitHub polling processes are still running. Final state for every target must be one of: merged PR; open PR waiting on checks/review; blocked needing user input with the surfaced question/comment URL; or no-PR with an evidence-backed issue/PR comment URL. Split the handoff into `Immediate maintainer attention` and `FYI / decisions made`. Put only true blockers or questions in Immediate. Put non-blocking decisions, no-PR rationales, autonomous nit outcomes, decision-point counts, confidence notes, and full-CI uncertainty that was already handled by requesting full CI in FYI. Final handoff must list branches, PR URLs, issue outcomes, validations, last-known CI state, blockers, no-PR comments, and next actions.
+Before final handoff, kill or confirm no stray GitHub polling processes are still running. Final state for every target must be one of: merged PR; open PR waiting on checks/review; blocked needing user input with the surfaced question/comment URL; or no-PR with an evidence-backed issue/PR comment URL. Do not report a target `complete` while its merge ledger has any `UNKNOWN` field or `complete_allowed: false`. Split the handoff into `Immediate maintainer attention` and `FYI / decisions made`. Put only true blockers or questions in Immediate. Put non-blocking decisions, no-PR rationales, autonomous nit outcomes, decision-point counts, confidence notes, full-CI uncertainty that was already handled by requesting full CI, and the per-PR merge-ledger summary in FYI. Final handoff must list branches, PR URLs, issue outcomes, validations, last-known CI state, merge-ledger path or JSON artifact, blockers, no-PR comments, and next actions.
 ```
 
 ### Question And Decision Handling
@@ -450,10 +466,14 @@ Split batch handoffs into two sections:
 - **FYI / decisions made**: no-PR rationales, non-blocking decisions, full CI
   requested because the coordinator was unsure at readiness time, validation
   evidence, review churn notes, autonomous nit outcomes, confidence notes,
-  decision-point counts per PR, and already-answered questions.
+  decision-point counts per PR, already-answered questions, and a per-PR
+  merge-ledger table or JSON artifact path.
 
 Do not put full-CI uncertainty in Immediate at final readiness after local
 validation and the final push. Request full CI and log it in FYI.
+Do not report a PR/target as `complete` while `script/pr-merge-ledger <PR>
+--strict` reports `UNKNOWN` fields, review-thread/review-object violations, or
+`complete_allowed: false`.
 
 ### Coordination State
 
@@ -562,11 +582,17 @@ The closeout lane is:
    polling.
 4. Fetch current unresolved review threads and triage them as fixed, waived, or
    still blocking.
-5. Refresh stale release-mode classification from the release tracker when
+5. Run `script/pr-merge-ledger <PR> --strict` for every worker PR, supplying
+   explicit changelog classification and any P0/P1/P2/Must-Fix disposition
+   evidence. Store the JSON artifact or table for the final handoff. Do not
+   mark a target complete while the ledger has `UNKNOWN` fields, unresolved
+   current-head review threads, `CHANGES_REQUESTED` review objects, or
+   `complete_allowed: false`.
+6. Refresh stale release-mode classification from the release tracker when
    needed. For accelerated-RC merge readiness, refresh the latest finalized
    PR-body `Agent Merge Confidence` block required by `AGENTS.md`; keep this
    distinct from tracker mode/classification updates.
-6. After the final push, if local validation passed and the only uncertainty is
+7. After the final push, if local validation passed and the only uncertainty is
    whether full CI is needed, request full CI with `+ci-run-full` and record the
    reason as FYI, then loop back to re-fetch and wait for the newly requested
    current-head checks before readiness or merge.
@@ -867,6 +893,9 @@ Before saying a PR is ready to merge:
 gh pr view <PR> --json headRefOid,mergeStateStatus,reviewDecision,isDraft,labels,latestReviews,reviews,comments,mergedAt
 gh pr checks <PR> --required
 gh pr checks <PR>
+script/pr-merge-ledger <PR> \
+  --changelog-classification <changelog_present|changelog_missing|deferred_to_update_changelog|not_user_visible> \
+  --strict
 ```
 
 Before evaluating review feedback at this gate, also fetch inline PR review
@@ -885,6 +914,7 @@ Also verify:
 - No requested adversarial review has unresolved `BLOCKING` or `DISCUSS` findings.
 - Required checks are green, or the user has explicitly accepted an auditable waiver for full CI.
 - The PR body or latest agent comment includes exact local validation commands and results.
+- The merge ledger has no `UNKNOWN` fields and reports `complete_allowed: true`.
 
 Merge qualification follows the canonical rule in `AGENTS.md` -> Review Workflow -> For All PRs: CI is passing, all current review comments and threads are addressed or explicitly triaged by tier, no major question or discussion item needs maintainer attention, and advisory AI systems such as CodeRabbit.ai are not special approval gates.
 

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -596,20 +596,20 @@ The closeout lane is:
    whether full CI is needed, request full CI with `+ci-run-full` and record the
    reason as FYI, then loop back to re-fetch and wait for the newly requested
    current-head checks before readiness or merge.
-7. Assemble or refresh the attention-contract closeout for each lane after any
+8. Assemble or refresh the attention-contract closeout for each lane after any
    full-CI waitback: autonomous nit outcomes, human decision-point count, current
    confidence or readiness note, and any remaining `UNKNOWN` facts.
-8. Under the current release mode, mark ready or merge PRs that satisfy the
+9. Under the current release mode, mark ready or merge PRs that satisfy the
    merge qualification rules, including the merge-endgame debounce and
    waiver-soak rules before merge; report only remaining blockers, questions,
    or `UNKNOWN` live state.
-9. After any closeout-lane merge action, run a lightweight sweep for late
-   post-merge bot findings before the final batch handoff: confirm the PR landed,
-   check `main` status, and inspect late review/check comments that arrived
-   around or after merge. Route release-relevant findings into the next
-   post-merge audit intake. Reserve the full post-merge audit workflow for
-   final-release readiness, suspected bad merges, or a lightweight sweep that
-   finds a blocker, failed post-merge check, or credible release-readiness risk.
+10. After any closeout-lane merge action, run a lightweight sweep for late
+    post-merge bot findings before the final batch handoff: confirm the PR landed,
+    check `main` status, and inspect late review/check comments that arrived
+    around or after merge. Route release-relevant findings into the next
+    post-merge audit intake. Reserve the full post-merge audit workflow for
+    final-release readiness, suspected bad merges, or a lightweight sweep that
+    finds a blocker, failed post-merge check, or credible release-readiness risk.
 
 ## Self-Review Gate
 

--- a/Rakefile
+++ b/Rakefile
@@ -70,7 +70,7 @@ end
 
 def root_rubocop_paths
   # Root lint covers repo-root tooling only; package-owned rakelib files stay under package RuboCop.
-  %w[Gemfile Rakefile rakelib]
+  %w[Gemfile Rakefile rakelib script/pr-merge-ledger]
 end
 
 def define_package_task(task_name, *arg_names)

--- a/react_on_rails/spec/react_on_rails/fixtures/pr_merge_ledger/pr_3613.json
+++ b/react_on_rails/spec/react_on_rails/fixtures/pr_merge_ledger/pr_3613.json
@@ -1,0 +1,88 @@
+{
+  "repository": "shakacode/react_on_rails",
+  "pull_request": {
+    "number": 3613,
+    "title": "ci(rspack): decouple per-bundler build + integration jobs so one bundler's build failure doesn't skip the other (#3593)",
+    "url": "https://github.com/shakacode/react_on_rails/pull/3613",
+    "state": "MERGED",
+    "isDraft": false,
+    "baseRefName": "main",
+    "headRefName": "jg-conductor/3593-fix",
+    "headRefOid": "62ecd5760e3466726a3be1ed77b0071665c5cf2d",
+    "mergedAt": "2026-06-05T01:32:12Z",
+    "reviewDecision": "CHANGES_REQUESTED"
+  },
+  "files": [
+    ".github/workflows/dummy-app-bundler-tests.yml",
+    ".github/workflows/integration-tests.yml"
+  ],
+  "review_threads": [
+    {
+      "id": "PRRT_kwDOAnNnU86HM4iZ",
+      "isResolved": false,
+      "isOutdated": false,
+      "path": ".github/workflows/integration-tests.yml",
+      "line": 131,
+      "comments": [
+        {
+          "id": "PRRC_kwDOAnNnU87INkFj",
+          "databaseId": 3358998883,
+          "body": "**P2** Keep CI rerun helper aligned with new check names.",
+          "author": {
+            "login": "chatgpt-codex-connector"
+          },
+          "url": "https://github.com/shakacode/react_on_rails/pull/3613#discussion_r3358998883",
+          "path": ".github/workflows/integration-tests.yml",
+          "line": 131,
+          "createdAt": "2026-06-04T21:26:41Z",
+          "outdated": false,
+          "commit": {
+            "oid": "62ecd5760e3466726a3be1ed77b0071665c5cf2d"
+          },
+          "originalCommit": {
+            "oid": "d4d94358873321664b1e3a8c2a297f793a8ae3ed"
+          },
+          "pullRequestReview": {
+            "id": "PRR_kwDOAnNnU88AAAABCCSc3Q",
+            "state": "COMMENTED",
+            "submittedAt": "2026-06-04T21:26:41Z",
+            "commit": {
+              "oid": "d4d94358873321664b1e3a8c2a297f793a8ae3ed"
+            },
+            "author": {
+              "login": "chatgpt-codex-connector"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "reviews": [
+    {
+      "id": "PRR_kwDOAnNnU88AAAABCCTgOg",
+      "state": "CHANGES_REQUESTED",
+      "submittedAt": "2026-06-04T21:29:57Z",
+      "author": {
+        "login": "coderabbitai"
+      },
+      "commit": {
+        "oid": "d4d94358873321664b1e3a8c2a297f793a8ae3ed"
+      },
+      "url": "https://github.com/shakacode/react_on_rails/pull/3613#pullrequestreview-4431601722",
+      "body": "**P2** Run this PR under full-ci before merge."
+    },
+    {
+      "id": "PRR_kwDOAnNnU88AAAABCC6cRg",
+      "state": "COMMENTED",
+      "submittedAt": "2026-06-04T23:36:33Z",
+      "author": {
+        "login": "coderabbitai"
+      },
+      "commit": {
+        "oid": "62ecd5760e3466726a3be1ed77b0071665c5cf2d"
+      },
+      "url": "https://github.com/shakacode/react_on_rails/pull/3613#pullrequestreview-4432239686",
+      "body": "Nitpick comments only."
+    }
+  ]
+}

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -2031,11 +2031,14 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
-      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P2])
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P2 P1])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
-        ["P2 findings resolved. Please also fix P1 regression."]
+        [
+          "P2 findings resolved. Please also fix P1 regression.",
+          "P2 findings resolved. Please also fix P1 regression."
+        ]
       )
-      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN])
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
     end
   end
 
@@ -2080,11 +2083,11 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
-      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P2])
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P2 P1])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
-        ["P2 issues fixed P1 still open"]
+        ["P2 issues fixed P1 still open", "P2 issues fixed P1 still open"]
       )
-      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN])
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
     end
   end
 
@@ -3022,13 +3025,13 @@ RSpec.describe "script/pr-merge-ledger" do
       script_path,
       "3996",
       "--repo",
-      "/react_on_rails",
+      "bad=owner/react_on_rails",
       chdir: repo_root
     )
 
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
-    expect(stderr).to include('repo must look like OWNER/REPO: "/react_on_rails"')
+    expect(stderr).to include('repo must look like OWNER/REPO: "bad=owner/react_on_rails"')
   end
 
   it "rejects fixture mode combined with positional PR arguments" do
@@ -3445,6 +3448,54 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status.exitstatus).to eq(2)
       expect(stdout).to be_empty
       expect(stderr).to include("pagination cursor did not advance for files")
+    end
+  end
+
+  it "fails when GraphQL pagination returns an empty cursor" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"Title","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch","headRefOid":"abc123","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":""}}}}}}
+      JSON
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("pagination cursor did not advance for files")
+    end
+  end
+
+  it "rejects GraphQL variables that gh would read from files" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"Title","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch","headRefOid":"abc123","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"@secret"}}}}}}
+      JSON
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("gh api graphql variable endCursor cannot start with @")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -536,6 +536,70 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks current-head change-request reviews even when the reviewer comments later" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "requested-changes",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/requested-changes",
+          "body" => "Please fix this."
+        },
+        {
+          "id" => "later-comment",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/later-comment",
+          "body" => "Follow-up comment."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-current-change-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      violation_codes = report.fetch("violations").map { |violation| violation.fetch("code") }
+      expect(pr_ledger.dig("review_objects", "latest_by_reviewer").first).to include(
+        "id" => "later-comment",
+        "state" => "COMMENTED"
+      )
+      expect(pr_ledger.dig("review_objects", "changes_requested").first).to include(
+        "id" => "requested-changes",
+        "state" => "CHANGES_REQUESTED",
+        "current_head" => true
+      )
+      expect(violation_codes).to include("changes_requested_review_object")
+    end
+  end
+
   it "ignores stale change-request review objects when the PR decision is clear" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -2602,7 +2666,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "bounds priority finding scans for very large comment bodies" do
+  it "blocks priority finding scans that truncate very large comment bodies" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
@@ -2638,11 +2702,28 @@ RSpec.describe "script/pr-merge-ledger" do
         chdir: repo_root
       )
 
-      expect(status).to be_success, stderr
+      expect(status).not_to be_success, stderr
       expect(stderr).to include(
         "pr-merge-ledger: https://example.com/large-comment body has 1005 lines; scanning first 1000"
       )
-      expect(JSON.parse(stdout).fetch("complete_allowed")).to be(true)
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(pr_ledger.dig("priority_finding_dispositions", "status")).to eq("UNKNOWN")
+      expect(pr_ledger.dig("priority_finding_dispositions", "truncated_sources").first).to include(
+        "id" => "large-comment",
+        "url" => "https://example.com/large-comment",
+        "line_count" => 1005,
+        "scanned_line_count" => 1000
+      )
+      expect(pr_ledger.fetch("unknown_fields").first).to include(
+        "field" => "priority_finding_dispositions.body_scan",
+        "message" => "priority finding source body was truncated before full scan",
+        "url" => "https://example.com/large-comment"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_priority_finding_body_scan"
+      )
     end
   end
 
@@ -3258,7 +3339,7 @@ RSpec.describe "script/pr-merge-ledger" do
       "reviews" => [
         {
           "id" => "bad-timestamp-review",
-          "state" => "CHANGES_REQUESTED",
+          "state" => "COMMENTED",
           "submittedAt" => "not-a-time",
           "author" => { "login" => "reviewer" },
           "commit" => { "oid" => "abc123" },
@@ -3850,6 +3931,10 @@ RSpec.describe "script/pr-merge-ledger" do
       schema.dig("$defs", "pull_request_ledger", "properties", "priority_finding_dispositions", "properties",
                  "findings", "items", "$ref")
     ).to eq("#/$defs/priority_finding")
+    expect(
+      schema.dig("$defs", "pull_request_ledger", "properties", "priority_finding_dispositions", "properties",
+                 "truncated_sources", "items", "$ref")
+    ).to eq("#/$defs/priority_finding_truncated_source")
     expect(schema.dig("$defs", "violation", "additionalProperties")).to be(false)
     expect(schema.dig("$defs", "violation", "properties")).to include(
       "path", "line", "reviewer", "head_sha", "current_head"

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -757,6 +757,66 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "uses API order as the review tie-breaker when timestamps match" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "requested-changes",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/requested-changes",
+          "body" => "Please fix this."
+        },
+        {
+          "id" => "same-second-approval",
+          "state" => "APPROVED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/same-second-approval",
+          "body" => "Approved now."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-current-approval-tie", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      violation_codes = report.fetch("violations").map { |violation| violation.fetch("code") }
+      expect(pr_ledger.dig("review_objects", "latest_by_reviewer").first).to include(
+        "id" => "same-second-approval",
+        "state" => "APPROVED"
+      )
+      expect(pr_ledger.dig("review_objects", "changes_requested")).to be_empty
+      expect(violation_codes).not_to include("changes_requested_review_object")
+    end
+  end
+
   it "ignores stale change-request review objects when the PR decision is clear" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1433,6 +1433,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks severity summaries when none starts a continuing unresolved phrase" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "none-the-less-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/none-the-less-review",
+          "body" => "P1: none the less, one issue remains"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-none-the-less-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "none-the-less-review",
+        "severity" => "P1",
+        "text_excerpt" => "P1: none the less, one issue remains",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
   it "blocks severity summaries that say no findings are fixed or resolved" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -2843,5 +2893,8 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "violations", "type")).to eq("array")
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "unknown_fields", "type")).to eq("array")
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "complete_allowed", "type")).to eq("boolean")
   end
 end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4278,6 +4278,86 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "does not report another PR's disposition key as unused in multi-PR aggregate mode" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      pr=""
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              pr=*) pr=${1#pr=} ;;
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"number":$pr,"title":"PR $pr","url":"https://example.com/pr/$pr","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-$pr","headRefOid":"head-$pr","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif [ "$pr" = "1" ]; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[{"id":"comment-1","url":"https://example.com/pr/1#issuecomment-1","author":{"login":"reviewer"},"createdAt":"2026-06-01T00:00:00Z","body":"[P2] Dispositioned finding."}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    Tempfile.create(["pr-merge-ledger-multi-pr-dispositions", ".json"]) do |dispositions_file|
+      dispositions_file.write(
+        JSON.generate(
+          "https://example.com/pr/1#issuecomment-1#L1" => {
+            "disposition" => "fixed",
+            "evidence" => "Handled in the fixture."
+          }
+        )
+      )
+      dispositions_file.flush
+
+      with_fake_gh(fake_gh) do |env|
+        stdout, stderr, status = Open3.capture3(
+          env,
+          script_path,
+          "1",
+          "2",
+          "--repo",
+          "shakacode/react_on_rails",
+          "--finding-dispositions",
+          dispositions_file.path,
+          chdir: repo_root
+        )
+
+        expect(status).to be_success, stderr
+        expect(stderr).not_to include("unused disposition keys")
+
+        report = JSON.parse(stdout)
+        unused_keys_by_pr = report.fetch("pull_requests").map do |ledger|
+          ledger.dig("priority_finding_dispositions", "unused_keys")
+        end
+        expect(unused_keys_by_pr).to eq([[], []])
+        expect(report.fetch("unknown_fields").map { |field| field.fetch("field") }).not_to include(
+          "priority_finding_dispositions.unused_keys"
+        )
+      end
+    end
+  end
+
   it "rejects strict multiple live PR ledgers before producing an incomplete gate result" do
     stdout, stderr, status = Open3.capture3(
       script_path,

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "script/pr-merge-ledger" do
       "current_head" => true
     )
     expect(pr_ledger.dig("unresolved_current_head_review_threads", "count")).to eq(1)
-    expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+    expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
       "severity" => "P2",
       "disposition" => "UNKNOWN"
     )
@@ -66,7 +66,7 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(violation_codes).to include(
       "review_decision_changes_requested",
       "unresolved_current_head_review_thread",
-      "unknown_p1_p2_must_fix_disposition"
+      "unknown_priority_finding_disposition"
     )
     expect(violation_codes).not_to include("changes_requested_review_object")
   end
@@ -691,7 +691,7 @@ RSpec.describe "script/pr-merge-ledger" do
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(true)
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings")).to be_empty
     end
   end
 
@@ -745,14 +745,14 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success
 
       report = JSON.parse(stdout)
-      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
       expect(findings.first).to include(
         "id" => "earlier-current-review",
         "severity" => "P2",
         "disposition" => "UNKNOWN"
       )
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
-        "unknown_p1_p2_must_fix_disposition"
+        "unknown_priority_finding_disposition"
       )
     end
   end
@@ -800,13 +800,13 @@ RSpec.describe "script/pr-merge-ledger" do
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(false)
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
         "id" => "critical-review",
         "severity" => "P0",
         "disposition" => "UNKNOWN"
       )
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
-        "unknown_p1_p2_must_fix_disposition"
+        "unknown_priority_finding_disposition"
       )
     end
   end
@@ -853,7 +853,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "badge-review",
         "severity" => "P2",
@@ -903,7 +903,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
       expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
         ["1. [P1] First numbered finding.", "2. P2: Second numbered finding."]
@@ -953,7 +953,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
-      findings = pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")
+      findings = pr_ledger.dig("priority_finding_dispositions", "findings")
       expect(findings.length).to eq(2)
       expect(findings.map { |finding| finding.fetch("source_line") }).to eq([1, 2])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
@@ -1002,7 +1002,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
       expect(findings.length).to eq(1)
       expect(findings.first).to include(
         "severity" => "MUST_FIX",
@@ -1059,7 +1059,7 @@ RSpec.describe "script/pr-merge-ledger" do
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(true)
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings")).to be_empty
     end
   end
 
@@ -1224,9 +1224,9 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(1)
-      expect(report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")).to be_empty
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).not_to include(
-        "unknown_p1_p2_must_fix_disposition"
+        "unknown_priority_finding_disposition"
       )
     end
   end
@@ -1283,7 +1283,7 @@ RSpec.describe "script/pr-merge-ledger" do
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(true)
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings")).to be_empty
     end
   end
 
@@ -1329,7 +1329,7 @@ RSpec.describe "script/pr-merge-ledger" do
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(true)
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings")).to be_empty
     end
   end
 
@@ -1379,7 +1379,7 @@ RSpec.describe "script/pr-merge-ledger" do
       report = JSON.parse(stdout)
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(true)
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings")).to be_empty
     end
   end
 
@@ -1423,7 +1423,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "open-review",
         "severity" => "P1",
@@ -1473,7 +1473,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "not-fully-resolved-review",
         "severity" => "P1",
@@ -1523,7 +1523,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "none-of-review",
         "severity" => "P1",
@@ -1573,7 +1573,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "none-the-less-review",
         "severity" => "P1",
@@ -1623,7 +1623,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
       expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
         ["P1 issues: none fixed yet.", "P2 findings: none resolved."]
@@ -1672,7 +1672,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "mixed-review",
         "severity" => "P1",
@@ -1722,7 +1722,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "comma-mixed-review",
         "severity" => "P1",
@@ -1772,7 +1772,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
       expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
         ["P1 issues fixed and P2 still open", "P1 issues fixed and P2 still open"]
@@ -1830,7 +1830,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
       expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2 P1 P2])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
         [
@@ -1884,7 +1884,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "parenthetical-mixed-review",
         "severity" => "P1",
@@ -1934,7 +1934,7 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings", 0)
       expect(finding).to include(
         "id" => "previous-review-still-applies",
         "severity" => "P1",
@@ -1985,7 +1985,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       expect(report.fetch("complete_allowed")).to be(true)
-      expect(report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")).to be_empty
     end
   end
 
@@ -2034,13 +2034,13 @@ RSpec.describe "script/pr-merge-ledger" do
         "id" => "comment-1",
         "author" => "reviewer"
       )
-      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
         "id" => "comment-1",
         "severity" => "P1",
         "disposition" => "UNKNOWN"
       )
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
-        "unknown_p1_p2_must_fix_disposition"
+        "unknown_priority_finding_disposition"
       )
     end
   end
@@ -2249,7 +2249,7 @@ RSpec.describe "script/pr-merge-ledger" do
         report = JSON.parse(stdout)
         pr_ledger = report.fetch("pull_requests").first
         expect(report.fetch("complete_allowed")).to be(true)
-        expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+        expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
           "id" => "comment-1",
           "disposition" => "fixed"
         )
@@ -2306,7 +2306,7 @@ RSpec.describe "script/pr-merge-ledger" do
         expect(status).not_to be_success, stderr
 
         report = JSON.parse(stdout)
-        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
         expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN fixed])
         expect(findings.map { |finding| finding.fetch("source_line") }).to eq([1, 2])
         expect(stderr).not_to include("unused disposition keys")
@@ -2363,7 +2363,7 @@ RSpec.describe "script/pr-merge-ledger" do
         expect(status).not_to be_success, stderr
 
         report = JSON.parse(stdout)
-        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
         expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
         expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
         expect(stderr).to include("unused disposition keys: https://example.com/multi-line-broad-review")
@@ -2420,7 +2420,7 @@ RSpec.describe "script/pr-merge-ledger" do
         expect(status).not_to be_success, stderr
 
         report = JSON.parse(stdout)
-        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
         expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
         expect(findings.map { |finding| finding.fetch("marker_index") }).to eq([1, 2])
         expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[fixed UNKNOWN])
@@ -2478,7 +2478,7 @@ RSpec.describe "script/pr-merge-ledger" do
         expect(status).not_to be_success, stderr
 
         report = JSON.parse(stdout)
-        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
         expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
         expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
         expect(stderr).to include("unused disposition keys: https://example.com/same-line-broad-review")
@@ -2659,6 +2659,20 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
     expect(stderr).to include("--changelog-classification applies to one PR at a time")
+  end
+
+  it "rejects malformed live repository names before calling GitHub" do
+    stdout, stderr, status = Open3.capture3(
+      script_path,
+      "3996",
+      "--repo",
+      "/react_on_rails",
+      chdir: repo_root
+    )
+
+    expect(status.exitstatus).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include('repo must look like OWNER/REPO: "/react_on_rails"')
   end
 
   it "rejects fixture mode combined with positional PR arguments" do
@@ -2904,7 +2918,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
       if printf '%s' "$query" | grep -q 'node(id:$threadId)'; then
         cat <<'JSON'
-      {"data":{"repository":{"id":"repo-id"},"node":{"comments":{"nodes":[{"id":"comment-2","databaseId":2,"body":"second page","author":{"login":"reviewer"},"url":"https://example.com/comment-2","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-02T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"originalCommit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-02T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"reviewer"}}}],"pageInfo":{"hasNextPage":false,"endCursor":"cursor-2"}}}}}
+      {"data":{"repository":{"id":"repo-id"},"node":{"comments":{"nodes":[{"id":"comment-2","databaseId":2,"body":"second page","author":{"login":"reviewer"},"url":"https://example.com/comment-2","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-02T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-02T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"reviewer"}}}],"pageInfo":{"hasNextPage":false,"endCursor":"cursor-2"}}}}}
       JSON
       elif printf '%s' "$query" | grep -q 'files(first'; then
         cat <<'JSON'
@@ -2912,7 +2926,7 @@ RSpec.describe "script/pr-merge-ledger" do
       JSON
       elif printf '%s' "$query" | grep -q 'reviewThreads'; then
         cat <<'JSON'
-      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"isOutdated":false,"path":"script/pr-merge-ledger","line":1,"comments":{"nodes":[{"id":"comment-1","databaseId":1,"body":"first page","author":{"login":"reviewer"},"url":"https://example.com/comment-1","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-01T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"originalCommit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-01T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"reviewer"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"isOutdated":false,"path":"script/pr-merge-ledger","line":1,"comments":{"nodes":[{"id":"comment-1","databaseId":1,"body":"first page","author":{"login":"reviewer"},"url":"https://example.com/comment-1","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-01T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-01T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"reviewer"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
       JSON
       elif printf '%s' "$query" | grep -q 'reviews(first'; then
         cat <<'JSON'
@@ -3050,7 +3064,7 @@ RSpec.describe "script/pr-merge-ledger" do
         report = JSON.parse(stdout)
         pr_ledger = report.fetch("pull_requests").first
         expect(report.fetch("complete_allowed")).to be(true)
-        expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+        expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
           "id" => "comment-2",
           "disposition" => "explicitly_waived",
           "evidence" => "maintainer waiver"

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -812,6 +812,71 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "ignores outdated comments inside unresolved current-head review threads when scanning findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "current-thread-with-stale-comment",
+          "isResolved" => false,
+          "isOutdated" => false,
+          "comments" => [
+            {
+              "id" => "stale-comment",
+              "url" => "https://example.com/stale-comment",
+              "body" => "[P1] Finding from a stale inline comment.",
+              "author" => { "login" => "reviewer" },
+              "createdAt" => "2026-06-01T00:00:00Z",
+              "outdated" => true,
+              "commit" => { "oid" => "old" }
+            },
+            {
+              "id" => "live-comment",
+              "url" => "https://example.com/live-comment",
+              "body" => "This thread is still live on the unchanged line.",
+              "author" => { "login" => "reviewer" },
+              "createdAt" => "2026-06-02T00:00:00Z",
+              "outdated" => false,
+              "commit" => { "oid" => "current" }
+            }
+          ]
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-stale-thread-comment", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(1)
+      expect(report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")).to be_empty
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).not_to include(
+        "unknown_p1_p2_must_fix_disposition"
+      )
+    end
+  end
+
   it "ignores findings from superseded review bodies" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -454,6 +454,65 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "orders latest reviews by parsed timestamps instead of string order" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "old-review",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "old" },
+          "url" => "https://example.com/old",
+          "body" => "Old requested change."
+        },
+        {
+          "id" => "new-review",
+          "state" => "APPROVED",
+          "submittedAt" => "2026-06-01T20:00:00-05:00",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/new",
+          "body" => "Approved."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-parsed-timestamp", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      latest_review = report.dig("pull_requests", 0, "review_objects", "latest_by_reviewer", 0)
+      expect(latest_review).to include(
+        "id" => "new-review",
+        "state" => "APPROVED",
+        "current_head" => true
+      )
+      expect(report.dig("pull_requests", 0, "review_objects", "changes_requested")).to be_empty
+    end
+  end
+
   it "ignores negative P1/P2 summary text" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -812,6 +871,49 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "does not mark commentless threads as current-head threads" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "commentless-thread",
+          "isResolved" => false,
+          "isOutdated" => false,
+          "comments" => []
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-commentless-thread", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(0)
+      expect(report.fetch("violations")).to be_empty
+    end
+  end
+
   it "ignores outdated comments inside unresolved current-head review threads when scanning findings" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1124,6 +1226,56 @@ RSpec.describe "script/pr-merge-ledger" do
         "id" => "comma-mixed-review",
         "severity" => "P1",
         "text_excerpt" => "P1 issues fixed, P2 still open",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
+  it "blocks parenthetical mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "parenthetical-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/parenthetical-mixed-review",
+          "body" => "P1 issues fixed (P2 still open)"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-parenthetical-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "parenthetical-mixed-review",
+        "severity" => "P1",
+        "text_excerpt" => "P1 issues fixed (P2 still open)",
         "disposition" => "UNKNOWN"
       )
     end
@@ -1492,6 +1644,63 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "allows line-specific finding dispositions for multi-finding sources" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-with-two-findings",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-with-two-findings",
+          "body" => "[P1] First finding.\n[P2] Second finding."
+        }
+      ],
+      "comments" => []
+    }
+    dispositions = {
+      "https://example.com/review-with-two-findings#L2" => "fixed"
+    }
+
+    Tempfile.create(["pr-merge-ledger-line-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-line-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).not_to be_success, stderr
+
+        report = JSON.parse(stdout)
+        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN fixed])
+        expect(findings.map { |finding| finding.fetch("source_line") }).to eq([1, 2])
+        expect(stderr).not_to include("unused disposition keys")
+      end
+    end
+  end
+
   it "warns when finding disposition keys do not match any finding" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1583,6 +1792,52 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "prints the rejected value for invalid finding dispositions" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "[P1] Top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+    dispositions = { "comment-1" => "fixd" }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--finding-dispositions",
+          dispositions_file.path,
+          chdir: repo_root
+        )
+
+        expect(status.exitstatus).to eq(2)
+        expect(stdout).to be_empty
+        expect(stderr).to include('finding disposition "fixd" must be one of')
+      end
+    end
+  end
+
   it "prints a clean error for unreadable fixture files" do
     skip "root can read chmod 000 files" if Process.uid.zero?
 
@@ -1619,6 +1874,64 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
     expect(stderr).to include("--changelog-classification applies to one PR at a time")
+  end
+
+  it "records an auto-detected repository in live source output" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      if [ "$1" = "repo" ]; then
+        printf '%s\\n' 'shakacode/react_on_rails'
+        exit 0
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--changelog-classification",
+        "not_user_visible",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("source", "repo")).to eq("shakacode/react_on_rails")
+      expect(report.fetch("repository")).to eq("shakacode/react_on_rails")
+    end
   end
 
   it "aggregates multiple live PR ledgers in one invocation" do
@@ -1682,6 +1995,70 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(report.fetch("complete_allowed")).to be(false)
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
         "review_decision_review_required"
+      )
+    end
+  end
+
+  it "paginates live review-thread comments before normalizing threads" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'node(id:$threadId)'; then
+        cat <<'JSON'
+      {"data":{"repository":{"id":"repo-id"},"node":{"comments":{"nodes":[{"id":"comment-2","databaseId":2,"body":"second page","author":{"login":"reviewer"},"url":"https://example.com/comment-2","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-02T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"originalCommit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-02T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"reviewer"}}}],"pageInfo":{"hasNextPage":false,"endCursor":"cursor-2"}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"isOutdated":false,"path":"script/pr-merge-ledger","line":1,"comments":{"nodes":[{"id":"comment-1","databaseId":1,"body":"first page","author":{"login":"reviewer"},"url":"https://example.com/comment-1","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-01T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"originalCommit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-01T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"reviewer"}}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      thread = report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "threads", 0)
+      expect(thread.fetch("comments_complete")).to be(true)
+      expect(thread.fetch("comments").map { |comment| comment.fetch("id") }).to eq(%w[comment-1 comment-2])
+      expect(report.fetch("unknown_fields").map { |field| field.fetch("field") }).not_to include(
+        "review_threads.comments"
       )
     end
   end
@@ -1802,6 +2179,9 @@ RSpec.describe "script/pr-merge-ledger" do
 
     schema = JSON.parse(stdout)
     expect(schema.fetch("$id")).to eq("https://reactonrails.com/schemas/pr-merge-ledger-v1.json")
+    expect(schema.dig("properties", "$schema", "const")).to eq(
+      "https://reactonrails.com/schemas/pr-merge-ledger-v1.json"
+    )
     expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -112,6 +112,50 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "reports UNKNOWN lockfile status when file data is unavailable" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-missing-files", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "lockfile_diff")).to include(
+        "status" => "UNKNOWN",
+        "has_lockfile_diff" => "UNKNOWN",
+        "files" => []
+      )
+      expect(report.fetch("unknown_fields").first).to include(
+        "field" => "lockfile_diff.has_lockfile_diff",
+        "message" => "lockfile diff flag is UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_lockfile_diff"
+      )
+    end
+  end
+
   it "blocks blank review decisions in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1017,7 +1061,12 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
+      thread = report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "threads", 0)
       expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(1)
+      expect(thread).to include(
+        "current_head" => true,
+        "current_head_evidence" => "conservative_non_outdated"
+      )
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
         "unresolved_current_head_review_thread"
       )
@@ -1329,6 +1378,56 @@ RSpec.describe "script/pr-merge-ledger" do
         "id" => "not-fully-resolved-review",
         "severity" => "P1",
         "text_excerpt" => "[P1] issue not fully resolved",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
+  it "blocks severity summaries when bare none is part of an unresolved claim" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "none-of-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/none-of-review",
+          "body" => "[P1] issue: none of the tests pass"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-none-of-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "none-of-review",
+        "severity" => "P1",
+        "text_excerpt" => "[P1] issue: none of the tests pass",
         "disposition" => "UNKNOWN"
       )
     end
@@ -2123,6 +2222,63 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "does not apply source-wide dispositions to same-line mixed severities" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "same-line-broad-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/same-line-broad-review",
+          "body" => "P1 issues fixed; P2 still open"
+        }
+      ],
+      "comments" => []
+    }
+    dispositions = {
+      "https://example.com/same-line-broad-review" => "fixed"
+    }
+
+    Tempfile.create(["pr-merge-ledger-same-line-broad-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-same-line-broad-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).not_to be_success, stderr
+
+        report = JSON.parse(stdout)
+        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+        expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+        expect(stderr).to include("unused disposition keys: https://example.com/same-line-broad-review")
+      end
+    end
+  end
+
   it "warns when finding disposition keys do not match any finding" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -2296,6 +2452,84 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
     expect(stderr).to include("--changelog-classification applies to one PR at a time")
+  end
+
+  it "rejects fixture mode combined with positional PR arguments" do
+    stdout, stderr, status = Open3.capture3(
+      script_path,
+      "3996",
+      "--fixture",
+      fixture_path,
+      chdir: repo_root
+    )
+
+    expect(status.exitstatus).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include(
+      "PR number args (3996) are ignored when --fixture is given; remove them or omit --fixture"
+    )
+  end
+
+  it "warns about invalid review submittedAt values while sorting latest reviews" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "bad-timestamp-review",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "not-a-time",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/bad-timestamp-review",
+          "body" => ""
+        },
+        {
+          "id" => "valid-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/valid-review",
+          "body" => ""
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-bad-submitted-at", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+      expect(stderr).to include(
+        'pr-merge-ledger: review bad-timestamp-review submitted_at has invalid timestamp "not-a-time"; ' \
+        "treating as oldest"
+      )
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "review_objects", "latest_by_reviewer", 0)).to include(
+        "id" => "valid-review",
+        "state" => "COMMENTED"
+      )
+      expect(report.dig("pull_requests", 0, "review_objects", "changes_requested")).to be_empty
+    end
   end
 
   it "records an auto-detected repository in live source output" do
@@ -2600,9 +2834,11 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status).to be_success, stderr
 
     schema = JSON.parse(stdout)
-    expect(schema.fetch("$id")).to eq("script/pr-merge-ledger.schema.json")
+    expect(schema.fetch("$id")).to eq(
+      "https://raw.githubusercontent.com/shakacode/react_on_rails/main/script/pr-merge-ledger.schema.json"
+    )
     expect(schema.dig("properties", "$schema", "const")).to eq(
-      "script/pr-merge-ledger.schema.json"
+      "https://raw.githubusercontent.com/shakacode/react_on_rails/main/script/pr-merge-ledger.schema.json"
     )
     expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -862,6 +862,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks numbered-list priority findings from review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "numbered-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/numbered-review",
+          "body" => "1. [P1] First numbered finding.\n2. P2: Second numbered finding."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-numbered-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["1. [P1] First numbered finding.", "2. P2: Second numbered finding."]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
   it "keeps same-severity findings from distinct lines in one source" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -2579,6 +2629,30 @@ RSpec.describe "script/pr-merge-ledger" do
         "state" => "COMMENTED"
       )
       expect(report.dig("pull_requests", 0, "review_objects", "changes_requested")).to be_empty
+    end
+  end
+
+  it "times out repository auto-detection" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      if [ "$1" = "repo" ]; then
+        sleep 2
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env.merge("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS" => "1"),
+        script_path,
+        "1",
+        "--changelog-classification",
+        "not_user_visible",
+        chdir: repo_root
+      )
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("gh repo view timed out after 1 seconds")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1512,7 +1512,8 @@ RSpec.describe "script/pr-merge-ledger" do
             "P1/P2 findings fixed.",
             "P1 and P2 findings fixed.",
             "P1 issues fixed; P2 findings resolved.",
-            "P1 issues fixed and P2 findings were waived."
+            "P1 issues fixed and P2 findings were waived.",
+            "P1 issues fixed or waived."
           ].join("\n")
         }
       ]
@@ -1940,6 +1941,55 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks however-separated mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "however-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/however-mixed-review",
+          "body" => "P1 issues fixed, however P2 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-however-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P1 issues fixed, however P2 still open", "P1 issues fixed, however P2 still open"]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
   it "blocks conjunction-separated mixed severity summary lines with open priority items" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -2197,7 +2247,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "blocks P1/P2/Must-Fix findings from top-level PR comments" do
+  it "blocks P0/P1/P2/Must-Fix findings from top-level PR comments" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
@@ -2212,7 +2262,7 @@ RSpec.describe "script/pr-merge-ledger" do
         {
           "id" => "comment-1",
           "url" => "https://example.com/comment-1",
-          "body" => "[P1] Top-level PR comment finding.",
+          "body" => "[P0] Top-level PR comment finding.",
           "author" => { "login" => "reviewer" },
           "createdAt" => "2026-06-01T00:00:00Z"
         }
@@ -2244,7 +2294,7 @@ RSpec.describe "script/pr-merge-ledger" do
       )
       expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
         "id" => "comment-1",
-        "severity" => "P1",
+        "severity" => "P0",
         "disposition" => "UNKNOWN"
       )
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
@@ -2985,6 +3035,24 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "rejects non-integer GitHub API timeout values without a backtrace" do
+    stdout, stderr, status = Open3.capture3(
+      { "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS" => "thirty" },
+      script_path,
+      "1",
+      "--repo",
+      "shakacode/react_on_rails",
+      "--changelog-classification",
+      "not_user_visible",
+      chdir: repo_root
+    )
+
+    expect(status.exitstatus).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be an integer")
+    expect(stderr).not_to include("from ")
+  end
+
   it "records an auto-detected repository in live source output" do
     fake_gh = <<~SH
       #!/bin/sh
@@ -3295,8 +3363,11 @@ RSpec.describe "script/pr-merge-ledger" do
     )
     expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")
+    expect(schema.dig("$defs", "pull_request_ledger", "additionalProperties")).to be(false)
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "violations", "type")).to eq("array")
+    expect(schema.dig("$defs", "violation", "additionalProperties")).to be(false)
+    expect(schema.dig("$defs", "violation", "properties")).to include("path", "line")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "unknown_fields", "type")).to eq("array")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "complete_allowed", "type")).to eq("boolean")
   end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1379,6 +1379,58 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "uses the review-thread comment URL when id fields are missing" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "url-identified-thread",
+          "isResolved" => false,
+          "isOutdated" => false,
+          "comments" => [
+            {
+              "url" => "https://example.com/url-identified-comment",
+              "body" => "Current-head comment with no numeric id.",
+              "author" => { "login" => "reviewer" },
+              "createdAt" => "2026-06-01T00:00:00Z",
+              "outdated" => false,
+              "commit" => { "oid" => "current" }
+            }
+          ]
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-url-comment-id", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      comment = report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "threads", 0, "comments", 0)
+      expect(comment.fetch("id")).to eq("https://example.com/url-identified-comment")
+    end
+  end
+
   it "does not mark commentless threads as current-head threads" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -3520,6 +3572,68 @@ RSpec.describe "script/pr-merge-ledger" do
       if [ ! -f "$count_file" ]; then
         touch "$count_file"
         printf '%s\\n' 'temporary gateway failure' >&2
+        exit 1
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(true)
+    end
+  end
+
+  it "retries 422 gh API failures before reporting the live ledger" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      count_file="$(dirname "$0")/failed-422-once"
+      if [ ! -f "$count_file" ]; then
+        touch "$count_file"
+        printf '%s\\n' 'HTTP 422 temporary validation window' >&2
         exit 1
       fi
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -2190,6 +2190,50 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "ignores priority summaries that say no items remain open" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "none-remaining-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/none-remaining-review",
+          "body" => "P1 findings: none remaining\nP2 issues: none open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-none-remaining-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")).to be_empty
+    end
+  end
+
   it "blocks severity summaries that say no findings are fixed or resolved" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -4197,6 +4241,11 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")
     expect(schema.dig("$defs", "pull_request_ledger", "additionalProperties")).to be(false)
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "pr", "additionalProperties")).to be(false)
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "pr", "properties", "review_decision",
+                      "enum")).to eq(%w[APPROVED CHANGES_REQUESTED REVIEW_REQUIRED UNKNOWN])
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "lockfile_diff", "properties",
+                      "has_lockfile_diff")).to eq("enum" => [true, false, "UNKNOWN"])
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "violations", "type")).to eq("array")
     expect(

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -299,6 +299,46 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks closed unmerged PRs in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "state" => "CLOSED",
+        "mergedAt" => nil,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-closed-unmerged", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "closed_unmerged_pr"
+      )
+    end
+  end
+
   it "blocks missing head SHA in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -717,7 +757,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "ignores non-outdated review threads from older head commits" do
+  it "blocks non-outdated review threads even when their original review used an older head commit" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
@@ -762,11 +802,13 @@ RSpec.describe "script/pr-merge-ledger" do
         chdir: repo_root
       )
 
-      expect(status).to be_success, stderr
+      expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(0)
-      expect(report.fetch("violations")).to be_empty
+      expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(1)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unresolved_current_head_review_thread"
+      )
     end
   end
 
@@ -919,6 +961,101 @@ RSpec.describe "script/pr-merge-ledger" do
         "text_excerpt" => "[P1] issue not resolved",
         "disposition" => "UNKNOWN"
       )
+    end
+  end
+
+  it "blocks mixed severity summary lines that still contain an open higher-priority item" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/mixed-review",
+          "body" => "P1 issues: resolved; P0 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "mixed-review",
+        "severity" => "P1",
+        "text_excerpt" => "P1 issues: resolved; P0 still open",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
+  it "ignores resolved first-clause summaries even when later context contains a negation" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "resolved-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/resolved-review",
+          "body" => "P1: Main issue fixed (not yet resolved in the beta branch)."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-resolved-first-clause", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")).to be_empty
     end
   end
 
@@ -1190,6 +1327,60 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "warns when finding disposition keys do not match any finding" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "[P1] Top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+    dispositions = {
+      "https://example.com/comment-1" => "fixed",
+      "https://example.com/typo" => "fixed"
+    }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).to be_success, stderr
+        expect(stderr).to include("unused disposition keys: https://example.com/typo")
+
+        report = JSON.parse(stdout)
+        expect(report.fetch("complete_allowed")).to be(true)
+      end
+    end
+  end
+
   it "rejects finding disposition files that are not JSON objects" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1263,6 +1454,71 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
     expect(stderr).to include("--changelog-classification applies to one PR at a time")
+  end
+
+  it "aggregates multiple live PR ledgers in one invocation" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      pr=""
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              pr=*) pr=${1#pr=} ;;
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      review_decision="APPROVED"
+      if [ "$pr" = "2" ]; then
+        review_decision="REVIEW_REQUIRED"
+      fi
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"number":$pr,"title":"PR $pr","url":"https://example.com/pr/$pr","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-$pr","headRefOid":"head-$pr","mergedAt":null,"reviewDecision":"$review_decision","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<JSON
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "2",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("source", "prs")).to eq([1, 2])
+      expect(report.fetch("pull_requests").map { |ledger| ledger.dig("pr", "number") }).to eq([1, 2])
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "review_decision_review_required"
+      )
+    end
   end
 
   it "prints GraphQL response errors from gh API calls" do

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -962,6 +962,63 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks or-separated priority findings after the first marker is dispositioned" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "or-separated-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/or-separated-review",
+          "body" => "P1 issue fixed or P2 still open."
+        }
+      ],
+      "comments" => []
+    }
+    dispositions = {
+      "https://example.com/or-separated-review#L1:1" => "fixed"
+    }
+
+    Tempfile.create(["pr-merge-ledger-or-separated-finding", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-or-separated-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).not_to be_success, stderr
+
+        report = JSON.parse(stdout)
+        findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+        expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+        expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[fixed UNKNOWN])
+        expect(stderr).not_to include("unused disposition keys")
+      end
+    end
+  end
+
   it "keeps same-severity findings from distinct lines in one source" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -454,6 +454,59 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "ignores stale change-request review objects when the PR decision is clear" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "stale-change-request",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "old" },
+          "url" => "https://example.com/stale-change-request",
+          "body" => "Old requested change."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-stale-change-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("review_objects", "changes_requested")).to be_empty
+      expect(pr_ledger.dig("review_objects", "all_changes_requested").first).to include(
+        "id" => "stale-change-request",
+        "current_head" => false
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).not_to include(
+        "changes_requested_review_object"
+      )
+    end
+  end
+
   it "orders latest reviews by parsed timestamps instead of string order" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -557,6 +610,68 @@ RSpec.describe "script/pr-merge-ledger" do
       pr_ledger = report.fetch("pull_requests").first
       expect(report.fetch("complete_allowed")).to be(true)
       expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "scans every current-head review body for priority findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 4,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "earlier-current-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/earlier-current-review",
+          "body" => "[P2] Earlier current-head finding still needs disposition."
+        },
+        {
+          "id" => "later-current-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/later-current-review",
+          "body" => "Later current-head review."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-all-current-reviews", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, _stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      expect(findings.first).to include(
+        "id" => "earlier-current-review",
+        "severity" => "P2",
+        "disposition" => "UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_p1_p2_must_fix_disposition"
+      )
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -912,6 +912,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks heading-style priority findings from review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "heading-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/heading-review",
+          "body" => "### [P1] Cache invalidation is broken\n## P2: Secondary issue remains"
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-heading-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["### [P1] Cache invalidation is broken", "## P2: Secondary issue remains"]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
   it "blocks slash-combined priority findings from review summaries" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1469,6 +1519,56 @@ RSpec.describe "script/pr-merge-ledger" do
     }
 
     Tempfile.create(["pr-merge-ledger-resolved-multi-severity-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "ignores priority summaries that explicitly report no issues or findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "clean-no-issues-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/clean-no-issues-review",
+          "body" => [
+            "P1: no issues found.",
+            "P1/P2: no findings",
+            "### P2: no items remaining"
+          ].join("\n")
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-no-issues-summary", ".json"]) do |file|
       file.write(JSON.generate(fixture))
       file.flush
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1079,6 +1079,106 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks comma-separated mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "comma-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/comma-mixed-review",
+          "body" => "P1 issues fixed, P2 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-comma-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "comma-mixed-review",
+        "severity" => "P1",
+        "text_excerpt" => "P1 issues fixed, P2 still open",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
+  it "requires an actual resolution word before suppressing previous-review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "previous-review-still-applies",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/previous-review-still-applies",
+          "body" => "[P1] issue from previous review still applies"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-previous-review-still-applies", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "previous-review-still-applies",
+        "severity" => "P1",
+        "text_excerpt" => "[P1] issue from previous review still applies",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
   it "ignores resolved first-clause summaries even when later context contains a negation" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -2264,6 +2264,63 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "does not apply source-wide dispositions to multi-line findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "multi-line-broad-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/multi-line-broad-review",
+          "body" => "[P1] First finding needs follow-up.\n[P2] Second finding still open."
+        }
+      ],
+      "comments" => []
+    }
+    dispositions = {
+      "https://example.com/multi-line-broad-review" => "fixed"
+    }
+
+    Tempfile.create(["pr-merge-ledger-multi-line-broad-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-multi-line-broad-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).not_to be_success, stderr
+
+        report = JSON.parse(stdout)
+        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+        expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+        expect(stderr).to include("unused disposition keys: https://example.com/multi-line-broad-review")
+      end
+    end
+  end
+
   it "requires occurrence-specific dispositions for same-line mixed severities" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1333,6 +1333,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "ignores resolved multi-severity summary lines" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "resolved-multi-severity-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/resolved-multi-severity-review",
+          "body" => [
+            "P1 and P2 findings fixed.",
+            "P1 issues fixed; P2 findings resolved.",
+            "P1 issues fixed and P2 findings were waived."
+          ].join("\n")
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-resolved-multi-severity-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+    end
+  end
+
   it "blocks severity summaries that say an issue is not resolved" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -112,6 +112,44 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks blank review decisions in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => ""
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-blank-review-decision", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("UNKNOWN")
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_review_decision"
+      )
+    end
+  end
+
   it "blocks REVIEW_REQUIRED review decisions in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1246,6 +1284,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks severity summaries that say an issue is not fully resolved" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "not-fully-resolved-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/not-fully-resolved-review",
+          "body" => "[P1] issue not fully resolved"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-not-fully-resolved-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "not-fully-resolved-review",
+        "severity" => "P1",
+        "text_excerpt" => "[P1] issue not fully resolved",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
   it "blocks severity summaries that say no findings are fixed or resolved" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1392,6 +1480,55 @@ RSpec.describe "script/pr-merge-ledger" do
         "text_excerpt" => "P1 issues fixed, P2 still open",
         "disposition" => "UNKNOWN"
       )
+    end
+  end
+
+  it "blocks conjunction-separated mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "conjunction-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/conjunction-mixed-review",
+          "body" => "P1 issues fixed and P2 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-conjunction-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P1 issues fixed and P2 still open", "P1 issues fixed and P2 still open"]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
     end
   end
 
@@ -2400,9 +2537,9 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status).to be_success, stderr
 
     schema = JSON.parse(stdout)
-    expect(schema.fetch("$id")).to eq("https://reactonrails.com/schemas/pr-merge-ledger-v1.json")
+    expect(schema.fetch("$id")).to eq("script/pr-merge-ledger.schema.json")
     expect(schema.dig("properties", "$schema", "const")).to eq(
-      "https://reactonrails.com/schemas/pr-merge-ledger-v1.json"
+      "script/pr-merge-ledger.schema.json"
     )
     expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -3714,6 +3714,52 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "rejects null finding dispositions" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "[P1] Top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+    dispositions = { "comment-1" => nil }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--finding-dispositions",
+          dispositions_file.path,
+          chdir: repo_root
+        )
+
+        expect(status.exitstatus).to eq(2)
+        expect(stdout).to be_empty
+        expect(stderr).to include("finding disposition for comment-1 cannot be null")
+      end
+    end
+  end
+
   it "prints a clean error for unreadable fixture files" do
     skip "root can read chmod 000 files" if Process.uid.zero?
 
@@ -4270,6 +4316,38 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       expect(report.fetch("complete_allowed")).to be(true)
+    end
+  end
+
+  it "does not retry GitHub secondary rate-limit responses" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      count_file="$(dirname "$0")/calls"
+      count=0
+      if [ -f "$count_file" ]; then
+        count=$(cat "$count_file")
+      fi
+      count=$((count + 1))
+      printf '%s\\n' "$count" > "$count_file"
+      printf '%s\\n' 'HTTP 429 Too Many Requests' >&2
+      exit 1
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      count_path = File.join(env.fetch("PATH").split(":").first, "calls")
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("HTTP 429 Too Many Requests")
+      expect(File.read(count_path).strip).to eq("1")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1,0 +1,1388 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "tempfile"
+require "tmpdir"
+require_relative "spec_helper"
+
+RSpec.describe "script/pr-merge-ledger" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:script_path) { File.join(repo_root, "script/pr-merge-ledger") }
+  let(:fixture_path) do
+    File.join(repo_root, "react_on_rails/spec/react_on_rails/fixtures/pr_merge_ledger/pr_3613.json")
+  end
+
+  def with_fake_gh(script_body)
+    Dir.mktmpdir("pr-merge-ledger-gh") do |bin_dir|
+      gh_path = File.join(bin_dir, "gh")
+      File.write(gh_path, script_body)
+      File.chmod(0o755, gh_path)
+
+      yield({ "PATH" => "#{bin_dir}:#{ENV.fetch('PATH', '')}" })
+    end
+  end
+
+  it "reports the known #3613 CHANGES_REQUESTED merge-ledger violation" do
+    stdout, stderr, status = Open3.capture3(
+      script_path,
+      "--fixture",
+      fixture_path,
+      "--changelog-classification",
+      "not_user_visible",
+      "--strict",
+      chdir: repo_root
+    )
+
+    expect(status).not_to be_success
+    expect(stderr).to include("ledger violations")
+
+    report = JSON.parse(stdout)
+    pr_ledger = report.fetch("pull_requests").first
+    violation_codes = report.fetch("violations").map { |violation| violation.fetch("code") }
+
+    expect(report.fetch("schema_version")).to eq("pr-merge-ledger/v1")
+    expect(report.fetch("complete_allowed")).to be(false)
+    expect(pr_ledger.dig("pr", "number")).to eq(3613)
+    expect(pr_ledger.dig("review_objects", "review_decision")).to eq("CHANGES_REQUESTED")
+    expect(pr_ledger.dig("review_objects", "changes_requested")).to be_empty
+    expect(pr_ledger.dig("review_objects", "all_changes_requested").first).to include(
+      "reviewer" => "coderabbitai",
+      "head_sha" => "d4d94358873321664b1e3a8c2a297f793a8ae3ed"
+    )
+    expect(pr_ledger.dig("review_objects", "latest_by_reviewer").first).to include(
+      "reviewer" => "coderabbitai",
+      "state" => "COMMENTED",
+      "head_sha" => "62ecd5760e3466726a3be1ed77b0071665c5cf2d",
+      "current_head" => true
+    )
+    expect(pr_ledger.dig("unresolved_current_head_review_threads", "count")).to eq(1)
+    expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+      "severity" => "P2",
+      "disposition" => "UNKNOWN"
+    )
+    expect(pr_ledger.dig("changelog_classification", "classification")).to eq("not_user_visible")
+    expect(pr_ledger.dig("lockfile_diff", "has_lockfile_diff")).to be(false)
+    expect(violation_codes).to include(
+      "review_decision_changes_requested",
+      "unresolved_current_head_review_thread",
+      "unknown_p1_p2_must_fix_disposition"
+    )
+    expect(violation_codes).not_to include("changes_requested_review_object")
+  end
+
+  it "blocks UNKNOWN review decisions in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => nil
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-unknown", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("unknown_fields").first).to include(
+        "field" => "pr.review_decision",
+        "message" => "GitHub reviewDecision is UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_review_decision"
+      )
+    end
+  end
+
+  it "blocks REVIEW_REQUIRED review decisions in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "REVIEW_REQUIRED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-review-required", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "review_decision_review_required"
+      )
+    end
+  end
+
+  it "blocks explicit missing changelog classifications in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 3,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-missing-changelog", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "changelog_missing",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "changelog_missing"
+      )
+    end
+  end
+
+  it "allows explicit non-blocking changelog classifications in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 4,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    %w[changelog_present deferred_to_update_changelog].each do |classification|
+      Tempfile.create(["pr-merge-ledger-#{classification}", ".json"]) do |file|
+        file.write(JSON.generate(fixture))
+        file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          file.path,
+          "--changelog-classification",
+          classification,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).to be_success, stderr
+
+        report = JSON.parse(stdout)
+        pr_ledger = report.fetch("pull_requests").first
+        expect(report.fetch("complete_allowed")).to be(true)
+        expect(pr_ledger.dig("changelog_classification", "classification")).to eq(classification)
+        expect(report.fetch("violations")).to be_empty
+      end
+    end
+  end
+
+  it "allows a clean approved PR in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-clean", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(report.fetch("unknown_fields")).to be_empty
+      expect(report.fetch("violations")).to be_empty
+    end
+  end
+
+  it "blocks draft PRs in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "isDraft" => true,
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-draft", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include("draft_pr")
+    end
+  end
+
+  it "blocks missing head SHA in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 6,
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-missing-head-sha", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "head_sha")).to eq("UNKNOWN")
+      expect(report.fetch("unknown_fields").first).to include(
+        "field" => "pr.head_sha",
+        "message" => "GitHub headRefOid is UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include("unknown_head_sha")
+    end
+  end
+
+  it "prints a clean error when fixtures are missing pull request data" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails"
+    }
+
+    Tempfile.create(["pr-merge-ledger-missing-pull-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("pr-merge-ledger: fixture is missing pull_request")
+      expect(stderr).not_to include("from ")
+    end
+  end
+
+  it "allows superseded change-request reviews after a newer review from the same reviewer" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "old-review",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "old" },
+          "url" => "https://example.com/old",
+          "body" => "Old requested change."
+        },
+        {
+          "id" => "new-review",
+          "state" => "APPROVED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/new",
+          "body" => "Approved."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-superseded", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("review_objects", "changes_requested")).to be_empty
+      expect(pr_ledger.dig("review_objects", "all_changes_requested").first).to include(
+        "id" => "old-review",
+        "current_head" => false
+      )
+    end
+  end
+
+  it "ignores negative P1/P2 summary text" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 4,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "clean-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/clean-review",
+          "body" => "No P1/P2 findings."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-negative-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "blocks P0 findings from review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "critical-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/critical-review",
+          "body" => "[P0] Critical blocker."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-p0", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+        "id" => "critical-review",
+        "severity" => "P0",
+        "disposition" => "UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_p1_p2_must_fix_disposition"
+      )
+    end
+  end
+
+  it "blocks badge-style priority findings from review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "badge-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/badge-review",
+          "body" => "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> " \
+                    "Parse badge-style priority findings**"
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-badge-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "badge-review",
+        "severity" => "P2",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
+  it "keeps same-severity findings from distinct lines in one source" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-with-two-findings",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-with-two-findings",
+          "body" => "[P1] First finding.\n[P1] Second finding."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-two-findings", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      findings = pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")
+      expect(findings.length).to eq(2)
+      expect(findings.map { |finding| finding.fetch("source_line") }).to eq([1, 2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["[P1] First finding.", "[P1] Second finding."]
+      )
+    end
+  end
+
+  it "uses only the first priority marker on one finding line" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-with-duplicate-severity",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-with-duplicate-severity",
+          "body" => "MUST-FIX [P1]: duplicated severity markers."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-duplicate-severity", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      expect(findings.length).to eq(1)
+      expect(findings.first).to include(
+        "severity" => "MUST_FIX",
+        "text_excerpt" => "MUST-FIX [P1]: duplicated severity markers."
+      )
+    end
+  end
+
+  it "ignores findings from outdated review-thread comments" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "outdated-thread",
+          "isResolved" => false,
+          "isOutdated" => true,
+          "comments" => [
+            {
+              "id" => "outdated-comment",
+              "url" => "https://example.com/outdated-comment",
+              "body" => "[P1] Finding from a stale diff.",
+              "author" => { "login" => "reviewer" },
+              "createdAt" => "2026-06-01T00:00:00Z"
+            }
+          ]
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-outdated-thread-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "ignores non-outdated review threads from older head commits" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "old-head-thread",
+          "isResolved" => false,
+          "isOutdated" => false,
+          "comments" => [
+            {
+              "id" => "old-head-comment",
+              "url" => "https://example.com/old-head-comment",
+              "body" => "Old-head comment on an unchanged line.",
+              "author" => { "login" => "reviewer" },
+              "createdAt" => "2026-06-01T00:00:00Z",
+              "outdated" => false,
+              "commit" => { "oid" => "old" }
+            }
+          ]
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-old-head-thread", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(0)
+      expect(report.fetch("violations")).to be_empty
+    end
+  end
+
+  it "ignores findings from superseded review bodies" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "old-review",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "old" },
+          "url" => "https://example.com/old-review",
+          "body" => "[P1] Finding from a superseded review."
+        },
+        {
+          "id" => "new-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/new-review",
+          "body" => "Follow-up review has no blocking findings."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-superseded-review-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "ignores leading severity summaries that only describe waived or resolved findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "clean-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/clean-review",
+          "body" => "P2 findings were waived in the previous review.\nP1 issue was resolved by the latest commit."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-waived-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "blocks severity summaries that say an issue is not resolved" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "open-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/open-review",
+          "body" => "[P1] issue not resolved"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-unresolved-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings", 0)
+      expect(finding).to include(
+        "id" => "open-review",
+        "severity" => "P1",
+        "text_excerpt" => "[P1] issue not resolved",
+        "disposition" => "UNKNOWN"
+      )
+    end
+  end
+
+  it "blocks P1/P2/Must-Fix findings from top-level PR comments" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "[P1] Top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-top-level-comment", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(pr_ledger.fetch("issue_comments").first).to include(
+        "id" => "comment-1",
+        "author" => "reviewer"
+      )
+      expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+        "id" => "comment-1",
+        "severity" => "P1",
+        "disposition" => "UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_p1_p2_must_fix_disposition"
+      )
+    end
+  end
+
+  it "keeps full issue comment bodies out of the output ledger" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "A long informational comment that should be excerpted in output.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-issue-comment-body", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      issue_comment = report.dig("pull_requests", 0, "issue_comments", 0)
+      expect(issue_comment).to include(
+        "body_excerpt" => "A long informational comment that should be excerpted in output."
+      )
+      expect(issue_comment).not_to have_key("body")
+    end
+  end
+
+  it "blocks truncated review-thread comment pages in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 6,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "thread-with-more-comments",
+          "isResolved" => true,
+          "isOutdated" => false,
+          "comments" => {
+            "nodes" => [],
+            "pageInfo" => {
+              "hasNextPage" => true,
+              "endCursor" => "cursor"
+            }
+          }
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-truncated-comments", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(pr_ledger.dig("unresolved_current_head_review_threads", "count")).to eq(0)
+      expect(pr_ledger.dig("unresolved_current_head_review_threads", "threads").first).to be_nil
+      expect(pr_ledger["unknown_fields"].first).to include(
+        "field" => "review_threads.comments",
+        "message" => "review thread comments were truncated by GitHub pagination"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_review_thread_comments"
+      )
+    end
+  end
+
+  it "does not classify incomplete unresolved threads as current-head thread violations" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 6,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "incomplete-unresolved-thread",
+          "isResolved" => false,
+          "isOutdated" => false,
+          "comments" => {
+            "nodes" => [],
+            "pageInfo" => {
+              "hasNextPage" => true,
+              "endCursor" => "cursor"
+            }
+          }
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-incomplete-unresolved-thread", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(pr_ledger.dig("unresolved_current_head_review_threads", "count")).to eq(0)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to contain_exactly(
+        "unknown_review_thread_comments"
+      )
+    end
+  end
+
+  it "accepts string finding dispositions" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "[P1] Top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+    dispositions = { "https://example.com/comment-1" => "fixed" }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).to be_success, stderr
+
+        report = JSON.parse(stdout)
+        pr_ledger = report.fetch("pull_requests").first
+        expect(report.fetch("complete_allowed")).to be(true)
+        expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+          "id" => "comment-1",
+          "disposition" => "fixed"
+        )
+      end
+    end
+  end
+
+  it "rejects finding disposition files that are not JSON objects" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(["fixed"]))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--finding-dispositions",
+          dispositions_file.path,
+          chdir: repo_root
+        )
+
+        expect(status.exitstatus).to eq(2)
+        expect(stdout).to be_empty
+        expect(stderr).to include("pr-merge-ledger: --finding-dispositions must contain a JSON object")
+        expect(stderr).not_to include("from ")
+      end
+    end
+  end
+
+  it "prints a clean error for unreadable fixture files" do
+    skip "root can read chmod 000 files" if Process.uid.zero?
+
+    Tempfile.create(["pr-merge-ledger-unreadable", ".json"]) do |file|
+      file.write("{}")
+      file.flush
+
+      begin
+        File.chmod(0, file.path)
+        stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
+
+        expect(status.exitstatus).to eq(2)
+        expect(stdout).to be_empty
+        expect(stderr).to include("pr-merge-ledger:")
+        expect(stderr).not_to include("from ")
+      ensure
+        File.chmod(0o600, file.path)
+      end
+    end
+  end
+
+  it "rejects per-run changelog classification for multi-PR live runs" do
+    stdout, stderr, status = Open3.capture3(
+      script_path,
+      "1",
+      "2",
+      "--repo",
+      "shakacode/react_on_rails",
+      "--changelog-classification",
+      "not_user_visible",
+      chdir: repo_root
+    )
+
+    expect(status.exitstatus).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include("--changelog-classification applies to one PR at a time")
+  end
+
+  it "prints GraphQL response errors from gh API calls" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      cat <<'JSON'
+      {"data":null,"errors":[{"message":"rate limit exceeded"},{"message":"bad credentials"}]}
+      JSON
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("gh api graphql returned errors: rate limit exceeded; bad credentials")
+    end
+  end
+
+  it "fails when GraphQL pagination cursors stop advancing" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"Title","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch","headRefOid":"abc123","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":true,"endCursor":"same"}}}}}}
+      JSON
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("pagination cursor did not advance for files")
+    end
+  end
+
+  it "accepts object finding dispositions with evidence" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-2",
+          "url" => "https://example.com/comment-2",
+          "body" => "MUST-FIX: top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+    dispositions = {
+      "comment-2" => {
+        "disposition" => "explicitly_waived",
+        "evidence" => "maintainer waiver"
+      }
+    }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).to be_success, stderr
+
+        report = JSON.parse(stdout)
+        pr_ledger = report.fetch("pull_requests").first
+        expect(report.fetch("complete_allowed")).to be(true)
+        expect(pr_ledger.dig("p1_p2_must_fix_dispositions", "findings").first).to include(
+          "id" => "comment-2",
+          "disposition" => "explicitly_waived",
+          "evidence" => "maintainer waiver"
+        )
+      end
+    end
+  end
+
+  it "prints the fixed JSON schema" do
+    stdout, stderr, status = Open3.capture3(script_path, "--schema", chdir: repo_root)
+
+    expect(status).to be_success, stderr
+
+    schema = JSON.parse(stdout)
+    expect(schema.fetch("$id")).to eq("https://reactonrails.com/schemas/pr-merge-ledger-v1.json")
+    expect(schema.dig("properties", "schema_version", "const")).to eq("pr-merge-ledger/v1")
+    expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")
+    expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")
+  end
+end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -3341,11 +3341,6 @@ RSpec.describe "script/pr-merge-ledger" do
   it "prints GraphQL response errors from gh API calls" do
     fake_gh = <<~SH
       #!/bin/sh
-      case " $* " in
-        *" --retry 3 "*) ;;
-        *) printf '%s\\n' 'missing --retry 3' >&2; exit 42 ;;
-      esac
-
       cat <<'JSON'
       {"data":null,"errors":[{"message":"rate limit exceeded"},{"message":"bad credentials"}]}
       JSON
@@ -3364,6 +3359,68 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status.exitstatus).to eq(2)
       expect(stdout).to be_empty
       expect(stderr).to include("gh api graphql returned errors: rate limit exceeded; bad credentials")
+    end
+  end
+
+  it "retries failed gh API calls before reporting the live ledger" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      count_file="$(dirname "$0")/failed-once"
+      if [ ! -f "$count_file" ]; then
+        touch "$count_file"
+        printf '%s\\n' 'temporary gateway failure' >&2
+        exit 1
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(true)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1246,6 +1246,55 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks severity summaries that say no findings are fixed or resolved" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "none-resolved-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/none-resolved-review",
+          "body" => "P1 issues: none fixed yet.\nP2 findings: none resolved."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-none-resolved-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P1 issues: none fixed yet.", "P2 findings: none resolved."]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
   it "blocks mixed severity summary lines that still contain an open higher-priority item" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -600,6 +600,71 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "allows current-head change-request reviews after a newer approval from the same reviewer" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "requested-changes",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/requested-changes",
+          "body" => "Please fix this."
+        },
+        {
+          "id" => "later-approval",
+          "state" => "APPROVED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "current" },
+          "url" => "https://example.com/later-approval",
+          "body" => "Approved now."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-current-approval", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      violation_codes = report.fetch("violations").map { |violation| violation.fetch("code") }
+      expect(pr_ledger.dig("review_objects", "latest_by_reviewer").first).to include(
+        "id" => "later-approval",
+        "state" => "APPROVED"
+      )
+      expect(pr_ledger.dig("review_objects", "changes_requested")).to be_empty
+      expect(pr_ledger.dig("review_objects", "all_changes_requested").first).to include(
+        "id" => "requested-changes",
+        "state" => "CHANGES_REQUESTED",
+        "current_head" => true
+      )
+      expect(violation_codes).not_to include("changes_requested_review_object")
+    end
+  end
+
   it "ignores stale change-request review objects when the PR decision is clear" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -2200,6 +2265,55 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
       expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
         ["P1 issues fixed, however P2 still open", "P1 issues fixed, however P2 still open"]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
+  it "blocks with-separated mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "with-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/with-mixed-review",
+          "body" => "P1 issues fixed with P2 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-with-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P1 issues fixed with P2 still open", "P1 issues fixed with P2 still open"]
       )
       expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
     end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -962,6 +962,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks task-list priority findings from review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "task-list-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/task-list-review",
+          "body" => "- [ ] [P1] Task-list finding.\n- [x] P2: Checked task-list finding."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-task-list-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["- [ ] [P1] Task-list finding.", "- [x] P2: Checked task-list finding."]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
   it "blocks slash-combined priority findings from review summaries" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1165,6 +1215,55 @@ RSpec.describe "script/pr-merge-ledger" do
         "severity" => "MUST_FIX",
         "text_excerpt" => "MUST-FIX [P1]: duplicated severity markers."
       )
+    end
+  end
+
+  it "does not treat priority-looking text inside words as extra findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-with-priority-looking-title",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-with-priority-looking-title",
+          "body" => "[P1] HTTP2 fallback is broken\n[P1] P256 keys fail"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-priority-looking-title", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.length).to eq(2)
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["[P1] HTTP2 fallback is broken", "[P1] P256 keys fail"]
+      )
+      expect(findings.map { |finding| finding.fetch("marker_index") }).to eq([1, 1])
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1990,6 +1990,104 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks period-separated resolved summaries with later open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "period-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/period-mixed-review",
+          "body" => "P2 findings resolved. Please also fix P1 regression."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-period-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P2 findings resolved. Please also fix P1 regression."]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN])
+    end
+  end
+
+  it "blocks whitespace-separated mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "space-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/space-mixed-review",
+          "body" => "P2 issues fixed P1 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-space-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P2 issues fixed P1 still open"]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN])
+    end
+  end
+
   it "blocks conjunction-separated mixed severity summary lines with open priority items" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -3243,6 +3341,11 @@ RSpec.describe "script/pr-merge-ledger" do
   it "prints GraphQL response errors from gh API calls" do
     fake_gh = <<~SH
       #!/bin/sh
+      case " $* " in
+        *" --retry 3 "*) ;;
+        *) printf '%s\\n' 'missing --retry 3' >&2; exit 42 ;;
+      esac
+
       cat <<'JSON'
       {"data":null,"errors":[{"message":"rate limit exceeded"},{"message":"bad credentials"}]}
       JSON
@@ -3367,7 +3470,9 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "violations", "type")).to eq("array")
     expect(schema.dig("$defs", "violation", "additionalProperties")).to be(false)
-    expect(schema.dig("$defs", "violation", "properties")).to include("path", "line")
+    expect(schema.dig("$defs", "violation", "properties")).to include(
+      "path", "line", "reviewer", "head_sha", "current_head"
+    )
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "unknown_fields", "type")).to eq("array")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "complete_allowed", "type")).to eq("boolean")
   end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4699,6 +4699,83 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "retries GitHub 403 secondary rate-limit responses" do
+    fake_gh = <<~SH
+      #!/bin/sh
+      count_file="$(dirname "$0")/calls"
+      count=0
+      if [ -f "$count_file" ]; then
+        count=$(cat "$count_file")
+      fi
+      count=$((count + 1))
+      printf '%s\\n' "$count" > "$count_file"
+
+      if [ "$count" -eq 1 ]; then
+        printf '%s\\n' 'HTTP 403 API rate limit exceeded' >&2
+        exit 1
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*)
+                query=${1#query=}
+                ;;
+            esac
+            ;;
+          query=*)
+            query=${1#query=}
+            ;;
+          query)
+            shift
+            if [ "$#" -gt 0 ]; then
+              query=$1
+            fi
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_fake_gh(fake_gh) do |env|
+      stdout, stderr, status = Open3.capture3(
+        env,
+        script_path,
+        "1",
+        "--repo",
+        "shakacode/react_on_rails",
+        chdir: repo_root
+      )
+
+      count_path = File.join(env.fetch("PATH").split(":").first, "calls")
+      expect(status).to be_success
+      expect(stderr).to be_empty
+      expect(JSON.parse(stdout).dig("pull_requests", 0, "pr", "number")).to eq(1)
+      expect(File.read(count_path).strip).to eq("5")
+    end
+  end
+
   it "fails when GraphQL pagination cursors stop advancing" do
     fake_gh = <<~SH
       #!/bin/sh

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -3366,7 +3366,7 @@ RSpec.describe "script/pr-merge-ledger" do
         }
       ]
     }
-    dispositions = { "comment-1" => "fixd" }
+    dispositions = { "comment-1" => "UNKNOWN" }
 
     Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
       Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
@@ -3386,7 +3386,7 @@ RSpec.describe "script/pr-merge-ledger" do
 
         expect(status.exitstatus).to eq(2)
         expect(stdout).to be_empty
-        expect(stderr).to include('finding disposition "fixd" must be one of')
+        expect(stderr).to include('finding disposition "UNKNOWN" must be one of')
       end
     end
   end
@@ -3575,6 +3575,24 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
     expect(stderr).to include("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be an integer")
+    expect(stderr).not_to include("from ")
+  end
+
+  it "rejects non-positive GitHub API timeout values without a backtrace" do
+    stdout, stderr, status = Open3.capture3(
+      { "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS" => "0" },
+      script_path,
+      "1",
+      "--repo",
+      "shakacode/react_on_rails",
+      "--changelog-classification",
+      "not_user_visible",
+      chdir: repo_root
+    )
+
+    expect(status.exitstatus).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be a positive integer")
     expect(stderr).not_to include("from ")
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -912,6 +912,56 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks slash-combined priority findings from review summaries" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "slash-combined-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/slash-combined-review",
+          "body" => "P1/P2 findings still need disposition."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-slash-combined-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        ["P1/P2 findings still need disposition.", "P1/P2 findings still need disposition."]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN])
+    end
+  end
+
   it "keeps same-severity findings from distinct lines in one source" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -1352,6 +1402,7 @@ RSpec.describe "script/pr-merge-ledger" do
           "commit" => { "oid" => "abc123" },
           "url" => "https://example.com/resolved-multi-severity-review",
           "body" => [
+            "P1/P2 findings fixed.",
             "P1 and P2 findings fixed.",
             "P1 issues fixed; P2 findings resolved.",
             "P1 issues fixed and P2 findings were waived."

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -2504,6 +2504,7 @@ RSpec.describe "script/pr-merge-ledger" do
   end
 
   it "keeps full issue comment bodies out of the output ledger" do
+    long_body = "A long informational comment that should be excerpted in output. " * 4
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
@@ -2518,7 +2519,7 @@ RSpec.describe "script/pr-merge-ledger" do
         {
           "id" => "comment-1",
           "url" => "https://example.com/comment-1",
-          "body" => "A long informational comment that should be excerpted in output.",
+          "body" => long_body,
           "author" => { "login" => "reviewer" },
           "createdAt" => "2026-06-01T00:00:00Z"
         }
@@ -2543,10 +2544,53 @@ RSpec.describe "script/pr-merge-ledger" do
 
       report = JSON.parse(stdout)
       issue_comment = report.dig("pull_requests", 0, "issue_comments", 0)
-      expect(issue_comment).to include(
-        "body_excerpt" => "A long informational comment that should be excerpted in output."
-      )
+      expect(issue_comment.fetch("body_excerpt")).to end_with("...")
+      expect(issue_comment.fetch("body_excerpt").length).to eq(180)
       expect(issue_comment).not_to have_key("body")
+    end
+  end
+
+  it "bounds priority finding scans for very large comment bodies" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 5,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "large-comment",
+          "url" => "https://example.com/large-comment",
+          "body" => (["informational"] * 1_005).join("\n"),
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-large-comment-body", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+      expect(stderr).to include(
+        "pr-merge-ledger: https://example.com/large-comment body has 1005 lines; scanning first 1000"
+      )
+      expect(JSON.parse(stdout).fetch("complete_allowed")).to be(true)
     end
   end
 
@@ -3361,10 +3405,15 @@ RSpec.describe "script/pr-merge-ledger" do
         "2",
         "--repo",
         "shakacode/react_on_rails",
+        "--strict",
         chdir: repo_root
       )
 
-      expect(status).to be_success, stderr
+      expect(status).not_to be_success
+      expect(stderr).to include(
+        "pr-merge-ledger: --strict with multiple PRs always fails until each PR has a " \
+        "non-UNKNOWN changelog classification"
+      )
 
       report = JSON.parse(stdout)
       expect(report.dig("source", "prs")).to eq([1, 2])
@@ -3676,10 +3725,23 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(schema.dig("$defs", "pull_request_ledger", "additionalProperties")).to be(false)
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "violations", "type")).to eq("array")
+    expect(
+      schema.dig("$defs", "pull_request_ledger", "properties", "unresolved_current_head_review_threads",
+                 "properties", "threads", "items", "$ref")
+    ).to eq("#/$defs/review_thread")
+    expect(schema.dig("$defs", "pull_request_ledger", "properties", "issue_comments", "items", "$ref")).to eq(
+      "#/$defs/issue_comment"
+    )
+    expect(
+      schema.dig("$defs", "pull_request_ledger", "properties", "priority_finding_dispositions", "properties",
+                 "findings", "items", "$ref")
+    ).to eq("#/$defs/priority_finding")
     expect(schema.dig("$defs", "violation", "additionalProperties")).to be(false)
     expect(schema.dig("$defs", "violation", "properties")).to include(
       "path", "line", "reviewer", "head_sha", "current_head"
     )
+    expect(schema.dig("$defs", "review_thread", "additionalProperties")).to be(false)
+    expect(schema.dig("$defs", "review_object", "properties")).to include("body_text")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "unknown_fields", "type")).to eq("array")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "complete_allowed", "type")).to eq("boolean")
   end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1532,6 +1532,69 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "blocks colon- and dash-separated mixed severity summary lines with open priority items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "colon-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/colon-mixed-review",
+          "body" => "P1 issues fixed: P2 still open"
+        },
+        {
+          "id" => "dash-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/dash-mixed-review",
+          "body" => "P1 issues fixed - P2 still open"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-colon-mixed-summary", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2 P1 P2])
+      expect(findings.map { |finding| finding.fetch("text_excerpt") }).to eq(
+        [
+          "P1 issues fixed: P2 still open",
+          "P1 issues fixed: P2 still open",
+          "P1 issues fixed - P2 still open",
+          "P1 issues fixed - P2 still open"
+        ]
+      )
+      expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[UNKNOWN UNKNOWN UNKNOWN UNKNOWN])
+    end
+  end
+
   it "blocks parenthetical mixed severity summary lines with open priority items" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4622,7 +4622,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "does not retry GitHub secondary rate-limit responses" do
+  it "retries GitHub secondary rate-limit responses" do
     fake_gh = <<~SH
       #!/bin/sh
       count_file="$(dirname "$0")/calls"
@@ -4632,8 +4632,53 @@ RSpec.describe "script/pr-merge-ledger" do
       fi
       count=$((count + 1))
       printf '%s\\n' "$count" > "$count_file"
-      printf '%s\\n' 'HTTP 429 Too Many Requests' >&2
-      exit 1
+
+      if [ "$count" -eq 1 ]; then
+        printf '%s\\n' 'HTTP 429 Too Many Requests' >&2
+        exit 1
+      fi
+
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*)
+                query=${1#query=}
+                ;;
+            esac
+            ;;
+          query=*)
+            query=${1#query=}
+            ;;
+          query)
+            shift
+            if [ "$#" -gt 0 ]; then
+              query=$1
+            fi
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
     SH
 
     with_fake_gh(fake_gh) do |env|
@@ -4647,10 +4692,10 @@ RSpec.describe "script/pr-merge-ledger" do
       )
 
       count_path = File.join(env.fetch("PATH").split(":").first, "calls")
-      expect(status.exitstatus).to eq(2)
-      expect(stdout).to be_empty
-      expect(stderr).to include("HTTP 429 Too Many Requests")
-      expect(File.read(count_path).strip).to eq("1")
+      expect(status).to be_success
+      expect(stderr).to be_empty
+      expect(JSON.parse(stdout).dig("pull_requests", 0, "pr", "number")).to eq(1)
+      expect(File.read(count_path).strip).to eq("5")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1415,6 +1415,105 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "does not split priority mentions embedded in a finding title" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-with-cross-priority-title",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-with-cross-priority-title",
+          "body" => "[P2] Fix handling of P1/P2 summaries"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-cross-priority-title", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.length).to eq(1)
+      expect(findings.first).to include(
+        "severity" => "P2",
+        "marker_index" => 1,
+        "text_excerpt" => "[P2] Fix handling of P1/P2 summaries"
+      )
+    end
+  end
+
+  it "reports the primary finding marker column for indented list items" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-with-indented-marker",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-with-indented-marker",
+          "body" => "  - **P0**: Critical issue"
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-indented-marker", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      finding = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings").first
+      expect(finding).to include(
+        "severity" => "P0",
+        "source_column" => 7,
+        "marker_index" => 1
+      )
+    end
+  end
+
   it "ignores findings from outdated review-thread comments" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -3704,15 +3803,10 @@ RSpec.describe "script/pr-merge-ledger" do
         "2",
         "--repo",
         "shakacode/react_on_rails",
-        "--strict",
         chdir: repo_root
       )
 
-      expect(status).not_to be_success
-      expect(stderr).to include(
-        "pr-merge-ledger: --strict with multiple PRs always fails until each PR has a " \
-        "non-UNKNOWN changelog classification"
-      )
+      expect(status).to be_success, stderr
 
       report = JSON.parse(stdout)
       expect(report.dig("source", "prs")).to eq([1, 2])
@@ -3722,6 +3816,25 @@ RSpec.describe "script/pr-merge-ledger" do
         "review_decision_review_required"
       )
     end
+  end
+
+  it "rejects strict multiple live PR ledgers before producing an incomplete gate result" do
+    stdout, stderr, status = Open3.capture3(
+      script_path,
+      "1",
+      "2",
+      "--repo",
+      "shakacode/react_on_rails",
+      "--strict",
+      chdir: repo_root
+    )
+
+    expect(status).not_to be_success
+    expect(stdout).to eq("")
+    expect(stderr).to include(
+      "pr-merge-ledger: --strict with multiple PRs requires separate per-PR runs with explicit " \
+      "--changelog-classification"
+    )
   end
 
   it "paginates live review-thread comments before normalizing threads" do

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -3940,7 +3940,7 @@ RSpec.describe "script/pr-merge-ledger" do
       "path", "line", "reviewer", "head_sha", "current_head"
     )
     expect(schema.dig("$defs", "review_thread", "additionalProperties")).to be(false)
-    expect(schema.dig("$defs", "review_object", "properties")).to include("body_text")
+    expect(schema.dig("$defs", "review_object", "properties")).not_to include("body_text")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "unknown_fields", "type")).to eq("array")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "complete_allowed", "type")).to eq("boolean")
   end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -347,6 +347,38 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "rejects explicit UNKNOWN changelog classification" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 41,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-unknown-changelog", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "UNKNOWN",
+        chdir: repo_root
+      )
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("invalid argument: --changelog-classification UNKNOWN")
+    end
+  end
+
   it "allows a clean approved PR in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -3792,6 +3792,58 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "rejects non-string finding disposition evidence" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => [
+        {
+          "id" => "comment-1",
+          "url" => "https://example.com/comment-1",
+          "body" => "[P1] Top-level PR comment finding.",
+          "author" => { "login" => "reviewer" },
+          "createdAt" => "2026-06-01T00:00:00Z"
+        }
+      ]
+    }
+    dispositions = {
+      "comment-1" => {
+        "disposition" => "fixed",
+        "evidence" => { "url" => "https://example.com/evidence" }
+      }
+    }
+
+    Tempfile.create(["pr-merge-ledger-disposition-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--finding-dispositions",
+          dispositions_file.path,
+          chdir: repo_root
+        )
+
+        expect(status.exitstatus).to eq(2)
+        expect(stdout).to be_empty
+        expect(stderr).to include("finding disposition evidence for comment-1 must be a string")
+        expect(stderr).not_to include("from ")
+      end
+    end
+  end
+
   it "rejects null finding dispositions" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -231,6 +231,43 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "exits successfully outside strict mode while still reporting violations" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 2,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "REVIEW_REQUIRED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-non-strict-violations", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "review_decision_review_required"
+      )
+    end
+  end
+
   it "blocks explicit missing changelog classifications in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -493,6 +530,25 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(stdout).to be_empty
       expect(stderr).to include("pr-merge-ledger:")
       expect(stderr).not_to include("from ")
+    end
+  end
+
+  it "surfaces unexpected fixture shape errors with a backtrace" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => "not-a-hash"
+    }
+
+    Tempfile.create(["pr-merge-ledger-programming-error", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
+
+      expect(status.exitstatus).not_to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("undefined method")
+      expect(stderr).to include("script/pr-merge-ledger")
     end
   end
 
@@ -902,6 +958,119 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
         "unknown_priority_finding_disposition"
       )
+    end
+  end
+
+  it "does not scan dismissed or pending review bodies for priority findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 4,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "dismissed-review",
+          "state" => "DISMISSED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/dismissed-review",
+          "body" => "[P1] Dismissed review body should not gate closeout."
+        },
+        {
+          "id" => "pending-review",
+          "state" => "PENDING",
+          "submittedAt" => nil,
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/pending-review",
+          "body" => "[P2] Pending review draft should not gate closeout."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-non-gating-review-findings", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")).to be_empty
+    end
+  end
+
+  it "still scans submitted merge-relevant review bodies for priority findings" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 4,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "commented-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/commented-review",
+          "body" => "[P1] Commented review finding still needs disposition."
+        },
+        {
+          "id" => "changes-requested-review",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-02T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/changes-requested-review",
+          "body" => "[P2] Changes-requested finding still needs disposition."
+        }
+      ],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-gating-review-findings", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      findings = report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")
+      expect(findings.map { |finding| finding.fetch("id") }).to eq(
+        %w[commented-review changes-requested-review]
+      )
+      expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
     end
   end
 
@@ -3397,7 +3566,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "warns when finding disposition keys do not match any finding" do
+  it "blocks unused finding disposition keys in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
@@ -3442,11 +3611,22 @@ RSpec.describe "script/pr-merge-ledger" do
           chdir: repo_root
         )
 
-        expect(status).to be_success, stderr
+        expect(status).not_to be_success
         expect(stderr).to include("unused disposition keys: https://example.com/typo")
 
         report = JSON.parse(stdout)
-        expect(report.fetch("complete_allowed")).to be(true)
+        pr_ledger = report.fetch("pull_requests").first
+        expect(report.fetch("complete_allowed")).to be(false)
+        expect(pr_ledger.dig("priority_finding_dispositions", "unused_keys")).to eq(
+          ["https://example.com/typo"]
+        )
+        expect(report.fetch("unknown_fields").first).to include(
+          "field" => "priority_finding_dispositions.unused_keys",
+          "message" => "finding disposition keys did not match any priority finding"
+        )
+        expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+          "unknown_priority_finding_disposition"
+        )
       end
     end
   end
@@ -4263,12 +4443,22 @@ RSpec.describe "script/pr-merge-ledger" do
       schema.dig("$defs", "pull_request_ledger", "properties", "priority_finding_dispositions", "properties",
                  "truncated_sources", "items", "$ref")
     ).to eq("#/$defs/priority_finding_truncated_source")
+    expect(
+      schema.dig("$defs", "pull_request_ledger", "properties", "priority_finding_dispositions", "required")
+    ).to include("unused_keys")
+    expect(
+      schema.dig("$defs", "pull_request_ledger", "properties", "priority_finding_dispositions", "properties",
+                 "unused_keys", "items", "type")
+    ).to eq("string")
     expect(schema.dig("$defs", "violation", "additionalProperties")).to be(false)
     expect(schema.dig("$defs", "violation", "properties")).to include(
       "path", "line", "reviewer", "head_sha", "current_head"
     )
+    expect(schema.dig("$defs", "violation", "properties", "reviewer", "type")).to eq(%w[string null])
     expect(schema.dig("$defs", "review_thread", "additionalProperties")).to be(false)
+    expect(schema.dig("$defs", "review_object", "required")).to include("body_excerpt")
     expect(schema.dig("$defs", "review_object", "properties")).not_to include("body_text")
+    expect(schema.dig("$defs", "issue_comment", "required")).to include("body_excerpt")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "unknown_fields", "type")).to eq("array")
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "complete_allowed", "type")).to eq("boolean")
   end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -477,6 +477,25 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "prints a clean error when fixture pull request data is malformed" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => nil
+    }
+
+    Tempfile.create(["pr-merge-ledger-malformed-pull-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("pr-merge-ledger:")
+      expect(stderr).not_to include("from ")
+    end
+  end
+
   it "allows superseded change-request reviews after a newer review from the same reviewer" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
@@ -3422,6 +3441,21 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(status.exitstatus).to eq(2)
     expect(stdout).to be_empty
     expect(stderr).to include('repo must look like OWNER/REPO: "bad=owner/react_on_rails"')
+  end
+
+  it "rejects non-positive PR numbers before calling GitHub" do
+    stdout, stderr, status = Open3.capture3(
+      script_path,
+      "--repo",
+      "shakacode/react_on_rails",
+      "--",
+      "-1",
+      chdir: repo_root
+    )
+
+    expect(status.exitstatus).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include('PR number must be a positive integer: "-1"')
   end
 
   it "rejects fixture mode combined with positional PR arguments" do

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe "script/pr-merge-ledger" do
     violation_codes = report.fetch("violations").map { |violation| violation.fetch("code") }
 
     expect(report.fetch("schema_version")).to eq("pr-merge-ledger/v1")
+    expect(report.dig("source", "path")).to eq(
+      "react_on_rails/spec/react_on_rails/fixtures/pr_merge_ledger/pr_3613.json"
+    )
     expect(report.fetch("complete_allowed")).to be(false)
     expect(pr_ledger.dig("pr", "number")).to eq(3613)
     expect(pr_ledger.dig("review_objects", "review_decision")).to eq("CHANGES_REQUESTED")
@@ -510,6 +513,20 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(status.exitstatus).to eq(2)
       expect(stdout).to be_empty
       expect(stderr).to include("pr-merge-ledger: fixture is missing pull_request")
+      expect(stderr).not_to include("from ")
+    end
+  end
+
+  it "prints a clean error when fixture root data is not an object" do
+    Tempfile.create(["pr-merge-ledger-non-object-fixture", ".json"]) do |file|
+      file.write(JSON.generate([]))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(script_path, "--fixture", file.path, chdir: repo_root)
+
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("pr-merge-ledger: fixture must be a JSON object")
       expect(stderr).not_to include("from ")
     end
   end
@@ -1950,6 +1967,67 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(report.dig("pull_requests", 0, "unresolved_current_head_review_threads", "count")).to eq(1)
       expect(report.dig("pull_requests", 0, "priority_finding_dispositions", "findings")).to be_empty
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).not_to include(
+        "unknown_priority_finding_disposition"
+      )
+    end
+  end
+
+  it "scans resolved current-head review threads for priority finding dispositions" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 8,
+        "headRefOid" => "current",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [
+        {
+          "id" => "resolved-current-thread",
+          "isResolved" => true,
+          "isOutdated" => false,
+          "comments" => [
+            {
+              "id" => "resolved-current-comment",
+              "url" => "https://example.com/resolved-current-comment",
+              "body" => "[P1] Finding from a resolved current-head thread.",
+              "author" => { "login" => "reviewer" },
+              "createdAt" => "2026-06-01T00:00:00Z",
+              "outdated" => false,
+              "commit" => { "oid" => "current" }
+            }
+          ]
+        }
+      ],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-resolved-thread-finding", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      pr_ledger = report.fetch("pull_requests").first
+      expect(pr_ledger.dig("unresolved_current_head_review_threads", "count")).to eq(0)
+      expect(pr_ledger.dig("priority_finding_dispositions", "findings").first).to include(
+        "id" => "resolved-current-comment",
+        "severity" => "P1",
+        "disposition" => "UNKNOWN"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
         "unknown_priority_finding_disposition"
       )
     end

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4559,7 +4559,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "retries 422 gh API failures before reporting the live ledger" do
+  it "does not retry 422 gh API failures" do
     fake_gh = <<~SH
       #!/bin/sh
       count_file="$(dirname "$0")/failed-422-once"
@@ -4614,10 +4614,11 @@ RSpec.describe "script/pr-merge-ledger" do
         chdir: repo_root
       )
 
-      expect(status).to be_success, stderr
-
-      report = JSON.parse(stdout)
-      expect(report.fetch("complete_allowed")).to be(true)
+      count_path = File.join(env.fetch("PATH").split(":").first, "failed-422-once")
+      expect(status.exitstatus).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("HTTP 422 temporary validation window")
+      expect(File.read(count_path).strip).to be_empty
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -1701,6 +1701,64 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  it "requires occurrence-specific dispositions for same-line mixed severities" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 7,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "same-line-mixed-review",
+          "state" => "COMMENTED",
+          "submittedAt" => "2026-06-01T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/same-line-mixed-review",
+          "body" => "P1 issues fixed; P2 still open"
+        }
+      ],
+      "comments" => []
+    }
+    dispositions = {
+      "https://example.com/same-line-mixed-review#L1:1" => "fixed"
+    }
+
+    Tempfile.create(["pr-merge-ledger-same-line-fixture", ".json"]) do |fixture_file|
+      Tempfile.create(["pr-merge-ledger-same-line-dispositions", ".json"]) do |dispositions_file|
+        fixture_file.write(JSON.generate(fixture))
+        fixture_file.flush
+        dispositions_file.write(JSON.generate(dispositions))
+        dispositions_file.flush
+
+        stdout, stderr, status = Open3.capture3(
+          script_path,
+          "--fixture",
+          fixture_file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--finding-dispositions",
+          dispositions_file.path,
+          "--strict",
+          chdir: repo_root
+        )
+
+        expect(status).not_to be_success, stderr
+
+        report = JSON.parse(stdout)
+        findings = report.dig("pull_requests", 0, "p1_p2_must_fix_dispositions", "findings")
+        expect(findings.map { |finding| finding.fetch("severity") }).to eq(%w[P1 P2])
+        expect(findings.map { |finding| finding.fetch("marker_index") }).to eq([1, 2])
+        expect(findings.map { |finding| finding.fetch("disposition") }).to eq(%w[fixed UNKNOWN])
+        expect(stderr).not_to include("unused disposition keys")
+      end
+    end
+  end
+
   it "warns when finding disposition keys do not match any finding" do
     fixture = {
       "repository" => "shakacode/react_on_rails",

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -62,7 +62,7 @@ class PrMergeLedger
   FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived)\b/i
   NEGATED_SUMMARY_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i
   ADDITIONAL_SEVERITY_PATTERN =
-    /[.;,]\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+    /[.;,(]\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 
@@ -134,7 +134,7 @@ class PrMergeLedger
       opts.on("--pretty", "Pretty-print JSON output.") do
         @options[:pretty] = true
       end
-      opts.on("--finding-dispositions FILE", "JSON map from finding URL/id to disposition evidence.") do |path|
+      opts.on("--finding-dispositions FILE", "JSON map from finding URL/id or URL#L<line>/id#L<line>.") do |path|
         @options[:finding_dispositions] = path
       end
       opts.on("--changelog-classification CLASS", CHANGELOG_CLASSIFICATIONS) do |classification|
@@ -161,7 +161,7 @@ class PrMergeLedger
     unknown_fields = ledgers.flat_map { |ledger| ledger.fetch("unknown_fields") }
 
     {
-      "$schema" => "script/pr-merge-ledger.schema.json",
+      "$schema" => "https://reactonrails.com/schemas/pr-merge-ledger-v1.json",
       "schema_version" => SCHEMA_VERSION,
       "generated_at" => Time.now.utc.iso8601,
       "repository" => datasets.first.fetch("repository"),
@@ -177,6 +177,7 @@ class PrMergeLedger
     raise Error, "provide at least one PR number or --fixture" if @argv.empty?
 
     repo = @options[:repo] || detect_repo
+    @options[:repo] = repo
     owner, name = repo.split("/", 2)
     raise Error, "repo must look like OWNER/REPO: #{repo.inspect}" unless owner && name
 
@@ -300,7 +301,7 @@ class PrMergeLedger
   def normalize_review_thread(thread, pull_request)
     comments, comments_complete = review_thread_comments(thread)
     normalized_comments = comments.map { |comment| normalize_thread_comment(comment, pull_request) }
-    latest_comment = normalized_comments.max_by { |comment| comment["created_at"].to_s }
+    latest_comment = normalized_comments.max_by { |comment| timestamp_sort_key(comment["created_at"]) }
 
     {
       "id" => thread.fetch("id"),
@@ -377,20 +378,23 @@ class PrMergeLedger
   end
 
   def latest_reviews_by_reviewer(reviews)
-    reviews
-      .group_by { |review| review.fetch("reviewer") }
-      .map { |_reviewer, reviewer_reviews| reviewer_reviews.max_by { |review| review["submitted_at"].to_s } }
-      .sort_by { |review| review.fetch("reviewer") }
+    latest_reviews = reviews.group_by { |review| review.fetch("reviewer") }
+                            .map do |_reviewer, reviewer_reviews|
+                              reviewer_reviews.max_by { |review| timestamp_sort_key(review["submitted_at"]) }
+                            end
+
+    latest_reviews.sort_by { |review| review.fetch("reviewer") }
   end
 
   def current_thread?(thread, comments, pull_request)
     return false if thread["isOutdated"] == true
-    return !thread["isOutdated"] if comments.empty?
+    return false if comments.empty?
 
     current_thread_comment?(comments, pull_request) || comments.any? { |comment| !comment.fetch("outdated") }
   end
 
   def current_thread_comment?(comments, pull_request)
+    # Exact commit matches are current-head evidence even when GitHub's outdated flag lags behind a force-push.
     comments.any? { |comment| comment.fetch("current_head") && !comment.fetch("outdated") } ||
       comments.any? { |comment| comment.fetch("comment_head_sha") == pull_request.fetch("head_sha") }
   end
@@ -452,12 +456,13 @@ class PrMergeLedger
       severity = finding_severity(line_text)
       next [] unless severity
 
-      disposition = disposition_for(url, id, dispositions, used_disposition_keys)
+      source_line = index + 1
+      disposition = disposition_for(url, id, source_line, dispositions, used_disposition_keys)
       [{
         "id" => id,
         "url" => url,
         "severity" => severity,
-        "source_line" => index + 1,
+        "source_line" => source_line,
         "text_excerpt" => excerpt(line_text),
         "disposition" => disposition.fetch("disposition"),
         "evidence" => disposition["evidence"]
@@ -470,6 +475,7 @@ class PrMergeLedger
   end
 
   def non_actionable_finding_summary?(line)
+    # Suppress only clearly resolved summary prose; ambiguous priority text remains a finding until triaged.
     match = line.match(FINDING_SUMMARY_PREFIX_PATTERN)
     return false unless match
 
@@ -483,15 +489,15 @@ class PrMergeLedger
     first_clause.match?(FINDING_SUMMARY_RESOLUTION_PATTERN)
   end
 
-  def disposition_for(url, id, dispositions, used_disposition_keys)
-    override = if dispositions.key?(url)
-                 used_disposition_keys << url
-                 dispositions[url]
-               elsif dispositions.key?(id)
-                 used_disposition_keys << id
-                 dispositions[id]
-               end
+  def disposition_for(url, id, source_line, dispositions, used_disposition_keys)
+    disposition_key = disposition_keys(url, id, source_line).find { |key| dispositions.key?(key) }
+    return { "disposition" => UNKNOWN } unless disposition_key
 
+    used_disposition_keys << disposition_key
+    normalize_disposition_override(dispositions.fetch(disposition_key), disposition_key)
+  end
+
+  def normalize_disposition_override(override, disposition_key)
     case override
     when String
       validate_disposition(override)
@@ -503,8 +509,17 @@ class PrMergeLedger
     when nil
       { "disposition" => UNKNOWN }
     else
-      raise Error, "finding disposition for #{url || id} must be a string or object"
+      raise Error, "finding disposition for #{disposition_key} must be a string or object"
     end
+  end
+
+  def disposition_keys(url, id, source_line)
+    [
+      url && "#{url}#L#{source_line}",
+      id && "#{id}#L#{source_line}",
+      url,
+      id
+    ].compact
   end
 
   def warn_unused_dispositions(dispositions, used_disposition_keys)
@@ -517,7 +532,13 @@ class PrMergeLedger
   def validate_disposition(disposition)
     return if DISPOSITIONS.include?(disposition)
 
-    raise Error, "finding disposition must be one of #{DISPOSITIONS.join(', ')}"
+    raise Error, "finding disposition #{disposition.inspect} must be one of #{DISPOSITIONS.join(', ')}"
+  end
+
+  def timestamp_sort_key(raw_timestamp)
+    Time.parse(raw_timestamp.to_s)
+  rescue ArgumentError
+    Time.at(0).utc
   end
 
   def changelog_classification
@@ -786,7 +807,9 @@ class PrMergeLedger
     end
 
     def fetch_review_threads(pr_number)
-      fetch_paginated_connection(pr_number, review_threads_query, "reviewThreads")
+      fetch_paginated_connection(pr_number, review_threads_query, "reviewThreads").map do |thread|
+        complete_review_thread_comments(thread)
+      end
     end
 
     def fetch_reviews(pr_number)
@@ -830,6 +853,39 @@ class PrMergeLedger
       end
 
       cursor
+    end
+
+    def complete_review_thread_comments(thread)
+      raw_comments = thread["comments"]
+      return thread unless raw_comments.is_a?(Hash)
+
+      page_info = raw_comments.fetch("pageInfo")
+      return thread unless page_info.fetch("hasNextPage")
+
+      nodes = raw_comments.fetch("nodes")
+      cursor = page_info.fetch("endCursor")
+      page_count = 0
+
+      loop do
+        page_count += 1
+        if page_count > MAX_GRAPHQL_PAGES
+          raise Error, "pagination exceeded #{MAX_GRAPHQL_PAGES} pages for reviewThread.comments"
+        end
+
+        response = graphql(review_thread_comments_query, threadId: thread.fetch("id"), commentsCursor: cursor)
+        fetched_thread = response.dig("data", "node")
+        raise Error, "review thread #{thread.fetch('id')} was not found" unless fetched_thread
+
+        connection = fetched_thread.fetch("comments")
+        nodes.concat(connection.fetch("nodes"))
+        page_info = connection.fetch("pageInfo")
+        break unless page_info.fetch("hasNextPage")
+
+        cursor = next_cursor(page_info, "reviewThread.comments", cursor)
+      end
+
+      raw_comments["pageInfo"] = page_info
+      thread
     end
 
     def graphql(query, variables)
@@ -929,6 +985,41 @@ class PrMergeLedger
                       }
                     }
                     pageInfo { hasNextPage endCursor }
+                  }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def review_thread_comments_query
+      <<~GRAPHQL
+        query($owner:String!, $name:String!, $threadId:ID!, $commentsCursor:String) {
+          repository(owner:$owner, name:$name) { id }
+          node(id:$threadId) {
+            ... on PullRequestReviewThread {
+              comments(first:100, after:$commentsCursor) {
+                nodes {
+                  id
+                  databaseId
+                  body
+                  author { login }
+                  url
+                  path
+                  line
+                  createdAt
+                  outdated
+                  commit { oid }
+                  originalCommit { oid }
+                  pullRequestReview {
+                    id
+                    state
+                    submittedAt
+                    commit { oid }
+                    author { login }
                   }
                 }
                 pageInfo { hasNextPage endCursor }

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -79,7 +79,7 @@ class PrMergeLedger
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN = %r{
-    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|while)\b)\s*
+    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|or|while)\b)\s*
     (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
     (?:\s|:|-|/|$)
   }ix

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -512,26 +512,30 @@ class PrMergeLedger
 
       finding_occurrences(line_text).length
     end
+    context = {
+      source_finding_count:,
+      dispositions:,
+      used_disposition_keys:
+    }
 
     lines.each_with_index.flat_map do |line_text, index|
-      findings_from_line(line_text, index + 1, { url:, id: }, dispositions, used_disposition_keys, source_finding_count)
+      findings_from_line(line_text, index + 1, { url:, id: }, context)
     end
   end
 
-  def findings_from_line(line_text, source_line, source, dispositions, used_disposition_keys, source_finding_count = nil)
+  def findings_from_line(line_text, source_line, source, context)
     return [] if non_actionable_finding_summary?(line_text)
 
     occurrences = finding_occurrences(line_text)
     return [] if occurrences.empty?
 
-    context = {
+    source_finding_count = context.fetch(:source_finding_count) || occurrences.length
+    finding_context = context.merge(
       multiple_markers: occurrences.length > 1,
-      source_finding_count: source_finding_count || occurrences.length,
-      dispositions:,
-      used_disposition_keys:
-    }
+      source_finding_count:
+    )
     occurrences.map do |occurrence|
-      finding_from_occurrence(line_text, source_line, source, occurrence, context)
+      finding_from_occurrence(line_text, source_line, source, occurrence, finding_context)
     end
   end
 
@@ -588,8 +592,26 @@ class PrMergeLedger
 
     summary = match[:summary].to_s
     return false unless summary.match?(FINDING_SUMMARY_SUBJECT_PATTERN)
-    return false if summary.match?(ADDITIONAL_SEVERITY_PATTERN)
+    return false unless resolved_finding_summary_clause?(summary)
 
+    additional_finding_summary_clauses(summary).all? do |clause|
+      resolved_finding_summary_clause?(clause)
+    end
+  end
+
+  def additional_finding_summary_clauses(summary)
+    matches = []
+    summary.scan(ADDITIONAL_SEVERITY_PATTERN) do
+      matches << Regexp.last_match
+    end
+
+    matches.map.with_index do |match, index|
+      clause_end = matches[index + 1]&.begin(0) || summary.length
+      summary[match.begin(:severity)...clause_end].to_s
+    end
+  end
+
+  def resolved_finding_summary_clause?(summary)
     first_clause = summary.split(/[.;(]/, 2).first.to_s
     return false if first_clause.match?(NEGATED_SUMMARY_RESOLUTION_PATTERN)
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -221,7 +221,10 @@ class PrMergeLedger
   def build_report
     datasets = @options[:fixture] ? [load_fixture(@options[:fixture])] : fetch_live_pull_requests
     dispositions = load_dispositions(@options[:finding_dispositions])
-    ledgers = datasets.map { |dataset| ledger_for(dataset, dispositions) }
+    enforce_unused_dispositions = datasets.length == 1
+    ledgers = datasets.map do |dataset|
+      ledger_for(dataset, dispositions, enforce_unused_dispositions:)
+    end
 
     violations = ledgers.flat_map { |ledger| ledger.fetch("violations") }
     unknown_fields = ledgers.flat_map { |ledger| ledger.fetch("unknown_fields") }
@@ -308,7 +311,7 @@ class PrMergeLedger
   end
 
   # rubocop:disable Metrics/AbcSize
-  def ledger_for(dataset, dispositions)
+  def ledger_for(dataset, dispositions, enforce_unused_dispositions: true)
     pull_request = normalize_pull_request(dataset.fetch("pull_request"))
     files = file_paths(dataset)
     review_threads = normalized_review_threads(dataset, pull_request)
@@ -321,7 +324,8 @@ class PrMergeLedger
     latest_reviews = latest_reviews_by_reviewer(output_reviews)
     all_changes_requested = output_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
     changes_requested = current_changes_requested(output_reviews)
-    finding_report = finding_dispositions(review_threads, reviews, issue_comments, dispositions)
+    finding_report = finding_dispositions(review_threads, reviews, issue_comments, dispositions,
+                                          enforce_unused_dispositions:)
     changelog = changelog_classification
     lockfile = lockfile_diff(files)
 
@@ -533,7 +537,7 @@ class PrMergeLedger
     complete_current_head_thread?(thread) && !thread.fetch("is_resolved")
   end
 
-  def finding_dispositions(review_threads, reviews, issue_comments, dispositions)
+  def finding_dispositions(review_threads, reviews, issue_comments, dispositions, enforce_unused_dispositions: true)
     findings = []
     used_disposition_keys = []
 
@@ -557,7 +561,8 @@ class PrMergeLedger
     )
     append_findings(issue_comments, "body", findings, context)
 
-    unused_disposition_keys = warn_unused_dispositions(dispositions, used_disposition_keys)
+    unused_disposition_keys = unused_disposition_keys(dispositions, used_disposition_keys,
+                                                      enforce_unused_dispositions:)
 
     unique_findings = findings.uniq do |finding|
       [
@@ -859,6 +864,12 @@ class PrMergeLedger
 
     warn "pr-merge-ledger: unused disposition keys: #{unused_keys.join(', ')}"
     unused_keys
+  end
+
+  def unused_disposition_keys(dispositions, used_disposition_keys, enforce_unused_dispositions: true)
+    return [] unless enforce_unused_dispositions
+
+    warn_unused_dispositions(dispositions, used_disposition_keys)
   end
 
   def validate_disposition(disposition)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -29,7 +29,7 @@ class PrMergeLedger
     bun.lock
     bun.lockb
   ].freeze
-  GITHUB_API_TIMEOUT_SECONDS = Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", "30"), 10)
+  DEFAULT_GITHUB_API_TIMEOUT_SECONDS = "30"
   MAX_GRAPHQL_PAGES = 500
   LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
   FINDING_LINE_PREFIX_PATTERN = /(?:#{LIST_MARKER_PATTERN.source})?(?:\#{1,6}\s+)?/
@@ -72,7 +72,8 @@ class PrMergeLedger
       (?:\s+(?:were|was|are|is|has|have|been|got|now|already|previously))*\s+
     )
     (?:fixed|resolved|waived)
-    (?=\s*(?:$|[.;,)]|\b(?:by|in|with|via|from|after|before|on|because|through)\b)) |
+    (?=\s*(?:$|[.;,)]|\bor\s+(?:fixed|resolved|waived)\b|
+      \b(?:by|in|with|via|from|after|before|on|because|through)\b)) |
     \bno\s+(?:findings?|issues?|items?|main\s+issue)\b
     (?=\s*(?:$|[.;,)]|\b(?:found|present|open|remaining|reported|detected)\b))
   /ix
@@ -82,12 +83,18 @@ class PrMergeLedger
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN = %r{
-    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|or|while)\b)\s*
+    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|however|or|while)\b)\s*
     (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
     (?:\s|:|-|/|$)
   }ix
 
   class Error < StandardError; end
+
+  def self.github_api_timeout_seconds
+    Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", DEFAULT_GITHUB_API_TIMEOUT_SECONDS), 10)
+  rescue ArgumentError
+    raise Error, "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be an integer (seconds)"
+  end
 
   def self.run(argv)
     new(argv).run
@@ -226,14 +233,15 @@ class PrMergeLedger
   end
 
   def detect_repo
-    Timeout.timeout(GITHUB_API_TIMEOUT_SECONDS) do
+    timeout = self.class.github_api_timeout_seconds
+    Timeout.timeout(timeout) do
       stdout, stderr, status = Open3.capture3("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
       raise Error, "could not detect gh repo: #{stderr.strip}" unless status.success?
 
       stdout.strip
     end
   rescue Timeout::Error
-    raise Error, "gh repo view timed out after #{GITHUB_API_TIMEOUT_SECONDS} seconds"
+    raise Error, "gh repo view timed out after #{timeout} seconds"
   end
 
   def load_fixture(path)
@@ -273,7 +281,7 @@ class PrMergeLedger
     latest_reviews = latest_reviews_by_reviewer(output_reviews)
     all_changes_requested = output_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
     changes_requested = current_changes_requested(latest_reviews)
-    finding_dispositions = finding_dispositions(review_threads, reviews, issue_comments, dispositions)
+    finding_report = finding_dispositions(review_threads, reviews, issue_comments, dispositions)
     changelog = changelog_classification
     lockfile = lockfile_diff(files)
 
@@ -292,12 +300,12 @@ class PrMergeLedger
         "all_changes_requested" => all_changes_requested
       },
       "issue_comments" => output_issue_comments,
-      "priority_finding_dispositions" => finding_dispositions,
+      "priority_finding_dispositions" => finding_report,
       "changelog_classification" => changelog,
       "lockfile_diff" => lockfile
     }
 
-    unknown_fields = unknown_fields_for(pull_request, review_threads, finding_dispositions, changelog, lockfile)
+    unknown_fields = unknown_fields_for(pull_request, review_threads, finding_report, changelog, lockfile)
     violations = violations_for(pull_request, unresolved_threads, changes_requested, changelog, unknown_fields)
     ledger.merge(
       "violations" => violations,
@@ -1071,7 +1079,7 @@ class PrMergeLedger
     end
 
     def capture_gh(args)
-      timeout = GITHUB_API_TIMEOUT_SECONDS
+      timeout = PrMergeLedger.github_api_timeout_seconds
       Timeout.timeout(timeout) do
         Open3.capture3("gh", *args)
       end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -11,6 +11,7 @@ require "timeout"
 class PrMergeLedger
   SCHEMA_VERSION = "pr-merge-ledger/v1"
   UNKNOWN = "UNKNOWN"
+  # Keep the schema URI on main until a versioned schema hosting policy exists.
   SCHEMA_URI = "https://raw.githubusercontent.com/shakacode/react_on_rails/main/script/pr-merge-ledger.schema.json"
   SCHEMA_PATH = File.expand_path("pr-merge-ledger.schema.json", __dir__)
   CHANGELOG_CLASSIFICATIONS = %w[
@@ -275,6 +276,7 @@ class PrMergeLedger
 
   def load_fixture(path)
     JSON.parse(File.read(path)).tap do |dataset|
+      raise Error, "fixture must be a JSON object" unless dataset.is_a?(Hash)
       raise Error, "fixture is missing repository" unless dataset["repository"]
       raise Error, "fixture is missing pull_request" unless dataset["pull_request"]
     end
@@ -290,10 +292,19 @@ class PrMergeLedger
 
   def source_summary
     if @options[:fixture]
-      { "mode" => "fixture", "path" => @options[:fixture] }
+      { "mode" => "fixture", "path" => fixture_source_path(@options[:fixture]) }
     else
       { "mode" => "live_github", "repo" => @options[:repo], "prs" => @argv.map(&:to_i) }
     end
+  end
+
+  def fixture_source_path(path)
+    expanded_path = File.expand_path(path)
+    repo_prefix = "#{File.expand_path(Dir.pwd)}/"
+
+    return expanded_path.delete_prefix(repo_prefix) if expanded_path.start_with?(repo_prefix)
+
+    File.basename(path)
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -517,7 +528,7 @@ class PrMergeLedger
 
   def unresolved_current_head_thread?(thread)
     # Truncated comment pages are reported through unknown_fields instead of counted from partial evidence.
-    thread.fetch("comments_complete") && !thread.fetch("is_resolved") && thread.fetch("current_head")
+    complete_current_head_thread?(thread) && !thread.fetch("is_resolved")
   end
 
   def finding_dispositions(review_threads, reviews, issue_comments, dispositions)
@@ -574,10 +585,14 @@ class PrMergeLedger
 
   def thread_comments_for_findings(review_threads)
     review_threads
-      .select { |thread| unresolved_current_head_thread?(thread) }
+      .select { |thread| complete_current_head_thread?(thread) }
       # Incomplete comment pages are blocked through unknown_fields; unfetched bodies cannot be scanned for priorities.
       .flat_map { |thread| thread.fetch("comments") }
       .reject { |comment| comment.fetch("outdated") }
+  end
+
+  def complete_current_head_thread?(thread)
+    thread.fetch("comments_complete") && thread.fetch("current_head")
   end
 
   def reviews_for_findings(reviews)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -32,9 +32,10 @@ class PrMergeLedger
   GITHUB_API_TIMEOUT_SECONDS = Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", "30"), 10)
   MAX_GRAPHQL_PAGES = 500
   LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
+  FINDING_LINE_PREFIX_PATTERN = /(?:#{LIST_MARKER_PATTERN.source})?(?:\#{1,6}\s+)?/
   PRIORITY_MARKER_PATTERN = /MUST[- ]?FIX|\[?P[0-2]\]?/
   FINDING_BADGE_PREFIX = %r{
-    \A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?
+    \A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?
     <sub><sub>!\[%<severity>s\s+Badge\]\([^)]+\)</sub></sub>
     (?:\*\*)?(?:\s|:|-|$)
   }ix
@@ -45,22 +46,22 @@ class PrMergeLedger
     ]
   end.freeze
   FINDING_PATTERNS = {
-    "MUST_FIX" => %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|/|$)}i,
+    "MUST_FIX" => %r{\A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|/|$)}i,
     "P0" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P0"),
-      %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|/|$)}i
+      %r{\A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|/|$)}i
     ),
     "P1" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P1"),
-      %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|/|$)}i
+      %r{\A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|/|$)}i
     ),
     "P2" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P2"),
-      %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|/|$)}i
+      %r{\A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|/|$)}i
     )
   }.freeze
   FINDING_SUMMARY_PREFIX_PATTERN =
-    %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?:#{PRIORITY_MARKER_PATTERN.source})
+    %r{\A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?(?:#{PRIORITY_MARKER_PATTERN.source})
       (?:\s*/\s*(?:#{PRIORITY_MARKER_PATTERN.source}))*(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z}ix
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /
@@ -71,7 +72,9 @@ class PrMergeLedger
       (?:\s+(?:were|was|are|is|has|have|been|got|now|already|previously))*\s+
     )
     (?:fixed|resolved|waived)
-    (?=\s*(?:$|[.;,)]|\b(?:by|in|with|via|from|after|before|on|because|through)\b))
+    (?=\s*(?:$|[.;,)]|\b(?:by|in|with|via|from|after|before|on|because|through)\b)) |
+    \bno\s+(?:findings?|issues?|items?|main\s+issue)\b
+    (?=\s*(?:$|[.;,)]|\b(?:found|present|open|remaining|reported|detected)\b))
   /ix
   NEGATED_SUMMARY_RESOLUTION_PATTERN = Regexp.union(
     /\bnot\s+(?:\S+\s+){0,3}?(?:fixed|resolved|waived)\b/i,

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1370,7 +1370,12 @@ class PrMergeLedger
     end
 
     def non_retryable_gh_error?(stderr)
-      stderr.to_s.match?(/\b4(?:0\d|1\d|2[0-8]|[3-9]\d)\b|\b(?:Not Found|Unauthorized|Forbidden)\b/i)
+      error_text = stderr.to_s
+      if error_text.match?(/\b(?:abuse detection|rate limit|rate-limit|secondary rate|too many requests)\b/i)
+        return false
+      end
+
+      error_text.match?(/\b4(?:0\d|1\d|2[0-8]|[3-9]\d)\b|\b(?:Not Found|Unauthorized|Forbidden)\b/i)
     end
 
     def capture_gh(args)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -208,7 +208,9 @@ class PrMergeLedger
     repo = @options[:repo] || detect_repo
     @options[:repo] = repo
     owner, name = repo.split("/", 2)
-    raise Error, "repo must look like OWNER/REPO: #{repo.inspect}" unless owner && name
+    unless owner.to_s.match?(/\A\S+\z/) && name.to_s.match?(/\A\S+\z/)
+      raise Error, "repo must look like OWNER/REPO: #{repo.inspect}"
+    end
 
     collector = GitHubCollector.new(owner, name)
     @argv.map do |pr_number|
@@ -285,7 +287,7 @@ class PrMergeLedger
         "all_changes_requested" => all_changes_requested
       },
       "issue_comments" => output_issue_comments,
-      "p1_p2_must_fix_dispositions" => finding_dispositions,
+      "priority_finding_dispositions" => finding_dispositions,
       "changelog_classification" => changelog,
       "lockfile_diff" => lockfile
     }
@@ -736,7 +738,7 @@ class PrMergeLedger
 
       unknowns << unknown_field(
         pull_request,
-        "p1_p2_must_fix_dispositions.findings",
+        "priority_finding_dispositions.findings",
         "P0/P1/P2/Must-Fix finding has no fixed/waived/follow-up disposition",
         finding["url"]
       )
@@ -882,8 +884,8 @@ class PrMergeLedger
 
   def unknown_violation_code(field)
     case field
-    when /\Ap1_p2_must_fix_dispositions/
-      "unknown_p1_p2_must_fix_disposition"
+    when /\Apriority_finding_dispositions/
+      "unknown_priority_finding_disposition"
     when /\Achangelog_classification/
       "unknown_changelog_classification"
     when /\Alockfile_diff/
@@ -1121,7 +1123,6 @@ class PrMergeLedger
                       createdAt
                       outdated
                       commit { oid }
-                      originalCommit { oid }
                       pullRequestReview {
                         id
                         state
@@ -1158,7 +1159,6 @@ class PrMergeLedger
                   createdAt
                   outdated
                   commit { oid }
-                  originalCommit { oid }
                   pullRequestReview {
                     id
                     state

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -56,10 +56,13 @@ class PrMergeLedger
       /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|$)/i
     )
   }.freeze
-  NON_ACTIONABLE_FINDING_PATTERN =
-    /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+
-      (?:findings?|issues?|items?)\b.*\b(?:none|resolved|waived|previous review)\b/ix
-  ACTIONABLE_NEGATED_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:resolved|waived)\b/i
+  FINDING_SUMMARY_PREFIX_PATTERN =
+    /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
+  FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
+  FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived|previous review)\b/i
+  NEGATED_SUMMARY_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i
+  ADDITIONAL_SEVERITY_PATTERN =
+    /[.;]\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 
@@ -381,8 +384,13 @@ class PrMergeLedger
   end
 
   def current_thread?(thread, comments, pull_request)
+    return false if thread["isOutdated"] == true
     return !thread["isOutdated"] if comments.empty?
 
+    current_thread_comment?(comments, pull_request) || comments.any? { |comment| !comment.fetch("outdated") }
+  end
+
+  def current_thread_comment?(comments, pull_request)
     comments.any? { |comment| comment.fetch("current_head") && !comment.fetch("outdated") } ||
       comments.any? { |comment| comment.fetch("comment_head_sha") == pull_request.fetch("head_sha") }
   end
@@ -393,24 +401,13 @@ class PrMergeLedger
 
   def finding_dispositions(review_threads, reviews, issue_comments, dispositions)
     findings = []
+    used_disposition_keys = []
 
-    thread_comments_for_findings(review_threads).each do |comment|
-      findings.concat(
-        findings_from_text(comment.fetch("body"), comment.fetch("url"), comment.fetch("id"), dispositions)
-      )
-    end
+    append_findings(thread_comments_for_findings(review_threads), "body", findings, dispositions, used_disposition_keys)
+    append_findings(reviews_for_findings(reviews), "body_text", findings, dispositions, used_disposition_keys)
+    append_findings(issue_comments, "body", findings, dispositions, used_disposition_keys)
 
-    reviews_for_findings(reviews).each do |review|
-      findings.concat(
-        findings_from_text(review.fetch("body_text"), review.fetch("url"), review.fetch("id"), dispositions)
-      )
-    end
-
-    issue_comments.each do |comment|
-      findings.concat(
-        findings_from_text(comment.fetch("body"), comment.fetch("url"), comment.fetch("id"), dispositions)
-      )
-    end
+    warn_unused_dispositions(dispositions, used_disposition_keys)
 
     unique_findings = findings.uniq do |finding|
       [
@@ -427,6 +424,15 @@ class PrMergeLedger
     }
   end
 
+  def append_findings(records, text_key, findings, dispositions, used_disposition_keys)
+    records.each do |record|
+      findings.concat(
+        findings_from_text(record.fetch(text_key), record.fetch("url"), record.fetch("id"), dispositions,
+                           used_disposition_keys)
+      )
+    end
+  end
+
   def thread_comments_for_findings(review_threads)
     review_threads
       .select { |thread| unresolved_current_head_thread?(thread) }
@@ -437,20 +443,21 @@ class PrMergeLedger
     latest_reviews_by_reviewer(reviews).select { |review| review.fetch("current_head") }
   end
 
-  def findings_from_text(text, url, id, dispositions)
+  def findings_from_text(text, url, id, dispositions, used_disposition_keys)
     text.to_s.each_line.with_index.flat_map do |line, index|
-      next [] if non_actionable_finding_summary?(line)
+      line_text = line.chomp
+      next [] if non_actionable_finding_summary?(line_text)
 
-      severity = finding_severity(line)
+      severity = finding_severity(line_text)
       next [] unless severity
 
-      disposition = disposition_for(url, id, dispositions)
+      disposition = disposition_for(url, id, dispositions, used_disposition_keys)
       [{
         "id" => id,
         "url" => url,
         "severity" => severity,
         "source_line" => index + 1,
-        "text_excerpt" => excerpt(line),
+        "text_excerpt" => excerpt(line_text),
         "disposition" => disposition.fetch("disposition"),
         "evidence" => disposition["evidence"]
       }]
@@ -462,13 +469,27 @@ class PrMergeLedger
   end
 
   def non_actionable_finding_summary?(line)
-    return false if line.match?(ACTIONABLE_NEGATED_RESOLUTION_PATTERN)
+    match = line.match(FINDING_SUMMARY_PREFIX_PATTERN)
+    return false unless match
 
-    line.match?(NON_ACTIONABLE_FINDING_PATTERN)
+    summary = match[:summary].to_s
+    return false unless summary.match?(FINDING_SUMMARY_SUBJECT_PATTERN)
+    return false if summary.match?(ADDITIONAL_SEVERITY_PATTERN)
+
+    first_clause = summary.split(/[.;(]/, 2).first.to_s
+    return false if first_clause.match?(NEGATED_SUMMARY_RESOLUTION_PATTERN)
+
+    first_clause.match?(FINDING_SUMMARY_RESOLUTION_PATTERN)
   end
 
-  def disposition_for(url, id, dispositions)
-    override = dispositions[url] || dispositions[id]
+  def disposition_for(url, id, dispositions, used_disposition_keys)
+    override = if dispositions.key?(url)
+                 used_disposition_keys << url
+                 dispositions[url]
+               elsif dispositions.key?(id)
+                 used_disposition_keys << id
+                 dispositions[id]
+               end
 
     case override
     when String
@@ -483,6 +504,13 @@ class PrMergeLedger
     else
       raise Error, "finding disposition for #{url || id} must be a string or object"
     end
+  end
+
+  def warn_unused_dispositions(dispositions, used_disposition_keys)
+    unused_keys = dispositions.keys - used_disposition_keys.to_a
+    return if unused_keys.empty?
+
+    warn "pr-merge-ledger: unused disposition keys: #{unused_keys.join(', ')}"
   end
 
   def validate_disposition(disposition)
@@ -577,6 +605,7 @@ class PrMergeLedger
     [
       review_decision_violation(pull_request),
       draft_pr_violation(pull_request),
+      closed_unmerged_pr_violation(pull_request),
       changelog_violation(pull_request, changelog),
       *changes_requested_violations(pull_request, changes_requested),
       *unresolved_thread_violations(pull_request, unresolved_threads),
@@ -610,6 +639,17 @@ class PrMergeLedger
       pull_request,
       "draft_pr",
       "PR is still a draft",
+      pull_request["url"]
+    )
+  end
+
+  def closed_unmerged_pr_violation(pull_request)
+    return unless pull_request["state"] == "CLOSED" && pull_request["merged_at"].nil?
+
+    violation(
+      pull_request,
+      "closed_unmerged_pr",
+      "PR is closed without being merged",
       pull_request["url"]
     )
   end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -277,7 +277,7 @@ class PrMergeLedger
       "pull_requests" => ledgers,
       "violations" => violations,
       "unknown_fields" => unknown_fields,
-      "complete_allowed" => violations.empty? && unknown_fields.empty?
+      "complete_allowed" => violations.empty?
     }
   end
 
@@ -393,7 +393,7 @@ class PrMergeLedger
     ledger.merge(
       "violations" => violations,
       "unknown_fields" => unknown_fields,
-      "complete_allowed" => violations.empty? && unknown_fields.empty?
+      "complete_allowed" => violations.empty?
     )
   end
   # rubocop:enable Metrics/AbcSize
@@ -1352,6 +1352,7 @@ class PrMergeLedger
       value_string = value.to_s
       raise Error, "gh api graphql variable #{key} cannot start with @" if value_string.start_with?("@")
 
+      # Arguments are passed to Open3 as argv, so values are not shell-expanded.
       flag = value.is_a?(Integer) || value == true || value == false ? "-F" : "-f"
       args.push(flag, "#{key}=#{value_string}")
     end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -34,6 +34,8 @@ class PrMergeLedger
   GITHUB_API_RETRY_BASE_DELAY_SECONDS = 0.25
   MAX_GRAPHQL_PAGES = 500
   GITHUB_REPO_NAME_PATTERN = /\A[A-Za-z0-9._-]+\z/
+  MAX_BODY_LINES = 1_000
+  MAX_EXCERPT_LENGTH = 180
   LIST_MARKER_PATTERN = /(?:[-*]\s*(?:\[[ xX]\]\s*)?|\d+[.)]\s*)/
   FINDING_LINE_PREFIX_PATTERN = /(?:#{LIST_MARKER_PATTERN.source})?(?:\#{1,6}\s+)?/
   PRIORITY_MARKER_PATTERN = /MUST[- ]?FIX|\[?P[0-2]\]?/
@@ -157,10 +159,15 @@ class PrMergeLedger
                    "remove them or omit --fixture"
     end
 
-    return unless @argv.length > 1 && @options[:changelog_classification_provided]
+    if @argv.length > 1 && @options[:changelog_classification_provided]
+      raise Error,
+            "--changelog-classification applies to one PR at a time; run multi-PR ledgers separately"
+    end
 
-    raise Error,
-          "--changelog-classification applies to one PR at a time; run multi-PR ledgers separately"
+    return unless @options[:strict] && @argv.length > 1
+
+    warn "pr-merge-ledger: --strict with multiple PRs always fails until each PR has a " \
+         "non-UNKNOWN changelog classification"
   end
 
   def build_option_parser
@@ -531,6 +538,11 @@ class PrMergeLedger
 
   def findings_from_text(text, url, id, dispositions, used_disposition_keys)
     lines = text.to_s.each_line.map(&:chomp)
+    if lines.length > MAX_BODY_LINES
+      warn "pr-merge-ledger: #{url} body has #{lines.length} lines; scanning first #{MAX_BODY_LINES}"
+      lines = lines.first(MAX_BODY_LINES)
+    end
+
     source_finding_count = lines.sum do |line_text|
       next 0 if non_actionable_finding_summary?(line_text)
 
@@ -981,7 +993,10 @@ class PrMergeLedger
   end
 
   def excerpt(text)
-    text.to_s.gsub(/\s+/, " ").strip[0, 180]
+    compacted = text.to_s.gsub(/\s+/, " ").strip
+    return compacted if compacted.length <= MAX_EXCERPT_LENGTH
+
+    "#{compacted[0, MAX_EXCERPT_LENGTH - 3]}..."
   end
 
   def write_report(report)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -21,6 +21,7 @@ class PrMergeLedger
     UNKNOWN
   ].freeze
   DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable UNKNOWN].freeze
+  REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze
   LOCKFILE_BASENAMES = %w[
     Gemfile.lock
     package-lock.json
@@ -93,7 +94,7 @@ class PrMergeLedger
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN = %r{
-    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|however|or|while)\b)\s*
+    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|however|or|while|with)\b)\s*
     (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
     (?:\s|:|-|/|$)
   }ix
@@ -475,7 +476,20 @@ class PrMergeLedger
   end
 
   def current_changes_requested(reviews)
-    reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" && review.fetch("current_head") }
+    latest_current_decision_reviews_by_reviewer(reviews).select do |review|
+      review.fetch("state") == "CHANGES_REQUESTED"
+    end
+  end
+
+  def latest_current_decision_reviews_by_reviewer(reviews)
+    reviews.select { |review| review.fetch("current_head") && REVIEW_DECISION_STATES.include?(review.fetch("state")) }
+           .group_by { |review| review.fetch("reviewer") }
+           .values
+           .map do |reviewer_reviews|
+             reviewer_reviews.max_by do |review|
+               timestamp_sort_key(review["submitted_at"], "review #{review.fetch('id')} submitted_at")
+             end
+           end
   end
 
   def current_thread_evidence(thread, comments, pull_request)
@@ -829,6 +843,7 @@ class PrMergeLedger
 
   def lockfile_path?(path)
     basename = File.basename(path)
+    # Keep generic *.lock conservative; narrow this if real closeouts produce false positives.
     LOCKFILE_BASENAMES.include?(basename) || basename.end_with?(".lock")
   end
 
@@ -1222,7 +1237,7 @@ class PrMergeLedger
     end
 
     def non_retryable_gh_error?(stderr)
-      stderr.to_s.match?(/\b(?:401|403|404|Not Found|Unauthorized|Forbidden)\b/i)
+      stderr.to_s.match?(/\b(?:401|403|404)\b|\b(?:Not Found|Unauthorized|Forbidden)\b/i)
     end
 
     def capture_gh(args)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -67,7 +67,7 @@ class PrMergeLedger
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN =
-    /(?:[.;,(]|\b(?:and|but)\b)\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+    /(?:[.;,(:-]|\b(?:and|but)\b)\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -59,10 +59,10 @@ class PrMergeLedger
   FINDING_SUMMARY_PREFIX_PATTERN =
     /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
-  FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived|previous review)\b/i
+  FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived)\b/i
   NEGATED_SUMMARY_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i
   ADDITIONAL_SEVERITY_PATTERN =
-    /[.;]\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+    /[.;,]\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1369,7 +1369,7 @@ class PrMergeLedger
     end
 
     def non_retryable_gh_error?(stderr)
-      stderr.to_s.match?(/\b4\d{2}\b|\b(?:Not Found|Unauthorized|Forbidden|Too Many Requests)\b/i)
+      stderr.to_s.match?(/\b4(?:0\d|1\d|2[0-8]|[3-9]\d)\b|\b(?:Not Found|Unauthorized|Forbidden)\b/i)
     end
 
     def capture_gh(args)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -62,7 +62,7 @@ class PrMergeLedger
   FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived)\b/i
   NEGATED_SUMMARY_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i
   ADDITIONAL_SEVERITY_PATTERN =
-    /[.;,(]\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+    /[.;,(]\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 
@@ -134,7 +134,7 @@ class PrMergeLedger
       opts.on("--pretty", "Pretty-print JSON output.") do
         @options[:pretty] = true
       end
-      opts.on("--finding-dispositions FILE", "JSON map from finding URL/id or URL#L<line>/id#L<line>.") do |path|
+      opts.on("--finding-dispositions FILE", "JSON map from finding URL/id, URL#L<line>, or URL#L<line>:<n>.") do |path|
         @options[:finding_dispositions] = path
       end
       opts.on("--changelog-classification CLASS", CHANGELOG_CLASSIFICATIONS) do |classification|
@@ -419,6 +419,7 @@ class PrMergeLedger
         finding.fetch("url"),
         finding.fetch("severity"),
         finding.fetch("source_line"),
+        finding.fetch("marker_index"),
         finding.fetch("text_excerpt")
       ]
     end
@@ -451,27 +452,70 @@ class PrMergeLedger
   def findings_from_text(text, url, id, dispositions, used_disposition_keys)
     text.to_s.each_line.with_index.flat_map do |line, index|
       line_text = line.chomp
-      next [] if non_actionable_finding_summary?(line_text)
-
-      severity = finding_severity(line_text)
-      next [] unless severity
-
-      source_line = index + 1
-      disposition = disposition_for(url, id, source_line, dispositions, used_disposition_keys)
-      [{
-        "id" => id,
-        "url" => url,
-        "severity" => severity,
-        "source_line" => source_line,
-        "text_excerpt" => excerpt(line_text),
-        "disposition" => disposition.fetch("disposition"),
-        "evidence" => disposition["evidence"]
-      }]
+      findings_from_line(line_text, index + 1, { url:, id: }, dispositions, used_disposition_keys)
     end
+  end
+
+  def findings_from_line(line_text, source_line, source, dispositions, used_disposition_keys)
+    return [] if non_actionable_finding_summary?(line_text)
+
+    occurrences = finding_occurrences(line_text)
+    return [] if occurrences.empty?
+
+    context = {
+      multiple_markers: occurrences.length > 1,
+      dispositions:,
+      used_disposition_keys:
+    }
+    occurrences.map do |occurrence|
+      finding_from_occurrence(line_text, source_line, source, occurrence, context)
+    end
+  end
+
+  def finding_from_occurrence(line_text, source_line, source, occurrence, context)
+    finding = source.merge(
+      source_line:,
+      marker_index: occurrence.fetch(:marker_index),
+      multiple_markers: context.fetch(:multiple_markers)
+    )
+    disposition = disposition_for(finding, context.fetch(:dispositions), context.fetch(:used_disposition_keys))
+
+    {
+      "id" => source.fetch(:id),
+      "url" => source.fetch(:url),
+      "severity" => occurrence.fetch(:severity),
+      "source_line" => source_line,
+      "source_column" => occurrence.fetch(:source_column),
+      "marker_index" => occurrence.fetch(:marker_index),
+      "text_excerpt" => excerpt(line_text),
+      "disposition" => disposition.fetch("disposition"),
+      "evidence" => disposition["evidence"]
+    }
   end
 
   def finding_severity(line)
     FINDING_PATTERNS.find { |_severity, pattern| line.match?(pattern) }&.first
+  end
+
+  def finding_occurrences(line)
+    first_severity = finding_severity(line)
+    return [] unless first_severity
+
+    occurrences = [{ severity: first_severity, source_column: 1, marker_index: 1 }]
+    line.to_enum(:scan, ADDITIONAL_SEVERITY_PATTERN).each do
+      match = Regexp.last_match
+      occurrences << {
+        severity: normalize_finding_severity(match[:severity]),
+        source_column: match.begin(:severity) + 1,
+        marker_index: occurrences.length + 1
+      }
+    end
+    occurrences
+  end
+
+  def normalize_finding_severity(raw_severity)
+    normalized = raw_severity.to_s.delete("[]").upcase.tr("- ", "_")
+    normalized == "MUST_FIX" ? "MUST_FIX" : normalized
   end
 
   def non_actionable_finding_summary?(line)
@@ -489,8 +533,10 @@ class PrMergeLedger
     first_clause.match?(FINDING_SUMMARY_RESOLUTION_PATTERN)
   end
 
-  def disposition_for(url, id, source_line, dispositions, used_disposition_keys)
-    disposition_key = disposition_keys(url, id, source_line).find { |key| dispositions.key?(key) }
+  def disposition_for(finding, dispositions, used_disposition_keys)
+    disposition_key = disposition_keys(finding).find do |key|
+      dispositions.key?(key)
+    end
     return { "disposition" => UNKNOWN } unless disposition_key
 
     used_disposition_keys << disposition_key
@@ -513,13 +559,23 @@ class PrMergeLedger
     end
   end
 
-  def disposition_keys(url, id, source_line)
-    [
+  def disposition_keys(finding)
+    url = finding.fetch(:url)
+    id = finding.fetch(:id)
+    source_line = finding.fetch(:source_line)
+    marker_index = finding.fetch(:marker_index)
+    marker_keys = [
+      url && "#{url}#L#{source_line}:#{marker_index}",
+      id && "#{id}#L#{source_line}:#{marker_index}"
+    ]
+    line_keys = [
       url && "#{url}#L#{source_line}",
       id && "#{id}#L#{source_line}",
       url,
       id
-    ].compact
+    ]
+
+    marker_keys.concat(finding.fetch(:multiple_markers) ? [url, id] : line_keys).compact
   end
 
   def warn_unused_dispositions(dispositions, used_disposition_keys)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -11,6 +11,7 @@ require "timeout"
 class PrMergeLedger
   SCHEMA_VERSION = "pr-merge-ledger/v1"
   UNKNOWN = "UNKNOWN"
+  SCHEMA_URI = "script/pr-merge-ledger.schema.json"
   SCHEMA_PATH = File.expand_path("pr-merge-ledger.schema.json", __dir__)
   CHANGELOG_CLASSIFICATIONS = %w[
     changelog_present
@@ -61,12 +62,12 @@ class PrMergeLedger
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived)\b/i
   NEGATED_SUMMARY_RESOLUTION_PATTERN = Regexp.union(
-    /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i,
+    /\bnot\s+(?:\S+\s+){0,3}?(?:fixed|resolved|waived)\b/i,
     /\b(?:none|nothing)\s+(?:fixed|resolved|waived)\b/i,
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN =
-    /[.;,(]\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+    /(?:[.;,(]|\b(?:and|but)\b)\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 
@@ -165,7 +166,7 @@ class PrMergeLedger
     unknown_fields = ledgers.flat_map { |ledger| ledger.fetch("unknown_fields") }
 
     {
-      "$schema" => "https://reactonrails.com/schemas/pr-merge-ledger-v1.json",
+      "$schema" => SCHEMA_URI,
       "schema_version" => SCHEMA_VERSION,
       "generated_at" => Time.now.utc.iso8601,
       "repository" => datasets.first.fetch("repository"),
@@ -296,10 +297,14 @@ class PrMergeLedger
       "is_draft" => raw_pr["isDraft"],
       "base_ref" => raw_pr["baseRefName"],
       "head_ref" => raw_pr["headRefName"],
-      "head_sha" => raw_pr["headRefOid"] || UNKNOWN,
+      "head_sha" => blank_to_unknown(raw_pr["headRefOid"]),
       "merged_at" => raw_pr["mergedAt"],
-      "review_decision" => raw_pr["reviewDecision"] || UNKNOWN
+      "review_decision" => blank_to_unknown(raw_pr["reviewDecision"])
     }
+  end
+
+  def blank_to_unknown(value)
+    value.to_s.empty? ? UNKNOWN : value
   end
 
   def normalize_review_thread(thread, pull_request)
@@ -398,6 +403,8 @@ class PrMergeLedger
     return false if thread["isOutdated"] == true
     return false if comments.empty?
 
+    # Conservative fallback: if no comment can be confirmed as current-head by SHA but GitHub has not marked
+    # a comment outdated, block rather than silently miss an unresolved thread after a non-force push.
     current_thread_comment?(comments, pull_request) || comments.any? { |comment| !comment.fetch("outdated") }
   end
 
@@ -522,8 +529,7 @@ class PrMergeLedger
   end
 
   def normalize_finding_severity(raw_severity)
-    normalized = raw_severity.to_s.delete("[]").upcase.tr("- ", "_")
-    normalized == "MUST_FIX" ? "MUST_FIX" : normalized
+    raw_severity.to_s.delete("[]").upcase.tr("- ", "_")
   end
 
   def non_actionable_finding_summary?(line)
@@ -1061,8 +1067,7 @@ class PrMergeLedger
 
     def review_thread_comments_query
       <<~GRAPHQL
-        query($owner:String!, $name:String!, $threadId:ID!, $commentsCursor:String) {
-          repository(owner:$owner, name:$name) { id }
+        query($threadId:ID!, $commentsCursor:String) {
           node(id:$threadId) {
             ... on PullRequestReviewThread {
               comments(first:100, after:$commentsCursor) {

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -506,13 +506,19 @@ class PrMergeLedger
   end
 
   def findings_from_text(text, url, id, dispositions, used_disposition_keys)
-    text.to_s.each_line.with_index.flat_map do |line, index|
-      line_text = line.chomp
-      findings_from_line(line_text, index + 1, { url:, id: }, dispositions, used_disposition_keys)
+    lines = text.to_s.each_line.map(&:chomp)
+    source_finding_count = lines.sum do |line_text|
+      next 0 if non_actionable_finding_summary?(line_text)
+
+      finding_occurrences(line_text).length
+    end
+
+    lines.each_with_index.flat_map do |line_text, index|
+      findings_from_line(line_text, index + 1, { url:, id: }, dispositions, used_disposition_keys, source_finding_count)
     end
   end
 
-  def findings_from_line(line_text, source_line, source, dispositions, used_disposition_keys)
+  def findings_from_line(line_text, source_line, source, dispositions, used_disposition_keys, source_finding_count = nil)
     return [] if non_actionable_finding_summary?(line_text)
 
     occurrences = finding_occurrences(line_text)
@@ -520,6 +526,7 @@ class PrMergeLedger
 
     context = {
       multiple_markers: occurrences.length > 1,
+      source_finding_count: source_finding_count || occurrences.length,
       dispositions:,
       used_disposition_keys:
     }
@@ -532,7 +539,8 @@ class PrMergeLedger
     finding = source.merge(
       source_line:,
       marker_index: occurrence.fetch(:marker_index),
-      multiple_markers: context.fetch(:multiple_markers)
+      multiple_markers: context.fetch(:multiple_markers),
+      multiple_source_findings: context.fetch(:source_finding_count) > 1
     )
     disposition = disposition_for(finding, context.fetch(:dispositions), context.fetch(:used_disposition_keys))
 
@@ -631,6 +639,7 @@ class PrMergeLedger
     ]
 
     return marker_keys.compact if finding.fetch(:multiple_markers)
+    return marker_keys.concat(line_keys.take(2)).compact if finding.fetch(:multiple_source_findings)
 
     marker_keys.concat(line_keys).compact
   end
@@ -1033,21 +1042,12 @@ class PrMergeLedger
     end
 
     def capture_gh(args)
-      Timeout.timeout(github_api_timeout) do
+      timeout = GITHUB_API_TIMEOUT_SECONDS
+      Timeout.timeout(timeout) do
         Open3.capture3("gh", *args)
       end
     rescue Timeout::Error
-      raise Error, "gh api graphql timed out after #{github_api_timeout} seconds"
-    end
-
-    def github_api_timeout
-      raw_timeout = ENV["GITHUB_API_TIMEOUT"].to_s.strip
-      raw_timeout = GITHUB_API_TIMEOUT_SECONDS.to_s if raw_timeout.empty?
-
-      match = raw_timeout.match(/\A(?<seconds>\d+)(?:s)?\z/)
-      raise Error, "GITHUB_API_TIMEOUT must be an integer number of seconds" unless match
-
-      Integer(match[:seconds], 10)
+      raise Error, "gh api graphql timed out after #{timeout} seconds"
     end
 
     def metadata_query

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -33,6 +33,7 @@ class PrMergeLedger
   GITHUB_API_MAX_ATTEMPTS = 3
   GITHUB_API_RETRY_BASE_DELAY_SECONDS = 0.25
   MAX_GRAPHQL_PAGES = 500
+  GITHUB_REPO_NAME_PATTERN = /\A[A-Za-z0-9._-]+\z/
   LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
   FINDING_LINE_PREFIX_PATTERN = /(?:#{LIST_MARKER_PATTERN.source})?(?:\#{1,6}\s+)?/
   PRIORITY_MARKER_PATTERN = /MUST[- ]?FIX|\[?P[0-2]\]?/
@@ -226,7 +227,7 @@ class PrMergeLedger
     repo = @options[:repo] || detect_repo
     @options[:repo] = repo
     owner, name = repo.split("/", 2)
-    unless owner.to_s.match?(/\A\S+\z/) && name.to_s.match?(/\A\S+\z/)
+    unless owner.to_s.match?(GITHUB_REPO_NAME_PATTERN) && name.to_s.match?(GITHUB_REPO_NAME_PATTERN)
       raise Error, "repo must look like OWNER/REPO: #{repo.inspect}"
     end
 
@@ -454,10 +455,6 @@ class PrMergeLedger
     reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" && review.fetch("current_head") }
   end
 
-  def current_thread?(thread, comments, pull_request)
-    !current_thread_evidence(thread, comments, pull_request).nil?
-  end
-
   def current_thread_evidence(thread, comments, pull_request)
     return nil if thread["isOutdated"] == true
     return nil if comments.empty?
@@ -584,12 +581,23 @@ class PrMergeLedger
   end
 
   def finding_severity(line)
-    FINDING_PATTERNS.find { |_severity, pattern| line.match?(pattern) }&.first
+    primary_finding_match(line)&.first
+  end
+
+  def primary_finding_match(line)
+    FINDING_PATTERNS.each do |severity, pattern|
+      match = line.match(pattern)
+      return [severity, match] if match
+    end
+
+    nil
   end
 
   def finding_occurrences(line)
-    first_severity = finding_severity(line)
-    return [] unless first_severity
+    primary_match = primary_finding_match(line)
+    return [] unless primary_match
+
+    first_severity, first_match = primary_match
 
     occurrences = [{ severity: first_severity, source_column: 1, marker_index: 1 }]
     line.scan(ADDITIONAL_SEVERITY_PATTERN) do
@@ -600,7 +608,30 @@ class PrMergeLedger
         marker_index: occurrences.length + 1
       }
     end
+
+    append_uncovered_priority_occurrences(line, first_match.end(0), occurrences)
+    occurrences.sort_by! { |occurrence| occurrence.fetch(:source_column) }
+    occurrences.each_with_index { |occurrence, index| occurrence[:marker_index] = index + 1 }
     occurrences
+  end
+
+  def append_uncovered_priority_occurrences(line, first_marker_end, occurrences)
+    line.scan(PRIORITY_MARKER_PATTERN) do
+      match = Regexp.last_match
+      next if match.begin(0) < first_marker_end
+
+      gap = line[first_marker_end...match.begin(0)].to_s
+      next if gap.match?(/\A\s*\z/)
+
+      source_column = match.begin(0) + 1
+      next if occurrences.any? { |occurrence| occurrence.fetch(:source_column) == source_column }
+
+      occurrences << {
+        severity: normalize_finding_severity(match[0]),
+        source_column:,
+        marker_index: nil
+      }
+    end
   end
 
   def normalize_finding_severity(raw_severity)
@@ -719,9 +750,8 @@ class PrMergeLedger
   def timestamp_sort_key(raw_timestamp, warning_context = nil)
     Time.parse(raw_timestamp.to_s)
   rescue ArgumentError
-    if warning_context
-      warn "pr-merge-ledger: #{warning_context} has invalid timestamp #{raw_timestamp.inspect}; treating as oldest"
-    end
+    label = warning_context || "timestamp"
+    warn "pr-merge-ledger: #{label} has invalid timestamp #{raw_timestamp.inspect}; treating as oldest"
     Time.at(0).utc
   end
 
@@ -1040,7 +1070,7 @@ class PrMergeLedger
 
     def next_cursor(page_info, connection_name, previous_cursor)
       cursor = page_info.fetch("endCursor")
-      if cursor.nil? || cursor == previous_cursor
+      if cursor.nil? || cursor.to_s.empty? || cursor == previous_cursor
         raise Error, "pagination cursor did not advance for #{connection_name}"
       end
 
@@ -1083,10 +1113,7 @@ class PrMergeLedger
     def graphql(query, variables)
       args = ["api", "graphql", "-f", "owner=#{@owner}", "-f", "name=#{@name}", "-f", "query=#{query}"]
       variables.each do |key, value|
-        next if value.nil?
-
-        flag = value.is_a?(Integer) ? "-F" : "-f"
-        args.push(flag, "#{key}=#{value}")
+        append_graphql_variable(args, key, value)
       end
 
       stdout, stderr, status = capture_gh_with_retries(args)
@@ -1100,15 +1127,32 @@ class PrMergeLedger
       end
     end
 
+    def append_graphql_variable(args, key, value)
+      return if value.nil?
+
+      value_string = value.to_s
+      if !value.is_a?(Integer) && value_string.start_with?("@")
+        raise Error, "gh api graphql variable #{key} cannot start with @"
+      end
+
+      flag = value.is_a?(Integer) ? "-F" : "-f"
+      args.push(flag, "#{key}=#{value_string}")
+    end
+
     def capture_gh_with_retries(args)
       attempt = 0
       loop do
         attempt += 1
         stdout, stderr, status = capture_gh(args)
         return [stdout, stderr, status] if status.success? || attempt >= GITHUB_API_MAX_ATTEMPTS
+        return [stdout, stderr, status] if non_retryable_gh_error?(stderr)
 
         sleep(GITHUB_API_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)))
       end
+    end
+
+    def non_retryable_gh_error?(stderr)
+      stderr.to_s.match?(/\b(?:401|403|404|422|Not Found|Unauthorized|Forbidden)\b/i)
     end
 
     def capture_gh(args)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -76,7 +76,7 @@ class PrMergeLedger
       (?:\s*/\s*(?:#{PRIORITY_MARKER_PATTERN.source}))*(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z}ix
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /
-    \bnone(?!\s+of\b)(?=\s*(?:$|[.;,)])) |
+    \bnone(?!\s+of\b)(?=\s*(?:$|[.;,)]|\b(?:open|remaining)\b)) |
     \b(?:findings?|issues?|items?|main\s+issue)\b
     (?:
       \s*[:=-]\s* |
@@ -377,7 +377,7 @@ class PrMergeLedger
   end
 
   def blank_to_unknown(value)
-    value.to_s.empty? ? UNKNOWN : value
+    value.nil? || value.to_s.empty? ? UNKNOWN : value
   end
 
   def normalize_review_thread(thread, pull_request)
@@ -1263,11 +1263,9 @@ class PrMergeLedger
       raise Error, "gh api graphql variable key cannot contain '=': #{key}" if key.to_s.include?("=")
 
       value_string = value.to_s
-      if value.is_a?(String) && value_string.start_with?("@")
-        raise Error, "gh api graphql variable #{key} cannot start with @"
-      end
+      raise Error, "gh api graphql variable #{key} cannot start with @" if value_string.start_with?("@")
 
-      flag = value.is_a?(Integer) ? "-F" : "-f"
+      flag = value.is_a?(Integer) || value == true || value == false ? "-F" : "-f"
       args.push(flag, "#{key}=#{value_string}")
     end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -483,12 +483,16 @@ class PrMergeLedger
   def latest_reviews_by_reviewer(reviews)
     latest_reviews = reviews.group_by { |review| review.fetch("reviewer") }
                             .map do |_reviewer, reviewer_reviews|
-                              reviewer_reviews.max_by do |review|
-                                timestamp_sort_key(review["submitted_at"], "review #{review.fetch('id')} submitted_at")
-                              end
+                              latest_review_by_timestamp_and_order(reviewer_reviews)
                             end
 
     latest_reviews.sort_by { |review| review.fetch("reviewer") }
+  end
+
+  def latest_review_by_timestamp_and_order(reviewer_reviews)
+    reviewer_reviews.each_with_index.max_by do |review, index|
+      [timestamp_sort_key(review["submitted_at"], "review #{review.fetch('id')} submitted_at"), index]
+    end.first
   end
 
   def current_changes_requested(reviews)
@@ -502,9 +506,7 @@ class PrMergeLedger
            .group_by { |review| review.fetch("reviewer") }
            .values
            .map do |reviewer_reviews|
-             reviewer_reviews.max_by do |review|
-               timestamp_sort_key(review["submitted_at"], "review #{review.fetch('id')} submitted_at")
-             end
+             latest_review_by_timestamp_and_order(reviewer_reviews)
            end
   end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -34,9 +34,14 @@ class PrMergeLedger
   GITHUB_API_RETRY_BASE_DELAY_SECONDS = 0.25
   MAX_GRAPHQL_PAGES = 500
   GITHUB_REPO_NAME_PATTERN = /\A[A-Za-z0-9._-]+\z/
-  LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
+  LIST_MARKER_PATTERN = /(?:[-*]\s*(?:\[[ xX]\]\s*)?|\d+[.)]\s*)/
   FINDING_LINE_PREFIX_PATTERN = /(?:#{LIST_MARKER_PATTERN.source})?(?:\#{1,6}\s+)?/
   PRIORITY_MARKER_PATTERN = /MUST[- ]?FIX|\[?P[0-2]\]?/
+  STANDALONE_PRIORITY_MARKER_PATTERN = /
+    (?<![A-Za-z0-9])
+    (?:#{PRIORITY_MARKER_PATTERN.source})
+    (?![A-Za-z0-9])
+  /ix
   FINDING_BADGE_PREFIX = %r{
     \A\s*(?:#{FINDING_LINE_PREFIX_PATTERN.source})(?:\*\*)?
     <sub><sub>!\[%<severity>s\s+Badge\]\([^)]+\)</sub></sub>
@@ -616,7 +621,7 @@ class PrMergeLedger
   end
 
   def append_uncovered_priority_occurrences(line, first_marker_end, occurrences)
-    line.scan(PRIORITY_MARKER_PATTERN) do
+    line.scan(STANDALONE_PRIORITY_MARKER_PATTERN) do
       match = Regexp.last_match
       next if match.begin(0) < first_marker_end
 
@@ -683,7 +688,7 @@ class PrMergeLedger
   end
 
   def priority_marker_count(text)
-    text.to_s.scan(PRIORITY_MARKER_PATTERN).length
+    text.to_s.scan(STANDALONE_PRIORITY_MARKER_PATTERN).length
   end
 
   def disposition_for(finding, dispositions, used_disposition_keys)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -30,6 +30,8 @@ class PrMergeLedger
     bun.lockb
   ].freeze
   DEFAULT_GITHUB_API_TIMEOUT_SECONDS = "30"
+  GITHUB_API_MAX_ATTEMPTS = 3
+  GITHUB_API_RETRY_BASE_DELAY_SECONDS = 0.25
   MAX_GRAPHQL_PAGES = 500
   LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
   FINDING_LINE_PREFIX_PATTERN = /(?:#{LIST_MARKER_PATTERN.source})?(?:\#{1,6}\s+)?/
@@ -1079,8 +1081,7 @@ class PrMergeLedger
     end
 
     def graphql(query, variables)
-      args = ["api", "graphql", "--retry", "3", "-f", "owner=#{@owner}", "-f", "name=#{@name}", "-f",
-              "query=#{query}"]
+      args = ["api", "graphql", "-f", "owner=#{@owner}", "-f", "name=#{@name}", "-f", "query=#{query}"]
       variables.each do |key, value|
         next if value.nil?
 
@@ -1088,7 +1089,7 @@ class PrMergeLedger
         args.push(flag, "#{key}=#{value}")
       end
 
-      stdout, stderr, status = capture_gh(args)
+      stdout, stderr, status = capture_gh_with_retries(args)
       raise Error, "gh api graphql failed: #{stderr.strip}" unless status.success?
 
       JSON.parse(stdout).tap do |parsed|
@@ -1096,6 +1097,17 @@ class PrMergeLedger
 
         messages = parsed.fetch("errors").map { |error| error.fetch("message", error.inspect) }
         raise Error, "gh api graphql returned errors: #{messages.join('; ')}"
+      end
+    end
+
+    def capture_gh_with_retries(args)
+      attempt = 0
+      loop do
+        attempt += 1
+        stdout, stderr, status = capture_gh(args)
+        return [stdout, stderr, status] if status.success? || attempt >= GITHUB_API_MAX_ATTEMPTS
+
+        sleep(GITHUB_API_RETRY_BASE_DELAY_SECONDS * (2**(attempt - 1)))
       end
     end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -61,7 +61,7 @@ class PrMergeLedger
     /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /
-    \bnone(?!\s+of\b) |
+    \bnone(?!\s+of\b)(?=\s*(?:$|[.;,)])) |
     \b(?:findings?|issues?|items?|main\s+issue)\b
     (?:
       \s*[:=-]\s* |
@@ -75,8 +75,11 @@ class PrMergeLedger
     /\b(?:none|nothing)\s+(?:fixed|resolved|waived)\b/i,
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
-  ADDITIONAL_SEVERITY_PATTERN =
-    /(?:[.;,(:-]|\b(?:and|but|while)\b)\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+  ADDITIONAL_SEVERITY_PATTERN = /
+    (?:[.;,(:-]|\b(?:and|but|while)\b)\s*
+    (?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
+    (?:\s|:|-|$)
+  /ix
 
   class Error < StandardError; end
 
@@ -153,15 +156,21 @@ class PrMergeLedger
       opts.on("--pretty", "Pretty-print JSON output.") do
         @options[:pretty] = true
       end
-      opts.on("--finding-dispositions FILE", "JSON map from finding URL/id, URL#L<line>, or URL#L<line>:<n>.") do |path|
-        @options[:finding_dispositions] = path
-      end
+      add_finding_dispositions_option(opts)
       opts.on("--changelog-classification CLASS", CHANGELOG_CLASSIFICATIONS) do |classification|
         @options[:changelog_classification] = classification
         @options[:changelog_classification_provided] = true
       end
       add_help_option(opts)
     end
+  end
+
+  def add_finding_dispositions_option(opts)
+    opts.on("--finding-dispositions FILE", "JSON map from finding URL/id, URL#L<line>, or URL#L<line>:<n>.") do |path|
+      @options[:finding_dispositions] = path
+    end
+    opts.separator "    Top-level PR comments have no head SHA; priority findings in those comments " \
+                   "require dispositions."
   end
 
   def add_help_option(opts)
@@ -234,7 +243,7 @@ class PrMergeLedger
     if @options[:fixture]
       { "mode" => "fixture", "path" => @options[:fixture] }
     else
-      { "mode" => "live_github", "repo" => @options[:repo] || "auto", "prs" => @argv.map(&:to_i) }
+      { "mode" => "live_github", "repo" => @options[:repo], "prs" => @argv.map(&:to_i) }
     end
   end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -245,9 +245,13 @@ class PrMergeLedger
 
     collector = GitHubCollector.new(owner, name)
     @argv.map do |pr_number|
-      collector.fetch(Integer(pr_number, 10)).merge("repository" => repo)
-    rescue ArgumentError
-      raise Error, "PR number must be an integer: #{pr_number.inspect}"
+      begin
+        pr_int = Integer(pr_number, 10)
+      rescue ArgumentError
+        raise Error, "PR number must be an integer: #{pr_number.inspect}"
+      end
+
+      collector.fetch(pr_int).merge("repository" => repo)
     end
   end
 
@@ -412,7 +416,7 @@ class PrMergeLedger
     review = comment["pullRequestReview"] || {}
 
     {
-      "id" => comment["id"] || comment["databaseId"].to_s,
+      "id" => review_thread_comment_identifier(comment),
       "url" => comment["url"],
       "path" => comment["path"],
       "line" => comment["line"],
@@ -425,6 +429,13 @@ class PrMergeLedger
       "comment_head_sha" => comment.dig("commit", "oid"),
       "current_head" => comment.dig("commit", "oid") == pull_request.fetch("head_sha")
     }
+  end
+
+  def review_thread_comment_identifier(comment)
+    identifier = comment["id"] || comment["databaseId"] || comment["url"]
+    return identifier.to_s if identifier.to_s.match?(/\S/)
+
+    raise Error, "review thread comment is missing id, databaseId, and url"
   end
 
   def normalize_review(review, pull_request)
@@ -1172,7 +1183,7 @@ class PrMergeLedger
     end
 
     def non_retryable_gh_error?(stderr)
-      stderr.to_s.match?(/\b(?:401|403|404|422|Not Found|Unauthorized|Forbidden)\b/i)
+      stderr.to_s.match?(/\b(?:401|403|404|Not Found|Unauthorized|Forbidden)\b/i)
     end
 
     def capture_gh(args)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -60,7 +60,11 @@ class PrMergeLedger
     /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived)\b/i
-  NEGATED_SUMMARY_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i
+  NEGATED_SUMMARY_RESOLUTION_PATTERN = Regexp.union(
+    /\bnot\s+(?:yet\s+)?(?:fixed|resolved|waived)\b/i,
+    /\b(?:none|nothing)\s+(?:fixed|resolved|waived)\b/i,
+    /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
+  )
   ADDITIONAL_SEVERITY_PATTERN =
     /[.;,(]\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -232,7 +232,7 @@ class PrMergeLedger
     output_issue_comments = issue_comments.map { |comment| comment.except("body") }
     latest_reviews = latest_reviews_by_reviewer(output_reviews)
     all_changes_requested = output_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
-    changes_requested = latest_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
+    changes_requested = current_changes_requested(latest_reviews)
     finding_dispositions = finding_dispositions(review_threads, reviews, issue_comments, dispositions)
     changelog = changelog_classification
     lockfile = lockfile_diff(files)
@@ -386,6 +386,10 @@ class PrMergeLedger
     latest_reviews.sort_by { |review| review.fetch("reviewer") }
   end
 
+  def current_changes_requested(reviews)
+    reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" && review.fetch("current_head") }
+  end
+
   def current_thread?(thread, comments, pull_request)
     return false if thread["isOutdated"] == true
     return false if comments.empty?
@@ -446,7 +450,7 @@ class PrMergeLedger
   end
 
   def reviews_for_findings(reviews)
-    latest_reviews_by_reviewer(reviews).select { |review| review.fetch("current_head") }
+    reviews.select { |review| review.fetch("current_head") }
   end
 
   def findings_from_text(text, url, id, dispositions, used_disposition_keys)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -20,7 +20,7 @@ class PrMergeLedger
     not_user_visible
     UNKNOWN
   ].freeze
-  DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable UNKNOWN].freeze
+  DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable].freeze
   REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze
   LOCKFILE_BASENAMES = %w[
     Gemfile.lock
@@ -106,7 +106,10 @@ class PrMergeLedger
   class Error < StandardError; end
 
   def self.github_api_timeout_seconds
-    Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", DEFAULT_GITHUB_API_TIMEOUT_SECONDS), 10)
+    timeout = Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", DEFAULT_GITHUB_API_TIMEOUT_SECONDS), 10)
+    return timeout if timeout.positive?
+
+    raise Error, "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be a positive integer (seconds)"
   rescue ArgumentError
     raise Error, "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be an integer (seconds)"
   end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -29,10 +29,11 @@ class PrMergeLedger
     bun.lock
     bun.lockb
   ].freeze
-  GITHUB_API_TIMEOUT_SECONDS = 30
+  GITHUB_API_TIMEOUT_SECONDS = Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", "30"), 10)
   MAX_GRAPHQL_PAGES = 500
+  LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
   FINDING_BADGE_PREFIX = %r{
-    \A\s*(?:[-*]\s*)?(?:\*\*)?
+    \A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?
     <sub><sub>!\[%<severity>s\s+Badge\]\([^)]+\)</sub></sub>
     (?:\*\*)?(?:\s|:|-|$)
   }ix
@@ -43,22 +44,22 @@ class PrMergeLedger
     ]
   end.freeze
   FINDING_PATTERNS = {
-    "MUST_FIX" => /\A\s*(?:[-*]\s*)?(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|$)/i,
+    "MUST_FIX" => /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|$)/i,
     "P0" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P0"),
-      /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|$)/i
+      /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|$)/i
     ),
     "P1" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P1"),
-      /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|$)/i
+      /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|$)/i
     ),
     "P2" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P2"),
-      /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|$)/i
+      /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|$)/i
     )
   }.freeze
   FINDING_SUMMARY_PREFIX_PATTERN =
-    /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
+    /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /
     \bnone(?!\s+of\b)(?=\s*(?:$|[.;,)])) |
@@ -76,8 +77,8 @@ class PrMergeLedger
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN = /
-    (?:[.;,(:-]|\b(?:and|but|while)\b)\s*
-    (?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
+    (?:(?<!\d)[.;,(:-]|\b(?:and|but|while)\b)\s*
+    (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
     (?:\s|:|-|$)
   /ix
 
@@ -218,10 +219,14 @@ class PrMergeLedger
   end
 
   def detect_repo
-    stdout, stderr, status = Open3.capture3("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
-    raise Error, "could not detect gh repo: #{stderr.strip}" unless status.success?
+    Timeout.timeout(GITHUB_API_TIMEOUT_SECONDS) do
+      stdout, stderr, status = Open3.capture3("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+      raise Error, "could not detect gh repo: #{stderr.strip}" unless status.success?
 
-    stdout.strip
+      stdout.strip
+    end
+  rescue Timeout::Error
+    raise Error, "gh repo view timed out after #{GITHUB_API_TIMEOUT_SECONDS} seconds"
   end
 
   def load_fixture(path)
@@ -553,7 +558,7 @@ class PrMergeLedger
     return [] unless first_severity
 
     occurrences = [{ severity: first_severity, source_column: 1, marker_index: 1 }]
-    line.to_enum(:scan, ADDITIONAL_SEVERITY_PATTERN).each do
+    line.scan(ADDITIONAL_SEVERITY_PATTERN) do
       match = Regexp.last_match
       occurrences << {
         severity: normalize_finding_severity(match[:severity]),

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -575,6 +575,7 @@ class PrMergeLedger
   def thread_comments_for_findings(review_threads)
     review_threads
       .select { |thread| unresolved_current_head_thread?(thread) }
+      # Incomplete comment pages are blocked through unknown_fields; unfetched bodies cannot be scanned for priorities.
       .flat_map { |thread| thread.fetch("comments") }
       .reject { |comment| comment.fetch("outdated") }
   end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -5,7 +5,6 @@ require "json"
 require "open3"
 require "optparse"
 require "time"
-require "timeout"
 
 # rubocop:disable Metrics/ClassLength
 class PrMergeLedger
@@ -113,6 +112,47 @@ class PrMergeLedger
     raise Error, "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be a positive integer (seconds)"
   rescue ArgumentError
     raise Error, "PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS must be an integer (seconds)"
+  end
+
+  def self.capture_command_with_timeout(args, timeout:, timeout_message:)
+    Open3.popen3(*args) do |stdin, stdout, stderr, wait_thread|
+      stdin.close
+      stdout_reader = Thread.new { read_stream(stdout) }
+      stderr_reader = Thread.new { read_stream(stderr) }
+
+      unless wait_thread.join(timeout)
+        terminate_process(wait_thread.pid, wait_thread)
+        close_io(stdout)
+        close_io(stderr)
+        stdout_reader.join(1)
+        stderr_reader.join(1)
+        raise Error, timeout_message
+      end
+
+      [stdout_reader.value, stderr_reader.value, wait_thread.value]
+    end
+  end
+
+  def self.terminate_process(pid, wait_thread)
+    Process.kill("TERM", pid)
+    return if wait_thread.join(1)
+
+    Process.kill("KILL", pid)
+    wait_thread.join(1)
+  rescue Errno::ESRCH
+    nil
+  end
+
+  def self.close_io(io)
+    io.close unless io.closed?
+  rescue IOError
+    nil
+  end
+
+  def self.read_stream(io)
+    io.read
+  rescue IOError
+    ""
   end
 
   def self.run(argv)
@@ -266,14 +306,14 @@ class PrMergeLedger
 
   def detect_repo
     timeout = self.class.github_api_timeout_seconds
-    Timeout.timeout(timeout) do
-      stdout, stderr, status = Open3.capture3("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
-      raise Error, "could not detect gh repo: #{stderr.strip}" unless status.success?
+    stdout, stderr, status = self.class.capture_command_with_timeout(
+      ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+      timeout:,
+      timeout_message: "gh repo view timed out after #{timeout} seconds"
+    )
+    raise Error, "could not detect gh repo: #{stderr.strip}" unless status.success?
 
-      stdout.strip
-    end
-  rescue Timeout::Error
-    raise Error, "gh repo view timed out after #{timeout} seconds"
+    stdout.strip
   end
 
   def load_fixture(path)
@@ -1329,18 +1369,16 @@ class PrMergeLedger
     end
 
     def non_retryable_gh_error?(stderr)
-      stderr.to_s.match?(/\b(?:401|403|404|429)\b|\b(?:Not Found|Unauthorized|Forbidden|Too Many Requests)\b/i)
+      stderr.to_s.match?(/\b4\d{2}\b|\b(?:Not Found|Unauthorized|Forbidden|Too Many Requests)\b/i)
     end
 
     def capture_gh(args)
       timeout = PrMergeLedger.github_api_timeout_seconds
-      # Timeout.timeout can interrupt Open3 mid-IO. The risk is acceptable for
-      # short-lived gh calls only; do not extend this pattern to stateful subprocesses.
-      Timeout.timeout(timeout) do
-        Open3.capture3("gh", *args)
-      end
-    rescue Timeout::Error
-      raise Error, "gh api graphql timed out after #{timeout} seconds"
+      PrMergeLedger.capture_command_with_timeout(
+        ["gh", *args],
+        timeout:,
+        timeout_message: "gh api graphql timed out after #{timeout} seconds"
+      )
     end
 
     def metadata_query

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -11,7 +11,7 @@ require "timeout"
 class PrMergeLedger
   SCHEMA_VERSION = "pr-merge-ledger/v1"
   UNKNOWN = "UNKNOWN"
-  SCHEMA_URI = "script/pr-merge-ledger.schema.json"
+  SCHEMA_URI = "https://raw.githubusercontent.com/shakacode/react_on_rails/main/script/pr-merge-ledger.schema.json"
   SCHEMA_PATH = File.expand_path("pr-merge-ledger.schema.json", __dir__)
   CHANGELOG_CLASSIFICATIONS = %w[
     changelog_present
@@ -60,14 +60,23 @@ class PrMergeLedger
   FINDING_SUMMARY_PREFIX_PATTERN =
     /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
-  FINDING_SUMMARY_RESOLUTION_PATTERN = /\b(?:none|fixed|resolved|waived)\b/i
+  FINDING_SUMMARY_RESOLUTION_PATTERN = /
+    \bnone(?!\s+of\b) |
+    \b(?:findings?|issues?|items?|main\s+issue)\b
+    (?:
+      \s*[:=-]\s* |
+      (?:\s+(?:were|was|are|is|has|have|been|got|now|already|previously))*\s+
+    )
+    (?:fixed|resolved|waived)
+    (?=\s*(?:$|[.;,)]|\b(?:by|in|with|via|from|after|before|on|because|through)\b))
+  /ix
   NEGATED_SUMMARY_RESOLUTION_PATTERN = Regexp.union(
     /\bnot\s+(?:\S+\s+){0,3}?(?:fixed|resolved|waived)\b/i,
     /\b(?:none|nothing)\s+(?:fixed|resolved|waived)\b/i,
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN =
-    /(?:[.;,(:-]|\b(?:and|but)\b)\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
+    /(?:[.;,(:-]|\b(?:and|but|while)\b)\s*(?:[-*]\s*)?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-|$)/i
 
   class Error < StandardError; end
 
@@ -115,6 +124,11 @@ class PrMergeLedger
   end
 
   def validate_options
+    if @options[:fixture] && !@argv.empty?
+      raise Error, "PR number args (#{@argv.join(', ')}) are ignored when --fixture is given; " \
+                   "remove them or omit --fixture"
+    end
+
     return unless @argv.length > 1 && @options[:changelog_classification_provided]
 
     raise Error,
@@ -273,6 +287,8 @@ class PrMergeLedger
   # rubocop:enable Metrics/AbcSize
 
   def file_paths(dataset)
+    return nil unless dataset.key?("files") && !dataset["files"].nil?
+
     Array(dataset["files"]).map { |file| file.is_a?(Hash) ? file.fetch("path") : file }
   end
 
@@ -311,6 +327,7 @@ class PrMergeLedger
     comments, comments_complete = review_thread_comments(thread)
     normalized_comments = comments.map { |comment| normalize_thread_comment(comment, pull_request) }
     latest_comment = normalized_comments.max_by { |comment| timestamp_sort_key(comment["created_at"]) }
+    current_head_evidence = current_thread_evidence(thread, normalized_comments, pull_request)
 
     {
       "id" => thread.fetch("id"),
@@ -325,7 +342,8 @@ class PrMergeLedger
       "review_state" => latest_comment&.fetch("review_state", nil),
       "review_head_sha" => latest_comment&.fetch("review_head_sha", nil),
       "comment_head_sha" => latest_comment&.fetch("comment_head_sha", nil),
-      "current_head" => current_thread?(thread, normalized_comments, pull_request),
+      "current_head" => !current_head_evidence.nil?,
+      "current_head_evidence" => current_head_evidence,
       "comments_complete" => comments_complete,
       "comments" => normalized_comments
     }
@@ -389,7 +407,9 @@ class PrMergeLedger
   def latest_reviews_by_reviewer(reviews)
     latest_reviews = reviews.group_by { |review| review.fetch("reviewer") }
                             .map do |_reviewer, reviewer_reviews|
-                              reviewer_reviews.max_by { |review| timestamp_sort_key(review["submitted_at"]) }
+                              reviewer_reviews.max_by do |review|
+                                timestamp_sort_key(review["submitted_at"], "review #{review.fetch('id')} submitted_at")
+                              end
                             end
 
     latest_reviews.sort_by { |review| review.fetch("reviewer") }
@@ -400,12 +420,19 @@ class PrMergeLedger
   end
 
   def current_thread?(thread, comments, pull_request)
-    return false if thread["isOutdated"] == true
-    return false if comments.empty?
+    !current_thread_evidence(thread, comments, pull_request).nil?
+  end
+
+  def current_thread_evidence(thread, comments, pull_request)
+    return nil if thread["isOutdated"] == true
+    return nil if comments.empty?
 
     # Conservative fallback: if no comment can be confirmed as current-head by SHA but GitHub has not marked
     # a comment outdated, block rather than silently miss an unresolved thread after a non-force push.
-    current_thread_comment?(comments, pull_request) || comments.any? { |comment| !comment.fetch("outdated") }
+    return "sha_match" if current_thread_comment?(comments, pull_request)
+    return "conservative_non_outdated" if comments.any? { |comment| !comment.fetch("outdated") }
+
+    nil
   end
 
   def current_thread_comment?(comments, pull_request)
@@ -589,7 +616,9 @@ class PrMergeLedger
       id
     ]
 
-    marker_keys.concat(finding.fetch(:multiple_markers) ? [url, id] : line_keys).compact
+    return marker_keys.compact if finding.fetch(:multiple_markers)
+
+    marker_keys.concat(line_keys).compact
   end
 
   def warn_unused_dispositions(dispositions, used_disposition_keys)
@@ -605,9 +634,12 @@ class PrMergeLedger
     raise Error, "finding disposition #{disposition.inspect} must be one of #{DISPOSITIONS.join(', ')}"
   end
 
-  def timestamp_sort_key(raw_timestamp)
+  def timestamp_sort_key(raw_timestamp, warning_context = nil)
     Time.parse(raw_timestamp.to_s)
   rescue ArgumentError
+    if warning_context
+      warn "pr-merge-ledger: #{warning_context} has invalid timestamp #{raw_timestamp.inspect}; treating as oldest"
+    end
     Time.at(0).utc
   end
 
@@ -619,6 +651,14 @@ class PrMergeLedger
   end
 
   def lockfile_diff(files)
+    if files.nil?
+      return {
+        "status" => UNKNOWN,
+        "has_lockfile_diff" => UNKNOWN,
+        "files" => []
+      }
+    end
+
     lockfiles = files.select { |path| lockfile_path?(path) }
     {
       "status" => "known",

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -32,6 +32,7 @@ class PrMergeLedger
   GITHUB_API_TIMEOUT_SECONDS = Integer(ENV.fetch("PR_MERGE_LEDGER_GITHUB_API_TIMEOUT_SECONDS", "30"), 10)
   MAX_GRAPHQL_PAGES = 500
   LIST_MARKER_PATTERN = /(?:[-*]|\d+[.)])\s*/
+  PRIORITY_MARKER_PATTERN = /MUST[- ]?FIX|\[?P[0-2]\]?/
   FINDING_BADGE_PREFIX = %r{
     \A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?
     <sub><sub>!\[%<severity>s\s+Badge\]\([^)]+\)</sub></sub>
@@ -44,22 +45,23 @@ class PrMergeLedger
     ]
   end.freeze
   FINDING_PATTERNS = {
-    "MUST_FIX" => /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|$)/i,
+    "MUST_FIX" => %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|/|$)}i,
     "P0" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P0"),
-      /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|$)/i
+      %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|/|$)}i
     ),
     "P1" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P1"),
-      /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|$)/i
+      %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|/|$)}i
     ),
     "P2" => Regexp.union(
       BADGE_FINDING_PATTERNS.fetch("P2"),
-      /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|$)/i
+      %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|/|$)}i
     )
   }.freeze
   FINDING_SUMMARY_PREFIX_PATTERN =
-    /\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z/i
+    %r{\A\s*(?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?:#{PRIORITY_MARKER_PATTERN.source})
+      (?:\s*/\s*(?:#{PRIORITY_MARKER_PATTERN.source}))*(?:\*\*)?(?:\s|:|-)+(?<summary>.*)\z}ix
   FINDING_SUMMARY_SUBJECT_PATTERN = /\b(?:findings?|issues?|items?|main issue)\b/i
   FINDING_SUMMARY_RESOLUTION_PATTERN = /
     \bnone(?!\s+of\b)(?=\s*(?:$|[.;,)])) |
@@ -76,11 +78,11 @@ class PrMergeLedger
     /\b(?:none|nothing)\s+(?:fixed|resolved|waived)\b/i,
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
-  ADDITIONAL_SEVERITY_PATTERN = /
-    (?:(?<!\d)[.;,(:-]|\b(?:and|but|while)\b)\s*
+  ADDITIONAL_SEVERITY_PATTERN = %r{
+    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|while)\b)\s*
     (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
-    (?:\s|:|-|$)
-  /ix
+    (?:\s|:|-|/|$)
+  }ix
 
   class Error < StandardError; end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -19,7 +19,6 @@ class PrMergeLedger
     changelog_missing
     deferred_to_update_changelog
     not_user_visible
-    UNKNOWN
   ].freeze
   DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable].freeze
   REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -598,10 +598,8 @@ class PrMergeLedger
     occurrences = finding_occurrences(line_text)
     return [] if occurrences.empty?
 
-    source_finding_count = context.fetch(:source_finding_count) || occurrences.length
     finding_context = context.merge(
-      multiple_markers: occurrences.length > 1,
-      source_finding_count:
+      multiple_markers: occurrences.length > 1
     )
     occurrences.map do |occurrence|
       finding_from_occurrence(line_text, source_line, source, occurrence, finding_context)
@@ -1147,7 +1145,17 @@ class PrMergeLedger
       page_info = raw_comments.fetch("pageInfo")
       return thread unless page_info.fetch("hasNextPage")
 
-      nodes = raw_comments.fetch("nodes")
+      completed_comments = raw_comments.merge("nodes" => raw_comments.fetch("nodes").dup)
+      page_info = append_remaining_review_thread_comments(
+        thread.fetch("id"),
+        completed_comments.fetch("nodes"),
+        page_info
+      )
+      completed_comments["pageInfo"] = page_info
+      thread.merge("comments" => completed_comments)
+    end
+
+    def append_remaining_review_thread_comments(thread_id, nodes, page_info)
       cursor = page_info.fetch("endCursor")
       page_count = 0
 
@@ -1157,9 +1165,9 @@ class PrMergeLedger
           raise Error, "pagination exceeded #{MAX_GRAPHQL_PAGES} pages for reviewThread.comments"
         end
 
-        response = graphql(review_thread_comments_query, threadId: thread.fetch("id"), commentsCursor: cursor)
+        response = graphql(review_thread_comments_query, threadId: thread_id, commentsCursor: cursor)
         fetched_thread = response.dig("data", "node")
-        raise Error, "review thread #{thread.fetch('id')} was not found" unless fetched_thread
+        raise Error, "review thread #{thread_id} was not found" unless fetched_thread
 
         connection = fetched_thread.fetch("comments")
         nodes.concat(connection.fetch("nodes"))
@@ -1169,8 +1177,7 @@ class PrMergeLedger
         cursor = next_cursor(page_info, "reviewThread.comments", cursor)
       end
 
-      raw_comments["pageInfo"] = page_info
-      thread
+      page_info
     end
 
     def graphql(query, variables)
@@ -1194,7 +1201,7 @@ class PrMergeLedger
       return if value.nil?
 
       value_string = value.to_s
-      if !value.is_a?(Integer) && value_string.start_with?("@")
+      if value.is_a?(String) && value_string.start_with?("@")
         raise Error, "gh api graphql variable #{key} cannot start with @"
       end
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -94,7 +94,7 @@ class PrMergeLedger
     /\bno\s+(?:\S+\s+){0,4}?(?:fixed|resolved|waived)\b/i
   )
   ADDITIONAL_SEVERITY_PATTERN = %r{
-    (?:(?<!\d)[.;,(:-]|/|\b(?:and|but|however|or|while|with)\b)\s*
+    (?:(?<!\d)[.;,(:-]|(?<![A-Za-z0-9])/|\b(?:and|but|however|or|while|with)\b)\s*
     (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
     (?:\s|:|-|/|$)
   }ix
@@ -170,8 +170,8 @@ class PrMergeLedger
 
     return unless @options[:strict] && @argv.length > 1
 
-    warn "pr-merge-ledger: --strict with multiple PRs always fails until each PR has a " \
-         "non-UNKNOWN changelog classification"
+    raise Error, "--strict with multiple PRs requires separate per-PR runs with explicit " \
+                 "--changelog-classification"
   end
 
   def build_option_parser
@@ -594,19 +594,23 @@ class PrMergeLedger
       lines = lines.first(MAX_BODY_LINES)
     end
 
-    source_finding_count = lines.sum do |line_text|
-      next 0 if non_actionable_finding_summary?(line_text)
+    finding_lines = lines.each_with_index.filter_map do |line_text, index|
+      next if non_actionable_finding_summary?(line_text)
 
-      finding_occurrences(line_text).length
+      occurrences = finding_occurrences(line_text)
+      next if occurrences.empty?
+
+      [line_text, index + 1, occurrences]
     end
+    source_finding_count = finding_lines.sum { |(_line_text, _source_line, occurrences)| occurrences.length }
     line_context = {
       source_finding_count:,
       dispositions: context.fetch(:dispositions),
       used_disposition_keys: context.fetch(:used_disposition_keys)
     }
 
-    lines.each_with_index.flat_map do |line_text, index|
-      findings_from_line(line_text, index + 1, { url:, id: }, line_context)
+    finding_lines.flat_map do |line_text, source_line, occurrences|
+      findings_from_occurrences(line_text, source_line, { url:, id: }, occurrences, line_context)
     end
   end
 
@@ -616,6 +620,10 @@ class PrMergeLedger
     occurrences = finding_occurrences(line_text)
     return [] if occurrences.empty?
 
+    findings_from_occurrences(line_text, source_line, source, occurrences, context)
+  end
+
+  def findings_from_occurrences(line_text, source_line, source, occurrences, context)
     finding_context = context.merge(
       multiple_markers: occurrences.length > 1
     )
@@ -665,7 +673,11 @@ class PrMergeLedger
 
     first_severity, first_match = primary_match
 
-    occurrences = [{ severity: first_severity, source_column: 1, marker_index: 1 }]
+    occurrences = [{
+      severity: first_severity,
+      source_column: primary_finding_source_column(line, first_severity, first_match),
+      marker_index: 1
+    }]
     line.scan(ADDITIONAL_SEVERITY_PATTERN) do
       match = Regexp.last_match
       occurrences << {
@@ -687,7 +699,11 @@ class PrMergeLedger
       next if match.begin(0) < first_marker_end
 
       gap = line[first_marker_end...match.begin(0)].to_s
-      next if gap.match?(/\A\s*\z/)
+      if gap.match?(/\A\s*\z/)
+        next unless match.begin(0).positive? && line[match.begin(0) - 1] == "/"
+      else
+        next unless separate_finding_gap?(gap)
+      end
 
       source_column = match.begin(0) + 1
       next if occurrences.any? { |occurrence| occurrence.fetch(:source_column) == source_column }
@@ -698,6 +714,26 @@ class PrMergeLedger
         marker_index: nil
       }
     end
+  end
+
+  def primary_finding_source_column(line, severity, match)
+    marker_pattern =
+      if severity == "MUST_FIX"
+        /MUST[- ]?FIX/i
+      else
+        /\[?#{Regexp.escape(severity)}\]?/i
+      end
+    matched_text = line[match.begin(0)...match.end(0)].to_s
+    marker_offset = matched_text.index(marker_pattern) || 0
+
+    match.begin(0) + marker_offset + 1
+  end
+
+  def separate_finding_gap?(gap)
+    return true if gap.match?(%r{\A\s*/\s*\z})
+
+    gap.match?(/[.!?;]/) ||
+      gap.match?(/\b(?:also|but|fixed|however|open|please|regression|remaining|resolved|still|unresolved|waived)\b/i)
   end
 
   def normalize_finding_severity(raw_severity)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -140,7 +140,7 @@ class PrMergeLedger
     warn "ledger violations: #{report.fetch('violations').length}; " \
          "unknown fields: #{report.fetch('unknown_fields').length}"
     1
-  rescue Error, JSON::ParserError, Errno::ENOENT, Errno::EACCES, KeyError => e
+  rescue Error, JSON::ParserError, Errno::ENOENT, Errno::EACCES, KeyError, NoMethodError, TypeError => e
     warn "pr-merge-ledger: #{e.message}"
     2
   end
@@ -248,8 +248,9 @@ class PrMergeLedger
     @argv.map do |pr_number|
       begin
         pr_int = Integer(pr_number, 10)
+        raise ArgumentError unless pr_int.positive?
       rescue ArgumentError
-        raise Error, "PR number must be an integer: #{pr_number.inspect}"
+        raise Error, "PR number must be a positive integer: #{pr_number.inspect}"
       end
 
       collector.fetch(pr_int).merge("repository" => repo)
@@ -810,6 +811,8 @@ class PrMergeLedger
   end
 
   def timestamp_sort_key(raw_timestamp, warning_context = nil)
+    # Pending/malformed GitHub review timestamps sort oldest so they cannot clear
+    # a later dated decision review.
     Time.parse(raw_timestamp.to_s)
   rescue ArgumentError
     label = warning_context || "timestamp"
@@ -1066,6 +1069,9 @@ class PrMergeLedger
     end
 
     def fetch(pr_number)
+      # Metadata, threads, reviews, and comments are fetched sequentially, so a
+      # push during collection can make SHA comparisons a best-effort snapshot
+      # rather than an atomic GitHub view.
       metadata, files = fetch_metadata_and_files(pr_number)
       {
         "pull_request" => metadata,
@@ -1215,6 +1221,8 @@ class PrMergeLedger
     def append_graphql_variable(args, key, value)
       return if value.nil?
 
+      raise Error, "gh api graphql variable key cannot contain '=': #{key}" if key.to_s.include?("=")
+
       value_string = value.to_s
       if value.is_a?(String) && value_string.start_with?("@")
         raise Error, "gh api graphql variable #{key} cannot start with @"
@@ -1242,6 +1250,8 @@ class PrMergeLedger
 
     def capture_gh(args)
       timeout = PrMergeLedger.github_api_timeout_seconds
+      # Timeout.timeout can interrupt Open3 mid-IO. The risk is acceptable for
+      # short-lived gh calls only; do not extend this pattern to stateful subprocesses.
       Timeout.timeout(timeout) do
         Open3.capture3("gh", *args)
       end

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -87,6 +87,10 @@ class PrMergeLedger
     (?:#{LIST_MARKER_PATTERN.source})?(?:\*\*)?(?<severity>MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?
     (?:\s|:|-|/|$)
   }ix
+  SUMMARY_TRAILING_PRIORITY_PATTERN = %r{
+    \b(?:fixed|resolved|waived)\s+
+    (?:#{PRIORITY_MARKER_PATTERN.source})(?:\s|:|-|/|$)
+  }ix
 
   class Error < StandardError; end
 
@@ -471,6 +475,7 @@ class PrMergeLedger
   end
 
   def unresolved_current_head_thread?(thread)
+    # Truncated comment pages are reported through unknown_fields instead of counted from partial evidence.
     thread.fetch("comments_complete") && !thread.fetch("is_resolved") && thread.fetch("current_head")
   end
 
@@ -609,7 +614,10 @@ class PrMergeLedger
     return false unless summary.match?(FINDING_SUMMARY_SUBJECT_PATTERN)
     return false unless resolved_finding_summary_clause?(summary)
 
-    additional_finding_summary_clauses(summary).all? do |clause|
+    additional_clauses = additional_finding_summary_clauses(summary)
+    return false if hidden_additional_priority?(summary, additional_clauses)
+
+    additional_clauses.all? do |clause|
       resolved_finding_summary_clause?(clause)
     end
   end
@@ -628,9 +636,21 @@ class PrMergeLedger
 
   def resolved_finding_summary_clause?(summary)
     first_clause = summary.split(/[.;(]/, 2).first.to_s
+    return false if first_clause.match?(SUMMARY_TRAILING_PRIORITY_PATTERN)
     return false if first_clause.match?(NEGATED_SUMMARY_RESOLUTION_PATTERN)
 
     first_clause.match?(FINDING_SUMMARY_RESOLUTION_PATTERN)
+  end
+
+  def hidden_additional_priority?(summary, additional_clauses)
+    rest = summary.split(/[.;(]/, 2)[1]
+    return false unless rest
+
+    priority_marker_count(rest) > additional_clauses.sum { |clause| priority_marker_count(clause) }
+  end
+
+  def priority_marker_count(text)
+    text.to_s.scan(PRIORITY_MARKER_PATTERN).length
   end
 
   def disposition_for(finding, dispositions, used_disposition_keys)
@@ -1059,7 +1079,8 @@ class PrMergeLedger
     end
 
     def graphql(query, variables)
-      args = ["api", "graphql", "-f", "owner=#{@owner}", "-f", "name=#{@name}", "-f", "query=#{query}"]
+      args = ["api", "graphql", "--retry", "3", "-f", "owner=#{@owner}", "-f", "name=#{@name}", "-f",
+              "query=#{query}"]
       variables.each do |key, value|
         next if value.nil?
 

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -22,6 +22,7 @@ class PrMergeLedger
   ].freeze
   DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable].freeze
   REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze
+  FINDING_REVIEW_STATES = %w[APPROVED CHANGES_REQUESTED COMMENTED].freeze
   LOCKFILE_BASENAMES = %w[
     Gemfile.lock
     package-lock.json
@@ -143,7 +144,7 @@ class PrMergeLedger
     warn "ledger violations: #{report.fetch('violations').length}; " \
          "unknown fields: #{report.fetch('unknown_fields').length}"
     1
-  rescue Error, JSON::ParserError, Errno::ENOENT, Errno::EACCES, KeyError, NoMethodError, TypeError => e
+  rescue Error, JSON::ParserError, Errno::ENOENT, Errno::EACCES, KeyError => e
     warn "pr-merge-ledger: #{e.message}"
     2
   end
@@ -543,7 +544,7 @@ class PrMergeLedger
     )
     append_findings(issue_comments, "body", findings, context)
 
-    warn_unused_dispositions(dispositions, used_disposition_keys)
+    unused_disposition_keys = warn_unused_dispositions(dispositions, used_disposition_keys)
 
     unique_findings = findings.uniq do |finding|
       [
@@ -558,7 +559,8 @@ class PrMergeLedger
     {
       "status" => truncated_sources.empty? ? "known" : UNKNOWN,
       "findings" => unique_findings,
-      "truncated_sources" => truncated_sources.uniq { |source| source.fetch("url") }
+      "truncated_sources" => truncated_sources.uniq { |source| source.fetch("url") },
+      "unused_keys" => unused_disposition_keys
     }
   end
 
@@ -578,7 +580,9 @@ class PrMergeLedger
   end
 
   def reviews_for_findings(reviews)
-    reviews.select { |review| review.fetch("current_head") }
+    reviews.select do |review|
+      review.fetch("current_head") && FINDING_REVIEW_STATES.include?(review.fetch("state"))
+    end
   end
 
   def findings_from_text(text, url, id, context)
@@ -602,6 +606,8 @@ class PrMergeLedger
 
       [line_text, index + 1, occurrences]
     end
+    # Count before extracting individual findings so broad disposition keys are disabled
+    # whenever one source contains multiple priority markers.
     source_finding_count = finding_lines.sum { |(_line_text, _source_line, occurrences)| occurrences.length }
     line_context = {
       source_finding_count:,
@@ -831,16 +837,17 @@ class PrMergeLedger
     ]
 
     return marker_keys.compact if finding.fetch(:multiple_markers)
-    return marker_keys.concat(line_keys.take(2)).compact if finding.fetch(:multiple_source_findings)
+    return (marker_keys + line_keys.take(2)).compact if finding.fetch(:multiple_source_findings)
 
-    marker_keys.concat(line_keys).compact
+    (marker_keys + line_keys).compact
   end
 
   def warn_unused_dispositions(dispositions, used_disposition_keys)
     unused_keys = dispositions.keys - used_disposition_keys.to_a
-    return if unused_keys.empty?
+    return [] if unused_keys.empty?
 
     warn "pr-merge-ledger: unused disposition keys: #{unused_keys.join(', ')}"
+    unused_keys
   end
 
   def validate_disposition(disposition)
@@ -903,24 +910,7 @@ class PrMergeLedger
       )
     end
 
-    finding_dispositions.fetch("findings").each do |finding|
-      next unless finding.fetch("disposition") == UNKNOWN
-
-      unknowns << unknown_field(
-        pull_request,
-        "priority_finding_dispositions.findings",
-        "P0/P1/P2/Must-Fix finding has no fixed/waived/follow-up disposition",
-        finding["url"]
-      )
-    end
-    finding_dispositions.fetch("truncated_sources").each do |source|
-      unknowns << unknown_field(
-        pull_request,
-        "priority_finding_dispositions.body_scan",
-        "priority finding source body was truncated before full scan",
-        source["url"]
-      )
-    end
+    unknowns.concat(priority_finding_unknown_fields(pull_request, finding_dispositions))
 
     if changelog.fetch("classification") == UNKNOWN
       unknowns << unknown_field(
@@ -935,6 +925,36 @@ class PrMergeLedger
     end
 
     unknowns
+  end
+
+  def priority_finding_unknown_fields(pull_request, finding_dispositions)
+    unknowns = finding_dispositions.fetch("findings").filter_map do |finding|
+      next unless finding.fetch("disposition") == UNKNOWN
+
+      unknown_field(
+        pull_request,
+        "priority_finding_dispositions.findings",
+        "P0/P1/P2/Must-Fix finding has no fixed/waived/follow-up disposition",
+        finding["url"]
+      )
+    end
+
+    finding_dispositions.fetch("truncated_sources").each do |source|
+      unknowns << unknown_field(
+        pull_request,
+        "priority_finding_dispositions.body_scan",
+        "priority finding source body was truncated before full scan",
+        source["url"]
+      )
+    end
+
+    return unknowns if finding_dispositions.fetch("unused_keys").empty?
+
+    unknowns << unknown_field(
+      pull_request,
+      "priority_finding_dispositions.unused_keys",
+      "finding disposition keys did not match any priority finding"
+    )
   end
 
   def pull_request_unknown_fields(pull_request)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -303,7 +303,7 @@ class PrMergeLedger
     output_issue_comments = issue_comments.map { |comment| comment.except("body") }
     latest_reviews = latest_reviews_by_reviewer(output_reviews)
     all_changes_requested = output_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
-    changes_requested = current_changes_requested(latest_reviews)
+    changes_requested = current_changes_requested(output_reviews)
     finding_report = finding_dispositions(review_threads, reviews, issue_comments, dispositions)
     changelog = changelog_classification
     lockfile = lockfile_diff(files)
@@ -505,9 +505,25 @@ class PrMergeLedger
     findings = []
     used_disposition_keys = []
 
-    append_findings(thread_comments_for_findings(review_threads), "body", findings, dispositions, used_disposition_keys)
-    append_findings(reviews_for_findings(reviews), "body_text", findings, dispositions, used_disposition_keys)
-    append_findings(issue_comments, "body", findings, dispositions, used_disposition_keys)
+    truncated_sources = []
+    context = {
+      dispositions:,
+      used_disposition_keys:,
+      truncated_sources:
+    }
+    append_findings(
+      thread_comments_for_findings(review_threads),
+      "body",
+      findings,
+      context
+    )
+    append_findings(
+      reviews_for_findings(reviews),
+      "body_text",
+      findings,
+      context
+    )
+    append_findings(issue_comments, "body", findings, context)
 
     warn_unused_dispositions(dispositions, used_disposition_keys)
 
@@ -522,16 +538,16 @@ class PrMergeLedger
       ]
     end
     {
-      "status" => "known",
-      "findings" => unique_findings
+      "status" => truncated_sources.empty? ? "known" : UNKNOWN,
+      "findings" => unique_findings,
+      "truncated_sources" => truncated_sources.uniq { |source| source.fetch("url") }
     }
   end
 
-  def append_findings(records, text_key, findings, dispositions, used_disposition_keys)
+  def append_findings(records, text_key, findings, context)
     records.each do |record|
       findings.concat(
-        findings_from_text(record.fetch(text_key), record.fetch("url"), record.fetch("id"), dispositions,
-                           used_disposition_keys)
+        findings_from_text(record.fetch(text_key), record.fetch("url"), record.fetch("id"), context)
       )
     end
   end
@@ -547,10 +563,16 @@ class PrMergeLedger
     reviews.select { |review| review.fetch("current_head") }
   end
 
-  def findings_from_text(text, url, id, dispositions, used_disposition_keys)
+  def findings_from_text(text, url, id, context)
     lines = text.to_s.each_line.map(&:chomp)
     if lines.length > MAX_BODY_LINES
       warn "pr-merge-ledger: #{url} body has #{lines.length} lines; scanning first #{MAX_BODY_LINES}"
+      context.fetch(:truncated_sources) << {
+        "id" => id,
+        "url" => url,
+        "line_count" => lines.length,
+        "scanned_line_count" => MAX_BODY_LINES
+      }
       lines = lines.first(MAX_BODY_LINES)
     end
 
@@ -559,14 +581,14 @@ class PrMergeLedger
 
       finding_occurrences(line_text).length
     end
-    context = {
+    line_context = {
       source_finding_count:,
-      dispositions:,
-      used_disposition_keys:
+      dispositions: context.fetch(:dispositions),
+      used_disposition_keys: context.fetch(:used_disposition_keys)
     }
 
     lines.each_with_index.flat_map do |line_text, index|
-      findings_from_line(line_text, index + 1, { url:, id: }, context)
+      findings_from_line(line_text, index + 1, { url:, id: }, line_context)
     end
   end
 
@@ -836,6 +858,14 @@ class PrMergeLedger
         finding["url"]
       )
     end
+    finding_dispositions.fetch("truncated_sources").each do |source|
+      unknowns << unknown_field(
+        pull_request,
+        "priority_finding_dispositions.body_scan",
+        "priority finding source body was truncated before full scan",
+        source["url"]
+      )
+    end
 
     if changelog.fetch("classification") == UNKNOWN
       unknowns << unknown_field(
@@ -977,6 +1007,8 @@ class PrMergeLedger
 
   def unknown_violation_code(field)
     case field
+    when /\Apriority_finding_dispositions\.body_scan/
+      "unknown_priority_finding_body_scan"
     when /\Apriority_finding_dispositions/
       "unknown_priority_finding_disposition"
     when /\Achangelog_classification/

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -437,6 +437,7 @@ class PrMergeLedger
     review_threads
       .select { |thread| unresolved_current_head_thread?(thread) }
       .flat_map { |thread| thread.fetch("comments") }
+      .reject { |comment| comment.fetch("outdated") }
   end
 
   def reviews_for_findings(reviews)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -621,15 +621,6 @@ class PrMergeLedger
     end
   end
 
-  def findings_from_line(line_text, source_line, source, context)
-    return [] if non_actionable_finding_summary?(line_text)
-
-    occurrences = finding_occurrences(line_text)
-    return [] if occurrences.empty?
-
-    findings_from_occurrences(line_text, source_line, source, occurrences, context)
-  end
-
   def findings_from_occurrences(line_text, source_line, source, occurrences, context)
     finding_context = context.merge(
       multiple_markers: occurrences.length > 1
@@ -815,7 +806,7 @@ class PrMergeLedger
       validate_disposition(disposition)
       { "disposition" => disposition, "evidence" => override["evidence"] }
     when nil
-      { "disposition" => UNKNOWN }
+      raise Error, "finding disposition for #{disposition_key} cannot be null"
     else
       raise Error, "finding disposition for #{disposition_key} must be a string or object"
     end
@@ -1303,7 +1294,7 @@ class PrMergeLedger
     end
 
     def non_retryable_gh_error?(stderr)
-      stderr.to_s.match?(/\b(?:401|403|404)\b|\b(?:Not Found|Unauthorized|Forbidden)\b/i)
+      stderr.to_s.match?(/\b(?:401|403|404|429)\b|\b(?:Not Found|Unauthorized|Forbidden|Too Many Requests)\b/i)
     end
 
     def capture_gh(args)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -819,7 +819,9 @@ class PrMergeLedger
     when Hash
       disposition = override.fetch("disposition")
       validate_disposition(disposition)
-      { "disposition" => disposition, "evidence" => override["evidence"] }
+      evidence = override["evidence"]
+      validate_disposition_evidence(evidence, disposition_key)
+      { "disposition" => disposition, "evidence" => evidence }
     when nil
       raise Error, "finding disposition for #{disposition_key} cannot be null"
     else
@@ -861,6 +863,12 @@ class PrMergeLedger
     return if DISPOSITIONS.include?(disposition)
 
     raise Error, "finding disposition #{disposition.inspect} must be one of #{DISPOSITIONS.join(', ')}"
+  end
+
+  def validate_disposition_evidence(evidence, disposition_key)
+    return if evidence.nil? || evidence.is_a?(String)
+
+    raise Error, "finding disposition evidence for #{disposition_key} must be a string"
   end
 
   def timestamp_sort_key(raw_timestamp, warning_context = nil)

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -1,0 +1,948 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "optparse"
+require "time"
+require "timeout"
+
+# rubocop:disable Metrics/ClassLength
+class PrMergeLedger
+  SCHEMA_VERSION = "pr-merge-ledger/v1"
+  UNKNOWN = "UNKNOWN"
+  SCHEMA_PATH = File.expand_path("pr-merge-ledger.schema.json", __dir__)
+  CHANGELOG_CLASSIFICATIONS = %w[
+    changelog_present
+    changelog_missing
+    deferred_to_update_changelog
+    not_user_visible
+    UNKNOWN
+  ].freeze
+  DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable UNKNOWN].freeze
+  LOCKFILE_BASENAMES = %w[
+    Gemfile.lock
+    package-lock.json
+    pnpm-lock.yaml
+    yarn.lock
+    bun.lock
+    bun.lockb
+  ].freeze
+  GITHUB_API_TIMEOUT_SECONDS = 30
+  MAX_GRAPHQL_PAGES = 500
+  FINDING_BADGE_PREFIX = %r{
+    \A\s*(?:[-*]\s*)?(?:\*\*)?
+    <sub><sub>!\[%<severity>s\s+Badge\]\([^)]+\)</sub></sub>
+    (?:\*\*)?(?:\s|:|-|$)
+  }ix
+  BADGE_FINDING_PATTERNS = %w[P0 P1 P2].to_h do |severity|
+    [
+      severity,
+      Regexp.new(format(FINDING_BADGE_PREFIX.source, severity:), Regexp::IGNORECASE | Regexp::EXTENDED)
+    ]
+  end.freeze
+  FINDING_PATTERNS = {
+    "MUST_FIX" => /\A\s*(?:[-*]\s*)?(?:\*\*)?MUST[- ]?FIX(?:\*\*)?(?:\s|:|-|$)/i,
+    "P0" => Regexp.union(
+      BADGE_FINDING_PATTERNS.fetch("P0"),
+      /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P0\]?(?:\*\*)?(?:\s|:|-|$)/i
+    ),
+    "P1" => Regexp.union(
+      BADGE_FINDING_PATTERNS.fetch("P1"),
+      /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P1\]?(?:\*\*)?(?:\s|:|-|$)/i
+    ),
+    "P2" => Regexp.union(
+      BADGE_FINDING_PATTERNS.fetch("P2"),
+      /\A\s*(?:[-*]\s*)?(?:\*\*)?\[?P2\]?(?:\*\*)?(?:\s|:|-|$)/i
+    )
+  }.freeze
+  NON_ACTIONABLE_FINDING_PATTERN =
+    /\A\s*(?:[-*]\s*)?(?:\*\*)?(?:MUST[- ]?FIX|\[?P[0-2]\]?)(?:\*\*)?(?:\s|:|-)+
+      (?:findings?|issues?|items?)\b.*\b(?:none|resolved|waived|previous review)\b/ix
+  ACTIONABLE_NEGATED_RESOLUTION_PATTERN = /\bnot\s+(?:yet\s+)?(?:resolved|waived)\b/i
+
+  class Error < StandardError; end
+
+  def self.run(argv)
+    new(argv).run
+  end
+
+  def initialize(argv)
+    @argv = argv.dup
+    @options = {
+      changelog_classification: UNKNOWN,
+      pretty: false,
+      strict: false
+    }
+  end
+
+  def run
+    parse_options
+
+    if @options[:schema]
+      puts File.read(SCHEMA_PATH)
+      return 0
+    end
+
+    report = build_report
+    write_report(report)
+
+    return 0 unless @options[:strict] && !report.fetch("complete_allowed")
+
+    warn "ledger violations: #{report.fetch('violations').length}; " \
+         "unknown fields: #{report.fetch('unknown_fields').length}"
+    1
+  rescue Error, JSON::ParserError, Errno::ENOENT, Errno::EACCES, KeyError => e
+    warn "pr-merge-ledger: #{e.message}"
+    2
+  end
+
+  private
+
+  def parse_options
+    build_option_parser.parse!(@argv)
+    validate_options
+  rescue OptionParser::InvalidOption, OptionParser::InvalidArgument => e
+    raise Error, e.message
+  end
+
+  def validate_options
+    return unless @argv.length > 1 && @options[:changelog_classification_provided]
+
+    raise Error,
+          "--changelog-classification applies to one PR at a time; run multi-PR ledgers separately"
+  end
+
+  def build_option_parser
+    OptionParser.new do |opts|
+      opts.banner = "Usage: script/pr-merge-ledger [PR ...] [options]"
+      opts.on("--repo OWNER/REPO", "GitHub repository. Defaults to gh repo view.") do |repo|
+        @options[:repo] = repo
+      end
+      opts.on("--fixture PATH", "Read one normalized fixture instead of live GitHub state.") do |path|
+        @options[:fixture] = path
+      end
+      opts.on("--schema", "Print the fixed JSON schema and exit.") do
+        @options[:schema] = true
+      end
+      opts.on("--strict", "Exit non-zero when violations or UNKNOWN fields block closeout.") do
+        @options[:strict] = true
+      end
+      opts.on("--pretty", "Pretty-print JSON output.") do
+        @options[:pretty] = true
+      end
+      opts.on("--finding-dispositions FILE", "JSON map from finding URL/id to disposition evidence.") do |path|
+        @options[:finding_dispositions] = path
+      end
+      opts.on("--changelog-classification CLASS", CHANGELOG_CLASSIFICATIONS) do |classification|
+        @options[:changelog_classification] = classification
+        @options[:changelog_classification_provided] = true
+      end
+      add_help_option(opts)
+    end
+  end
+
+  def add_help_option(opts)
+    opts.on("-h", "--help", "Show this help.") do
+      puts opts
+      exit 0
+    end
+  end
+
+  def build_report
+    datasets = @options[:fixture] ? [load_fixture(@options[:fixture])] : fetch_live_pull_requests
+    dispositions = load_dispositions(@options[:finding_dispositions])
+    ledgers = datasets.map { |dataset| ledger_for(dataset, dispositions) }
+
+    violations = ledgers.flat_map { |ledger| ledger.fetch("violations") }
+    unknown_fields = ledgers.flat_map { |ledger| ledger.fetch("unknown_fields") }
+
+    {
+      "$schema" => "script/pr-merge-ledger.schema.json",
+      "schema_version" => SCHEMA_VERSION,
+      "generated_at" => Time.now.utc.iso8601,
+      "repository" => datasets.first.fetch("repository"),
+      "source" => source_summary,
+      "pull_requests" => ledgers,
+      "violations" => violations,
+      "unknown_fields" => unknown_fields,
+      "complete_allowed" => violations.empty? && unknown_fields.empty?
+    }
+  end
+
+  def fetch_live_pull_requests
+    raise Error, "provide at least one PR number or --fixture" if @argv.empty?
+
+    repo = @options[:repo] || detect_repo
+    owner, name = repo.split("/", 2)
+    raise Error, "repo must look like OWNER/REPO: #{repo.inspect}" unless owner && name
+
+    collector = GitHubCollector.new(owner, name)
+    @argv.map do |pr_number|
+      collector.fetch(Integer(pr_number, 10)).merge("repository" => repo)
+    rescue ArgumentError
+      raise Error, "PR number must be an integer: #{pr_number.inspect}"
+    end
+  end
+
+  def detect_repo
+    stdout, stderr, status = Open3.capture3("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+    raise Error, "could not detect gh repo: #{stderr.strip}" unless status.success?
+
+    stdout.strip
+  end
+
+  def load_fixture(path)
+    JSON.parse(File.read(path)).tap do |dataset|
+      raise Error, "fixture is missing repository" unless dataset["repository"]
+      raise Error, "fixture is missing pull_request" unless dataset["pull_request"]
+    end
+  end
+
+  def load_dispositions(path)
+    return {} unless path
+
+    JSON.parse(File.read(path)).tap do |dispositions|
+      raise Error, "--finding-dispositions must contain a JSON object" unless dispositions.is_a?(Hash)
+    end
+  end
+
+  def source_summary
+    if @options[:fixture]
+      { "mode" => "fixture", "path" => @options[:fixture] }
+    else
+      { "mode" => "live_github", "repo" => @options[:repo] || "auto", "prs" => @argv.map(&:to_i) }
+    end
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def ledger_for(dataset, dispositions)
+    pull_request = normalize_pull_request(dataset.fetch("pull_request"))
+    files = file_paths(dataset)
+    review_threads = normalized_review_threads(dataset, pull_request)
+    reviews = normalized_reviews(dataset, pull_request)
+    issue_comments = normalized_issue_comments(dataset)
+
+    unresolved_threads = review_threads.select { |thread| unresolved_current_head_thread?(thread) }
+    output_reviews = reviews.map { |review| review.except("body_text") }
+    output_issue_comments = issue_comments.map { |comment| comment.except("body") }
+    latest_reviews = latest_reviews_by_reviewer(output_reviews)
+    all_changes_requested = output_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
+    changes_requested = latest_reviews.select { |review| review.fetch("state") == "CHANGES_REQUESTED" }
+    finding_dispositions = finding_dispositions(review_threads, reviews, issue_comments, dispositions)
+    changelog = changelog_classification
+    lockfile = lockfile_diff(files)
+
+    ledger = {
+      "pr" => pull_request,
+      "unresolved_current_head_review_threads" => {
+        "status" => "known",
+        "count" => unresolved_threads.length,
+        "threads" => unresolved_threads
+      },
+      "review_objects" => {
+        "status" => "known",
+        "review_decision" => pull_request.fetch("review_decision"),
+        "latest_by_reviewer" => latest_reviews,
+        "changes_requested" => changes_requested,
+        "all_changes_requested" => all_changes_requested
+      },
+      "issue_comments" => output_issue_comments,
+      "p1_p2_must_fix_dispositions" => finding_dispositions,
+      "changelog_classification" => changelog,
+      "lockfile_diff" => lockfile
+    }
+
+    unknown_fields = unknown_fields_for(pull_request, review_threads, finding_dispositions, changelog, lockfile)
+    violations = violations_for(pull_request, unresolved_threads, changes_requested, changelog, unknown_fields)
+    ledger.merge(
+      "violations" => violations,
+      "unknown_fields" => unknown_fields,
+      "complete_allowed" => violations.empty? && unknown_fields.empty?
+    )
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def file_paths(dataset)
+    Array(dataset["files"]).map { |file| file.is_a?(Hash) ? file.fetch("path") : file }
+  end
+
+  def normalized_review_threads(dataset, pull_request)
+    Array(dataset["review_threads"]).map { |thread| normalize_review_thread(thread, pull_request) }
+  end
+
+  def normalized_reviews(dataset, pull_request)
+    Array(dataset["reviews"]).map { |review| normalize_review(review, pull_request) }
+  end
+
+  def normalized_issue_comments(dataset)
+    Array(dataset["comments"]).map { |comment| normalize_issue_comment(comment) }
+  end
+
+  def normalize_pull_request(raw_pr)
+    {
+      "number" => raw_pr.fetch("number"),
+      "title" => raw_pr["title"],
+      "url" => raw_pr["url"],
+      "state" => raw_pr["state"],
+      "is_draft" => raw_pr["isDraft"],
+      "base_ref" => raw_pr["baseRefName"],
+      "head_ref" => raw_pr["headRefName"],
+      "head_sha" => raw_pr["headRefOid"] || UNKNOWN,
+      "merged_at" => raw_pr["mergedAt"],
+      "review_decision" => raw_pr["reviewDecision"] || UNKNOWN
+    }
+  end
+
+  def normalize_review_thread(thread, pull_request)
+    comments, comments_complete = review_thread_comments(thread)
+    normalized_comments = comments.map { |comment| normalize_thread_comment(comment, pull_request) }
+    latest_comment = normalized_comments.max_by { |comment| comment["created_at"].to_s }
+
+    {
+      "id" => thread.fetch("id"),
+      "is_resolved" => thread["isResolved"] == true,
+      "is_outdated" => thread["isOutdated"] == true,
+      "path" => thread["path"] || latest_comment&.fetch("path", nil),
+      "line" => thread["line"] || latest_comment&.fetch("line", nil),
+      "url" => latest_comment&.fetch("url", nil),
+      "author" => latest_comment&.fetch("author", nil),
+      "created_at" => latest_comment&.fetch("created_at", nil),
+      "body_excerpt" => excerpt(latest_comment&.fetch("body", nil)),
+      "review_state" => latest_comment&.fetch("review_state", nil),
+      "review_head_sha" => latest_comment&.fetch("review_head_sha", nil),
+      "comment_head_sha" => latest_comment&.fetch("comment_head_sha", nil),
+      "current_head" => current_thread?(thread, normalized_comments, pull_request),
+      "comments_complete" => comments_complete,
+      "comments" => normalized_comments
+    }
+  end
+
+  def review_thread_comments(thread)
+    raw_comments = thread["comments"]
+    comments = Array(raw_comments.is_a?(Hash) ? raw_comments["nodes"] : raw_comments)
+
+    [comments, review_thread_comments_complete?(raw_comments)]
+  end
+
+  def review_thread_comments_complete?(raw_comments)
+    !raw_comments.is_a?(Hash) || raw_comments.dig("pageInfo", "hasNextPage") != true
+  end
+
+  def normalize_thread_comment(comment, pull_request)
+    review = comment["pullRequestReview"] || {}
+
+    {
+      "id" => comment["id"] || comment["databaseId"].to_s,
+      "url" => comment["url"],
+      "path" => comment["path"],
+      "line" => comment["line"],
+      "created_at" => comment["createdAt"],
+      "author" => comment.dig("author", "login"),
+      "body" => comment["body"].to_s,
+      "outdated" => comment["outdated"] == true,
+      "review_state" => review["state"],
+      "review_head_sha" => review.dig("commit", "oid"),
+      "comment_head_sha" => comment.dig("commit", "oid"),
+      "current_head" => comment.dig("commit", "oid") == pull_request.fetch("head_sha")
+    }
+  end
+
+  def normalize_review(review, pull_request)
+    {
+      "id" => review.fetch("id"),
+      "reviewer" => review.dig("author", "login") || UNKNOWN,
+      "state" => review["state"] || UNKNOWN,
+      "submitted_at" => review["submittedAt"],
+      "head_sha" => review.dig("commit", "oid") || UNKNOWN,
+      "url" => review["url"],
+      "body_excerpt" => excerpt(review["body"]),
+      "body_text" => review["body"].to_s,
+      "current_head" => review.dig("commit", "oid") == pull_request.fetch("head_sha")
+    }
+  end
+
+  def normalize_issue_comment(comment)
+    {
+      "id" => comment.fetch("id"),
+      "url" => comment["url"],
+      "author" => comment.dig("author", "login"),
+      "created_at" => comment["createdAt"],
+      "body_excerpt" => excerpt(comment["body"]),
+      "body" => comment["body"].to_s
+    }
+  end
+
+  def latest_reviews_by_reviewer(reviews)
+    reviews
+      .group_by { |review| review.fetch("reviewer") }
+      .map { |_reviewer, reviewer_reviews| reviewer_reviews.max_by { |review| review["submitted_at"].to_s } }
+      .sort_by { |review| review.fetch("reviewer") }
+  end
+
+  def current_thread?(thread, comments, pull_request)
+    return !thread["isOutdated"] if comments.empty?
+
+    comments.any? { |comment| comment.fetch("current_head") && !comment.fetch("outdated") } ||
+      comments.any? { |comment| comment.fetch("comment_head_sha") == pull_request.fetch("head_sha") }
+  end
+
+  def unresolved_current_head_thread?(thread)
+    thread.fetch("comments_complete") && !thread.fetch("is_resolved") && thread.fetch("current_head")
+  end
+
+  def finding_dispositions(review_threads, reviews, issue_comments, dispositions)
+    findings = []
+
+    thread_comments_for_findings(review_threads).each do |comment|
+      findings.concat(
+        findings_from_text(comment.fetch("body"), comment.fetch("url"), comment.fetch("id"), dispositions)
+      )
+    end
+
+    reviews_for_findings(reviews).each do |review|
+      findings.concat(
+        findings_from_text(review.fetch("body_text"), review.fetch("url"), review.fetch("id"), dispositions)
+      )
+    end
+
+    issue_comments.each do |comment|
+      findings.concat(
+        findings_from_text(comment.fetch("body"), comment.fetch("url"), comment.fetch("id"), dispositions)
+      )
+    end
+
+    unique_findings = findings.uniq do |finding|
+      [
+        finding.fetch("id"),
+        finding.fetch("url"),
+        finding.fetch("severity"),
+        finding.fetch("source_line"),
+        finding.fetch("text_excerpt")
+      ]
+    end
+    {
+      "status" => "known",
+      "findings" => unique_findings
+    }
+  end
+
+  def thread_comments_for_findings(review_threads)
+    review_threads
+      .select { |thread| unresolved_current_head_thread?(thread) }
+      .flat_map { |thread| thread.fetch("comments") }
+  end
+
+  def reviews_for_findings(reviews)
+    latest_reviews_by_reviewer(reviews).select { |review| review.fetch("current_head") }
+  end
+
+  def findings_from_text(text, url, id, dispositions)
+    text.to_s.each_line.with_index.flat_map do |line, index|
+      next [] if non_actionable_finding_summary?(line)
+
+      severity = finding_severity(line)
+      next [] unless severity
+
+      disposition = disposition_for(url, id, dispositions)
+      [{
+        "id" => id,
+        "url" => url,
+        "severity" => severity,
+        "source_line" => index + 1,
+        "text_excerpt" => excerpt(line),
+        "disposition" => disposition.fetch("disposition"),
+        "evidence" => disposition["evidence"]
+      }]
+    end
+  end
+
+  def finding_severity(line)
+    FINDING_PATTERNS.find { |_severity, pattern| line.match?(pattern) }&.first
+  end
+
+  def non_actionable_finding_summary?(line)
+    return false if line.match?(ACTIONABLE_NEGATED_RESOLUTION_PATTERN)
+
+    line.match?(NON_ACTIONABLE_FINDING_PATTERN)
+  end
+
+  def disposition_for(url, id, dispositions)
+    override = dispositions[url] || dispositions[id]
+
+    case override
+    when String
+      validate_disposition(override)
+      { "disposition" => override }
+    when Hash
+      disposition = override.fetch("disposition")
+      validate_disposition(disposition)
+      { "disposition" => disposition, "evidence" => override["evidence"] }
+    when nil
+      { "disposition" => UNKNOWN }
+    else
+      raise Error, "finding disposition for #{url || id} must be a string or object"
+    end
+  end
+
+  def validate_disposition(disposition)
+    return if DISPOSITIONS.include?(disposition)
+
+    raise Error, "finding disposition must be one of #{DISPOSITIONS.join(', ')}"
+  end
+
+  def changelog_classification
+    {
+      "status" => @options[:changelog_classification] == UNKNOWN ? UNKNOWN : "known",
+      "classification" => @options[:changelog_classification]
+    }
+  end
+
+  def lockfile_diff(files)
+    lockfiles = files.select { |path| lockfile_path?(path) }
+    {
+      "status" => "known",
+      "has_lockfile_diff" => !lockfiles.empty?,
+      "files" => lockfiles
+    }
+  end
+
+  def lockfile_path?(path)
+    basename = File.basename(path)
+    LOCKFILE_BASENAMES.include?(basename) || basename.end_with?(".lock")
+  end
+
+  def unknown_fields_for(pull_request, review_threads, finding_dispositions, changelog, lockfile)
+    unknowns = pull_request_unknown_fields(pull_request)
+
+    review_threads.each do |thread|
+      next if thread.fetch("comments_complete")
+
+      unknowns << unknown_field(
+        pull_request,
+        "review_threads.comments",
+        "review thread comments were truncated by GitHub pagination",
+        thread["url"]
+      )
+    end
+
+    finding_dispositions.fetch("findings").each do |finding|
+      next unless finding.fetch("disposition") == UNKNOWN
+
+      unknowns << unknown_field(
+        pull_request,
+        "p1_p2_must_fix_dispositions.findings",
+        "P0/P1/P2/Must-Fix finding has no fixed/waived/follow-up disposition",
+        finding["url"]
+      )
+    end
+
+    if changelog.fetch("classification") == UNKNOWN
+      unknowns << unknown_field(
+        pull_request,
+        "changelog_classification.classification",
+        "changelog classification is UNKNOWN"
+      )
+    end
+
+    if lockfile.fetch("status") == UNKNOWN
+      unknowns << unknown_field(pull_request, "lockfile_diff.has_lockfile_diff", "lockfile diff flag is UNKNOWN")
+    end
+
+    unknowns
+  end
+
+  def pull_request_unknown_fields(pull_request)
+    unknowns = []
+    if pull_request.fetch("review_decision") == UNKNOWN
+      unknowns << unknown_field(pull_request, "pr.review_decision", "GitHub reviewDecision is UNKNOWN")
+    end
+    if pull_request["head_sha"].to_s.empty? || pull_request["head_sha"] == UNKNOWN
+      unknowns << unknown_field(pull_request, "pr.head_sha", "GitHub headRefOid is UNKNOWN")
+    end
+
+    unknowns
+  end
+
+  def unknown_field(pull_request, field, message, url = nil)
+    {
+      "pr_number" => pull_request.fetch("number"),
+      "field" => field,
+      "message" => message,
+      "url" => url
+    }.compact
+  end
+
+  def violations_for(pull_request, unresolved_threads, changes_requested, changelog, unknown_fields)
+    [
+      review_decision_violation(pull_request),
+      draft_pr_violation(pull_request),
+      changelog_violation(pull_request, changelog),
+      *changes_requested_violations(pull_request, changes_requested),
+      *unresolved_thread_violations(pull_request, unresolved_threads),
+      *unknown_field_violations(pull_request, unknown_fields)
+    ].compact
+  end
+
+  def review_decision_violation(pull_request)
+    case pull_request.fetch("review_decision")
+    when "CHANGES_REQUESTED"
+      violation(
+        pull_request,
+        "review_decision_changes_requested",
+        "GitHub reviewDecision is CHANGES_REQUESTED",
+        pull_request["url"]
+      )
+    when "REVIEW_REQUIRED"
+      violation(
+        pull_request,
+        "review_decision_review_required",
+        "GitHub reviewDecision is REVIEW_REQUIRED",
+        pull_request["url"]
+      )
+    end
+  end
+
+  def draft_pr_violation(pull_request)
+    return unless pull_request["is_draft"]
+
+    violation(
+      pull_request,
+      "draft_pr",
+      "PR is still a draft",
+      pull_request["url"]
+    )
+  end
+
+  def changelog_violation(pull_request, changelog)
+    return unless changelog.fetch("classification") == "changelog_missing"
+
+    violation(
+      pull_request,
+      "changelog_missing",
+      "Changelog classification is changelog_missing",
+      pull_request["url"]
+    )
+  end
+
+  def changes_requested_violations(pull_request, changes_requested)
+    changes_requested.map do |review|
+      violation(
+        pull_request,
+        "changes_requested_review_object",
+        "Review object requested changes",
+        review["url"],
+        "reviewer" => review.fetch("reviewer"),
+        "head_sha" => review.fetch("head_sha"),
+        "current_head" => review.fetch("current_head")
+      )
+    end
+  end
+
+  def unresolved_thread_violations(pull_request, unresolved_threads)
+    unresolved_threads.map do |thread|
+      violation(
+        pull_request,
+        "unresolved_current_head_review_thread",
+        "Unresolved current-head review thread",
+        thread["url"],
+        "path" => thread["path"],
+        "line" => thread["line"]
+      )
+    end
+  end
+
+  def unknown_field_violations(pull_request, unknown_fields)
+    unknown_fields.map do |unknown|
+      violation(
+        pull_request,
+        unknown_violation_code(unknown.fetch("field")),
+        unknown.fetch("message"),
+        unknown["url"]
+      )
+    end
+  end
+
+  def unknown_violation_code(field)
+    case field
+    when /\Ap1_p2_must_fix_dispositions/
+      "unknown_p1_p2_must_fix_disposition"
+    when /\Achangelog_classification/
+      "unknown_changelog_classification"
+    when /\Alockfile_diff/
+      "unknown_lockfile_diff"
+    when /\Areview_threads\.comments/
+      "unknown_review_thread_comments"
+    when /\Apr\.head_sha/
+      "unknown_head_sha"
+    when /\Apr\.review_decision/
+      "unknown_review_decision"
+    else
+      "unknown_ledger_field"
+    end
+  end
+
+  def violation(pull_request, code, message, url, extra = {})
+    {
+      "pr_number" => pull_request.fetch("number"),
+      "code" => code,
+      "message" => message,
+      "url" => url
+    }.merge(extra).compact
+  end
+
+  def excerpt(text)
+    text.to_s.gsub(/\s+/, " ").strip[0, 180]
+  end
+
+  def write_report(report)
+    puts(@options[:pretty] ? JSON.pretty_generate(report) : JSON.generate(report))
+  end
+
+  class GitHubCollector
+    def initialize(owner, name)
+      @owner = owner
+      @name = name
+    end
+
+    def fetch(pr_number)
+      metadata, files = fetch_metadata_and_files(pr_number)
+      {
+        "pull_request" => metadata,
+        "files" => files,
+        "review_threads" => fetch_review_threads(pr_number),
+        "reviews" => fetch_reviews(pr_number),
+        "comments" => fetch_comments(pr_number)
+      }
+    end
+
+    private
+
+    def fetch_metadata_and_files(pr_number)
+      files = []
+      metadata = nil
+      cursor = nil
+      page_count = 0
+
+      loop do
+        page_count += 1
+        raise Error, "pagination exceeded #{MAX_GRAPHQL_PAGES} pages for files" if page_count > MAX_GRAPHQL_PAGES
+
+        response = graphql(metadata_query, pr: pr_number, endCursor: cursor)
+        pull_request = response.dig("data", "repository", "pullRequest")
+        raise Error, "PR ##{pr_number} was not found" unless pull_request
+
+        metadata ||= pull_request.except("files")
+        file_connection = pull_request.fetch("files")
+        files.concat(file_connection.fetch("nodes").map { |file| file.fetch("path") })
+        page_info = file_connection.fetch("pageInfo")
+        break unless page_info.fetch("hasNextPage")
+
+        cursor = next_cursor(page_info, "files", cursor)
+      end
+
+      [metadata, files]
+    end
+
+    def fetch_review_threads(pr_number)
+      fetch_paginated_connection(pr_number, review_threads_query, "reviewThreads")
+    end
+
+    def fetch_reviews(pr_number)
+      fetch_paginated_connection(pr_number, reviews_query, "reviews")
+    end
+
+    def fetch_comments(pr_number)
+      fetch_paginated_connection(pr_number, comments_query, "comments")
+    end
+
+    def fetch_paginated_connection(pr_number, query, connection_name)
+      nodes = []
+      cursor = nil
+      page_count = 0
+
+      loop do
+        page_count += 1
+        if page_count > MAX_GRAPHQL_PAGES
+          raise Error, "pagination exceeded #{MAX_GRAPHQL_PAGES} pages for #{connection_name}"
+        end
+
+        response = graphql(query, pr: pr_number, endCursor: cursor)
+        pull_request = response.dig("data", "repository", "pullRequest")
+        raise Error, "PR ##{pr_number} was not found" unless pull_request
+
+        connection = pull_request.fetch(connection_name)
+        nodes.concat(connection.fetch("nodes"))
+        page_info = connection.fetch("pageInfo")
+        break unless page_info.fetch("hasNextPage")
+
+        cursor = next_cursor(page_info, connection_name, cursor)
+      end
+
+      nodes
+    end
+
+    def next_cursor(page_info, connection_name, previous_cursor)
+      cursor = page_info.fetch("endCursor")
+      if cursor.nil? || cursor == previous_cursor
+        raise Error, "pagination cursor did not advance for #{connection_name}"
+      end
+
+      cursor
+    end
+
+    def graphql(query, variables)
+      args = ["api", "graphql", "-f", "owner=#{@owner}", "-f", "name=#{@name}", "-f", "query=#{query}"]
+      variables.each do |key, value|
+        next if value.nil?
+
+        flag = value.is_a?(Integer) ? "-F" : "-f"
+        args.push(flag, "#{key}=#{value}")
+      end
+
+      stdout, stderr, status = capture_gh(args)
+      raise Error, "gh api graphql failed: #{stderr.strip}" unless status.success?
+
+      JSON.parse(stdout).tap do |parsed|
+        next unless parsed["errors"]
+
+        messages = parsed.fetch("errors").map { |error| error.fetch("message", error.inspect) }
+        raise Error, "gh api graphql returned errors: #{messages.join('; ')}"
+      end
+    end
+
+    def capture_gh(args)
+      Timeout.timeout(github_api_timeout) do
+        Open3.capture3("gh", *args)
+      end
+    rescue Timeout::Error
+      raise Error, "gh api graphql timed out after #{github_api_timeout} seconds"
+    end
+
+    def github_api_timeout
+      raw_timeout = ENV["GITHUB_API_TIMEOUT"].to_s.strip
+      raw_timeout = GITHUB_API_TIMEOUT_SECONDS.to_s if raw_timeout.empty?
+
+      match = raw_timeout.match(/\A(?<seconds>\d+)(?:s)?\z/)
+      raise Error, "GITHUB_API_TIMEOUT must be an integer number of seconds" unless match
+
+      Integer(match[:seconds], 10)
+    end
+
+    def metadata_query
+      <<~GRAPHQL
+        query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) {
+          repository(owner:$owner, name:$name) {
+            pullRequest(number:$pr) {
+              number
+              title
+              url
+              state
+              isDraft
+              baseRefName
+              headRefName
+              headRefOid
+              mergedAt
+              reviewDecision
+              files(first:100, after:$endCursor) {
+                nodes { path }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def review_threads_query
+      <<~GRAPHQL
+        query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) {
+          repository(owner:$owner, name:$name) {
+            pullRequest(number:$pr) {
+              reviewThreads(first:100, after:$endCursor) {
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  path
+                  line
+                  comments(first:100) {
+                    nodes {
+                      id
+                      databaseId
+                      body
+                      author { login }
+                      url
+                      path
+                      line
+                      createdAt
+                      outdated
+                      commit { oid }
+                      originalCommit { oid }
+                      pullRequestReview {
+                        id
+                        state
+                        submittedAt
+                        commit { oid }
+                        author { login }
+                      }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def reviews_query
+      <<~GRAPHQL
+        query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) {
+          repository(owner:$owner, name:$name) {
+            pullRequest(number:$pr) {
+              reviews(first:100, after:$endCursor) {
+                nodes {
+                  id
+                  state
+                  submittedAt
+                  author { login }
+                  commit { oid }
+                  url
+                  body
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    def comments_query
+      <<~GRAPHQL
+        query($owner:String!, $name:String!, $pr:Int!, $endCursor:String) {
+          repository(owner:$owner, name:$name) {
+            pullRequest(number:$pr) {
+              comments(first:100, after:$endCursor) {
+                nodes {
+                  id
+                  body
+                  author { login }
+                  url
+                  createdAt
+                }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+  end
+end
+# rubocop:enable Metrics/ClassLength
+
+exit PrMergeLedger.run(ARGV)

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -369,9 +369,6 @@
         "body_excerpt": {
           "type": "string"
         },
-        "body_text": {
-          "type": "string"
-        },
         "current_head": {
           "type": "boolean"
         }

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -160,7 +160,7 @@
         "priority_finding_dispositions": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["status", "findings"],
+          "required": ["status", "findings", "truncated_sources"],
           "properties": {
             "status": {
               "enum": ["known", "UNKNOWN"]
@@ -169,6 +169,12 @@
               "type": "array",
               "items": {
                 "$ref": "#/$defs/priority_finding"
+              }
+            },
+            "truncated_sources": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/priority_finding_truncated_source"
               }
             }
           }
@@ -433,6 +439,27 @@
         },
         "evidence": {
           "type": ["string", "null"]
+        }
+      }
+    },
+    "priority_finding_truncated_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "url", "line_count", "scanned_line_count"],
+      "properties": {
+        "id": {
+          "type": ["string", "integer"]
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "line_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "scanned_line_count": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://reactonrails.com/schemas/pr-merge-ledger-v1.json",
+  "$id": "script/pr-merge-ledger.schema.json",
   "title": "React on Rails PR merge ledger",
   "type": "object",
   "additionalProperties": false,
@@ -17,7 +17,7 @@
   ],
   "properties": {
     "$schema": {
-      "const": "https://reactonrails.com/schemas/pr-merge-ledger-v1.json"
+      "const": "script/pr-merge-ledger.schema.json"
     },
     "schema_version": {
       "const": "pr-merge-ledger/v1"

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -182,7 +182,7 @@
         "priority_finding_dispositions": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["status", "findings", "truncated_sources"],
+          "required": ["status", "findings", "truncated_sources", "unused_keys"],
           "properties": {
             "status": {
               "enum": ["known", "UNKNOWN"]
@@ -197,6 +197,12 @@
               "type": "array",
               "items": {
                 "$ref": "#/$defs/priority_finding_truncated_source"
+              }
+            },
+            "unused_keys": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
           }
@@ -367,7 +373,7 @@
     "review_object": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "reviewer", "state", "head_sha", "current_head"],
+      "required": ["id", "reviewer", "state", "head_sha", "body_excerpt", "current_head"],
       "properties": {
         "id": {
           "type": "string"
@@ -504,7 +510,7 @@
           "type": ["integer", "null"]
         },
         "reviewer": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "head_sha": {
           "type": ["string", "null"]

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -82,16 +82,38 @@
       "properties": {
         "pr": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["number", "head_sha", "review_decision"],
           "properties": {
             "number": {
               "type": "integer"
             },
+            "title": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            },
+            "state": {
+              "type": ["string", "null"]
+            },
+            "is_draft": {
+              "type": ["boolean", "null"]
+            },
+            "base_ref": {
+              "type": ["string", "null"]
+            },
+            "head_ref": {
+              "type": ["string", "null"]
+            },
             "head_sha": {
               "type": "string"
             },
+            "merged_at": {
+              "type": ["string", "null"]
+            },
             "review_decision": {
-              "type": "string"
+              "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", "UNKNOWN"]
             }
           }
         },
@@ -129,7 +151,7 @@
               "enum": ["known", "UNKNOWN"]
             },
             "review_decision": {
-              "type": "string"
+              "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", "UNKNOWN"]
             },
             "latest_by_reviewer": {
               "type": "array",
@@ -207,7 +229,6 @@
               "enum": ["known", "UNKNOWN"]
             },
             "has_lockfile_diff": {
-              "type": ["boolean", "string"],
               "enum": [true, false, "UNKNOWN"]
             },
             "files": {

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -174,6 +174,15 @@
         },
         "line": {
           "type": ["integer", "null"]
+        },
+        "reviewer": {
+          "type": "string"
+        },
+        "head_sha": {
+          "type": ["string", "null"]
+        },
+        "current_head": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -135,6 +135,21 @@
         "lockfile_diff": {
           "type": "object",
           "required": ["status", "has_lockfile_diff", "files"]
+        },
+        "violations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/violation"
+          }
+        },
+        "unknown_fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/unknown_field"
+          }
+        },
+        "complete_allowed": {
+          "type": "boolean"
         }
       }
     },

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -66,7 +66,7 @@
   "$defs": {
     "pull_request_ledger": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": [
         "pr",
         "unresolved_current_head_review_threads",
@@ -168,9 +168,15 @@
         },
         "url": {
           "type": ["string", "null"]
+        },
+        "path": {
+          "type": ["string", "null"]
+        },
+        "line": {
+          "type": ["integer", "null"]
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
     "unknown_field": {
       "type": "object",

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -72,7 +72,7 @@
         "unresolved_current_head_review_threads",
         "review_objects",
         "issue_comments",
-        "p1_p2_must_fix_dispositions",
+        "priority_finding_dispositions",
         "changelog_classification",
         "lockfile_diff",
         "violations",
@@ -124,7 +124,7 @@
         "issue_comments": {
           "type": "array"
         },
-        "p1_p2_must_fix_dispositions": {
+        "priority_finding_dispositions": {
           "type": "object",
           "required": ["status", "findings"]
         },

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "script/pr-merge-ledger.schema.json",
+  "$id": "https://raw.githubusercontent.com/shakacode/react_on_rails/main/script/pr-merge-ledger.schema.json",
   "title": "React on Rails PR merge ledger",
   "type": "object",
   "additionalProperties": false,
@@ -17,7 +17,7 @@
   ],
   "properties": {
     "$schema": {
-      "const": "script/pr-merge-ledger.schema.json"
+      "const": "https://raw.githubusercontent.com/shakacode/react_on_rails/main/script/pr-merge-ledger.schema.json"
     },
     "schema_version": {
       "const": "pr-merge-ledger/v1"

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://reactonrails.com/schemas/pr-merge-ledger-v1.json",
+  "title": "React on Rails PR merge ledger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "generated_at",
+    "repository",
+    "source",
+    "pull_requests",
+    "violations",
+    "unknown_fields",
+    "complete_allowed"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "script/pr-merge-ledger.schema.json"
+    },
+    "schema_version": {
+      "const": "pr-merge-ledger/v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "type": "string",
+      "pattern": "^[^/]+/[^/]+$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "enum": ["fixture", "live_github"]
+        }
+      }
+    },
+    "pull_requests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/pull_request_ledger"
+      }
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/violation"
+      }
+    },
+    "unknown_fields": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/unknown_field"
+      }
+    },
+    "complete_allowed": {
+      "type": "boolean"
+    }
+  },
+  "$defs": {
+    "pull_request_ledger": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "pr",
+        "unresolved_current_head_review_threads",
+        "review_objects",
+        "issue_comments",
+        "p1_p2_must_fix_dispositions",
+        "changelog_classification",
+        "lockfile_diff",
+        "violations",
+        "unknown_fields",
+        "complete_allowed"
+      ],
+      "properties": {
+        "pr": {
+          "type": "object",
+          "required": ["number", "head_sha", "review_decision"],
+          "properties": {
+            "number": {
+              "type": "integer"
+            },
+            "head_sha": {
+              "type": "string"
+            },
+            "review_decision": {
+              "type": "string"
+            }
+          }
+        },
+        "unresolved_current_head_review_threads": {
+          "type": "object",
+          "required": ["status", "count", "threads"],
+          "properties": {
+            "status": {
+              "enum": ["known", "UNKNOWN"]
+            },
+            "count": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "threads": {
+              "type": "array"
+            }
+          }
+        },
+        "review_objects": {
+          "type": "object",
+          "required": [
+            "status",
+            "review_decision",
+            "latest_by_reviewer",
+            "changes_requested",
+            "all_changes_requested"
+          ]
+        },
+        "issue_comments": {
+          "type": "array"
+        },
+        "p1_p2_must_fix_dispositions": {
+          "type": "object",
+          "required": ["status", "findings"]
+        },
+        "changelog_classification": {
+          "type": "object",
+          "required": ["status", "classification"]
+        },
+        "lockfile_diff": {
+          "type": "object",
+          "required": ["status", "has_lockfile_diff", "files"]
+        }
+      }
+    },
+    "violation": {
+      "type": "object",
+      "required": ["pr_number", "code", "message"],
+      "properties": {
+        "pr_number": {
+          "type": "integer"
+        },
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "url": {
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": true
+    },
+    "unknown_field": {
+      "type": "object",
+      "required": ["pr_number", "field", "message"],
+      "properties": {
+        "pr_number": {
+          "type": "integer"
+        },
+        "field": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "url": {
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -17,7 +17,7 @@
   ],
   "properties": {
     "$schema": {
-      "const": "script/pr-merge-ledger.schema.json"
+      "const": "https://reactonrails.com/schemas/pr-merge-ledger-v1.json"
     },
     "schema_version": {
       "const": "pr-merge-ledger/v1"

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -107,34 +107,110 @@
               "minimum": 0
             },
             "threads": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/review_thread"
+              }
             }
           }
         },
         "review_objects": {
           "type": "object",
+          "additionalProperties": false,
           "required": [
             "status",
             "review_decision",
             "latest_by_reviewer",
             "changes_requested",
             "all_changes_requested"
-          ]
+          ],
+          "properties": {
+            "status": {
+              "enum": ["known", "UNKNOWN"]
+            },
+            "review_decision": {
+              "type": "string"
+            },
+            "latest_by_reviewer": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/review_object"
+              }
+            },
+            "changes_requested": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/review_object"
+              }
+            },
+            "all_changes_requested": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/review_object"
+              }
+            }
+          }
         },
         "issue_comments": {
-          "type": "array"
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/issue_comment"
+          }
         },
         "priority_finding_dispositions": {
           "type": "object",
-          "required": ["status", "findings"]
+          "additionalProperties": false,
+          "required": ["status", "findings"],
+          "properties": {
+            "status": {
+              "enum": ["known", "UNKNOWN"]
+            },
+            "findings": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/priority_finding"
+              }
+            }
+          }
         },
         "changelog_classification": {
           "type": "object",
-          "required": ["status", "classification"]
+          "additionalProperties": false,
+          "required": ["status", "classification"],
+          "properties": {
+            "status": {
+              "enum": ["known", "UNKNOWN"]
+            },
+            "classification": {
+              "enum": [
+                "changelog_present",
+                "changelog_missing",
+                "deferred_to_update_changelog",
+                "not_user_visible",
+                "UNKNOWN"
+              ]
+            }
+          }
         },
         "lockfile_diff": {
           "type": "object",
-          "required": ["status", "has_lockfile_diff", "files"]
+          "additionalProperties": false,
+          "required": ["status", "has_lockfile_diff", "files"],
+          "properties": {
+            "status": {
+              "enum": ["known", "UNKNOWN"]
+            },
+            "has_lockfile_diff": {
+              "type": ["boolean", "string"],
+              "enum": [true, false, "UNKNOWN"]
+            },
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         },
         "violations": {
           "type": "array",
@@ -150,6 +226,213 @@
         },
         "complete_allowed": {
           "type": "boolean"
+        }
+      }
+    },
+    "review_thread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "is_resolved",
+        "is_outdated",
+        "current_head",
+        "comments_complete",
+        "comments"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "is_resolved": {
+          "type": "boolean"
+        },
+        "is_outdated": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": ["string", "null"]
+        },
+        "line": {
+          "type": ["integer", "null"]
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "author": {
+          "type": ["string", "null"]
+        },
+        "created_at": {
+          "type": ["string", "null"]
+        },
+        "body_excerpt": {
+          "type": "string"
+        },
+        "review_state": {
+          "type": ["string", "null"]
+        },
+        "review_head_sha": {
+          "type": ["string", "null"]
+        },
+        "comment_head_sha": {
+          "type": ["string", "null"]
+        },
+        "current_head": {
+          "type": "boolean"
+        },
+        "current_head_evidence": {
+          "type": ["string", "null"]
+        },
+        "comments_complete": {
+          "type": "boolean"
+        },
+        "comments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/review_thread_comment"
+          }
+        }
+      }
+    },
+    "review_thread_comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "body", "outdated", "current_head"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "path": {
+          "type": ["string", "null"]
+        },
+        "line": {
+          "type": ["integer", "null"]
+        },
+        "created_at": {
+          "type": ["string", "null"]
+        },
+        "author": {
+          "type": ["string", "null"]
+        },
+        "body": {
+          "type": "string"
+        },
+        "outdated": {
+          "type": "boolean"
+        },
+        "review_state": {
+          "type": ["string", "null"]
+        },
+        "review_head_sha": {
+          "type": ["string", "null"]
+        },
+        "comment_head_sha": {
+          "type": ["string", "null"]
+        },
+        "current_head": {
+          "type": "boolean"
+        }
+      }
+    },
+    "review_object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "reviewer", "state", "head_sha", "current_head"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reviewer": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "submitted_at": {
+          "type": ["string", "null"]
+        },
+        "head_sha": {
+          "type": "string"
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "body_excerpt": {
+          "type": "string"
+        },
+        "body_text": {
+          "type": "string"
+        },
+        "current_head": {
+          "type": "boolean"
+        }
+      }
+    },
+    "issue_comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "body_excerpt"],
+      "properties": {
+        "id": {
+          "type": ["string", "integer"]
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "author": {
+          "type": ["string", "null"]
+        },
+        "created_at": {
+          "type": ["string", "null"]
+        },
+        "body_excerpt": {
+          "type": "string"
+        }
+      }
+    },
+    "priority_finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "url",
+        "severity",
+        "source_line",
+        "source_column",
+        "marker_index",
+        "text_excerpt",
+        "disposition"
+      ],
+      "properties": {
+        "id": {
+          "type": ["string", "integer"]
+        },
+        "url": {
+          "type": ["string", "null"]
+        },
+        "severity": {
+          "enum": ["MUST_FIX", "P0", "P1", "P2"]
+        },
+        "source_line": {
+          "type": "integer"
+        },
+        "source_column": {
+          "type": "integer"
+        },
+        "marker_index": {
+          "type": "integer"
+        },
+        "text_excerpt": {
+          "type": "string"
+        },
+        "disposition": {
+          "enum": ["fixed", "explicitly_waived", "follow_up_issue", "not_applicable", "UNKNOWN"]
+        },
+        "evidence": {
+          "type": ["string", "null"]
         }
       }
     },


### PR DESCRIPTION
## Summary

- Adds `script/pr-merge-ledger` plus `script/pr-merge-ledger.schema.json` to produce a machine-checkable PR closeout ledger from GitHub PR state.
- Requires the strict ledger in `.agents/workflows/pr-processing.md` and `$pr-batch` closeout guidance before merge readiness or batch handoff.
- Adds fixture/RSpec coverage for merged PR #3613 and wires root RuboCop coverage for the new script.
- Hardens the ledger after review: resolved-thread priority findings are scanned, disposition evidence is validated, review ordering ties are stable, multi-PR disposition reuse is scoped, explicit `UNKNOWN` changelog classifications are rejected, `gh` subprocess timeouts avoid Ruby `Timeout.timeout` around `Open3.capture3`, and rate-limit/secondary-limit responses stay on the retry path.

Closes #3907.

## Validation

Current head SHA: `fba964e48f09ca7a61258103cdad77f001087f7a`

- `ruby -c script/pr-merge-ledger` -> `Syntax OK`.
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/pr_merge_ledger_script_spec.rb` -> 105 examples, 0 failures.
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../script/pr-merge-ledger spec/react_on_rails/pr_merge_ledger_script_spec.rb` -> no offenses.
- `git diff --check` -> passed.
- `pnpm start format.listDifferent` -> passed with the repo's existing Node dependency bin path.
- Pre-commit hooks passed scoped Ruby autofix/RuboCop and trailing-newline checks.
- Pre-push hooks passed branch RuboCop and online Markdown link checks.
- `script/ci-changes-detector origin/main` -> full suite recommended; no benchmarks indicated.

Acceptance dry run:

- `script/pr-merge-ledger --fixture react_on_rails/spec/react_on_rails/fixtures/pr_merge_ledger/pr_3613.json --changelog-classification not_user_visible --strict --pretty > /tmp/pr-3613-merge-ledger-fba964e48.json` -> strict exit 1.
- Result reproduces the rc.2 miss: `complete_allowed=false` with `review_decision_changes_requested`, `unresolved_current_head_review_thread`, and `unknown_priority_finding_disposition` violations.

Self-ledger:

- Finding dispositions artifact: `/tmp/pr-3996-finding-dispositions-after-fba964e48-complete.json`.
- `script/pr-merge-ledger 3996 --repo shakacode/react_on_rails --changelog-classification not_user_visible --finding-dispositions /tmp/pr-3996-finding-dispositions-after-fba964e48-complete.json --strict --pretty > /tmp/pr-3996-merge-ledger-final-fba964e48.json` -> strict exit 1 only for `unknown_review_decision`.
- Result: `complete_allowed=false`; unresolved current-head review threads: 0; unknown priority dispositions: 0; unused disposition keys: 0.

Current GitHub checks snapshot:

- All current-head checks are complete: 44 pass and 7 expected skips.
- Passing/skipped/advisory in the latest snapshot: `claude-review` passed, CodeRabbit skipped, Cursor Bugbot neutral/skipping, benchmark confirmation jobs skipped.
- No failed current-head checks observed in the final snapshot.

## Codex Decision Log

- **Resolved:** Current-head ledger hardening after review.
  - **Decision:** Fixed resolved-thread priority scanning, disposition validation, review-order tie handling, multi-PR disposition reuse, explicit `UNKNOWN` changelog classification handling, 4xx retry handling, 429 retry handling, 403 secondary/rate-limit retry handling, and subprocess timeout cleanup.
  - **Evidence:** 105-example focused RSpec suite passes; strict self-ledger has zero unresolved current-head threads, zero unknown priority dispositions, and zero unused disposition keys.
- **Non-blocking:** Schema URI currently points at `main`.
  - **Decision:** Keep the current `$schema` URI and rely on emitted `schema_version: pr-merge-ledger/v1` for this initial internal gate.
  - **Why:** Tag-pinning or publishing schema URLs is a compatibility policy decision and is not required to close the machine-checkable #3907 closeout gap.
  - **Review later:** Choose a stable schema hosting/tagging policy before external consumers depend on archived ledger artifacts.
- **Non-blocking:** `conservative_non_outdated` evidence is a string.
  - **Decision:** Keep the v1 schema stable; operators still get the PR head SHA and each thread comment's `comment_head_sha` in the same ledger thread object.
  - **Review later:** Consider structured evidence if real closeouts show ambiguity.
- **Non-blocking:** Broad `.lock` suffix detection.
  - **Decision:** Keep the conservative lockfile detector for this initial gate.
  - **Review later:** Narrow package-lock detection if false positives appear in real batch ledgers.
## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: `fba964e48f09ca7a61258103cdad77f001087f7a`
Score: 8/10 for maintainer-delegated human merge
Auto-merge recommendation: no; the independent accelerated-RC finalizer is not present, so this is not an unattended auto-merge path
Maintainer-delegated merge recommendation: yes, per current-session maintainer instruction: "You can merge if you are confident. Just document your criteria in the pr description."
Affected areas: CI/process tooling, root Ruby script, JSON schema, RSpec coverage
CI detector: `script/ci-changes-detector origin/main` -> full suite recommended; labels remain `full-ci, full-ci-no-benchmarks`
Validation run:
- `ruby -c script/pr-merge-ledger` -> `Syntax OK`
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/pr_merge_ledger_script_spec.rb` -> 105 examples, 0 failures
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../script/pr-merge-ledger spec/react_on_rails/pr_merge_ledger_script_spec.rb` -> no offenses
- `pnpm start format.listDifferent` -> passed with the repo's existing Node dependency bin path
- `git diff --check` -> passed
- Pre-commit and pre-push hooks -> passed scoped RuboCop, markdown, and link checks
- #3613 fixture ledger -> strict exit 1 with the expected historical #3613 ledger violations
- Strict self-ledger -> exit 1 only for GitHub `reviewDecision` `UNKNOWN`; unresolved current-head review threads, unknown priority dispositions, and unused disposition keys are 0
Review/check gate:
- GitHub checks: complete for current head `fba964e48f09ca7a61258103cdad77f001087f7a`; 44 pass and 7 expected skips
- Review threads: current strict ledger/GraphQL unresolved count is 0
- Current-head reviewer verdicts: `claude-review` completed successfully; Cursor Bugbot neutral/skipping; CodeRabbit skipped
- Review-object safety: no current-head `CHANGES_REQUESTED` review object remains; all actionable current-head findings were fixed, replied to, or dispositioned
- Stale reviewer verdicts, advisory only: prior Claude/Codex/Cursor/CodeRabbit feedback on older heads was triaged or resolved, not used as a current-head gate
Known residual risk: GitHub aggregate `reviewDecision` is blank/`UNKNOWN`; this is explicitly waived for this maintainer-delegated human merge because concrete review-thread, review-object, finding-disposition, and check evidence is otherwise complete for the current head
Finalized by: maintainer-delegated merge authority from `justin808` in the Codex session on 2026-06-15; not an independent accelerated-RC auto-merge finalizer

## Merge Criteria

Current head SHA: `fba964e48f09ca7a61258103cdad77f001087f7a`

Release mode is `accelerated-rc` from #3823. This PR is mergeable only through the maintainer-delegated human merge path, not unattended accelerated-RC auto-merge. I am comfortable merging when all of these are true immediately before merge:

- Current head is still `fba964e48f09ca7a61258103cdad77f001087f7a`.
- Full current-head GitHub check list is complete; every check is successful or skipped with selector/waiver evidence allowed by `AGENTS.md`.
- `claude-review` has completed for the current head without a confirmed blocker.
- A fresh GraphQL/ledger review-thread fetch reports zero unresolved current-head review threads.
- The strict self-ledger reports zero unresolved current-head threads, zero unknown priority dispositions, and zero unused disposition keys.
- The only strict self-ledger violation is `unknown_review_decision`, caused by GitHub returning a blank aggregate `reviewDecision` while concrete review-object/thread evidence is clean.
- The blank aggregate `reviewDecision` is explicitly waived for this maintainer-delegated human merge because no current-head `CHANGES_REQUESTED` review object remains, all current-head threads are resolved, all priority findings are dispositioned, and all checks are green or expected skips.
- The merge actor re-fetches live PR state after this PR description update and before merge.

Current merge decision: **mergeable by maintainer-delegated human path after one final live re-fetch**. This remains **not** an unattended accelerated-RC auto-merge because no independent finalizer is present.

Labels: `full-ci, full-ci-no-benchmarks`. This PR changes merge-gate/process tooling and specs, so it needs broad CI coverage but no runtime benchmark signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-gate and batch-closeout policy for agents; incorrect ledger logic could block merges or miss real blockers, though scope is tooling/docs plus extensive fixture tests rather than runtime app code.
> 
> **Overview**
> Introduces a **machine-checkable merge closeout gate** via `script/pr-merge-ledger` (with `script/pr-merge-ledger.schema.json`): it pulls GitHub PR state (reviews, threads, comments, lockfiles), emits versioned JSON with `complete_allowed`, violations, and `UNKNOWN` fields, and exits non-zero under `--strict` when changelog classification or P0/P1/P2/Must-Fix dispositions are missing or merge blockers remain.
> 
> **Agent workflow** docs (`pr-processing.md`, `pr-batch` skill) now require running the strict ledger at merge readiness and coordinator closeout, forbid marking targets `complete` while the ledger has `UNKNOWN` or `complete_allowed: false`, and expect ledger JSON in batch handoffs.
> 
> **Repo tooling**: root RuboCop covers `script/pr-merge-ledger`; a large RSpec suite plus a **#3613 fixture** exercise review-decision/thread/finding edge cases and live `gh` behavior (fixtures, pagination, retries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba964e48f09ca7a61258103cdad77f001087f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


