### PR TITLE
Raise RSC peer recommendedMin to stable 19.0.5 (#3632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 #### Changed
 
 - **[Pro]** **Pinned `react-on-rails-rsc` to the stable `19.0.5` release**: The generator default, the root and Pro package manifests, the lockfile, and the Pro RSC install docs now pin the stable `react-on-rails-rsc@19.0.5` (previously the `19.0.5-rc.7` prerelease). The native RSC CSS FOUC fix requires `react-on-rails-rsc >= 19.0.5`. Closes [Issue 3634](https://github.com/shakacode/react_on_rails/issues/3634). [PR 4080](https://github.com/shakacode/react_on_rails/pull/4080) by [justin808](https://github.com/justin808).
+- **[Pro]** **RSC peer-compatibility warn-tier floor raised to stable `19.0.5`**: The Pro node renderer's `recommendedMin` for `react-on-rails-rsc` is now the published stable `19.0.5` (previously the dormant `19.0.2`). Anyone still on an older 19.x build (`19.0.2`–`19.0.4`) now gets a loud startup warning that they are missing the coordinated RSC fixes shipped in `19.0.5` (FOUC stylesheet preloading, async manifest signatures); `19.0.5`+ no longer warns. Refs [Issue 3632](https://github.com/shakacode/react_on_rails/issues/3632). [PR 4078](https://github.com/shakacode/react_on_rails/pull/4078) by [justin808](https://github.com/justin808).
 
 ### [17.0.0.rc.5] - 2026-06-16
 

--- a/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts
@@ -16,14 +16,14 @@
 // Single source of truth for react-on-rails-pro's RSC peer compatibility window.
 // This is the only value to bump when compatibility changes.
 //
-// `recommendedMin` deliberately starts at the stable floor we currently recommend.
-// Raise it to the stable `react-on-rails-rsc` release (expected 19.0.5) once
-// 19.0.5-rc.7 is promoted, which activates the warn tier for anyone still on an older
-// 19.x build.
+// `recommendedMin` is the published stable `react-on-rails-rsc` floor we recommend.
+// It is now raised to 19.0.5 (the published stable release), which activates the warn
+// tier for anyone still on an older 19.x build in the 19.0.2–19.0.4 range — those
+// predate the coordinated fixes (FOUC stylesheet preloading, async manifest signatures).
 // Bump tracked by https://github.com/shakacode/react_on_rails/issues/3632
 // (the stable 19.0.5 ship/pin is tracked by issue #3634).
 export const RSC_PEER_SUPPORT = {
-  reactOnRailsRsc: { recommendedMin: '19.0.2', supportedMajor: 19 },
+  reactOnRailsRsc: { recommendedMin: '19.0.5', supportedMajor: 19 },
   react: {
     supportedMajor: 19,
     supportedRanges: [

--- a/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts
@@ -32,8 +32,12 @@ describe('checkRscPeerCompatibility', () => {
     expect(checkRscPeerCompatibility({ rscVersion: null, reactVersion: '19.0.4' })).toEqual({ level: 'ok' });
   });
 
-  it('returns ok for a supported stable rsc + react', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.0.4', reactVersion: '19.0.4' }).level).toBe('ok');
+  it('returns ok for a supported stable rsc + react at the recommended floor', () => {
+    expect(checkRscPeerCompatibility({ rscVersion: '19.0.5', reactVersion: '19.0.4' }).level).toBe('ok');
+  });
+
+  it('warns for a stable rsc below the recommended floor (e.g. 19.0.4)', () => {
+    expect(checkRscPeerCompatibility({ rscVersion: '19.0.4', reactVersion: '19.0.4' }).level).toBe('warn');
   });
 
   it('returns ok for the React 19.2.7 floor required by the 19.2 RSC package line', () => {
@@ -45,7 +49,7 @@ describe('checkRscPeerCompatibility', () => {
   });
 
   it('returns ok for a version with a leading v (prefix stripped for comparison)', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: 'v19.0.4', reactVersion: '19.0.4' }).level).toBe('ok');
+    expect(checkRscPeerCompatibility({ rscVersion: 'v19.0.5', reactVersion: '19.0.4' }).level).toBe('ok');
   });
 
   it('errors when rsc major is above the supported major', () => {
@@ -163,6 +167,6 @@ describe('checkRscPeerCompatibility', () => {
   });
 
   it('skips the React check when React is not resolvable', () => {
-    expect(checkRscPeerCompatibility({ rscVersion: '19.0.4', reactVersion: null }).level).toBe('ok');
+    expect(checkRscPeerCompatibility({ rscVersion: '19.0.5', reactVersion: null }).level).toBe('ok');
   });
 });

--- a/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/runRscPeerCompatibilityCheck.test.ts
@@ -117,6 +117,24 @@ describe('runRscPeerCompatibilityCheck', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('warns when on the dormant 19.0.4 build (now below the 19.0.5 floor)', () => {
+    expect(() =>
+      runRscPeerCompatibilityCheck({
+        resolveVersion: resolveVersions('19.0.4'),
+      }),
+    ).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn at the recommended stable floor (19.0.5)', () => {
+    expect(() =>
+      runRscPeerCompatibilityCheck({
+        resolveVersion: resolveVersions('19.0.5'),
+      }),
+    ).not.toThrow();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('does not label an existing warning as downgraded when the env hatch is set', () => {
     expect(() =>
       runRscPeerCompatibilityCheck({


### PR DESCRIPTION
## Why

Stable `react-on-rails-rsc@19.0.5` is now published on npm `latest`. Pro's RSC peer-compatibility check (in `react-on-rails-pro-node-renderer`) has a **warn tier** driven by a single source-of-truth constant, `RSC_PEER_SUPPORT.reactOnRailsRsc.recommendedMin`, which until now shipped at the dormant floor `19.0.2` — so nothing in the `19.x` line was ever below it and the warn tier never fired.

This raises `recommendedMin` to the published stable `19.0.5`, activating the warn tier: anyone still on an older `19.x` `react-on-rails-rsc` (`19.0.2`–`19.0.4`) now gets a loud runtime warning that they are missing the coordinated fixes (FOUC stylesheet preloading, async manifest signatures, RSC manifest CSS collection) that landed in `19.0.5`. Users on `19.0.5`+ are unaffected.

This is the follow-up the original code comment and issue #3632 explicitly deferred until stable `19.0.5` shipped. The `react-on-rails-rsc` install-pin flip itself is tracked separately by #3634; the optional `peerDependencies` floor tightening is tracked by #3965.

## Changes

- `packages/react-on-rails-pro-node-renderer/src/shared/rscPeerSupport.ts`: `recommendedMin` `19.0.2` → `19.0.5`; comment updated to reflect the now-active floor.
- `packages/react-on-rails-pro-node-renderer/tests/checkRscPeerCompatibility.test.ts` and `runRscPeerCompatibilityCheck.test.ts`: updated cases that assumed the dormant floor, and added explicit boundary coverage — `19.0.4` now warns, `19.0.5` does not.
- `CHANGELOG.md`: `[Unreleased]` entry.

## Validation

- `jest` on both affected suites: **40/40 passing** (incl. new `19.0.4`→warn / `19.0.5`→ok cases).
- `pnpm run type-check`, `eslint` (source), and `prettier --check`: clean.
- No `pnpm-lock.yaml` changes (no dependency versions touched).

## Scope notes

- Pro `peerDependencies` floor (`react-on-rails-rsc: "*"`) intentionally **not** touched here — deferred to #3965.

Fixes #3632

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in dev-time compatibility warnings only; no runtime behavior or dependency pins altered.
> 
> **Overview**
> Raises Pro’s **`react-on-rails-rsc` recommended minimum** in `RSC_PEER_SUPPORT` from **`19.0.2` → `19.0.5`**, so the existing warn-tier peer check actually fires for installs still on **`19.0.2`–`19.0.4`** (missing coordinated RSC fixes from stable **19.0.5**). **`19.0.5`+** stays **ok** with no startup warning.
> 
> Tests in **`checkRscPeerCompatibility`** and **`runRscPeerCompatibilityCheck`** are aligned to the new floor (explicit **19.0.4 → warn**, **19.0.5 → ok**). **`CHANGELOG.md`** documents the change under **[Unreleased]**. No dependency or lockfile bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37180bd9ea766c24a99c8fd54a2eb046fccf5e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated the minimum recommended `react-on-rails-rsc` version for Pro users to **19.0.5**.
  * Pro users on **19.0.2–19.0.4** will now receive a startup warning about missing coordinated RSC compatibility fixes; **19.0.5+** will no longer warn.
* **Tests**
  * Expanded compatibility-check tests to verify warning vs. no-warning at and below the recommended floor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->