### PR TITLE
Add post-merge audit scope resolver

### DIFF
--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -27,7 +27,7 @@ When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-au
 .agents/skills/post-merge-audit/bin/post-merge-audit-scope --json
 ```
 
-The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, carry-over PRs, and the remaining `to_audit` list. Use its output as the initial scope table, then verify assumptions before deep audit.
+The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Use its output as the initial scope table, then verify assumptions before deep audit.
 
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -27,7 +27,7 @@ When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-au
 .agents/skills/post-merge-audit/bin/post-merge-audit-scope --json
 ```
 
-The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Use its output as the initial scope table, then verify assumptions before deep audit.
+The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Open finding markers create carry-over PRs that are subtracted from `to_audit`; closed markers remain fingerprint context only. Use the output as the initial scope table, then verify assumptions before deep audit.
 
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -21,6 +21,14 @@ Use `.agents/workflows/post-merge-audit.md` for reusable copy-paste prompts, inc
 
 Start by resolving the exact audit range:
 
+When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-audit-scope`, run it first:
+
+```bash
+.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json
+```
+
+The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, carry-over PRs, and the remaining `to_audit` list. Use its output as the initial scope table, then verify assumptions before deep audit.
+
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.
 3. Merged PR list: every PR merged between base and head.

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -13,6 +13,8 @@ Options:
       --limit N        Max issue-search results per state for existing findings. Default: 200.
       --self-check     Run parser checks plus read-only git/gh smoke checks.
   -h, --help           Show this help.
+
+Requires: ruby, gh (GitHub CLI)
 USAGE
 }
 
@@ -78,6 +80,8 @@ ARGF.each_line do |line|
   pr_number ||= subject[/\AMerge pull request #(\d+)\b/, 1]
   next if pr_number.nil?
 
+  # Keep first-seen position but update to the most-recent commit: with --first-parent
+  # --reverse, the last occurrence of a PR number is its authoritative merge commit.
   order << pr_number unless records.key?(pr_number)
   records[pr_number] = [pr_number, sha, subject]
 end
@@ -564,6 +568,13 @@ pma_scope_main() (
     pma_scope_require_command gh || return 1
     repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
   fi
+  case "$repo" in
+    */*) ;;
+    *)
+      pma_scope_error "--repo must be in OWNER/REPO form (got: '$repo')"
+      return 1
+      ;;
+  esac
 
   head_sha="$(pma_scope_resolve_ref_sha "$head_ref")" || {
     pma_scope_error "could not resolve head ref: $head_ref"

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -42,9 +42,19 @@ pma_scope_default_head_ref() {
 }
 
 pma_scope_default_base_ref() {
-  local head_ref="$1"
+  local commit head_ref tag
 
-  git describe --tags --match '*.rc.*' --first-parent --abbrev=0 "$head_ref" 2>/dev/null || true
+  head_ref="$1"
+
+  while IFS= read -r commit; do
+    tag="$(git tag --points-at "$commit" --list '*.rc.*' | head -n 1)"
+    if [ -n "$tag" ]; then
+      printf '%s\n' "$tag"
+      return 0
+    fi
+  done < <(git rev-list --first-parent "$head_ref" 2>/dev/null || true)
+
+  return 0
 }
 
 pma_scope_resolve_ref_sha() {
@@ -205,7 +215,7 @@ pma_scope_fetch_issue_markers() {
   local limit="$2"
   local output_file="$3"
   local open_output_file="$4"
-  local tmpdir open_json closed_json
+  local closed_markers tmpdir open_json closed_json
 
   pma_scope_require_command gh || return 1
   if [ -n "${PMA_SCOPE_TMPDIR:-}" ]; then
@@ -215,6 +225,7 @@ pma_scope_fetch_issue_markers() {
   fi
   open_json="$tmpdir/open.json"
   closed_json="$tmpdir/closed.json"
+  closed_markers="$tmpdir/closed-markers.tsv"
 
   if ! gh search issues "post-merge-audit-finding v1" \
     --repo "$repo" \
@@ -244,9 +255,15 @@ pma_scope_fetch_issue_markers() {
     return 1
   fi
 
-  if ! pma_scope_extract_issue_markers_from_json_files "$open_json" "$closed_json" > "$output_file"; then
+  if ! pma_scope_extract_issue_markers_from_json_files "$closed_json" > "$closed_markers"; then
     rm -rf "$tmpdir"
-    pma_scope_error "failed to parse post-merge audit finding issues"
+    pma_scope_error "failed to parse closed post-merge audit finding issues"
+    return 1
+  fi
+
+  if ! cat "$open_output_file" "$closed_markers" > "$output_file"; then
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to combine post-merge audit finding markers"
     return 1
   fi
   rm -rf "$tmpdir"

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -64,7 +64,7 @@ ARGF.each_line do |line|
 
   # GitHub squash merges append the PR number at the end. Prefer that marker over quoted refs.
   pr_number = subject[/\s\(#(\d+)\)\s*\z/, 1]
-  pr_number ||= subject[/\bMerge pull request #(\d+)\b/, 1]
+  pr_number ||= subject[/\AMerge pull request #(\d+)\b/, 1]
   next if pr_number.nil? || seen[pr_number]
 
   seen[pr_number] = true
@@ -74,35 +74,20 @@ end
 }
 
 pma_scope_extract_issue_markers_from_json() {
-  ruby -rjson -e '
-raw = STDIN.read
-data = raw.strip.empty? ? [] : JSON.parse(raw)
-issues = data.is_a?(Array) ? data : [data]
-seen = {}
+  local tmpdir input_file rc
 
-issues.each do |issue|
-  body = issue.fetch("body", "").to_s
-  body.scan(/<!--\s*post-merge-audit-finding\s+v1\s*(.*?)-->/m).each do |match|
-    marker = match[0]
-    fingerprint = marker[/^\s*fingerprint:\s*(.+?)\s*$/i, 1]&.strip
-    affected_prs = marker[/^\s*affected_prs:\s*(.+?)\s*$/i, 1]&.strip
-    audit = marker[/^\s*audit:\s*(.+?)\s*$/i, 1]&.strip.to_s
-    next if fingerprint.nil? || affected_prs.nil?
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-json.XXXXXX")" || return 1
+  input_file="$tmpdir/stdin.json"
+  cat > "$input_file" || {
+    rc=$?
+    rm -rf "$tmpdir"
+    return "$rc"
+  }
 
-    prs = affected_prs.scan(/\d+/)
-    next if prs.empty?
-
-    issue_number = issue.fetch("number", "").to_s
-    state = issue.fetch("state", "").to_s
-    url = issue.fetch("url", "").to_s
-    dedupe_key = [fingerprint, issue_number, prs.join(",")].join("\0")
-    next if seen[dedupe_key]
-
-    seen[dedupe_key] = true
-    puts [fingerprint, issue_number, state, prs.join(","), audit, url].join("\t")
-  end
-end
-'
+  pma_scope_extract_issue_markers_from_json_files "$input_file"
+  rc=$?
+  rm -rf "$tmpdir"
+  return "$rc"
 }
 
 pma_scope_extract_issue_markers_from_json_files() {
@@ -488,7 +473,7 @@ JSON
   printf 'self-check passed\n'
 }
 
-pma_scope_main() {
+pma_scope_main() (
   local base_ref=""
   local head_ref=""
   local repo=""
@@ -557,8 +542,8 @@ pma_scope_main() {
     esac
   done
 
-  pma_scope_require_command git
-  pma_scope_require_command ruby
+  pma_scope_require_command git || return 1
+  pma_scope_require_command ruby || return 1
 
   repo_root="$(pma_scope_repo_root)"
   cd "$repo_root"
@@ -568,7 +553,7 @@ pma_scope_main() {
   fi
 
   if [ -z "$repo" ]; then
-    pma_scope_require_command gh
+    pma_scope_require_command gh || return 1
     repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
   fi
 
@@ -590,7 +575,7 @@ pma_scope_main() {
     return 1
   }
 
-  first_parent_match="$(git rev-list --first-parent "$head_sha" | grep -Fx "$base_sha" || true)"
+  first_parent_match="$(git rev-list --first-parent "$head_sha" | grep -Fxm1 "$base_sha" || true)"
   if [ "$first_parent_match" != "$base_sha" ]; then
     pma_scope_error "base ref is not on the first-parent history of head ref: $base_ref is not a mainline boundary for $head_ref"
     return 1
@@ -632,7 +617,7 @@ pma_scope_main() {
       return 1
       ;;
   esac
-}
+)
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   set -euo pipefail

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -55,7 +55,8 @@ pma_scope_resolve_ref_sha() {
 
 pma_scope_parse_git_log() {
   ruby -e '
-seen = {}
+records = {}
+order = []
 
 ARGF.each_line do |line|
   line = line.chomp
@@ -65,10 +66,14 @@ ARGF.each_line do |line|
   # GitHub squash merges append the PR number at the end. Prefer that marker over quoted refs.
   pr_number = subject[/\s\(#(\d+)\)\s*\z/, 1]
   pr_number ||= subject[/\AMerge pull request #(\d+)\b/, 1]
-  next if pr_number.nil? || seen[pr_number]
+  next if pr_number.nil?
 
-  seen[pr_number] = true
-  puts [pr_number, sha, subject].join("\t")
+  order << pr_number unless records.key?(pr_number)
+  records[pr_number] = [pr_number, sha, subject]
+end
+
+order.each do |pr_number|
+  puts records.fetch(pr_number).join("\t")
 end
 '
 }
@@ -406,7 +411,7 @@ pma_scope_self_check() {
     } | pma_scope_parse_git_log
   )"
   expected="$(
-    printf '%s\t%s\t%s\n' "4014" "abc123" "Fix audit scope resolver (#4014)"
+    printf '%s\t%s\t%s\n' "4014" "fedcba" "Duplicate mention (#4014)"
     printf '%s\t%s\t%s' "4015" "def456" "Merge pull request #4015 from shakacode/example"
   )"
   pma_scope_self_check_assert_equals "$expected" "$parsed" "git log parser" || return 1

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -44,7 +44,7 @@ pma_scope_default_head_ref() {
 pma_scope_default_base_ref() {
   local head_ref="$1"
 
-  git tag --list '*.rc.*' --merged "$head_ref" --sort=-creatordate | head -n 1
+  git describe --tags --match '*.rc.*' --first-parent --abbrev=0 "$head_ref" 2>/dev/null || true
 }
 
 pma_scope_resolve_ref_sha() {

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -49,12 +49,13 @@ pma_scope_default_base_ref() {
   head_ref="$1"
 
   while IFS= read -r commit; do
+    # If multiple RC tags point at the same commit, git tag order is the tie-breaker.
     tag="$(git tag --points-at "$commit" --list '*.rc.*' | head -n 1)"
     if [ -n "$tag" ]; then
       printf '%s\n' "$tag"
       return 0
     fi
-  done < <(git rev-list --first-parent "$head_ref" 2>/dev/null || true)
+  done < <(git rev-list --first-parent --max-count=10000 "$head_ref" 2>/dev/null || true)
 
   return 0
 }
@@ -615,7 +616,7 @@ pma_scope_main() (
   git log --first-parent --reverse --format='%H%x09%s' "${base_sha}..${head_sha}" |
     pma_scope_parse_git_log > "$merged_file"
   pma_scope_tsv_pr_numbers "$merged_file" > "$merged_numbers_file"
-  pma_scope_fetch_issue_markers "$repo" "$limit" "$markers_file" "$open_markers_file"
+  pma_scope_fetch_issue_markers "$repo" "$limit" "$markers_file" "$open_markers_file" || return 1
   pma_scope_marker_pr_numbers "$open_markers_file" > "$marker_numbers_file"
   pma_scope_intersect_prs "$merged_numbers_file" "$marker_numbers_file" > "$carry_file"
   pma_scope_subtract_prs "$merged_numbers_file" "$carry_file" > "$to_audit_file"

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -6,7 +6,7 @@ pma_scope_usage() {
 Usage: post-merge-audit-scope [options]
 
 Options:
-      --base REF       Base tag/commit/ref. Defaults to the most recent *.rc.* tag.
+      --base REF       Base tag/commit/ref. Defaults to the most recent *.rc.* tag reachable from head.
       --head REF       Head ref. Defaults to origin/main when present, otherwise HEAD.
       --repo REPO      GitHub repo in OWNER/REPO form. Defaults to gh repo view.
       --json           Print JSON instead of text.
@@ -42,7 +42,9 @@ pma_scope_default_head_ref() {
 }
 
 pma_scope_default_base_ref() {
-  git tag --list '*.rc.*' --sort=-creatordate | head -n 1
+  local head_ref="$1"
+
+  git tag --list '*.rc.*' --merged "$head_ref" --sort=-creatordate | head -n 1
 }
 
 pma_scope_resolve_ref_sha() {
@@ -60,8 +62,8 @@ ARGF.each_line do |line|
   sha, subject = line.split("\t", 2)
   next if sha.nil? || subject.nil?
 
-  pr_number = nil
-  subject.scan(/\(#(\d+)\)/) { |match| pr_number = match[0] }
+  # GitHub squash merges append the PR number at the end. Prefer that marker over quoted refs.
+  pr_number = subject[/\s\(#(\d+)\)\s*\z/, 1]
   pr_number ||= subject[/\bMerge pull request #(\d+)\b/, 1]
   next if pr_number.nil? || seen[pr_number]
 
@@ -216,7 +218,11 @@ pma_scope_fetch_issue_markers() {
   local tmpdir open_json closed_json
 
   pma_scope_require_command gh || return 1
-  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-gh.XXXXXX")" || return 1
+  if [ -n "${PMA_SCOPE_TMPDIR:-}" ]; then
+    tmpdir="$(mktemp -d "${PMA_SCOPE_TMPDIR}/gh.XXXXXX")" || return 1
+  else
+    tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-gh.XXXXXX")" || return 1
+  fi
   open_json="$tmpdir/open.json"
   closed_json="$tmpdir/closed.json"
 
@@ -242,8 +248,17 @@ pma_scope_fetch_issue_markers() {
     return 1
   fi
 
-  pma_scope_extract_issue_markers_from_json_files "$open_json" > "$open_output_file"
-  pma_scope_extract_issue_markers_from_json_files "$open_json" "$closed_json" > "$output_file"
+  if ! pma_scope_extract_issue_markers_from_json_files "$open_json" > "$open_output_file"; then
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to parse open post-merge audit finding issues"
+    return 1
+  fi
+
+  if ! pma_scope_extract_issue_markers_from_json_files "$open_json" "$closed_json" > "$output_file"; then
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to parse post-merge audit finding issues"
+    return 1
+  fi
   rm -rf "$tmpdir"
 }
 
@@ -520,6 +535,12 @@ pma_scope_main() {
           return 1
         }
         limit="$2"
+        case "$limit" in
+          ''|*[!0-9]*|0)
+            pma_scope_error "--limit must be a positive integer"
+            return 1
+            ;;
+        esac
         shift 2
         ;;
       --self-check)
@@ -544,14 +565,6 @@ pma_scope_main() {
   repo_root="$(pma_scope_repo_root)"
   cd "$repo_root"
 
-  if [ -z "$base_ref" ]; then
-    base_ref="$(pma_scope_default_base_ref)"
-    if [ -z "$base_ref" ]; then
-      pma_scope_error "no *.rc.* tag found; pass --base explicitly"
-      return 1
-    fi
-  fi
-
   if [ -z "$head_ref" ]; then
     head_ref="$(pma_scope_default_head_ref)"
   fi
@@ -561,14 +574,28 @@ pma_scope_main() {
     repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
   fi
 
-  base_sha="$(pma_scope_resolve_ref_sha "$base_ref")" || {
-    pma_scope_error "could not resolve base ref: $base_ref"
-    return 1
-  }
   head_sha="$(pma_scope_resolve_ref_sha "$head_ref")" || {
     pma_scope_error "could not resolve head ref: $head_ref"
     return 1
   }
+
+  if [ -z "$base_ref" ]; then
+    base_ref="$(pma_scope_default_base_ref "$head_sha")"
+    if [ -z "$base_ref" ]; then
+      pma_scope_error "no *.rc.* tag found in head history; pass --base explicitly"
+      return 1
+    fi
+  fi
+
+  base_sha="$(pma_scope_resolve_ref_sha "$base_ref")" || {
+    pma_scope_error "could not resolve base ref: $base_ref"
+    return 1
+  }
+
+  if ! git merge-base --is-ancestor "$base_sha" "$head_sha"; then
+    pma_scope_error "base ref is not an ancestor of head ref: $base_ref is not in $head_ref history"
+    return 1
+  fi
 
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope.XXXXXX")"
   PMA_SCOPE_TMPDIR="$tmpdir"

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -1,0 +1,613 @@
+#!/usr/bin/env bash
+# Resolve the post-merge-audit scope without writing to git or GitHub.
+
+pma_scope_usage() {
+  cat <<'USAGE'
+Usage: post-merge-audit-scope [options]
+
+Options:
+      --base REF       Base tag/commit/ref. Defaults to the most recent *.rc.* tag.
+      --head REF       Head ref. Defaults to origin/main when present, otherwise HEAD.
+      --repo REPO      GitHub repo in OWNER/REPO form. Defaults to gh repo view.
+      --json           Print JSON instead of text.
+      --limit N        Max issue-search results per state for existing findings. Default: 200.
+      --self-check     Run parser checks plus read-only git/gh smoke checks.
+  -h, --help           Show this help.
+USAGE
+}
+
+pma_scope_error() {
+  printf 'Error: %s\n' "$*" >&2
+}
+
+pma_scope_require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    pma_scope_error "missing required command: $command_name"
+    return 1
+  fi
+}
+
+pma_scope_repo_root() {
+  git rev-parse --show-toplevel
+}
+
+pma_scope_default_head_ref() {
+  if git rev-parse --verify "origin/main^{commit}" >/dev/null 2>&1; then
+    printf 'origin/main\n'
+  else
+    printf 'HEAD\n'
+  fi
+}
+
+pma_scope_default_base_ref() {
+  git tag --list '*.rc.*' --sort=-creatordate | head -n 1
+}
+
+pma_scope_resolve_ref_sha() {
+  local ref="$1"
+
+  git rev-parse --verify "${ref}^{commit}"
+}
+
+pma_scope_parse_git_log() {
+  ruby -e '
+seen = {}
+
+ARGF.each_line do |line|
+  line = line.chomp
+  sha, subject = line.split("\t", 2)
+  next if sha.nil? || subject.nil?
+
+  pr_number = nil
+  subject.scan(/\(#(\d+)\)/) { |match| pr_number = match[0] }
+  pr_number ||= subject[/\bMerge pull request #(\d+)\b/, 1]
+  next if pr_number.nil? || seen[pr_number]
+
+  seen[pr_number] = true
+  puts [pr_number, sha, subject].join("\t")
+end
+'
+}
+
+pma_scope_extract_issue_markers_from_json() {
+  ruby -rjson -e '
+raw = STDIN.read
+data = raw.strip.empty? ? [] : JSON.parse(raw)
+issues = data.is_a?(Array) ? data : [data]
+seen = {}
+
+issues.each do |issue|
+  body = issue.fetch("body", "").to_s
+  body.scan(/<!--\s*post-merge-audit-finding\s+v1\s*(.*?)-->/m).each do |match|
+    marker = match[0]
+    fingerprint = marker[/^\s*fingerprint:\s*(.+?)\s*$/i, 1]&.strip
+    affected_prs = marker[/^\s*affected_prs:\s*(.+?)\s*$/i, 1]&.strip
+    audit = marker[/^\s*audit:\s*(.+?)\s*$/i, 1]&.strip.to_s
+    next if fingerprint.nil? || affected_prs.nil?
+
+    prs = affected_prs.scan(/\d+/)
+    next if prs.empty?
+
+    issue_number = issue.fetch("number", "").to_s
+    state = issue.fetch("state", "").to_s
+    url = issue.fetch("url", "").to_s
+    dedupe_key = [fingerprint, issue_number, prs.join(",")].join("\0")
+    next if seen[dedupe_key]
+
+    seen[dedupe_key] = true
+    puts [fingerprint, issue_number, state, prs.join(","), audit, url].join("\t")
+  end
+end
+'
+}
+
+pma_scope_extract_issue_markers_from_json_files() {
+  ruby -rjson - "$@" <<'RUBY'
+issues = ARGV.flat_map do |path|
+  raw = File.read(path)
+  data = raw.strip.empty? ? [] : JSON.parse(raw)
+  data.is_a?(Array) ? data : [data]
+end
+
+seen = {}
+issues.each do |issue|
+  body = issue.fetch("body", "").to_s
+  body.scan(/<!--\s*post-merge-audit-finding\s+v1\s*(.*?)-->/m).each do |match|
+    marker = match[0]
+    fingerprint = marker[/^\s*fingerprint:\s*(.+?)\s*$/i, 1]&.strip
+    affected_prs = marker[/^\s*affected_prs:\s*(.+?)\s*$/i, 1]&.strip
+    audit = marker[/^\s*audit:\s*(.+?)\s*$/i, 1]&.strip.to_s
+    next if fingerprint.nil? || affected_prs.nil?
+
+    prs = affected_prs.scan(/\d+/)
+    next if prs.empty?
+
+    issue_number = issue.fetch("number", "").to_s
+    state = issue.fetch("state", "").to_s
+    url = issue.fetch("url", "").to_s
+    dedupe_key = [fingerprint, issue_number, prs.join(",")].join("\0")
+    next if seen[dedupe_key]
+
+    seen[dedupe_key] = true
+    puts [fingerprint, issue_number, state, prs.join(","), audit, url].join("\t")
+  end
+end
+RUBY
+}
+
+pma_scope_marker_pr_numbers() {
+  ruby -e '
+seen = {}
+
+ARGF.each_line do |line|
+  _fingerprint, _issue_number, _state, affected_prs = line.chomp.split("\t", 5)
+  next if affected_prs.nil?
+
+  affected_prs.scan(/\d+/).each do |pr_number|
+    next if seen[pr_number]
+
+    seen[pr_number] = true
+    puts pr_number
+  end
+end
+' "$@"
+}
+
+pma_scope_tsv_pr_numbers() {
+  ruby -e '
+seen = {}
+
+ARGF.each_line do |line|
+  pr_number = line.split("\t", 2).first.to_s.strip
+  next unless pr_number =~ /\A\d+\z/
+  next if seen[pr_number]
+
+  seen[pr_number] = true
+  puts pr_number
+end
+' "$@"
+}
+
+pma_scope_intersect_prs() {
+  local left_file="$1"
+  local right_file="$2"
+
+  ruby - "$left_file" "$right_file" <<'RUBY'
+left_path, right_path = ARGV
+right = File.readlines(right_path, chomp: true).map(&:strip).reject(&:empty?).to_h { |value| [value, true] }
+seen = {}
+
+File.readlines(left_path, chomp: true).each do |value|
+  value = value.strip
+  next if value.empty? || seen[value] || !right[value]
+
+  seen[value] = true
+  puts value
+end
+RUBY
+}
+
+pma_scope_subtract_prs() {
+  local merged_file="$1"
+  local carry_file="$2"
+
+  ruby - "$merged_file" "$carry_file" <<'RUBY'
+merged_path, carry_path = ARGV
+carry = File.readlines(carry_path, chomp: true).map(&:strip).reject(&:empty?).to_h { |value| [value, true] }
+seen = {}
+
+File.readlines(merged_path, chomp: true).each do |value|
+  value = value.strip
+  next if value.empty? || seen[value] || carry[value]
+
+  seen[value] = true
+  puts value
+end
+RUBY
+}
+
+pma_scope_fetch_issue_markers() {
+  local repo="$1"
+  local limit="$2"
+  local output_file="$3"
+  local open_output_file="$4"
+  local tmpdir open_json closed_json
+
+  pma_scope_require_command gh || return 1
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-gh.XXXXXX")" || return 1
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+
+  if ! gh search issues "post-merge-audit-finding v1" \
+    --repo "$repo" \
+    --match body \
+    --state open \
+    --limit "$limit" \
+    --json number,state,title,body,url > "$open_json"; then
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to search open post-merge audit finding issues"
+    return 1
+  fi
+
+  if ! gh search issues "post-merge-audit-finding v1" \
+    --repo "$repo" \
+    --match body \
+    --state closed \
+    --limit "$limit" \
+    --json number,state,title,body,url > "$closed_json"; then
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to search closed post-merge audit finding issues"
+    return 1
+  fi
+
+  pma_scope_extract_issue_markers_from_json_files "$open_json" > "$open_output_file"
+  pma_scope_extract_issue_markers_from_json_files "$open_json" "$closed_json" > "$output_file"
+  rm -rf "$tmpdir"
+}
+
+pma_scope_write_json() {
+  local base_ref="$1"
+  local base_sha="$2"
+  local head_ref="$3"
+  local head_sha="$4"
+  local repo="$5"
+  local merged_file="$6"
+  local carry_file="$7"
+  local markers_file="$8"
+  local to_audit_file="$9"
+
+  ruby -rjson - \
+    "$base_ref" "$base_sha" "$head_ref" "$head_sha" "$repo" \
+    "$merged_file" "$carry_file" "$markers_file" "$to_audit_file" <<'RUBY'
+base_ref, base_sha, head_ref, head_sha, repo, merged_path, carry_path, markers_path, to_audit_path = ARGV
+
+def read_numbers(path)
+  File.readlines(path, chomp: true).map(&:strip).reject(&:empty?).map(&:to_i)
+end
+
+merged_prs = File.readlines(merged_path, chomp: true).filter_map do |line|
+  number, sha, subject = line.split("\t", 3)
+  next if number.nil? || sha.nil? || subject.nil?
+
+  { "number" => number.to_i, "sha" => sha, "subject" => subject }
+end
+
+fingerprints = File.readlines(markers_path, chomp: true).filter_map do |line|
+  fingerprint, issue_number, state, affected_prs, audit, url = line.split("\t", 6)
+  next if fingerprint.nil? || issue_number.nil? || affected_prs.nil?
+
+  {
+    "fingerprint" => fingerprint,
+    "issue_number" => issue_number.to_i,
+    "state" => state.to_s,
+    "affected_prs" => affected_prs.scan(/\d+/).map(&:to_i),
+    "audit" => audit.to_s,
+    "url" => url.to_s
+  }
+end
+
+puts JSON.pretty_generate(
+  {
+    "base" => { "ref" => base_ref, "sha" => base_sha },
+    "head" => { "ref" => head_ref, "sha" => head_sha },
+    "range" => "#{base_sha}..#{head_sha}",
+    "repo" => repo,
+    "merged_prs" => merged_prs,
+    "carry_over_prs" => read_numbers(carry_path),
+    "existing_fingerprints" => fingerprints,
+    "to_audit" => read_numbers(to_audit_path)
+  }
+)
+RUBY
+}
+
+pma_scope_write_text() {
+  local base_ref="$1"
+  local base_sha="$2"
+  local head_ref="$3"
+  local head_sha="$4"
+  local repo="$5"
+  local merged_file="$6"
+  local carry_file="$7"
+  local markers_file="$8"
+  local to_audit_file="$9"
+
+  ruby - \
+    "$base_ref" "$base_sha" "$head_ref" "$head_sha" "$repo" \
+    "$merged_file" "$carry_file" "$markers_file" "$to_audit_file" <<'RUBY'
+base_ref, base_sha, head_ref, head_sha, repo, merged_path, carry_path, markers_path, to_audit_path = ARGV
+
+def read_numbers(path)
+  File.readlines(path, chomp: true).map(&:strip).reject(&:empty?)
+end
+
+def short_sha(sha)
+  sha[0, 12]
+end
+
+puts "Post-merge audit scope"
+puts "repo: #{repo}"
+puts "base: #{base_ref} #{base_sha}"
+puts "head: #{head_ref} #{head_sha}"
+puts "range: #{base_sha}..#{head_sha}"
+puts
+
+puts "merged_prs:"
+merged_lines = File.readlines(merged_path, chomp: true)
+if merged_lines.empty?
+  puts "  none"
+else
+  merged_lines.each do |line|
+    number, sha, subject = line.split("\t", 3)
+    puts "  - ##{number} #{short_sha(sha)} #{subject}"
+  end
+end
+puts
+
+puts "carry_over_prs:"
+carry = read_numbers(carry_path)
+if carry.empty?
+  puts "  none"
+else
+  carry.each { |number| puts "  - ##{number}" }
+end
+puts
+
+puts "existing_fingerprints:"
+marker_lines = File.readlines(markers_path, chomp: true)
+if marker_lines.empty?
+  puts "  none"
+else
+  marker_lines.each do |line|
+    fingerprint, issue_number, state, affected_prs, audit, url = line.split("\t", 6)
+    prs = affected_prs.to_s.scan(/\d+/).map { |number| "##{number}" }.join(", ")
+    audit_suffix = audit.to_s.empty? ? "" : " audit=#{audit}"
+    url_suffix = url.to_s.empty? ? "" : " #{url}"
+    puts "  - #{fingerprint} -> issue ##{issue_number} #{state} affected=#{prs}#{audit_suffix}#{url_suffix}"
+  end
+end
+puts
+
+puts "to_audit:"
+to_audit = read_numbers(to_audit_path)
+if to_audit.empty?
+  puts "  none"
+else
+  to_audit.each { |number| puts "  - ##{number}" }
+end
+RUBY
+}
+
+pma_scope_self_check_assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$expected" != "$actual" ]; then
+    printf 'self-check failed: %s\nexpected:\n%s\nactual:\n%s\n' "$label" "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+pma_scope_self_check() {
+  local parsed expected markers tmpdir merged carry to_audit repo
+
+  pma_scope_require_command ruby || return 1
+  pma_scope_require_command git || return 1
+
+  parsed="$(
+    {
+      printf '%s\t%s\n' "abc123" "Fix audit scope resolver (#4014)"
+      printf '%s\t%s\n' "def456" "Merge pull request #4015 from shakacode/example"
+      printf '%s\t%s\n' "fedcba" "Duplicate mention (#4014)"
+      printf '%s\t%s\n' "999999" "No pull request marker"
+    } | pma_scope_parse_git_log
+  )"
+  expected="$(
+    printf '%s\t%s\t%s\n' "4014" "abc123" "Fix audit scope resolver (#4014)"
+    printf '%s\t%s\t%s' "4015" "def456" "Merge pull request #4015 from shakacode/example"
+  )"
+  pma_scope_self_check_assert_equals "$expected" "$parsed" "git log parser" || return 1
+
+  markers="$(
+    cat <<'JSON' | pma_scope_extract_issue_markers_from_json
+[
+  {
+    "number": 88,
+    "state": "OPEN",
+    "url": "https://example.test/issues/88",
+    "body": "<!-- post-merge-audit-finding v1\naudit: 2026-06-14-test\nfingerprint: pr-4014:scope-resolver\naffected_prs: 4014, 4015\n-->"
+  }
+]
+JSON
+  )"
+  expected="$(
+    printf '%s\t%s\t%s\t%s\t%s\t%s' \
+      "pr-4014:scope-resolver" \
+      "88" \
+      "OPEN" \
+      "4014,4015" \
+      "2026-06-14-test" \
+      "https://example.test/issues/88"
+  )"
+  pma_scope_self_check_assert_equals "$expected" "$markers" "issue marker parser" || return 1
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-self.XXXXXX")" || return 1
+  merged="$tmpdir/merged.txt"
+  carry="$tmpdir/carry.txt"
+  to_audit="$tmpdir/to-audit.txt"
+  printf '%s\n' 4014 4015 > "$merged"
+  : > "$carry"
+  pma_scope_subtract_prs "$merged" "$carry" > "$to_audit"
+  expected="$(printf '%s\n%s' 4014 4015)"
+  pma_scope_self_check_assert_equals "$expected" "$(cat "$to_audit")" "empty carry-over subtraction" || {
+    rm -rf "$tmpdir"
+    return 1
+  }
+  rm -rf "$tmpdir"
+
+  git rev-parse --show-toplevel >/dev/null
+  git rev-parse --verify "HEAD^{commit}" >/dev/null
+
+  if command -v gh >/dev/null 2>&1; then
+    repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    gh search issues "post-merge-audit-finding v1" \
+      --repo "$repo" \
+      --match body \
+      --state open \
+      --limit 1 \
+      --json number,state,title,body,url >/dev/null
+    gh search issues "post-merge-audit-finding v1" \
+      --repo "$repo" \
+      --match body \
+      --state closed \
+      --limit 1 \
+      --json number,state,title,body,url >/dev/null
+    printf 'gh search: ok for %s (open + closed states)\n' "$repo"
+  else
+    printf 'gh search: skipped (gh not installed)\n'
+  fi
+
+  printf 'self-check passed\n'
+}
+
+pma_scope_main() {
+  set -euo pipefail
+
+  local base_ref=""
+  local head_ref=""
+  local repo=""
+  local output_format="text"
+  local limit="200"
+  local repo_root base_sha head_sha tmpdir merged_file merged_numbers_file
+  local markers_file open_markers_file marker_numbers_file carry_file to_audit_file
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --base)
+        [ "$#" -ge 2 ] || {
+          pma_scope_error "--base requires a value"
+          return 1
+        }
+        base_ref="$2"
+        shift 2
+        ;;
+      --head)
+        [ "$#" -ge 2 ] || {
+          pma_scope_error "--head requires a value"
+          return 1
+        }
+        head_ref="$2"
+        shift 2
+        ;;
+      --repo)
+        [ "$#" -ge 2 ] || {
+          pma_scope_error "--repo requires a value"
+          return 1
+        }
+        repo="$2"
+        shift 2
+        ;;
+      --json)
+        output_format="json"
+        shift
+        ;;
+      --limit)
+        [ "$#" -ge 2 ] || {
+          pma_scope_error "--limit requires a value"
+          return 1
+        }
+        limit="$2"
+        shift 2
+        ;;
+      --self-check)
+        pma_scope_self_check
+        return
+        ;;
+      -h|--help)
+        pma_scope_usage
+        return
+        ;;
+      *)
+        pma_scope_error "unknown option: $1"
+        pma_scope_usage >&2
+        return 1
+        ;;
+    esac
+  done
+
+  pma_scope_require_command git
+  pma_scope_require_command ruby
+
+  repo_root="$(pma_scope_repo_root)"
+  cd "$repo_root"
+
+  if [ -z "$base_ref" ]; then
+    base_ref="$(pma_scope_default_base_ref)"
+    if [ -z "$base_ref" ]; then
+      pma_scope_error "no *.rc.* tag found; pass --base explicitly"
+      return 1
+    fi
+  fi
+
+  if [ -z "$head_ref" ]; then
+    head_ref="$(pma_scope_default_head_ref)"
+  fi
+
+  if [ -z "$repo" ]; then
+    pma_scope_require_command gh
+    repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+  fi
+
+  base_sha="$(pma_scope_resolve_ref_sha "$base_ref")" || {
+    pma_scope_error "could not resolve base ref: $base_ref"
+    return 1
+  }
+  head_sha="$(pma_scope_resolve_ref_sha "$head_ref")" || {
+    pma_scope_error "could not resolve head ref: $head_ref"
+    return 1
+  }
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope.XXXXXX")"
+  PMA_SCOPE_TMPDIR="$tmpdir"
+  trap 'rm -rf "${PMA_SCOPE_TMPDIR:-}"' EXIT
+
+  merged_file="$tmpdir/merged.tsv"
+  merged_numbers_file="$tmpdir/merged-numbers.txt"
+  markers_file="$tmpdir/markers.tsv"
+  open_markers_file="$tmpdir/open-markers.tsv"
+  marker_numbers_file="$tmpdir/marker-numbers.txt"
+  carry_file="$tmpdir/carry-over.txt"
+  to_audit_file="$tmpdir/to-audit.txt"
+
+  git log --first-parent --reverse --format='%H%x09%s' "${base_sha}..${head_sha}" |
+    pma_scope_parse_git_log > "$merged_file"
+  pma_scope_tsv_pr_numbers "$merged_file" > "$merged_numbers_file"
+  pma_scope_fetch_issue_markers "$repo" "$limit" "$markers_file" "$open_markers_file"
+  pma_scope_marker_pr_numbers "$open_markers_file" > "$marker_numbers_file"
+  pma_scope_intersect_prs "$merged_numbers_file" "$marker_numbers_file" > "$carry_file"
+  pma_scope_subtract_prs "$merged_numbers_file" "$carry_file" > "$to_audit_file"
+
+  case "$output_format" in
+    json)
+      pma_scope_write_json \
+        "$base_ref" "$base_sha" "$head_ref" "$head_sha" "$repo" \
+        "$merged_file" "$carry_file" "$markers_file" "$to_audit_file"
+      ;;
+    text)
+      pma_scope_write_text \
+        "$base_ref" "$base_sha" "$head_ref" "$head_sha" "$repo" \
+        "$merged_file" "$carry_file" "$markers_file" "$to_audit_file"
+      ;;
+    *)
+      pma_scope_error "unknown output format: $output_format"
+      return 1
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  pma_scope_main "$@"
+fi

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -49,8 +49,7 @@ pma_scope_default_base_ref() {
   head_ref="$1"
 
   while IFS= read -r commit; do
-    # If multiple RC tags point at the same commit, git tag order is the tie-breaker.
-    tag="$(git tag --points-at "$commit" --list '*.rc.*' | head -n 1)"
+    tag="$(git tag --points-at "$commit" --list '*.rc.*' --sort=-version:refname | head -n 1)"
     if [ -n "$tag" ]; then
       printf '%s\n' "$tag"
       return 0
@@ -119,6 +118,7 @@ issues = ARGV.flat_map do |path|
 end
 
 seen = {}
+sanitize_tsv_field = ->(value) { value.to_s.tr("\t", " ") }
 issues.each do |issue|
   body = issue.fetch("body", "").to_s
   body.scan(/<!--\s*post-merge-audit-finding\s+v1\s*(.*?)-->/m).each do |match|
@@ -138,7 +138,14 @@ issues.each do |issue|
     next if seen[dedupe_key]
 
     seen[dedupe_key] = true
-    puts [fingerprint, issue_number, state, prs.join(","), audit, url].join("\t")
+    puts [
+      sanitize_tsv_field.call(fingerprint),
+      sanitize_tsv_field.call(issue_number),
+      sanitize_tsv_field.call(state),
+      prs.join(","),
+      sanitize_tsv_field.call(audit),
+      sanitize_tsv_field.call(url)
+    ].join("\t")
   end
 end
 RUBY

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -181,6 +181,25 @@ end
 RUBY
 }
 
+pma_scope_subtract_prs() {
+  local left_file="$1"
+  local right_file="$2"
+
+  ruby - "$left_file" "$right_file" <<'RUBY'
+left_path, right_path = ARGV
+right = File.readlines(right_path, chomp: true).map(&:strip).reject(&:empty?).to_h { |value| [value, true] }
+seen = {}
+
+File.readlines(left_path, chomp: true).each do |value|
+  value = value.strip
+  next if value.empty? || seen[value] || right[value]
+
+  seen[value] = true
+  puts value
+end
+RUBY
+}
+
 pma_scope_fetch_issue_markers() {
   local repo="$1"
   local limit="$2"
@@ -571,8 +590,7 @@ pma_scope_main() (
   pma_scope_fetch_issue_markers "$repo" "$limit" "$markers_file" "$open_markers_file"
   pma_scope_marker_pr_numbers "$open_markers_file" > "$marker_numbers_file"
   pma_scope_intersect_prs "$merged_numbers_file" "$marker_numbers_file" > "$carry_file"
-  # Prior findings are carry-over context; they do not prove the whole PR was fully audited.
-  cp "$merged_numbers_file" "$to_audit_file"
+  pma_scope_subtract_prs "$merged_numbers_file" "$carry_file" > "$to_audit_file"
 
   case "$output_format" in
     json)

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -494,7 +494,7 @@ pma_scope_main() {
   local repo=""
   local output_format="text"
   local limit="200"
-  local repo_root base_sha head_sha tmpdir merged_file merged_numbers_file
+  local repo_root base_sha head_sha first_parent_match tmpdir merged_file merged_numbers_file
   local markers_file open_markers_file marker_numbers_file carry_file to_audit_file
 
   while [ "$#" -gt 0 ]; do
@@ -590,8 +590,9 @@ pma_scope_main() {
     return 1
   }
 
-  if ! git merge-base --is-ancestor "$base_sha" "$head_sha"; then
-    pma_scope_error "base ref is not an ancestor of head ref: $base_ref is not in $head_ref history"
+  first_parent_match="$(git rev-list --first-parent "$head_sha" | grep -Fx "$base_sha" || true)"
+  if [ "$first_parent_match" != "$base_sha" ]; then
+    pma_scope_error "base ref is not on the first-parent history of head ref: $base_ref is not a mainline boundary for $head_ref"
     return 1
   fi
 

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -22,6 +22,10 @@ pma_scope_error() {
   printf 'Error: %s\n' "$*" >&2
 }
 
+pma_scope_warn() {
+  printf 'Warning: %s\n' "$*" >&2
+}
+
 pma_scope_require_command() {
   local command_name="$1"
 
@@ -44,19 +48,68 @@ pma_scope_default_head_ref() {
 }
 
 pma_scope_default_base_ref() {
-  local commit head_ref tag
+  local head_ref
 
   head_ref="$1"
 
-  while IFS= read -r commit; do
-    tag="$(git tag --points-at "$commit" --list '*.rc.*' --sort=-version:refname | head -n 1)"
-    if [ -n "$tag" ]; then
-      printf '%s\n' "$tag"
-      return 0
-    fi
-  done < <(git rev-list --first-parent --max-count=10000 "$head_ref" 2>/dev/null || true)
+  {
+    git log --first-parent --decorate=full --format='%D' "$head_ref" 2>/dev/null || true
+  } | ruby -e '
+def version_key(tag)
+  tag.scan(/\d+|[^\d]+/).map do |part|
+    part.match?(/\A\d+\z/) ? [1, part.to_i] : [0, part]
+  end
+end
 
-  return 0
+ARGF.each_line do |line|
+  tags = line.split(",").map do |decoration|
+    decoration.strip[/\Atag: refs\/tags\/(.+\.rc\..+)\z/, 1]
+  end.compact
+  next if tags.empty?
+
+  puts tags.sort_by { |tag| version_key(tag) }.last
+  exit
+end
+'
+}
+
+pma_scope_ref_on_first_parent() {
+  local base_sha="$1"
+  local head_sha="$2"
+  local oldest_commit parent _commit _rest
+
+  if [ "$base_sha" = "$head_sha" ]; then
+    return 0
+  fi
+
+  if ! git merge-base --is-ancestor "$base_sha" "$head_sha" 2>/dev/null; then
+    return 1
+  fi
+
+  oldest_commit="$(git rev-list --first-parent --ancestry-path --parents "${base_sha}..${head_sha}" 2>/dev/null | tail -n 1 || true)"
+  if [ -z "$oldest_commit" ]; then
+    return 1
+  fi
+
+  read -r _commit parent _rest <<< "$oldest_commit"
+  [ "$parent" = "$base_sha" ]
+}
+
+pma_scope_json_array_count() {
+  ruby -rjson -e '
+data = JSON.parse(File.read(ARGV.fetch(0)))
+puts(data.is_a?(Array) ? data.length : 0)
+' "$1"
+}
+
+pma_scope_warn_if_limit_reached() {
+  local label="$1"
+  local count="$2"
+  local limit="$3"
+
+  if [ "$count" -ge "$limit" ]; then
+    pma_scope_warn "$label issue search returned $count results (limit=$limit); some findings may be truncated -- increase --limit"
+  fi
 }
 
 pma_scope_resolve_ref_sha() {
@@ -227,7 +280,7 @@ pma_scope_fetch_issue_markers() {
   local limit="$2"
   local output_file="$3"
   local open_output_file="$4"
-  local closed_markers tmpdir open_json closed_json
+  local closed_count closed_markers open_count tmpdir open_json closed_json
 
   pma_scope_require_command gh || return 1
   if [ -n "${PMA_SCOPE_TMPDIR:-}" ]; then
@@ -266,12 +319,24 @@ pma_scope_fetch_issue_markers() {
     pma_scope_error "failed to parse open post-merge audit finding issues"
     return 1
   fi
+  open_count="$(pma_scope_json_array_count "$open_json")" || {
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to count open post-merge audit finding issues"
+    return 1
+  }
+  pma_scope_warn_if_limit_reached "open" "$open_count" "$limit"
 
   if ! pma_scope_extract_issue_markers_from_json_files "$closed_json" > "$closed_markers"; then
     rm -rf "$tmpdir"
     pma_scope_error "failed to parse closed post-merge audit finding issues"
     return 1
   fi
+  closed_count="$(pma_scope_json_array_count "$closed_json")" || {
+    rm -rf "$tmpdir"
+    pma_scope_error "failed to count closed post-merge audit finding issues"
+    return 1
+  }
+  pma_scope_warn_if_limit_reached "closed" "$closed_count" "$limit"
 
   if ! cat "$open_output_file" "$closed_markers" > "$output_file"; then
     rm -rf "$tmpdir"
@@ -499,7 +564,7 @@ pma_scope_main() (
   local repo=""
   local output_format="text"
   local limit="200"
-  local repo_root base_sha head_sha first_parent_match tmpdir merged_file merged_numbers_file
+  local repo_root base_sha head_sha tmpdir merged_file merged_numbers_file
   local markers_file open_markers_file marker_numbers_file carry_file to_audit_file
 
   while [ "$#" -gt 0 ]; do
@@ -602,8 +667,7 @@ pma_scope_main() (
     return 1
   }
 
-  first_parent_match="$(git rev-list --first-parent "$head_sha" | grep -Fxm1 "$base_sha" || true)"
-  if [ "$first_parent_match" != "$base_sha" ]; then
+  if ! pma_scope_ref_on_first_parent "$base_sha" "$head_sha"; then
     pma_scope_error "base ref is not on the first-parent history of head ref: $base_ref is not a mainline boundary for $head_ref"
     return 1
   fi

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -489,8 +489,6 @@ JSON
 }
 
 pma_scope_main() {
-  set -euo pipefail
-
   local base_ref=""
   local head_ref=""
   local repo=""
@@ -636,5 +634,6 @@ pma_scope_main() {
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -euo pipefail
   pma_scope_main "$@"
 fi

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope
@@ -181,25 +181,6 @@ end
 RUBY
 }
 
-pma_scope_subtract_prs() {
-  local merged_file="$1"
-  local carry_file="$2"
-
-  ruby - "$merged_file" "$carry_file" <<'RUBY'
-merged_path, carry_path = ARGV
-carry = File.readlines(carry_path, chomp: true).map(&:strip).reject(&:empty?).to_h { |value| [value, true] }
-seen = {}
-
-File.readlines(merged_path, chomp: true).each do |value|
-  value = value.strip
-  next if value.empty? || seen[value] || carry[value]
-
-  seen[value] = true
-  puts value
-end
-RUBY
-}
-
 pma_scope_fetch_issue_markers() {
   local repo="$1"
   local limit="$2"
@@ -397,7 +378,7 @@ pma_scope_self_check_assert_equals() {
 }
 
 pma_scope_self_check() {
-  local parsed expected markers tmpdir merged carry to_audit repo
+  local parsed expected markers repo
 
   pma_scope_require_command ruby || return 1
   pma_scope_require_command git || return 1
@@ -438,20 +419,6 @@ JSON
       "https://example.test/issues/88"
   )"
   pma_scope_self_check_assert_equals "$expected" "$markers" "issue marker parser" || return 1
-
-  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-self.XXXXXX")" || return 1
-  merged="$tmpdir/merged.txt"
-  carry="$tmpdir/carry.txt"
-  to_audit="$tmpdir/to-audit.txt"
-  printf '%s\n' 4014 4015 > "$merged"
-  : > "$carry"
-  pma_scope_subtract_prs "$merged" "$carry" > "$to_audit"
-  expected="$(printf '%s\n%s' 4014 4015)"
-  pma_scope_self_check_assert_equals "$expected" "$(cat "$to_audit")" "empty carry-over subtraction" || {
-    rm -rf "$tmpdir"
-    return 1
-  }
-  rm -rf "$tmpdir"
 
   git rev-parse --show-toplevel >/dev/null
   git rev-parse --verify "HEAD^{commit}" >/dev/null
@@ -604,7 +571,8 @@ pma_scope_main() (
   pma_scope_fetch_issue_markers "$repo" "$limit" "$markers_file" "$open_markers_file"
   pma_scope_marker_pr_numbers "$open_markers_file" > "$marker_numbers_file"
   pma_scope_intersect_prs "$merged_numbers_file" "$marker_numbers_file" > "$carry_file"
-  pma_scope_subtract_prs "$merged_numbers_file" "$carry_file" > "$to_audit_file"
+  # Prior findings are carry-over context; they do not prove the whole PR was fully audited.
+  cp "$merged_numbers_file" "$to_audit_file"
 
   case "$output_format" in
     json)

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -465,6 +465,40 @@ test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure() {
   assert_equals "" "$leftovers" "inner tmpdir cleanup"
 }
 
+test_fetch_issue_markers_warns_when_search_hits_limit() {
+  local tmpdir fake_bin open_json closed_json markers open_markers out rc
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  markers="$tmpdir/markers.tsv"
+  open_markers="$tmpdir/open-markers.tsv"
+  mkdir -p "$fake_bin"
+  cat > "$open_json" <<'JSON'
+[
+  {"number": 1, "state": "OPEN", "url": "https://example.test/issues/1", "body": ""},
+  {"number": 2, "state": "OPEN", "url": "https://example.test/issues/2", "body": ""}
+]
+JSON
+  printf '[]\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  set +e
+  out="$(PATH="$fake_bin:$PATH" pma_scope_fetch_issue_markers owner/repo 2 "$markers" "$open_markers" 2>&1)"
+  rc=$?
+  set -e
+
+  rm -rf "$tmpdir"
+  assert_equals "0" "$rc" "limit warning rc"
+  case "$out" in
+    *"Warning: open issue search returned 2 results (limit=2)"*) ;;
+    *)
+      fail "limit warning missing: $out"
+      ;;
+  esac
+}
+
 test_limit_requires_positive_integer() {
   local out rc
 
@@ -633,6 +667,7 @@ run_test test_default_base_uses_nearest_rc_on_first_parent_history
 run_test test_resolver_rejects_base_outside_head_history
 run_test test_resolver_rejects_base_outside_first_parent_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
+run_test test_fetch_issue_markers_warns_when_search_hits_limit
 run_test test_limit_requires_positive_integer
 run_test test_repo_requires_owner_repo_form
 run_test test_sourced_main_propagates_marker_fetch_failure_without_errexit

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -167,18 +167,48 @@ JSON
   assert_equals "$expected" "$out" "issue markers"
 }
 
-test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty() {
-  local tmpdir out expected
+test_open_markers_do_not_suppress_to_audit() {
+  local tmpdir repo fake_bin open_json closed_json base out actual expected carry fingerprints
 
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
-  printf '%s\n' 4014 4015 > "$tmpdir/merged.txt"
-  : > "$tmpdir/carry.txt"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  mkdir -p "$repo" "$fake_bin"
+  cat > "$open_json" <<'JSON'
+[
+  {
+    "number": 89,
+    "state": "OPEN",
+    "url": "https://example.test/issues/89",
+    "body": "<!-- post-merge-audit-finding v1\naudit: current-audit\nfingerprint: pr-4014:open-finding\naffected_prs: 4014\n-->"
+  }
+]
+JSON
+  printf '[]\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
 
-  out="$(pma_scope_subtract_prs "$tmpdir/merged.txt" "$tmpdir/carry.txt")"
-  expected="$(printf '%s\n%s' 4014 4015)"
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" commit --quiet --allow-empty -m "Fix audit scope resolver (#4014)"
+
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV PATH="$fake_bin:$PATH" "$RESOLVER" --base "$base" --head HEAD --repo owner/repo --json
+  )"
+  actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
+  carry="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("carry_over_prs").join(",")' <<< "$out")"
+  fingerprints="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("existing_fingerprints").map { |fp| fp.fetch("state") }.join(",")' <<< "$out")"
+  expected="4014"
 
   rm -rf "$tmpdir"
-  assert_equals "$expected" "$out" "to_audit with empty carry-over"
+  assert_equals "$expected" "$actual" "open markers do not suppress to_audit"
+  assert_equals "$expected" "$carry" "open markers remain carry-over context"
+  assert_equals "OPEN" "$fingerprints" "open markers remain dedupe context"
 }
 
 test_resolver_uses_first_parent_for_merged_pr_scope() {
@@ -517,7 +547,7 @@ test_sourced_main_run_preserves_cwd_and_exit_trap() {
 
 run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once
 run_test test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs
-run_test test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty
+run_test test_open_markers_do_not_suppress_to_audit
 run_test test_resolver_uses_first_parent_for_merged_pr_scope
 run_test test_closed_markers_do_not_suppress_to_audit
 run_test test_default_base_ignores_rc_tags_on_merged_side_branches

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -507,6 +507,50 @@ test_repo_requires_owner_repo_form() {
   esac
 }
 
+test_sourced_main_propagates_marker_fetch_failure_without_errexit() {
+  local tmpdir repo fake_bin base out actual_rc
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  mkdir -p "$repo" "$fake_bin"
+  cat > "$fake_bin/gh" <<'BASH'
+#!/usr/bin/env bash
+echo "simulated gh failure" >&2
+exit 1
+BASH
+  chmod +x "$fake_bin/gh"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
+
+  out="$(
+    bash -c '
+      set +e
+      set -u
+      set -o pipefail
+      source "$1"
+      cd "$2"
+      PATH="$3:$PATH" pma_scope_main --base "$4" --head HEAD --repo owner/repo --json 2>&1
+      printf "\nrc=%s\n" "$?"
+    ' bash "$RESOLVER" "$repo" "$fake_bin" "$base"
+  )"
+  actual_rc="$(printf '%s\n' "$out" | awk -F= '$1 == "rc" { print $2 }')"
+
+  rm -rf "$tmpdir"
+  assert_equals "1" "$actual_rc" "sourced marker fetch failure rc"
+  case "$out" in
+    *"failed to search open post-merge audit finding issues"*) ;;
+    *)
+      fail "marker fetch error message missing: $out"
+      ;;
+  esac
+}
+
 test_sourced_main_help_does_not_change_shell_options() {
   local out expected
 
@@ -590,6 +634,7 @@ run_test test_resolver_rejects_base_outside_first_parent_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
 run_test test_limit_requires_positive_integer
 run_test test_repo_requires_owner_repo_form
+run_test test_sourced_main_propagates_marker_fetch_failure_without_errexit
 run_test test_sourced_main_help_does_not_change_shell_options
 run_test test_sourced_main_run_preserves_cwd_and_exit_trap
 

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -293,6 +293,42 @@ test_default_base_uses_latest_rc_reachable_from_head() {
   assert_equals "4014" "$actual" "default-base to_audit"
 }
 
+test_default_base_uses_nearest_rc_on_first_parent_history() {
+  local tmpdir repo fake_bin open_json closed_json base out base_ref actual
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  mkdir -p "$repo" "$fake_bin"
+  printf '[]\n' > "$open_json"
+  printf '[]\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" tag -a v1.0.0.rc.1 -m "first rc"
+  git -C "$repo" commit --quiet --allow-empty -m "Second release candidate"
+  git -C "$repo" tag -a v1.0.0.rc.2 -m "second rc"
+  git -C "$repo" tag -a v9.0.0.rc.1 "$base" -m "newer tag on older rc"
+  git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
+
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV PATH="$fake_bin:$PATH" "$RESOLVER" --head HEAD --repo owner/repo --json
+  )"
+  base_ref="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("base").fetch("ref")' <<< "$out")"
+  actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
+
+  rm -rf "$tmpdir"
+  assert_equals "v1.0.0.rc.2" "$base_ref" "nearest default base on first-parent history"
+  assert_equals "4014" "$actual" "nearest default-base to_audit"
+}
+
 test_resolver_rejects_base_outside_head_history() {
   local tmpdir repo side_sha out rc
 
@@ -361,7 +397,7 @@ test_limit_requires_positive_integer() {
   local out rc
 
   set +e
-  out="$("$RESOLVER" --limit nope --self-check 2>&1)"
+  out="$(env -u BASH_ENV "$RESOLVER" --limit nope --self-check 2>&1)"
   rc=$?
   set -e
 
@@ -403,6 +439,7 @@ run_test test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty
 run_test test_resolver_uses_first_parent_for_merged_pr_scope
 run_test test_closed_markers_do_not_suppress_to_audit
 run_test test_default_base_uses_latest_rc_reachable_from_head
+run_test test_default_base_uses_nearest_rc_on_first_parent_history
 run_test test_resolver_rejects_base_outside_head_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
 run_test test_limit_requires_positive_integer

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -143,7 +143,7 @@ test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs() 
     "number": 3842,
     "state": "CLOSED",
     "url": "https://github.com/shakacode/react_on_rails/issues/3842",
-    "body": "Resolved\n\n<!-- post-merge-audit-finding v1\naudit: 2026-06-14-post-rc\nfingerprint: pr-3724:changelog-server-bundle-load-error\naffected_prs: 3724, 3725\n-->"
+    "body": "Resolved\n\n<!-- post-merge-audit-finding v1\naudit: 2026-06-14\tpost-rc\nfingerprint: pr-3724:\tchangelog-server-bundle-load-error\naffected_prs: 3724, 3725\n-->"
   },
   {
     "number": 3900,
@@ -157,11 +157,11 @@ JSON
 
   expected="$(
     printf '%s\t%s\t%s\t%s\t%s\t%s' \
-      "pr-3724:changelog-server-bundle-load-error" \
+      "pr-3724: changelog-server-bundle-load-error" \
       "3842" \
       "CLOSED" \
       "3724,3725" \
-      "2026-06-14-post-rc" \
+      "2026-06-14 post-rc" \
       "https://github.com/shakacode/react_on_rails/issues/3842"
   )"
 
@@ -348,6 +348,7 @@ test_default_base_uses_nearest_rc_on_first_parent_history() {
   git -C "$repo" tag -a v1.0.0.rc.1 -m "first rc"
   git -C "$repo" commit --quiet --allow-empty -m "Second release candidate"
   git -C "$repo" tag -a v1.0.0.rc.2 -m "second rc"
+  git -C "$repo" tag -a v9.0.0.rc.2 -m "same commit higher rc"
   git -C "$repo" tag -a v9.0.0.rc.1 "$base" -m "newer tag on older rc"
   git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
 
@@ -359,7 +360,7 @@ test_default_base_uses_nearest_rc_on_first_parent_history() {
   actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
 
   rm -rf "$tmpdir"
-  assert_equals "v1.0.0.rc.2" "$base_ref" "nearest default base on first-parent history"
+  assert_equals "v9.0.0.rc.2" "$base_ref" "nearest default base on first-parent history"
   assert_equals "4014" "$actual" "nearest default-base to_audit"
 }
 

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -70,6 +70,7 @@ fail() {
   TESTS_FAILED=$((TESTS_FAILED + 1))
   FAILURES+=("$CURRENT_TEST: $message")
   echo "  FAIL: $message" >&2
+  return 1
 }
 
 assert_equals() {
@@ -112,6 +113,9 @@ test_parse_git_log_extracts_squash_and_merge_subject_prs_once() {
     {
       printf '%s\t%s\n' "abc123" "Fix audit scope resolver (#4014)"
       printf '%s\t%s\n' "def456" "Merge pull request #4015 from shakacode/example"
+      printf '%s\t%s\n' "b00b00" "Mention issue (#9999) before final text"
+      printf '%s\t%s\n' "f00f00" "Revert 'feat: foo (#4010)' (#4012)"
+      printf '%s\t%s\n' "dad000" "Revert \"Merge pull request #4015 from shakacode/example\" (#4020)"
       printf '%s\t%s\n' "fedcba" "Duplicate mention (#4014)"
       printf '%s\t%s\n' "999999" "No pull request marker"
     } | pma_scope_parse_git_log
@@ -120,6 +124,8 @@ test_parse_git_log_extracts_squash_and_merge_subject_prs_once() {
   expected="$(
     printf '%s\t%s\t%s\n' "4014" "abc123" "Fix audit scope resolver (#4014)"
     printf '%s\t%s\t%s' "4015" "def456" "Merge pull request #4015 from shakacode/example"
+    printf '\n%s\t%s\t%s' "4012" "f00f00" "Revert 'feat: foo (#4010)' (#4012)"
+    printf '\n%s\t%s\t%s' "4020" "dad000" "Revert \"Merge pull request #4015 from shakacode/example\" (#4020)"
   )"
 
   assert_equals "$expected" "$out" "parsed PR log"
@@ -251,11 +257,132 @@ JSON
   assert_equals "CLOSED" "$fingerprints" "closed markers remain dedupe context"
 }
 
+test_default_base_uses_latest_rc_reachable_from_head() {
+  local tmpdir repo fake_bin open_json closed_json out base_ref actual
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  mkdir -p "$repo" "$fake_bin"
+  printf '[]\n' > "$open_json"
+  printf '[]\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  git -C "$repo" tag v1.0.0.rc.1
+  git -C "$repo" checkout --quiet -b next-release
+  git -C "$repo" commit --quiet --allow-empty -m "Next release candidate"
+  git -C "$repo" tag v2.0.0.rc.1
+  git -C "$repo" checkout --quiet main
+  git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
+
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV PATH="$fake_bin:$PATH" "$RESOLVER" --head HEAD --repo owner/repo --json
+  )"
+  base_ref="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("base").fetch("ref")' <<< "$out")"
+  actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
+
+  rm -rf "$tmpdir"
+  assert_equals "v1.0.0.rc.1" "$base_ref" "default base reachable from head"
+  assert_equals "4014" "$actual" "default-base to_audit"
+}
+
+test_resolver_rejects_base_outside_head_history() {
+  local tmpdir repo side_sha out rc
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  mkdir -p "$repo"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  git -C "$repo" checkout --quiet -b other-release
+  git -C "$repo" commit --quiet --allow-empty -m "Other release candidate"
+  side_sha="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" checkout --quiet main
+  git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
+
+  set +e
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV "$RESOLVER" --base "$side_sha" --head HEAD --repo owner/repo --json 2>&1
+  )"
+  rc=$?
+  set -e
+
+  rm -rf "$tmpdir"
+
+  assert_equals "1" "$rc" "non-ancestor range rc"
+  case "$out" in
+    *"base ref is not an ancestor of head ref"*) ;;
+    *)
+      fail "non-ancestor range error message missing: $out"
+      ;;
+  esac
+}
+
+test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure() {
+  local tmpdir fake_bin open_json closed_json markers open_markers scoped_tmpdirs rc leftovers
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  markers="$tmpdir/markers.tsv"
+  open_markers="$tmpdir/open-markers.tsv"
+  scoped_tmpdirs="$tmpdir/scoped"
+  mkdir -p "$fake_bin" "$scoped_tmpdirs"
+  printf '[]\n' > "$open_json"
+  printf '{not-json}\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  set +e
+  PATH="$fake_bin:$PATH" PMA_SCOPE_TMPDIR="$scoped_tmpdirs" \
+    pma_scope_fetch_issue_markers owner/repo 10 "$markers" "$open_markers" >/dev/null 2>&1
+  rc=$?
+  set -e
+
+  leftovers="$(find "$scoped_tmpdirs" -mindepth 1 -maxdepth 1 -type d -print)"
+  rm -rf "$tmpdir"
+
+  assert_equals "1" "$rc" "parse failure rc"
+  assert_equals "" "$leftovers" "inner tmpdir cleanup"
+}
+
+test_limit_requires_positive_integer() {
+  local out rc
+
+  set +e
+  out="$("$RESOLVER" --limit nope --self-check 2>&1)"
+  rc=$?
+  set -e
+
+  assert_equals "1" "$rc" "invalid limit rc"
+  case "$out" in
+    *"--limit must be a positive integer"*) ;;
+    *)
+      fail "invalid limit error message missing: $out"
+      ;;
+  esac
+}
+
 run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once
 run_test test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs
 run_test test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty
 run_test test_resolver_uses_first_parent_for_merged_pr_scope
 run_test test_closed_markers_do_not_suppress_to_audit
+run_test test_default_base_uses_latest_rc_reachable_from_head
+run_test test_resolver_rejects_base_outside_head_history
+run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
+run_test test_limit_requires_positive_integer
 
 if [ "$TESTS_FAILED" -ne 0 ]; then
   printf '\n%d of %d tests failed:\n' "$TESTS_FAILED" "$TESTS_RUN" >&2

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# Unit tests for post-merge-audit-scope parsing helpers.
+# Run with: bash .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="$SCRIPT_DIR/post-merge-audit-scope"
+
+if [ ! -f "$RESOLVER" ]; then
+  echo "missing resolver: $RESOLVER" >&2
+  exit 1
+fi
+
+# shellcheck source=.agents/skills/post-merge-audit/bin/post-merge-audit-scope
+source "$RESOLVER"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+make_fake_gh() {
+  local path="$1"
+  local open_json="$2"
+  local closed_json="$3"
+
+  cat > "$path" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "search" ] && [ "${2:-}" = "issues" ]; then
+  state=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state)
+        state="${2:-}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "$state" in
+    open)
+      cat "$PMA_TEST_OPEN_JSON"
+      ;;
+    closed)
+      cat "$PMA_TEST_CLOSED_JSON"
+      ;;
+    *)
+      echo "unexpected gh issue search state: $state" >&2
+      exit 1
+      ;;
+  esac
+else
+  echo "unexpected gh invocation: $*" >&2
+  exit 1
+fi
+BASH
+  chmod +x "$path"
+  export PMA_TEST_OPEN_JSON="$open_json"
+  export PMA_TEST_CLOSED_JSON="$closed_json"
+}
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  echo "  FAIL: $message" >&2
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-value}"
+
+  if [ "$expected" != "$actual" ]; then
+    fail "$label: expected '$expected', got '$actual'"
+    return 1
+  fi
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local before_failed="$TESTS_FAILED"
+  set +e
+  (
+    set -euo pipefail
+    "$test_fn"
+  )
+  local rc=$?
+  set -u
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+}
+
+test_parse_git_log_extracts_squash_and_merge_subject_prs_once() {
+  local out expected
+
+  out="$(
+    {
+      printf '%s\t%s\n' "abc123" "Fix audit scope resolver (#4014)"
+      printf '%s\t%s\n' "def456" "Merge pull request #4015 from shakacode/example"
+      printf '%s\t%s\n' "fedcba" "Duplicate mention (#4014)"
+      printf '%s\t%s\n' "999999" "No pull request marker"
+    } | pma_scope_parse_git_log
+  )"
+
+  expected="$(
+    printf '%s\t%s\t%s\n' "4014" "abc123" "Fix audit scope resolver (#4014)"
+    printf '%s\t%s\t%s' "4015" "def456" "Merge pull request #4015 from shakacode/example"
+  )"
+
+  assert_equals "$expected" "$out" "parsed PR log"
+}
+
+test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs() {
+  local out expected
+
+  out="$(
+    cat <<'JSON' | pma_scope_extract_issue_markers_from_json
+[
+  {
+    "number": 3842,
+    "state": "CLOSED",
+    "url": "https://github.com/shakacode/react_on_rails/issues/3842",
+    "body": "Resolved\n\n<!-- post-merge-audit-finding v1\naudit: 2026-06-14-post-rc\nfingerprint: pr-3724:changelog-server-bundle-load-error\naffected_prs: 3724, 3725\n-->"
+  },
+  {
+    "number": 3900,
+    "state": "OPEN",
+    "url": "https://github.com/shakacode/react_on_rails/issues/3900",
+    "body": "No marker here"
+  }
+]
+JSON
+  )"
+
+  expected="$(
+    printf '%s\t%s\t%s\t%s\t%s\t%s' \
+      "pr-3724:changelog-server-bundle-load-error" \
+      "3842" \
+      "CLOSED" \
+      "3724,3725" \
+      "2026-06-14-post-rc" \
+      "https://github.com/shakacode/react_on_rails/issues/3842"
+  )"
+
+  assert_equals "$expected" "$out" "issue markers"
+}
+
+test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty() {
+  local tmpdir out expected
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  printf '%s\n' 4014 4015 > "$tmpdir/merged.txt"
+  : > "$tmpdir/carry.txt"
+
+  out="$(pma_scope_subtract_prs "$tmpdir/merged.txt" "$tmpdir/carry.txt")"
+  expected="$(printf '%s\n%s' 4014 4015)"
+
+  rm -rf "$tmpdir"
+  assert_equals "$expected" "$out" "to_audit with empty carry-over"
+}
+
+test_resolver_uses_first_parent_for_merged_pr_scope() {
+  local tmpdir repo fake_bin open_json closed_json base merge_sha out actual expected
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  mkdir -p "$repo" "$fake_bin"
+  printf '[]\n' > "$open_json"
+  printf '[]\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" checkout --quiet -b side
+  git -C "$repo" commit --quiet --allow-empty -m "Historical import (#111)"
+  git -C "$repo" checkout --quiet main
+  git -C "$repo" merge --quiet --no-ff side -m "Merge pull request #222 from test/side"
+  merge_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV PATH="$fake_bin:$PATH" "$RESOLVER" --base "$base" --head HEAD --repo owner/repo --json
+  )"
+  actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("merged_prs").map { |pr| [pr.fetch("number"), pr.fetch("sha"), pr.fetch("subject")].join("\t") }' <<< "$out")"
+  expected="$(printf '%s\t%s\t%s' "222" "$merge_sha" "Merge pull request #222 from test/side")"
+
+  rm -rf "$tmpdir"
+  assert_equals "$expected" "$actual" "first-parent merged PR scope"
+}
+
+test_closed_markers_do_not_suppress_to_audit() {
+  local tmpdir repo fake_bin open_json closed_json base out actual expected fingerprints
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  mkdir -p "$repo" "$fake_bin"
+  printf '[]\n' > "$open_json"
+  cat > "$closed_json" <<'JSON'
+[
+  {
+    "number": 88,
+    "state": "CLOSED",
+    "url": "https://example.test/issues/88",
+    "body": "<!-- post-merge-audit-finding v1\naudit: old-audit\nfingerprint: pr-4014:old-finding\naffected_prs: 4014\n-->"
+  }
+]
+JSON
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" commit --quiet --allow-empty -m "Fix audit scope resolver (#4014)"
+
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV PATH="$fake_bin:$PATH" "$RESOLVER" --base "$base" --head HEAD --repo owner/repo --json
+  )"
+  actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
+  fingerprints="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("existing_fingerprints").map { |fp| fp.fetch("state") }.join(",")' <<< "$out")"
+  expected="4014"
+
+  rm -rf "$tmpdir"
+  assert_equals "$expected" "$actual" "closed markers do not suppress to_audit"
+  assert_equals "CLOSED" "$fingerprints" "closed markers remain dedupe context"
+}
+
+run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once
+run_test test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs
+run_test test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty
+run_test test_resolver_uses_first_parent_for_merged_pr_scope
+run_test test_closed_markers_do_not_suppress_to_audit
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  printf '\n%d of %d tests failed:\n' "$TESTS_FAILED" "$TESTS_RUN" >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi
+
+printf '\n%d tests passed.\n' "$TESTS_RUN"

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -481,6 +481,32 @@ test_limit_requires_positive_integer() {
   esac
 }
 
+test_repo_requires_owner_repo_form() {
+  local tmpdir repo out rc
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  mkdir -p "$repo"
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+
+  set +e
+  out="$(cd "$repo" && env -u BASH_ENV "$RESOLVER" --head HEAD --repo owner --json 2>&1)"
+  rc=$?
+  set -e
+
+  rm -rf "$tmpdir"
+  assert_equals "1" "$rc" "invalid repo rc"
+  case "$out" in
+    *"--repo must be in OWNER/REPO form"*) ;;
+    *)
+      fail "invalid repo error message missing: $out"
+      ;;
+  esac
+}
+
 test_sourced_main_help_does_not_change_shell_options() {
   local out expected
 
@@ -563,6 +589,7 @@ run_test test_resolver_rejects_base_outside_head_history
 run_test test_resolver_rejects_base_outside_first_parent_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
 run_test test_limit_requires_positive_integer
+run_test test_repo_requires_owner_repo_form
 run_test test_sourced_main_help_does_not_change_shell_options
 run_test test_sourced_main_run_preserves_cwd_and_exit_trap
 

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -116,6 +116,7 @@ test_parse_git_log_extracts_squash_and_merge_subject_prs_once() {
       printf '%s\t%s\n' "b00b00" "Mention issue (#9999) before final text"
       printf '%s\t%s\n' "f00f00" "Revert 'feat: foo (#4010)' (#4012)"
       printf '%s\t%s\n' "dad000" "Revert \"Merge pull request #4015 from shakacode/example\" (#4020)"
+      printf '%s\t%s\n' "bad999" "Revert \"Merge pull request #4016 from shakacode/example\""
       printf '%s\t%s\n' "fedcba" "Duplicate mention (#4014)"
       printf '%s\t%s\n' "999999" "No pull request marker"
     } | pma_scope_parse_git_log
@@ -257,7 +258,7 @@ JSON
   assert_equals "CLOSED" "$fingerprints" "closed markers remain dedupe context"
 }
 
-test_default_base_uses_latest_rc_reachable_from_head() {
+test_default_base_ignores_rc_tags_on_merged_side_branches() {
   local tmpdir repo fake_bin open_json closed_json out base_ref actual
 
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
@@ -279,6 +280,8 @@ test_default_base_uses_latest_rc_reachable_from_head() {
   git -C "$repo" commit --quiet --allow-empty -m "Next release candidate"
   git -C "$repo" tag v2.0.0.rc.1
   git -C "$repo" checkout --quiet main
+  git -C "$repo" commit --quiet --allow-empty -m "Main line before side merge"
+  git -C "$repo" merge --quiet --no-ff next-release -m "Merge pull request #4010 from test/next-release"
   git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
 
   out="$(
@@ -289,8 +292,8 @@ test_default_base_uses_latest_rc_reachable_from_head() {
   actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
 
   rm -rf "$tmpdir"
-  assert_equals "v1.0.0.rc.1" "$base_ref" "default base reachable from head"
-  assert_equals "4014" "$actual" "default-base to_audit"
+  assert_equals "v1.0.0.rc.1" "$base_ref" "default base on mainline"
+  assert_equals "4010,4014" "$actual" "default-base to_audit"
 }
 
 test_default_base_uses_nearest_rc_on_first_parent_history() {
@@ -470,18 +473,61 @@ test_sourced_main_help_does_not_change_shell_options() {
   assert_equals "$expected" "$out" "sourced pma_scope_main shell options"
 }
 
+test_sourced_main_run_preserves_cwd_and_exit_trap() {
+  local tmpdir repo fake_bin open_json closed_json base out expected expected_pwd
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  fake_bin="$tmpdir/bin"
+  open_json="$tmpdir/open.json"
+  closed_json="$tmpdir/closed.json"
+  mkdir -p "$repo/subdir" "$fake_bin"
+  printf '[]\n' > "$open_json"
+  printf '[]\n' > "$closed_json"
+  make_fake_gh "$fake_bin/gh" "$open_json" "$closed_json"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  base="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" commit --quiet --allow-empty -m "Main line change (#4014)"
+  expected_pwd="$(cd "$repo/subdir" && pwd)"
+
+  out="$(
+    bash -c '
+      set -uo pipefail
+      source "$1"
+      cd "$2/subdir"
+      trap '\''printf caller-exit-trap >/dev/null'\'' EXIT
+      PATH="$3:$PATH" pma_scope_main --base "$4" --head HEAD --repo owner/repo --json >/dev/null
+      rc=$?
+      printf "rc=%s\npwd=%s\ntrap=%s\n" "$rc" "$PWD" "$(trap -p EXIT)"
+    ' bash "$RESOLVER" "$repo" "$fake_bin" "$base"
+  )"
+  expected="$(
+    printf 'rc=0\n'
+    printf 'pwd=%s\n' "$expected_pwd"
+    printf "trap=trap -- 'printf caller-exit-trap >/dev/null' EXIT"
+  )"
+
+  rm -rf "$tmpdir"
+  assert_equals "$expected" "$out" "sourced pma_scope_main caller context"
+}
+
 run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once
 run_test test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs
 run_test test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty
 run_test test_resolver_uses_first_parent_for_merged_pr_scope
 run_test test_closed_markers_do_not_suppress_to_audit
-run_test test_default_base_uses_latest_rc_reachable_from_head
+run_test test_default_base_ignores_rc_tags_on_merged_side_branches
 run_test test_default_base_uses_nearest_rc_on_first_parent_history
 run_test test_resolver_rejects_base_outside_head_history
 run_test test_resolver_rejects_base_outside_first_parent_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
 run_test test_limit_requires_positive_integer
 run_test test_sourced_main_help_does_not_change_shell_options
+run_test test_sourced_main_run_preserves_cwd_and_exit_trap
 
 if [ "$TESTS_FAILED" -ne 0 ]; then
   printf '\n%d of %d tests failed:\n' "$TESTS_FAILED" "$TESTS_RUN" >&2

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -123,7 +123,7 @@ test_parse_git_log_extracts_squash_and_merge_subject_prs_once() {
   )"
 
   expected="$(
-    printf '%s\t%s\t%s\n' "4014" "abc123" "Fix audit scope resolver (#4014)"
+    printf '%s\t%s\t%s\n' "4014" "fedcba" "Duplicate mention (#4014)"
     printf '%s\t%s\t%s' "4015" "def456" "Merge pull request #4015 from shakacode/example"
     printf '\n%s\t%s\t%s' "4012" "f00f00" "Revert 'feat: foo (#4010)' (#4012)"
     printf '\n%s\t%s\t%s' "4020" "dad000" "Revert \"Merge pull request #4015 from shakacode/example\" (#4020)"

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -358,9 +358,46 @@ test_resolver_rejects_base_outside_head_history() {
 
   assert_equals "1" "$rc" "non-ancestor range rc"
   case "$out" in
-    *"base ref is not an ancestor of head ref"*) ;;
+    *"base ref is not on the first-parent history of head ref"*) ;;
     *)
       fail "non-ancestor range error message missing: $out"
+      ;;
+  esac
+}
+
+test_resolver_rejects_base_outside_first_parent_history() {
+  local tmpdir repo side_sha out rc
+
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
+  repo="$tmpdir/repo"
+  mkdir -p "$repo"
+
+  git -C "$repo" init --quiet --initial-branch=main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" commit --quiet --allow-empty -m "base"
+  git -C "$repo" checkout --quiet -b side
+  git -C "$repo" commit --quiet --allow-empty -m "Side branch boundary"
+  side_sha="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" checkout --quiet main
+  git -C "$repo" commit --quiet --allow-empty -m "Main line before merge (#4013)"
+  git -C "$repo" merge --quiet --no-ff side -m "Merge pull request #4014 from test/side"
+
+  set +e
+  out="$(
+    cd "$repo" &&
+      env -u BASH_ENV "$RESOLVER" --base "$side_sha" --head HEAD --repo owner/repo --json 2>&1
+  )"
+  rc=$?
+  set -e
+
+  rm -rf "$tmpdir"
+
+  assert_equals "1" "$rc" "side-branch base rc"
+  case "$out" in
+    *"base ref is not on the first-parent history of head ref"*) ;;
+    *)
+      fail "side-branch base error message missing: $out"
       ;;
   esac
 }
@@ -441,6 +478,7 @@ run_test test_closed_markers_do_not_suppress_to_audit
 run_test test_default_base_uses_latest_rc_reachable_from_head
 run_test test_default_base_uses_nearest_rc_on_first_parent_history
 run_test test_resolver_rejects_base_outside_head_history
+run_test test_resolver_rejects_base_outside_first_parent_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
 run_test test_limit_requires_positive_integer
 run_test test_sourced_main_help_does_not_change_shell_options

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -374,6 +374,29 @@ test_limit_requires_positive_integer() {
   esac
 }
 
+test_sourced_main_help_does_not_change_shell_options() {
+  local out expected
+
+  out="$(
+    bash -c '
+      set +e
+      set -u
+      set -o pipefail
+      source "$1"
+      pma_scope_main --help >/dev/null
+      set -o | awk '\''$1 == "errexit" || $1 == "nounset" || $1 == "pipefail" { print $1 "=" $2 }'\''
+    ' bash "$RESOLVER"
+  )"
+  expected="$(
+    printf '%s\n' \
+      "errexit=off" \
+      "nounset=on" \
+      "pipefail=on"
+  )"
+
+  assert_equals "$expected" "$out" "sourced pma_scope_main shell options"
+}
+
 run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once
 run_test test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs
 run_test test_subtract_prs_preserves_all_merged_prs_when_carry_over_is_empty
@@ -383,6 +406,7 @@ run_test test_default_base_uses_latest_rc_reachable_from_head
 run_test test_resolver_rejects_base_outside_head_history
 run_test test_fetch_issue_markers_cleans_inner_tmpdir_on_parse_failure
 run_test test_limit_requires_positive_integer
+run_test test_sourced_main_help_does_not_change_shell_options
 
 if [ "$TESTS_FAILED" -ne 0 ]; then
   printf '\n%d of %d tests failed:\n' "$TESTS_FAILED" "$TESTS_RUN" >&2

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -61,6 +61,7 @@ else
 fi
 BASH
   chmod +x "$path"
+  unset PMA_TEST_OPEN_JSON PMA_TEST_CLOSED_JSON
   export PMA_TEST_OPEN_JSON="$open_json"
   export PMA_TEST_CLOSED_JSON="$closed_json"
 }
@@ -504,7 +505,7 @@ test_sourced_main_help_does_not_change_shell_options() {
 }
 
 test_sourced_main_run_preserves_cwd_and_exit_trap() {
-  local tmpdir repo fake_bin open_json closed_json base out expected expected_pwd
+  local actual_rc_pwd expected_rc_pwd tmpdir repo fake_bin open_json closed_json base out expected_pwd
 
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
   repo="$tmpdir/repo"
@@ -535,14 +536,20 @@ test_sourced_main_run_preserves_cwd_and_exit_trap() {
       printf "rc=%s\npwd=%s\ntrap=%s\n" "$rc" "$PWD" "$(trap -p EXIT)"
     ' bash "$RESOLVER" "$repo" "$fake_bin" "$base"
   )"
-  expected="$(
+  expected_rc_pwd="$(
     printf 'rc=0\n'
-    printf 'pwd=%s\n' "$expected_pwd"
-    printf "trap=trap -- 'printf caller-exit-trap >/dev/null' EXIT"
+    printf 'pwd=%s' "$expected_pwd"
   )"
 
   rm -rf "$tmpdir"
-  assert_equals "$expected" "$out" "sourced pma_scope_main caller context"
+  actual_rc_pwd="$(printf '%s\n' "$out" | sed -n '1,2p')"
+  assert_equals "$expected_rc_pwd" "$actual_rc_pwd" "sourced pma_scope_main caller context"
+  case "$out" in
+    *"printf caller-exit-trap >/dev/null"*) ;;
+    *)
+      fail "caller exit trap not preserved: $out"
+      ;;
+  esac
 }
 
 run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once

--- a/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
+++ b/.agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash
@@ -167,7 +167,7 @@ JSON
   assert_equals "$expected" "$out" "issue markers"
 }
 
-test_open_markers_do_not_suppress_to_audit() {
+test_open_markers_create_carry_over_and_suppress_to_audit() {
   local tmpdir repo fake_bin open_json closed_json base out actual expected carry fingerprints
 
   tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/post-merge-audit-scope-test.XXXXXX")"
@@ -203,11 +203,11 @@ JSON
   actual="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("to_audit").join(",")' <<< "$out")"
   carry="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("carry_over_prs").join(",")' <<< "$out")"
   fingerprints="$(ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("existing_fingerprints").map { |fp| fp.fetch("state") }.join(",")' <<< "$out")"
-  expected="4014"
+  expected=""
 
   rm -rf "$tmpdir"
-  assert_equals "$expected" "$actual" "open markers do not suppress to_audit"
-  assert_equals "$expected" "$carry" "open markers remain carry-over context"
+  assert_equals "$expected" "$actual" "open markers suppress to_audit"
+  assert_equals "4014" "$carry" "open markers remain carry-over context"
   assert_equals "OPEN" "$fingerprints" "open markers remain dedupe context"
 }
 
@@ -547,7 +547,7 @@ test_sourced_main_run_preserves_cwd_and_exit_trap() {
 
 run_test test_parse_git_log_extracts_squash_and_merge_subject_prs_once
 run_test test_extract_issue_markers_from_json_keeps_fingerprint_state_and_affected_prs
-run_test test_open_markers_do_not_suppress_to_audit
+run_test test_open_markers_create_carry_over_and_suppress_to_audit
 run_test test_resolver_uses_first_parent_for_merged_pr_scope
 run_test test_closed_markers_do_not_suppress_to_audit
 run_test test_default_base_ignores_rc_tags_on_merged_side_branches


### PR DESCRIPTION
Fixes #4014

## Summary
- Add `.agents/skills/post-merge-audit/bin/post-merge-audit-scope`, a read-only resolver for the post-merge audit base/head range, squash-aware merged PR list, prior finding fingerprints, carry-over PRs, and `to_audit` list.
- Wire the resolver into `$post-merge-audit` as the initial scope gate.
- Cover parser behavior, first-parent mainline scope, and closed-finding carry-over rules with shell tests.

## Validation
- `bash -n .agents/skills/post-merge-audit/bin/post-merge-audit-scope .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash` -> passed
- `bash .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash` -> 5 tests passed
- `shellcheck .agents/skills/post-merge-audit/bin/post-merge-audit-scope .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash` -> passed
- `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --self-check` -> passed with live open/closed `gh search` smoke
- `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json --limit 50` -> `range=v17.0.0.rc.3..origin/main merged=24 to_audit=10 fingerprints=12`
- `git diff origin/main --check` -> passed
- `script/ci-changes-detector origin/main` -> documentation-only; recommended CI jobs: none
- `codex review --base origin/main` -> accepted two P2 findings (first-parent history and closed-marker suppression), fixed both, rerun clean

## CI / Labels
Labels: none. This is agent process tooling under `.agents/`; detector recommends no CI expansion.

Confidence note:
- Validated: command list above, pre-commit trailing-newlines hook, and clean branch review after accepted P2 fixes.
- Evidence: local command output and clean review output.
- UNKNOWN: none.
- Residual risk: low-medium; the resolver is read-only but will shape future audit scope, so PR reviewers should look closely at scope semantics.

Decision points: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-only agent tooling, but incorrect scope semantics (first-parent range, open vs closed markers) could mis-route which merged PRs get audited before release.
> 
> **Overview**
> Adds a **read-only scope gate** for `$post-merge-audit`: new `post-merge-audit-scope` resolves base/head (default nearest `*.rc.*` on first-parent mainline), squash-aware merged PRs, existing `post-merge-audit-finding` fingerprints via `gh search`, **carry-over** PRs from **open** markers, and **`to_audit`** (merged minus carry-over). Closed finding issues stay dedupe context only.
> 
> The post-merge-audit skill now tells agents to run `post-merge-audit-scope --json` first and treat that output as the initial scope table. A Bash test harness covers log/marker parsing, first-parent boundaries, RC default-base rules, and sourced-vs-executed CLI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b1234c32dce08f3d2f0a8d0d3f39f802694c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Scope Gate” for post-merge audits by introducing a new scope generator that computes merged PRs, carry-over PRs, existing fingerprints, and the remaining PRs to audit (outputs JSON or readable summaries).
  * Included a `--self-check` mode to verify scope generation assumptions.
* **Documentation**
  * Updated the post-merge audit instructions to start with the scope gate output and then confirm assumptions.
* **Tests**
  * Added a Bash test harness for scope computation, marker parsing/deduping, and CLI/error-path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: f6b1234c32dce08f3d2f0a8d0d3f39f802694c2b
Score: 8/10
Auto-merge recommendation: yes
Affected areas: agent post-merge-audit workflow/tooling; read-only shell resolver
CI detector: `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none
Checks: `gh pr checks 4029` -> 39 pass, 6 skipped, 0 pending, 0 failing. Benchmark confirmation/report skips and docs-format skip are explained by CI selector output for this non-benchmark process-tooling change.
Validation run:
- `bash -n .agents/skills/post-merge-audit/bin/post-merge-audit-scope .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash` -> passed
- `bash .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash` -> 16 tests passed
- `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --self-check` -> passed
- `shellcheck .agents/skills/post-merge-audit/bin/post-merge-audit-scope .agents/skills/post-merge-audit/bin/post-merge-audit-scope-test.bash` -> passed
- `git diff --check && git diff --check origin/main...HEAD` -> passed
- `script/ci-changes-detector origin/main` -> documentation-only; recommended CI jobs: none
Review/check gate:
- GitHub checks: complete for `f6b1234c32dce08f3d2f0a8d0d3f39f802694c2b`; no failed or pending checks
- Review threads: live GraphQL unresolved count is 0
- Feedback triage: CodeRabbit/Claude/Codex/Cursor findings were fixed, resolved, or stale/advisory; no current unresolved non-trivial concern remains
- Current-head reviewer verdicts:
  - `claude-review` check: success for `f6b1234c32dce08f3d2f0a8d0d3f39f802694c2b` ([run](https://github.com/shakacode/react_on_rails/actions/runs/27517272510), [job](https://github.com/shakacode/react_on_rails/actions/runs/27517272510/job/81328130359))
  - Cursor Bugbot: pass for current head
  - CodeRabbit: pass for current head
- Stale reviewer verdicts, advisory only:
  - CodeRabbit requested changes on older heads `92ac5b8840f5f82ce9a905a5fe11a24b5b7d1f50` and `d6220edd65760e3a07c06fdf553bbbeb2c632a93`, then approved an intermediate head; not cited as a merge gate
Labels: none. Agent tooling/process change; CI detector recommends no CI expansion.
Known residual risk: low-medium; resolver is read-only but shapes future audit scope, so mistakes would affect audit routing rather than runtime behavior.
Merge recommendation: merge now by squash.
Finalized by: `claude-review` GitHub check, Claude Code Review run `27517272510` / job `81328130359`, completed successfully for current head `f6b1234c32dce08f3d2f0a8d0d3f39f802694c2b`.
