### PR TITLE
Fix invalid CI command help response

### DIFF
--- a/.github/workflows/detect-invalid-ci-commands.yml
+++ b/.github/workflows/detect-invalid-ci-commands.yml
@@ -1,12 +1,14 @@
+---
 name: Detect Invalid CI Commands
 
-on:
+"on":
   issue_comment:
     types: [created]
 
 jobs:
   detect-invalid-commands:
-    # Only run on PR comments that contain potential commands but don't match valid commands
+    # Only run on PR comments that contain potential commands but don't match
+    # valid commands.
     if: |
       github.event.issue.pull_request &&
       (
@@ -30,9 +32,14 @@ jobs:
           script: |
             const comment = context.payload.comment.body;
 
-            // Pattern to detect potential command attempts at the start of a line
-            // Matches: /ci*, /run*, /stop*, /delete*, /deploy*, /help* at beginning or after newline
-            const commandPattern = /(?:^|\n)\s*(\/(ci|run|stop|delete|deploy|help)[\w-]*)/gi;
+            // Detect command attempts at the start of a line.
+            // Matches /ci*, /run*, /stop*, /delete*, /deploy*, and /help*
+            // at the beginning of a comment or after a newline.
+            const commandPattern = new RegExp(
+              String.raw`(?:^|\n)\s*` +
+                String.raw`(/(ci|run|stop|delete|deploy|help)[\w-]*)`,
+              'gi',
+            );
             const matches = [...comment.matchAll(commandPattern)];
 
             if (matches.length === 0) {
@@ -57,13 +64,15 @@ jobs:
             }
 
             return { shouldRespond: false };
-          # Default result-encoding (json) JSON.stringifies the returned object so
-          # the downstream `fromJSON(...)` condition and `JSON.parse` can read it.
-          # `result-encoding: string` would coerce the object to "[object Object]",
-          # which breaks `fromJSON` and fails the job on every triggering comment.
+          # Default result-encoding (json) JSON.stringifies the returned object.
+          # That lets downstream `fromJSON(...)` and `JSON.parse` read it.
+          # `result-encoding: string` would coerce the object to
+          # "[object Object]", which breaks `fromJSON` and fails each job.
 
       - name: Post helpful comment
-        if: steps.check_command.outputs.result != '' && fromJSON(steps.check_command.outputs.result).shouldRespond == true
+        if: >-
+          steps.check_command.outputs.result != '' &&
+          fromJSON(steps.check_command.outputs.result).shouldRespond == true
         uses: actions/github-script@v7
         env:
           CHECK_RESULT: ${{ steps.check_command.outputs.result }}
@@ -73,22 +82,30 @@ jobs:
             const invalidCommands = result.invalidCommands || [];
 
             const invalidCmdsList = invalidCommands.length > 0
-              ? ['', `**Invalid command(s) detected:** ${invalidCommands.map((cmd) => `\`${cmd}\``).join(', ')}`]
+              ? [
+                  '',
+                  '**Invalid command(s) detected:** ' +
+                    invalidCommands.map((cmd) => `\`${cmd}\``).join(', '),
+                ]
               : [];
 
             const body = [
-              "👋 It looks like you may have tried to use a CI command, but it doesn't match the available commands.",
+              '👋 It looks like you may have tried to use a CI command, ' +
+                "but it doesn't match the available commands.",
               ...invalidCmdsList,
               '',
               '## Available GitHub Comment Commands',
               '',
               '### 1. `+ci-run-hosted` - Request Optimized Hosted CI',
-              'Marks the PR ready for hosted GitHub Actions while keeping suite selection path-based.',
+              'Marks the PR ready for hosted GitHub Actions while keeping ' +
+                'suite selection path-based.',
               '',
               '**What it does:**',
               '- Dispatches hosted workflows for the current head SHA',
-              '- Adds the `ready-for-hosted-ci` label to persist hosted validation on future commits',
-              '- Lets `script/ci-changes-detector` choose the applicable suites',
+              '- Adds the `ready-for-hosted-ci` label to persist hosted ' +
+                'validation on future commits',
+              '- Lets `script/ci-changes-detector` choose the applicable ' +
+                'suites',
               '',
               '**Requirements:**',
               '- Must have write access to the repository',
@@ -102,7 +119,8 @@ jobs:
               '---',
               '',
               '### 2. `+ci-force-full` - Force Full Hosted CI',
-              'Bypasses optimized suite selection for the current head and future commits.',
+              'Bypasses optimized suite selection for the current head and ' +
+                'future commits.',
               '',
               '**What it does:**',
               '- Dispatches hosted workflows with `force_full_hosted: true`',
@@ -129,12 +147,14 @@ jobs:
               '---',
               '',
               '### 4. `+ci-stop-full` - Disable Only Force-Full Mode',
-              'Removes `force-full-hosted-ci` while leaving `ready-for-hosted-ci` in place if present.',
+              'Removes `force-full-hosted-ci` while leaving ' +
+                '`ready-for-hosted-ci` in place if present.',
               '',
               '---',
               '',
               '### 5. `+ci-skip-hosted [reason]` - Record a Hosted CI Waiver',
-              'Records that a maintainer intentionally waived hosted CI for the current PR head SHA.',
+              'Records that a maintainer intentionally waived hosted CI for ' +
+                'the current PR head SHA.',
               '',
               '**Example:**',
               '```',
@@ -144,7 +164,8 @@ jobs:
               '---',
               '',
               '### 6. `@claude` - Claude Code AI Review',
-              'Invokes Claude Code AI to perform code review or answer questions.',
+              'Invokes Claude Code AI to perform code review or answer ' +
+                'questions.',
               '',
               '**What it does:**',
               '- Analyzes code changes and provides feedback',
@@ -160,7 +181,8 @@ jobs:
               '',
               '## Local CI Debugging',
               '',
-              'Instead of using comment commands, you can replicate CI failures locally:',
+              'Instead of using comment commands, you can replicate CI ' +
+                'failures locally:',
               '',
               '**Check CI status:**',
               '```bash',
@@ -179,15 +201,21 @@ jobs:
               '',
               '**Switch between CI configurations:**',
               '```bash',
-              'bin/ci-switch-config minimum  # Test with Ruby 3.3, Node 20, etc.',
-              'bin/ci-switch-config latest   # Return to Ruby 4.0, Node 22, etc.',
+              'bin/ci-switch-config minimum  # Test with Ruby 3.3, ' +
+                'Node 20, etc.',
+              'bin/ci-switch-config latest   # Return to Ruby 4.0, ' +
+                'Node 22, etc.',
               '```',
               '',
               '---',
               '',
-              "Legacy slash aliases were removed. Use `+ci-*` commands because GitHub's comment editor reserves `/` for built-in slash command autocomplete.",
+              'Legacy slash aliases were removed. Use `+ci-*` commands ' +
+                "because GitHub's comment editor reserves `/` for built-in " +
+                'slash command autocomplete.',
               '',
-              '📖 For more details, see the [Contributing Guide](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md#using-comment-commands-to-trigger-ci)'
+              '📖 For more details, see the [Contributing Guide]' +
+                '(https://github.com/shakacode/react_on_rails/blob/main/' +
+                'CONTRIBUTING.md#using-comment-commands-to-trigger-ci)'
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/detect-invalid-ci-commands.yml
+++ b/.github/workflows/detect-invalid-ci-commands.yml
@@ -73,119 +73,122 @@ jobs:
             const invalidCommands = result.invalidCommands || [];
 
             const invalidCmdsList = invalidCommands.length > 0
-              ? `\n\n**Invalid command(s) detected:** ${invalidCommands.map(cmd => \`\\\`${cmd}\\\`\`).join(', ')}`
-              : '';
+              ? ['', `**Invalid command(s) detected:** ${invalidCommands.map((cmd) => `\`${cmd}\``).join(', ')}`]
+              : [];
 
-            const body = \`👋 It looks like you may have tried to use a CI command, but it doesn't match the available commands.${invalidCmdsList}
-
-            ## Available GitHub Comment Commands
-
-            ### 1. \\\`+ci-run-hosted\\\` - Request Optimized Hosted CI
-            Marks the PR ready for hosted GitHub Actions while keeping suite selection path-based.
-
-            **What it does:**
-            - Dispatches hosted workflows for the current head SHA
-            - Adds the \\\`ready-for-hosted-ci\\\` label to persist hosted validation on future commits
-            - Lets \\\`script/ci-changes-detector\\\` choose the applicable suites
-
-            **Requirements:**
-            - Must have write access to the repository
-            - Use at the start of a comment or after a newline
-
-            **Example:**
-            \\\`\\\`\\\`
-            +ci-run-hosted
-            \\\`\\\`\\\`
-
-            ---
-
-            ### 2. \\\`+ci-force-full\\\` - Force Full Hosted CI
-            Bypasses optimized suite selection for the current head and future commits.
-
-            **What it does:**
-            - Dispatches hosted workflows with \\\`force_full_hosted: true\\\`
-            - Adds both \\\`ready-for-hosted-ci\\\` and \\\`force-full-hosted-ci\\\`
-
-            **Example:**
-            \\\`\\\`\\\`
-            +ci-force-full
-            \\\`\\\`\\\`
-
-            ---
-
-            ### 3. \\\`+ci-stop-hosted\\\` - Disable Hosted CI Mode
-            Removes hosted CI labels for future commits.
-
-            **Requirements:**
-            - Must have write access to the repository
-
-            **Example:**
-            \\\`\\\`\\\`
-            +ci-stop-hosted
-            \\\`\\\`\\\`
-
-            ---
-
-            ### 4. \\\`+ci-stop-full\\\` - Disable Only Force-Full Mode
-            Removes \\\`force-full-hosted-ci\\\` while leaving \\\`ready-for-hosted-ci\\\` in place if present.
-
-            ---
-
-            ### 5. \\\`+ci-skip-hosted [reason]\\\` - Record a Hosted CI Waiver
-            Records that a maintainer intentionally waived hosted CI for the current PR head SHA.
-
-            **Example:**
-            \\\`\\\`\\\`
-            +ci-skip-hosted docs-only change; markdown checks are enough
-            \\\`\\\`\\\`
-
-            ---
-
-            ### 6. \\\`@claude\\\` - Claude Code AI Review
-            Invokes Claude Code AI to perform code review or answer questions.
-
-            **What it does:**
-            - Analyzes code changes and provides feedback
-            - Follows instructions specified in the comment
-            - Can read CI results on PRs
-
-            **Example:**
-            \\\`\\\`\\\`
-            @claude please review the error handling in this PR
-            \\\`\\\`\\\`
-
-            ---
-
-            ## Local CI Debugging
-
-            Instead of using comment commands, you can replicate CI failures locally:
-
-            **Check CI status:**
-            \\\`\\\`\\\`bash
-            gh pr view --json statusCheckRollup
-            \\\`\\\`\\\`
-
-            **Re-run only failed jobs:**
-            \\\`\\\`\\\`bash
-            bin/ci-rerun-failures
-            \\\`\\\`\\\`
-
-            **Run specific failed specs:**
-            \\\`\\\`\\\`bash
-            pbpaste | bin/ci-run-failed-specs  # macOS
-            \\\`\\\`\\\`
-
-            **Switch between CI configurations:**
-            \\\`\\\`\\\`bash
-            bin/ci-switch-config minimum  # Test with Ruby 3.3, Node 20, etc.
-            bin/ci-switch-config latest   # Return to Ruby 4.0, Node 22, etc.
-            \\\`\\\`\\\`
-
-            ---
-
-            Legacy slash aliases were removed. Use \\\`+ci-*\\\` commands because GitHub's comment editor reserves \\\`/\\\` for built-in slash command autocomplete.
-
-            📖 For more details, see the [Contributing Guide](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md#using-comment-commands-to-trigger-ci)\`;
+            const body = [
+              "👋 It looks like you may have tried to use a CI command, but it doesn't match the available commands.",
+              ...invalidCmdsList,
+              '',
+              '## Available GitHub Comment Commands',
+              '',
+              '### 1. `+ci-run-hosted` - Request Optimized Hosted CI',
+              'Marks the PR ready for hosted GitHub Actions while keeping suite selection path-based.',
+              '',
+              '**What it does:**',
+              '- Dispatches hosted workflows for the current head SHA',
+              '- Adds the `ready-for-hosted-ci` label to persist hosted validation on future commits',
+              '- Lets `script/ci-changes-detector` choose the applicable suites',
+              '',
+              '**Requirements:**',
+              '- Must have write access to the repository',
+              '- Use at the start of a comment or after a newline',
+              '',
+              '**Example:**',
+              '```',
+              '+ci-run-hosted',
+              '```',
+              '',
+              '---',
+              '',
+              '### 2. `+ci-force-full` - Force Full Hosted CI',
+              'Bypasses optimized suite selection for the current head and future commits.',
+              '',
+              '**What it does:**',
+              '- Dispatches hosted workflows with `force_full_hosted: true`',
+              '- Adds both `ready-for-hosted-ci` and `force-full-hosted-ci`',
+              '',
+              '**Example:**',
+              '```',
+              '+ci-force-full',
+              '```',
+              '',
+              '---',
+              '',
+              '### 3. `+ci-stop-hosted` - Disable Hosted CI Mode',
+              'Removes hosted CI labels for future commits.',
+              '',
+              '**Requirements:**',
+              '- Must have write access to the repository',
+              '',
+              '**Example:**',
+              '```',
+              '+ci-stop-hosted',
+              '```',
+              '',
+              '---',
+              '',
+              '### 4. `+ci-stop-full` - Disable Only Force-Full Mode',
+              'Removes `force-full-hosted-ci` while leaving `ready-for-hosted-ci` in place if present.',
+              '',
+              '---',
+              '',
+              '### 5. `+ci-skip-hosted [reason]` - Record a Hosted CI Waiver',
+              'Records that a maintainer intentionally waived hosted CI for the current PR head SHA.',
+              '',
+              '**Example:**',
+              '```',
+              '+ci-skip-hosted docs-only change; markdown checks are enough',
+              '```',
+              '',
+              '---',
+              '',
+              '### 6. `@claude` - Claude Code AI Review',
+              'Invokes Claude Code AI to perform code review or answer questions.',
+              '',
+              '**What it does:**',
+              '- Analyzes code changes and provides feedback',
+              '- Follows instructions specified in the comment',
+              '- Can read CI results on PRs',
+              '',
+              '**Example:**',
+              '```',
+              '@claude please review the error handling in this PR',
+              '```',
+              '',
+              '---',
+              '',
+              '## Local CI Debugging',
+              '',
+              'Instead of using comment commands, you can replicate CI failures locally:',
+              '',
+              '**Check CI status:**',
+              '```bash',
+              'gh pr view --json statusCheckRollup',
+              '```',
+              '',
+              '**Re-run only failed jobs:**',
+              '```bash',
+              'bin/ci-rerun-failures',
+              '```',
+              '',
+              '**Run specific failed specs:**',
+              '```bash',
+              'pbpaste | bin/ci-run-failed-specs  # macOS',
+              '```',
+              '',
+              '**Switch between CI configurations:**',
+              '```bash',
+              'bin/ci-switch-config minimum  # Test with Ruby 3.3, Node 20, etc.',
+              'bin/ci-switch-config latest   # Return to Ruby 4.0, Node 22, etc.',
+              '```',
+              '',
+              '---',
+              '',
+              "Legacy slash aliases were removed. Use `+ci-*` commands because GitHub's comment editor reserves `/` for built-in slash command autocomplete.",
+              '',
+              '📖 For more details, see the [Contributing Guide](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md#using-comment-commands-to-trigger-ci)'
+            ].join('\n');
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Why

The post-merge smoke test for #4036 found that `/run-skipped-ci` correctly triggered `Detect Invalid CI Commands`, but the workflow failed before posting its migration/help response. The broken path mattered because maintainers and agents rely on that response to discover the supported `+ci-*` commands after the legacy slash commands were removed.

The immediate failure was a JavaScript syntax error in the large inline template literal used by the `Post helpful comment` GitHub Script step. A follow-up review also caught that the repaired workflow should satisfy stricter YAML linting, so this PR fixes both the broken script and the lint/style issue without changing the posted help text.

## What Changed

- Rebuilt the invalid-command help body from an array of strings instead of a huge escaped template literal.
- Added YAML lint compatibility for this workflow (`---`, quoted `"on"`, wrapped long lines).
- Preserved the generated invalid-command help comment body byte-for-byte from the first fixed implementation.
- Rebased onto current `main` before final validation so the PR diff is only `.github/workflows/detect-invalid-ci-commands.yml`.

## Test Plan

- Reproduced the pre-fix failure locally with `node --check` on the extracted `Post helpful comment` script.
- `node --check /tmp/detect-invalid-post-helpful-rebased.js`
- `ruby -e 'require "yaml"; YAML.safe_load_file(".github/workflows/detect-invalid-ci-commands.yml", permitted_classes: [], aliases: false)'`
- `actionlint .github/workflows/detect-invalid-ci-commands.yml`
- `/tmp/ror-yamllint-venv/bin/yamllint .github/workflows/detect-invalid-ci-commands.yml`
- `git diff --check origin/main..HEAD`
- Compared the generated invalid-command comment body before and after the review-fix commit; output was unchanged.
- `lefthook run pre-push`

## Post-Merge Verification

Post-merge verification continues in #4055. After this lands, rebase #4056 on current `main` and rerun `/run-skipped-ci` to verify the invalid-command helper posts the intended response instead of failing.

## Agent Merge Confidence

Mode: accelerated-rc
Current head SHA: cd24b25a9992175105bb37330b61e27e789a8594
Score: 9/10
Auto-merge recommendation: yes
Affected areas: CI workflow comment-command helper only; no runtime package code
CI detector: `script/ci-changes-detector origin/main` -> CI infrastructure, full test suite recommended, no benchmarks; merge base `9fa782c2f0cf55ed928cce54a43e99cf53ad4dbd`
Validation run:
- `ruby -e 'require "yaml"; YAML.safe_load_file(".github/workflows/detect-invalid-ci-commands.yml", permitted_classes: [], aliases: false)'` -> passed
- `actionlint .github/workflows/detect-invalid-ci-commands.yml` -> passed
- `/tmp/ror-yamllint-venv/bin/yamllint .github/workflows/detect-invalid-ci-commands.yml` -> passed
- extracted `Post helpful comment` script with Ruby/YAML and ran `node --check` -> passed
- generated invalid-command comment body comparison before/after review-fix commit -> unchanged
- `git diff --check origin/main..HEAD` -> passed
- `lefthook run pre-push` -> passed before force-push
Review/check gate:
- GitHub checks: complete for `cd24b25a9992175105bb37330b61e27e789a8594`; 22 success, 22 skipped, 0 pending, 0 failed. Skips are optimized hosted-CI skips for app/test suites not selected on this workflow-helper PR; workflow-specific `Lint GitHub Actions / actionlint`, `ci-required / required-pr-gate`, CodeQL, Claude, CodeRabbit, Cursor Bugbot all completed successfully.
- Review threads: GraphQL unresolved count is 0.
- Current-head reviewer verdicts:
  - Claude review: success for `cd24b25a9992175105bb37330b61e27e789a8594`, run https://github.com/shakacode/react_on_rails/actions/runs/27638908461
  - CodeRabbit: approved/current status success for `cd24b25a9992175105bb37330b61e27e789a8594`
  - Cursor Bugbot: success for `cd24b25a9992175105bb37330b61e27e789a8594`
- Stale reviewer verdicts, advisory only:
  - CodeRabbit `CHANGES_REQUESTED` for `284b41f415c5f0292ef4a0adf39122867c5bb4a3`; fixed by later commits and replaced by current-head approval/status.
Known residual risk: live `issue_comment` execution must still be verified post-merge on #4056 because workflow changes are only authoritative after merge; tracked in #4055.
Finalized by: Claude Code Review check run https://github.com/shakacode/react_on_rails/actions/runs/27638908461 for current head `cd24b25a9992175105bb37330b61e27e789a8594`
