### PR TITLE
Document GitHub Actions follow-up verification rule

### DIFF
--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -193,6 +193,21 @@ new-gate rollout or Dependabot/lockfile compatibility results. The audit comment
 is the human-readable summary; CI check results for the current head SHA are the
 objective verification record.
 
+Before reporting merge readiness for a PR with `.github/workflows/**` or
+`.github/actions/**` changes, classify the diff as semantic or non-semantic.
+Semantic changes include trigger, permission, job, matrix, condition,
+concurrency, secret, reusable-action, command-parsing, workflow-dispatch, and
+CI-routing behavior changes. For semantic changes, link an existing tracking
+issue or create one bundled issue titled
+`Follow-up: Exercise GitHub Actions changes from PR #NNNN` before merge. The
+issue must include the source PR, changed workflow/action files, exact
+post-merge event or secondary verification PR to exercise, expected evidence,
+cleanup instructions for any verification-only PR, and owner if known. Treat
+comments, docs, typo fixes, formatting-only changes, and non-semantic actionlint
+cleanup as exempt only when the PR evidence states that classification and local
+validation. This is a standing exception to the default follow-up tracking
+policy because some GitHub Actions behavior can only be proven from `main`.
+
 When adding or broadening a repo-wide lint, CI, release, review, or merge gate,
 include at least one stale-base race control in the PR evidence. This is a
 `checklist+replay` process-gap disposition: name the stale-base race-control
@@ -826,7 +841,11 @@ Use `.agents/skills/address-review/SKILL.md` when skills are available; Claude C
   inline or escalate it to `DISCUSS`; autonomous defer does not apply.
 - `SKIPPED`: reply with rationale only when useful; do not create work from noise.
 
-Do not let follow-up issues become a substitute for finishing the PR. Follow-up tracking is allowed only for real, non-blocking work that remains valuable outside the PR context.
+Do not let follow-up issues become a substitute for finishing the PR. Follow-up
+tracking is allowed only for real, non-blocking work that remains valuable
+outside the PR context. The standing GitHub Actions post-merge exercise rule in
+the workflow/build-config scope section is an explicit exception because it
+verifies behavior that may not be provable before merge.
 
 ## Merge Endgame Debounce And Waiver Soak
 

--- a/.github/read-me.md
+++ b/.github/read-me.md
@@ -93,6 +93,35 @@ GitHub Actions workflows triggered by `issue_comment` events always use the work
 
 For more details, see [GitHub's documentation on issue_comment events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment).
 
+## Post-Merge Exercise Follow-Ups
+
+Semantic changes to `.github/workflows/**` or `.github/actions/**` require a
+linked `Follow-up:` issue before merge. The follow-up exists to prove behavior
+that cannot be fully exercised from the original PR branch, especially
+default-branch event handling such as `issue_comment`.
+
+Use this title:
+
+```text
+Follow-up: Exercise GitHub Actions changes from PR #NNNN
+```
+
+The issue body must include:
+
+- Source PR
+- Changed workflow/action files
+- Exact post-merge event, command, or secondary verification PR to exercise
+- Expected evidence, such as run links, PR comments, labels, artifacts, or check
+  conclusions
+- Cleanup instructions for any verification-only PR
+- Owner, if known
+
+This requirement applies to trigger, permission, job, matrix, condition,
+concurrency, secret, reusable-action, command-parsing, workflow-dispatch, and
+CI-routing behavior changes. It does not apply to comments, docs, typo fixes,
+formatting-only changes, or non-semantic actionlint cleanup when the PR evidence
+documents that classification.
+
 ## Available Workflows
 
 ### CI Workflows (Triggered on Push/PR)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,15 @@ restores/saves the gem cache, and supports non-frozen installs via `frozen: 'fal
 
 **GitHub follow-up issues**: Follow-up issues are the exception. Prefer fixing or declining review feedback in the PR. If deferred work remains valuable, present one bundled deferred-work summary and ask whether to track it. Prefer an existing issue; otherwise create at most one bundled issue per PR unless the user explicitly approves more. New follow-up issue titles must begin with `Follow-up:`. Build multi-line issue bodies as Markdown files and pass them with `gh issue create --body-file`; do not pass escaped newline strings through `--body`.
 
+**GitHub Actions post-merge exercise follow-ups**: Semantic changes to `.github/workflows/**` or `.github/actions/**`
+are a standing exception to the default "no follow-up issue" rule. Before merge, link an existing tracking issue or
+create one bundled issue titled `Follow-up: Exercise GitHub Actions changes from PR #NNNN`. The issue must name the
+source PR, changed workflow/action files, exact post-merge event or secondary verification PR to exercise, expected
+evidence, cleanup instructions for any verification-only PR, and owner if known. This is required for trigger,
+permission, job, matrix, condition, concurrency, secret, reusable-action, command-parsing, workflow-dispatch, or
+CI-routing behavior changes. It is not required for comments, docs, typo fixes, formatting-only changes, or
+non-semantic actionlint cleanup when local validation evidence documents that classification.
+
 **Process gap disposition**: When an audit, review, or batch closeout finds a recurring process miss, do not add a prose-only rule by default. The issue plan or PR evidence must choose one mechanism target: `script`, `schema`, `checklist+replay`, or `park`, and record the motivating miss, replay evidence or park reason, and non-goal. `park` means the miss is plausible but not worth mechanizing now.
 
 ## Maintainer Attention Contract


### PR DESCRIPTION
## Summary

- Add a canonical `AGENTS.md` rule requiring a linked `Follow-up:` issue for semantic `.github/workflows/**` or `.github/actions/**` changes before merge.
- Update the PR-processing workflow so agents classify Actions changes as semantic or non-semantic and enforce the follow-up gate during merge readiness.
- Document the `.github/read-me.md` follow-up issue title, required body fields, semantic-change examples, and exemptions.

## Test plan

- `git diff --check`
- `script/check-docs-sidebar`
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)`
- `pnpm install --frozen-lockfile` to install dependencies in the fresh worktree
- `pnpm start format.listDifferent`
- Pre-commit hook: trailing newlines, offline markdown links, and Prettier on changed files
- Pre-push hook: branch lint and online markdown links

## Notes

- Docs/policy-only change; no changelog entry.
- This PR updates `.github/read-me.md` but does not change `.github/workflows/**` or `.github/actions/**`, so the new post-merge exercise follow-up requirement does not apply to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent policy only; no workflow YAML or runtime behavior changes.
> 
> **Overview**
> **Documents a standing exception** to the default “avoid follow-up issues” rule: **semantic** edits under `.github/workflows/**` or `.github/actions/**` must have a linked `Follow-up: Exercise GitHub Actions changes from PR #NNNN` issue **before merge**, because behavior such as `issue_comment` triggers is only fully verifiable on `main`.
> 
> **`AGENTS.md`** adds the canonical rule (required issue fields, semantic change categories, and exemptions for docs/comments/non-semantic actionlint cleanup with evidence).
> 
> **`.agents/workflows/pr-processing.md`** extends merge-readiness for Actions diffs: classify semantic vs non-semantic, create/link the follow-up for semantic changes, and cross-references the exception in the general follow-up tracking section.
> 
> **`.github/read-me.md`** adds a contributor-facing section with the issue title template, required body bullets, and the same semantic vs exempt scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50049e3bf87a8d30f07984598f28beda39bc66f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established a new policy requiring follow-up tracking issues for semantic changes to GitHub Actions workflows and actions
  * Follow-up issues must include source PR reference, modified files, post-merge verification steps, expected evidence, cleanup instructions, and owner assignment where applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->