### PR TITLE
Fix ci-local detector JSON parsing

### DIFF
--- a/bin/ci-local
+++ b/bin/ci-local
@@ -173,6 +173,10 @@ if [ "$RUN_ALL" = false ]; then
     DETECTOR_JSON=$(
       CI_JSON_OUTPUT=1 script/ci-changes-detector "$BASE_REF" 2>&1 |
         awk '
+          # Relies on the detector emitting "{" and "}" as exact standalone
+          # lines (its current bare-echo/heredoc JSON format). A trailing
+          # carriage return is stripped first so CRLF checkouts still match.
+          # A nested or indented "{" would need brace counting instead.
           { line = $0; sub(/\r$/, "", line) }
           line == "{" && !seen_json { in_json = 1; seen_json = 1 }
           in_json { print line }

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -167,8 +167,17 @@ if [ "$RUN_ALL" = false ]; then
 
   # Try JSON output first (if jq is available)
   if command -v jq >/dev/null 2>&1; then
-    # Get JSON output (hide from stdout)
-    DETECTOR_JSON=$(CI_JSON_OUTPUT=1 script/ci-changes-detector "$BASE_REF" 2>&1 | grep -E '^\{|^\s|^\}' | tr -d '\n')
+    # Get JSON output (hide from stdout). The detector also emits human-readable
+    # context, so extract the JSON object as a block instead of scraping by
+    # indentation.
+    DETECTOR_JSON=$(
+      CI_JSON_OUTPUT=1 script/ci-changes-detector "$BASE_REF" 2>&1 |
+        awk '
+          $0 == "{" && !seen_json { in_json = 1; seen_json = 1 }
+          in_json { print }
+          $0 == "}" && in_json { in_json = 0 }
+        '
+    )
 
     if [ -n "$DETECTOR_JSON" ] && echo "$DETECTOR_JSON" | jq -e . >/dev/null 2>&1; then
       # Show human-readable output

--- a/bin/ci-local
+++ b/bin/ci-local
@@ -173,9 +173,10 @@ if [ "$RUN_ALL" = false ]; then
     DETECTOR_JSON=$(
       CI_JSON_OUTPUT=1 script/ci-changes-detector "$BASE_REF" 2>&1 |
         awk '
-          $0 == "{" && !seen_json { in_json = 1; seen_json = 1 }
-          in_json { print }
-          $0 == "}" && in_json { in_json = 0 }
+          { line = $0; sub(/\r$/, "", line) }
+          line == "{" && !seen_json { in_json = 1; seen_json = 1 }
+          in_json { print line }
+          line == "}" && in_json { in_json = 0 }
         '
     )
 


### PR DESCRIPTION
## Why

The #4036 post-merge audit proved that `bin/ci-local` correctly auto-detects a PR's base ref, but it also exposed a local usability regression: when `jq` is installed, `bin/ci-local` still printed `JSON parsing failed, using text parsing` because `script/ci-changes-detector` emits human-readable context around its JSON block and `bin/ci-local` tried to scrape JSON by indentation.

That warning makes the documented human/agent local-CI path look less reliable than it is, and it quietly pushes the runner onto the fragile text parser even when structured detector output is available. This PR keeps the detector output contract unchanged and fixes the local runner to extract the JSON object as a block before passing it to `jq`.

Linked audit: #4055

## Summary

- Replaces the indentation-based `grep | tr` JSON scrape in `bin/ci-local` with an `awk` block extractor.
- Extracts only the first JSON object while consuming the full detector stream, preserving `set -euo pipefail` behavior.
- Leaves the existing text fallback in place for malformed or missing JSON.

## Verification

Red check before the fix:

```bash
set +e
output=$(bin/ci-local --changed 2>&1)
rc=$?
printf '%s\n' "$output"
if printf '%s\n' "$output" | grep -q 'JSON parsing failed'; then
  echo 'RED: bin/ci-local unexpectedly fell back from JSON parsing' >&2
  exit 1
fi
exit "$rc"
```

Result: failed as expected with `JSON parsing failed, using text parsing`.

Green/current checks:

```bash
CI=true bin/ci-local --changed
bash -n bin/ci-local script/ci-changes-detector script/ci-changes-detector-test.bash script/lib/git-diff-base-test.bash
git diff --check
bash script/ci-changes-detector-test.bash
bash script/lib/git-diff-base-test.bash
codex review --uncommitted
```

Results:

- `CI=true bin/ci-local --changed` exited through the docs/no-changes path with no JSON fallback warning.
- Shell syntax and `git diff --check` passed.
- `script/ci-changes-detector-test.bash`: 49 run, 0 failed.
- `script/lib/git-diff-base-test.bash`: 41 run, 0 failed.
- `codex review --uncommitted`: no actionable regressions found.
- Pre-commit hook passed.
- Pre-push hook passed.

## Labels

Labels: none. This changes a local helper script, and hosted CI does not exercise `bin/ci-local`; the targeted local shell and detector harnesses above are the relevant proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local-only change to how `bin/ci-local` reads detector stdout; no hosted CI or product runtime impact, with existing text fallback preserved.
> 
> **Overview**
> When `jq` is available, **`bin/ci-local` no longer mis-parses** `script/ci-changes-detector` output and spuriously warns `JSON parsing failed, using text parsing`.
> 
> The old pipeline used `grep`/`tr` to scrape JSON by indentation, which broke once the detector printed human-readable lines around its JSON block. The fix pipes `CI_JSON_OUTPUT=1` output through **`awk`** that captures the first object delimited by standalone `{` and `}` lines (with CRLF trimming), then validates with `jq` as before. The text fallback path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a017d3138bce1f8a12f3879e015cfe0dacdebcba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved change detection robustness in the CI pipeline for better handling of cross-platform checkouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Criteria

Status: ready to merge under maintainer-delegated merge authority from the Codex thread on 2026-06-20.

- Head SHA verified: `a017d3138bce1f8a12f3879e015cfe0dacdebcba`.
- Base / release gate: targets `main`; release tracker #3823 `Agent Release Mode` block reads `Mode: development`. `agent-coord doctor/status` timed out, so backend phase was not used.
- CI: `.agents/skills/pr-batch/bin/pr-ci-readiness 4061 --repo shakacode/react_on_rails` returned `READY`; `gh pr checks` showed 22 pass / 22 skipping and no failing or pending checks.
- Reviews: current-head review-thread scan found 0 unresolved threads and 0 changes-requested review objects.
- Ledger: `script/pr-merge-ledger 4061 --repo shakacode/react_on_rails --changelog-classification not_user_visible --strict` passed with `complete_allowed: true`, 0 unknown fields, and 0 violations.
- Changelog: not required; this is contributor tooling only.
- Merge method: repository allows squash only; merge should use `--squash --match-head-commit a017d3138bce1f8a12f3879e015cfe0dacdebcba`.
