### PR TITLE
Document health-probe status-code contract and Control Plane probes (#4053)

### DIFF
--- a/docs/oss/building-features/node-renderer/health-checks.md
+++ b/docs/oss/building-features/node-renderer/health-checks.md
@@ -246,19 +246,40 @@ always fails against these endpoints — use a **Command** probe with an h2c-awa
 inside the container, so the default `localhost` binding works and no `0.0.0.0` host is required.
 
 Use `/health` (always `200`) for liveness and readiness by default so a normal cold start cannot fail the workload
-before the first render compiles a bundle:
+before the first render compiles a bundle. Control Plane uses the Kubernetes-style `readinessProbe` / `livenessProbe`
+fields on the workload container (the same shape as the [Kubernetes example above](#kubernetes-probes) and the
+existing [Control Plane deployment docs](../../deployment/docker-deployment.md#deploying-with-control-plane)), with a Command
+probe expressed as `exec.command`:
 
 ```yaml
-# Control Plane workload — readiness / liveness as a Command probe
-readiness:
-  exec:
-    command:
-      - curl
-      - -sf
-      - --max-time
-      - '3'
-      - --http2-prior-knowledge
-      - http://localhost:3800/health
+kind: workload
+spec:
+  containers:
+    - name: node-renderer
+      # ... image, ports, env (RENDERER_ENABLE_HEALTH_ENDPOINTS: 'true') ...
+      # Command probe — h2c-aware curl against /health (always 200).
+      readinessProbe:
+        exec:
+          command:
+            - curl
+            - -sf
+            - --max-time
+            - '3'
+            - --http2-prior-knowledge
+            - http://localhost:3800/health
+        periodSeconds: 5
+        failureThreshold: 3
+      livenessProbe:
+        exec:
+          command:
+            - curl
+            - -sf
+            - --max-time
+            - '3'
+            - --http2-prior-knowledge
+            - http://localhost:3800/health
+        periodSeconds: 10
+        failureThreshold: 3
 ```
 
 Do **not** point a `--fail` Command probe at `/ready` unless something pre-warms the renderer, or the probe will fail

--- a/docs/oss/building-features/node-renderer/health-checks.md
+++ b/docs/oss/building-features/node-renderer/health-checks.md
@@ -269,6 +269,7 @@ spec:
             - http://localhost:3800/health
         periodSeconds: 5
         failureThreshold: 3
+        timeoutSeconds: 5 # exceed curl --max-time 3 so the probe, not the orchestrator, owns the timeout
       livenessProbe:
         exec:
           command:
@@ -280,6 +281,7 @@ spec:
             - http://localhost:3800/health
         periodSeconds: 10
         failureThreshold: 3
+        timeoutSeconds: 5 # exceed curl --max-time 3 so the probe, not the orchestrator, owns the timeout
 ```
 
 Do **not** point a `--fail` Command probe at `/ready` unless something pre-warms the renderer, or the probe will fail

--- a/docs/oss/building-features/node-renderer/health-checks.md
+++ b/docs/oss/building-features/node-renderer/health-checks.md
@@ -20,6 +20,24 @@ routes outside the authenticated render and asset endpoints and do not require t
 probes cannot carry it). Keep the renderer on `localhost` or private networking as usual; see
 [Network Security](./basics.md#network-security).
 
+## Status-Code Contract
+
+Probe tooling that uses `curl --fail` / `-f` (which `-sf` and `-fsS` both include) exits non-zero on any HTTP status
+`>= 400`. Whether `--fail` is safe therefore depends on which endpoint you probe:
+
+| Endpoint  | Status codes                                                           | Safe with `curl --fail` / `-f`?                                                                 |
+| --------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `/health` | Always `200` (process can answer)                                      | **Yes** — never non-2xx.                                                                        |
+| `/info`   | Always `200` (returns Node and renderer versions)                      | **Yes** — never non-2xx.                                                                        |
+| `/ready`  | `200` once a bundle is compiled; `503` `waiting_for_bundle` until then | **Only with a warm-up path.** Without one, `-f` turns the cold-start `503` into a failed probe. |
+
+> **Why `curl -fsS .../ready` can break container startup:** during the cold-start window `/ready` returns `503`
+> (`{"status":"waiting_for_bundle"}`) until the answering worker compiles its first bundle, and `-f`/`--fail` turns
+> that `503` into a non-zero exit. If that command gates startup/readiness and nothing pre-warms the renderer, the
+> probe never passes and the container never becomes ready. This is the `503` working as designed, not a bug — see
+> [Gating traffic on `/ready`](#gating-traffic-on-ready). For a probe that must always pass once the process is up,
+> point `--fail` at `/health` (or `/info`); reserve `--fail` against `/ready` for setups with a warm-up path.
+
 ## Enabling the Endpoints
 
 The endpoints are **off by default**. Enable them with the `enableHealthEndpoints` config option or the
@@ -219,6 +237,34 @@ services:
       retries: 5
       start_period: 10s
 ```
+
+## Control Plane (CPLN)
+
+Control Plane exposes two relevant probe shapes: an **HTTP** probe and a **Command** (exec) probe. The HTTP probe is
+HTTP/1.1 and **cannot speak the renderer's h2c listener** (see [h2c](#h2c-why-httpget-probes-do-not-work)), so it
+always fails against these endpoints — use a **Command** probe with an h2c-aware curl instead. Command probes run
+inside the container, so the default `localhost` binding works and no `0.0.0.0` host is required.
+
+Use `/health` (always `200`) for liveness and readiness by default so a normal cold start cannot fail the workload
+before the first render compiles a bundle:
+
+```yaml
+# Control Plane workload — readiness / liveness as a Command probe
+readiness:
+  exec:
+    command:
+      - curl
+      - -sf
+      - --max-time
+      - '3'
+      - --http2-prior-knowledge
+      - http://localhost:3800/health
+```
+
+Do **not** point a `--fail` Command probe at `/ready` unless something pre-warms the renderer, or the probe will fail
+on the cold-start `503` and the workload never becomes ready (the exact failure in
+[Status-Code Contract](#status-code-contract)). Only switch the path to `/ready` once a warm-up path delivers the
+first render to every worker that answers probes — see [Gating traffic on `/ready`](#gating-traffic-on-ready).
 
 ## Semantics and Caveats
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15507,6 +15507,7 @@ spec:
             - http://localhost:3800/health
         periodSeconds: 5
         failureThreshold: 3
+        timeoutSeconds: 5 # exceed curl --max-time 3 so the probe, not the orchestrator, owns the timeout
       livenessProbe:
         exec:
           command:
@@ -15518,6 +15519,7 @@ spec:
             - http://localhost:3800/health
         periodSeconds: 10
         failureThreshold: 3
+        timeoutSeconds: 5 # exceed curl --max-time 3 so the probe, not the orchestrator, owns the timeout
 ```
 
 Do **not** point a `--fail` Command probe at `/ready` unless something pre-warms the renderer, or the probe will fail

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15258,6 +15258,24 @@ routes outside the authenticated render and asset endpoints and do not require t
 probes cannot carry it). Keep the renderer on `localhost` or private networking as usual; see
 [Network Security](./basics.md#network-security).
 
+## Status-Code Contract
+
+Probe tooling that uses `curl --fail` / `-f` (which `-sf` and `-fsS` both include) exits non-zero on any HTTP status
+`>= 400`. Whether `--fail` is safe therefore depends on which endpoint you probe:
+
+| Endpoint  | Status codes                                                           | Safe with `curl --fail` / `-f`?                                                                 |
+| --------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `/health` | Always `200` (process can answer)                                      | **Yes** — never non-2xx.                                                                        |
+| `/info`   | Always `200` (returns Node and renderer versions)                      | **Yes** — never non-2xx.                                                                        |
+| `/ready`  | `200` once a bundle is compiled; `503` `waiting_for_bundle` until then | **Only with a warm-up path.** Without one, `-f` turns the cold-start `503` into a failed probe. |
+
+> **Why `curl -fsS .../ready` can break container startup:** during the cold-start window `/ready` returns `503`
+> (`{"status":"waiting_for_bundle"}`) until the answering worker compiles its first bundle, and `-f`/`--fail` turns
+> that `503` into a non-zero exit. If that command gates startup/readiness and nothing pre-warms the renderer, the
+> probe never passes and the container never becomes ready. This is the `503` working as designed, not a bug — see
+> [Gating traffic on `/ready`](#gating-traffic-on-ready). For a probe that must always pass once the process is up,
+> point `--fail` at `/health` (or `/info`); reserve `--fail` against `/ready` for setups with a warm-up path.
+
 ## Enabling the Endpoints
 
 The endpoints are **off by default**. Enable them with the `enableHealthEndpoints` config option or the
@@ -15457,6 +15475,55 @@ services:
       retries: 5
       start_period: 10s
 ```
+
+## Control Plane (CPLN)
+
+Control Plane exposes two relevant probe shapes: an **HTTP** probe and a **Command** (exec) probe. The HTTP probe is
+HTTP/1.1 and **cannot speak the renderer's h2c listener** (see [h2c](#h2c-why-httpget-probes-do-not-work)), so it
+always fails against these endpoints — use a **Command** probe with an h2c-aware curl instead. Command probes run
+inside the container, so the default `localhost` binding works and no `0.0.0.0` host is required.
+
+Use `/health` (always `200`) for liveness and readiness by default so a normal cold start cannot fail the workload
+before the first render compiles a bundle. Control Plane uses the Kubernetes-style `readinessProbe` / `livenessProbe`
+fields on the workload container (the same shape as the [Kubernetes example above](#kubernetes-probes) and the
+existing [Control Plane deployment docs](../../deployment/docker-deployment.md#deploying-with-control-plane)), with a Command
+probe expressed as `exec.command`:
+
+```yaml
+kind: workload
+spec:
+  containers:
+    - name: node-renderer
+      # ... image, ports, env (RENDERER_ENABLE_HEALTH_ENDPOINTS: 'true') ...
+      # Command probe — h2c-aware curl against /health (always 200).
+      readinessProbe:
+        exec:
+          command:
+            - curl
+            - -sf
+            - --max-time
+            - '3'
+            - --http2-prior-knowledge
+            - http://localhost:3800/health
+        periodSeconds: 5
+        failureThreshold: 3
+      livenessProbe:
+        exec:
+          command:
+            - curl
+            - -sf
+            - --max-time
+            - '3'
+            - --http2-prior-knowledge
+            - http://localhost:3800/health
+        periodSeconds: 10
+        failureThreshold: 3
+```
+
+Do **not** point a `--fail` Command probe at `/ready` unless something pre-warms the renderer, or the probe will fail
+on the cold-start `503` and the workload never becomes ready (the exact failure in
+[Status-Code Contract](#status-code-contract)). Only switch the path to `/ready` once a warm-up path delivers the
+first render to every worker that answers probes — see [Gating traffic on `/ready`](#gating-traffic-on-ready).
 
 ## Semantics and Caveats
 


### PR DESCRIPTION
## Why

Issue #4053: the recommended renderer readiness probe `curl --http2-prior-knowledge -fsS http://localhost:3800/ready` breaks container startup. The container never becomes ready; removing `-fsS` "fixes" it (but then the probe always passes, defeating its purpose).

**Root cause (confirmed in `worker.ts`):** `-f`/`--fail` makes curl exit non-zero on any HTTP status `>= 400`, and `/ready` returns `503 {"status":"waiting_for_bundle"}` during the cold-start window until the answering worker compiles its first bundle. A `--fail` probe against `/ready` with no warm-up path therefore deadlocks startup. This is intended gating behavior — but the docs lacked an explicit per-endpoint status-code contract and any Control Plane guidance, so the reporter hit the deadlock without a clear answer.

Endpoint contract (from [`worker.ts`](packages/react-on-rails-pro-node-renderer/src/worker.ts)):
- `/health` → always `200`
- `/info` → always `200`
- `/ready` → `200` once a bundle is compiled, else `503`

## What changed

Documentation only — `docs/oss/building-features/node-renderer/health-checks.md`:

1. **Status-Code Contract** section with a per-endpoint table and a callout explaining exactly why `curl -fsS .../ready` breaks startup, and what to probe instead (`/health` or `/info` for an always-passes probe; reserve `--fail` against `/ready` for setups with a warm-up path).
2. **Control Plane (CPLN)** section: CPLN exposes HTTP and Command (exec) probes; the HTTP probe is HTTP/1.1 and cannot speak the renderer's h2c listener, so use a Command probe with h2c-aware curl against `/health` by default, switching to `/ready` only with a warm-up path.

This addresses all three of the issue's requests: a probe command that works, the `/ready`+`/info` status-code contract, and the CPLN-specific probe options.

## Validation

- `npx prettier --check` passes on the changed file.
- Docs-only; no CHANGELOG entry per `.claude/docs/changelog-guidelines.md` (docs fixes excluded).

Fixes #4053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or deployment code modifications.
> 
> **Overview**
> Documents why **`curl --fail` against `/ready`** can deadlock container readiness during cold start, and how to probe safely.
> 
> Adds a **Status-Code Contract** table for `/health`, `/info`, and `/ready` (including when `503 waiting_for_bundle` is expected) plus guidance to use **`/health` or `/info`** for probes that must pass once the process is up, and **`/ready` with `--fail` only when a warm-up path** compiles the first bundle.
> 
> Adds a **Control Plane (CPLN)** section explaining that HTTP probes cannot use the renderer’s **h2c** listener, with example **`exec` Command probes** using h2c-aware `curl` against `/health` for readiness and liveness. The same content is mirrored in **`llms-full.txt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ae833c226a1196736c6047d019bce97e579154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Status-Code Contract” describing expected HTTP responses for health endpoints, including when `/ready` may return `503` during cold start
  * Expanded guidance on `curl --fail`/`-f`/`-fsS`, warning against using `/ready` as a failing readiness gate without a warm-up path
  * Added Control Plane-specific probe instructions and example probe shapes to match connectivity constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence (coordinator)

**Merged by Claude Code coordinator under explicit maintainer (justin808) delegation** — "merge authorization if confident + documented."

- **Confidence: HIGH.** Docs-only (`docs/oss/.../health-checks.md`) + regenerated `llms-full.txt`.
- **Rebased** onto merged #4087 (Group B, generated `llms-full.txt` serialization); `llms-full.txt` regenerated via `node script/generate-llms-full.mjs` — regeneration produced zero diff and the `--check` guard passes (auto-merge was correct).
- **Doc accuracy verified vs source:** `/health`→200, `/ready`→200/503 `waiting_for_bundle` confirmed against `packages/react-on-rails-pro-node-renderer/src/worker.ts`; CPLN probe schema confirmed against `react_on_rails_pro/.controlplane/rails.yml`.
- **Current-head review threads triaged against the actual file (not merged blind):** the recurring CodeRabbit/claude/codex "missing `timeoutSeconds`" and greptile "missing liveness probe" flags are **stale/incorrect** — the CPLN snippet already contains `timeoutSeconds: 5` on both `readinessProbe` and `livenessProbe`. `startupProbe` omission is intentional and safe (probes `/health`, always 200; cold start cannot misfire). The `-sfS` and localhost-qualification notes are advisory/misreads. No actionable must-fix remained.
- **CI:** `mergeStateStatus: CLEAN`, all checks pass/skip. **Merge ledger** sole hard violation `unknown_review_decision` — overridden by maintainer merge delegation. Changelog `not_user_visible`.
- **Cross-batch:** Batch-1 #4037 also touches `llms-full.txt` and must rebase+regenerate after this merge.
