### PR TITLE
Point coordination docs at agent-coord bootstrap

### DIFF
--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -27,15 +27,17 @@ Plan a PR batch
    - For filters, run focused `gh pr list` or `gh issue list` commands and keep the query in the report.
    - Record title, URL, state, branch/author for PRs, labels, linked PR/issue refs, and blockers. If a fact cannot be verified, write `UNKNOWN`.
    - Treat the private `shakacode/agent-coordination` backend as available when
-     `agent-coord status` exits 0. If available, run `agent-coord status` and
+     `agent-coord doctor` and `agent-coord status` exit 0. If available, run
+     `agent-coord status` and
      exclude/report targets that already have active live or stale private
      claims, including holder and heartbeat liveness. Report dead or
      fallback-expired claims as recoverable before assigning takeover work. If
      backend state cannot be checked, write `UNKNOWN`; public claim comments are
      advisory only. `UNKNOWN` applies to unavailable status checks, not live
-     claim refusals during `$pr-batch`, which remain hard stops. Include active
-     batches, lane `depends_on` refs, and current `blocked_on` refs in the plan
-     so workers can see cross-batch status before they start.
+     claim refusals during `$pr-batch`; `CLAIM_REFUSED` / exit code 3 remains a
+     hard stop. Include active batches, lane `depends_on` refs, and current
+     `blocked_on` refs in the plan so workers can see cross-batch status before
+     they start.
 
 3. Shape
    - Exclude issues labeled `needs-customer-feedback` from implementation batches unless the user explicitly provides customer evidence or maintainer approval for that issue; list them under "Excluded or deferred" with `needs-customer-feedback` as the reason.
@@ -103,7 +105,8 @@ Execution rules:
   `<batch-id>:<lane-name>`, and create or update the private backend
   `batches/<batch-id>.json` before dispatching dependent workers.
   When the private coordination backend is available,
-  use `agent-coord claim` before creating worktrees/branches,
+  verify it with `agent-coord doctor` and `agent-coord status`, use
+  `agent-coord claim` before creating worktrees/branches,
   `agent-coord heartbeat` at phase transitions, and `agent-coord status` at
   lane start and before rebase or push. If the lane shows unmet `blocked_on`
   refs, set heartbeat `--status blocked`, report the blocked refs, and move to

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -225,11 +225,12 @@ canonical source for coordination state and worker rules. Keep this skill as a
 routing entry point; do not duplicate the full protocol here.
 
 In short: exact lane assignments beat labels; private `agent-coord` state is the
-source of truth when `agent-coord status` exits 0; refused claims hard-stop
-machine agents; workers heartbeat at phase transitions; coordinators create
-private batch files before dependency lanes start; dependency-sensitive lanes run
-`agent-coord status` before rebase, push, readiness, and closeout; and structured
-public claim comments are only advisory fallback state.
+source of truth when `agent-coord doctor` and `agent-coord status` exit 0;
+`CLAIM_REFUSED` / exit code 3 hard-stops machine agents; workers heartbeat at
+phase transitions; coordinators create private batch files before dependency
+lanes start; dependency-sensitive lanes run `agent-coord status` before rebase,
+push, readiness, and closeout; and structured public claim comments are only
+advisory fallback state.
 
 ## Worker Rules
 

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -29,14 +29,15 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
 3. Isolate the work:
    - Fetch/prune `main`, confirm the expected repository root, and verify nested repo paths before assigning work.
    - When the private `shakacode/agent-coordination` backend is available
-     (`agent-coord status` exits 0), acquire an `agent-coord claim` for each
-     issue/PR lane before creating that lane's worktree or branch. Machine
-     agents must hard-stop when the claim is refused and report the holder plus
-     heartbeat liveness. `agent-coord status` is a preflight view; the claim
-     operation is the backend's compare-and-swap gate, so the claim result is the
-     source of truth for races. If `agent-coord status` cannot be checked,
-     report private state as `UNKNOWN` and use structured public claim comments
-     as an advisory fallback.
+     (`agent-coord doctor` and `agent-coord status` exit 0), acquire an
+     `agent-coord claim` for each issue/PR lane before creating that lane's
+     worktree or branch. Machine agents must hard-stop when the claim is refused
+     with `CLAIM_REFUSED` / exit code 3 and report the holder plus heartbeat
+     liveness. `agent-coord status` is a preflight view; the claim operation is
+     the backend's compare-and-swap gate, so the claim result is the source of
+     truth for races. If `agent-coord doctor` or `agent-coord status` cannot be
+     checked, report private state as `UNKNOWN` and use structured public claim
+     comments as an advisory fallback.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
@@ -447,10 +448,12 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
 - For concurrent or multi-machine batches, use the private `shakacode/agent-coordination`
   backend when available. Each lane gets a stable agent id such as
   `mobile-codex-batch2` or `desktop-claude-fable-lane1`.
-- Treat the backend as available when `agent-coord status` exits 0. If the
-  command is missing, auth fails, or status exits non-zero, report private state
-  as `UNKNOWN` and use advisory public claim comments. A refused
-  `agent-coord claim` after a successful status check remains a hard stop.
+- Treat the backend as available when `agent-coord doctor` and
+  `agent-coord status` exit 0. If the command is missing, auth fails, doctor
+  fails, or status exits non-zero, report private state as `UNKNOWN` and use
+  advisory public claim comments where dependency rules allow it. A refused
+  `agent-coord claim` after a successful status check returns `CLAIM_REFUSED` /
+  exit code 3 and remains a hard stop.
 - Acquire an `agent-coord claim` for each issue/PR lane before creating that
   lane's worktree or branch. A refused claim is a hard stop for machine agents:
   report the holder, heartbeat liveness, and target instead of creating a
@@ -461,9 +464,10 @@ Use exact lane assignments as the primary coordination mechanism. Labels are use
   start, branch or PR update, review pass, blocked state, resumed state, and
   done state.
   Heartbeat liveness is timestamp-derived: `live` before the TTL expires,
-  `stale` until the backend dead threshold, and `dead` after that. Check the
-  private backend README and CLI help for current TTL defaults and threshold
-  calculations; do not model liveness with sticky labels.
+  `stale` until the backend dead threshold, and `dead` after that. Check
+  `agent-coord config show --json`, the private backend README, and CLI help for
+  current TTL defaults, terminal heartbeat statuses, and threshold calculations;
+  do not model liveness with sticky labels.
 - Use `agent-coord status` before starting dependency-sensitive lanes and before
   rebase, push, readiness, or closeout decisions that depend on another lane.
   If `agent-coord status` cannot be checked for a declared dependency lane, stop

--- a/internal/contributor-info/agent-coordination-backend.md
+++ b/internal/contributor-info/agent-coordination-backend.md
@@ -8,11 +8,10 @@ React on Rails repository should only carry this pointer and the public workflow
 rules in [AGENTS.md](../../AGENTS.md), [.agents/skills/pr-batch/SKILL.md](../../.agents/skills/pr-batch/SKILL.md),
 and [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md).
 
-Until the private repo has tagged releases, pull the private repo and rerun the
-smoke checks below after backend CLI or schema changes. The command examples in
-this page were verified at the initial backend rollout; the private README and
-`bin/agent-coord --help` output are authoritative if they differ from this
-public pointer.
+Until the private repo has tagged releases, use `agent-coord version --json` and
+`agent-coord config show --json` as the CLI contract. The private README,
+`agent-coord --help`, and `agent-coord config show --json` output are
+authoritative if they differ from this public pointer.
 
 ## Setup
 
@@ -26,28 +25,34 @@ gh repo clone shakacode/agent-coordination
 cd agent-coordination
 ruby -Itest test/agent_coord_test.rb
 bin/agent-coord --help
-mkdir -p "$HOME/.local/bin"
-ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
+bin/agent-coord bootstrap
 export PATH="$HOME/.local/bin:$PATH"
 agent-coord --help
+agent_coord --help
+agent-coord version --json
+agent-coord config show --json
+agent-coord doctor
 ```
 
-The workflow docs assume `agent-coord` is available on `PATH`. Add
-`$HOME/.local/bin` to the shell `PATH` if needed, or run the command by its full
-path inside the private clone.
+The workflow docs assume `agent-coord` is available on `PATH`.
+`bin/agent-coord bootstrap` installs both `agent-coord` and the compatibility
+alias `agent_coord` into `$HOME/.local/bin` by default. Add that directory to the
+active shell `PATH` if the shell has not reloaded its profile yet.
 
-Treat the backend as available when `agent-coord status` exits 0. If the command
-is missing, auth fails, the private repo cannot be read, or `status` exits
-non-zero, report private state as `UNKNOWN` and use structured public claim
-comments as an advisory fallback. A successful status check followed by a
-refused `agent-coord claim` is not unavailability; it is a hard stop.
+Treat the backend as available when `agent-coord doctor` and `agent-coord status`
+exit 0. If the command is missing, auth fails, the private repo cannot be read,
+or either command exits non-zero, report private state as `UNKNOWN` and use
+structured public claim comments as an advisory fallback where dependency rules
+allow it. A successful status check followed by a refused `agent-coord claim`
+with exit code 3 / `CLAIM_REFUSED` is not unavailability; it is a hard stop.
 `agent-coord status` is a preflight view; `agent-coord claim` is the backend's
 compare-and-swap gate for concurrent claim races.
 
 Do not use an unverified private clone for hard-stop gates. If the local private
 CLI or README no longer matches this public pointer and the operator cannot
-validate the current private backend version, report private state as `UNKNOWN`
-and stay in advisory fallback mode until a coordinator validates the backend.
+validate the current private backend version/config output, report private state
+as `UNKNOWN` and stay in advisory fallback mode until a coordinator validates the
+backend.
 
 Machine agents must not override a refused private claim on their own. A human
 coordinator may authorize a one-off manual override only after running
@@ -109,22 +114,26 @@ agent-coord status
 ```
 
 Heartbeat liveness is derived from timestamps: `live` before the TTL expires,
-`stale` until 4x TTL, and `dead` after that. See the private backend README and
-CLI help for current default TTL values and the dead-threshold calculation.
+`stale` until the backend dead threshold, and `dead` after that. Use
+`agent-coord config show --json`, the private backend README, and CLI help for
+current default TTL values, terminal heartbeat statuses, and dead-threshold
+calculation.
 Dependent lanes blocked on a dead-heartbeat takeover should wait until current
 backend liveness marks the holder `dead` before takeover is safe. The default
 claim lease TTL is only a fallback when heartbeat liveness is missing or invalid.
-Use the private repo's launchd template for desktop sessions that need
-out-of-band renewal while an agent is between tool calls.
+Use the private repo's scheduler templates, such as macOS `launchd` or Linux
+`systemd --user`, for sessions that need out-of-band renewal while an agent is
+between tool calls.
 
 For dependency-sensitive lanes, coordinators create or update
 `batches/<batch-id>.json` in the private backend before dispatching dependent
 workers. Batch files are edited as JSON in the private repo in v1. Use the
 private backend README and schema files for that JSON layout; this public pointer
 intentionally omits the batch-state schema and terminal-status list. The private
-backend README and CLI are authoritative for the terminal heartbeat statuses that
-unblock `depends_on` refs; re-check them after backend updates. A released claim
-is audit state and does not unblock dependent lanes by itself.
+backend README, schema files, and `agent-coord config show --json` output are
+authoritative for the terminal heartbeat statuses that unblock `depends_on`
+refs; re-check them after backend updates. A released claim is audit state and
+does not unblock dependent lanes by itself.
 
 If a worker lane declares `depends_on` but `agent-coord status` shows no matching
 batch file or lane state, the worker must treat dependency state as `UNKNOWN` and

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -223,8 +223,8 @@ one batch wait for the other lane's done heartbeat.
    in the same package.
 4. If the heartbeat is dead, a replacement worker may claim the target only
    after checking the branch/PR state and recording the takeover in coordination
-   status. Use the private backend README and CLI help for the current TTL and
-   dead-threshold calculation.
+   status. Use `agent-coord config show --json`, the private backend README, and
+   CLI help for the current TTL and dead-threshold calculation.
 5. If local unpushed work may exist on the laptop, mark the lane blocked instead
    of recreating a competing implementation.
 

--- a/internal/contributor-info/multi-batch-operations.md
+++ b/internal/contributor-info/multi-batch-operations.md
@@ -37,20 +37,23 @@ should use this PR branch or `main` for the current workflow docs.
    cd agent-coordination
    ruby -Itest test/agent_coord_test.rb
    bin/agent-coord --help
-   mkdir -p "$HOME/.local/bin"
-   ln -sf "$PWD/bin/agent-coord" "$HOME/.local/bin/agent-coord"
+   bin/agent-coord bootstrap
    export PATH="$HOME/.local/bin:$PATH"
+   agent-coord doctor
+   agent-coord config show --json
    agent-coord status
    ```
 
    The remaining snippets assume that `PATH` entry is present in the active
    shell. In another shell, add the export first or replace each `agent-coord`
-   command below with `"$HOME/.local/bin/agent-coord"`.
+   command below with `"$HOME/.local/bin/agent-coord"`. The private bootstrap
+   also installs `agent_coord` as an underscore alias for launchers or prompts
+   that use that spelling.
 
-4. If the status command exits non-zero, report private state as `UNKNOWN` and
-   use the structured public claim comment fallback. Do not start a
-   dependency-sensitive lane when the lane declares `depends_on` and private
-   status cannot be checked.
+4. If `doctor` or `status` exits non-zero, report private state as `UNKNOWN` and
+   use the structured public claim comment fallback where dependency rules allow
+   it. Do not start a dependency-sensitive lane when the lane declares
+   `depends_on` and private status cannot be checked.
 5. Before dependent lanes start, the coordinator creates or updates
    `batches/<batch-id>.json` in the private backend so `agent-coord status` can
    render `blocked_on` refs.
@@ -65,8 +68,10 @@ should use this PR branch or `main` for the current workflow docs.
      --branch <branch>
    ```
 
-   A refused claim after successful status is a hard stop. Report the holder,
-   heartbeat liveness, and target instead of creating competing work.
+   A refused claim after successful status exits with `CLAIM_REFUSED` / code 3
+   and is a hard stop. Report the holder, heartbeat liveness, and target instead
+   of creating competing work. Operational failures are `UNKNOWN`, not claim
+   overrides.
 
 7. Each worker heartbeats at item start, branch/PR update, review pass, blocked
    state, resumed state, and done state:
@@ -138,7 +143,10 @@ dead, or explicitly transferred by the coordinator.
 Do not let conductor become an invisible side channel. If conductor takes a PR,
 record the claim in shakacode/agent-coordination with the same repo and target
 identity that batch workers use, then refresh heartbeats while conductor owns
-the lane.
+the lane. If `agent-coord` is not installed in the conductor environment, install
+it with the private backend bootstrap first or use the structured public claim
+comment fallback until the host is configured; do not treat an unbootstrapped
+conductor session as a private claim override.
 
 ## Coordination Lifecycle
 


### PR DESCRIPTION
## Summary

- update `$plan-pr-batch`, `$pr-batch`, and PR-processing workflow text to require `agent-coord doctor` plus `agent-coord status` before trusting private state
- clarify `CLAIM_REFUSED` / exit code 3 as a hard stop and operational failures as `UNKNOWN` fallback
- point cold-start and multi-batch docs at the private repo bootstrap/config contract instead of manual symlink setup
- document the `agent_coord` alias and conductor/fresh-host fallback behavior

## Validation

- `git diff --check`
- `pnpm start format.listDifferent`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `bin/check-links`
- pre-commit hook: trailing newlines, offline markdown links, Prettier on changed files
- pre-push hook: branch lint, online markdown links
- `codex review --uncommitted` / autoreview -> clean for documentation changes

## Merge Criteria

- Release mode: `accelerated-rc`, from release gate #3823.
- Current head: `10788022529b4427e9bc2de28aa61eb18dfeb594`.
- Scope: docs/workflow-only changes to agent coordination prompts and internal contributor docs; no runtime, package, release, auth, or application code changes.
- Backend dependency: private backend PR shakacode/agent-coordination#1 is merged (`9006e72731ee0eb43431f2ea91617fe2c7ffce18`).
- CI detector: `script/ci-changes-detector origin/main` reports documentation-only changes and recommends no expanded CI jobs.
- Review threads: thread-aware GraphQL sweep found 0 review threads and 0 unresolved current threads.
- Review feedback: Greptile's TTL lookup inconsistency was fixed in `107880225`; Claude's current-head review comment reported no blocking issues; CodeRabbit's rate-limit notice had no actionable finding; Cursor Bugbot passed.
- Local validation: `git diff --check`, `pnpm start format.listDifferent`, OSS RuboCop, `bin/check-links`, pre-commit/pre-push hooks, and local autoreview passed.
- Current-head GitHub checks after final verification: Cursor Bugbot, `markdown-format-check`, `markdown-link-check`, `detect-changes`, `claude-review`, and CodeQL completed successfully or neutrally/skipped as expected for docs-only changes.
- Maintainer merge decision: after the queued-check state was reported, Justin instructed Codex to merge if confident. Confidence is based on docs-only scope, clean thread-aware review state, passing local equivalents, CI detector docs-only result, and the merged private backend dependency.


## Coordination

- Private backend implementation PR: https://github.com/shakacode/agent-coordination/pull/1
- Refs #3984

Labels: none. Docs/workflow-only change; standard path-based checks and local doc validation are enough.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent workflow text only; no runtime, auth, or application code changes.
> 
> **Overview**
> Updates **agent coordination** workflow and contributor docs so private backend readiness matches the new **`agent-coord` bootstrap** contract instead of manual `~/.local/bin` symlinks.
> 
> **Availability gates** now require both **`agent-coord doctor`** and **`agent-coord status`** to succeed before treating private state as authoritative; failures map to **`UNKNOWN`** and advisory public claim comments where rules allow. **`CLAIM_REFUSED` / exit code 3** is spelled out as a **hard stop** for machine agents, distinct from operational check failures.
> 
> **Setup and ops** point cold-start and multi-batch guides at **`bin/agent-coord bootstrap`**, **`agent-coord version --json`**, **`agent-coord config show --json`** (TTL, terminal heartbeat statuses), the **`agent_coord`** underscore alias, Linux **`systemd --user`** scheduler mention, and conductor hosts that must bootstrap before claiming lanes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10788022529b4427e9bc2de28aa61eb18dfeb594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



