### PR TITLE
test(benchmark): cover route normalization, sanitization, and env_or_default (#3459)

### DIFF
--- a/benchmarks/spec/benchmark_config_spec.rb
+++ b/benchmarks/spec/benchmark_config_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require_relative "../lib/benchmark_config"
+
+# env_or_default underpins every benchmark parameter (RATE, CONNECTIONS, ...).
+# The benchmark workflow passes "" for any omitted workflow_dispatch input, so an
+# empty string must be treated as unset and fall back to the default rather than
+# overriding it with a blank value (#3459). These pin that "0 = unset" branch was
+# replaced by "empty = unset" semantics.
+RSpec.describe "benchmark_config env_or_default" do
+  around do |example|
+    saved = ENV.key?("BENCHMARK_SPEC_KEY") ? ENV["BENCHMARK_SPEC_KEY"] : :unset
+    example.run
+  ensure
+    if saved == :unset
+      ENV.delete("BENCHMARK_SPEC_KEY")
+    else
+      ENV["BENCHMARK_SPEC_KEY"] = saved
+    end
+  end
+
+  it "returns the default when the key is unset" do
+    ENV.delete("BENCHMARK_SPEC_KEY")
+
+    expect(env_or_default("BENCHMARK_SPEC_KEY", "fallback")).to eq("fallback")
+  end
+
+  it "treats an empty string (omitted workflow_dispatch input) as unset" do
+    ENV["BENCHMARK_SPEC_KEY"] = ""
+
+    expect(env_or_default("BENCHMARK_SPEC_KEY", "fallback")).to eq("fallback")
+  end
+
+  it "returns the env value when one is present" do
+    ENV["BENCHMARK_SPEC_KEY"] = "from-env"
+
+    expect(env_or_default("BENCHMARK_SPEC_KEY", "fallback")).to eq("from-env")
+  end
+
+  it "preserves a literal '0' value rather than treating it as unset" do
+    # The old implementation special-cased "0" as unset; after that branch was
+    # removed a caller asking for 0 (e.g. RATE/CONNECTIONS edge inputs) must get
+    # the real value back so validation, not env_or_default, decides if it's legal.
+    ENV["BENCHMARK_SPEC_KEY"] = "0"
+
+    expect(env_or_default("BENCHMARK_SPEC_KEY", "fallback")).to eq("0")
+  end
+
+  it "returns the default unchanged (non-string defaults pass through)" do
+    ENV.delete("BENCHMARK_SPEC_KEY")
+
+    # CONNECTIONS et al. pass Integer defaults and call .to_i on the result, so
+    # env_or_default must hand the default back untouched rather than stringifying it.
+    expect(env_or_default("BENCHMARK_SPEC_KEY", 10)).to eq(10)
+  end
+end

--- a/benchmarks/spec/benchmark_config_spec.rb
+++ b/benchmarks/spec/benchmark_config_spec.rb
@@ -6,10 +6,13 @@ require_relative "../lib/benchmark_config"
 # env_or_default underpins every benchmark parameter (RATE, CONNECTIONS, ...).
 # The benchmark workflow passes "" for any omitted workflow_dispatch input, so an
 # empty string must be treated as unset and fall back to the default rather than
-# overriding it with a blank value (#3459). These pin that "0 = unset" branch was
-# replaced by "empty = unset" semantics.
+# overriding it with a blank value (#3459). These specs also pin the current
+# semantics: the old "0 = unset" branch is gone, so a literal "0" now passes
+# through as a real value.
 RSpec.describe "benchmark_config env_or_default" do
   around do |example|
+    # Initialized before the begin/ensure flow so `ensure` always sees a value.
+    saved = :unset
     saved = ENV.key?("BENCHMARK_SPEC_KEY") ? ENV["BENCHMARK_SPEC_KEY"] : :unset
     example.run
   ensure

--- a/benchmarks/spec/benchmark_routes_spec.rb
+++ b/benchmarks/spec/benchmark_routes_spec.rb
@@ -203,5 +203,64 @@ RSpec.describe "benchmark route discovery helpers" do
         end.to raise_error("Failed to get routes from #{app_dir}")
       end
     end
+
+    it "normalizes and strips optional params on explicit comma-split routes" do
+      # Explicit ROUTES= inputs are copied from `rails routes` output, so they may
+      # arrive with "(.:format)" suffixes, surrounding whitespace, missing leading
+      # slashes, and trailing empties from a dangling comma. The result must be the
+      # canonical "/path" form bench.rb uses verbatim as the BMF name (#3459).
+      expect(
+        benchmark_routes_for_app("unused", " server_side_hello_world(.:format) , /client_side_hello_world ,")
+      ).to eq(["/server_side_hello_world", "/client_side_hello_world"])
+    end
+  end
+
+  describe "#strip_optional_params" do
+    it "removes optional parameter groups" do
+      expect(strip_optional_params("/client_side_hello_world(.:format)")).to eq("/client_side_hello_world")
+    end
+
+    it "removes an optional locale prefix group" do
+      expect(strip_optional_params("(/:locale)/dashboard(.:format)")).to eq("/dashboard")
+    end
+
+    it "leaves a route with no optional groups unchanged" do
+      expect(strip_optional_params("/server_side_hello_world")).to eq("/server_side_hello_world")
+    end
+  end
+
+  describe "#normalize_route_path" do
+    it "prepends a leading slash when missing" do
+      expect(normalize_route_path("server_side_hello_world")).to eq("/server_side_hello_world")
+    end
+
+    it "leaves an already-rooted path unchanged" do
+      expect(normalize_route_path("/server_side_hello_world")).to eq("/server_side_hello_world")
+    end
+  end
+
+  describe "#sanitize_route_name" do
+    it "maps the root route to a non-empty filesystem-safe name" do
+      expect(sanitize_route_name("/")).to eq("root")
+    end
+
+    it "strips the leading slash and joins nested segments with underscores" do
+      expect(sanitize_route_name("/nested/path")).to eq("nested_path")
+    end
+
+    it "drops optional params before building the name" do
+      expect(sanitize_route_name("/client_side_hello_world(.:format)")).to eq("client_side_hello_world")
+    end
+
+    it "replaces shell metacharacters and Actions-disallowed characters with underscores" do
+      # The name becomes an artifact name and is embedded in shell/k6 commands, so
+      # the allowlist must collapse anything outside it. Adjacent unsafe runs
+      # squeeze to a single underscore and leading/trailing underscores are trimmed.
+      expect(sanitize_route_name("/a$b;c|d&e")).to eq("a_b_c_d_e")
+    end
+
+    it "trims leading and trailing underscores produced by sanitizing edge characters" do
+      expect(sanitize_route_name("/<weird>")).to eq("weird")
+    end
   end
 end


### PR DESCRIPTION
## Why

Part of #3459 ("Benchmark workflow follow-ups"). That issue's **"Expand benchmark spec coverage"** task notes that several `benchmarks/` route/config helpers have no unit tests. This PR adds focused coverage for the route-parsing and env-default helpers so their edge cases are pinned and safe to refactor.

This is **test-only** — no runtime or CI behavior changes.

## What

New/extended specs under `benchmarks/spec/`:

- **`benchmark_routes_spec.rb`** (extended)
  - `benchmark_routes_for_app` with an explicit comma-split `ROUTES` string, exercising the `strip_optional_params` + `normalize_route_path` chain (whitespace, `(.:format)` suffixes, missing leading slash, trailing empty from a dangling comma → canonical `/path` form).
  - `strip_optional_params`: optional param groups, optional locale prefix group, no-op on plain paths.
  - `normalize_route_path`: prepends a leading slash when missing; leaves rooted paths unchanged.
  - `sanitize_route_name`: root → `root`, nested-segment underscore joining, optional-param stripping, and the filesystem/shell-safety allowlist (collapsing disallowed characters and trimming the resulting underscores) — this name becomes an artifact name and is embedded in shell/k6 commands.
- **`benchmark_config_spec.rb`** (new)
  - `env_or_default`: an empty string (an omitted `workflow_dispatch` input) is treated as unset and falls back to the default, pinning the "empty = unset" semantics that replaced the old "0 = unset" branch.

## Validation

- `bundle exec rspec benchmarks/spec` → **287 examples, 0 failures** (the `::error::` lines in output are intentional error-path test assertions).
- `bundle exec rubocop benchmarks/spec/benchmark_routes_spec.rb benchmarks/spec/benchmark_config_spec.rb` → **no offenses**.

## Scope note (what is NOT here, and why)

While scoping this I confirmed several #3459 items already landed on `main` and need no further work:

- **Per-route k6 failure propagation** (`bench.rb#run_benchmark_suite` / `run_k6_benchmark`) is already implemented (collect failures, never ship fabricated metrics to Bencher, `exit 1` on any failure) and already covered by `benchmarks/spec/bench_spec.rb`.
- **Suite-job unification** into the matrix-driven `benchmark-suite.yml` is done.

Deliberately **deferred** to follow-ups (larger/riskier or not locally verifiable here):
- Splitting `benchmarks/track_benchmarks.rb` into focused modules (large refactor).
- Backgrounded server / node-renderer process monitoring in `benchmark.yml` (YAML, needs live runners to verify).
- Remaining spec sub-items: `bench.rb#shard_benchmark_routes` modulo distribution, per-filter parser rejection cases, and `count_benchmark_shards.rb` golden output.

Refs #3459

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Specs-only change; no application, CI workflow, or library logic is modified in this diff.
> 
> **Overview**
> **Test-only** expansion for benchmark helpers (#3459); no production or workflow behavior changes.
> 
> Adds **`benchmark_config_spec.rb`** to pin **`env_or_default`**: unset key → default, **`""`** (omitted `workflow_dispatch` input) → default, present values honored, literal **`"0"`** no longer treated as unset, and non-string defaults returned unchanged.
> 
> Extends **`benchmark_routes_spec.rb`** with coverage for explicit **`ROUTES=`** comma-split parsing (whitespace, **`(.:format)`**, missing leading slash, dangling comma), plus unit examples for **`strip_optional_params`**, **`normalize_route_path`**, and **`sanitize_route_name`** (root → `root`, nested paths, optional-param stripping, shell/artifact-safe character collapsing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2a3295571b0647055694f04fdaa3fd727bd189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added RSpec coverage for benchmark environment variable handling, including defaults, empty-string behavior, preserving `"0"`, and keeping non-string defaults unchanged.
  * Added RSpec coverage for benchmark route parsing and normalization, including whitespace trimming, optional format suffix handling, leading-slash normalization, and route-name sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->