### PR TITLE
ci: add zizmor static analysis for GitHub Actions (#3449)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,6 +26,8 @@ on:
       - '.github/actions/**'
       - '.github/dependabot.yml'
       - '.github/zizmor.yml'
+  # No `branches:` filter on purpose: auditing PRs that target any branch
+  # (not just main) catches security issues early. Mirrors actionlint.yml.
   pull_request:
     paths:
       - '.github/workflows/**'
@@ -65,6 +67,11 @@ jobs:
         with:
           # Audit the whole repo (workflows and composite actions).
           inputs: .
+          # Pin the zizmor binary version (the action otherwise installs
+          # `latest`, so the finding count would drift release-to-release and
+          # the documented baseline could go stale). Bump deliberately when
+          # re-triaging the baseline.
+          version: 1.25.2
           # Emit findings as GitHub annotations instead of uploading SARIF.
           # SARIF upload requires GitHub Advanced Security and
           # `security-events: write`; annotations keep this job

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,6 +28,13 @@ name: Zizmor GitHub Actions Security Audit
 permissions:
   contents: read
 
+# Single source of truth for the pinned zizmor image (tag + digest). Defined at
+# workflow level so the version-print and audit steps can't drift apart on a
+# version bump.
+env:
+  # yamllint disable-line rule:line-length
+  ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.16.3@sha256:f09cee55087d54e7a162fc255ffe82ef942f68e683f967c8a6471ffe35e7ec64
+
 on:
   push:
     branches:
@@ -65,10 +72,8 @@ jobs:
           persist-credentials: false
       - name: Print zizmor version
         # Logs the exact pinned version and confirms the image pulled
-        # successfully before the audit runs.
-        env:
-          # yamllint disable-line rule:line-length
-          ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.16.3@sha256:f09cee55087d54e7a162fc255ffe82ef942f68e683f967c8a6471ffe35e7ec64
+        # successfully before the audit runs. ZIZMOR_IMAGE comes from the
+        # workflow-level env above.
         run: docker run --rm "${ZIZMOR_IMAGE}" --version
         shell: bash
       - name: Run zizmor
@@ -79,9 +84,8 @@ jobs:
         # the action would use, pinned by both tag and digest (zizmor 1.16.3).
         # The workspace is mounted read-only and the only token exposed is the
         # job-scoped GITHUB_TOKEN; the job has `contents: read` only.
+        # ZIZMOR_IMAGE comes from the workflow-level env above.
         env:
-          # yamllint disable-line rule:line-length
-          ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.16.3@sha256:f09cee55087d54e7a162fc255ffe82ef942f68e683f967c8a6471ffe35e7ec64
           GH_TOKEN: ${{ github.token }}
         run: |
           docker run --rm \

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,9 +15,12 @@ name: Zizmor GitHub Actions Security Audit
 # audit actually ran. (A blanket `continue-on-error: true` was avoided because
 # it would also hide tool failures behind a green check.)
 #
-# Pre-existing findings are suppressed via a baseline in .github/zizmor.yml so
-# that NEW findings introduced by future PRs surface as annotations without
-# being pushed past GitHub's 10-annotations-per-step cap.
+# Pre-existing workflow-file findings are suppressed via a baseline in
+# .github/zizmor.yml so that NEW findings introduced by future PRs surface as
+# annotations without being pushed past GitHub's 10-annotations-per-step cap.
+# Composite-action (action.yml) findings cannot be suppressed via config (a
+# documented zizmor limitation) and, like online-audit findings, still surface
+# as advisory annotations — acceptable while the gate is non-blocking.
 #
 # Follow-up (issue #3449): once the baseline backlog in .github/zizmor.yml is
 # cleared, drop `--no-exit-codes` to make this a required, blocking gate.
@@ -60,6 +63,14 @@ jobs:
           # No need for history in a lint/audit job.
           fetch-depth: 1
           persist-credentials: false
+      - name: Print zizmor version
+        # Logs the exact pinned version and confirms the image pulled
+        # successfully before the audit runs.
+        env:
+          # yamllint disable-line rule:line-length
+          ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.16.3@sha256:f09cee55087d54e7a162fc255ffe82ef942f68e683f967c8a6471ffe35e7ec64
+        run: docker run --rm "${ZIZMOR_IMAGE}" --version
+        shell: bash
       - name: Run zizmor
         # We invoke the pinned zizmor container directly rather than via
         # zizmorcore/zizmor-action because that action does not expose

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,63 @@
+name: Zizmor GitHub Actions Security Audit
+
+# zizmor (https://github.com/zizmorcore/zizmor) is a static analysis tool
+# that finds security issues in GitHub Actions workflows and composite
+# actions. It runs ALONGSIDE actionlint (.github/workflows/actionlint.yml):
+# actionlint checks syntax and correctness, zizmor checks for security
+# weaknesses (unpinned actions, template injection, credential persistence).
+#
+# ROLLOUT: This gate is intentionally NON-BLOCKING for now
+# (`continue-on-error: true`). A baseline scan of `main` surfaced pre-existing
+# findings across the existing workflows. Findings are surfaced as PR
+# annotations so they can be triaged and fixed incrementally.
+# Follow-up (issue #3449): once the backlog is cleared, remove
+# `continue-on-error: true` to make this a required, blocking gate.
+# See .github/zizmor.yml for configuration.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-22.04
+    # Non-blocking during initial rollout; see header and .github/zizmor.yml.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # No need for history in a lint/audit job.
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Run zizmor
+        # Official action, pinned to a commit SHA (v0.5.6) per supply-chain
+        # best practice.
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
+        with:
+          # Audit the whole repo (workflows and composite actions).
+          inputs: .
+          # Emit findings as GitHub annotations instead of uploading SARIF.
+          # SARIF upload requires GitHub Advanced Security and
+          # `security-events: write`; annotations keep this job
+          # least-privilege (contents: read only) and work on any repo tier.
+          advanced-security: false
+          annotations: true
+          # token defaults to ${{ github.token }} for online audits.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,11 +24,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
       - '.github/zizmor.yml'
   pull_request:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
       - '.github/zizmor.yml'
   workflow_dispatch:
 
@@ -40,7 +42,10 @@ jobs:
   zizmor:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to a commit SHA (v4.2.2) to model the target state for the
+      # rest of the repo, since this workflow introduces zizmor's
+      # `unpinned-uses` rule.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           # No need for history in a lint/audit job.
           fetch-depth: 1
@@ -66,4 +71,7 @@ jobs:
           # least-privilege (contents: read only) and work on any repo tier.
           advanced-security: false
           annotations: true
+          # Point at the repo config explicitly so the wiring is obvious
+          # (zizmor would otherwise discover it via the default search path).
+          config: .github/zizmor.yml
           # token defaults to ${{ github.token }} for online audits.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,11 +6,11 @@ name: Zizmor GitHub Actions Security Audit
 # actionlint checks syntax and correctness, zizmor checks for security
 # weaknesses (unpinned actions, template injection, credential persistence).
 #
-# ROLLOUT: This gate is intentionally NON-BLOCKING for now
-# (`continue-on-error: true`). A baseline scan of `main` surfaced pre-existing
-# findings across the existing workflows. Findings are surfaced as PR
-# annotations so they can be triaged and fixed incrementally.
-# Follow-up (issue #3449): once the backlog is cleared, remove
+# ROLLOUT: This gate is intentionally NON-BLOCKING for now. The "Run zizmor"
+# step sets `continue-on-error: true`, so a baseline scan of `main` (which
+# surfaced pre-existing findings across the existing workflows) does not fail
+# the check. Findings still surface as PR annotations for incremental triage.
+# Follow-up (issue #3449): once the backlog is cleared, remove the step's
 # `continue-on-error: true` to make this a required, blocking gate.
 # See .github/zizmor.yml for configuration.
 
@@ -39,8 +39,6 @@ concurrency:
 jobs:
   zizmor:
     runs-on: ubuntu-22.04
-    # Non-blocking during initial rollout; see header and .github/zizmor.yml.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,6 +46,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Run zizmor
+        # Non-blocking during initial rollout: `continue-on-error` is set on
+        # the STEP (not the job) so zizmor's findings still surface as
+        # annotations while the job — and therefore the `zizmor` check —
+        # stays green. A job-level `continue-on-error` would leave the check
+        # run itself red even when the workflow succeeds. See the header and
+        # .github/zizmor.yml. Follow-up (#3449): remove this line to make
+        # zizmor a blocking gate once the baseline findings are triaged.
+        continue-on-error: true
         # Official action, pinned to a commit SHA (v0.5.6) per supply-chain
         # best practice.
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -6,13 +6,21 @@ name: Zizmor GitHub Actions Security Audit
 # actionlint checks syntax and correctness, zizmor checks for security
 # weaknesses (unpinned actions, template injection, credential persistence).
 #
-# ROLLOUT: This gate is intentionally NON-BLOCKING for now. The "Run zizmor"
-# step sets `continue-on-error: true`, so a baseline scan of `main` (which
-# surfaced pre-existing findings across the existing workflows) does not fail
-# the check. Findings still surface as PR annotations for incremental triage.
-# Follow-up (issue #3449): once the backlog is cleared, remove the step's
-# `continue-on-error: true` to make this a required, blocking gate.
-# See .github/zizmor.yml for configuration.
+# ROLLOUT: This gate is intentionally NON-BLOCKING for now, but in a way that
+# still fails on real problems. The "Run zizmor" step invokes the pinned
+# zizmor CLI with `--no-exit-codes`: zizmor then exits 0 for both "clean" and
+# "findings", and non-zero ONLY for a genuine tool/config failure (bad config,
+# unknown version, Docker/image error). So pre-existing findings do not fail
+# the `zizmor` check, but a broken audit DOES — a green check always means the
+# audit actually ran. (A blanket `continue-on-error: true` was avoided because
+# it would also hide tool failures behind a green check.)
+#
+# Pre-existing findings are suppressed via a baseline in .github/zizmor.yml so
+# that NEW findings introduced by future PRs surface as annotations without
+# being pushed past GitHub's 10-annotations-per-step cap.
+#
+# Follow-up (issue #3449): once the baseline backlog in .github/zizmor.yml is
+# cleared, drop `--no-exit-codes` to make this a required, blocking gate.
 
 permissions:
   contents: read
@@ -53,32 +61,26 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Run zizmor
-        # Non-blocking during initial rollout: `continue-on-error` is set on
-        # the STEP (not the job) so zizmor's findings still surface as
-        # annotations while the job — and therefore the `zizmor` check —
-        # stays green. A job-level `continue-on-error` would leave the check
-        # run itself red even when the workflow succeeds. See the header and
-        # .github/zizmor.yml. Follow-up (#3449): remove this line to make
-        # zizmor a blocking gate once the baseline findings are triaged.
-        continue-on-error: true
-        # Official action, pinned to a commit SHA (v0.5.6) per supply-chain
-        # best practice.
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
-        with:
-          # Audit the whole repo (workflows and composite actions).
-          inputs: .
-          # Pin the zizmor binary version (the action otherwise installs
-          # `latest`, so the finding count would drift release-to-release and
-          # the documented baseline could go stale). Bump deliberately when
-          # re-triaging the baseline.
-          version: 1.25.2
-          # Emit findings as GitHub annotations instead of uploading SARIF.
-          # SARIF upload requires GitHub Advanced Security and
-          # `security-events: write`; annotations keep this job
-          # least-privilege (contents: read only) and work on any repo tier.
-          advanced-security: false
-          annotations: true
-          # Point at the repo config explicitly so the wiring is obvious
-          # (zizmor would otherwise discover it via the default search path).
-          config: .github/zizmor.yml
-          # token defaults to ${{ github.token }} for online audits.
+        # We invoke the pinned zizmor container directly rather than via
+        # zizmorcore/zizmor-action because that action does not expose
+        # `--no-exit-codes`, which is what lets us forgive FINDINGS while still
+        # failing on a genuine tool/config error. The image is the exact one
+        # the action would use, pinned by both tag and digest (zizmor 1.16.3).
+        # The workspace is mounted read-only and the only token exposed is the
+        # job-scoped GITHUB_TOKEN; the job has `contents: read` only.
+        env:
+          # yamllint disable-line rule:line-length
+          ZIZMOR_IMAGE: ghcr.io/zizmorcore/zizmor:1.16.3@sha256:f09cee55087d54e7a162fc255ffe82ef942f68e683f967c8a6471ffe35e7ec64
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          docker run --rm \
+            --volume "${GITHUB_WORKSPACE}:/workspace:ro" \
+            --workdir /workspace \
+            --env "GH_TOKEN=${GH_TOKEN}" \
+            "${ZIZMOR_IMAGE}" \
+            --format=github \
+            --config=.github/zizmor.yml \
+            --no-exit-codes \
+            -- \
+            .
+        shell: bash

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -19,5 +19,15 @@
 # No rules are globally disabled here on purpose: keeping all audits ON
 # while the gate is non-blocking gives maintainers the full picture without
 # masking future regressions.
+#
+# `rules: {}` below is effectively a no-op today (same as having no config),
+# but it gives the file a valid, ready-to-extend structure. To suppress a
+# specific finding while triaging the baseline, add a per-finding `ignore`
+# entry rather than disabling a rule globally. Example (commented out):
+#   rules:
+#     unpinned-uses:
+#       ignore:
+#         - some-workflow.yml:42:9   # reason for the suppression
+# See https://docs.zizmor.sh/configuration/#ignoring-findings
 
 rules: {}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,35 +1,132 @@
 # zizmor configuration — static analysis for GitHub Actions
 # https://docs.zizmor.sh/configuration/
 #
-# ROLLOUT NOTE (issue #3449):
-# zizmor is introduced as a NON-BLOCKING gate first (see
-# .github/workflows/zizmor.yml, which sets `continue-on-error: true`).
-# A baseline scan of `main` with the pinned zizmor version surfaced ~56
-# findings in the default ("regular") persona across the existing workflows
-# — primarily `unpinned-uses` (third-party actions not pinned to a commit
-# SHA) plus some `template-injection`, `artipacked`, and `dependabot-cooldown`.
-# The zizmor binary version is pinned in the workflow (see the `version:`
-# input) so this count stays reproducible across runs.
+# ROLLOUT (issue #3449): zizmor runs as a NON-BLOCKING gate during phase 1.
+# The workflow (.github/workflows/zizmor.yml) invokes the pinned zizmor CLI
+# with `--no-exit-codes`, so pre-existing FINDINGS do not fail the `zizmor`
+# check — but genuine TOOL/CONFIG failures (bad config, unknown version,
+# Docker/image error) still fail it, so a broken audit never masquerades as a
+# green check. See the workflow for the exit-code handling.
 #
-# These are pre-existing and out of scope for the workflow-introduction PR,
-# so the gate does not fail the build yet. The findings remain VISIBLE (as
-# PR annotations) so they can be triaged and fixed incrementally. Once the
-# backlog is cleared, the follow-up is to remove `continue-on-error: true`
-# from the workflow to make zizmor a blocking gate, and to replace any
-# blanket rule disables below with targeted per-finding `ignore` entries.
+# BASELINE SUPPRESSION (why the `ignore` list below):
+# A scan of `main` with the pinned zizmor version (1.16.3 — see the workflow's
+# `--version`) surfaces ~56 pre-existing findings across the existing
+# workflows/actions. GitHub caps annotations at 10 per step, so with an
+# un-suppressed baseline a NEW finding introduced by a future PR could be
+# pushed past the cap and never render — defeating the point of a non-blocking
+# "surface new issues" gate. To keep the signal useful, every KNOWN baseline
+# finding is suppressed below with a precise `filename:line` `ignore` entry.
+# Net effect: a brand-new finding in a PR is NOT in this list, so it surfaces
+# as an annotation (and stays well under the cap).
 #
-# No rules are globally disabled here on purpose: keeping all audits ON
-# while the gate is non-blocking gives maintainers the full picture without
-# masking future regressions.
+# These suppressions are the phase-1 triage backlog, NOT permanent waivers.
+# As each underlying issue is fixed (e.g. pinning an action to a SHA, adding
+# an explicit `permissions:` block), remove its `ignore` entry. When the list
+# is empty, drop `--no-exit-codes` from the workflow to flip zizmor to a
+# blocking gate. If a baseline line shifts due to an unrelated edit, the stale
+# finding simply re-surfaces as an annotation (safe failure mode — more
+# visibility, not less).
 #
-# `rules: {}` below is effectively a no-op today (same as having no config),
-# but it gives the file a valid, ready-to-extend structure. To suppress a
-# specific finding while triaging the baseline, add a per-finding `ignore`
-# entry rather than disabling a rule globally. Example (commented out):
-#   rules:
-#     unpinned-uses:
-#       ignore:
-#         - some-workflow.yml:42:9   # reason for the suppression
+# NOTE: zizmor matches `ignore` entries by filename basename only (its own
+# documented limitation), so the composite actions all named `action.yml` are
+# matched by basename + line. Multiple lines per finding are listed because a
+# finding is ignored if ANY of its locations matches. Regenerate after a
+# binary version bump with the pinned version:
+#   zizmor --no-online-audits --color=never --format=json . \
+#     | jq -r '.[] | .ident as $r | .locations[]
+#              | "\($r) \(.symbolic.key.Local.given_path | split("/") | last):"
+#                + "\(.concrete.location.start_point.row + 1)"'
+# then group by rule.
 # See https://docs.zizmor.sh/configuration/#ignoring-findings
 
-rules: {}
+rules:
+  artipacked:
+    ignore:
+      - bundle-size.yml:23
+      - check-markdown-links.yml:34
+      - check-markdown-links.yml:70
+      - claude-code-review.yml:17
+      - claude.yml:25
+      - codeql.yml:24
+      - playwright.yml:79
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml:36
+      - dependabot.yml:55
+      - dependabot.yml:81
+      - dependabot.yml:100
+      - dependabot.yml:121
+  template-injection:
+    ignore:
+      - action.yml:30
+      - action.yml:32
+      - action.yml:34
+      - action.yml:35
+      - action.yml:37
+      - action.yml:38
+      - dummy-app-bundler-tests.yml:240
+      - dummy-app-bundler-tests.yml:241
+      - dummy-app-bundler-tests.yml:242
+      - examples.yml:54
+      - examples.yml:56
+      - examples.yml:59
+      - examples.yml:208
+      - examples.yml:209
+      - examples.yml:210
+      - gem-tests.yml:56
+      - gem-tests.yml:58
+      - gem-tests.yml:61
+      - gem-tests.yml:171
+      - gem-tests.yml:172
+      - gem-tests.yml:173
+      - integration-tests.yml:55
+      - integration-tests.yml:57
+      - integration-tests.yml:60
+      - lint-js-and-ruby.yml:49
+      - lint-js-and-ruby.yml:51
+      - lint-js-and-ruby.yml:54
+      - package-js-tests.yml:51
+      - package-js-tests.yml:53
+      - package-js-tests.yml:56
+      - playwright.yml:48
+      - playwright.yml:50
+      - playwright.yml:53
+      - precompile-check.yml:45
+      - precompile-check.yml:47
+      - precompile-check.yml:50
+      - pro-integration-tests.yml:54
+      - pro-integration-tests.yml:57
+      - pro-integration-tests.yml:60
+      - pro-test-package-and-gem.yml:53
+      - pro-test-package-and-gem.yml:56
+      - pro-test-package-and-gem.yml:59
+  unpinned-uses:
+    ignore:
+      - action.yml:51
+      - action.yml:60
+      - benchmark-suite.yml:104
+      - benchmark-suite.yml:113
+      - benchmark-suite.yml:155
+      - bundle-size.yml:70
+      - bundle-size.yml:129
+      - check-markdown-links.yml:37
+      - check-markdown-links.yml:80
+      - claude-code-review.yml:24
+      - claude.yml:32
+      - dummy-app-bundler-tests.yml:46
+      - dummy-app-bundler-tests.yml:160
+      - examples.yml:154
+      - lint-js-and-ruby.yml:96
+      - lint-js-and-ruby.yml:130
+      - package-js-tests.yml:106
+      - playwright.yml:96
+      - precompile-check.yml:92
+      - pro-integration-tests.yml:116
+      - pro-integration-tests.yml:224
+      - pro-integration-tests.yml:408
+      - pro-integration-tests.yml:572
+      - pro-test-package-and-gem.yml:119
+      - pro-test-package-and-gem.yml:225
+      - pro-test-package-and-gem.yml:324
+      - shakaperf-release-gates.yml:56
+      - trigger-docs-site.yml:23

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,12 +4,12 @@
 # ROLLOUT NOTE (issue #3449):
 # zizmor is introduced as a NON-BLOCKING gate first (see
 # .github/workflows/zizmor.yml, which sets `continue-on-error: true`).
-# A baseline scan of `main` surfaced ~56 surfaced findings in the default
-# ("regular") persona across the existing workflows — primarily
-# `unpinned-uses` (third-party actions not pinned to a commit SHA) plus
-# some `template-injection`, `artipacked`, and `dependabot-cooldown`. The
-# zizmor binary version is pinned in the workflow (see the `version:` input)
-# so this count stays reproducible across runs.
+# A baseline scan of `main` with the pinned zizmor version surfaced ~56
+# findings in the default ("regular") persona across the existing workflows
+# — primarily `unpinned-uses` (third-party actions not pinned to a commit
+# SHA) plus some `template-injection`, `artipacked`, and `dependabot-cooldown`.
+# The zizmor binary version is pinned in the workflow (see the `version:`
+# input) so this count stays reproducible across runs.
 #
 # These are pre-existing and out of scope for the workflow-introduction PR,
 # so the gate does not fail the build yet. The findings remain VISIBLE (as

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,10 +4,12 @@
 # ROLLOUT NOTE (issue #3449):
 # zizmor is introduced as a NON-BLOCKING gate first (see
 # .github/workflows/zizmor.yml, which sets `continue-on-error: true`).
-# A baseline scan of `main` surfaced ~56 findings in the default
+# A baseline scan of `main` surfaced ~56 surfaced findings in the default
 # ("regular") persona across the existing workflows — primarily
 # `unpinned-uses` (third-party actions not pinned to a commit SHA) plus
-# some `template-injection`, `artipacked`, and `dependabot-cooldown`.
+# some `template-injection`, `artipacked`, and `dependabot-cooldown`. The
+# zizmor binary version is pinned in the workflow (see the `version:` input)
+# so this count stays reproducible across runs.
 #
 # These are pre-existing and out of scope for the workflow-introduction PR,
 # so the gate does not fail the build yet. The findings remain VISIBLE (as

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -27,15 +27,21 @@
 # finding simply re-surfaces as an annotation (safe failure mode — more
 # visibility, not less).
 #
-# NOTE: zizmor matches `ignore` entries by filename basename only (its own
-# documented limitation), so the composite actions all named `action.yml` are
-# matched by basename + line. Multiple lines per finding are listed because a
-# finding is ignored if ANY of its locations matches. Regenerate after a
-# binary version bump with the pinned version:
+# SCOPE LIMITATION: zizmor's `ignore` matches by workflow filename, and per its
+# documentation composite-action findings (in .github/actions/*/action.yml)
+# CANNOT be suppressed via this config — so no `action.yml` entries are listed
+# below (they were no-ops). Those composite-action findings, and any
+# online-audit findings, therefore still surface as annotations. That is
+# acceptable under the non-blocking phase-1 gate (more visibility, never a false
+# green); only the higher-volume workflow-file findings are baselined here so a
+# genuinely NEW workflow finding stays under GitHub's 10-annotation cap.
+# Regenerate the workflow-file baseline after a binary version bump with the
+# pinned version, EXCLUDING any action.yml locations (not suppressible):
 #   zizmor --no-online-audits --color=never --format=json . \
 #     | jq -r '.[] | .ident as $r | .locations[]
 #              | "\($r) \(.symbolic.key.Local.given_path | split("/") | last):"
-#                + "\(.concrete.location.start_point.row + 1)"'
+#                + "\(.concrete.location.start_point.row + 1)"' \
+#     | grep -v ' action.yml:'
 # then group by rule.
 # See https://docs.zizmor.sh/configuration/#ignoring-findings
 
@@ -58,12 +64,6 @@ rules:
       - dependabot.yml:121
   template-injection:
     ignore:
-      - action.yml:30
-      - action.yml:32
-      - action.yml:34
-      - action.yml:35
-      - action.yml:37
-      - action.yml:38
       - dummy-app-bundler-tests.yml:240
       - dummy-app-bundler-tests.yml:241
       - dummy-app-bundler-tests.yml:242
@@ -102,8 +102,6 @@ rules:
       - pro-test-package-and-gem.yml:59
   unpinned-uses:
     ignore:
-      - action.yml:51
-      - action.yml:60
       - benchmark-suite.yml:104
       - benchmark-suite.yml:113
       - benchmark-suite.yml:155

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,23 @@
+# zizmor configuration — static analysis for GitHub Actions
+# https://docs.zizmor.sh/configuration/
+#
+# ROLLOUT NOTE (issue #3449):
+# zizmor is introduced as a NON-BLOCKING gate first (see
+# .github/workflows/zizmor.yml, which sets `continue-on-error: true`).
+# A baseline scan of `main` surfaced ~56 findings in the default
+# ("regular") persona across the existing workflows — primarily
+# `unpinned-uses` (third-party actions not pinned to a commit SHA) plus
+# some `template-injection`, `artipacked`, and `dependabot-cooldown`.
+#
+# These are pre-existing and out of scope for the workflow-introduction PR,
+# so the gate does not fail the build yet. The findings remain VISIBLE (as
+# PR annotations) so they can be triaged and fixed incrementally. Once the
+# backlog is cleared, the follow-up is to remove `continue-on-error: true`
+# from the workflow to make zizmor a blocking gate, and to replace any
+# blanket rule disables below with targeted per-finding `ignore` entries.
+#
+# No rules are globally disabled here on purpose: keeping all audits ON
+# while the gate is non-blocking gives maintainers the full picture without
+# masking future regressions.
+
+rules: {}


### PR DESCRIPTION
## Summary

Adds [zizmor](https://github.com/zizmorcore/zizmor) as a security-focused static analysis gate for GitHub Actions, running **alongside** the existing `actionlint` workflow (`.github/workflows/actionlint.yml`).

- **actionlint** → syntax & correctness
- **zizmor** → security weaknesses (unpinned actions, template injection, credential persistence, etc.)

Closes the long-standing request in #3449.

## Why zizmor

zizmor catches a class of GitHub Actions security issues actionlint does not: third-party actions not pinned to a commit SHA, template-injection sinks in `run:` blocks, over-broad credential persistence (`artipacked`), and more. It is the de-facto community standard for GHA security linting.

## What's added

**`.github/workflows/zizmor.yml`**
- Runs the **pinned zizmor container directly** (`ghcr.io/zizmorcore/zizmor:1.16.3`, pinned by tag **and** digest), invoked with `--no-exit-codes`. The official `zizmor-action` is not used for the audit step because it does not expose `--no-exit-codes`, which is what lets the gate forgive findings while still failing on a real tool/config error. Workspace is mounted read-only; only the job-scoped `GITHUB_TOKEN` is exposed; job stays at `contents: read`.
- Triggers mirror `actionlint.yml`: `push` to `main` + `pull_request`, both filtered to `.github/workflows/**`, `.github/actions/**`, and `.github/zizmor.yml`; plus `workflow_dispatch`.
- Least-privilege `permissions: contents: read` only.
- `concurrency` group cancels superseded runs.
- `--format=github` → findings surface as **PR annotations** instead of SARIF upload, so the job needs **no** GitHub Advanced Security and **no** `security-events: write`.

**`.github/zizmor.yml`**
- Configuration file with rollout documentation. No rules are globally disabled — keeping all audits ON (while the gate is non-blocking) gives the full picture without masking future regressions.

## Rollout threshold chosen (and why)

A baseline scan of `main` (default "regular" persona) with the pinned binary (**1.16.3**) surfaces **56 findings**. Breakdown across the existing 25+ workflows:

| Rule | Count |
|------|-------|
| `unpinned-uses` | 28 |
| `template-injection` | 16 |
| `artipacked` | 7 |
| `dependabot-cooldown` | 5 |

By severity: 30 High, 12 Medium, 9 Informational, 5 Low. (195 total including suppressed.)

These are **pre-existing** and out of scope for a workflow-introduction PR — e.g. `unpinned-uses` would require pinning every third-party action to a SHA across all workflows, a large separate change. Immediately red-failing `main` on them is unacceptable for a new gate.

**Decision: introduce the gate as NON-BLOCKING for findings (phase 1)** using `--no-exit-codes` — zizmor exits 0 for clean/findings but non-zero for a genuine tool/config failure, so a broken audit can never masquerade as a green check (a blanket `continue-on-error: true` was deliberately avoided for exactly that reason). The ~56 baseline findings are suppressed via precise `filename:line` `ignore` entries in `.github/zizmor.yml` so that **new** findings introduced by future PRs still surface as annotations (and are not buried past GitHub's 10-annotations-per-step cap). Follow-up: clear the baseline backlog, then drop `--no-exit-codes` to make the gate blocking.

## Validation evidence

- `actionlint .github/workflows/zizmor.yml` → **pass** (exit 0).
- `yamllint .github/workflows/zizmor.yml .github/zizmor.yml` → **pass** (only `document-start` / `truthy` warnings, identical to the existing `actionlint.yml`; the repo has no `.yamllint` config and accepts these).
- `zizmor --offline --config .github/zizmor.yml .github/workflows/zizmor.yml` → **No findings** (the new workflow itself is clean).
- `script/ci-changes-detector origin/main` → categorized as CI infrastructure; recommends full suite (expected for a workflow change).

## Follow-up plan

1. Triage the 56 baseline findings (start with the 28 `unpinned-uses` — pin third-party actions to SHAs).
2. Once clean (baseline `ignore` list in `.github/zizmor.yml` emptied), drop `--no-exit-codes` from `.github/workflows/zizmor.yml` to make zizmor a blocking required check.

Refs #3449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds advisory security scanning; it does not alter application runtime, auth, or data paths.
> 
> **Overview**
> Adds a **zizmor** security audit alongside **actionlint**, triggered on changes under `.github/workflows/**`, `.github/actions/**`, `.github/dependabot.yml`, and `.github/zizmor.yml` (push to `main`, all PRs, `workflow_dispatch`).
> 
> The new workflow runs the **pinned** zizmor Docker image (tag + digest) with read-only workspace mount, `contents: read` only, SHA-pinned checkout, and `--format=github` so findings show as PR annotations without SARIF or `security-events` permissions. It uses **`--no-exit-codes`** so existing findings do not fail the job while real tool/config errors still do (instead of `continue-on-error`).
> 
> **`.github/zizmor.yml`** documents phase-1 rollout and lists precise `filename:line` **ignore** entries for ~56 known baseline hits (`unpinned-uses`, `template-injection`, `artipacked`, `dependabot-cooldown`) so **new** workflow findings stay visible under GitHub’s annotation cap; composite `action.yml` findings are not suppressible and remain advisory until the baseline is cleared and `--no-exit-codes` is removed (issue #3449).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8672460377e492538f59f11054659d23543a5dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow that runs a Zizmor security/static analysis audit on pushes to the main branch, pull requests, and via manual trigger.
  * Added a Zizmor configuration file with rollout documentation and an explicit baseline rules setup (no custom rules enabled).
  * Configured the audit to publish findings as GitHub annotations while keeping the workflow non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


