### PR TITLE
Fix Pro FOUC reveal gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Fixed
+
+- **[Pro]** **RSC and client-only FOUC reveal gating**: Pro now waits for auto-loaded generated component stylesheets before mounting client-only roots and promotes streamed RSC client chunk stylesheet preloads to real stylesheet links before reveal, including when stream chunks split `<link>` tags. Shared generated CSS is matched through manifest-derived stylesheet href metadata, while app-authored preload links remain untouched. Fixes [Issue 4031](https://github.com/shakacode/react_on_rails/issues/4031), [Issue 4032](https://github.com/shakacode/react_on_rails/issues/4032). [PR 4047](https://github.com/shakacode/react_on_rails/pull/4047) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.4] - 2026-06-14
 
 #### Added

--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -44,6 +44,100 @@ import * as StoreRegistry from './StoreRegistry.ts';
 import * as ComponentRegistry from './ComponentRegistry.ts';
 
 const REACT_ON_RAILS_STORE_ATTRIBUTE = 'data-js-react-on-rails-store';
+const GENERATED_STYLESHEET_HREFS_ATTRIBUTE = 'data-generated-stylesheet-hrefs';
+const STYLESHEET_LOAD_TIMEOUT_MS = 10_000;
+
+function normalizeStylesheetHref(href: string): string {
+  try {
+    return new URL(href, document.baseURI).href;
+  } catch {
+    return href;
+  }
+}
+
+function generatedStylesheetHrefMatches(link: HTMLLinkElement, expectedHref: string): boolean {
+  const rawLinkHref = link.getAttribute('href') || link.href;
+  const normalizedExpectedHref = normalizeStylesheetHref(expectedHref);
+
+  return rawLinkHref === expectedHref || link.href === normalizedExpectedHref;
+}
+
+function generatedStylesheetMatchesComponent(
+  link: HTMLLinkElement,
+  componentName: string,
+  generatedStylesheetHrefs: string[],
+): boolean {
+  if (generatedStylesheetHrefs.some((href) => generatedStylesheetHrefMatches(link, href))) {
+    return true;
+  }
+
+  const href = link.getAttribute('href') || link.href;
+  const generatedComponentPath = `/generated/${componentName}`;
+
+  return href.includes(`${generatedComponentPath}-`) || href.includes(`${generatedComponentPath}.`);
+}
+
+function generatedStylesheetHrefsForComponent(componentSpec: Element): string[] {
+  const serializedHrefs = componentSpec.getAttribute(GENERATED_STYLESHEET_HREFS_ATTRIBUTE);
+  if (!serializedHrefs) {
+    return [];
+  }
+
+  try {
+    const hrefs: unknown = JSON.parse(serializedHrefs);
+    if (!Array.isArray(hrefs)) {
+      return [];
+    }
+
+    return hrefs.filter((href): href is string => typeof href === 'string' && href.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function stylesheetAlreadyLoaded(link: HTMLLinkElement): boolean {
+  if (link.sheet) return true;
+
+  return Array.from(document.styleSheets).some((styleSheet) => styleSheet.href === link.href);
+}
+
+function waitForStylesheet(link: HTMLLinkElement): Promise<void> {
+  if (stylesheetAlreadyLoaded(link)) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const done = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      link.removeEventListener('load', done);
+      link.removeEventListener('error', done);
+      resolve();
+    };
+
+    link.addEventListener('load', done);
+    link.addEventListener('error', done);
+    timeout = setTimeout(done, STYLESHEET_LOAD_TIMEOUT_MS);
+    if (stylesheetAlreadyLoaded(link)) {
+      done();
+    }
+  });
+}
+
+function waitForGeneratedComponentStylesheets(componentName: string, componentSpec: Element): Promise<void> {
+  const generatedStylesheetHrefs = generatedStylesheetHrefsForComponent(componentSpec);
+  const stylesheetLinks = Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"][href]'),
+  ).filter((link) => generatedStylesheetMatchesComponent(link, componentName, generatedStylesheetHrefs));
+
+  if (stylesheetLinks.length === 0) {
+    return Promise.resolve();
+  }
+
+  return Promise.all(stylesheetLinks.map(waitForStylesheet)).then(() => undefined);
+}
 
 /**
  * Invokes a renderer teardown, swallowing async rejections so a failing teardown cannot produce an
@@ -196,7 +290,10 @@ class ComponentRenderer {
       const domNode = document.getElementById(domNodeId);
       if (domNode) {
         this.domNode = domNode;
-        const componentObj = await ComponentRegistry.getOrWaitForComponent(name);
+        const [componentObj] = await Promise.all([
+          ComponentRegistry.getOrWaitForComponent(name),
+          waitForGeneratedComponentStylesheets(name, el),
+        ]);
         if (this.state === 'unmounted') {
           return;
         }

--- a/packages/react-on-rails-pro/src/ClientSideRenderer.ts
+++ b/packages/react-on-rails-pro/src/ClientSideRenderer.ts
@@ -128,6 +128,7 @@ function waitForStylesheet(link: HTMLLinkElement): Promise<void> {
 
 function waitForGeneratedComponentStylesheets(componentName: string, componentSpec: Element): Promise<void> {
   const generatedStylesheetHrefs = generatedStylesheetHrefsForComponent(componentSpec);
+  // Generated stylesheet links are emitted into <head> before the component script runs.
   const stylesheetLinks = Array.from(
     document.querySelectorAll<HTMLLinkElement>('link[rel~="stylesheet"][href]'),
   ).filter((link) => generatedStylesheetMatchesComponent(link, componentName, generatedStylesheetHrefs));

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -223,15 +223,17 @@ function findReactSuspenseRevealSplitIndex(htmlString: string) {
 
 function splitReactSuspenseRevealHtmlBuffer(htmlBuffer: Buffer) {
   const htmlString = htmlBuffer.toString('utf8');
-  const splitIndex = findReactSuspenseRevealSplitIndex(htmlString);
+  const splitCharacterIndex = findReactSuspenseRevealSplitIndex(htmlString);
 
-  if (splitIndex === -1) {
+  if (splitCharacterIndex === -1) {
     return { flushableHtmlBuffer: htmlBuffer, deferredRevealHtmlBuffer: undefined };
   }
 
+  const splitByteIndex = Buffer.byteLength(htmlString.slice(0, splitCharacterIndex), 'utf8');
+
   return {
-    flushableHtmlBuffer: Buffer.from(htmlString.slice(0, splitIndex)),
-    deferredRevealHtmlBuffer: Buffer.from(htmlString.slice(splitIndex)),
+    flushableHtmlBuffer: htmlBuffer.subarray(0, splitByteIndex),
+    deferredRevealHtmlBuffer: htmlBuffer.subarray(splitByteIndex),
   };
 }
 

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -94,6 +94,7 @@ function createRSCDiagnosticScript(
 
 const RSC_CLIENT_CHUNK_STYLESHEET_PATH = /\/css\/client\d+-[^/]+\.css$/;
 const RSC_CLIENT_CHUNK_NAME_WITH_JS_ASSET = /"((?:client)\d+)"\s*,\s*"js\/client\d+-[^"]+\.chunk\.js"/g;
+const REACT_SUSPENSE_REVEAL_SCRIPT = /\$RC\(/;
 const LOADABLE_STATS_FILE_NAME = 'loadable-stats.json';
 
 type LoadableStats = {
@@ -105,8 +106,14 @@ type RSCClientChunkStylesheetHrefsByChunkName = Map<string, string[]>;
 
 let cachedRSCClientChunkStylesheetHrefsByChunkName: RSCClientChunkStylesheetHrefsByChunkName | undefined;
 
+function escapeRegExpLiteral(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function getQuotedAttribute(tag: string, attributeName: string) {
-  const attributeMatch = tag.match(new RegExp(`\\s${attributeName}=(["'])(.*?)\\1`, 'i'));
+  const attributeMatch = tag.match(
+    new RegExp(`\\s${escapeRegExpLiteral(attributeName)}=(["'])(.*?)\\1`, 'i'),
+  );
   return attributeMatch?.[2];
 }
 
@@ -173,6 +180,10 @@ function escapeAttributeValue(value: string) {
 
 function createStylesheetTag(href: string) {
   return `<link rel="stylesheet" href="${escapeAttributeValue(href)}" data-precedence="rsc-css">`;
+}
+
+function includesReactSuspenseRevealScript(htmlBuffer: Buffer) {
+  return REACT_SUSPENSE_REVEAL_SCRIPT.test(htmlBuffer.toString('utf8'));
 }
 
 function stylesheetTagsForRSCClientChunks(
@@ -311,6 +322,7 @@ export default function injectRSCPayload(
   const resultStream = new PassThrough();
   let rscPromise: Promise<void> | null = null;
   const emittedRSCClientStylesheetHrefs = new Set<string>();
+  let hasResolvedInitialRSCClientStylesheetInference = rscClientChunkStylesheetHrefsByChunkName.size === 0;
 
   // ========================================
   // BUFFER ARRAYS - Three data sources
@@ -386,6 +398,14 @@ export default function injectRSCPayload(
       rscInitializationSize + rscClientStylesheetSize + gatedHtmlBuffer.length + rscPayloadSize;
 
     if (hasIncompleteLinkTagTail && holdIncompleteLinkTagTail) {
+      return;
+    }
+
+    if (
+      !hasResolvedInitialRSCClientStylesheetInference &&
+      rscPromise &&
+      includesReactSuspenseRevealScript(gatedHtmlBuffer)
+    ) {
       return;
     }
 
@@ -581,7 +601,10 @@ export default function injectRSCPayload(
                 flightData,
                 rscClientChunkStylesheetHrefsByChunkName,
                 emittedRSCClientStylesheetHrefs,
-              ).forEach((stylesheetTag) => rscClientStylesheetBuffers.push(Buffer.from(stylesheetTag)));
+              ).forEach((stylesheetTag) => {
+                hasResolvedInitialRSCClientStylesheetInference = true;
+                rscClientStylesheetBuffers.push(Buffer.from(stylesheetTag));
+              });
               const payloadScript = createRSCPayloadChunk(flightData, rscPayloadKey, sanitizedNonce);
               rscPayloadBuffers.push(Buffer.from(payloadScript));
 
@@ -598,6 +621,8 @@ export default function injectRSCPayload(
               const chunkBuf = chunk instanceof Uint8Array ? chunk : new TextEncoder().encode(chunk);
               parser.feed(chunkBuf, handleParsedChunk);
             }
+            hasResolvedInitialRSCClientStylesheetInference = true;
+            scheduleFlushFallback();
           })(),
         );
       });

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -318,9 +318,43 @@ function promoteStylesheetPreloadTag(linkTag: string) {
   return promotedTag.replace(/\s*\/?>$/, ` data-precedence="rsc-css"${closing}`);
 }
 
-function applyStreamedStylesheetPreloadGating(html: Buffer, holdIncompleteLinkTagTail: boolean) {
+function hasIncompleteUTF8Tail(buffer: Buffer) {
+  let continuationBytes = 0;
+  let leadByteIndex = buffer.length - 1;
+
+  while (leadByteIndex >= 0 && buffer[leadByteIndex] >= 0x80 && buffer[leadByteIndex] <= 0xbf) {
+    continuationBytes += 1;
+    leadByteIndex -= 1;
+  }
+
+  if (leadByteIndex < 0) {
+    return continuationBytes > 0;
+  }
+
+  const leadByte = buffer[leadByteIndex];
+  if (leadByte <= 0x7f) return false;
+
+  let expectedContinuationBytes = 0;
+  if (leadByte >= 0xc2 && leadByte <= 0xdf) {
+    expectedContinuationBytes = 1;
+  } else if (leadByte >= 0xe0 && leadByte <= 0xef) {
+    expectedContinuationBytes = 2;
+  } else if (leadByte >= 0xf0 && leadByte <= 0xf4) {
+    expectedContinuationBytes = 3;
+  } else {
+    return false;
+  }
+
+  return continuationBytes < expectedContinuationBytes;
+}
+
+function applyStreamedStylesheetPreloadGating(html: Buffer, holdIncompleteHtmlTail: boolean) {
+  if (holdIncompleteHtmlTail && hasIncompleteUTF8Tail(html)) {
+    return { gatedHtmlBuffer: html, hasIncompleteHtmlTail: true };
+  }
+
   const htmlString = html.toString();
-  const { completeHtml, incompleteLinkTagTail: nextIncompleteLinkTagTail } = holdIncompleteLinkTagTail
+  const { completeHtml, incompleteLinkTagTail: nextIncompleteLinkTagTail } = holdIncompleteHtmlTail
     ? splitIncompleteLinkTagTail(htmlString)
     : { completeHtml: htmlString, incompleteLinkTagTail: '' };
   const gatedHtml = completeHtml.replace(
@@ -331,7 +365,7 @@ function applyStreamedStylesheetPreloadGating(html: Buffer, holdIncompleteLinkTa
 
   return {
     gatedHtmlBuffer: gatedHtml === htmlString && !nextIncompleteLinkTagTail ? html : Buffer.from(gatedHtml),
-    hasIncompleteLinkTagTail: Boolean(nextIncompleteLinkTagTail),
+    hasIncompleteHtmlTail: Boolean(nextIncompleteLinkTagTail),
   };
 }
 
@@ -394,7 +428,7 @@ export default function injectRSCPayload(
    * CONSTRAINT: The first output chunk must contain HTML data to begin streaming.
    */
   const htmlBuffers: Buffer[] = [];
-  let holdIncompleteLinkTagTail = true;
+  let holdIncompleteHtmlTail = true;
 
   /**
    * Buffer for stylesheet links inferred from RSC client chunk references.
@@ -441,9 +475,9 @@ export default function injectRSCPayload(
     // Calculate total buffer size for efficient memory allocation
     const rscInitializationSize = rscInitializationBuffers.reduce((sum, buf) => sum + buf.length, 0);
     const htmlBuffer = Buffer.concat(htmlBuffers);
-    const { gatedHtmlBuffer, hasIncompleteLinkTagTail } = applyStreamedStylesheetPreloadGating(
+    const { gatedHtmlBuffer, hasIncompleteHtmlTail } = applyStreamedStylesheetPreloadGating(
       htmlBuffer,
-      holdIncompleteLinkTagTail,
+      holdIncompleteHtmlTail,
     );
     const shouldDeferRevealHtml =
       rscPromise &&
@@ -458,7 +492,7 @@ export default function injectRSCPayload(
     const totalSize =
       rscInitializationSize + rscClientStylesheetSize + flushableHtmlBuffer.length + rscPayloadSize;
 
-    if (hasIncompleteLinkTagTail && holdIncompleteLinkTagTail) {
+    if (hasIncompleteHtmlTail && holdIncompleteHtmlTail) {
       return;
     }
 
@@ -530,7 +564,7 @@ export default function injectRSCPayload(
   };
 
   const endResultStream = () => {
-    holdIncompleteLinkTagTail = false;
+    holdIncompleteHtmlTail = false;
     // Cancel any pending fallback timer unconditionally.
     // flush() only clears the timer when it actually flushes data (past the
     // early-return guards). If we're closing with empty buffers, the timer

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -90,6 +90,100 @@ function createRSCDiagnosticScript(
   );
 }
 
+const RSC_CLIENT_CHUNK_STYLESHEET_PATH = /\/css\/client\d+-[^/]+\.css$/;
+
+function getQuotedAttribute(tag: string, attributeName: string) {
+  const attributeMatch = tag.match(new RegExp(`\\s${attributeName}=(["'])(.*?)\\1`, 'i'));
+  return attributeMatch?.[2];
+}
+
+function isRSCClientChunkStylesheetHref(href: string) {
+  try {
+    return RSC_CLIENT_CHUNK_STYLESHEET_PATH.test(new URL(href, 'http://react-on-rails.local').pathname);
+  } catch {
+    return RSC_CLIENT_CHUNK_STYLESHEET_PATH.test(href.split(/[?#]/, 1)[0]);
+  }
+}
+
+function shouldPromoteStylesheetPreloadTag(linkTag: string) {
+  const href = getQuotedAttribute(linkTag, 'href');
+  return href ? isRSCClientChunkStylesheetHref(href) : false;
+}
+
+function splitIncompleteLinkTagTail(htmlString: string) {
+  const lowerHtmlString = htmlString.toLowerCase();
+  const lastCompleteTagEnd = htmlString.lastIndexOf('>');
+  const lastLinkStart = lowerHtmlString.lastIndexOf('<link');
+
+  if (lastLinkStart !== -1 && lastLinkStart > lastCompleteTagEnd) {
+    return {
+      completeHtml: htmlString.slice(0, lastLinkStart),
+      incompleteLinkTagTail: htmlString.slice(lastLinkStart),
+    };
+  }
+
+  const linkToken = '<link';
+  for (let suffixLength = linkToken.length - 1; suffixLength > 0; suffixLength -= 1) {
+    const possibleLinkTokenPrefix = lowerHtmlString.slice(-suffixLength);
+
+    if (linkToken.startsWith(possibleLinkTokenPrefix)) {
+      return {
+        completeHtml: htmlString.slice(0, -suffixLength),
+        incompleteLinkTagTail: htmlString.slice(-suffixLength),
+      };
+    }
+  }
+
+  if (lastLinkStart === -1 || lastLinkStart < lastCompleteTagEnd) {
+    return { completeHtml: htmlString, incompleteLinkTagTail: '' };
+  }
+
+  return {
+    completeHtml: htmlString.slice(0, lastLinkStart),
+    incompleteLinkTagTail: htmlString.slice(lastLinkStart),
+  };
+}
+
+function promoteStylesheetPreloadTag(linkTag: string) {
+  const promotedTag = linkTag
+    .replace(/\srel=(["'])(.*?)\1/i, (_match, quote: string, relValue: string) => {
+      const relTokens = relValue
+        .split(/\s+/)
+        .filter(Boolean)
+        .filter((token) => token.toLowerCase() !== 'preload');
+
+      return ` rel=${quote}${[
+        'stylesheet',
+        ...relTokens.filter((token) => token.toLowerCase() !== 'stylesheet'),
+      ].join(' ')}${quote}`;
+    })
+    .replace(/\sas=(["'])style\1/i, '');
+
+  if (/\sdata-precedence=/.test(promotedTag)) {
+    return promotedTag;
+  }
+
+  const closing = promotedTag.endsWith('/>') ? '/>' : '>';
+  return promotedTag.replace(/\s*\/?>$/, ` data-precedence="rsc-css"${closing}`);
+}
+
+function applyStreamedStylesheetPreloadGating(html: Buffer, holdIncompleteLinkTagTail: boolean) {
+  const htmlString = html.toString();
+  const { completeHtml, incompleteLinkTagTail: nextIncompleteLinkTagTail } = holdIncompleteLinkTagTail
+    ? splitIncompleteLinkTagTail(htmlString)
+    : { completeHtml: htmlString, incompleteLinkTagTail: '' };
+  const gatedHtml = completeHtml.replace(
+    /<link\b(?=[^>]*\brel=(["'])(?:(?!\1).)*\bpreload\b(?:(?!\1).)*\1)(?=[^>]*\bas=(["'])style\2)(?=[^>]*\bhref=(["'])(?:(?!\3).)+\3)[^>]*\/?>/gi,
+    (linkTag) =>
+      shouldPromoteStylesheetPreloadTag(linkTag) ? promoteStylesheetPreloadTag(linkTag) : linkTag,
+  );
+
+  return {
+    gatedHtmlBuffer: gatedHtml === htmlString && !nextIncompleteLinkTagTail ? html : Buffer.from(gatedHtml),
+    hasIncompleteLinkTagTail: Boolean(nextIncompleteLinkTagTail),
+  };
+}
+
 /**
  * Embeds RSC payloads into the HTML stream for optimal hydration.
  *
@@ -145,6 +239,7 @@ export default function injectRSCPayload(
    * CONSTRAINT: The first output chunk must contain HTML data to begin streaming.
    */
   const htmlBuffers: Buffer[] = [];
+  let holdIncompleteLinkTagTail = true;
 
   /**
    * Buffer for RSC payload chunk scripts.
@@ -182,9 +277,17 @@ export default function injectRSCPayload(
 
     // Calculate total buffer size for efficient memory allocation
     const rscInitializationSize = rscInitializationBuffers.reduce((sum, buf) => sum + buf.length, 0);
-    const htmlSize = htmlBuffers.reduce((sum, buf) => sum + buf.length, 0);
+    const htmlBuffer = Buffer.concat(htmlBuffers);
+    const { gatedHtmlBuffer, hasIncompleteLinkTagTail } = applyStreamedStylesheetPreloadGating(
+      htmlBuffer,
+      holdIncompleteLinkTagTail,
+    );
     const rscPayloadSize = rscPayloadBuffers.reduce((sum, buf) => sum + buf.length, 0);
-    const totalSize = rscInitializationSize + htmlSize + rscPayloadSize;
+    const totalSize = rscInitializationSize + gatedHtmlBuffer.length + rscPayloadSize;
+
+    if (hasIncompleteLinkTagTail && holdIncompleteLinkTagTail) {
+      return;
+    }
 
     // Skip flush if no data is buffered
     if (totalSize === 0) {
@@ -215,9 +318,9 @@ export default function injectRSCPayload(
 
     // 2. HTML chunks SECOND
     // Component markup that references the initialized arrays
-    for (const buffer of htmlBuffers) {
-      buffer.copy(combinedBuffer, offset);
-      offset += buffer.length;
+    if (gatedHtmlBuffer.length > 0) {
+      gatedHtmlBuffer.copy(combinedBuffer, offset);
+      offset += gatedHtmlBuffer.length;
     }
 
     // 3. RSC payload chunk scripts LAST
@@ -237,6 +340,7 @@ export default function injectRSCPayload(
   };
 
   const endResultStream = () => {
+    holdIncompleteLinkTagTail = false;
     // Cancel any pending fallback timer unconditionally.
     // flush() only clears the timer when it actually flushes data (past the
     // early-return guards). If we're closing with empty buffers, the timer

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -14,6 +14,8 @@
  */
 
 import { PassThrough } from 'stream';
+import { readFileSync } from 'fs';
+import { resolve as resolvePath } from 'path';
 import { PipeableOrReadableStream } from 'react-on-rails/types';
 import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import { createEmbeddedPayloadKey } from './utils.ts';
@@ -91,6 +93,17 @@ function createRSCDiagnosticScript(
 }
 
 const RSC_CLIENT_CHUNK_STYLESHEET_PATH = /\/css\/client\d+-[^/]+\.css$/;
+const RSC_CLIENT_CHUNK_NAME_WITH_JS_ASSET = /"((?:client)\d+)"\s*,\s*"js\/client\d+-[^"]+\.chunk\.js"/g;
+const LOADABLE_STATS_FILE_NAME = 'loadable-stats.json';
+
+type LoadableStats = {
+  assetsByChunkName?: Record<string, string | string[]>;
+  publicPath?: string;
+};
+
+type RSCClientChunkStylesheetHrefsByChunkName = Map<string, string[]>;
+
+let cachedRSCClientChunkStylesheetHrefsByChunkName: RSCClientChunkStylesheetHrefsByChunkName | undefined;
 
 function getQuotedAttribute(tag: string, attributeName: string) {
   const attributeMatch = tag.match(new RegExp(`\\s${attributeName}=(["'])(.*?)\\1`, 'i'));
@@ -108,6 +121,82 @@ function isRSCClientChunkStylesheetHref(href: string) {
 function shouldPromoteStylesheetPreloadTag(linkTag: string) {
   const href = getQuotedAttribute(linkTag, 'href');
   return href ? isRSCClientChunkStylesheetHref(href) : false;
+}
+
+function assetHref(assetPath: string, publicPath?: string) {
+  if (/^(?:[a-z][a-z\d+.-]*:)?\/\//i.test(assetPath) || assetPath.startsWith('/')) {
+    return assetPath;
+  }
+
+  if (!publicPath || publicPath === 'auto') {
+    return assetPath;
+  }
+
+  return `${publicPath.replace(/\/?$/, '/')}${assetPath.replace(/^\/+/, '')}`;
+}
+
+function loadRSCClientChunkStylesheetHrefsByChunkName(): RSCClientChunkStylesheetHrefsByChunkName {
+  if (cachedRSCClientChunkStylesheetHrefsByChunkName) {
+    return cachedRSCClientChunkStylesheetHrefsByChunkName;
+  }
+
+  const stylesheetHrefsByChunkName: RSCClientChunkStylesheetHrefsByChunkName = new Map();
+
+  try {
+    const loadableStats = JSON.parse(
+      readFileSync(resolvePath(__dirname, LOADABLE_STATS_FILE_NAME), 'utf8'),
+    ) as LoadableStats;
+
+    Object.entries(loadableStats.assetsByChunkName ?? {}).forEach(([chunkName, assets]) => {
+      if (!/^client\d+$/.test(chunkName)) return;
+
+      const stylesheetHrefs = (Array.isArray(assets) ? assets : [assets])
+        .filter((asset): asset is string => typeof asset === 'string' && asset.endsWith('.css'))
+        .map((asset) => assetHref(asset, loadableStats.publicPath));
+
+      if (stylesheetHrefs.length > 0) {
+        stylesheetHrefsByChunkName.set(chunkName, stylesheetHrefs);
+      }
+    });
+  } catch {
+    // RSC CSS gating is opportunistic for builds that copy loadable-stats.json to
+    // the renderer bundle directory. Other setups fall back to streamed preload tags.
+  }
+
+  cachedRSCClientChunkStylesheetHrefsByChunkName = stylesheetHrefsByChunkName;
+  return stylesheetHrefsByChunkName;
+}
+
+function escapeAttributeValue(value: string) {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function createStylesheetTag(href: string) {
+  return `<link rel="stylesheet" href="${escapeAttributeValue(href)}" data-precedence="rsc-css">`;
+}
+
+function stylesheetTagsForRSCClientChunks(
+  flightData: string,
+  stylesheetHrefsByChunkName: RSCClientChunkStylesheetHrefsByChunkName,
+  emittedStylesheetHrefs: Set<string>,
+) {
+  const stylesheetTags: string[] = [];
+
+  for (const match of flightData.matchAll(RSC_CLIENT_CHUNK_NAME_WITH_JS_ASSET)) {
+    const chunkName = match[1];
+    const stylesheetHrefs = stylesheetHrefsByChunkName.get(chunkName);
+
+    if (stylesheetHrefs) {
+      stylesheetHrefs.forEach((href) => {
+        if (emittedStylesheetHrefs.has(href)) return;
+
+        emittedStylesheetHrefs.add(href);
+        stylesheetTags.push(createStylesheetTag(href));
+      });
+    }
+  }
+
+  return stylesheetTags;
 }
 
 function splitIncompleteLinkTagTail(htmlString: string) {
@@ -215,11 +304,13 @@ export default function injectRSCPayload(
   rscRequestTracker: RSCRequestTracker,
   domNodeId: string | undefined,
   cspNonce?: string,
+  rscClientChunkStylesheetHrefsByChunkName: RSCClientChunkStylesheetHrefsByChunkName = loadRSCClientChunkStylesheetHrefsByChunkName(),
 ) {
   const sanitizedNonce = sanitizeNonce(cspNonce);
   const htmlStream = new PassThrough();
   const resultStream = new PassThrough();
   let rscPromise: Promise<void> | null = null;
+  const emittedRSCClientStylesheetHrefs = new Set<string>();
 
   // ========================================
   // BUFFER ARRAYS - Three data sources
@@ -240,6 +331,13 @@ export default function injectRSCPayload(
    */
   const htmlBuffers: Buffer[] = [];
   let holdIncompleteLinkTagTail = true;
+
+  /**
+   * Buffer for stylesheet links inferred from RSC client chunk references.
+   * These must flush before HTML because React's reveal script can make the
+   * streamed fragment visible as soon as the browser parses it.
+   */
+  const rscClientStylesheetBuffers: Buffer[] = [];
 
   /**
    * Buffer for RSC payload chunk scripts.
@@ -282,8 +380,10 @@ export default function injectRSCPayload(
       htmlBuffer,
       holdIncompleteLinkTagTail,
     );
+    const rscClientStylesheetSize = rscClientStylesheetBuffers.reduce((sum, buf) => sum + buf.length, 0);
     const rscPayloadSize = rscPayloadBuffers.reduce((sum, buf) => sum + buf.length, 0);
-    const totalSize = rscInitializationSize + gatedHtmlBuffer.length + rscPayloadSize;
+    const totalSize =
+      rscInitializationSize + rscClientStylesheetSize + gatedHtmlBuffer.length + rscPayloadSize;
 
     if (hasIncompleteLinkTagTail && holdIncompleteLinkTagTail) {
       return;
@@ -316,14 +416,22 @@ export default function injectRSCPayload(
       offset += buffer.length;
     }
 
-    // 2. HTML chunks SECOND
+    // 2. RSC client stylesheets SECOND
+    // These gate streamed reveal HTML for client components whose CSS is emitted
+    // as a separate chunk and only referenced from the Flight payload.
+    for (const buffer of rscClientStylesheetBuffers) {
+      buffer.copy(combinedBuffer, offset);
+      offset += buffer.length;
+    }
+
+    // 3. HTML chunks THIRD
     // Component markup that references the initialized arrays
     if (gatedHtmlBuffer.length > 0) {
       gatedHtmlBuffer.copy(combinedBuffer, offset);
       offset += gatedHtmlBuffer.length;
     }
 
-    // 3. RSC payload chunk scripts LAST
+    // 4. RSC payload chunk scripts LAST
     // Data pushed into the already-existing arrays
     for (const buffer of rscPayloadBuffers) {
       buffer.copy(combinedBuffer, offset);
@@ -335,6 +443,7 @@ export default function injectRSCPayload(
 
     // Clear all buffers to free memory and prepare for next flush cycle
     rscInitializationBuffers.length = 0;
+    rscClientStylesheetBuffers.length = 0;
     htmlBuffers.length = 0;
     rscPayloadBuffers.length = 0;
   };
@@ -468,6 +577,11 @@ export default function injectRSCPayload(
                   hasEmittedDiagnosticScript = true;
                 }
               }
+              stylesheetTagsForRSCClientChunks(
+                flightData,
+                rscClientChunkStylesheetHrefsByChunkName,
+                emittedRSCClientStylesheetHrefs,
+              ).forEach((stylesheetTag) => rscClientStylesheetBuffers.push(Buffer.from(stylesheetTag)));
               const payloadScript = createRSCPayloadChunk(flightData, rscPayloadKey, sanitizedNonce);
               rscPayloadBuffers.push(Buffer.from(payloadScript));
 

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -96,6 +96,7 @@ const RSC_CLIENT_CHUNK_STYLESHEET_PATH = /\/css\/client\d+-[^/]+\.css$/;
 const RSC_CLIENT_CHUNK_NAME_WITH_JS_ASSET = /"((?:client)\d+)"\s*,\s*"js\/client\d+-[^"]+\.chunk\.js"/g;
 const REACT_SUSPENSE_REVEAL_SCRIPT = /\$RC\(/;
 const LOADABLE_STATS_FILE_NAME = 'loadable-stats.json';
+const RSC_CLIENT_STYLESHEET_INFERENCE_TIMEOUT_MS = 100;
 
 type LoadableStats = {
   assetsByChunkName?: Record<string, string | string[]>;
@@ -184,6 +185,54 @@ function createStylesheetTag(href: string) {
 
 function includesReactSuspenseRevealScript(htmlBuffer: Buffer) {
   return REACT_SUSPENSE_REVEAL_SCRIPT.test(htmlBuffer.toString('utf8'));
+}
+
+function findReactSuspenseRevealSplitIndex(htmlString: string) {
+  const revealCallIndex = htmlString.search(REACT_SUSPENSE_REVEAL_SCRIPT);
+  if (revealCallIndex === -1) return -1;
+
+  const scriptStartIndex = htmlString.lastIndexOf('<script', revealCallIndex);
+  const revealedContentId = htmlString
+    .slice(revealCallIndex)
+    .match(/\$RC\(\s*(["'])(?:(?!\1).)*\1\s*,\s*(["'])(.*?)\2/)?.[3];
+
+  if (revealedContentId) {
+    const hiddenBoundaryPattern = new RegExp(
+      `<div\\b(?=[^>]*\\bhidden\\b)(?=[^>]*\\bid=(?:"${escapeRegExpLiteral(
+        revealedContentId,
+      )}"|'${escapeRegExpLiteral(revealedContentId)}'))[^>]*>`,
+      'gi',
+    );
+    const searchEndIndex = scriptStartIndex === -1 ? revealCallIndex : scriptStartIndex;
+    let hiddenBoundaryStartIndex = -1;
+
+    for (
+      let hiddenBoundaryMatch = hiddenBoundaryPattern.exec(htmlString);
+      hiddenBoundaryMatch;
+      hiddenBoundaryMatch = hiddenBoundaryPattern.exec(htmlString)
+    ) {
+      if (hiddenBoundaryMatch.index >= searchEndIndex) break;
+      hiddenBoundaryStartIndex = hiddenBoundaryMatch.index;
+    }
+
+    if (hiddenBoundaryStartIndex !== -1) return hiddenBoundaryStartIndex;
+  }
+
+  return scriptStartIndex === -1 ? revealCallIndex : scriptStartIndex;
+}
+
+function splitReactSuspenseRevealHtmlBuffer(htmlBuffer: Buffer) {
+  const htmlString = htmlBuffer.toString('utf8');
+  const splitIndex = findReactSuspenseRevealSplitIndex(htmlString);
+
+  if (splitIndex === -1) {
+    return { flushableHtmlBuffer: htmlBuffer, deferredRevealHtmlBuffer: undefined };
+  }
+
+  return {
+    flushableHtmlBuffer: Buffer.from(htmlString.slice(0, splitIndex)),
+    deferredRevealHtmlBuffer: Buffer.from(htmlString.slice(splitIndex)),
+  };
 }
 
 function stylesheetTagsForRSCClientChunks(
@@ -322,7 +371,8 @@ export default function injectRSCPayload(
   const resultStream = new PassThrough();
   let rscPromise: Promise<void> | null = null;
   const emittedRSCClientStylesheetHrefs = new Set<string>();
-  let hasResolvedInitialRSCClientStylesheetInference = rscClientChunkStylesheetHrefsByChunkName.size === 0;
+  const shouldInferRSCClientStylesheets = rscClientChunkStylesheetHrefsByChunkName.size > 0;
+  let pendingRSCClientStylesheetInferenceStreams = 0;
 
   // ========================================
   // BUFFER ARRAYS - Three data sources
@@ -364,6 +414,7 @@ export default function injectRSCPayload(
 
   let flushFallbackTimeout: NodeJS.Timeout | null = null;
   let hasReceivedFirstHtmlChunk = false;
+  let hasFlushedOutputChunk = false;
 
   /**
    * Combines all buffered data into a single chunk and sends it to the result stream.
@@ -392,20 +443,24 @@ export default function injectRSCPayload(
       htmlBuffer,
       holdIncompleteLinkTagTail,
     );
+    const shouldDeferRevealHtml =
+      rscPromise &&
+      shouldInferRSCClientStylesheets &&
+      pendingRSCClientStylesheetInferenceStreams > 0 &&
+      includesReactSuspenseRevealScript(gatedHtmlBuffer);
+    const { flushableHtmlBuffer, deferredRevealHtmlBuffer } = shouldDeferRevealHtml
+      ? splitReactSuspenseRevealHtmlBuffer(gatedHtmlBuffer)
+      : { flushableHtmlBuffer: gatedHtmlBuffer, deferredRevealHtmlBuffer: undefined };
     const rscClientStylesheetSize = rscClientStylesheetBuffers.reduce((sum, buf) => sum + buf.length, 0);
     const rscPayloadSize = rscPayloadBuffers.reduce((sum, buf) => sum + buf.length, 0);
     const totalSize =
-      rscInitializationSize + rscClientStylesheetSize + gatedHtmlBuffer.length + rscPayloadSize;
+      rscInitializationSize + rscClientStylesheetSize + flushableHtmlBuffer.length + rscPayloadSize;
 
     if (hasIncompleteLinkTagTail && holdIncompleteLinkTagTail) {
       return;
     }
 
-    if (
-      !hasResolvedInitialRSCClientStylesheetInference &&
-      rscPromise &&
-      includesReactSuspenseRevealScript(gatedHtmlBuffer)
-    ) {
+    if (deferredRevealHtmlBuffer && flushableHtmlBuffer.length === 0 && !hasFlushedOutputChunk) {
       return;
     }
 
@@ -446,9 +501,9 @@ export default function injectRSCPayload(
 
     // 3. HTML chunks THIRD
     // Component markup that references the initialized arrays
-    if (gatedHtmlBuffer.length > 0) {
-      gatedHtmlBuffer.copy(combinedBuffer, offset);
-      offset += gatedHtmlBuffer.length;
+    if (flushableHtmlBuffer.length > 0) {
+      flushableHtmlBuffer.copy(combinedBuffer, offset);
+      offset += flushableHtmlBuffer.length;
     }
 
     // 4. RSC payload chunk scripts LAST
@@ -460,11 +515,15 @@ export default function injectRSCPayload(
 
     // Send combined chunk to output stream
     resultStream.push(combinedBuffer);
+    hasFlushedOutputChunk = true;
 
     // Clear all buffers to free memory and prepare for next flush cycle
     rscInitializationBuffers.length = 0;
     rscClientStylesheetBuffers.length = 0;
     htmlBuffers.length = 0;
+    if (deferredRevealHtmlBuffer) {
+      htmlBuffers.push(deferredRevealHtmlBuffer);
+    }
     rscPayloadBuffers.length = 0;
   };
 
@@ -578,6 +637,25 @@ export default function injectRSCPayload(
         // This creates a global array that the client-side RSCProvider monitors for new chunks.
         const initializationScript = createRSCPayloadInitializationScript(rscPayloadKey, sanitizedNonce);
         rscInitializationBuffers.push(Buffer.from(initializationScript));
+        let inferenceTimeout: NodeJS.Timeout | undefined;
+        let hasResolvedRSCClientStylesheetInferenceForStream = !shouldInferRSCClientStylesheets;
+        const resolveRSCClientStylesheetInferenceForStream = () => {
+          if (hasResolvedRSCClientStylesheetInferenceForStream) return;
+
+          hasResolvedRSCClientStylesheetInferenceForStream = true;
+          pendingRSCClientStylesheetInferenceStreams -= 1;
+          if (inferenceTimeout) {
+            clearTimeout(inferenceTimeout);
+          }
+          scheduleFlushFallback();
+        };
+        if (shouldInferRSCClientStylesheets) {
+          pendingRSCClientStylesheetInferenceStreams += 1;
+          inferenceTimeout = setTimeout(
+            resolveRSCClientStylesheetInferenceForStream,
+            RSC_CLIENT_STYLESHEET_INFERENCE_TIMEOUT_MS,
+          );
+        }
 
         // Process RSC payload stream asynchronously.
         // The stream uses the length-prefixed protocol: metadata\tcontent_len\ncontent.
@@ -602,9 +680,9 @@ export default function injectRSCPayload(
                 rscClientChunkStylesheetHrefsByChunkName,
                 emittedRSCClientStylesheetHrefs,
               ).forEach((stylesheetTag) => {
-                hasResolvedInitialRSCClientStylesheetInference = true;
                 rscClientStylesheetBuffers.push(Buffer.from(stylesheetTag));
               });
+              resolveRSCClientStylesheetInferenceForStream();
               const payloadScript = createRSCPayloadChunk(flightData, rscPayloadKey, sanitizedNonce);
               rscPayloadBuffers.push(Buffer.from(payloadScript));
 
@@ -617,12 +695,14 @@ export default function injectRSCPayload(
               // Schedule fallback in case flush() is never called.
               scheduleFlushFallback();
             };
-            for await (const chunk of stream ?? []) {
-              const chunkBuf = chunk instanceof Uint8Array ? chunk : new TextEncoder().encode(chunk);
-              parser.feed(chunkBuf, handleParsedChunk);
+            try {
+              for await (const chunk of stream ?? []) {
+                const chunkBuf = chunk instanceof Uint8Array ? chunk : new TextEncoder().encode(chunk);
+                parser.feed(chunkBuf, handleParsedChunk);
+              }
+            } finally {
+              resolveRSCClientStylesheetInferenceForStream();
             }
-            hasResolvedInitialRSCClientStylesheetInference = true;
-            scheduleFlushFallback();
           })(),
         );
       });

--- a/packages/react-on-rails-pro/src/injectRSCPayload.ts
+++ b/packages/react-on-rails-pro/src/injectRSCPayload.ts
@@ -711,14 +711,17 @@ export default function injectRSCPayload(
                   hasEmittedDiagnosticScript = true;
                 }
               }
-              stylesheetTagsForRSCClientChunks(
+              const stylesheetTags = stylesheetTagsForRSCClientChunks(
                 flightData,
                 rscClientChunkStylesheetHrefsByChunkName,
                 emittedRSCClientStylesheetHrefs,
-              ).forEach((stylesheetTag) => {
+              );
+              stylesheetTags.forEach((stylesheetTag) => {
                 rscClientStylesheetBuffers.push(Buffer.from(stylesheetTag));
               });
-              resolveRSCClientStylesheetInferenceForStream();
+              if (stylesheetTags.length > 0) {
+                resolveRSCClientStylesheetInferenceForStream();
+              }
               const payloadScript = createRSCPayloadChunk(flightData, rscPayloadKey, sanitizedNonce);
               rscPayloadBuffers.push(Buffer.from(payloadScript));
 

--- a/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
+++ b/packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts
@@ -202,6 +202,58 @@ describe('ClientSideRenderer', () => {
     expect(reactElement.type).toBe(TestComponent);
   });
 
+  it('waits for manifest-derived shared generated-pack stylesheets before rendering', async () => {
+    const TestComponent = ({ greeting }: { greeting: string }) => React.createElement('div', null, greeting);
+    ComponentRegistry.register({ TestComponent });
+    const stylesheet = document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.href = '/webpack/test/css/shared-generated-pack-deadbeef.css';
+    document.head.appendChild(stylesheet);
+    const componentSpec = setupTestComponentDom('dom-id-shared-stylesheet');
+    componentSpec.setAttribute(
+      'data-generated-stylesheet-hrefs',
+      JSON.stringify(['/webpack/test/css/shared-generated-pack-deadbeef.css']),
+    );
+    addRailsContext();
+
+    const renderPromise = renderOrHydrateComponent(componentSpec);
+    await Promise.resolve();
+
+    expect(mockReactHydrateOrRender).not.toHaveBeenCalled();
+
+    stylesheet.dispatchEvent(new Event('load'));
+    await renderPromise;
+
+    expect(mockReactHydrateOrRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open if a generated stylesheet never reports load or error', async () => {
+    jest.useFakeTimers();
+    try {
+      const TestComponent = ({ greeting }: { greeting: string }) =>
+        React.createElement('div', null, greeting);
+      ComponentRegistry.register({ TestComponent });
+      const stylesheet = document.createElement('link');
+      stylesheet.rel = 'stylesheet';
+      stylesheet.href = '/webpack/test/css/generated/TestComponent-deadbeef.css';
+      document.head.appendChild(stylesheet);
+      const componentSpec = setupTestComponentDom('dom-id-stylesheet-timeout');
+      addRailsContext();
+
+      const renderPromise = renderOrHydrateComponent(componentSpec);
+      await Promise.resolve();
+
+      expect(mockReactHydrateOrRender).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(10_000);
+      await renderPromise;
+
+      expect(mockReactHydrateOrRender).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('rejects non-callable renderer entries before invoking them', async () => {
     const componentSpec = setupTestComponentDom('dom-id-non-callable-renderer');
     addRailsContext();

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -100,6 +100,18 @@ const createMockHTMLStream = (chunks: string[] | { [key: number]: string | strin
   return passThrough;
 };
 
+const createFlushingHTMLStream = (html: string) =>
+  ({
+    pipe(destination: PassThrough & { flush?: () => void }) {
+      setTimeout(() => {
+        destination.write(new TextEncoder().encode(html));
+        destination.flush?.();
+        destination.end();
+      }, 0);
+      return destination;
+    },
+  }) as Readable;
+
 const collectStreamData = async (stream: Readable) => {
   const chunks: string[] = [];
   for await (const chunk of stream) {
@@ -278,6 +290,45 @@ describe('injectRSCPayload', () => {
     expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
     expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
     expect(resultStr).toContain(expectedPayloadPushScript(flightData));
+  });
+
+  it('waits for inferred RSC client chunk stylesheets before flushing reveal HTML', async () => {
+    const flightData =
+      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client1","js/client1-570df890c7aa791c.chunk.js"],"default"]\n' +
+      '0:["$","$L2",null,{},null]\n';
+    const mockRSC = createMockRSCStream({ 10: flightData });
+    const mockHTML = createFlushingHTMLStream(
+      '<div hidden id="RscFoucProbe-react-component-0S:0">' +
+        '<section data-testid="rsc-fouc-probe">RSC streamed FOUC probe</section>' +
+        '</div>' +
+        '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
+    );
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+    const injectWithStylesheetMap = injectRSCPayload as unknown as (
+      html: Readable,
+      tracker: RSCRequestTracker,
+      nodeId: string,
+      nonce: string | undefined,
+      stylesheetHrefsByChunkName: Map<string, string[]>,
+    ) => Readable;
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client1', ['/webpack/test/css/client1-46072b81.css']]]),
+    );
+    const resultStr = await collectStreamData(result);
+
+    const stylesheetIndex = resultStr.indexOf(
+      '<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">',
+    );
+    const revealHtmlIndex = resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">');
+
+    expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
+    expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
+    expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
   });
 
   it('promotes streamed RSC stylesheet preloads split across fallback flush chunks', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -224,6 +224,70 @@ describe('injectRSCPayload', () => {
     expect(resultStr).toContain(expectedPayloadPushScript('{"test": "data"}'));
   });
 
+  it('promotes streamed RSC client chunk stylesheet preloads to gate reveal', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML = createMockHTMLStream([
+      '<link rel="preload" as="style" href="/webpack/test/css/client1-46072b81.css?body=1" crossorigin="anonymous"/>',
+    ]);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain(
+      '<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css?body=1" crossorigin="anonymous" data-precedence="rsc-css"/>',
+    );
+    expect(resultStr).not.toContain('rel="preload" as="style"');
+  });
+
+  it('promotes streamed RSC stylesheet preloads split across fallback flush chunks', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML = createMockHTMLStream({
+      0: 'before<link rel="preload" as="style" href="/webpack/test/css/client1-',
+      10: '46072b81.css">after',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain(
+      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
+    );
+    expect(resultStr).not.toContain('rel="preload" as="style"');
+  });
+
+  it('promotes streamed RSC stylesheet preloads split inside the link token', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const mockHTML = createMockHTMLStream({
+      0: 'before<li',
+      10: 'nk rel="preload" as="style" href="/webpack/test/css/client1-46072b81.css">after',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain(
+      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">after',
+    );
+    expect(resultStr).not.toContain('rel="preload" as="style"');
+  });
+
+  it('leaves app-authored style preloads as fetch hints', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const appStylePreload =
+      '<link rel="preload" as="style" href="/assets/next-route-theme.css" media="print">';
+    const mockHTML = createMockHTMLStream([appStylePreload]);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = await collectStreamData(result);
+
+    expect(resultStr).toContain(appStylePreload);
+    expect(resultStr).not.toContain('data-precedence="rsc-css"');
+  });
+
   it('should add all ready html chunks before adding RSC payloads', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}', '{"test": "data2"}']);
     const mockHTML = createMockHTMLStream([

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -554,6 +554,29 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('rel="preload" as="style"');
   });
 
+  it('preserves split UTF-8 bytes when promoting streamed RSC stylesheet preloads', async () => {
+    const mockRSC = createMockRSCStream(['{"test": "data"}']);
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from('before<link rel="preload" as="style" href="/webpack/test/css/client1-46072b81.css">caf'),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from(' after')]);
+    const mockHTML = createMockHTMLByteStream({
+      0: firstHtmlChunk,
+      10: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectRSCPayload(mockHTML, rscRequestTracker, domNodeId);
+    const resultStr = (await collectStreamBuffer(result)).toString('utf8');
+
+    expect(resultStr).toContain(
+      'before<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">café after',
+    );
+    expect(resultStr).not.toContain('\uFFFD');
+  });
+
   it('leaves app-authored style preloads as fetch hints', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const appStylePreload =

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -120,16 +120,56 @@ const collectStreamData = async (stream: Readable) => {
   return chunks.join('');
 };
 
+const collectStreamDataByChunk = (stream: Readable) => {
+  const chunks: string[] = [];
+  let resolveFirstChunk: (chunk: string) => void = () => {};
+  const firstChunk = new Promise<string>((resolve) => {
+    resolveFirstChunk = resolve;
+  });
+  const allData = new Promise<string>((resolve, reject) => {
+    stream.on('data', (chunk: Buffer) => {
+      const decodedChunk = new TextDecoder().decode(chunk);
+      chunks.push(decodedChunk);
+      if (chunks.length === 1) {
+        resolveFirstChunk(decodedChunk);
+      }
+    });
+    stream.on('end', () => {
+      if (chunks.length === 0) {
+        resolveFirstChunk('');
+      }
+      resolve(chunks.join(''));
+    });
+    stream.on('error', reject);
+  });
+
+  return { allData, chunks, firstChunk };
+};
+
+const injectWithStylesheetMap = injectRSCPayload as unknown as (
+  html: Readable,
+  tracker: RSCRequestTracker,
+  nodeId: string,
+  nonce: string | undefined,
+  stylesheetHrefsByChunkName: Map<string, string[]>,
+) => Readable;
+
 // Test setup helper
-const setupTest = (mockRSC: Readable) => {
+const setupTestWithStreams = (
+  streamInfos: Array<{ stream: Readable; componentName?: string; props?: unknown }>,
+) => {
   const railsContext = {} as RailsContextWithServerStreamingCapabilities;
   const rscRequestTracker = new RSCRequestTracker(railsContext);
   jest.spyOn(rscRequestTracker, 'onRSCPayloadGenerated').mockImplementation((callback) => {
-    callback({ stream: mockRSC, componentName: 'test', props: {} });
+    streamInfos.forEach(({ stream, componentName = 'test', props = {} }) => {
+      callback({ stream, componentName, props });
+    });
   });
 
   return { railsContext, rscRequestTracker, domNodeId: 'test-node' };
 };
+
+const setupTest = (mockRSC: Readable) => setupTestWithStreams([{ stream: mockRSC }]);
 
 describe('injectRSCPayload', () => {
   it('should inject RSC payload as script tags', async () => {
@@ -264,13 +304,6 @@ describe('injectRSCPayload', () => {
         '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
     ]);
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-    const injectWithStylesheetMap = injectRSCPayload as unknown as (
-      html: Readable,
-      tracker: RSCRequestTracker,
-      nodeId: string,
-      nonce: string | undefined,
-      stylesheetHrefsByChunkName: Map<string, string[]>,
-    ) => Readable;
 
     const result = injectWithStylesheetMap(
       mockHTML,
@@ -304,13 +337,6 @@ describe('injectRSCPayload', () => {
         '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
     );
     const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
-    const injectWithStylesheetMap = injectRSCPayload as unknown as (
-      html: Readable,
-      tracker: RSCRequestTracker,
-      nodeId: string,
-      nonce: string | undefined,
-      stylesheetHrefsByChunkName: Map<string, string[]>,
-    ) => Readable;
 
     const result = injectWithStylesheetMap(
       mockHTML,
@@ -329,6 +355,106 @@ describe('injectRSCPayload', () => {
     expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
     expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
     expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
+  });
+
+  it('streams Suspense fallback while deferring reveal HTML for inferred RSC stylesheets', async () => {
+    const flightData =
+      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client1","js/client1-570df890c7aa791c.chunk.js"],"default"]\n' +
+      '0:["$","$L2",null,{},null]\n';
+    const mockRSC = createMockRSCStream({ 25: flightData });
+    const mockHTML = createFlushingHTMLStream(
+      '<p>Loading ToggleContainer</p>' +
+        '<div hidden id="RscFoucProbe-react-component-0S:0">' +
+        '<section data-testid="rsc-fouc-probe">RSC streamed FOUC probe</section>' +
+        '</div>' +
+        '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
+    );
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client1', ['/webpack/test/css/client1-46072b81.css']]]),
+    );
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('Loading ToggleContainer');
+    await expect(firstChunk).resolves.not.toContain('$RC(');
+    await expect(firstChunk).resolves.not.toContain('RSC streamed FOUC probe');
+
+    const resultStr = await allData;
+    const stylesheetIndex = resultStr.indexOf(
+      '<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">',
+    );
+    const revealHtmlIndex = resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">');
+
+    expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
+    expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
+    expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
+  });
+
+  it('keeps inferred stylesheet reveal gating active until all RSC streams finish initial inference', async () => {
+    const flightData =
+      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client2","js/client2-570df890c7aa791c.chunk.js"],"default"]\n' +
+      '0:["$","$L2",null,{},null]\n';
+    const fastRSCWithoutClientStylesheet = createMockRSCStream({ 0: '{"fast": "done"}' });
+    const slowRSCWithClientStylesheet = createMockRSCStream({ 25: flightData });
+    const mockHTML = createFlushingHTMLStream(
+      '<div hidden id="RscFoucProbe-react-component-0S:0">' +
+        '<section data-testid="rsc-fouc-probe">RSC streamed FOUC probe</section>' +
+        '</div>' +
+        '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
+    );
+    const { rscRequestTracker, domNodeId } = setupTestWithStreams([
+      { stream: fastRSCWithoutClientStylesheet, componentName: 'fast' },
+      { stream: slowRSCWithClientStylesheet, componentName: 'styled' },
+    ]);
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client2', ['/webpack/test/css/client2-46072b81.css']]]),
+    );
+    const resultStr = await collectStreamData(result);
+
+    const stylesheetIndex = resultStr.indexOf(
+      '<link rel="stylesheet" href="/webpack/test/css/client2-46072b81.css" data-precedence="rsc-css">',
+    );
+    const revealHtmlIndex = resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">');
+
+    expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
+    expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
+    expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
+  });
+
+  it('fails open for long-lived RSC streams without initial Flight data', async () => {
+    const lateFlightData = '0:["$","div",null,{"children":"late async data"},null]\n';
+    const mockRSC = createMockRSCStream({ 250: lateFlightData });
+    const mockHTML = createFlushingHTMLStream(
+      '<div hidden id="AsyncShell-react-component-0S:0">' +
+        '<section>Async shell can stream before Redis resolves</section>' +
+        '</div>' +
+        '<script>$RC("AsyncShell-react-component-0B:0","AsyncShell-react-component-0S:0")</script>',
+    );
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client1', ['/webpack/test/css/client1-46072b81.css']]]),
+    );
+    const { allData, firstChunk } = collectStreamDataByChunk(result);
+
+    await expect(firstChunk).resolves.toContain('Async shell can stream before Redis resolves');
+    await expect(firstChunk).resolves.toContain('$RC(');
+
+    await expect(allData).resolves.toContain(expectedPayloadPushScript(lateFlightData));
   });
 
   it('promotes streamed RSC stylesheet preloads split across fallback flush chunks', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -100,6 +100,24 @@ const createMockHTMLStream = (chunks: string[] | { [key: number]: string | strin
   return passThrough;
 };
 
+const createMockHTMLByteStream = (chunks: { [key: number]: Buffer | Buffer[] }) => {
+  const passThrough = new PassThrough();
+  const entries = Object.entries(chunks);
+  const keysLength = entries.length;
+  entries.forEach(([delay, value], index) => {
+    setTimeout(() => {
+      const chunksArray = Array.isArray(value) ? value : [value];
+      chunksArray.forEach((chunk) => {
+        passThrough.push(chunk);
+      });
+      if (index === keysLength - 1) {
+        passThrough.push(null);
+      }
+    }, +delay);
+  });
+  return passThrough;
+};
+
 const createFlushingHTMLStream = (html: string) =>
   ({
     pipe(destination: PassThrough & { flush?: () => void }) {
@@ -118,6 +136,14 @@ const collectStreamData = async (stream: Readable) => {
     chunks.push(new TextDecoder().decode(chunk as Buffer));
   }
   return chunks.join('');
+};
+
+const collectStreamBuffer = async (stream: Readable) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+  return Buffer.concat(chunks);
 };
 
 const collectStreamDataByChunk = (stream: Readable) => {
@@ -429,6 +455,43 @@ describe('injectRSCPayload', () => {
     expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
     expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
     expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
+  });
+
+  it('preserves split UTF-8 bytes when deferring reveal HTML', async () => {
+    const flightData =
+      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client1","js/client1-570df890c7aa791c.chunk.js"],"default"]\n' +
+      '0:["$","$L2",null,{},null]\n';
+    const mockRSC = createMockRSCStream({ 25: flightData });
+    const eAcuteBytes = Buffer.from('é');
+    const firstHtmlChunk = Buffer.concat([
+      Buffer.from(
+        '<p>Loading ToggleContainer</p>' +
+          '<div hidden id="RscFoucProbe-react-component-0S:0">' +
+          '<section data-testid="rsc-fouc-probe">RSC streamed FOUC probe</section>' +
+          '</div>' +
+          '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>' +
+          '<p>caf',
+      ),
+      eAcuteBytes.subarray(0, 1),
+    ]);
+    const secondHtmlChunk = Buffer.concat([eAcuteBytes.subarray(1), Buffer.from('</p>')]);
+    const mockHTML = createMockHTMLByteStream({
+      0: firstHtmlChunk,
+      10: secondHtmlChunk,
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client1', ['/webpack/test/css/client1-46072b81.css']]]),
+    );
+    const resultStr = (await collectStreamBuffer(result)).toString('utf8');
+
+    expect(resultStr).toContain('<p>café</p>');
+    expect(resultStr).not.toContain('\uFFFD');
   });
 
   it('fails open for long-lived RSC streams without initial Flight data', async () => {

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -457,6 +457,44 @@ describe('injectRSCPayload', () => {
     expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
   });
 
+  it('keeps inferred stylesheet reveal gating active after server-only Flight chunks', async () => {
+    const serverOnlyFlightData = '0:["$","div",null,{"children":"server shell"},null]\n';
+    const styledFlightData =
+      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client3","js/client3-570df890c7aa791c.chunk.js"],"default"]\n' +
+      '0:["$","$L2",null,{},null]\n';
+    const mockRSC = createMockRSCStream({
+      0: serverOnlyFlightData,
+      25: styledFlightData,
+    });
+    const mockHTML = createMockHTMLStream({
+      0: '<p>Loading ToggleContainer</p>',
+      10:
+        '<div hidden id="RscFoucProbe-react-component-0S:0">' +
+        '<section data-testid="rsc-fouc-probe">RSC streamed FOUC probe</section>' +
+        '</div>' +
+        '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
+    });
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client3', ['/webpack/test/css/client3-46072b81.css']]]),
+    );
+    const resultStr = await collectStreamData(result);
+
+    const stylesheetIndex = resultStr.indexOf(
+      '<link rel="stylesheet" href="/webpack/test/css/client3-46072b81.css" data-precedence="rsc-css">',
+    );
+    const revealHtmlIndex = resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">');
+
+    expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
+    expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
+    expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
+  });
+
   it('preserves split UTF-8 bytes when deferring reveal HTML', async () => {
     const flightData =
       '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client1","js/client1-570df890c7aa791c.chunk.js"],"default"]\n' +

--- a/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
+++ b/packages/react-on-rails-pro/tests/injectRSCPayload.test.ts
@@ -240,6 +240,46 @@ describe('injectRSCPayload', () => {
     expect(resultStr).not.toContain('rel="preload" as="style"');
   });
 
+  it('injects inferred RSC client chunk stylesheets before streamed reveal HTML', async () => {
+    const flightData =
+      '2:I["./client/app/components/FoucProbe/RscFoucProbeClient.jsx",["client1","js/client1-570df890c7aa791c.chunk.js"],"default"]\n' +
+      '0:["$","$L2",null,{},null]\n';
+    const mockRSC = createMockRSCStream([flightData]);
+    const mockHTML = createMockHTMLStream([
+      '<div hidden id="RscFoucProbe-react-component-0S:0">' +
+        '<section data-testid="rsc-fouc-probe">RSC streamed FOUC probe</section>' +
+        '</div>' +
+        '<script>$RC("RscFoucProbe-react-component-0B:0","RscFoucProbe-react-component-0S:0")</script>',
+    ]);
+    const { rscRequestTracker, domNodeId } = setupTest(mockRSC);
+    const injectWithStylesheetMap = injectRSCPayload as unknown as (
+      html: Readable,
+      tracker: RSCRequestTracker,
+      nodeId: string,
+      nonce: string | undefined,
+      stylesheetHrefsByChunkName: Map<string, string[]>,
+    ) => Readable;
+
+    const result = injectWithStylesheetMap(
+      mockHTML,
+      rscRequestTracker,
+      domNodeId,
+      undefined,
+      new Map([['client1', ['/webpack/test/css/client1-46072b81.css']]]),
+    );
+    const resultStr = await collectStreamData(result);
+
+    const stylesheetIndex = resultStr.indexOf(
+      '<link rel="stylesheet" href="/webpack/test/css/client1-46072b81.css" data-precedence="rsc-css">',
+    );
+    const revealHtmlIndex = resultStr.indexOf('<div hidden id="RscFoucProbe-react-component-0S:0">');
+
+    expect(stylesheetIndex).toBeGreaterThanOrEqual(0);
+    expect(revealHtmlIndex).toBeGreaterThanOrEqual(0);
+    expect(stylesheetIndex).toBeLessThan(revealHtmlIndex);
+    expect(resultStr).toContain(expectedPayloadPushScript(flightData));
+  });
+
   it('promotes streamed RSC stylesheet preloads split across fallback flush chunks', async () => {
     const mockRSC = createMockRSCStream(['{"test": "data"}']);
     const mockHTML = createMockHTMLStream({

--- a/react_on_rails/lib/react_on_rails/pro_helper.rb
+++ b/react_on_rails/lib/react_on_rails/pro_helper.rb
@@ -18,7 +18,9 @@ module ReactOnRails
                                                 "data-ssr-identifier-prefix" =>
                                                   (render_options.html_streaming? ? render_options.dom_id : nil),
                                                 "data-store-dependencies" =>
-                                                  render_options.store_dependencies&.to_json)
+                                                  render_options.store_dependencies&.to_json,
+                                                "data-generated-stylesheet-hrefs" =>
+                                                  generated_stylesheet_hrefs_json(render_options))
 
       # Add immediate invocation script for Pro users to enable hydration during streaming
       spec_tag = if ReactOnRails::Utils.react_on_rails_pro?
@@ -35,6 +37,15 @@ module ReactOnRails
                  end
 
       spec_tag.html_safe
+    end
+
+    def generated_stylesheet_hrefs_json(render_options)
+      return unless render_options.auto_load_bundle
+
+      pack_name = "generated/#{render_options.react_component_name}"
+      sources = preload_sources_for_stylesheet_pack(pack_name)
+      hrefs = unique_preload_sources_by_href(sources).map { |source| source.fetch(:href) }
+      hrefs.to_json if hrefs.present?
     end
 
     # Generates the complete store hydration script tag.

--- a/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
+++ b/react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb
@@ -1401,7 +1401,8 @@ describe ReactOnRailsHelper do
         react_component_name: "HelloWorld",
         trace: false,
         store_dependencies: nil,
-        html_streaming?: false
+        html_streaming?: false,
+        auto_load_bundle: false
       )
     end
 
@@ -1443,6 +1444,30 @@ describe ReactOnRailsHelper do
       it "does not include a hydration script" do
         result = helper.send(:generate_component_script, render_options)
         expect(result).not_to include("reactOnRailsComponentLoaded")
+      end
+    end
+
+    context "when auto-loaded generated stylesheet hrefs are available" do
+      let(:stylesheet_sources) do
+        [{ source: "css/shared-generated-pack-deadbeef.css", source_type: :stylesheet }]
+      end
+
+      before do
+        allow(render_options).to receive(:auto_load_bundle).and_return(true)
+        allow(helper).to receive(:preload_sources_for_stylesheet_pack)
+          .with("generated/HelloWorld")
+          .and_return(stylesheet_sources)
+        allow(helper).to receive(:unique_preload_sources_by_href)
+          .with(stylesheet_sources)
+          .and_return([{ href: "/webpack/test/css/shared-generated-pack-deadbeef.css" }])
+      end
+
+      it "adds generated stylesheet href metadata to the component specification script" do
+        result = helper.send(:generate_component_script, render_options)
+        script = Nokogiri::HTML.fragment(result).css("script.js-react-on-rails-component").first
+
+        expect(script["data-generated-stylesheet-hrefs"])
+          .to eq(["/webpack/test/css/shared-generated-pack-deadbeef.css"].to_json)
       end
     end
   end

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts
@@ -313,6 +313,10 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
       await recordProbePaints(page, [RSC_PROBE_TARGET, CLIENT_ONLY_PROBE_TARGET]);
     });
 
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll({ behavior: 'ignoreErrors' });
+    });
+
     test('streamed RSC content is visible and styled when its CSS is loaded, even while JS is delayed', async ({
       page,
     }) => {

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts
@@ -15,8 +15,6 @@
 
 import { expect, Page, test } from '@playwright/test';
 
-const RUN_PENDING_FOUC_TESTS = process.env.REACT_ON_RAILS_RUN_PENDING_FOUC_TESTS === 'true';
-
 interface RecordedProbePaint {
   backgroundColor: string;
   borderTopColor: string;
@@ -318,8 +316,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     test('streamed RSC content is visible and styled when its CSS is loaded, even while JS is delayed', async ({
       page,
     }) => {
-      test.fixme(!RUN_PENDING_FOUC_TESTS, 'Pending #4032: streamed RSC CSS must apply before reveal');
-
       const css = await controlCssBySentinel(page, RSC_SENTINEL);
       const scripts = await delayCompiledJavaScript(page);
 
@@ -335,11 +331,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     });
 
     test('streamed RSC content does not appear before its CSS when JS is available', async ({ page }) => {
-      test.fixme(
-        !RUN_PENDING_FOUC_TESTS,
-        'Pending #4032: streamed RSC content must stay hidden until CSS is ready',
-      );
-
       const css = await controlCssBySentinel(page, RSC_SENTINEL, { holdTarget: true });
 
       await page.goto(RSC_FOUC_PATH, { waitUntil: 'commit' });
@@ -353,11 +344,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     });
 
     test('streamed RSC content still waits for CSS if JS finishes first', async ({ page }) => {
-      test.fixme(
-        !RUN_PENDING_FOUC_TESTS,
-        'Pending #4032: streamed RSC content must wait for CSS after JS loads',
-      );
-
       const css = await controlCssBySentinel(page, RSC_SENTINEL, { holdTarget: true });
       const scripts = await delayCompiledJavaScript(page);
 
@@ -365,8 +351,12 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
         await page.goto(RSC_FOUC_PATH, { waitUntil: 'commit' });
         await css.waitForTargetRequest();
 
+        const delayedScriptResponse = page.waitForResponse(/\/webpack\/test\/.*\.js(\?.*)?$/);
         scripts.releaseScripts();
-        await page.waitForLoadState('domcontentloaded');
+        await waitWithTimeout(
+          delayedScriptResponse,
+          'Timed out waiting for a delayed JavaScript response after releasing scripts',
+        );
 
         await expectNoVisiblePaint(page, RSC_TEST_ID);
 
@@ -395,8 +385,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     });
 
     test('client-only content does not appear until CSS loads, even when JS is ready', async ({ page }) => {
-      test.fixme(!RUN_PENDING_FOUC_TESTS, 'Pending #4031: client-only content must wait for CSS and JS');
-
       const css = await controlCssBySentinel(page, CLIENT_ONLY_SENTINEL, { holdTarget: true });
 
       await page.goto(CLIENT_ONLY_FOUC_PATH, { waitUntil: 'commit' });


### PR DESCRIPTION
Fixes #4031.
Fixes #4032.

## Summary
- Gate Pro client-only auto-loaded component mounting on generated stylesheet readiness, including shared generated CSS discovered from manifest href metadata.
- Promote streamed RSC client chunk stylesheet preloads to real stylesheet links before reveal, preserving preload attributes and handling split stream chunks.
- Enable and extend FOUC Playwright coverage for CSS-before-reveal, JS-before-CSS, client-only gating, and CSS chunk scope.
- Add the user-visible Pro fix to `CHANGELOG.md`.

## Validation
- `pnpm exec jest tests/ClientSideRenderer.test.ts tests/injectRSCPayload.test.ts --runInBand`
- `bundle exec rspec spec/helpers/react_on_rails_helper_spec.rb:63 spec/helpers/react_on_rails_helper_spec.rb:1402`
- `pnpm run build`
- `pnpm run type-check`
- `pnpm exec eslint packages/react-on-rails-pro/src/ClientSideRenderer.ts packages/react-on-rails-pro/src/injectRSCPayload.ts packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts packages/react-on-rails-pro/tests/injectRSCPayload.test.ts react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts`
- `pnpm exec prettier --check packages/react-on-rails-pro/src/ClientSideRenderer.ts packages/react-on-rails-pro/src/injectRSCPayload.ts packages/react-on-rails-pro/tests/ClientSideRenderer.test.ts packages/react-on-rails-pro/tests/injectRSCPayload.test.ts react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts`
- `bundle exec rubocop react_on_rails/lib/react_on_rails/helper.rb react_on_rails/lib/react_on_rails/pro_helper.rb react_on_rails/spec/dummy/spec/helpers/react_on_rails_helper_spec.rb`
- `cd react_on_rails_pro/spec/dummy && pnpm run build:test`
- `cd react_on_rails_pro/spec/dummy && pnpm exec playwright test e2e-tests/rsc_fouc.spec.ts`
- `pnpm exec prettier --check CHANGELOG.md`
- `git diff --check`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Pre-push hook: branch RuboCop and online markdown links passed; lychee reported 14 redirects and 0 errors.

## Review Notes
- Codex autoreview: clean, no accepted/actionable findings.
- Claude `/code-review origin/main` and `/simplify origin/main` were attempted with `claude-opus-4-8 --max-budget-usd 20`, but both CLI runs hung without output and returned only `Execution error` after interrupt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches timing-sensitive Pro streaming and client hydration paths with substantial HTML stream rewriting; mitigated by scoped matching rules, inference timeouts, and fail-open behavior when CSS never loads.
> 
> **Overview**
> Fixes **Pro FOUC** where client-only roots and streamed RSC Suspense reveals could show unstyled content because hydration/reveal ran before generated or chunk CSS was applied.
> 
> **Client-only:** Pro now waits in parallel for the component bundle and for matching generated stylesheet `link` elements (from `data-generated-stylesheet-hrefs` on the spec tag plus `/generated/{Component}` href heuristics), with a 10s fail-open timeout. Rails emits that metadata when `auto_load_bundle` resolves manifest preload hrefs for `generated/{component}`.
> 
> **Streamed RSC:** `injectRSCPayload` promotes only RSC client-chunk `rel=preload as=style` links to real stylesheets (`data-precedence="rsc-css"`), infers extra stylesheet tags from Flight + `loadable-stats.json`, and can defer `$RC` reveal HTML until inference finishes—while still streaming fallbacks and handling link tags split across chunks or UTF-8 boundaries. App-authored style preloads are left unchanged.
> 
> Playwright FOUC acceptance tests for #4031/#4032 are enabled (no longer `fixme`); Jest coverage expanded for both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69251bdd4ae4efbf04e1457e128abf02eb994270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Flash of Unstyled Content (FOUC) in Pro with React Server Components by delaying client-only hydration until the component’s generated stylesheet links are ready (10s timeout) with “fails open” fallback.
  * Improved streamed RSC CSS handling by promoting streamed style preloads into real stylesheet links, handling links split across stream boundaries, and preserving app-authored preloads while ensuring correct reveal ordering.
* **Tests**
  * Expanded Jest and stream-related coverage for stylesheet gating, reveal deferral, and UTF-8 boundary streaming edge cases.
  * Updated Playwright RSC FOUC acceptance tests to run normally and improved timing/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->