### PR TITLE
Post-merge CI smoke: release-target base detection

### DIFF
--- a/internal/planning/post-merge-ci-release-target-smoke.md
+++ b/internal/planning/post-merge-ci-release-target-smoke.md
@@ -1,0 +1,7 @@
+# Post-Merge CI Release-Target Smoke
+
+Temporary audit marker for PR base detection against a non-main target branch.
+
+This file exists only to create a harmless sacrificial pull request targeting
+`jg-codex/release-target-audit-base`. Close the PR unmerged after evidence is
+recorded in #4055.


### PR DESCRIPTION
## Why

This is a sacrificial post-merge audit PR for #4055. It targets a temporary non-main base branch so humans and agents can verify that local CI and GitHub selectors discover the actual PR base automatically instead of assuming `origin/main`.

The PR should be closed unmerged after the release-target base-detection evidence is recorded in #4055. The temporary base branch should be deleted after cleanup.

## What Changed

- Adds one temporary internal planning marker file.
- Does not change product code, CI logic, docs published to users, or release behavior.

## Audit Plan

- Verify `gh pr view` reports base `jg-codex/release-target-audit-base`.
- Verify `bin/ci-local` auto-detects `origin/jg-codex/release-target-audit-base`.
- Verify `script/ci-changes-detector` compares against the actual PR base.
- Verify agents do not need to ask maintainers for a manual `<base-ref>` in normal PR validation.

## Test Plan

- `lefthook run pre-push`
- Local base-detection commands will be recorded in #4055.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only internal marker with no runtime, CI logic, or release changes.
> 
> **Overview**
> Adds a **temporary** internal planning note at `internal/planning/post-merge-ci-release-target-smoke.md` so a sacrificial PR can target `jg-codex/release-target-audit-base` instead of `main`.
> 
> The file documents that the PR is for #4055 audit only (CI/base-ref auto-detection) and should be **closed unmerged** after evidence is captured. **No** product code, CI scripts, user docs, or release behavior are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8ca73dada8a2c06d61fb27a7f1cb2fdbdd4662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->