### PR TITLE
Treat docs-internal/ tree as documentation in CI change detection

### DIFF
--- a/script/ci-changes-detector
+++ b/script/ci-changes-detector
@@ -277,13 +277,18 @@ while IFS= read -r file; do
     # the catch-all below, which forces the entire test + benchmark suite to run
     # (see the #3474 regression and the benchmarks-on-a-docs-PR case in #3597).
     #   - internal/**              : planning, contributor-info, testimonials, history docs
+    #   - docs-internal/**         : internal-only deep-dive docs and their image
+    #     assets (outside the published docs site). Sibling of docs/ and
+    #     internal/. A binary asset here (the .png infographic in PR #4006) used
+    #     to miss every category and hit the catch-all, running the full JS+Ruby
+    #     suite on a docs-only PR; the markdown was already caught by *.md.
     #   - .github/ISSUE_TEMPLATE/** : GitHub issue templates (repo metadata, not CI infra)
     #   - .claude/** .agents/** .cursor/** : agent/editor tooling (skills, prompts,
     #     hooks, workflows). These run locally for coding agents, never in GitHub
     #     Actions CI, so they don't affect the runtime, tests, or benchmarks. The
     #     non-extension .claude/skills symlink is what slipped through the catch-all
     #     and ran benchmarks on the docs-only PR #3717.
-    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|internal/*|internal/**/*|.github/ISSUE_TEMPLATE/*|.github/ISSUE_TEMPLATE/**/*|.claude/*|.claude/**/*|.agents/*|.agents/**/*|.cursor/*|.cursor/**/*|.lychee.toml)
+    *.md|*.mdx|*.markdown|*.rst|*.txt|docs/*|docs-internal/*|docs-internal/**/*|internal/*|internal/**/*|.github/ISSUE_TEMPLATE/*|.github/ISSUE_TEMPLATE/**/*|.claude/*|.claude/**/*|.agents/*|.agents/**/*|.cursor/*|.cursor/**/*|.lychee.toml)
       # Don't change DOCS_ONLY flag, just continue
       ;;
 

--- a/script/ci-changes-detector-test.bash
+++ b/script/ci-changes-detector-test.bash
@@ -253,6 +253,30 @@ test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only() {
   assert_contains "$out" '"benchmarks_changed": false' "docs PR output"
 }
 
+# Regression for PR #4006: a docs-only PR under docs-internal/ that also ships a
+# binary asset (the .png infographic) used to fall through to the uncategorized
+# catch-all, forcing the ENTIRE JS + Ruby + Pro test suite to run. The markdown
+# itself was always caught by the *.md extension; the image was not, and
+# docs-internal/ was not recognized as a documentation directory the way docs/
+# and internal/ are. Everything under docs-internal/ is internal documentation
+# and must stay non-runtime regardless of file type.
+test_docs_internal_tree_with_image_asset_is_non_runtime_only() {
+  setup_repo
+  mkdir -p docs-internal/rsc-architecture-deep-dive/images
+  printf '# Deep dive\n' > docs-internal/rsc-architecture-deep-dive/00-START-HERE.md
+  printf 'binary-ish png bytes\n' > docs-internal/rsc-architecture-deep-dive/images/flow.png
+  commit_change "internal architecture docs with infographic"
+
+  local out
+  out="$(detector_output)"
+  assert_contains "$out" '"docs_only": true' "docs-internal image output"
+  assert_contains "$out" '"non_runtime_only": true' "docs-internal image output"
+  assert_contains "$out" '"run_lint": false' "docs-internal image output"
+  assert_contains "$out" '"run_ruby_tests": false' "docs-internal image output"
+  assert_contains "$out" '"run_js_tests": false' "docs-internal image output"
+  assert_contains "$out" '"benchmarks_changed": false' "docs-internal image output"
+}
+
 # Regression for PR #3717: agent/editor tooling under .claude/** and .agents/**
 # is non-runtime. The .claude/skills symlink (a tracked path with no extension)
 # used to miss every category and hit the catch-all, forcing the full test +
@@ -829,6 +853,7 @@ run_test test_docs_changes_are_non_runtime_only
 run_test test_internal_non_markdown_docs_are_non_runtime_only
 run_test test_issue_template_changes_are_non_runtime_only
 run_test test_docs_pr_with_internal_and_issue_template_yaml_is_non_runtime_only
+run_test test_docs_internal_tree_with_image_asset_is_non_runtime_only
 run_test test_agent_tooling_changes_are_non_runtime_only
 run_test test_ci_infrastructure_only_change_runs_tests_but_skips_benchmarks
 run_test test_suite_workflow_file_runs_its_tests_but_no_benchmark


### PR DESCRIPTION
## Summary

A docs-only PR (#4006) that added markdown under `docs-internal/` plus a single `.png` infographic ran the **entire JS + Ruby + Pro test suite**. This fixes the path-filter that decides which CI jobs run.

### Root cause

`script/ci-changes-detector` classifies changed files. The markdown was correctly caught by the `*.md` extension, but `docs-internal/` was **not** recognized as a documentation directory — only `docs/` and `internal/` were. So the binary image asset (`docs-internal/.../images/rsc-end-to-end-flow.png`) matched no category and fell through to the uncategorized catch-all, which runs every test suite "for safety." One image dragged a docs PR into full CI.

### Fix

Add `docs-internal/` (and its subtree) to the documentation arm of the detector, exactly parallel to the existing `internal/` handling. Any file type under it — including images — is now non-runtime.

Image extensions are intentionally **not** treated as docs globally: 70+ image fixtures live under `react_on_rails/spec` and `react_on_rails_pro/spec`, where running the suite is the correct default (visual/integration tests, asset pipeline). The fix is scoped to the internal-docs directory rather than blanket-classifying all images.

### Verification

- New regression test reproduces the #4006 file set (markdown + image under `docs-internal/`) and asserts `docs_only: true` with all `run_*` flags false.
- Re-running the detector against PR #4006's actual diff now yields `docs_only: true` (previously "Uncategorized → full suite").
- Full gate passes locally — matching `.github/workflows/git-diff-base-tests.yml`:
  - `shellcheck -x` clean
  - `script/ci-changes-detector-test.bash`: 46 run, 0 failed
  - `script/lib/git-diff-base-test.bash`: 41 run, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped path-glob change to CI job selection only; behavior for runtime paths and spec image fixtures is unchanged.
> 
> **Overview**
> **Fixes docs-only PRs under `docs-internal/` accidentally running the full CI suite** when they include non-markdown assets (e.g. PNG infographics). Markdown was already treated as docs via `*.md`; paths like `docs-internal/.../images/*.png` hit the uncategorized catch-all and turned on every `run_*` job (#4006).
> 
> `script/ci-changes-detector` now treats **`docs-internal/`** like **`docs/`** and **`internal/`**: any file under that tree is documentation/non-runtime, including images, without globally classifying all image extensions (spec fixtures under `react_on_rails/spec` still default to full tests).
> 
> A **regression test** commits markdown plus a `.png` under `docs-internal/` and asserts `docs_only: true` with all test/benchmark flags off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874f0186b9f5d3becb5475fbd5bec8d1f6a387fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI efficiency by skipping unnecessary test and benchmark runs when documentation-only changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->