### PR TITLE
Allow Pro RSC peer check for React 19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Changed
+
+- **[Pro]** **RSC peer compatibility accepts the coordinated React 19.2 floor**: The Pro node renderer now allows React and React DOM `19.2.x` starting at `19.2.7`, matching the floor required by the `react-on-rails-rsc` 19.2 package line while preserving the existing React `19.0.x` support window. Refs [Issue 3865](https://github.com/shakacode/react_on_rails/issues/3865).
+
 #### Fixed
 
 - **Rspack generated apps start in HMR mode**: Fresh `rails generate react_on_rails:install --rspack` and `create-react-on-rails-app` projects now install `@rspack/dev-server`, use the `ReactRefreshRspackPlugin` export, and keep `bin/switch-bundler rspack`'s dev dependencies complete so `bin/dev` can launch Rspack serve instead of crashing during dev-server startup. Fixes [Issue 3925](https://github.com/shakacode/react_on_rails/issues/3925). [PR 3926](https://github.com/shakacode/react_on_rails/pull/3926) by [AbanoubGhadban](https://github.com/AbanoubGhadban) and [ihabadham](https://github.com/ihabadham).

--- a/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
@@ -58,15 +58,25 @@ const isAtLeast = (actual: VersionTuple, floor: VersionTuple): boolean => {
 const sameTuple = (left: VersionTuple, right: VersionTuple): boolean =>
   left.every((value, index) => value === right[index]);
 
+const supportedRscRange = (
+  { supportedMajor }: typeof RSC_PEER_SUPPORT.reactOnRailsRsc,
+  { supportedRanges }: typeof RSC_PEER_SUPPORT.react,
+): string => {
+  const supportedMinors = [...new Set(supportedRanges.map((range) => range.rscMinor))].sort(
+    (left, right) => left - right,
+  );
+
+  return supportedMinors.map((minor) => `${supportedMajor}.${minor}.x`).join(' or ');
+};
+
 const supportedReactRange = (
   rscTuple: VersionTuple,
   { supportedMajor, supportedRanges }: typeof RSC_PEER_SUPPORT.react,
 ): string => {
   const rscMinor = rscTuple[1];
   const matchingRanges = supportedRanges.filter((range) => range.rscMinor === rscMinor);
-  const ranges = matchingRanges.length > 0 ? matchingRanges : supportedRanges;
 
-  return ranges
+  return matchingRanges
     .map(
       ({ minor, minPatch }) =>
         `${supportedMajor}.${minor}.x with patch >= ${supportedMajor}.${minor}.${minPatch}`,
@@ -83,6 +93,11 @@ const isSupportedReactTuple = (
   supportedRanges.some(
     (range) => rscTuple[1] === range.rscMinor && minor === range.minor && patch >= range.minPatch,
   );
+
+const isSupportedRscMinor = (
+  rscTuple: VersionTuple,
+  { supportedRanges }: typeof RSC_PEER_SUPPORT.react,
+): boolean => supportedRanges.some((range) => rscTuple[1] === range.rscMinor);
 
 const proLabel = (proVersion?: string) =>
   proVersion ? `React on Rails Pro (${proVersion})` : 'React on Rails Pro';
@@ -120,6 +135,18 @@ export function checkRscPeerCompatibility(input: RscPeerCheckInput): RscPeerChec
         'react-on-rails-rsc',
         rscVersion,
         `${reactOnRailsRsc.supportedMajor}.x`,
+        proVersion,
+      ),
+    };
+  }
+
+  if (!isSupportedRscMinor(rscTuple, react)) {
+    return {
+      level: 'error',
+      message: errorMessage(
+        'react-on-rails-rsc',
+        rscVersion,
+        supportedRscRange(reactOnRailsRsc, react),
         proVersion,
       ),
     };

--- a/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
@@ -58,20 +58,31 @@ const isAtLeast = (actual: VersionTuple, floor: VersionTuple): boolean => {
 const sameTuple = (left: VersionTuple, right: VersionTuple): boolean =>
   left.every((value, index) => value === right[index]);
 
-const supportedReactRange = ({ supportedMajor, supportedRanges }: typeof RSC_PEER_SUPPORT.react): string =>
-  supportedRanges
+const supportedReactRange = (
+  rscTuple: VersionTuple,
+  { supportedMajor, supportedRanges }: typeof RSC_PEER_SUPPORT.react,
+): string => {
+  const rscMinor = rscTuple[1];
+  const matchingRanges = supportedRanges.filter((range) => range.rscMinor === rscMinor);
+  const ranges = matchingRanges.length > 0 ? matchingRanges : supportedRanges;
+
+  return ranges
     .map(
       ({ minor, minPatch }) =>
         `${supportedMajor}.${minor}.x with patch >= ${supportedMajor}.${minor}.${minPatch}`,
     )
     .join(' or ');
+};
 
 const isSupportedReactTuple = (
   [major, minor, patch]: VersionTuple,
+  rscTuple: VersionTuple,
   { supportedMajor, supportedRanges }: typeof RSC_PEER_SUPPORT.react,
 ): boolean =>
   major === supportedMajor &&
-  supportedRanges.some((range) => minor === range.minor && patch >= range.minPatch);
+  supportedRanges.some(
+    (range) => rscTuple[1] === range.rscMinor && minor === range.minor && patch >= range.minPatch,
+  );
 
 const proLabel = (proVersion?: string) =>
   proVersion ? `React on Rails Pro (${proVersion})` : 'React on Rails Pro';
@@ -119,20 +130,20 @@ export function checkRscPeerCompatibility(input: RscPeerCheckInput): RscPeerChec
   let reactTuple: VersionTuple | null = null;
   if (reactVersion) {
     reactTuple = parseTuple(reactVersion);
-    if (!isSupportedReactTuple(reactTuple, react)) {
+    if (!isSupportedReactTuple(reactTuple, rscTuple, react)) {
       return {
         level: 'error',
-        message: errorMessage('react', reactVersion, supportedReactRange(react), proVersion),
+        message: errorMessage('react', reactVersion, supportedReactRange(rscTuple, react), proVersion),
       };
     }
   }
 
   if (reactDomVersion) {
     const reactDomTuple = parseTuple(reactDomVersion);
-    if (!isSupportedReactTuple(reactDomTuple, react)) {
+    if (!isSupportedReactTuple(reactDomTuple, rscTuple, react)) {
       return {
         level: 'error',
-        message: errorMessage('react-dom', reactDomVersion, supportedReactRange(react), proVersion),
+        message: errorMessage('react-dom', reactDomVersion, supportedReactRange(rscTuple, react), proVersion),
       };
     }
 

--- a/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/checkRscPeerCompatibility.ts
@@ -58,17 +58,20 @@ const isAtLeast = (actual: VersionTuple, floor: VersionTuple): boolean => {
 const sameTuple = (left: VersionTuple, right: VersionTuple): boolean =>
   left.every((value, index) => value === right[index]);
 
-const supportedReactRange = ({
-  supportedMajor,
-  supportedMinor,
-  minPatch,
-}: typeof RSC_PEER_SUPPORT.react): string =>
-  `${supportedMajor}.${supportedMinor}.x with patch >= ${supportedMajor}.${supportedMinor}.${minPatch}`;
+const supportedReactRange = ({ supportedMajor, supportedRanges }: typeof RSC_PEER_SUPPORT.react): string =>
+  supportedRanges
+    .map(
+      ({ minor, minPatch }) =>
+        `${supportedMajor}.${minor}.x with patch >= ${supportedMajor}.${minor}.${minPatch}`,
+    )
+    .join(' or ');
 
 const isSupportedReactTuple = (
   [major, minor, patch]: VersionTuple,
-  { supportedMajor, supportedMinor, minPatch }: typeof RSC_PEER_SUPPORT.react,
-): boolean => major === supportedMajor && minor === supportedMinor && patch >= minPatch;
+  { supportedMajor, supportedRanges }: typeof RSC_PEER_SUPPORT.react,
+): boolean =>
+  major === supportedMajor &&
+  supportedRanges.some((range) => minor === range.minor && patch >= range.minPatch);
 
 const proLabel = (proVersion?: string) =>
   proVersion ? `React on Rails Pro (${proVersion})` : 'React on Rails Pro';

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -24,5 +24,12 @@
 // (the stable 19.0.5 ship/pin is tracked by issue #3634).
 export const RSC_PEER_SUPPORT = {
   reactOnRailsRsc: { recommendedMin: '19.0.2', supportedMajor: 19 },
-  react: { supportedMajor: 19, supportedMinor: 0, minPatch: 4 },
+  react: {
+    supportedMajor: 19,
+    supportedRanges: [
+      { minor: 0, minPatch: 4 },
+      // React 19.2.7 is the coordinated floor for react-on-rails-rsc 19.2.x.
+      { minor: 2, minPatch: 7 },
+    ],
+  },
 } as const;

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -27,9 +27,9 @@ export const RSC_PEER_SUPPORT = {
   react: {
     supportedMajor: 19,
     supportedRanges: [
-      { minor: 0, minPatch: 4 },
+      { rscMinor: 0, minor: 0, minPatch: 4 },
       // React 19.2.7 is the coordinated floor for react-on-rails-rsc 19.2.x.
-      { minor: 2, minPatch: 7 },
+      { rscMinor: 2, minor: 2, minPatch: 7 },
     ],
   },
 } as const;

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -65,7 +65,7 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.message).toContain('react');
     expect(r.message).toContain('18.3.1');
     expect(r.message).toContain('19.0.x with patch >= 19.0.4');
-    expect(r.message).toContain('19.2.x with patch >= 19.2.7');
+    expect(r.message).not.toContain('19.2.x with patch >= 19.2.7');
   });
 
   it('errors when React 19.0 patch is below the supported minimum', () => {
@@ -82,6 +82,24 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.message).toContain('react');
     expect(r.message).toContain('19.2.6');
     expect(r.message).toContain('19.2.x with patch >= 19.2.7');
+  });
+
+  it('errors when React 19.2 is paired with the React 19.0 RSC package line', () => {
+    const r = checkRscPeerCompatibility({ rscVersion: '19.0.5', reactVersion: '19.2.7' });
+    expect(r.level).toBe('error');
+    expect(r.message).toContain('react');
+    expect(r.message).toContain('19.2.7');
+    expect(r.message).toContain('19.0.x with patch >= 19.0.4');
+    expect(r.message).not.toContain('19.2.x with patch >= 19.2.7');
+  });
+
+  it('errors when React 19.0 is paired with the React 19.2 RSC package line', () => {
+    const r = checkRscPeerCompatibility({ rscVersion: '19.2.0-rc.1', reactVersion: '19.0.4' });
+    expect(r.level).toBe('error');
+    expect(r.message).toContain('react');
+    expect(r.message).toContain('19.0.4');
+    expect(r.message).toContain('19.2.x with patch >= 19.2.7');
+    expect(r.message).not.toContain('19.0.x with patch >= 19.0.4');
   });
 
   it('errors when React uses an unsupported React 19 minor', () => {
@@ -101,7 +119,7 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.level).toBe('error');
     expect(r.message).toContain('react-dom');
     expect(r.message).toContain('19.0.x with patch >= 19.0.4');
-    expect(r.message).toContain('19.2.x with patch >= 19.2.7');
+    expect(r.message).not.toContain('19.2.x with patch >= 19.2.7');
   });
 
   it('errors when react-dom does not match react', () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -59,6 +59,23 @@ describe('checkRscPeerCompatibility', () => {
     expect(checkRscPeerCompatibility({ rscVersion: '18.3.1', reactVersion: '19.0.4' }).level).toBe('error');
   });
 
+  it('errors on unsupported rsc minors before suggesting React changes', () => {
+    const r = checkRscPeerCompatibility({ rscVersion: '19.1.0', reactVersion: '19.0.4' });
+    expect(r.level).toBe('error');
+    expect(r.message).toContain('react-on-rails-rsc');
+    expect(r.message).toContain('19.1.0');
+    expect(r.message).toContain('19.0.x or 19.2.x');
+    expect(r.message).not.toContain('Incompatible react version');
+  });
+
+  it('errors on future unlisted rsc minors before suggesting React changes', () => {
+    const r = checkRscPeerCompatibility({ rscVersion: '19.3.0-rc.1', reactVersion: '19.2.7' });
+    expect(r.level).toBe('error');
+    expect(r.message).toContain('react-on-rails-rsc');
+    expect(r.message).toContain('19.3.0-rc.1');
+    expect(r.message).toContain('19.0.x or 19.2.x');
+  });
+
   it('errors when React major is below the RSC minimum', () => {
     const r = checkRscPeerCompatibility({ rscVersion: '19.0.4', reactVersion: '18.3.1' });
     expect(r.level).toBe('error');

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -36,6 +36,10 @@ describe('checkRscPeerCompatibility', () => {
     expect(checkRscPeerCompatibility({ rscVersion: '19.0.4', reactVersion: '19.0.4' }).level).toBe('ok');
   });
 
+  it('returns ok for the React 19.2.7 floor required by the 19.2 RSC package line', () => {
+    expect(checkRscPeerCompatibility({ rscVersion: '19.2.0-rc.1', reactVersion: '19.2.7' }).level).toBe('ok');
+  });
+
   it('returns ok for a coordinated prerelease (prerelease stripped for comparison)', () => {
     expect(checkRscPeerCompatibility({ rscVersion: '19.0.5-rc.6', reactVersion: '19.0.4' }).level).toBe('ok');
   });
@@ -61,6 +65,7 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.message).toContain('react');
     expect(r.message).toContain('18.3.1');
     expect(r.message).toContain('19.0.x with patch >= 19.0.4');
+    expect(r.message).toContain('19.2.x with patch >= 19.2.7');
   });
 
   it('errors when React 19.0 patch is below the supported minimum', () => {
@@ -69,6 +74,14 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.message).toContain('react');
     expect(r.message).toContain('19.0.3');
     expect(r.message).toContain('19.0.x with patch >= 19.0.4');
+  });
+
+  it('errors when React 19.2 patch is below the supported minimum', () => {
+    const r = checkRscPeerCompatibility({ rscVersion: '19.2.0-rc.1', reactVersion: '19.2.6' });
+    expect(r.level).toBe('error');
+    expect(r.message).toContain('react');
+    expect(r.message).toContain('19.2.6');
+    expect(r.message).toContain('19.2.x with patch >= 19.2.7');
   });
 
   it('errors when React uses an unsupported React 19 minor', () => {
@@ -88,6 +101,7 @@ describe('checkRscPeerCompatibility', () => {
     expect(r.level).toBe('error');
     expect(r.message).toContain('react-dom');
     expect(r.message).toContain('19.0.x with patch >= 19.0.4');
+    expect(r.message).toContain('19.2.x with patch >= 19.2.7');
   });
 
   it('errors when react-dom does not match react', () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
@@ -158,6 +158,24 @@ describe('runRscPeerCompatibilityCheck', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('throws when React 19.2 is paired with the React 19.0 RSC package line', () => {
+    expect(() =>
+      runRscPeerCompatibilityCheck({
+        resolveVersion: resolveVersions('19.0.5', '19.2.7'),
+      }),
+    ).toThrow(/Incompatible react/);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws when React 19.0 is paired with the React 19.2 RSC package line', () => {
+    expect(() =>
+      runRscPeerCompatibilityCheck({
+        resolveVersion: resolveVersions('19.2.0-rc.1', '19.0.4'),
+      }),
+    ).toThrow(/Incompatible react/);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('does not rerun after a hard startup error', () => {
     const resolveVersion = resolveVersions('20.0.0');
     expect(() => runRscPeerCompatibilityCheck({ resolveVersion })).toThrow(/Incompatible react-on-rails-rsc/);

--- a/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
@@ -99,6 +99,15 @@ describe('runRscPeerCompatibilityCheck', () => {
     ).toThrow(/Incompatible react-on-rails-rsc/);
   });
 
+  it('throws on an unsupported rsc minor', () => {
+    expect(() =>
+      runRscPeerCompatibilityCheck({
+        resolveVersion: resolveVersions('19.1.0', '19.0.4'),
+      }),
+    ).toThrow(/Incompatible react-on-rails-rsc/);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('warns (does not throw) when below recommendedMin', () => {
     expect(() =>
       runRscPeerCompatibilityCheck({

--- a/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
@@ -149,6 +149,15 @@ describe('runRscPeerCompatibilityCheck', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
+  it('does not throw on the coordinated React 19.2.7 runtime floor', () => {
+    expect(() =>
+      runRscPeerCompatibilityCheck({
+        resolveVersion: resolveVersions('19.2.0-rc.1', '19.2.7'),
+      }),
+    ).not.toThrow();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('does not rerun after a hard startup error', () => {
     const resolveVersion = resolveVersions('20.0.0');
     expect(() => runRscPeerCompatibilityCheck({ resolveVersion })).toThrow(/Incompatible react-on-rails-rsc/);

--- a/packages/react-on-rails-pro-node-renderer/tests/serverRenderRSCReactComponent.test.js
+++ b/packages/react-on-rails-pro-node-renderer/tests/serverRenderRSCReactComponent.test.js
@@ -72,6 +72,7 @@ describe('serverRenderRSCReactComponent', () => {
     buildConfig({
       serverBundleCachePath: tempDir,
       supportModules: true,
+      additionalContext: { AbortController, AbortSignal },
       stubTimers: false,
       maxVMPoolSize: 2,
     });


### PR DESCRIPTION
## Summary

- Allows the Pro node-renderer RSC peer check to accept the coordinated React/React DOM `19.2.x` floor starting at `19.2.7`, while preserving the existing React `19.0.x >= 19.0.4` support window.
- Constrains each React support window to the matching `react-on-rails-rsc` minor line so cross-minor pairs such as RSC `19.0.x` + React `19.2.7` are rejected.
- Rejects unlisted RSC `19.x` minor lines, such as `19.1.x` or future `19.3.x`, as `react-on-rails-rsc` incompatibilities instead of suggesting impossible React changes.
- Keeps React `19.1.x` unsupported in this narrow release unblock.
- Updates peer-compatibility tests and fixes the RSC render test fixture to pass documented abort globals through `additionalContext`.

Refs #3865.

## Release / Merge Criteria

- Release mode: accelerated RC unblock for the React on Rails / `react-on-rails-rsc` 19.2.x line.
- Current head SHA: `a15f15878f7f306b2971f71e398241d7bb842d26`.
- CI/check status: current-head full GitHub checks are green or intentionally skipped as of 2026-06-14 20:20Z, including full CI, benchmark workflows, CodeQL, Claude Code Review, CodeRabbit, and Cursor Bugbot.
- Review-thread status: `0` unresolved after the latest GraphQL sweep at 2026-06-14 20:20Z. Codex, Greptile, and Claude review feedback was replied to and resolved.
- Review feedback triage: MUST-FIX cross-minor issue fixed in `33c31e5d3ba002fb495c40a066ee1780483c6a79`; MUST-FIX unsupported-RSC-minor diagnostic issue fixed in `a15f15878f7f306b2971f71e398241d7bb842d26`; optional duplicate boot-wrapper message assertions, defensive `supportedReactRange` fallback/throw suggestions, and symmetric `react-dom` 19.2 duplicate coverage were auto-deferred with rationale to avoid restarting the now-green full CI for this accelerated RC unblock.
- Label / CI decision: `script/ci-changes-detector origin/main` classifies this as a React on Rails Pro Node Renderer package change and recommends full Pro lint, Pro tests, Pro dummy integration, node-renderer tests, and Pro/node-renderer benchmarks. Keep `full-ci` and `benchmark`.
- Known residual risk: this intentionally unblocks only the React 19.2.7 floor for the RSC 19.2 package line. Broader React 19.1 support and longer-term feature-adoption tracking remain outside this PR. The RSC package PR still needs a downstream run against React on Rails `main` after this lands, or an explicit maintainer waiver to use branch evidence.
- Merge recommendation: ready for maintainer merge review now that full CI/benchmark lanes are green and review threads are resolved. Do not auto-merge from the batch coordinator; merge only if a maintainer accepts the narrow 19.2.7 support window and high-risk Pro/runtime change.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm list react react-dom --depth 0` after downstream validation restored workspace deps to `react@19.0.7` / `react-dom@19.0.7`
- `pnpm run lint`
- `pnpm start format.listDifferent`
- `pnpm --filter react-on-rails-pro-node-renderer run type-check`
- `pnpm --filter react-on-rails-pro-node-renderer run build`
- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/checkRscPeerCompatibility.test.ts tests/runRscPeerCompatibilityCheck.test.ts --runInBand`: 2 suites / 36 tests passed
- `pnpm --filter react-on-rails-pro-node-renderer exec jest tests/serverRenderRSCReactComponent.test.js --runInBand`
- `pnpm --filter react-on-rails-pro-node-renderer run ci` with local Redis on `127.0.0.1:6379`: 30 suites / 368 tests passed; Jest still prints its existing open-handle shutdown warning
- `script/check-pro-license-headers`
- `script/ci-changes-detector origin/main`
- `git diff --check`
- Downstream RSC validation using `react-on-rails-rsc` PR #102 tarball (`19.2.0-rc.1`) and this branch at `a15f15878f7f306b2971f71e398241d7bb842d26`: `scripts/e2e/downstream.sh --react-on-rails-dir /Users/justin/.codex/worktrees/4469/react_on_rails-3865 --work-dir /tmp/ror-rsc-downstream-pr102-ror4026-20260614011312` passed 30/30 Playwright tests across Chromium, Firefox, and WebKit.
- Hosted branch-name downstream validation for RSC #102 plus this branch completed successfully before the latest review-fix commit: https://github.com/shakacode/react_on_rails_rsc/actions/runs/27496338653
- Exact-SHA hosted downstream validation succeeded in `react_on_rails_rsc` for RSC `e79203124e593c9358110a4dac16ef24809f0efc` plus this branch head `a15f15878f7f306b2971f71e398241d7bb842d26`: https://github.com/shakacode/react_on_rails_rsc/actions/runs/27497017319. The stale pre-`a15f1587` exact-SHA run was cancelled to free the downstream lane: https://github.com/shakacode/react_on_rails_rsc/actions/runs/27496718573


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated the Pro node renderer’s React peer compatibility to support coordinated React 19.2.x requirements (React minimum **19.2.7**) alongside the existing React 19.0.x support (minimum **19.0.4**).
  * Compatibility validation and error messages now reflect the correct minimums based on the matched React/RSC version line.

* **Tests**
  * Added and updated coverage for React 19.2.x scenarios, including prerelease RSC pairing and failure cases below the 19.2.7 threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->