### PR TITLE
Fix CI command reply permissions

### DIFF
--- a/.github/workflows/ci-commands.yml
+++ b/.github/workflows/ci-commands.yml
@@ -21,7 +21,7 @@ jobs:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Handle +ci command
         uses: actions/github-script@v9


### PR DESCRIPTION
## Why

The post-merge smoke test for #4036 found that `+ci-status` computed the correct response but failed to post it on PR #4056. The workflow token had `issues: write`, but GitHub returned `403 Resource not accessible by integration` when posting a PR issue comment. The sibling invalid-command workflow already requests `pull-requests: write`, and this command workflow should match that permission shape for PR comment/reaction writes.

## What Changed

- Changed `.github/workflows/ci-commands.yml` from `pull-requests: read` to `pull-requests: write`.

## Test Plan

- `ruby -e 'require "yaml"; YAML.safe_load_file(".github/workflows/ci-commands.yml", permitted_classes: [], aliases: false)'`
- `actionlint .github/workflows/ci-commands.yml`
- `git diff --check`
- Pre-commit hook passed.
- Pre-push hook passed.
- GitHub checks for current head completed with no failures or pending checks.

Post-merge verification continues in #4055; after this lands, rerun `+ci-status` on #4056.

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: 316ad0f37039ae9d583489903f9cc24106cf1feb
Score: 9/10
Auto-merge recommendation: yes
Affected areas: CI command workflow permissions
CI detector: docs/workflow-only change; hosted runtime-heavy jobs skipped by selector, required/actionlint/review checks completed.
Validation run:
- `ruby -e 'require "yaml"; YAML.safe_load_file(".github/workflows/ci-commands.yml", permitted_classes: [], aliases: false)'` -> passed.
- `actionlint .github/workflows/ci-commands.yml` -> passed.
- `git diff --check` -> passed.
- Pre-commit hook -> passed.
- Pre-push hook -> passed.
- GitHub checks -> complete for current head; no failures or pending checks.
Review/check gate:
- Review threads: GraphQL unresolved review-thread count is 0.
- Current-head reviewer verdicts:
  - Claude review: success for current head via https://github.com/shakacode/react_on_rails/actions/runs/27615696141.
  - CodeRabbit: approved for current head at 2026-06-16T11:58:22Z.
Known residual risk: the permission fix must be proven by rerunning `+ci-status` on #4056 after merge; tracked in #4055.
Finalized by: Claude Code Review check run `27615696141` for current head SHA `316ad0f37039ae9d583489903f9cc24106cf1feb`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow permission tweak with no application or data-path changes; slightly broader token scope for this job only.
>
> **Overview**
> Fixes **`+ci-*` commands** (e.g. `+ci-status`) that built the right reply but could not post it on the PR because the workflow token only had **`pull-requests: read`**, which led to GitHub **`403 Resource not accessible by integration`** on PR issue comments.
>
> **`ci-commands.yml`** now requests **`pull-requests: write`**, aligned with the invalid-command workflow, so `postComment` and comment reactions can succeed.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316ad0f37039ae9d583489903f9cc24106cf1feb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes to report.

This release includes only internal infrastructure updates with no impact on end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
