### PR TITLE
Clarify agent freshness and skill resolution

### DIFF
--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -8,6 +8,10 @@ argument-hint: '[issue/PR numbers, labels, milestone, or search query]'
 
 Create verified scope and a goal prompt for `$pr-batch`. Do not implement items here.
 
+If a skill picker only exposes installed/global skills, treat this skill as an
+entry point. After fetching, prefer repo-local `.agents/skills/...` and
+`.agents/workflows/...` files when they exist.
+
 Memorable invocation:
 
 ```text
@@ -247,6 +251,7 @@ Items:
   Done when: PR merged only if explicitly authorized by the current user or batch goal and allowed by release-mode gates, ready/blocked/no-PR evidence, or documented no-fix rationale.
 
 Execution rules:
+- Run `git fetch --prune origin main` first. Verify repo-local `.agents/skills/pr-batch/SKILL.md` and `.agents/workflows/pr-processing.md` exist before launching workers. If either is missing in the checkout but present on `origin/main`, update the worktree before continuing; if still missing, stop and report repo workflow state as `UNKNOWN`.
 - Follow `.agents/skills/pr-batch/SKILL.md` "Goal Prompt Template"; if skill autoloading is unavailable, copy its safety, review, /simplify, CI, and readiness gates before running.
 - Dispatch one subagent per independent item; group dependent items only when shared context is required. Dispatch only the current file-disjoint wave. Hold serial and `UNKNOWN`
   discovery lanes until no active editor lane can collide with them.

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -8,6 +8,10 @@ argument-hint: '[exact issue/PR numbers or filters]'
 
 Turn a short batch request into a safe, explicit launch plan and, when requested, a ready-to-paste `/goal` prompt.
 
+If a skill picker only exposes installed/global skills, treat this skill as an
+entry point. After fetching, prefer repo-local `.agents/skills/...` and
+`.agents/workflows/...` files when they exist.
+
 Memorable invocation:
 
 ```text
@@ -15,7 +19,7 @@ $pr-batch
 Run a Codex batch
 ```
 
-Use `.agents/workflows/pr-processing.md` as the deeper operating model for each issue, PR, review-fix pass, or merge-readiness item.
+Run `git fetch --prune origin main`, then use `.agents/workflows/pr-processing.md` as the deeper operating model for each issue, PR, review-fix pass, or merge-readiness item. If repo-local `.agents/skills/...` or `.agents/workflows/pr-processing.md` is missing in the checkout but present on `origin/main`, update the worktree before launching workers; if it remains missing, report repo workflow state as `UNKNOWN`.
 If the target scope is not verified yet, use `.agents/skills/plan-pr-batch/SKILL.md` first.
 For release-mode coordination, auto-merge confidence, and shared release tracker updates, follow `AGENTS.md` and the release-mode sections of `.agents/workflows/pr-processing.md`; do not invent new labels or overwrite tracker issue bodies from stale reads.
 If any target's value, priority, or proposed fix scope is unclear, use `.agents/skills/evaluate-issue/SKILL.md` before assigning implementation workers.
@@ -62,7 +66,7 @@ Before implementation or worker launch, produce:
 1. A concrete goal name.
 2. A disposition summary for speculative, AI/code-analysis-only, over-scoped, or unclear candidates, or `N/A - all targets pre-approved`.
    - Include any `needs-customer-feedback` targets skipped from implementation, with that label as the reason.
-3. A repo preflight: fetch/prune `main`, confirm the expected repository root, and verify nested repo paths before assigning work.
+3. A repo preflight: run `git fetch --prune origin main`, confirm the expected repository root, verify repo-local workflow files, and verify nested repo paths before assigning work.
 4. A short batch table:
    - target number and title
    - branch name
@@ -105,7 +109,7 @@ not escalate behavior-preserving optional nits, batch real questions into one
 decision block per lane, self-verify machine-checkable claims before escalation,
 and include decision-point counts plus confidence notes in handoffs.
 
-Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
+Run `git fetch --prune origin main` first, confirm the expected repo root, verify repo-local workflow files, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
 For issue targets, create one focused branch and PR unless exact same-file overlap makes a bundle safer. Start new issue branches from updated origin/main. For existing PR, review-fix, or merge-readiness targets, work on the existing PR head branch and do not create replacement PRs; if the branch cannot be updated safely, report the blocker. Follow local validation, pre-push review/simplify, CI backpressure, and merge-readiness gates.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 - `AGENTS.md`: canonical entry point for agent instructions and workflow discovery
 - `.agents/skills/`: agent skills; `.claude/skills` is a symlink here so Claude Code exposes the same workflows as slash commands
 - `.agents/workflows/`: shared prompt templates and reusable workflows for Codex, GPT, and other non-Claude tools
+- If a tool or skill picker only exposes installed/global skills, treat those
+  skills as launchers. After fetching, prefer repo-local `.agents/skills/...`
+  and `.agents/workflows/...` files when they exist; installed/global skills do
+  not override this repo's policy.
 - `internal/contributor-info/agent-workflow-adoption.md`: guide for copying these agent workflows into other repositories
 - `internal/contributor-info/agent-pr-batch-skills.md`: contributor guide for choosing and sequencing `$plan-issue-triage`, `$plan-pr-batch`, and `$pr-batch`
 - `internal/contributor-info/multi-batch-operations.md`: operator guide for running multiple batches across machines, launch surfaces, and repos
@@ -36,6 +40,26 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
 
 Other agent-facing docs (for example `CLAUDE.md`) should contain only tool-specific workflow notes and link back here.
 If there is a conflict, `AGENTS.md` wins.
+
+## Freshness And Skill Resolution
+
+Before planning issue/PR work, creating a new branch, or creating a new
+worktree, run:
+
+```bash
+git fetch --prune origin main
+```
+
+Base new issue branches and new worktrees on the freshly fetched `origin/main`
+unless the user explicitly asks to reproduce an old SHA, continue an existing PR
+branch, bisect, or work offline. Creating a new worktree does not fetch from
+GitHub by itself.
+
+After fetching, verify repo-local workflow files before falling back to installed
+skills. If `.agents/skills/...` or `.agents/workflows/pr-processing.md` is
+missing in the checkout but present on `origin/main`, update the worktree before
+continuing; if it is still missing, report the repo workflow state as `UNKNOWN`
+instead of silently using a global skill fallback.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Document that agents should fetch `origin/main` before planning issue/PR work or creating new branches/worktrees.
- Clarify that installed/global skills are launchers, while repo-local `.agents/skills/...` and `.agents/workflows/...` remain the source of truth when present.
- Update the repo-local `$plan-pr-batch` and `$pr-batch` guidance to verify repo-local workflow files before launching workers.

## Validation

- `git diff --check`
- `pnpm start format.listDifferent`
- `ruby -ryaml -e '...' .agents/skills/plan-pr-batch/SKILL.md .agents/skills/pr-batch/SKILL.md`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- pre-commit hook: trailing-newlines, markdown-links, prettier
- pre-push hook: branch-lint, markdown-links

## Notes

RuboCop completed with no offenses and printed dependency deprecation warnings from RuboCop/Ruby libraries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent guidance; no application code, CI, or runtime behavior changes.
> 
> **Overview**
> **Agents must refresh `origin/main` and treat repo-local workflows as canonical** before planning batches, opening branches, or spawning worktrees.
> 
> `AGENTS.md` adds a **Freshness And Skill Resolution** section: run `git fetch --prune origin main`, base new branches/worktrees on updated `origin/main`, and prefer `.agents/skills/...` / `.agents/workflows/...` over installed/global skills (launchers only). If repo-local files are missing locally but exist on `origin/main`, update the worktree; if still missing, report workflow state as `UNKNOWN` instead of silently using global fallbacks.
> 
> **`$plan-pr-batch` and `$pr-batch` skills** mirror that policy: entry-point notes for skill pickers, mandatory fetch + verification of `pr-batch/SKILL.md` and `pr-processing.md` before worker launch, and expanded repo preflight in planning output and goal prompt templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ed3f0282d7797078378b17758fbd21195f5f93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workflow and skill resolution to prioritize repository-local configurations over global ones.
  * Added freshness verification steps to ensure workflows are up-to-date before execution.
  * Improved pre-flight checks to validate workflow availability and report status accurately when local files are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->