### PR TITLE
Post-merge CI smoke: force-full hosted path

### DIFF
--- a/internal/planning/post-merge-ci-force-full-smoke.md
+++ b/internal/planning/post-merge-ci-force-full-smoke.md
@@ -5,3 +5,5 @@ Temporary audit marker for the hosted CI force-full path after PR #4036.
 This file exists only to create a harmless sacrificial pull request for
 post-merge verification. The PR should be closed unmerged after the audit
 evidence is recorded in #4055.
+
+Follow-up marker: verify `+ci-stop-full` leaves optimized hosted CI active.

--- a/internal/planning/post-merge-ci-force-full-smoke.md
+++ b/internal/planning/post-merge-ci-force-full-smoke.md
@@ -1,0 +1,7 @@
+# Post-Merge CI Force-Full Smoke
+
+Temporary audit marker for the hosted CI force-full path after PR #4036.
+
+This file exists only to create a harmless sacrificial pull request for
+post-merge verification. The PR should be closed unmerged after the audit
+evidence is recorded in #4055.


### PR DESCRIPTION
## Why

This is a sacrificial post-merge audit PR for #4055. PR #4036 changed hosted CI from old labels/full-CI vocabulary to explicit comment commands. Phase 1 verified optimized hosted CI and invalid-command guidance; this PR exists only to verify the force-full hosted path on default-branch workflow code.

The PR should be closed unmerged after the evidence is recorded in #4055.

## What Changed

- Adds one temporary internal planning marker file.
- Does not change product code, CI logic, docs published to users, or release behavior.

## Audit Plan

- Use `+ci-force-full` to verify both `ready-for-hosted-ci` and `force-full-hosted-ci` are added.
- Verify the command dispatches hosted workflows with force-full behavior.
- Verify benchmark suites remain opt-in and are not implied by force-full hosted CI.
- Use `+ci-stop-full` to verify only `force-full-hosted-ci` is removed.
- Push a tiny follow-up docs-only change to verify `ready-for-hosted-ci` remains and future pushes use optimized hosted CI.

## Test Plan

- `lefthook run pre-push`
- GitHub Actions evidence will be linked in #4055.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only internal marker with no runtime or CI logic changes.
> 
> **Overview**
> Adds **`internal/planning/post-merge-ci-force-full-smoke.md`**, a temporary internal note so maintainers can open a **harmless sacrificial PR** to audit the hosted CI **`+ci-force-full`** / **`+ci-stop-full`** path after #4036 (#4055).
> 
> **No** application code, workflow definitions, user docs, or release behavior change. The PR is meant to be **closed unmerged** once audit evidence is captured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266dfa9179e25976e39188736bd58e4a450717c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->