### PR TITLE
Fail Claude review job on invalid/expired token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,37 +44,38 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
-      # The action exits 0 even when the review never ran (e.g. an invalid or
-      # expired CLAUDE_CODE_OAUTH_TOKEN makes the first API call fail in <1s at
-      # $0). Without this gate the check reports a misleading "pass". Inspect the
-      # execution output and fail the job when no real review was produced.
+      # The action exits 0 even when the review never ran: an invalid or expired
+      # CLAUDE_CODE_OAUTH_TOKEN makes the first API call fail in <1s at $0 cost,
+      # yet the result still reports a green "pass" and posts no review. Inspect
+      # the execution output and fail only that silent-success case.
+      #
+      # Scoped to outcome == 'success' on purpose. When the action itself fails
+      # (missing token on Dependabot PRs, the "workflow validation failed" safety
+      # skip on PRs that edit this file, a real action error) the job is already
+      # red and the action prints its own message — re-failing here would only
+      # add a misleading one. And a successful run that legitimately skips Claude
+      # (so emits no execution_file/result) is treated as a pass, not a failure.
       - name: Verify review completed (fail on invalid/expired token)
-        if: always() && steps.claude-review.outcome != 'skipped'
+        if: steps.claude-review.outcome == 'success'
         env:
-          REVIEW_OUTCOME: ${{ steps.claude-review.outcome }}
           EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
         run: |
-          set -uo pipefail
-
-          fail() { echo "::error::$1"; exit 1; }
+          set -euo pipefail
           TOKEN_HINT="Rotate CLAUDE_CODE_OAUTH_TOKEN with 'claude setup-token' and update the repo secret."
 
-          # The action step itself failed (e.g. env-var validation when the token
-          # is empty, as happens on Dependabot PRs that can't read the secret).
-          if [ "$REVIEW_OUTCOME" != "success" ]; then
-            fail "Claude review step did not succeed (outcome: $REVIEW_OUTCOME). If this is an auth error: $TOKEN_HINT"
-          fi
-
-          # No execution output means the review never produced anything.
+          # No execution output: the action skipped Claude (e.g. the workflow-
+          # validation safety skip). Nothing was claimed to run — let it pass.
           if [ -z "${EXECUTION_FILE:-}" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            fail "Claude review produced no execution output — the review did not run. This usually means the token is missing, invalid, or expired. $TOKEN_HINT"
+            echo "No execution output found; the action skipped Claude. Nothing to verify."
+            exit 0
           fi
 
           # The execution file may be a JSON array or newline-delimited JSON;
           # slurp + flatten handles both, then grab the final result record.
           result=$(jq -s 'flatten | map(select(type == "object" and .type == "result")) | last' "$EXECUTION_FILE" 2>/dev/null || echo null)
           if [ "$result" = "null" ] || [ -z "$result" ]; then
-            fail "Claude review did not produce a result record — the review did not complete (often an invalid or expired token). $TOKEN_HINT"
+            echo "No result record in execution output; nothing to verify."
+            exit 0
           fi
 
           is_error=$(echo "$result" | jq -r '.is_error // false')
@@ -85,5 +86,6 @@ jobs:
           # is_error=true with $0 cost and a single turn is the signature of an
           # invalid/expired token, but any is_error means the review failed.
           if [ "$is_error" = "true" ]; then
-            fail "Claude review failed (is_error=true, cost=$cost, turns=$turns). This usually means the token is invalid or expired. $TOKEN_HINT"
+            echo "::error::Claude review failed (is_error=true, cost=$cost, turns=$turns). This usually means the token is invalid or expired. $TOKEN_HINT"
+            exit 1
           fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,3 +43,47 @@ jobs:
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The action exits 0 even when the review never ran (e.g. an invalid or
+      # expired CLAUDE_CODE_OAUTH_TOKEN makes the first API call fail in <1s at
+      # $0). Without this gate the check reports a misleading "pass". Inspect the
+      # execution output and fail the job when no real review was produced.
+      - name: Verify review completed (fail on invalid/expired token)
+        if: always() && steps.claude-review.outcome != 'skipped'
+        env:
+          REVIEW_OUTCOME: ${{ steps.claude-review.outcome }}
+          EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+
+          fail() { echo "::error::$1"; exit 1; }
+          TOKEN_HINT="Rotate CLAUDE_CODE_OAUTH_TOKEN with 'claude setup-token' and update the repo secret."
+
+          # The action step itself failed (e.g. env-var validation when the token
+          # is empty, as happens on Dependabot PRs that can't read the secret).
+          if [ "$REVIEW_OUTCOME" != "success" ]; then
+            fail "Claude review step did not succeed (outcome: $REVIEW_OUTCOME). If this is an auth error: $TOKEN_HINT"
+          fi
+
+          # No execution output means the review never produced anything.
+          if [ -z "${EXECUTION_FILE:-}" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            fail "Claude review produced no execution output — the review did not run. This usually means the token is missing, invalid, or expired. $TOKEN_HINT"
+          fi
+
+          # The execution file may be a JSON array or newline-delimited JSON;
+          # slurp + flatten handles both, then grab the final result record.
+          result=$(jq -s 'flatten | map(select(type == "object" and .type == "result")) | last' "$EXECUTION_FILE" 2>/dev/null || echo null)
+          if [ "$result" = "null" ] || [ -z "$result" ]; then
+            fail "Claude review did not produce a result record — the review did not complete (often an invalid or expired token). $TOKEN_HINT"
+          fi
+
+          is_error=$(echo "$result" | jq -r '.is_error // false')
+          cost=$(echo "$result" | jq -r '.total_cost_usd // 0')
+          turns=$(echo "$result" | jq -r '.num_turns // 0')
+          echo "Claude review result: is_error=$is_error total_cost_usd=$cost num_turns=$turns"
+
+          # is_error=true with $0 cost and a single turn is the signature of an
+          # invalid/expired token, but any is_error means the review failed.
+          if [ "$is_error" = "true" ]; then
+            fail "Claude review failed (is_error=true, cost=$cost, turns=$turns). This usually means the token is invalid or expired. $TOKEN_HINT"
+          fi


### PR DESCRIPTION
## Problem

The `claude-review` check reports a green **pass** even when the review never ran. An invalid or expired `CLAUDE_CODE_OAUTH_TOKEN` makes Claude Code's first API call fail in under a second at `$0` cost, but `anthropics/claude-code-action@v1` still exits `0` and posts no review. This silently masked ~10 open PRs that received no review (the token had expired and nobody noticed because every check was green).

Result signature of the silent failure:

```json
{ "type": "result", "subtype": "success",
  "is_error": true, "duration_ms": 393, "num_turns": 1, "total_cost_usd": 0 }
```

The action exposes no `conclusion` output, so nothing was inspecting this.

## Fix

Add a gate step that reads the action's `execution_file` output and fails the job when the review did not actually complete:

- the action step's outcome is not `success` (e.g. env-var validation failure when the token is empty), **or**
- no execution output / no `result` record was produced, **or**
- the final result has `is_error: true` (the auth-failure signature).

The error message points at rotating the token (`claude setup-token` + update the repo secret). Action outcome/output values are passed via `env:` and referenced as shell variables, avoiding script injection.

Verified the `jq` parsing handles both JSONL and JSON-array execution-file formats, and that a healthy review (`is_error: false`, non-zero cost) passes while the broken signature fails.

## Note

This makes the review a meaningful signal: a transient Anthropic API error mid-review would now fail the job too (rerun fixes it). That tradeoff is intended — silent green was the worse failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no production code; may fail the job on any `is_error` result, including transient API errors until rerun.
> 
> **Overview**
> Fixes **silent green checks** when `anthropics/claude-code-action` exits successfully but never posts a review (e.g. invalid/expired `CLAUDE_CODE_OAUTH_TOKEN` → fast `$0` failure with `is_error: true`).
> 
> Adds **Verify review completed** after a successful review step: reads `execution_file`, parses the final `type: "result"` record (JSON or JSONL), and **fails the job** when `is_error` is true, with a hint to rotate the secret via `claude setup-token`. Runs only when the review step outcome is `success`; missing execution output or no result record is treated as a pass (intentional skips). Transient API errors mid-review will also fail the job until rerun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4cedf54702cac951d9f4ce2e60897a3a83dc608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow validation for code review runs.
  * Added checks to ensure review output is present and correctly interpretable before proceeding.
  * Enhanced failure reporting by surfacing review error signals and providing guidance for token-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->