### PR TITLE
[codex] Add fast required PR gate

### DIFF
--- a/.github/actions/check-full-ci-label/action.yml
+++ b/.github/actions/check-full-ci-label/action.yml
@@ -1,13 +1,13 @@
-name: Check for full-ci label
-description: Checks if the PR has the full-ci label to enable full CI mode
+name: Check for full CI readiness label
+description: Checks if the PR has a full CI readiness label to enable full CI mode
 outputs:
   result:
-    description: 'Whether the full-ci label is present (string: "true" or "false")'
+    description: 'Whether a full CI readiness label is present (string: "true" or "false")'
     value: ${{ steps.check.outputs.result }}
 runs:
   using: composite
   steps:
-    - name: Check for full-ci label
+    - name: Check for full CI readiness label
       id: check
       uses: actions/github-script@v7
       with:
@@ -24,6 +24,8 @@ runs:
             issue_number: context.payload.pull_request.number
           });
 
-          const hasLabel = labels.some(label => label.name === 'full-ci');
-          console.log(`full-ci label present: ${hasLabel}`);
+          const fullCiLabels = ['ready-for-full-ci', 'full-ci'];
+          const labelNames = labels.map(label => label.name);
+          const hasLabel = labelNames.some(name => fullCiLabels.includes(name));
+          console.log(`Full CI readiness labels present: ${labelNames.filter(name => fullCiLabels.includes(name)).join(', ') || 'none'}`);
           return hasLabel ? 'true' : 'false';

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,48 @@
+name: ci-required
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-required-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  required-pr-gate:
+    name: required-pr-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+          persist-credentials: false
+
+      - name: Validate workflow files
+        run: |
+          ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].sort.each { |f| YAML.load_file(f); puts f }"
+
+      - name: Validate CI shell scripts
+        run: |
+          bash -n bin/ci-local
+          bash -n bin/ci-rerun-failures
+          bash -n script/ci-changes-detector
+          if [ -f bin/request-full-ci ]; then
+            bash -n bin/request-full-ci
+          fi
+
+      - name: Run changed-files detector
+        run: script/ci-changes-detector "${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
+
+      - name: Lightweight repo sanity check
+        run: |
+          test -f Gemfile
+          test -f package.json
+          test -d .github/workflows

--- a/.github/workflows/detect-invalid-ci-commands.yml
+++ b/.github/workflows/detect-invalid-ci-commands.yml
@@ -80,11 +80,11 @@ jobs:
             ## Available GitHub Comment Commands
 
             ### 1. \\\`/run-skipped-ci\\\` (or \\\`/run-skipped-tests\\\`) - Enable Full CI Mode
-            Triggers all CI workflows that were skipped due to unchanged code.
+            Requests full CI for this PR.
 
             **What it does:**
             - Runs tests across all supported versions (Ruby 3.2-3.4, Node 20-22, Shakapacker 8-9, React 18-19)
-            - Adds the \\\`full-ci\\\` label to persist full testing on future commits
+            - Adds the \\\`ready-for-full-ci\\\` label to persist full testing on future commits
             - Triggers: Main tests, Generator tests, and React on Rails Pro tests
 
             **Requirements:**
@@ -101,10 +101,11 @@ jobs:
             ---
 
             ### 2. \\\`/stop-run-skipped-ci\\\` - Disable Full CI Mode
-            Returns to standard CI behavior (optimized suite, skips tests for unchanged code).
+            Returns to standard CI behavior (fast required PR gate only until full CI is requested).
 
             **What it does:**
-            - Removes the \\\`full-ci\\\` label from the PR
+            - Removes the \\\`ready-for-full-ci\\\` label from the PR
+            - Also removes legacy \\\`full-ci\\\` if present
             - Future commits will use the fast feedback CI suite
             - Does NOT stop currently running workflows
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,9 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -22,6 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -37,20 +37,22 @@ jobs:
           # Fetch enough history for change detection (50 commits is usually sufficient for PRs)
           fetch-depth: 50
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -72,30 +74,37 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
+          # Determine if we should run full matrix (main, merge queue, manual, release PR, or readiness label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
+             [[ "${{ github.event_name }}" == "merge_group" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]] || \
+             [[ "${{ startsWith(github.base_ref, 'release/') || startsWith(github.base_ref, 'releases/') || startsWith(github.base_ref, 'release-') }}" == "true" ]] || \
              [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   examples:
     needs: [detect-changes, setup-matrix]
-    # Run on main, workflow_dispatch, OR when generators needed
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_generators == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     strategy:
       fail-fast: false
@@ -120,7 +129,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -176,7 +185,7 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Verify rake tasks exist
         run: |
           cd react_on_rails

--- a/.github/workflows/gem-tests.yml
+++ b/.github/workflows/gem-tests.yml
@@ -6,11 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'packages/**'
-      - 'react_on_rails_pro/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -24,6 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -39,20 +37,22 @@ jobs:
           # Fetch enough history for change detection (50 commits is usually sufficient for PRs)
           fetch-depth: 50
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -74,29 +74,37 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Determine if we should run full matrix (main or full-ci label)
+          # Determine if we should run full matrix (main, merge queue, manual, release PR, or readiness label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
+             [[ "${{ github.event_name }}" == "merge_group" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "${{ inputs.force_run }}" == "true" ]] || \
+             [[ "${{ startsWith(github.base_ref, 'release/') || startsWith(github.base_ref, 'releases/') || startsWith(github.base_ref, 'release-') }}" == "true" ]] || \
              [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"},{"ruby-version":"3.2","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   rspec-package-tests:
     needs: [detect-changes, setup-gem-tests-matrix]
-    # Skip only if: main push AND docs-only changes
-    # Otherwise run if: on main OR Ruby tests needed
-    # This allows docs-only commits to skip heavy jobs while ensuring full CI on main for code changes
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
-        needs.detect-changes.outputs.run_ruby_tests == 'true'
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     strategy:
       fail-fast: false
@@ -139,7 +147,7 @@ jobs:
           git commit -am "stop generators from complaining about uncommitted code"
       - name: Set dependency level environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Run rspec tests
         run: cd react_on_rails && bundle exec rspec spec/react_on_rails
       - name: Store test results

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,10 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails_pro/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -23,6 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -38,20 +37,22 @@ jobs:
           # Fetch enough history for change detection (50 commits is usually sufficient for PRs)
           fetch-depth: 50
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
           else
             BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
             script/ci-changes-detector "$BASE_REF"
@@ -72,32 +73,37 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # Determine if we should run full matrix (main, workflow_dispatch, force_run, or full-ci label)
+          # Determine if we should run full matrix (main, merge queue, manual, release PR, or readiness label)
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
+             [[ "${{ github.event_name }}" == "merge_group" ]] || \
              [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
              [[ "${{ inputs.force_run }}" == "true" ]] || \
+             [[ "${{ startsWith(github.base_ref, 'release/') || startsWith(github.base_ref, 'releases/') || startsWith(github.base_ref, 'release-') }}" == "true" ]] || \
              [[ "${{ needs.detect-changes.outputs.has_full_ci_label }}" == "true" ]]; then
             # Full matrix: test both latest and minimum supported versions
-            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"},{"ruby-version":"3.2","node-version":"20","dependency-level":"minimum"}]}' >> "$GITHUB_OUTPUT"
           else
             # PR matrix: test only latest versions for fast feedback
-            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[{"ruby-version":"3.4","node-version":"22","dependency-level":"latest"}]}' >> "$GITHUB_OUTPUT"
           fi
 
   build-dummy-app-webpack-test-bundles:
     needs: [detect-changes, setup-integration-matrix]
-    # Skip only if: main push AND docs-only changes
-    # Otherwise run if: on main OR workflow_dispatch OR dummy tests needed
-    # This allows docs-only commits to skip heavy jobs while ensuring full CI on main for code changes
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_dummy_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     strategy:
       matrix: ${{ fromJson(needs.setup-integration-matrix.outputs.matrix) }}
@@ -123,7 +129,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -181,16 +187,21 @@ jobs:
 
   dummy-app-integration-tests:
     needs: [detect-changes, setup-integration-matrix, build-dummy-app-webpack-test-bundles]
-    # Run on main, workflow_dispatch, OR when tests needed on PR
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_dummy_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     strategy:
       matrix: ${{ fromJson(needs.setup-integration-matrix.outputs.matrix) }}
@@ -212,7 +223,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -295,7 +306,7 @@ jobs:
       - run: cd react_on_rails/spec/dummy && bundle info shakapacker
       - name: Set packer version environment variable
         run: |
-          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> $GITHUB_ENV
+          echo "CI_DEPENDENCY_LEVEL=ruby${{ matrix.ruby-version }}-${{ matrix.dependency-level }}" >> "$GITHUB_ENV"
       - name: Main CI
         run: cd react_on_rails && bundle exec rake run_rspec:all_dummy
       - name: Store test results

--- a/.github/workflows/lint-js-and-ruby.yml
+++ b/.github/workflows/lint-js-and-ruby.yml
@@ -6,10 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails_pro/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -23,6 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -37,20 +36,22 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -66,17 +67,21 @@ jobs:
 
   build:
     needs: detect-changes
-    # Skip only if: main push AND docs-only changes
-    # Otherwise run if: on main OR lint needed
-    # This allows docs-only commits to skip linting while ensuring full CI on main for code changes
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
-        needs.detect-changes.outputs.run_lint == 'true'
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     env:
       BUNDLE_FROZEN: true
@@ -102,7 +107,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -128,7 +133,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Ruby Gems for package
-        run: cd react_on_rails && bundle check --path=vendor/bundle || bundle _2.5.9_ install --path=vendor/bundle --jobs=4 --retry=3
+        run: cd react_on_rails && (bundle check --path=vendor/bundle || bundle _2.5.9_ install --path=vendor/bundle --jobs=4 --retry=3)
       - name: Lint Ruby
         run: cd react_on_rails && bundle exec rubocop
       - name: Validate RBS type signatures

--- a/.github/workflows/package-js-tests.yml
+++ b/.github/workflows/package-js-tests.yml
@@ -6,12 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails/lib/**'
-      - 'react_on_rails/spec/react_on_rails/**'
-      - 'react_on_rails_pro/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -25,6 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -40,20 +37,22 @@ jobs:
           # Fetch enough history for change detection (50 commits is usually sufficient for PRs)
           fetch-depth: 50
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_js_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_ruby_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "run_generators=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_lint=true"
+              echo "run_js_tests=true"
+              echo "run_ruby_tests=true"
+              echo "run_dummy_tests=true"
+              echo "run_generators=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -69,26 +68,32 @@ jobs:
 
   build:
     needs: detect-changes
-    # Run on main OR when JS tests needed on PR
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
-        needs.detect-changes.outputs.run_js_tests == 'true'
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     strategy:
       matrix:
         node-version:
           # Always run: Latest Node version (fast feedback on PRs)
           - '22'
-          # Main and full-ci label: Minimum supported Node version (full coverage)
+          # Main and full CI readiness label: Minimum supported Node version (full coverage)
           - '20'
         exclude:
-          # Skip minimum dependency matrix on regular PRs (run only on main or with full-ci label)
-          - node-version: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' && needs.detect-changes.outputs.has_full_ci_label != 'true' && '20' || '' }}
+          # Skip minimum dependency matrix on regular PRs.
+          - node-version: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.has_full_ci_label != 'true' && !startsWith(github.base_ref, 'release/') && !startsWith(github.base_ref, 'releases/') && !startsWith(github.base_ref, 'release-') && '20' || '' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +107,7 @@ jobs:
         uses: pnpm/action-setup@v4
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
     # Always trigger on main; docs-only detection handles skipping heavy jobs
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
 
 jobs:
@@ -11,18 +14,23 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      has_full_ci_label: ${{ steps.check-label.outputs.result }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Check for full CI readiness label
+        id: check-label
+        uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
-          BASE_REF="${{ github.event.before || 'origin/main' }}"
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}"
           script/ci-changes-detector "$BASE_REF"
         shell: bash
       - name: Guard docs-only main pushes
@@ -36,10 +44,18 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' || !(
+      !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
+      ) && (
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +74,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/precompile-check.yml
+++ b/.github/workflows/precompile-check.yml
@@ -5,10 +5,8 @@ on:
     branches:
       - 'main'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails_pro/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -22,6 +20,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -32,15 +31,18 @@ jobs:
         with:
           fetch-depth: 50
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         run: |
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_dummy_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_dummy_tests=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -56,17 +58,21 @@ jobs:
 
   precompile-check:
     needs: detect-changes
-    # Skip only if: main push AND docs-only changes
-    # Otherwise run if: on main OR workflow_dispatch OR dummy tests needed
+    # Regular PRs use ci-required only. Heavy jobs run for main, merge queue, manual dispatch,
+    # release branch PRs, or PRs labeled for full CI.
     if: |
       !(
         github.event_name == 'push' &&
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_dummy_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pro-integration-tests.yml
+++ b/.github/workflows/pro-integration-tests.yml
@@ -6,12 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails/lib/**'
-      - 'react_on_rails/spec/**'
-      - 'packages/react_on_rails/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -29,6 +25,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -40,18 +37,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         working-directory: .
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -74,9 +73,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     env:
@@ -104,7 +107,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -181,9 +184,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     env:
@@ -211,7 +218,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -370,9 +377,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     env:
@@ -411,7 +422,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/pro-lint.yml
+++ b/.github/workflows/pro-lint.yml
@@ -6,12 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails/lib/**'
-      - 'react_on_rails/spec/**'
-      - 'packages/react_on_rails/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -29,6 +25,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -40,18 +37,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         working-directory: .
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -73,8 +72,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
-        needs.detect-changes.outputs.run_pro_lint == 'true'
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     env:
@@ -102,7 +106,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4

--- a/.github/workflows/pro-test-package-and-gem.yml
+++ b/.github/workflows/pro-test-package-and-gem.yml
@@ -6,12 +6,8 @@ on:
       - 'main'
     # Always trigger on main; docs-only detection handles skipping heavy jobs
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'react_on_rails/lib/**'
-      - 'react_on_rails/spec/**'
-      - 'packages/react_on_rails/**'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -29,6 +25,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: read
     runs-on: ubuntu-22.04
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
@@ -40,18 +37,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Check for full-ci label
+      - name: Check for full CI readiness label
         id: check-label
         uses: ./.github/actions/check-full-ci-label
       - name: Detect relevant changes
         id: detect
         working-directory: .
         run: |
-          # If force_run is true OR full-ci label is present, run everything
+          # If force_run is true OR a full CI readiness label is present, run everything
           if [ "${{ inputs.force_run }}" = "true" ] || [ "${{ steps.check-label.outputs.result }}" = "true" ]; then
-            echo "run_pro_lint=true" >> "$GITHUB_OUTPUT"
-            echo "run_pro_tests=true" >> "$GITHUB_OUTPUT"
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "run_pro_lint=true"
+              echo "run_pro_tests=true"
+              echo "docs_only=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -74,9 +73,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     env:
@@ -104,7 +107,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -181,9 +184,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     runs-on: ubuntu-22.04
     # Redis service container
@@ -216,7 +223,7 @@ jobs:
 
       - name: Get pnpm store directory
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Setup pnpm cache
         uses: actions/cache@v4
@@ -281,9 +288,13 @@ jobs:
         github.ref == 'refs/heads/main' &&
         needs.detect-changes.outputs.docs_only == 'true'
       ) && (
-        github.ref == 'refs/heads/main' ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group' ||
         github.event_name == 'workflow_dispatch' ||
-        needs.detect-changes.outputs.run_pro_tests == 'true'
+        needs.detect-changes.outputs.has_full_ci_label == 'true' ||
+        startsWith(github.base_ref, 'release/') ||
+        startsWith(github.base_ref, 'releases/') ||
+        startsWith(github.base_ref, 'release-')
       )
     strategy:
       matrix:

--- a/.github/workflows/run-skipped-ci.yml
+++ b/.github/workflows/run-skipped-ci.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      actions: write
+      issues: write
     steps:
       - name: Check if user has write access
         id: check_access
@@ -68,194 +68,51 @@ jobs:
           comment-id: ${{ github.event.comment.id }}
           reactions: 'rocket'
 
-      - name: Get PR details
-        id: pr
+      - name: Add full CI readiness label
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            return {
-              ref: pr.data.head.ref,
-              sha: pr.data.head.sha
-            };
-
-      - name: Get skipped checks and trigger workflows
-        id: trigger_workflows
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prData = ${{ steps.pr.outputs.result }};
-
-            // Fetch PR checks to find skipped ones
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            const checks = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: pr.head.sha,
-              per_page: 100
-            });
-
-            // Find all skipped checks
-            const skippedChecks = checks.data.check_runs.filter(check =>
-              check.conclusion === 'SKIPPED' && check.status === 'COMPLETED'
-            );
-
-            console.log(`Found ${skippedChecks.length} skipped checks:`);
-            skippedChecks.forEach(check => {
-              console.log(`  - ${check.name} (${check.workflow_name})`);
-            });
-
-            // Map workflow names to workflow files
-            const workflowMap = {
-              'Integration Tests': 'integration-tests.yml',
-              'Rspec test for gem': 'gem-tests.yml',
-              'Generator tests': 'examples.yml',
-              'React on Rails Pro - Integration Tests': 'pro-integration-tests.yml',
-              'React on Rails Pro - Package Tests': 'pro-test-package-and-gem.yml',
-              'React on Rails Pro - Lint': 'pro-lint.yml'
-            };
-
-            // Get unique workflows that have skipped checks
-            const uniqueWorkflows = new Set();
-            skippedChecks.forEach(check => {
-              if (workflowMap[check.workflow_name]) {
-                uniqueWorkflows.add(check.workflow_name);
-              }
-            });
-
-            const succeeded = [];
-            const failed = [];
-            const notApplicable = [];
-
-            // If no skipped checks found, trigger ALL workflows in the map
-            // This handles the case where workflows haven't run yet (e.g., Pro tests on fresh PRs)
-            const workflowsToTrigger = uniqueWorkflows.size > 0
-              ? Array.from(uniqueWorkflows)
-              : Object.keys(workflowMap);
-
-            if (uniqueWorkflows.size === 0) {
-              console.log('ℹ️  No skipped checks found - triggering all workflows to ensure full coverage');
-            }
-
-            // Trigger each workflow
-            for (const workflowName of workflowsToTrigger) {
-              const workflowFile = workflowMap[workflowName];
+            const readyLabel = 'ready-for-full-ci';
+            try {
               try {
-                await github.rest.actions.createWorkflowDispatch({
+                await github.rest.issues.createLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  workflow_id: workflowFile,
-                  ref: prData.ref,
-                  inputs: {
-                    force_run: 'true'
-                  }
+                  name: readyLabel,
+                  color: '0E8A16',
+                  description: 'Run full GitHub CI for this PR'
                 });
-                console.log(`✅ Triggered ${workflowFile} (${workflowName})`);
-                succeeded.push({ id: workflowFile, name: workflowName });
+                console.log(`✅ Created ${readyLabel} label`);
               } catch (error) {
-                console.error(`❌ Failed to trigger ${workflowFile}:`, error.message);
-                failed.push({ workflow: workflowName, error: error.message });
-              }
-            }
-
-            // Wait a bit for workflows to queue
-            if (succeeded.length > 0) {
-              console.log('Waiting 5 seconds for workflows to queue...');
-              await new Promise(resolve => setTimeout(resolve, 5000));
-            }
-
-            // Verify workflows are queued/running
-            const verified = [];
-            const notFound = [];
-
-            if (succeeded.length > 0) {
-              const runs = await github.rest.actions.listWorkflowRunsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                per_page: 100,
-                created: `>${new Date(Date.now() - 60000).toISOString()}`
-              });
-
-              for (const workflow of succeeded) {
-                const found = runs.data.workflow_runs.some(run =>
-                  run.path === `.github/workflows/${workflow.id}` &&
-                  run.head_sha === prData.sha &&
-                  run.event === 'workflow_dispatch'
-                );
-
-                if (found) {
-                  verified.push(workflow);
-                } else {
-                  notFound.push(workflow);
+                if (error.status !== 422) {
+                  throw error;
                 }
+                console.log(`ℹ️  ${readyLabel} label already exists`);
               }
-            }
 
-            // Build the comment body based on actual results
-            let status;
-            if (failed.length > 0 && notFound.length > 0) {
-              status = '❌ **Failed to trigger or verify workflows**';
-            } else if (failed.length > 0) {
-              status = '⚠️ **Some workflows failed to trigger**';
-            } else if (notFound.length > 0) {
-              status = '⚠️ **Workflows triggered but not yet verified**';
-            } else if (uniqueWorkflows.size === 0) {
-              status = '✅ **Triggered all workflows for full CI coverage**';
-            } else {
-              status = '✅ **Successfully triggered skipped CI checks**';
-            }
-
-            // Don't list individual checks - keep it simple
-            const skippedChecksList = '';
-            const verifiedList = '';
-            const notFoundList = '';
-            const failedList = failed.length > 0 ? `\n\n**Failed to trigger:**\n${failed.map(f => `- ❌ ${f.workflow}: ${f.error}`).join('\n')}` : '';
-
-            // Add full-ci label only if we actually triggered workflows or if checks are already running
-            let labelAdded = false;
-            try {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: ['full-ci']
+                labels: [readyLabel]
               });
-              labelAdded = true;
-              console.log('✅ Added full-ci label to PR');
+              console.log(`✅ Added ${readyLabel} label to PR`);
             } catch (error) {
-              console.error('⚠️  Failed to add label:', error.message);
+              core.setFailed(`Failed to add ${readyLabel} label: ${error.message}`);
+              return;
             }
 
             const body = `🚀 **Full CI Mode Enabled**
 
-            ${status}
-            ${skippedChecksList}
-            ${verifiedList}${notFoundList}${failedList}
-
-            ${labelAdded && succeeded.length > 0 ? `\n**Note:** Added the \`full-ci\` label to this PR. All future commits will run the full CI suite (including minimum dependency tests) until the label is removed.
+            Added the \`ready-for-full-ci\` label to this PR. The label event will start the full CI workflows, and future commits will keep running the full suite until the label is removed.
 
             To disable full CI mode, use the \`/stop-run-skipped-ci\` command.
 
-            View progress in the [Actions tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions).` : ''}`;
+            View progress in the [Actions tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions).`;
 
-            // Post the comment
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: body
             });
-
-            // Fail the job if any workflows failed to trigger
-            if (failed.length > 0) {
-              core.setFailed(`Failed to trigger ${failed.length} workflow(s): ${failed.map(f => f.workflow).join(', ')}`);
-            }

--- a/.github/workflows/stop-run-skipped-ci.yml
+++ b/.github/workflows/stop-run-skipped-ci.yml
@@ -61,24 +61,56 @@ jobs:
           comment-id: ${{ github.event.comment.id }}
           reactions: 'eyes'
 
-      - name: Remove full-ci label
+      - name: Remove full CI readiness labels
         uses: actions/github-script@v7
         with:
           script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'full-ci'
-              });
-              console.log('✅ Removed full-ci label from PR');
+            const labelsToRemove = ['ready-for-full-ci', 'full-ci'];
+            const removedLabels = [];
+            const missingLabels = [];
 
-              // Post success comment
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                });
+                removedLabels.push(label);
+                console.log(`✅ Removed ${label} label from PR`);
+              } catch (error) {
+                if (error.status === 404) {
+                  missingLabels.push(label);
+                  console.log(`ℹ️  ${label} label not found - already removed or never added`);
+                } else {
+                  console.error('❌ Failed to remove label:', error);
+
+                  const errorBody = [
+                    '❌ **Error Removing Label**',
+                    '',
+                    `Failed to remove the \`${label}\` label: ${error.message}`
+                  ].join('\n');
+
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body: errorBody
+                  });
+                  core.setFailed(`Failed to remove label: ${error.message}`);
+                  return;
+                }
+              }
+            }
+
+            if (removedLabels.length > 0) {
               const successBody = [
                 '✅ **Full CI Mode Disabled**',
                 '',
-                'The `full-ci` label has been removed. Future commits will use the standard CI suite (skipping tests for unchanged code).',
+                `Removed: ${removedLabels.map(label => `\`${label}\``).join(', ')}.`,
+                '',
+                'Future commits will use the fast required PR gate unless full CI is requested again.',
                 '',
                 'To re-enable full CI mode, use the `/run-skipped-ci` command.'
               ].join('\n');
@@ -89,38 +121,18 @@ jobs:
                 issue_number: context.issue.number,
                 body: successBody
               });
-            } catch (error) {
-              if (error.status === 404) {
-                console.log('ℹ️  Label not found - already removed or never added');
-
-                const notFoundBody = [
-                  'ℹ️  **Full CI Mode Already Disabled**',
-                  '',
-                  'The `full-ci` label is not present on this PR. CI is already running in standard mode.'
-                ].join('\n');
-
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: notFoundBody
-                });
-              } else {
-                console.error('❌ Failed to remove label:', error);
-
-                const errorBody = [
-                  '❌ **Error Removing Label**',
-                  '',
-                  'Failed to remove the `full-ci` label: ' + error.message
-                ].join('\n');
-
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: errorBody
-                });
-                // Use core.setFailed instead of throw to properly fail the workflow
-                core.setFailed(`Failed to remove label: ${error.message}`);
-              }
+              return;
             }
+
+            const notFoundBody = [
+              'ℹ️  **Full CI Mode Already Disabled**',
+              '',
+              'Neither `ready-for-full-ci` nor legacy `full-ci` is present on this PR. CI is already running in standard mode.'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: notFoundBody
+            });

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Local CI Runner
 # Runs appropriate CI checks based on changes in current branch
-# Usage: bin/ci-local [--all] [--fast] [base-ref]
+# Usage: bin/ci-local [--all] [--fast] [--changed] [base-ref]
 
 set -euo pipefail
 
@@ -18,6 +18,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --fast)
       FAST_MODE=true
+      shift
+      ;;
+    --changed)
+      RUN_ALL=false
       shift
       ;;
     *)

--- a/bin/ci-rerun-failures
+++ b/bin/ci-rerun-failures
@@ -176,17 +176,31 @@ fi
 # Map CI job names to identifiers
 # NOTE: Version numbers below must match .github/workflows/main.yml matrix configuration
 declare -A JOB_MAP
+JOB_MAP["required-pr-gate"]="ci-required"
 JOB_MAP["lint-js-and-ruby"]="lint-js-and-ruby"
 JOB_MAP["rspec-package-tests"]="rspec-package-tests"
 JOB_MAP["package-js-tests"]="package-js-tests"
 JOB_MAP["dummy-app-integration-tests (3.4, 22, latest)"]="dummy-app-integration-tests"
 JOB_MAP["dummy-app-integration-tests (3.2, 20, minimum)"]="dummy-app-integration-tests"
 JOB_MAP["examples"]="examples"
+JOB_MAP["precompile-check"]="precompile-check"
+JOB_MAP["pro-lint-js-and-ruby"]="pro-lint-js-and-ruby"
+JOB_MAP["rspec-gem-specs"]="pro-rspec-gem-specs"
+JOB_MAP["rspec-dummy-app-node-renderer"]="pro-rspec-dummy-app-node-renderer"
+JOB_MAP["dummy-app-node-renderer-e2e-tests"]="pro-dummy-app-node-renderer-e2e-tests"
 
 # Function to execute commands without eval
 run_command() {
   local cmd_id="$1"
   case "$cmd_id" in
+    "ci-required")
+      ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].sort.each { |f| YAML.load_file(f); puts f }" &&
+        bash -n bin/ci-local &&
+        bash -n bin/ci-rerun-failures &&
+        bash -n script/ci-changes-detector &&
+        bash -n bin/request-full-ci &&
+        script/ci-changes-detector origin/main
+      ;;
     "lint-js-and-ruby")
       bundle exec rubocop && pnpm run eslint --report-unused-disable-directives && pnpm start format.listDifferent
       ;;
@@ -201,6 +215,26 @@ run_command() {
       ;;
     "examples")
       bundle exec rake run_rspec:shakapacker_examples
+      ;;
+    "precompile-check")
+      cd react_on_rails/spec/dummy && RAILS_ENV=production bundle exec rake assets:precompile
+      ;;
+    "pro-lint-js-and-ruby")
+      cd react_on_rails_pro &&
+        bundle exec rubocop --ignore-parent-exclusion &&
+        bundle exec rake rbs:validate &&
+        pnpm run nps eslint &&
+        pnpm run nps format.listDifferent &&
+        pnpm run nps check-typescript
+      ;;
+    "pro-rspec-gem-specs")
+      cd react_on_rails_pro && bundle exec rspec spec/react_on_rails_pro
+      ;;
+    "pro-rspec-dummy-app-node-renderer")
+      cd react_on_rails_pro/spec/dummy && bundle exec rspec
+      ;;
+    "pro-dummy-app-node-renderer-e2e-tests")
+      cd react_on_rails_pro/spec/dummy && pnpm e2e-test
       ;;
     *)
       echo "Unknown command ID: $cmd_id"

--- a/bin/request-full-ci
+++ b/bin/request-full-ci
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is required: brew install gh"
+  exit 1
+fi
+
+pr_number="${1:-}"
+
+if [ -z "$pr_number" ]; then
+  pr_number="$(gh pr view --json number --jq .number)"
+fi
+
+if ! gh label list --search "ready-for-full-ci" --json name --jq '.[].name' | grep -qx "ready-for-full-ci"; then
+  gh label create "ready-for-full-ci" \
+    --description "Run full GitHub CI for this PR" \
+    --color 0E8A16 || true
+fi
+
+if ! gh pr edit "$pr_number" --add-label "ready-for-full-ci"; then
+  echo "Failed to add ready-for-full-ci. If the label is missing, create it with:"
+  echo "  gh label create ready-for-full-ci --description \"Run full GitHub CI for this PR\" --color 0E8A16"
+  exit 1
+fi
+
+echo "Requested full CI for PR #$pr_number"

--- a/internal/contributor-info/ci-optimization.md
+++ b/internal/contributor-info/ci-optimization.md
@@ -1,259 +1,155 @@
 # CI Optimization Guide
 
-This document explains the CI optimization strategy implemented for React on Rails.
+This document explains the fast, safe CI cycle for React on Rails pull requests.
 
-## Overview
+## Goals
 
-The CI pipeline has been optimized to:
+The CI setup optimizes for two things:
 
-1. **Skip unnecessary workflows** for documentation-only changes
-2. **Run reduced test matrices on PRs** (full matrix only on main)
-3. **Provide local CI tooling** to run appropriate tests before pushing
+1. Fast PR review iteration.
+2. Reliable merge safety.
 
-## Optimization Strategies
+Routine feedback should happen locally and through a small required GitHub check. Expensive GitHub test suites run when a PR is ready for final validation, when code reaches merge-sensitive events, or when a maintainer manually requests them.
 
-### 1. Path-Based Filtering
+## PR CI Model
 
-All workflows now use `paths-ignore` to skip when only certain files change:
+Every PR update runs the always-required check:
+
+```text
+ci-required / required-pr-gate
+```
+
+This gate is intentionally lightweight. It validates workflow YAML syntax, shell script syntax for CI helper scripts, the changed-files detector, and a few repository sanity checks. It does not install the full dependency graph or run the full test matrix.
+
+Full CI jobs run on PRs only when one of these is true:
+
+- The PR has the `ready-for-full-ci` label.
+- The PR targets a release branch matching `release/*`, `releases/*`, or `release-*`.
+- A maintainer manually dispatches the workflow.
+
+The legacy `full-ci` label is still accepted as a compatibility alias, but new automation and docs should use `ready-for-full-ci`.
+
+## Merge Safety
+
+Full CI still runs for merge-sensitive events:
+
+- `push` to `main`
+- `merge_group`
+- `workflow_dispatch`
+
+Docs-only pushes to `main` keep the existing `ensure-main-docs-safety` guard so a documentation-only commit does not hide a previously broken main branch. For code changes, main and merge queue events run the full suites.
+
+## Required Checks
+
+Do not make required checks depend on workflow-level `paths`, `paths-ignore`, or branch filters that can leave checks skipped or pending.
+
+Preferred pattern:
 
 ```yaml
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-```
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
-**Benefits:**
-
-- Documentation changes don't trigger CI
-- Workflows skip when irrelevant files change
-- Reduces GitHub Actions minutes usage
-
-### 2. Change Detection
-
-The main test workflow includes a `detect-changes` job that:
-
-- Analyzes which files changed
-- Determines if tests are needed
-- Skips downstream jobs for docs-only changes
-
-**Example:**
-
-```yaml
 jobs:
-  detect-changes:
-    runs-on: ubuntu-22.04
-    outputs:
-      skip_tests: ${{ steps.changes.outputs.skip_tests }}
-    steps:
-      - name: Detect changes
-        # ... analyzes git diff
+  expensive-job:
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.has_full_ci_label == 'true'
 ```
 
-### 3. Reduced Test Matrix on PRs
+The workflow starts, then job-level `if:` logic decides whether expensive work should run.
 
-On PRs, we run a reduced test matrix for faster feedback:
+## Requesting Full CI
 
-| Environment   | Main Branch     | Pull Requests |
-| ------------- | --------------- | ------------- |
-| Ruby versions | 3.2, 3.4        | 3.4 only      |
-| Node versions | 20, 22          | 22 only       |
-| Dependencies  | minimum, latest | latest only   |
-
-**Benefits:**
-
-- ~75% reduction in CI time for PRs
-- Faster feedback for developers
-- Full coverage still runs on main before release
-
-**Implementation:**
-
-```yaml
-matrix:
-  ruby-version: ${{ github.ref == 'refs/heads/main' && fromJSON('["3.2", "3.4"]') || fromJSON('["3.4"]') }}
-  node-version: ${{ github.ref == 'refs/heads/main' && fromJSON('["20", "22"]') || fromJSON('["22"]') }}
-```
-
-### 4. Smart Path Filtering per Workflow
-
-Each workflow ignores paths that don't affect its tests:
-
-- **JS tests**: Skip when only Ruby files change (`lib/**`, `spec/react_on_rails/**`)
-- **Ruby tests**: Skip when only JS files change (`packages/react-on-rails/src/**`)
-- **All tests**: Skip for docs-only changes
-
-## Local CI Tools
-
-### `bin/ci-local` - Smart Local CI Runner
-
-Runs appropriate CI checks based on your changes:
+Preferred helper:
 
 ```bash
-# Auto-detect what to test based on changes
+bin/request-full-ci
+```
+
+To request full CI for a specific PR:
+
+```bash
+bin/request-full-ci 2818
+```
+
+Maintainers can also add the label directly:
+
+```bash
+gh pr edit 2818 --add-label ready-for-full-ci
+```
+
+If the label does not exist yet:
+
+```bash
+gh label create ready-for-full-ci --description "Run full GitHub CI for this PR" --color 0E8A16
+```
+
+The older PR comment command still works:
+
+```text
+/run-skipped-ci
+```
+
+It now adds `ready-for-full-ci` for future commits. To return a PR to the fast review loop:
+
+```text
+/stop-run-skipped-ci
+```
+
+This removes both `ready-for-full-ci` and the legacy `full-ci` label if present.
+
+## Local CI Contract
+
+Before pushing review-comment fixes, run local CI. See:
+
+```text
+internal/contributor-info/local-ci-contract.md
+```
+
+Common commands:
+
+```bash
 bin/ci-local
-
-# Run all CI checks (same as main)
-bin/ci-local --all
-
-# Run only fast checks
+bin/ci-local --changed
 bin/ci-local --fast
-
-# Compare against specific branch
-bin/ci-local origin/develop
 ```
 
-**Features:**
-
-- Analyzes your git diff
-- Skips unnecessary tests
-- Shows clear success/failure summary
-- Provides feedback before pushing
-
-### `script/ci-changes-detector` - Change Analysis Tool
-
-Analyzes which files changed and recommends CI jobs:
+For a full local pass:
 
 ```bash
-# Check changes since main
-script/ci-changes-detector origin/main
-
-# Check changes between any refs
-script/ci-changes-detector origin/develop HEAD
+bin/ci-local --all
 ```
 
-**Output:**
+## Rerunning Failures Locally
 
-```
-=== CI Changes Analysis ===
-Changed file categories:
-  • Ruby source code
-  • JavaScript/TypeScript code
+Use:
 
-Recommended CI jobs:
-  ✓ Lint (Ruby + JS)
-  ✓ RSpec gem tests
-  ✓ JS unit tests
-  ✓ Dummy app integration tests
+```bash
+bin/ci-rerun-failures
 ```
 
-### `/run-ci` Claude Command
+The script reads GitHub check results and maps known check names to local commands. It includes the required gate, core Ruby/JS/integration jobs, examples, precompile, and known Pro job names.
 
-Claude Code command for interactive CI execution:
+## Safety Notes
 
-```
-/run-ci
-```
+Do not configure a personal MacBook or other persistent personal machine as a public self-hosted runner for untrusted public PR code.
 
-Claude will:
+If self-hosted runners are added later:
 
-1. Analyze your changes
-2. Show recommended CI jobs
-3. Ask which option you prefer
-4. Execute and report results
-
-## CI Workflow Reference
-
-### Workflows and Their Triggers
-
-| Workflow                   | Runs On           | Skips For        | Matrix Reduction       |
-| -------------------------- | ----------------- | ---------------- | ---------------------- |
-| `main.yml`                 | Code changes      | Docs only        | Yes (75% faster)       |
-| `lint-js-and-ruby.yml`     | Code changes      | Docs only        | No (already fast)      |
-| `examples.yml`             | Generator changes | Docs only        | Yes (50% faster)       |
-| `package-js-tests.yml`     | JS changes        | Docs, Ruby files | Yes (50% faster)       |
-| `rspec-package-specs.yml`  | Ruby changes      | Docs, JS files   | Yes (75% faster)       |
-| `check-markdown-links.yml` | Markdown changes  | Non-docs         | No (already optimized) |
-
-## Expected Time Savings
-
-### Before Optimization
-
-- PR with code changes: ~45 minutes (all matrices)
-- PR with docs changes: ~45 minutes (unnecessary)
-- Total CI time per day: High
-
-### After Optimization
-
-- PR with code changes: ~12 minutes (reduced matrix)
-- PR with docs changes: 0 minutes (skipped)
-- Main merge: ~45 minutes (full matrix)
-- Total CI time saved: ~70%
-
-## Best Practices
-
-### For Developers
-
-1. **Run local CI before pushing:**
-
-   ```bash
-   bin/ci-local
-   ```
-
-2. **Use fast mode for quick checks:**
-
-   ```bash
-   bin/ci-local --fast
-   ```
-
-3. **Separate doc changes from code changes:**
-   - Docs-only PRs skip CI entirely
-   - Mixed PRs run full CI
-
-4. **Trust the PR CI:**
-   - Reduced matrix is sufficient for most changes
-   - Main branch validates full matrix before release
-
-### For Maintainers
-
-1. **Monitor CI performance:**
-   - Check GitHub Actions usage
-   - Identify slow tests
-   - Adjust matrix as needed
-
-2. **Update path filters:**
-   - Add new file patterns as project evolves
-   - Keep filters accurate
-
-3. **Review main CI failures:**
-   - Main runs full matrix
-   - Catches edge cases not found in PR CI
-
-## Troubleshooting
-
-### CI not skipping for docs changes
-
-Check if:
-
-- Changes are truly docs-only (use `git diff --name-only`)
-- Path patterns match your files
-- Workflow has correct `paths-ignore`
-
-### CI taking too long on PRs
-
-- Ensure you're not on main branch
-- Check if matrix reduction is working
-- Use `bin/ci-local --fast` for local testing
-
-### Tests pass locally but fail in CI
-
-- Different dependency versions
-- Environment differences
-- Run `bin/ci-local --all` to match CI exactly
-
-## Future Improvements
-
-Potential further optimizations:
-
-1. **Parallel test execution** within jobs
-2. **Smarter caching** of dependencies
-3. **Test splitting** for faster execution
-4. **Conditional job dependencies** based on changes
-5. **Reusable workflows** to reduce duplication
+- Use them only for trusted branches or internal repositories.
+- Do not expose secrets to fork PRs.
+- Prefer ephemeral runners.
+- Keep the GitHub-hosted `ci-required / required-pr-gate` as the public PR default.
 
 ## Related Files
 
-- `script/ci-changes-detector` - Change detection script
-- `bin/ci-local` - Local CI runner
-- `.claude/commands/run-ci.md` - Claude command
-- `.github/workflows/*.yml` - All CI workflows
+- `.github/workflows/ci-required.yml`
+- `.github/workflows/*`
+- `.github/actions/check-full-ci-label/action.yml`
+- `bin/ci-local`
+- `bin/request-full-ci`
+- `bin/ci-rerun-failures`
+- `script/ci-changes-detector`

--- a/internal/contributor-info/local-ci-contract.md
+++ b/internal/contributor-info/local-ci-contract.md
@@ -1,0 +1,31 @@
+# Local CI Contract for AI and Maintainers
+
+Before pushing review-comment fixes, run:
+
+```bash
+bin/ci-local
+```
+
+For narrow changes, the changed-files path is explicit:
+
+```bash
+bin/ci-local --changed
+```
+
+For a faster smoke pass while iterating:
+
+```bash
+bin/ci-local --fast
+```
+
+For final local validation before requesting full GitHub CI:
+
+```bash
+bin/ci-local --all
+```
+
+The goal is to catch routine failures locally on fast hardware instead of using GitHub Actions as the first feedback loop. Request full GitHub CI with:
+
+```bash
+bin/request-full-ci
+```


### PR DESCRIPTION
## Summary

Adds a fast always-running PR gate named `ci-required / required-pr-gate` and moves expensive test/lint workflows behind full-CI readiness conditions.

Key changes:

- Adds `.github/workflows/ci-required.yml` for lightweight required PR validation.
- Removes PR path filters from heavyweight core and Pro test/lint workflows, replacing them with job-level gating.
- Runs full CI for `push` to `main`, `merge_group`, `workflow_dispatch`, release-target PRs, or PRs labeled `ready-for-full-ci`.
- Keeps legacy `full-ci` as a compatibility alias.
- Adds `bin/request-full-ci` and updates `/run-skipped-ci` / `/stop-run-skipped-ci` behavior.
- Updates CI docs and the local CI contract.
- Expands `bin/ci-rerun-failures` mappings for the new required gate and current workflow names.

## Why

This keeps required PR feedback fast while preserving full validation for merge-sensitive paths and explicit ready-for-final-validation PRs. It also avoids required checks getting stuck because workflows were skipped by path filters.

## Validation

- `bash -n bin/ci-local bin/ci-rerun-failures bin/request-full-ci script/ci-changes-detector`
- `ruby -e "require 'yaml'; Dir['.github/workflows/*.{yml,yaml}'].sort.each { |f| YAML.load_file(f); puts f }"`
- `script/ci-changes-detector origin/main`
- `actionlint .github/workflows/ci-required.yml .github/workflows/detect-invalid-ci-commands.yml .github/workflows/examples.yml .github/workflows/gem-tests.yml .github/workflows/integration-tests.yml .github/workflows/lint-js-and-ruby.yml .github/workflows/package-js-tests.yml .github/workflows/playwright.yml .github/workflows/precompile-check.yml .github/workflows/pro-integration-tests.yml .github/workflows/pro-lint.yml .github/workflows/pro-test-package-and-gem.yml .github/workflows/run-skipped-ci.yml .github/workflows/stop-run-skipped-ci.yml`
- `git diff --check`
- Pre-commit hook: trailing-newlines and Prettier passed
- Pre-push hook completed successfully
- Autoreview local pass: no actionable findings

Notes:

- `yamllint` is not installed in the local environment.
- Full-repo `actionlint` still reports pre-existing issues in untouched workflows (`actionlint.yml`, `benchmark.yml`, `bundle-size.yml`), but the workflows changed in this PR pass targeted `actionlint`.
- The pre-push hook printed `fatal: origin/main...HEAD: no merge base` inside `branch-lint`, then reported success and allowed the push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shifts merge safety to explicit full-CI labels and main/merge-queue runs—regular PRs no longer auto-run path-scoped heavy jobs, so mis-labeling or branch protection misconfiguration could merge without the full matrix.
> 
> **Overview**
> Introduces **`ci-required / required-pr-gate`**, a lightweight always-on PR check (workflow YAML, CI shell syntax, change detector, basic repo sanity) so required status does not depend on path filters that can skip workflows entirely.
> 
> **Heavy test and lint workflows** drop PR `paths-ignore` and instead gate expensive jobs on **push to main**, **merge queue**, **manual dispatch**, **release-target PRs**, or a **`ready-for-full-ci`** label (legacy **`full-ci`** still honored). Routine PRs only get the fast gate unless full CI is requested; label add/remove retriggers via `labeled` / `unlabeled` events.
> 
> **Full CI request path** is simplified: `/run-skipped-ci` and new **`bin/request-full-ci`** add the readiness label instead of dispatching workflows; **`bin/ci-rerun-failures`** and contributor docs reflect the new model and local CI contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f09c7a1542c245765d6be6e521b6859279c67f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->