### PR TITLE
Update CHANGELOG.md for 17.0.0.rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+### [17.0.0.rc.5] - 2026-06-16
+
 #### Fixed
 
 - **[Pro]** **RSC and client-only FOUC reveal gating**: Pro now waits for auto-loaded generated component stylesheets before mounting client-only roots and promotes streamed RSC client chunk stylesheet preloads to real stylesheet links before reveal, including when stream chunks split `<link>` tags. Shared generated CSS is matched through manifest-derived stylesheet href metadata, while app-authored preload links remain untouched. Fixes [Issue 4031](https://github.com/shakacode/react_on_rails/issues/4031), [Issue 4032](https://github.com/shakacode/react_on_rails/issues/4032). [PR 4047](https://github.com/shakacode/react_on_rails/pull/4047) by [justin808](https://github.com/justin808).
@@ -2320,7 +2322,8 @@ such as:
 
 - Fix several generator-related issues.
 
-[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.4...main
+[unreleased]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.5...main
+[17.0.0.rc.5]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.4...v17.0.0.rc.5
 [17.0.0.rc.4]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.3...v17.0.0.rc.4
 [17.0.0.rc.3]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.2...v17.0.0.rc.3
 [17.0.0.rc.2]: https://github.com/shakacode/react_on_rails/compare/v17.0.0.rc.1...v17.0.0.rc.2


### PR DESCRIPTION
## Summary

Stamps the `17.0.0.rc.5` changelog header ahead of the release.

This collects the work merged since `v17.0.0.rc.4` (2026-06-14). A classification sweep of all 14 merged PRs in `v17.0.0.rc.4..origin/main` found exactly one user-visible change:

- **[Pro]** RSC and client-only FOUC reveal gating ([PR 4047](https://github.com/shakacode/react_on_rails/pull/4047)) — already present under `[Unreleased]`, now moved under the new `17.0.0.rc.5` header.

The other 13 PRs were all maintainer/agent tooling, CI-command workflows, and docs (release-process / internal), so no new entries were added.

## Changes

- Inserted `### [17.0.0.rc.5] - 2026-06-16` immediately after `### [Unreleased]`.
- Moved the existing Pro FOUC reveal-gating entry under the new header.
- Updated compare links: `[unreleased]` → `v17.0.0.rc.5...main`; added `[17.0.0.rc.5]` → `v17.0.0.rc.4...v17.0.0.rc.5`.
- Prior RC sections (`rc.4`…`rc.0`) and their compare links left intact (RC sections are coalesced only at the stable release).

## Next step

After merge, run `rake release` (no args) — it reads `17.0.0.rc.5` from CHANGELOG.md and auto-creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and release-link updates with no application code impact.
> 
> **Overview**
> Prepares **17.0.0.rc.5** (2026-06-16) in `CHANGELOG.md` by adding the version section and moving the existing **[Pro] RSC and client-only FOUC reveal gating** fix (PR 4047) out of `[Unreleased]`.
> 
> Compare links are updated so `[unreleased]` points at `v17.0.0.rc.5...main` and a new `[17.0.0.rc.5]` link covers `v17.0.0.rc.4...v17.0.0.rc.5`. No runtime or library code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ad04952de2144934cc1e96421030bbc45e6491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog documentation to prepare for version 17.0.0.rc.5 release with updated version comparison references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->