### PR TITLE
Stop Claude Code workflow from skipping on normal reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,15 +7,12 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

The skipped job in PR #4036 came from the interactive `Claude Code` workflow, not from the automatic `Claude Code Review` workflow. The interactive workflow currently triggers on every submitted PR review, but its job-level `if:` only runs when that review body contains `@claude`. Normal bot or human reviews, such as Cursor Bugbot reviews, therefore create a skipped `claude` job that looks like Claude review was skipped even though no Claude summon was requested.

This makes the Actions/check UI misleading during review-heavy PRs. The intended summon paths are still comments that explicitly contain `@claude`; normal review submissions should not create a skipped Claude job at all.

## What changed

Removed `pull_request_review` from `.github/workflows/claude.yml` and removed the matching review-body condition. `@claude` still works from issue comments and PR review comments. The separate automatic `.github/workflows/claude-code-review.yml` workflow is unchanged.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude.yml"); puts "yaml ok"'` -> `yaml ok`
- `actionlint .github/workflows/claude.yml` -> passed
- `git diff --check` -> passed
- Lefthook pre-commit/pre-push relevant checks -> passed

## CI scope

This is a trigger-only cleanup for the interactive Claude summon workflow. It does not change runtime code, package output, tests, or the automatic Claude Code Review workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change with no application code or automatic review workflow impact.
> 
> **Overview**
> Stops the interactive **Claude Code** workflow from firing on every submitted PR review. Previously it listened to `pull_request_review` with `types: [submitted]` but only ran the job when the review body contained `@claude`, so routine reviews (e.g. Bugbot) still produced a **skipped** `claude` job in Actions.
> 
> The `pull_request_review` trigger and its matching `if` branch are removed from `.github/workflows/claude.yml`. Summoning via `@claude` in issue comments, PR review **comments**, and issues is unchanged; the automatic `claude-code-review` workflow is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549eb7923355aa96d704fe1f743de5022c6302ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation workflow event configuration to streamline trigger conditions and improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->