### PR TITLE
docs(pro): convert streaming-ssr.md Mermaid diagrams to polished SVGs (#3804 Part A)

### DIFF
--- a/docs/pro/images/async-props-sequence.svg
+++ b/docs/pro/images/async-props-sequence.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 470" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <title>How async props stream each slow value to its Suspense boundary</title>
+  <desc>Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks for a page, Rails starts the page with placeholders, the renderer returns an HTML shell with loading states, and the browser shows the shell. Then a loop runs for each slow data value: Rails sends the value, the renderer returns the HTML for that section, and the browser replaces the loading state.</desc>
+  <defs>
+    <linearGradient id="railsGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#CC0000"/><stop offset="100%" stop-color="#990000"/>
+    </linearGradient>
+    <linearGradient id="browserGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4A90D9"/><stop offset="100%" stop-color="#2E5A8A"/>
+    </linearGradient>
+    <linearGradient id="nodeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#68A063"/><stop offset="100%" stop-color="#3C873A"/>
+    </linearGradient>
+    <filter id="shadow"><feDropShadow dx="1" dy="2" stdDeviation="3" flood-opacity="0.1"/></filter>
+    <style>
+      .bg { fill: #F8FAFC; }
+      .title { fill: #0F172A; }
+      .subtitle { fill: #64748B; }
+      .lane-line { stroke: #E2E8F0; }
+      .loop-box { fill: none; stroke: #CBD5E1; }
+      .loop-label-bg { fill: #F1F5F9; stroke: #CBD5E1; }
+      .loop-label { fill: #475569; }
+      .msg-box { fill: #EFF6FF; stroke: #93C5FD; }
+      .msg-text { fill: #1E40AF; }
+      .ret-box { fill: #ECFDF5; stroke: #86EFAC; }
+      .ret-text { fill: #166534; }
+      .arrow-fwd { stroke: #94A3B8; }
+      .arrow-ret { stroke: #22C55E; }
+      .head-fwd { fill: #94A3B8; }
+      .head-ret { fill: #22C55E; }
+      @media (prefers-color-scheme: dark) {
+        .bg { fill: #0F172A; }
+        .title { fill: #F1F5F9; }
+        .subtitle { fill: #94A3B8; }
+        .lane-line { stroke: #334155; }
+        .loop-box { stroke: #475569; }
+        .loop-label-bg { fill: #1E293B; stroke: #475569; }
+        .loop-label { fill: #94A3B8; }
+        .msg-box { fill: #172554; stroke: #3B82F6; }
+        .msg-text { fill: #93C5FD; }
+        .ret-box { fill: #052E16; stroke: #10B981; }
+        .ret-text { fill: #6EE7B7; }
+        .arrow-ret { stroke: #4ADE80; }
+        .head-ret { fill: #4ADE80; }
+      }
+      .st1 { opacity:0; animation: reveal 11s ease 0.2s infinite; }
+      .st2 { opacity:0; animation: reveal 11s ease 1.0s infinite; }
+      .st3 { opacity:0; animation: reveal 11s ease 1.8s infinite; }
+      .st4 { opacity:0; animation: reveal 11s ease 2.6s infinite; }
+      .st5 { opacity:0; animation: reveal 11s ease 3.8s infinite; }
+      .st6 { opacity:0; animation: reveal 11s ease 4.6s infinite; }
+      .st7 { opacity:0; animation: reveal 11s ease 5.4s infinite; }
+      @keyframes reveal { 0% { opacity:0; } 3% { opacity:1; } 92% { opacity:1; } 97% { opacity:0; } 100% { opacity:0; } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; opacity: 1 !important; } }
+    </style>
+  </defs>
+
+  <rect width="840" height="470" class="bg"/>
+  <text x="420" y="28" text-anchor="middle" font-size="18" font-weight="700" class="title">Async props: Rails emits each value, the boundary fills</text>
+  <text x="420" y="47" text-anchor="middle" font-size="11" class="subtitle">The shell ships first; each slow prop streams in and replaces its loading state</text>
+
+  <rect x="70" y="62" width="100" height="30" rx="8" fill="url(#browserGrad)" filter="url(#shadow)"/>
+  <text x="120" y="82" text-anchor="middle" font-size="11" font-weight="600" fill="white">Browser</text>
+  <rect x="350" y="62" width="100" height="30" rx="8" fill="url(#railsGrad)" filter="url(#shadow)"/>
+  <text x="400" y="82" text-anchor="middle" font-size="11" font-weight="600" fill="white">Rails</text>
+  <rect x="635" y="62" width="130" height="30" rx="8" fill="url(#nodeGrad)" filter="url(#shadow)"/>
+  <text x="700" y="82" text-anchor="middle" font-size="11" font-weight="600" fill="white">Node Renderer</text>
+
+  <line x1="120" y1="98" x2="120" y2="440" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <line x1="400" y1="98" x2="400" y2="440" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <line x1="700" y1="98" x2="700" y2="440" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+
+  <g class="st1">
+    <line x1="126" y1="138" x2="392" y2="138" class="arrow-fwd" stroke-width="1.5"/>
+    <polygon points="392,135 399,138 392,141" class="head-fwd"/>
+    <rect x="205" y="128" width="110" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="260" y="140" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Ask for a page</text>
+  </g>
+
+  <g class="st2">
+    <line x1="406" y1="176" x2="694" y2="176" class="arrow-fwd" stroke-width="1.5"/>
+    <polygon points="694,173 701,176 694,179" class="head-fwd"/>
+    <rect x="478" y="166" width="144" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="550" y="178" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Start page with placeholders</text>
+  </g>
+
+  <g class="st3">
+    <line x1="694" y1="214" x2="406" y2="214" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="406,211 399,214 406,217" class="head-ret"/>
+    <rect x="478" y="204" width="144" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="550" y="216" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">HTML shell + loading states</text>
+  </g>
+
+  <g class="st4">
+    <line x1="394" y1="252" x2="126" y2="252" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="126,249 119,252 126,255" class="head-ret"/>
+    <rect x="196" y="242" width="128" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="260" y="254" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Browser shows the shell</text>
+  </g>
+
+  <rect x="40" y="284" width="760" height="148" rx="8" class="loop-box" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <rect x="40" y="284" width="266" height="20" rx="6" class="loop-label-bg" stroke-width="1"/>
+  <text x="52" y="298" font-size="10" font-weight="600" class="loop-label">loop — each slow value becomes ready</text>
+
+  <g class="st5">
+    <line x1="406" y1="332" x2="694" y2="332" class="arrow-fwd" stroke-width="1.5"/>
+    <polygon points="694,329 701,332 694,335" class="head-fwd"/>
+    <rect x="490" y="322" width="120" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="550" y="334" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Send the data value</text>
+  </g>
+
+  <g class="st6">
+    <line x1="694" y1="370" x2="406" y2="370" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="406,367 399,370 406,373" class="head-ret"/>
+    <rect x="476" y="360" width="148" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="550" y="372" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">HTML for that section</text>
+  </g>
+
+  <g class="st7">
+    <line x1="394" y1="408" x2="126" y2="408" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="126,405 119,408 126,411" class="head-ret"/>
+    <rect x="192" y="398" width="136" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="260" y="410" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Replace the loading state</text>
+  </g>
+</svg>

--- a/docs/pro/images/async-props-sequence.svg
+++ b/docs/pro/images/async-props-sequence.svg
@@ -40,6 +40,8 @@
         .msg-text { fill: #93C5FD; }
         .ret-box { fill: #052E16; stroke: #10B981; }
         .ret-text { fill: #6EE7B7; }
+        .arrow-fwd { stroke: #CBD5E1; }
+        .head-fwd { fill: #CBD5E1; }
         .arrow-ret { stroke: #4ADE80; }
         .head-ret { fill: #4ADE80; }
       }

--- a/docs/pro/images/discouraged-direct-fetch.svg
+++ b/docs/pro/images/discouraged-direct-fetch.svg
@@ -40,6 +40,8 @@
         .ret-text { fill: #CBD5E1; }
         .arrow-ret { stroke: #CBD5E1; }
         .head-ret { fill: #CBD5E1; }
+        .arrow-warn { stroke: #FCD34D; }
+        .head-warn { fill: #FCD34D; }
       }
       .st1 { opacity:0; animation: reveal 9s ease 0.6s infinite; }
       .st2 { opacity:0; animation: reveal 9s ease 1.4s infinite; }
@@ -67,8 +69,8 @@
   <line x1="690" y1="94" x2="690" y2="372" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
 
   <g>
-    <rect x="40" y="102" width="760" height="34" rx="8" class="callout-box" stroke-width="1.5" filter="url(#shadow)"/>
-    <text x="420" y="123" text-anchor="middle" font-size="11" font-weight="600" class="callout-title">Discouraged — usually let Rails pass the data in via async props so auth, session, and caching stay on the Rails side</text>
+    <rect x="40" y="100" width="760" height="46" rx="8" class="callout-box" stroke-width="1.5" filter="url(#shadow)"/>
+    <text x="420" y="118" text-anchor="middle" font-size="11" font-weight="600" class="callout-title">Discouraged — usually let Rails pass the data in via async props,<tspan x="420" dy="16" font-weight="500">so auth, session, and caching stay on the Rails side</tspan></text>
   </g>
 
   <g class="st1">

--- a/docs/pro/images/discouraged-direct-fetch.svg
+++ b/docs/pro/images/discouraged-direct-fetch.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 400" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <title>Discouraged pattern: a Server Component fetching Rails directly</title>
+  <desc>Sequence diagram across three lanes — Node Renderer, Rails API, and DB / Models. A warning banner notes this is discouraged. The renderer asks the Rails API for data, Rails loads and authorizes it from the database, returns the data to Rails, Rails returns JSON to the renderer, and the renderer continues rendering. Prefer async props so Rails keeps owning auth and caching.</desc>
+  <defs>
+    <linearGradient id="railsGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#CC0000"/><stop offset="100%" stop-color="#990000"/>
+    </linearGradient>
+    <linearGradient id="nodeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#68A063"/><stop offset="100%" stop-color="#3C873A"/>
+    </linearGradient>
+    <linearGradient id="dataGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7C8DA6"/><stop offset="100%" stop-color="#475569"/>
+    </linearGradient>
+    <filter id="shadow"><feDropShadow dx="1" dy="2" stdDeviation="3" flood-opacity="0.1"/></filter>
+    <style>
+      .bg { fill: #F8FAFC; }
+      .title { fill: #0F172A; }
+      .subtitle { fill: #64748B; }
+      .lane-line { stroke: #E2E8F0; }
+      .callout-box { fill: #FFFBEB; stroke: #FCD34D; }
+      .callout-title { fill: #92400E; }
+      .msg-box { fill: #FEF3C7; stroke: #F59E0B; }
+      .msg-text { fill: #92400E; }
+      .ret-box { fill: #F1F5F9; stroke: #CBD5E1; }
+      .ret-text { fill: #475569; }
+      .arrow-warn { stroke: #F59E0B; }
+      .head-warn { fill: #F59E0B; }
+      .arrow-ret { stroke: #94A3B8; }
+      .head-ret { fill: #94A3B8; }
+      @media (prefers-color-scheme: dark) {
+        .bg { fill: #0F172A; }
+        .title { fill: #F1F5F9; }
+        .subtitle { fill: #94A3B8; }
+        .lane-line { stroke: #334155; }
+        .callout-box { fill: #422006; stroke: #F59E0B; }
+        .callout-title { fill: #FCD34D; }
+        .msg-box { fill: #422006; stroke: #F59E0B; }
+        .msg-text { fill: #FDE68A; }
+        .ret-box { fill: #1E293B; stroke: #475569; }
+        .ret-text { fill: #CBD5E1; }
+      }
+      .st1 { opacity:0; animation: reveal 9s ease 0.6s infinite; }
+      .st2 { opacity:0; animation: reveal 9s ease 1.4s infinite; }
+      .st3 { opacity:0; animation: reveal 9s ease 2.2s infinite; }
+      .st4 { opacity:0; animation: reveal 9s ease 3.0s infinite; }
+      .st5 { opacity:0; animation: reveal 9s ease 3.8s infinite; }
+      @keyframes reveal { 0% { opacity:0; } 4% { opacity:1; } 90% { opacity:1; } 96% { opacity:0; } 100% { opacity:0; } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; opacity: 1 !important; } }
+    </style>
+  </defs>
+
+  <rect width="840" height="400" class="bg"/>
+  <text x="420" y="26" text-anchor="middle" font-size="18" font-weight="700" class="title">Discouraged: fetching Rails directly from the renderer</text>
+  <text x="420" y="44" text-anchor="middle" font-size="11" class="subtitle">A plain network round-trip that bypasses Rails auth and caching — prefer async props</text>
+
+  <rect x="85" y="58" width="130" height="30" rx="8" fill="url(#nodeGrad)" filter="url(#shadow)"/>
+  <text x="150" y="78" text-anchor="middle" font-size="11" font-weight="600" fill="white">Node Renderer</text>
+  <rect x="365" y="58" width="110" height="30" rx="8" fill="url(#railsGrad)" filter="url(#shadow)"/>
+  <text x="420" y="78" text-anchor="middle" font-size="11" font-weight="600" fill="white">Rails API</text>
+  <rect x="630" y="58" width="120" height="30" rx="8" fill="url(#dataGrad)" filter="url(#shadow)"/>
+  <text x="690" y="78" text-anchor="middle" font-size="11" font-weight="600" fill="white">DB / Models</text>
+
+  <line x1="150" y1="94" x2="150" y2="372" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <line x1="420" y1="94" x2="420" y2="372" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <line x1="690" y1="94" x2="690" y2="372" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+
+  <g>
+    <rect x="40" y="102" width="760" height="34" rx="8" class="callout-box" stroke-width="1.5" filter="url(#shadow)"/>
+    <text x="420" y="123" text-anchor="middle" font-size="11" font-weight="600" class="callout-title">⚠ Discouraged — usually let Rails pass the data in via async props so auth, session, and caching stay on the Rails side</text>
+  </g>
+
+  <g class="st1">
+    <line x1="156" y1="172" x2="414" y2="172" class="arrow-warn" stroke-width="1.5"/>
+    <polygon points="414,169 421,172 414,175" class="head-warn"/>
+    <rect x="210" y="162" width="120" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="270" y="174" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Ask Rails API for data</text>
+  </g>
+
+  <g class="st2">
+    <line x1="426" y1="210" x2="684" y2="210" class="arrow-warn" stroke-width="1.5"/>
+    <polygon points="684,207 691,210 684,213" class="head-warn"/>
+    <rect x="486" y="200" width="138" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="555" y="212" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Load and authorize data</text>
+  </g>
+
+  <g class="st3">
+    <line x1="684" y1="248" x2="426" y2="248" class="arrow-ret" stroke-width="1.5" stroke-dasharray="6 3"/>
+    <polygon points="426,245 419,248 426,251" class="head-ret"/>
+    <rect x="520" y="238" width="70" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="555" y="250" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Data</text>
+  </g>
+
+  <g class="st4">
+    <line x1="414" y1="286" x2="156" y2="286" class="arrow-ret" stroke-width="1.5" stroke-dasharray="6 3"/>
+    <polygon points="156,283 149,286 156,289" class="head-ret"/>
+    <rect x="220" y="276" width="100" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="270" y="288" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">JSON data</text>
+  </g>
+
+  <g class="st5">
+    <path d="M 156 318 h 44 v 26 h -44" fill="none" class="arrow-ret" stroke-width="1.5"/>
+    <polygon points="159,341 152,344 159,347" class="head-ret"/>
+    <rect x="206" y="322" width="124" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="268" y="334" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Continue rendering</text>
+  </g>
+</svg>

--- a/docs/pro/images/discouraged-direct-fetch.svg
+++ b/docs/pro/images/discouraged-direct-fetch.svg
@@ -68,7 +68,7 @@
 
   <g>
     <rect x="40" y="102" width="760" height="34" rx="8" class="callout-box" stroke-width="1.5" filter="url(#shadow)"/>
-    <text x="420" y="123" text-anchor="middle" font-size="11" font-weight="600" class="callout-title">⚠ Discouraged — usually let Rails pass the data in via async props so auth, session, and caching stay on the Rails side</text>
+    <text x="420" y="123" text-anchor="middle" font-size="11" font-weight="600" class="callout-title">Discouraged — usually let Rails pass the data in via async props so auth, session, and caching stay on the Rails side</text>
   </g>
 
   <g class="st1">

--- a/docs/pro/images/discouraged-direct-fetch.svg
+++ b/docs/pro/images/discouraged-direct-fetch.svg
@@ -38,6 +38,8 @@
         .msg-text { fill: #FDE68A; }
         .ret-box { fill: #1E293B; stroke: #475569; }
         .ret-text { fill: #CBD5E1; }
+        .arrow-ret { stroke: #CBD5E1; }
+        .head-ret { fill: #CBD5E1; }
       }
       .st1 { opacity:0; animation: reveal 9s ease 0.6s infinite; }
       .st2 { opacity:0; animation: reveal 9s ease 1.4s infinite; }

--- a/docs/pro/images/progressive-stages.svg
+++ b/docs/pro/images/progressive-stages.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <title>How a streaming page fills in stage by stage in the browser</title>
+  <desc>Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done. Each Suspense boundary swaps its fallback for real content as its prop arrives.</desc>
+  <defs>
+    <linearGradient id="browserGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4A90D9"/><stop offset="100%" stop-color="#2E5A8A"/>
+    </linearGradient>
+    <filter id="shadow"><feDropShadow dx="1" dy="2" stdDeviation="3" flood-opacity="0.12"/></filter>
+    <style>
+      .bg { fill: #F8FAFC; }
+      .title { fill: #0F172A; }
+      .subtitle { fill: #64748B; }
+      .card { fill: white; stroke: #E2E8F0; }
+      .stage-label { fill: #334155; }
+      .stage-sub { fill: #64748B; }
+      .done-box { fill: #D1FAE5; stroke: #22C55E; }
+      .done-text { fill: #166534; }
+      .load-box { fill: #FEF3C7; stroke: #F59E0B; }
+      .load-text { fill: #92400E; }
+      .flow-arrow { stroke: #94A3B8; }
+      .flow-head { fill: #94A3B8; }
+      @media (prefers-color-scheme: dark) {
+        .bg { fill: #0F172A; }
+        .title { fill: #F1F5F9; }
+        .subtitle { fill: #94A3B8; }
+        .card { fill: #1E293B; stroke: #334155; }
+        .stage-label { fill: #E2E8F0; }
+        .stage-sub { fill: #94A3B8; }
+        .done-box { fill: #052E16; stroke: #10B981; }
+        .done-text { fill: #6EE7B7; }
+        .load-box { fill: #422006; stroke: #F59E0B; }
+        .load-text { fill: #FDE68A; }
+      }
+      .spinner { animation: spin 1s linear infinite; transform-box: fill-box; transform-origin: center; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+    </style>
+  </defs>
+
+  <rect width="900" height="300" class="bg"/>
+  <text x="450" y="26" text-anchor="middle" font-size="18" font-weight="700" class="title">Progressive streaming: the page fills in stage by stage</text>
+  <text x="450" y="44" text-anchor="middle" font-size="11" class="subtitle">Each Suspense boundary swaps its fallback for real content as its prop arrives</text>
+
+  <g>
+    <rect x="20" y="60" width="250" height="196" rx="10" class="card" stroke-width="1.5" filter="url(#shadow)"/>
+    <rect x="20" y="60" width="250" height="26" rx="10" fill="url(#browserGrad)"/>
+    <rect x="20" y="76" width="250" height="10" fill="url(#browserGrad)"/>
+    <circle cx="34" cy="73" r="4" fill="#EF4444"/><circle cx="48" cy="73" r="4" fill="#F59E0B"/><circle cx="62" cy="73" r="4" fill="#22C55E"/>
+    <text x="160" y="77" text-anchor="middle" font-size="10" font-weight="600" fill="white">Stage 1 · shell (~50 ms)</text>
+
+    <rect x="32" y="98" width="226" height="30" rx="5" class="done-box" stroke-width="1.5"/>
+    <text x="44" y="117" font-size="11" font-weight="600" class="done-text">Header</text>
+    <text x="246" y="117" text-anchor="end" font-size="11" class="done-text">✓</text>
+
+    <rect x="32" y="134" width="226" height="30" rx="5" class="load-box" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text x="44" y="153" font-size="11" font-weight="500" class="load-text">Users</text>
+    <circle cx="240" cy="149" r="6" fill="none" stroke="#F59E0B" stroke-width="2" stroke-dasharray="12 6" class="spinner"/>
+
+    <rect x="32" y="170" width="226" height="30" rx="5" class="load-box" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text x="44" y="189" font-size="11" font-weight="500" class="load-text">Posts</text>
+    <circle cx="240" cy="185" r="6" fill="none" stroke="#F59E0B" stroke-width="2" stroke-dasharray="12 6" class="spinner"/>
+
+    <text x="145" y="222" text-anchor="middle" font-size="9" class="stage-sub">visible now · interactive as JS loads</text>
+  </g>
+
+  <line x1="278" y1="155" x2="318" y2="155" class="flow-arrow" stroke-width="2"/>
+  <polygon points="318,150 326,155 318,160" class="flow-head"/>
+
+  <g>
+    <rect x="328" y="60" width="250" height="196" rx="10" class="card" stroke-width="1.5" filter="url(#shadow)"/>
+    <rect x="328" y="60" width="250" height="26" rx="10" fill="url(#browserGrad)"/>
+    <rect x="328" y="76" width="250" height="10" fill="url(#browserGrad)"/>
+    <circle cx="342" cy="73" r="4" fill="#EF4444"/><circle cx="356" cy="73" r="4" fill="#F59E0B"/><circle cx="370" cy="73" r="4" fill="#22C55E"/>
+    <text x="468" y="77" text-anchor="middle" font-size="10" font-weight="600" fill="white">Stage 2 · users fill in</text>
+
+    <rect x="340" y="98" width="226" height="30" rx="5" class="done-box" stroke-width="1.5"/>
+    <text x="352" y="117" font-size="11" font-weight="600" class="done-text">Header</text>
+    <text x="554" y="117" text-anchor="end" font-size="11" class="done-text">✓</text>
+
+    <rect x="340" y="134" width="226" height="30" rx="5" class="done-box" stroke-width="1.5"/>
+    <text x="352" y="153" font-size="11" font-weight="600" class="done-text">Users</text>
+    <text x="554" y="153" text-anchor="end" font-size="11" class="done-text">✓</text>
+
+    <rect x="340" y="170" width="226" height="30" rx="5" class="load-box" stroke-width="1.5" stroke-dasharray="5 3"/>
+    <text x="352" y="189" font-size="11" font-weight="500" class="load-text">Posts</text>
+    <circle cx="548" cy="185" r="6" fill="none" stroke="#F59E0B" stroke-width="2" stroke-dasharray="12 6" class="spinner"/>
+
+    <text x="453" y="222" text-anchor="middle" font-size="9" class="stage-sub">users streamed in independently</text>
+  </g>
+
+  <line x1="586" y1="155" x2="626" y2="155" class="flow-arrow" stroke-width="2"/>
+  <polygon points="626,150 634,155 626,160" class="flow-head"/>
+
+  <g>
+    <rect x="636" y="60" width="250" height="196" rx="10" class="card" stroke-width="1.5" filter="url(#shadow)"/>
+    <rect x="636" y="60" width="250" height="26" rx="10" fill="url(#browserGrad)"/>
+    <rect x="636" y="76" width="250" height="10" fill="url(#browserGrad)"/>
+    <circle cx="650" cy="73" r="4" fill="#EF4444"/><circle cx="664" cy="73" r="4" fill="#F59E0B"/><circle cx="678" cy="73" r="4" fill="#22C55E"/>
+    <text x="776" y="77" text-anchor="middle" font-size="10" font-weight="600" fill="white">Stage 3 · complete</text>
+
+    <rect x="648" y="98" width="226" height="30" rx="5" class="done-box" stroke-width="1.5"/>
+    <text x="660" y="117" font-size="11" font-weight="600" class="done-text">Header</text>
+    <text x="862" y="117" text-anchor="end" font-size="11" class="done-text">✓</text>
+
+    <rect x="648" y="134" width="226" height="30" rx="5" class="done-box" stroke-width="1.5"/>
+    <text x="660" y="153" font-size="11" font-weight="600" class="done-text">Users</text>
+    <text x="862" y="153" text-anchor="end" font-size="11" class="done-text">✓</text>
+
+    <rect x="648" y="170" width="226" height="30" rx="5" class="done-box" stroke-width="1.5"/>
+    <text x="660" y="189" font-size="11" font-weight="600" class="done-text">Posts</text>
+    <text x="862" y="189" text-anchor="end" font-size="11" class="done-text">✓</text>
+
+    <text x="761" y="222" text-anchor="middle" font-size="9" class="stage-sub">all sections hydrated</text>
+  </g>
+</svg>

--- a/docs/pro/images/progressive-stages.svg
+++ b/docs/pro/images/progressive-stages.svg
@@ -33,7 +33,7 @@
       }
       .spinner { animation: spin 1s linear infinite; transform-box: fill-box; transform-origin: center; }
       @keyframes spin { to { transform: rotate(360deg); } }
-      @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; opacity: 1 !important; } }
     </style>
   </defs>
 

--- a/docs/pro/images/streaming-sequence.svg
+++ b/docs/pro/images/streaming-sequence.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 840 430" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <title>How streaming SSR sends HTML to the browser progressively</title>
+  <desc>Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks Rails for a page, Rails asks the renderer to start, the renderer streams the first HTML piece back through Rails so the browser can paint right away, then a loop streams each further HTML piece as more of the page becomes ready.</desc>
+  <defs>
+    <linearGradient id="railsGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#CC0000"/><stop offset="100%" stop-color="#990000"/>
+    </linearGradient>
+    <linearGradient id="browserGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4A90D9"/><stop offset="100%" stop-color="#2E5A8A"/>
+    </linearGradient>
+    <linearGradient id="nodeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#68A063"/><stop offset="100%" stop-color="#3C873A"/>
+    </linearGradient>
+    <filter id="shadow"><feDropShadow dx="1" dy="2" stdDeviation="3" flood-opacity="0.1"/></filter>
+    <style>
+      .bg { fill: #F8FAFC; }
+      .title { fill: #0F172A; }
+      .subtitle { fill: #64748B; }
+      .lane-line { stroke: #E2E8F0; }
+      .loop-box { fill: none; stroke: #CBD5E1; }
+      .loop-label-bg { fill: #F1F5F9; stroke: #CBD5E1; }
+      .loop-label { fill: #475569; }
+      .msg-box { fill: #EFF6FF; stroke: #93C5FD; }
+      .msg-text { fill: #1E40AF; }
+      .ret-box { fill: #ECFDF5; stroke: #86EFAC; }
+      .ret-text { fill: #166534; }
+      .arrow-fwd { stroke: #94A3B8; }
+      .arrow-ret { stroke: #22C55E; }
+      .head-fwd { fill: #94A3B8; }
+      .head-ret { fill: #22C55E; }
+      @media (prefers-color-scheme: dark) {
+        .bg { fill: #0F172A; }
+        .title { fill: #F1F5F9; }
+        .subtitle { fill: #94A3B8; }
+        .lane-line { stroke: #334155; }
+        .loop-box { stroke: #475569; }
+        .loop-label-bg { fill: #1E293B; stroke: #475569; }
+        .loop-label { fill: #94A3B8; }
+        .msg-box { fill: #172554; stroke: #3B82F6; }
+        .msg-text { fill: #93C5FD; }
+        .ret-box { fill: #052E16; stroke: #10B981; }
+        .ret-text { fill: #6EE7B7; }
+        .arrow-ret { stroke: #4ADE80; }
+        .head-ret { fill: #4ADE80; }
+      }
+      .st1 { opacity:0; animation: reveal 9s ease 0.2s infinite; }
+      .st2 { opacity:0; animation: reveal 9s ease 1.0s infinite; }
+      .st3 { opacity:0; animation: reveal 9s ease 1.8s infinite; }
+      .st4 { opacity:0; animation: reveal 9s ease 2.6s infinite; }
+      .st5 { opacity:0; animation: reveal 9s ease 3.6s infinite; }
+      .st6 { opacity:0; animation: reveal 9s ease 4.4s infinite; }
+      @keyframes reveal { 0% { opacity:0; } 4% { opacity:1; } 90% { opacity:1; } 96% { opacity:0; } 100% { opacity:0; } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; opacity: 1 !important; } }
+    </style>
+  </defs>
+
+  <rect width="840" height="430" class="bg"/>
+  <text x="420" y="28" text-anchor="middle" font-size="18" font-weight="700" class="title">Streaming SSR: HTML arrives progressively</text>
+  <text x="420" y="47" text-anchor="middle" font-size="11" class="subtitle">The browser paints the first piece immediately, then more pieces stream in</text>
+
+  <rect x="70" y="62" width="100" height="30" rx="8" fill="url(#browserGrad)" filter="url(#shadow)"/>
+  <text x="120" y="82" text-anchor="middle" font-size="11" font-weight="600" fill="white">Browser</text>
+  <rect x="350" y="62" width="100" height="30" rx="8" fill="url(#railsGrad)" filter="url(#shadow)"/>
+  <text x="400" y="82" text-anchor="middle" font-size="11" font-weight="600" fill="white">Rails</text>
+  <rect x="635" y="62" width="130" height="30" rx="8" fill="url(#nodeGrad)" filter="url(#shadow)"/>
+  <text x="700" y="82" text-anchor="middle" font-size="11" font-weight="600" fill="white">Node Renderer</text>
+
+  <line x1="120" y1="98" x2="120" y2="400" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <line x1="400" y1="98" x2="400" y2="400" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <line x1="700" y1="98" x2="700" y2="400" class="lane-line" stroke-width="1.5" stroke-dasharray="6 4"/>
+
+  <g class="st1">
+    <line x1="126" y1="138" x2="392" y2="138" class="arrow-fwd" stroke-width="1.5"/>
+    <polygon points="392,135 399,138 392,141" class="head-fwd"/>
+    <rect x="205" y="128" width="110" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="260" y="140" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Ask for a page</text>
+  </g>
+
+  <g class="st2">
+    <line x1="406" y1="176" x2="694" y2="176" class="arrow-fwd" stroke-width="1.5"/>
+    <polygon points="694,173 701,176 694,179" class="head-fwd"/>
+    <rect x="490" y="166" width="120" height="18" rx="4" class="msg-box" stroke-width="1"/>
+    <text x="550" y="178" text-anchor="middle" font-size="9" font-weight="500" class="msg-text">Start rendering page</text>
+  </g>
+
+  <g class="st3">
+    <line x1="694" y1="214" x2="406" y2="214" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="406,211 399,214 406,217" class="head-ret"/>
+    <rect x="490" y="204" width="120" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="550" y="216" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">First HTML piece</text>
+  </g>
+
+  <g class="st4">
+    <line x1="394" y1="252" x2="126" y2="252" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="126,249 119,252 126,255" class="head-ret"/>
+    <rect x="200" y="242" width="120" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="260" y="254" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Paint right away</text>
+  </g>
+
+  <rect x="40" y="284" width="760" height="104" rx="8" class="loop-box" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <rect x="40" y="284" width="240" height="20" rx="6" class="loop-label-bg" stroke-width="1"/>
+  <text x="52" y="298" font-size="10" font-weight="600" class="loop-label">loop — more page parts ready</text>
+
+  <g class="st5">
+    <line x1="694" y1="334" x2="406" y2="334" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="406,331 399,334 406,337" class="head-ret"/>
+    <rect x="490" y="324" width="120" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="550" y="336" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Next HTML piece</text>
+  </g>
+
+  <g class="st6">
+    <line x1="394" y1="370" x2="126" y2="370" class="arrow-ret" stroke-width="2" stroke-dasharray="6 3"/>
+    <polygon points="126,367 119,370 126,373" class="head-ret"/>
+    <rect x="196" y="360" width="128" height="18" rx="4" class="ret-box" stroke-width="1"/>
+    <text x="260" y="372" text-anchor="middle" font-size="9" font-weight="500" class="ret-text">Add it to the page</text>
+  </g>
+</svg>

--- a/docs/pro/images/streaming-sequence.svg
+++ b/docs/pro/images/streaming-sequence.svg
@@ -40,6 +40,8 @@
         .msg-text { fill: #93C5FD; }
         .ret-box { fill: #052E16; stroke: #10B981; }
         .ret-text { fill: #6EE7B7; }
+        .arrow-fwd { stroke: #CBD5E1; }
+        .head-fwd { fill: #CBD5E1; }
         .arrow-ret { stroke: #4ADE80; }
         .head-ret { fill: #4ADE80; }
       }

--- a/docs/pro/images/traditional-vs-streaming.svg
+++ b/docs/pro/images/traditional-vs-streaming.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 330" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif">
+  <title>Traditional SSR versus Streaming SSR first-paint timing</title>
+  <desc>Two side-by-side timelines on the same scale. With traditional SSR the first paint happens only after the slowest data fetch and the HTML render finish (about 1000 ms). With streaming SSR plus async props the shell paints almost immediately (about 50 ms) and each slow section streams in afterward.</desc>
+  <defs>
+    <linearGradient id="tradGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#64748B"/><stop offset="100%" stop-color="#475569"/>
+    </linearGradient>
+    <linearGradient id="streamGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22C55E"/><stop offset="100%" stop-color="#16A34A"/>
+    </linearGradient>
+    <filter id="shadow"><feDropShadow dx="1" dy="2" stdDeviation="3" flood-opacity="0.1"/></filter>
+    <style>
+      .bg { fill: #F8FAFC; }
+      .title { fill: #0F172A; }
+      .subtitle { fill: #64748B; }
+      .card { fill: white; stroke: #E2E8F0; }
+      .axis { stroke: #CBD5E1; }
+      .tick-text { fill: #94A3B8; }
+      .bar-fetch { fill: #FEF3C7; stroke: #F59E0B; }
+      .bar-fetch-text { fill: #92400E; }
+      .bar-render { fill: #DBEAFE; stroke: #93C5FD; }
+      .bar-render-text { fill: #1E40AF; }
+      .bar-stream { fill: #D1FAE5; stroke: #22C55E; }
+      .bar-stream-text { fill: #166534; }
+      .paint-late { stroke: #DC2626; }
+      .paint-late-text { fill: #DC2626; }
+      .paint-early { stroke: #16A34A; }
+      .paint-early-text { fill: #16A34A; }
+      .caption { fill: #475569; }
+      @media (prefers-color-scheme: dark) {
+        .bg { fill: #0F172A; }
+        .title { fill: #F1F5F9; }
+        .subtitle { fill: #94A3B8; }
+        .card { fill: #1E293B; stroke: #334155; }
+        .axis { stroke: #475569; }
+        .tick-text { fill: #94A3B8; }
+        .bar-fetch { fill: #422006; stroke: #F59E0B; }
+        .bar-fetch-text { fill: #FDE68A; }
+        .bar-render { fill: #172554; stroke: #3B82F6; }
+        .bar-render-text { fill: #93C5FD; }
+        .bar-stream { fill: #052E16; stroke: #10B981; }
+        .bar-stream-text { fill: #6EE7B7; }
+        .paint-late { stroke: #F87171; }
+        .paint-late-text { fill: #F87171; }
+        .paint-early { stroke: #4ADE80; }
+        .paint-early-text { fill: #4ADE80; }
+        .caption { fill: #94A3B8; }
+      }
+      .pulse { animation: pulse 1.6s ease-in-out infinite; }
+      @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.45; } }
+      .stream-in { opacity: 0; animation: streamIn 4s ease infinite; }
+      .stream-in-2 { opacity: 0; animation: streamIn 4s ease 0.5s infinite; }
+      @keyframes streamIn { 0%,20% { opacity: 0; } 35%,90% { opacity: 1; } 100% { opacity: 0; } }
+      @media (prefers-reduced-motion: reduce) { * { animation: none !important; opacity: 1 !important; } }
+    </style>
+  </defs>
+
+  <rect width="900" height="330" class="bg"/>
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="700" class="title">Traditional SSR vs Streaming SSR: when does the page paint?</text>
+  <text x="450" y="47" text-anchor="middle" font-size="11" class="subtitle">Same time scale on both sides. Timings are illustrative, not benchmarks.</text>
+
+  <!-- ===== Traditional card ===== -->
+  <g>
+    <rect x="20" y="64" width="410" height="246" rx="10" class="card" stroke-width="1.5" filter="url(#shadow)"/>
+    <rect x="20" y="64" width="410" height="30" rx="10" fill="url(#tradGrad)"/>
+    <rect x="20" y="84" width="410" height="10" fill="url(#tradGrad)"/>
+    <text x="225" y="84" text-anchor="middle" font-size="12" font-weight="700" fill="white">Traditional SSR — paint waits for all data</text>
+
+    <text x="44" y="120" font-size="10" class="bar-fetch-text" font-weight="600">Fetch users · ~800 ms</text>
+    <rect x="44" y="124" width="290" height="16" rx="3" class="bar-fetch" stroke-width="1"/>
+
+    <text x="44" y="156" font-size="10" class="bar-fetch-text" font-weight="600">Fetch posts · ~600 ms</text>
+    <rect x="44" y="160" width="217" height="16" rx="3" class="bar-fetch" stroke-width="1"/>
+
+    <text x="44" y="192" font-size="10" class="bar-render-text" font-weight="600">Render HTML · ~200 ms</text>
+    <rect x="334" y="196" width="72" height="16" rx="3" class="bar-render" stroke-width="1"/>
+
+    <line x1="406" y1="116" x2="406" y2="244" class="paint-late pulse" stroke-width="2" stroke-dasharray="4 3"/>
+    <polygon points="406,116 430,116 430,130 406,130" class="paint-late pulse" fill="#DC2626" stroke="none"/>
+    <text x="402" y="240" text-anchor="end" font-size="10" font-weight="700" class="paint-late-text">First paint ~1000 ms</text>
+
+    <line x1="44" y1="252" x2="406" y2="252" class="axis" stroke-width="1.5"/>
+    <text x="44" y="266" text-anchor="middle" font-size="9" class="tick-text">0</text>
+    <text x="225" y="266" text-anchor="middle" font-size="9" class="tick-text">500 ms</text>
+    <text x="406" y="266" text-anchor="middle" font-size="9" class="tick-text">1000 ms</text>
+    <text x="225" y="294" text-anchor="middle" font-size="10" class="caption">Nothing visible until the slowest query and render finish.</text>
+  </g>
+
+  <!-- ===== Streaming card ===== -->
+  <g>
+    <rect x="470" y="64" width="410" height="246" rx="10" class="card" stroke-width="1.5" filter="url(#shadow)"/>
+    <rect x="470" y="64" width="410" height="30" rx="10" fill="url(#streamGrad)"/>
+    <rect x="470" y="84" width="410" height="10" fill="url(#streamGrad)"/>
+    <text x="675" y="84" text-anchor="middle" font-size="12" font-weight="700" fill="white">Streaming SSR + async props — paint first</text>
+
+    <text x="494" y="120" font-size="10" class="bar-stream-text" font-weight="600">Render shell · ~50 ms</text>
+    <rect x="494" y="124" width="18" height="16" rx="3" class="bar-stream" stroke-width="1"/>
+
+    <text x="711" y="156" font-size="10" font-weight="600" class="bar-stream-text stream-in">Users stream in</text>
+    <rect x="711" y="160" width="80" height="16" rx="3" class="bar-stream stream-in" stroke-width="1" stroke-dasharray="4 2"/>
+
+    <text x="784" y="192" text-anchor="end" font-size="10" font-weight="600" class="bar-stream-text stream-in-2">Posts stream in</text>
+    <rect x="784" y="196" width="72" height="16" rx="3" class="bar-stream stream-in-2" stroke-width="1" stroke-dasharray="4 2"/>
+
+    <line x1="512" y1="116" x2="512" y2="244" class="paint-early pulse" stroke-width="2" stroke-dasharray="4 3"/>
+    <polygon points="512,116 536,116 536,130 512,130" class="paint-early pulse" fill="#16A34A" stroke="none"/>
+    <text x="540" y="128" text-anchor="start" font-size="10" font-weight="700" class="paint-early-text">First paint ~50 ms</text>
+
+    <line x1="494" y1="252" x2="856" y2="252" class="axis" stroke-width="1.5"/>
+    <text x="494" y="266" text-anchor="middle" font-size="9" class="tick-text">0</text>
+    <text x="675" y="266" text-anchor="middle" font-size="9" class="tick-text">500 ms</text>
+    <text x="856" y="266" text-anchor="middle" font-size="9" class="tick-text">1000 ms</text>
+    <text x="675" y="294" text-anchor="middle" font-size="10" class="caption">Shell paints immediately; each section streams in as its data is ready.</text>
+  </g>
+</svg>

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -15,23 +15,9 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 
 With traditional SSR the first paint waits for the slowest query; with streaming the shell paints first and each slow section streams in afterward:
 
-```mermaid
-flowchart LR
-    subgraph TRAD["Traditional SSR — paint waits for all data"]
-        direction LR
-        t0([Request]) --> t1["Fetch users<br/>~800 ms"]
-        t0 --> t2["Fetch posts<br/>~600 ms"]
-        t1 --> t3["Render HTML<br/>~200 ms"]
-        t2 --> t3
-        t3 --> t4(["First paint<br/>~1000 ms"])
-    end
-    subgraph STREAM["Streaming SSR + async props — paint first, data streams in"]
-        direction LR
-        s0([Request]) --> s1["Render shell<br/>~50 ms"] --> s2(["First paint<br/>~50 ms"])
-        s2 -. stream as ready .-> s3["Users fill in"]
-        s2 -. stream as ready .-> s4["Posts fill in"]
-    end
-```
+<p>
+  <img src="images/traditional-vs-streaming.svg" alt="Two side-by-side timelines on the same scale. With traditional SSR the first paint happens only after the slowest data fetch and the HTML render finish (about 1000 ms). With streaming SSR plus async props the shell paints almost immediately (about 50 ms) and each slow section streams in afterward." width="840" />
+</p>
 
 _Timings are illustrative, not benchmarks — the point is **when** the first paint happens: only after all data is ready for traditional SSR, but right after the shell for streaming._
 
@@ -42,21 +28,9 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 3. As each `<Suspense>` boundary resolves (e.g., an async data fetch completes), the rendered HTML chunk is streamed to the browser
 4. The browser replaces placeholders with real content — no full-page reload needed
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Browser
-    participant Rails
-    participant Renderer as Node Renderer
-    Browser->>Rails: Ask for a page
-    Rails->>Renderer: Start rendering the page
-    Renderer-->>Rails: First HTML piece
-    Rails-->>Browser: Browser can paint right away
-    loop more page parts become ready
-        Renderer-->>Rails: Next HTML piece
-        Rails-->>Browser: Browser adds it to the page
-    end
-```
+<p>
+  <img src="images/streaming-sequence.svg" alt="Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks Rails for a page, Rails asks the renderer to start, the renderer streams the first HTML piece back through Rails so the browser can paint right away, then a loop streams each further HTML piece as more of the page becomes ready." width="840" />
+</p>
 
 ## Prerequisites
 
@@ -77,22 +51,9 @@ This is the recommended answer to "my component needs Rails data during render":
 
 Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML back to Rails for forwarding to the browser:
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Browser
-    participant Rails
-    participant Renderer as Node Renderer
-    Browser->>Rails: Ask for a page
-    Rails->>Renderer: Start page with placeholders
-    Renderer-->>Rails: HTML shell + loading states
-    Rails-->>Browser: Browser shows the shell
-    loop each slow data value becomes ready
-        Rails->>Renderer: Send the data value
-        Renderer-->>Rails: HTML for that page section
-        Rails-->>Browser: Browser replaces the loading state
-    end
-```
+<p>
+  <img src="images/async-props-sequence.svg" alt="Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks for a page, Rails starts the page with placeholders, the renderer returns an HTML shell with loading states, and the browser shows the shell. Then a loop runs for each slow data value: Rails sends the value, the renderer returns the HTML for that section, and the browser replaces the loading state." width="840" />
+</p>
 
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
 
@@ -113,19 +74,9 @@ For the full data-fetching guidance — synchronous props, parallelizing indepen
 
 For contrast, a Server Component _can_ reach Rails by calling `fetch` itself. This is a plain **network round-trip** — the renderer's VM has no in-process access to Rails models, sessions, or cookies — and it gives up what async props provide for free, so prefer async props for Rails-owned data:
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Renderer as Node Renderer
-    participant Rails as Rails API
-    participant Data as DB / Models
-    Note over Renderer: Discouraged — usually let Rails pass the data instead
-    Renderer->>Rails: Ask Rails API for data
-    Rails->>Data: Load and authorize data
-    Data-->>Rails: Data
-    Rails-->>Renderer: JSON data
-    Renderer->>Renderer: Continue rendering
-```
+<p>
+  <img src="images/discouraged-direct-fetch.svg" alt="Sequence diagram across three lanes — Node Renderer, Rails API, and DB / Models. A warning banner notes this is discouraged. The renderer asks the Rails API for data, Rails loads and authorizes it from the database, returns the data to Rails, Rails returns JSON to the renderer, and the renderer continues rendering. Prefer async props so Rails keeps owning auth and caching." width="840" />
+</p>
 
 Caveats: `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal` are **not** in the VM by default (bundle an HTTP client or inject them via [runtime globals](../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc)); cookies, auth, session, and CSRF are **not** forwarded automatically; and it bypasses Rails' authorization and caching layers.
 
@@ -356,11 +307,9 @@ To render more of the page progressively, add an async prop and a `<Suspense>` b
 
 Extending the example with a second slow section (`users`), the page fills in stage by stage from the browser's perspective — visible from the first paint and interactive as each part hydrates, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
 
-```mermaid
-flowchart LR
-    A["Stage 1 · shell (~50 ms)<br/><br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>visible now · interactive as JS loads"] --> B["Stage 2 · users fill in<br/><br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
-    B --> C["Stage 3 · complete<br/><br/>Header ✓<br/>Users ✓<br/>Posts ✓"]
-```
+<p>
+  <img src="images/progressive-stages.svg" alt="Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done." width="840" />
+</p>
 
 ## Compression Middleware Compatibility
 

--- a/docs/pro/streaming-ssr.md
+++ b/docs/pro/streaming-ssr.md
@@ -308,7 +308,7 @@ To render more of the page progressively, add an async prop and a `<Suspense>` b
 Extending the example with a second slow section (`users`), the page fills in stage by stage from the browser's perspective — visible from the first paint and interactive as each part hydrates, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
 
 <p>
-  <img src="images/progressive-stages.svg" alt="Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done." width="840" />
+  <img src="images/progressive-stages.svg" alt="Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done. Each Suspense boundary swaps its fallback for real content as its prop arrives." width="840" />
 </p>
 
 ## Compression Middleware Compatibility

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -2170,7 +2170,7 @@ To render more of the page progressively, add an async prop and a `<Suspense>` b
 Extending the example with a second slow section (`users`), the page fills in stage by stage from the browser's perspective — visible from the first paint and interactive as each part hydrates, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
 
 <p>
-  <img src="images/progressive-stages.svg" alt="Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done." width="840" />
+  <img src="images/progressive-stages.svg" alt="Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done. Each Suspense boundary swaps its fallback for real content as its prop arrives." width="840" />
 </p>
 
 ## Compression Middleware Compatibility

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1877,23 +1877,9 @@ Traditional SSR renders the full page on the server, then sends the complete HTM
 
 With traditional SSR the first paint waits for the slowest query; with streaming the shell paints first and each slow section streams in afterward:
 
-```mermaid
-flowchart LR
-    subgraph TRAD["Traditional SSR — paint waits for all data"]
-        direction LR
-        t0([Request]) --> t1["Fetch users<br/>~800 ms"]
-        t0 --> t2["Fetch posts<br/>~600 ms"]
-        t1 --> t3["Render HTML<br/>~200 ms"]
-        t2 --> t3
-        t3 --> t4(["First paint<br/>~1000 ms"])
-    end
-    subgraph STREAM["Streaming SSR + async props — paint first, data streams in"]
-        direction LR
-        s0([Request]) --> s1["Render shell<br/>~50 ms"] --> s2(["First paint<br/>~50 ms"])
-        s2 -. stream as ready .-> s3["Users fill in"]
-        s2 -. stream as ready .-> s4["Posts fill in"]
-    end
-```
+<p>
+  <img src="images/traditional-vs-streaming.svg" alt="Two side-by-side timelines on the same scale. With traditional SSR the first paint happens only after the slowest data fetch and the HTML render finish (about 1000 ms). With streaming SSR plus async props the shell paints almost immediately (about 50 ms) and each slow section streams in afterward." width="840" />
+</p>
 
 _Timings are illustrative, not benchmarks — the point is **when** the first paint happens: only after all data is ready for traditional SSR, but right after the shell for streaming._
 
@@ -1904,21 +1890,9 @@ _Timings are illustrative, not benchmarks — the point is **when** the first pa
 3. As each `<Suspense>` boundary resolves (e.g., an async data fetch completes), the rendered HTML chunk is streamed to the browser
 4. The browser replaces placeholders with real content — no full-page reload needed
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Browser
-    participant Rails
-    participant Renderer as Node Renderer
-    Browser->>Rails: Ask for a page
-    Rails->>Renderer: Start rendering the page
-    Renderer-->>Rails: First HTML piece
-    Rails-->>Browser: Browser can paint right away
-    loop more page parts become ready
-        Renderer-->>Rails: Next HTML piece
-        Rails-->>Browser: Browser adds it to the page
-    end
-```
+<p>
+  <img src="images/streaming-sequence.svg" alt="Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks Rails for a page, Rails asks the renderer to start, the renderer streams the first HTML piece back through Rails so the browser can paint right away, then a loop streams each further HTML piece as more of the page becomes ready." width="840" />
+</p>
 
 ## Prerequisites
 
@@ -1939,22 +1913,9 @@ This is the recommended answer to "my component needs Rails data during render":
 
 Under the hood, Rails opens a bidirectional HTTP/2 NDJSON stream to the renderer and feeds props in as it resolves them. Each update runs in that request's isolated `sharedExecutionContext` and resolves a Promise, which lets React flush the corresponding HTML back to Rails for forwarding to the browser:
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Browser
-    participant Rails
-    participant Renderer as Node Renderer
-    Browser->>Rails: Ask for a page
-    Rails->>Renderer: Start page with placeholders
-    Renderer-->>Rails: HTML shell + loading states
-    Rails-->>Browser: Browser shows the shell
-    loop each slow data value becomes ready
-        Rails->>Renderer: Send the data value
-        Renderer-->>Rails: HTML for that page section
-        Rails-->>Browser: Browser replaces the loading state
-    end
-```
+<p>
+  <img src="images/async-props-sequence.svg" alt="Sequence diagram across three lanes — Browser, Rails, and the Node Renderer. The browser asks for a page, Rails starts the page with placeholders, the renderer returns an HTML shell with loading states, and the browser shows the shell. Then a loop runs for each slow data value: Rails sends the value, the renderer returns the HTML for that section, and the browser replaces the loading state." width="840" />
+</p>
 
 The view helper is `stream_react_component_with_async_props`, which yields an emitter:
 
@@ -1975,19 +1936,9 @@ For the full data-fetching guidance — synchronous props, parallelizing indepen
 
 For contrast, a Server Component _can_ reach Rails by calling `fetch` itself. This is a plain **network round-trip** — the renderer's VM has no in-process access to Rails models, sessions, or cookies — and it gives up what async props provide for free, so prefer async props for Rails-owned data:
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Renderer as Node Renderer
-    participant Rails as Rails API
-    participant Data as DB / Models
-    Note over Renderer: Discouraged — usually let Rails pass the data instead
-    Renderer->>Rails: Ask Rails API for data
-    Rails->>Data: Load and authorize data
-    Data-->>Rails: Data
-    Rails-->>Renderer: JSON data
-    Renderer->>Renderer: Continue rendering
-```
+<p>
+  <img src="images/discouraged-direct-fetch.svg" alt="Sequence diagram across three lanes — Node Renderer, Rails API, and DB / Models. A warning banner notes this is discouraged. The renderer asks the Rails API for data, Rails loads and authorizes it from the database, returns the data to Rails, Rails returns JSON to the renderer, and the renderer continues rendering. Prefer async props so Rails keeps owning auth and caching." width="840" />
+</p>
 
 Caveats: `fetch`, `Headers`, `Request`, `Response`, `AbortController`, and `AbortSignal` are **not** in the VM by default (bundle an HTTP client or inject them via [runtime globals](../oss/building-features/node-renderer/js-configuration.md#runtime-globals-for-ssr-and-rsc)); cookies, auth, session, and CSRF are **not** forwarded automatically; and it bypasses Rails' authorization and caching layers.
 
@@ -2218,11 +2169,9 @@ To render more of the page progressively, add an async prop and a `<Suspense>` b
 
 Extending the example with a second slow section (`users`), the page fills in stage by stage from the browser's perspective — visible from the first paint and interactive as each part hydrates, with each `<Suspense>` boundary swapping its fallback for real content as its prop arrives:
 
-```mermaid
-flowchart LR
-    A["Stage 1 · shell (~50 ms)<br/><br/>Header ✓<br/>Users …loading<br/>Posts …loading<br/><br/>visible now · interactive as JS loads"] --> B["Stage 2 · users fill in<br/><br/>Header ✓<br/>Users ✓<br/>Posts …loading"]
-    B --> C["Stage 3 · complete<br/><br/>Header ✓<br/>Users ✓<br/>Posts ✓"]
-```
+<p>
+  <img src="images/progressive-stages.svg" alt="Three browser snapshots. Stage 1 is the shell at about 50 ms: the header is done while users and posts show loading states, but the page is already visible and becomes interactive as JS loads. Stage 2: the users section fills in while posts still load. Stage 3: the page is complete with header, users, and posts all done." width="840" />
+</p>
 
 ## Compression Middleware Compatibility
 


### PR DESCRIPTION
## Summary

Converts all five Mermaid diagrams in the canonical streaming SSR overview (`docs/pro/streaming-ssr.md`) into polished, end-user-facing SVGs, matching the look/animation quality of the endorsed reference set under `docs/pro/react-server-components/images/` (e.g. `rendering-flow-sequence.svg`, `async-props-execution.svg`).

This is **Part A of #3804** — the `streaming-ssr.md` file only. The other files owned by #3804 (`node-renderer.md`, `js-memory-leaks.md`, `rolling-deploy-adapters.md`, `rolling-deploy-custom-adapters.md`) are file-disjoint and will follow as separate PRs.

## New SVGs (`docs/pro/images/`)

| File | Replaces | Notes |
| --- | --- | --- |
| `traditional-vs-streaming.svg` | traditional-vs-streaming `flowchart` | Same-scale timeline comparison; emphasizes *when* first paint happens (~1000 ms vs ~50 ms) |
| `streaming-sequence.svg` | basic streaming `sequenceDiagram` | Browser ↔ Rails ↔ Node Renderer swim lanes with a "more parts ready" loop |
| `async-props-sequence.svg` | async-props `sequenceDiagram` | Shell + per-value emit/fill loop |
| `discouraged-direct-fetch.svg` | discouraged-fetch `sequenceDiagram` | Renderer → Rails API → DB, with a "Discouraged" warning banner |
| `progressive-stages.svg` | 3-stage fill-in `flowchart` | Three browser snapshots filling in stage by stage |

## Style guide conformance (per #3804 / #3802)

- Standalone `.svg` files with `viewBox` (responsive), co-located in an `images/` subfolder next to the doc.
- Embedded as `<p>``&lt;img src="images/&lt;name&gt;.svg" alt="…" width="840" /&gt;``</p>` with descriptive alt text for accessibility.
- Palette / typography per the shared style guide (Rails/React/Browser gradients, slate text, `system-ui` / `monospace`).
- **Light + dark theme** via `@media (prefers-color-scheme: dark)`.
- Tasteful CSS-keyframe animation where it aids comprehension (progressive reveal on sequences, spinners on loading states), with a **`prefers-reduced-motion`** fallback that shows the final state.
- The old Mermaid blocks are deleted in the same change.

## Validation

- SVGs validated as well-formed XML locally before pushing.
- No `mermaid` blocks remain in `docs/pro/streaming-ssr.md`; surrounding prose/code is unchanged.

Part of #3804 · umbrella #3802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NE3KNjRuLwNhki4t3phACu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only asset and markup swap; no application or renderer behavior changes.
> 
> **Overview**
> **Part A of the Mermaid-to-SVG docs effort:** the five diagrams in `docs/pro/streaming-ssr.md` are no longer inline Mermaid; they are static SVGs under `docs/pro/images/` (`traditional-vs-streaming`, `streaming-sequence`, `async-props-sequence`, `discouraged-direct-fetch`, `progressive-stages`).
> 
> Each diagram is embedded with descriptive `alt` text and fixed width, aligned with the existing RSC image style (light/dark theme, optional animation, `prefers-reduced-motion`). The same `streaming-ssr` section in `llms-full-pro.txt` is updated to match. Prose and code examples in the guide are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1f2f847dec1697e44588616bba21d526f58036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Streaming SSR documentation with enhanced visual illustrations. Replaced interactive diagrams with clearer static images to improve explanations of streaming workflows, including timing comparisons, sequence interactions, async properties handling, and progressive rendering stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->