### PR TITLE
Add FOUC integration tests for generated CSS

### DIFF
--- a/react_on_rails/spec/dummy/app/views/layouts/application.html.erb
+++ b/react_on_rails/spec/dummy/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
 
   <%= yield :head %>
 
+  <%= stylesheet_pack_tag %>
   <%= javascript_pack_tag('client-bundle', 'data-turbo-track': 'reload', defer: true) %>
 
   <%= csrf_meta_tags %>

--- a/react_on_rails/spec/dummy/e2e/playwright/e2e/react_on_rails/fouc.spec.js
+++ b/react_on_rails/spec/dummy/e2e/playwright/e2e/react_on_rails/fouc.spec.js
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { app } from '../../support/on-rails';
+
+const cssModulesExamplePath = '/css_modules_images_fonts_example';
+const cssModulesHeadingText = 'This should be open sans light green.';
+const expectedStyledColor = 'rgb(0, 128, 0)';
+
+async function delayCompiledJavaScript(page) {
+  const delayedRequests = [];
+  let releaseScripts;
+  const releaseGate = new Promise((resolve) => {
+    releaseScripts = resolve;
+  });
+
+  await page.route(/\/webpack\/test\/.*\.js(\?.*)?$/, async (route) => {
+    delayedRequests.push(route.request().url());
+    await releaseGate;
+    await route.continue();
+  });
+
+  return {
+    delayedRequests,
+    releaseScripts,
+  };
+}
+
+async function readCssModulesHeadingStyle(page) {
+  const heading = page.getByRole('heading', { name: cssModulesHeadingText });
+  await expect(heading).toBeVisible();
+
+  return heading.evaluate((element, styledColor) => {
+    const style = window.getComputedStyle(element);
+
+    return {
+      className: element.className,
+      color: style.color,
+      fontFamily: style.fontFamily,
+      hasFouc: style.color !== styledColor,
+    };
+  }, expectedStyledColor);
+}
+
+test.describe('FOUC regression coverage', () => {
+  test.beforeEach(async () => {
+    await app('clean');
+  });
+
+  test('detector flags a deliberately unstyled first paint', async ({ page }) => {
+    await page.route(/\/webpack\/test\/.*\.css(\?.*)?$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/css',
+        body: '',
+      }),
+    );
+
+    const { releaseScripts } = await delayCompiledJavaScript(page);
+
+    try {
+      await page.goto(cssModulesExamplePath, { waitUntil: 'commit' });
+
+      await expect
+        .poll(async () => readCssModulesHeadingStyle(page))
+        .toMatchObject({
+          hasFouc: true,
+        });
+    } finally {
+      releaseScripts();
+    }
+  });
+
+  test('server-rendered CSS module content is styled before generated React packs hydrate', async ({
+    page,
+  }) => {
+    const { delayedRequests, releaseScripts } = await delayCompiledJavaScript(page);
+    const stylesheetResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/webpack/test/css/generated/CssModulesImagesFontsExample') &&
+        response.url().endsWith('.css') &&
+        response.status() === 200,
+      { timeout: 5000 },
+    );
+
+    try {
+      await page.goto(cssModulesExamplePath, { waitUntil: 'commit' });
+      await stylesheetResponse;
+
+      const beforeHydration = await readCssModulesHeadingStyle(page);
+
+      expect(delayedRequests).not.toHaveLength(0);
+      expect(beforeHydration).toMatchObject({
+        color: expectedStyledColor,
+        hasFouc: false,
+      });
+    } finally {
+      releaseScripts();
+    }
+
+    await page.waitForLoadState('networkidle');
+
+    await expect
+      .poll(async () => readCssModulesHeadingStyle(page))
+      .toMatchObject({
+        color: expectedStyledColor,
+        hasFouc: false,
+      });
+  });
+});

--- a/react_on_rails/spec/dummy/e2e/playwright/e2e/react_on_rails/fouc.spec.js
+++ b/react_on_rails/spec/dummy/e2e/playwright/e2e/react_on_rails/fouc.spec.js
@@ -26,7 +26,7 @@ async function delayCompiledJavaScript(page) {
 
 async function readCssModulesHeadingStyle(page) {
   const heading = page.getByRole('heading', { name: cssModulesHeadingText });
-  await expect(heading).toBeVisible();
+  await expect(heading).toBeVisible({ timeout: 0 });
 
   return heading.evaluate((element, styledColor) => {
     const style = window.getComputedStyle(element);
@@ -78,7 +78,7 @@ test.describe('FOUC regression coverage', () => {
         response.url().includes('/webpack/test/css/generated/CssModulesImagesFontsExample') &&
         response.url().endsWith('.css') &&
         response.status() === 200,
-      { timeout: 5000 },
+      { timeout: 15000 },
     );
 
     try {


### PR DESCRIPTION
## Summary

- Emit the dummy app's queued stylesheet packs before the deferred `client-bundle` script so generated component CSS can load before hydration.
- Add Playwright FOUC regression coverage for the SSR CSS modules/images/fonts example.
- Prove the detector is not guessing by first simulating a visible unstyled first paint with an empty CSS response while compiled JavaScript is held back.

## Coverage paths

- Runtime path 1: generated component stylesheet packs queued by React on Rails/Shakapacker are flushed through the layout with `stylesheet_pack_tag`.
- Runtime path 2: generated React JavaScript packs are deliberately delayed, so the test asserts SSR content is already styled before hydration can rescue the page.
- Detector proof path: CSS responses are intentionally replaced with empty CSS and the same style reader must report `hasFouc: true`.

I found one layout/code path that needed the product change: the dummy app layout was emitting generated JS but not the matching generated CSS. The new integration spec covers that path and the hydration timing path; generated store auto-load only appends JS, so it is not a separate server-rendered CSS/FOUC path.

## Validation

- Red check before the layout fix: the detector self-test passed, and the real no-FOUC check failed in Chromium, Firefox, and WebKit because no generated CSS response arrived.
- `pnpm run build:test` -> passed
- `pnpm exec playwright test --config=e2e/playwright.config.js e2e/react_on_rails/fouc.spec.js` -> 6 passed across Chromium, Firefox, and WebKit
- `pnpm run lint` -> passed
- `pnpm start format.listDifferent` -> passed
- `(cd react_on_rails && RUBOCOP_CACHE_ROOT=tmp/rubocop_cache BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --no-server)` -> 218 files inspected, no offenses detected
- `codex review --uncommitted` -> no actionable bugs found; review also reran the focused Playwright spec successfully

Labels: full-ci, because this touches the dummy app layout plus generated SSR/hydration asset-loading behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the dummy app layout and new e2e tests; no production gem runtime behavior changes.
> 
> **Overview**
> The dummy app **application layout** now includes `<%= stylesheet_pack_tag %>` **before** the deferred `client-bundle` script so Shakapacker/React-on-Rails queued component CSS can load ahead of hydration—matching the canonical layout pattern the generators already document.
> 
> New **Playwright** coverage on the CSS modules/images/fonts example exercises two paths: one test stubs empty CSS (with JS held back) and expects `hasFouc: true`; the other waits for the generated component stylesheet while delaying webpack JS and asserts SSR heading styles (green Open Sans) **before** hydration, then again after `networkidle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84eff04e0bda8650d644b3c161377a9ef0aef9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Codex Decision Log

- **Non-blocking:** Local Claude CLI review and `/simplify` were unavailable from this Codex session.
  - **Decision:** Use the completed `codex review --base origin/main` plus the queued GitHub `claude-review` check as the review gate evidence.
  - **Why:** Two report-only `claude -p` attempts with tools disabled produced no output within bounded waits and were interrupted; the GitHub `claude-review` check is already queued for the current head SHA.
  - **Review later:** None if GitHub `claude-review` completes cleanly; otherwise triage its findings or failure reason before merge.

## Review / Churn Notes

- Coordination: `agent-coord` claim held for `shakacode/react_on_rails#4005` by `codex-desktop-pr4005-fouc`, batch `pr4005-fouc-2026-06-13`.
- Pre-push review gate: `codex review --uncommitted` before PR creation found no actionable bugs.
- Branch review gate: `codex review --base origin/main` found no actionable correctness regressions and independently reran the focused Playwright spec. GitHub Claude current-head review comments were triaged, replied to, and resolved.
- Claude local pass: skipped as unavailable/timed out from this Codex session; exact evidence above.
- `/simplify`: skipped for the same local Claude timeout/unavailability.
- Post-push churn so far: 1 follow-up commit after first push (`d84eff04e`) to address Greptile flake-hardening review comments.
- Current full-CI handling: `full-ci` label applied; current-head checks restarted after `d84eff04e`. `+ci-run-full` was requested for the final candidate; when the issue-comment command runner stayed pending without creating a job, the same full-CI workflow map was manually dispatched with `force_run=true` and linked in PR comment https://github.com/shakacode/react_on_rails/pull/4005#issuecomment-4700248048.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end regression tests for stylesheet loading behavior to prevent visual flashing during page load.

* **Chores**
  * Enhanced stylesheet loading in the application layout to ensure proper synchronization with JavaScript bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: d84eff04e0bda8650d644b3c161377a9ef0aef9a
Score: 9/10
Auto-merge recommendation: yes
Affected areas: dummy app layout, generated CSS emission, SSR/hydration asset-loading, Playwright E2E coverage
CI detector: `script/ci-changes-detector origin/main` -> Dummy app; recommends Lint (Ruby + JS), Dummy app integration tests, Playwright E2E tests, Core benchmarks, React on Rails Pro benchmarks.
Validation run:
- Local red check before layout fix: detector self-test passed and real no-FOUC failed in Chromium/Firefox/WebKit without generated CSS.
- `pnpm run build:test` -> passed
- `pnpm exec playwright test --config=e2e/playwright.config.js e2e/react_on_rails/fouc.spec.js` -> 6 passed across Chromium, Firefox, and WebKit
- `pnpm run lint` -> passed
- `pnpm start format.listDifferent` -> passed
- `git diff --check` -> passed
- `(cd react_on_rails && RUBOCOP_CACHE_ROOT=tmp/rubocop_cache BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --no-server)` -> passed
- `codex review --base origin/main` -> no actionable regressions; reran focused Playwright spec
- PR checks for current head -> 36 passed, 0 failed, 0 pending; 5 skipped rows explained below
- Manual `workflow_dispatch` full-CI map linked in PR comment https://github.com/shakacode/react_on_rails/pull/4005#issuecomment-4700248048 -> all 8 runs passed
Review/check gate:
- GitHub checks: complete for current head; expected skips are benchmark reporting/confirmation rows, docs-format-check for no docs changes, and comment/review-triggered `Claude Code` rows separate from the passed `claude-review` gate.
- Review threads: GraphQL unresolved count is 0 after triaging/resolving current-head Claude optional comments.
- Current-head reviewer verdicts:
  - GitHub `claude-review`: passed for current head (`27483627608` / job `81235634516`).
  - Cursor Bugbot: passed for current head.
  - Codex review: clean; reran focused Playwright spec.
- Stale reviewer verdicts, advisory only:
  - CodeRabbit approval was for old SHA `64be19845666be0e6e9258fea0a93d4f37840014`; CodeRabbit check is green on the current PR but not used as the formal gate.
Known residual risk: low; change is scoped to dummy app layout and E2E regression coverage, not production gem runtime.
Finalized by: GitHub `claude-review` check for current head (`27483627608` / job `81235634516`), independent named check/app identity.

