### PR TITLE
Post-merge CI smoke: docs-only lifecycle

### DIFF
--- a/internal/planning/post-merge-ci-smoke-docs.md
+++ b/internal/planning/post-merge-ci-smoke-docs.md
@@ -7,3 +7,5 @@ Second smoke commit to verify synchronize-event checks rerun on the current head
 Third smoke commit to verify ready-for-hosted-ci persists optimized hosted checks.
 
 Fourth smoke commit to verify hosted CI stop returns later pushes to baseline.
+
+Fifth smoke commit to verify SHA-bound hosted CI waivers do not carry forward.

--- a/internal/planning/post-merge-ci-smoke-docs.md
+++ b/internal/planning/post-merge-ci-smoke-docs.md
@@ -5,3 +5,5 @@ Temporary docs-only change for verifying the hosted CI gating rollout from PR #4
 Second smoke commit to verify synchronize-event checks rerun on the current head.
 
 Third smoke commit to verify ready-for-hosted-ci persists optimized hosted checks.
+
+Fourth smoke commit to verify hosted CI stop returns later pushes to baseline.

--- a/internal/planning/post-merge-ci-smoke-docs.md
+++ b/internal/planning/post-merge-ci-smoke-docs.md
@@ -3,3 +3,5 @@
 Temporary docs-only change for verifying the hosted CI gating rollout from PR #4036.
 
 Second smoke commit to verify synchronize-event checks rerun on the current head.
+
+Third smoke commit to verify ready-for-hosted-ci persists optimized hosted checks.

--- a/internal/planning/post-merge-ci-smoke-docs.md
+++ b/internal/planning/post-merge-ci-smoke-docs.md
@@ -1,3 +1,5 @@
 # Post-Merge CI Smoke
 
 Temporary docs-only change for verifying the hosted CI gating rollout from PR #4036.
+
+Second smoke commit to verify synchronize-event checks rerun on the current head.

--- a/internal/planning/post-merge-ci-smoke-docs.md
+++ b/internal/planning/post-merge-ci-smoke-docs.md
@@ -1,0 +1,3 @@
+# Post-Merge CI Smoke
+
+Temporary docs-only change for verifying the hosted CI gating rollout from PR #4036.


### PR DESCRIPTION
## Why

This draft PR is a temporary smoke test for the hosted CI gating rollout merged in #4036. It exists to verify default-branch workflow behavior from a real PR after the new GitHub Actions setup is live on `main`.

## What Changed

- Added a tiny internal planning note only.

## Verification Plan

- Confirm draft PR creation runs the required PR gate and review tooling without triggering hosted heavyweight jobs by default.
- Push a second tiny docs commit and confirm current-head checks update.
- Mark ready for review and confirm ready-for-review behavior remains distinct from hosted-CI commands.
- Exercise `+ci-status`, `+ci-run-hosted`, `+ci-stop-hosted`, `+ci-skip-hosted`, and legacy invalid-command handling.

Tracking issue: #4055

This PR should be closed unmerged after the smoke evidence is recorded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or application logic impact.
> 
> **Overview**
> Adds **`internal/planning/post-merge-ci-smoke-docs.md`**, a temporary internal note that documents a **five-commit** docs-only smoke sequence for validating hosted CI gating after #4036.
> 
> The note labels each planned push: synchronize reruns on current head, ready-for-hosted-ci behavior, stopping hosted CI returning to baseline, and confirming **SHA-bound hosted CI waivers** do not carry forward. Intended for manual PR/workflow verification (#4055) and closure without merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c43c163f2688a471a62c4fe6d3e59c9cd37e8264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the CI “Post-Merge Verification” documentation to describe **five** sequential smoke commits instead of four.
  * Added a final verification step to confirm that **SHA-bound hosted CI waivers** do not carry over beyond the intended scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->