### PR TITLE
Fix RSCProvider retry after rejected getComponent promise

### DIFF
--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -120,10 +120,14 @@ export const createRSCProvider = ({
           return payload;
         };
         const evictPromiseIfRejected = (error: unknown) => {
-          if (fetchRSCPromisesRef.current[key] === promise) {
-            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-            delete fetchRSCPromisesRef.current[key];
-          }
+          // Keep the rejected promise visible for React's Suspense retry, then
+          // evict it so a later getComponent call can refetch the same key.
+          setTimeout(() => {
+            if (fetchRSCPromisesRef.current[key] === promise) {
+              // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+              delete fetchRSCPromisesRef.current[key];
+            }
+          }, 0);
           throw error;
         };
         promise = getServerComponent({ componentName, componentProps }).then(
@@ -178,6 +182,8 @@ export const createRSCProvider = ({
               return payload;
             },
             (error: unknown) => {
+              // Non-recovering refetches keep the rejected promise so the
+              // caller observes the failure; route refetches recover in production.
               if (recoverOnError) {
                 restoreLastSuccessfulPromise();
               }

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -119,7 +119,17 @@ export const createRSCProvider = ({
           }
           return payload;
         };
-        promise = getServerComponent({ componentName, componentProps }).then(markPayloadIfSuccessful);
+        const evictPromiseIfRejected = (error: unknown) => {
+          if (fetchRSCPromisesRef.current[key] === promise) {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete fetchRSCPromisesRef.current[key];
+          }
+          throw error;
+        };
+        promise = getServerComponent({ componentName, componentProps }).then(
+          markPayloadIfSuccessful,
+          evictPromiseIfRejected,
+        );
         fetchRSCPromisesRef.current[key] = promise;
         return promise;
       },

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -124,9 +124,9 @@ export const createRSCProvider = ({
           // observe the rejection before we clear the cache entry. setTimeout(0)
           // is intentional over queueMicrotask because microtasks could race
           // with React's own queue and evict before Suspense sees the throw.
-          // During that same macrotask, duplicate callers for the key reuse the
-          // already-rejected promise and see the same failure; the next macrotask
-          // starts the retry.
+          // During that same macrotask, the cached entry is this chained promise,
+          // which is already rejected with the same error. Duplicate callers for
+          // the key see the same failure; the next macrotask starts the retry.
           //
           // Safe on unmount: this closure captures the unmounted provider
           // instance's ref and may evict from that old ref, but a remounted

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -124,6 +124,9 @@ export const createRSCProvider = ({
           // observe the rejection before we clear the cache entry. setTimeout(0)
           // is intentional over queueMicrotask because microtasks could race
           // with React's own queue and evict before Suspense sees the throw.
+          // During that same macrotask, duplicate callers for the key reuse the
+          // already-rejected promise and see the same failure; the next macrotask
+          // starts the retry.
           //
           // Safe on unmount: this closure captures the current
           // fetchRSCPromisesRef instance. After unmount the identity guard below

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -120,8 +120,14 @@ export const createRSCProvider = ({
           return payload;
         };
         const evictPromiseIfRejected = (error: unknown) => {
-          // Keep the rejected promise visible for React's Suspense retry, then
-          // evict it so a later getComponent call can refetch the same key.
+          // Delay eviction by one macrotask so React's Suspense machinery can
+          // observe the rejection before we clear the cache entry. setTimeout(0)
+          // is intentional over queueMicrotask because microtasks could race
+          // with React's own queue and evict before Suspense sees the throw.
+          //
+          // Safe on unmount: this closure captures the current
+          // fetchRSCPromisesRef instance. After unmount the identity guard below
+          // will simply not match and no eviction happens.
           setTimeout(() => {
             if (fetchRSCPromisesRef.current[key] === promise) {
               // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/packages/react-on-rails-pro/src/RSCProvider.tsx
+++ b/packages/react-on-rails-pro/src/RSCProvider.tsx
@@ -128,9 +128,10 @@ export const createRSCProvider = ({
           // already-rejected promise and see the same failure; the next macrotask
           // starts the retry.
           //
-          // Safe on unmount: this closure captures the current
-          // fetchRSCPromisesRef instance. After unmount the identity guard below
-          // will simply not match and no eviction happens.
+          // Safe on unmount: this closure captures the unmounted provider
+          // instance's ref and may evict from that old ref, but a remounted
+          // provider gets a fresh ref. The old timeout cannot delete the new
+          // instance's in-flight promise.
           setTimeout(() => {
             if (fetchRSCPromisesRef.current[key] === promise) {
               // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -163,10 +163,7 @@ class CapturingErrorBoundary extends React.Component<
     return pending;
   };
 
-  const usingJestFakeTimers = () => {
-    const timerApi = setTimeout as unknown as { clock?: unknown };
-    return jest.isMockFunction(setTimeout) || Boolean(timerApi.clock);
-  };
+  const usingJestFakeTimers = () => jest.isMockFunction(setTimeout);
 
   // Waits for the deferred eviction scheduled by evictPromiseIfRejected to
   // complete. The eviction uses setTimeout(0), so scheduling a second
@@ -286,6 +283,8 @@ class CapturingErrorBoundary extends React.Component<
       await expect(probeRef.current!.getComponent('UserCard', { id: 1 })).rejects.toThrow(
         'transient RSC fetch failed',
       );
+      // FIFO timer ordering keeps this wait behind the deferred eviction timer,
+      // so the immediate retry below starts from an empty cache entry.
       await waitForRejectedGetComponentEviction();
     });
 

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -163,6 +163,10 @@ class CapturingErrorBoundary extends React.Component<
     return pending;
   };
 
+  // Waits for the deferred eviction scheduled by evictPromiseIfRejected to
+  // complete. The eviction uses setTimeout(0), so scheduling a second
+  // setTimeout(0) here guarantees via FIFO macrotask ordering that the eviction
+  // fires before this promise resolves.
   const waitForRejectedGetComponentEviction = () =>
     new Promise<void>((resolve) => {
       setTimeout(resolve, 0);

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -166,7 +166,8 @@ class CapturingErrorBoundary extends React.Component<
   // Waits for the deferred eviction scheduled by evictPromiseIfRejected to
   // complete. The eviction uses setTimeout(0), so scheduling a second
   // setTimeout(0) here guarantees via FIFO macrotask ordering that the eviction
-  // fires before this promise resolves.
+  // fires before this promise resolves. Keep this helper in real-timer test
+  // scopes, or explicitly advance fake timers if a future test enables them.
   const waitForRejectedGetComponentEviction = () =>
     new Promise<void>((resolve) => {
       setTimeout(resolve, 0);

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -163,15 +163,26 @@ class CapturingErrorBoundary extends React.Component<
     return pending;
   };
 
+  const usingJestFakeTimers = () => {
+    const timerApi = setTimeout as unknown as { clock?: unknown };
+    return jest.isMockFunction(setTimeout) || Boolean(timerApi.clock);
+  };
+
   // Waits for the deferred eviction scheduled by evictPromiseIfRejected to
   // complete. The eviction uses setTimeout(0), so scheduling a second
   // setTimeout(0) here guarantees via FIFO macrotask ordering that the eviction
-  // fires before this promise resolves. Keep this helper in real-timer test
-  // scopes, or explicitly advance fake timers if a future test enables them.
-  const waitForRejectedGetComponentEviction = () =>
-    new Promise<void>((resolve) => {
+  // fires before this promise resolves.
+  const waitForRejectedGetComponentEviction = () => {
+    if (usingJestFakeTimers()) {
+      throw new Error(
+        'waitForRejectedGetComponentEviction requires real timers; advance fake timers explicitly',
+      );
+    }
+
+    return new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });
+  };
 
   /**
    * Wrap the initial render in an act() so React drains microtasks queued by

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -19,7 +19,7 @@ import { Suspense } from 'react';
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { createRSCProvider } from '../src/RSCProvider.tsx';
+import { createRSCProvider, useRSC } from '../src/RSCProvider.tsx';
 import RSCRoute, { type RSCRouteHandle, useCurrentRSCRoute } from '../src/RSCRoute.tsx';
 import { getNodeVersion } from './testUtils';
 
@@ -85,6 +85,24 @@ class CapturingErrorBoundary extends React.Component<
       <Suspense fallback={<div data-testid="fallback">loading…</div>}>{children}</Suspense>
     </RSCProvider>
   );
+
+  type RSCProbeHandle = {
+    getComponent: (componentName: string, componentProps: unknown) => Promise<React.ReactNode>;
+    refetchComponent: (
+      componentName: string,
+      componentProps: unknown,
+      recoverOnError?: boolean,
+    ) => Promise<React.ReactNode>;
+  };
+
+  const RSCProbe = React.forwardRef<RSCProbeHandle>((_, ref) => {
+    const { getComponent, refetchComponent } = useRSC();
+    React.useImperativeHandle(ref, () => ({ getComponent, refetchComponent }), [
+      getComponent,
+      refetchComponent,
+    ]);
+    return null;
+  });
 
   /**
    * Build a fetcher whose Nth call resolves with payloads[N]. Resolution is
@@ -164,6 +182,16 @@ class CapturingErrorBoundary extends React.Component<
     });
   };
 
+  const renderRSCProbe = async () => {
+    const probeRef = React.createRef<RSCProbeHandle>();
+    await renderInAct(
+      <RSCProvider>
+        <RSCProbe ref={probeRef} />
+      </RSCProvider>,
+    );
+    return probeRef;
+  };
+
   const RecoverableInlineControls: React.FC = () => {
     const { refetch, refetchError, retry } = useCurrentRSCRoute();
 
@@ -201,6 +229,88 @@ class CapturingErrorBoundary extends React.Component<
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('0a. getComponent dedupes in-flight requests and keeps successful promises cached', async () => {
+    const pending = setupDeferredFetcher();
+    const payload = <div data-testid="cached-card">Cached card</div>;
+    const probeRef = await renderRSCProbe();
+
+    const firstPromise = probeRef.current!.getComponent('UserCard', { id: 1 });
+    const secondPromise = probeRef.current!.getComponent('UserCard', { id: 1 });
+
+    expect(secondPromise).toBe(firstPromise);
+    expect(getServerComponent).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending[0].resolve(payload);
+      await expect(firstPromise).resolves.toBe(payload);
+    });
+
+    const cachedPromise = probeRef.current!.getComponent('UserCard', { id: 1 });
+
+    expect(cachedPromise).toBe(firstPromise);
+    await expect(cachedPromise).resolves.toBe(payload);
+    expect(getServerComponent).toHaveBeenCalledTimes(1);
+  });
+
+  it('0b. getComponent evicts rejected promises so the same key can retry', async () => {
+    const transientError = new Error('transient RSC fetch failed');
+    const recoveredPayload = <div data-testid="recovered-card">Recovered card</div>;
+    setupSequencedFetcher([rejectWith(transientError), recoveredPayload]);
+    const probeRef = await renderRSCProbe();
+
+    await act(async () => {
+      await expect(probeRef.current!.getComponent('UserCard', { id: 1 })).rejects.toThrow(
+        'transient RSC fetch failed',
+      );
+    });
+
+    expect(getServerComponent).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await expect(probeRef.current!.getComponent('UserCard', { id: 1 })).resolves.toBe(recoveredPayload);
+    });
+
+    expect(getServerComponent).toHaveBeenCalledTimes(2);
+
+    const cachedPromise = probeRef.current!.getComponent('UserCard', { id: 1 });
+
+    await expect(cachedPromise).resolves.toBe(recoveredPayload);
+    expect(getServerComponent).toHaveBeenCalledTimes(2);
+  });
+
+  it('0c. getComponent rejection does not evict a newer same-key refetch promise', async () => {
+    const pending = setupDeferredFetcher();
+    const staleError = new Error('stale initial RSC fetch failed');
+    const recoveredPayload = <div data-testid="refetched-card">Refetched card</div>;
+    const probeRef = await renderRSCProbe();
+
+    const initialPromise = probeRef.current!.getComponent('UserCard', { id: 1 });
+    let refetchPromise!: Promise<React.ReactNode>;
+
+    await act(async () => {
+      refetchPromise = probeRef.current!.refetchComponent('UserCard', { id: 1 });
+      await Promise.resolve();
+    });
+
+    expect(getServerComponent).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      pending[0].reject(staleError);
+      await expect(initialPromise).rejects.toThrow('stale initial RSC fetch failed');
+    });
+
+    await act(async () => {
+      pending[1].resolve(recoveredPayload);
+      await expect(refetchPromise).resolves.toBe(recoveredPayload);
+    });
+
+    const cachedPromise = probeRef.current!.getComponent('UserCard', { id: 1 });
+
+    expect(cachedPromise).toBe(refetchPromise);
+    await expect(cachedPromise).resolves.toBe(recoveredPayload);
+    expect(getServerComponent).toHaveBeenCalledTimes(2);
   });
 
   it('1. ref.current.refetch() triggers a fresh getServerComponent call with enforceRefetch=true', async () => {

--- a/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/imperativeRefetch.client.test.tsx
@@ -103,6 +103,7 @@ class CapturingErrorBoundary extends React.Component<
     ]);
     return null;
   });
+  RSCProbe.displayName = 'RSCProbe';
 
   /**
    * Build a fetcher whose Nth call resolves with payloads[N]. Resolution is
@@ -161,6 +162,11 @@ class CapturingErrorBoundary extends React.Component<
     RSCProvider = createRSCProvider({ getServerComponent });
     return pending;
   };
+
+  const waitForRejectedGetComponentEviction = () =>
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
   /**
    * Wrap the initial render in an act() so React drains microtasks queued by
@@ -264,6 +270,7 @@ class CapturingErrorBoundary extends React.Component<
       await expect(probeRef.current!.getComponent('UserCard', { id: 1 })).rejects.toThrow(
         'transient RSC fetch failed',
       );
+      await waitForRejectedGetComponentEviction();
     });
 
     expect(getServerComponent).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

- Fixes the Pro `RSCProvider` retry path after a rejected `getComponent` promise by evicting the rejected same-key cache entry on the next macrotask.
- Preserves the identity guard so newer same-key refetch promises are not evicted by stale failures.
- Adds focused client tests for retry, superseded same-key refetches, and timing comments documenting the Suspense/macrotask behavior.

## Issue Disposition

- #3929: implementation PR. The issue is assigned to `ihabadham`; this remains draft until maintainer/assignee coordination and current-head CI/review finish.

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: a00d2510e1da2603e0c81c906d536bc59e94c9b7
Score: 3/10
Auto-merge recommendation: no
Affected areas: Pro RSCProvider retry behavior, Pro RSC client tests
CI detector: `script/ci-changes-detector origin/main` -> Pro/RSC runtime coverage expected; labels `full-ci`, `benchmark` remain appropriate.
Validation run:
- `pnpm --dir packages/react-on-rails-pro exec jest tests/imperativeRefetch.client.test.tsx --runInBand` -> passed, 25 tests.
- `pnpm --dir packages/react-on-rails-pro run type-check` -> passed.
- `/Users/justin/.codex/worktrees/7e0e/react_on_rails/node_modules/.bin/prettier --check packages/react-on-rails-pro/src/RSCProvider.tsx` -> passed for the latest comment-only change.
- `git diff --check` and `git diff --check origin/main...HEAD` -> passed.
- Pre-commit and pre-push hooks passed for `a00d2510e1da2603e0c81c906d536bc59e94c9b7`.
Review/check gate:
- GitHub checks: current head `a00d2510e1da2603e0c81c906d536bc59e94c9b7` has one failed check and multiple jobs still queued/in progress. `Bundle Size / check-bundle-size` failed because static size limits were exceeded; the log includes unchanged OSS bundle entries (`react-on-rails/client` 63,845 > 63,392 gzip and 54,774 > 54,406 brotli), so this appears broader than the two Pro files touched by this PR, but it remains merge-blocking until fixed, rerun clean, or explicitly waived.
- Prior failed job on superseded head `de31fe2afa76ad966e9bced42a23ef9b03642b02`: `webpack-dummy-app-tests / build-dummy-app-test-bundles (4.0, 22, latest, webpack)` failed before repo build/test code because hosted runner `apt-get update` received 403s from Microsoft package repositories while installing `libyaml-dev`.
- Review threads: GraphQL unresolved count is 5. Two threads remain the Error-as-value retryability product/contract decision; three new current-head review threads call out documentation/comment follow-ups for non-recovering `refetchComponent` rejection caching, the delayed-eviction closure over `promise`, and timer FIFO assumptions. The non-blocking macrotask-window thread was addressed and resolved in `a00d2510e`.
- Current-head reviewer verdicts: Claude review, CodeRabbit, and Cursor Bugbot are complete/success for `a00d2510e1da2603e0c81c906d536bc59e94c9b7`; full CI/benchmark completion is still pending.
Feedback triage:
- `de31fe2af` removed the Sinon-specific `timerApi.clock` fake-timer branch from the Jest-only test helper.
- `de31fe2af` added a concise FIFO timer-ordering comment at the rejected `getComponent` eviction wait.
- `a00d2510e` clarified that the cached macrotask-window entry is the chained rejected promise itself.
- Error-as-value retryability is blocked as a product/contract decision: #3929 covers rejected `getComponent` promises, `createRscPayloadNode` already turns serialized Error payloads into rejections for route-loader payloads, and changing fulfilled `Error` retention could expand the direct `getServerComponent` contract.
Labels: `full-ci`, `benchmark`. This changes Pro/RSC retry behavior and should retain broad CI plus benchmarks.
Known residual risk: High until the current-head bundle-size failure is resolved or waived, the five unresolved review threads are addressed or explicitly triaged, and the Error-as-value product decision is made; PR remains draft pending maintainer/assignee coordination for #3929.
Finalized by: pending current-head independent review/check completion.

## Current Readiness

Draft, not merge-ready. Local validation is green for `a00d2510e1da2603e0c81c906d536bc59e94c9b7`, but current-head GitHub checks include a failed `Bundle Size / check-bundle-size` job, and five current review threads remain open. #3929 is assigned to `ihabadham`, so undraft/merge should wait for maintainer or assignee coordination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pro RSC promise caching and retry timing around Suspense; behavior is well-tested but affects production RSC fetch recovery paths.
> 
> **Overview**
> Fixes **Pro `RSCProvider`** so a failed **`getComponent`** fetch does not leave a permanently cached rejected promise for the same cache key.
> 
> **`getComponent`** now chains a rejection handler that still **re-throws** for Suspense, then **deletes** the in-flight cache entry on the next **`setTimeout(0)`** macrotask, but only when the entry is still the same promise—so a newer same-key **`refetchComponent`** promise is not cleared by a stale failure. Comments document the Suspense timing choice and unmount safety.
> 
> **`refetchComponent`** behavior is unchanged; a comment clarifies that non-recovering refetches keep the rejected promise in cache.
> 
> Client tests add an **`RSCProbe`** harness and cases for dedupe/success caching, retry after eviction, and superseded refetches, plus a real-timer helper aligned with the deferred eviction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704b7f9e5e4fe72a79a40173ff5cdc4e3f8c1684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



