### PR TITLE
docs: add accessibility best-practices guide (RoR + RSC) (#3927)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ React on Rails is one product with two tiers: open source for Rails + React inte
 
 - [Introduction](./oss/introduction.md)
 - [Core Concepts](./oss/core-concepts/how-react-on-rails-works.md)
+- [Accessibility (a11y)](./oss/building-features/accessibility.md) — WCAG AA practices for SSR, hydration, and RSC-streamed UI
 - [API Reference](./oss/api-reference/view-helpers-api.md)
 - [Deployment and troubleshooting](./oss/deployment/README.md)
 - [Configuration](./oss/configuration/README.md)

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -1,0 +1,385 @@
+# Accessibility (a11y)
+
+Accessibility is not a feature you bolt on at the end — it is a property of every
+surface your app renders. React on Rails apps have an unusual accessibility
+surface area because the same UI can be produced three different ways: as
+server-rendered HTML (SSR), as client-hydrated React, and — in
+[React on Rails Pro](../../pro/react-on-rails-pro.md) — as
+[React Server Components (RSC)](../../pro/react-server-components/index.md)
+streamed over the wire. Each path has its own failure modes for focus, live
+regions, and progressive enhancement.
+
+This guide collects the accessibility practices that matter for React on Rails
+specifically. The baseline target is **WCAG 2.1 Level AA**. Where a practice is
+RSC-specific, it is called out in the [Server Components](#server-components)
+section.
+
+> **Scope note:** Most of the general guidance below is plain web a11y that
+> applies to any React on Rails app. The Server Components section assumes the
+> Pro RSC stack. Concrete RSC streaming/Suspense behavior referenced here is
+> documented in the
+> [Pro RSC docs](../../pro/react-server-components/index.md).
+
+## General React on Rails accessibility
+
+### Color contrast (WCAG AA)
+
+Every text and interactive surface must meet WCAG AA contrast ratios:
+
+- **4.5:1** for normal text
+- **3:1** for large text (≥ 24px, or ≥ 19px bold) and for UI component
+  boundaries / focus indicators
+
+Contrast is a design-token concern, not a per-component one. If you use
+[Tailwind](./styling-with-tailwind.md), pin accessible color pairs in your theme
+rather than reaching for arbitrary values per component, and audit them with a
+contrast checker (browser DevTools, or the axe tooling described
+[below](#automated-a11y-tooling)). Do not rely on color alone to convey state —
+pair color with text or an icon.
+
+### Keyboard navigation
+
+Everything actionable must be reachable and operable with the keyboard alone:
+
+- Use native interactive elements (`<button>`, `<a href>`, `<input>`) so you get
+  focusability, Enter/Space activation, and roles for free. A `<div onClick>` is
+  not keyboard-accessible.
+- Keep a visible focus indicator. Never `outline: none` without a replacement.
+- Maintain a logical tab order that follows the visual/reading order. Avoid
+  positive `tabIndex` values.
+
+Verify keyboard behavior in an E2E test rather than by hand — see
+[Testing](#testing-accessibility).
+
+### `aria-live` for Rails flash messages and form errors
+
+Content that appears asynchronously (flash messages after a Turbo navigation,
+validation errors after a failed submit) is invisible to screen readers unless
+it lands in a **live region**. Render the live region container in the initial
+markup and update its contents — do not create the region at the moment the
+message appears, or the announcement may be missed.
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+<div aria-live="polite" aria-atomic="true" id="flash">
+  <% flash.each do |type, message| %>
+    <div class="flash flash--<%= type %>"><%= message %></div>
+  <% end %>
+</div>
+```
+
+Use `aria-live="polite"` for non-urgent updates (flash notices) and
+`aria-live="assertive"` (or `role="alert"`) for errors that need immediate
+attention.
+
+For React forms, the same rule applies. If you use
+[`useRailsForm`](./forms.md), the hook exposes a per-field `errors` object
+(`{ field: ["message", ...] }`). Surface validation errors in a live region and
+associate each message with its field via `aria-describedby` so the error is
+announced when focus reaches the input:
+
+```tsx
+const form = useRailsForm({ email: '' });
+
+<div>
+  <label htmlFor="email">Email</label>
+  <input
+    id="email"
+    name="email"
+    aria-invalid={Boolean(form.errors.email)}
+    aria-describedby={form.errors.email ? 'email-error' : undefined}
+    value={form.data.email}
+    onChange={(e) => form.setData('email', e.target.value)}
+  />
+  {form.errors.email?.[0] && (
+    <p id="email-error" role="alert" className="error">
+      {form.errors.email[0]}
+    </p>
+  )}
+</div>;
+```
+
+After a submit that returns a 422, move focus to a summary of errors (or to the
+first invalid field) so keyboard and screen-reader users are taken to the
+problem rather than left at the submit button.
+
+### Focus management on dialogs and route changes
+
+React on Rails apps commonly mix client-side routing
+([React Router](./react-router.md),
+[TanStack Router](./tanstack-router.md),
+[instant navigation](./client-side-routing-instant-navigation.md)) with
+server-rendered pages. Both transitions need explicit focus handling:
+
+- **Dialogs / modals:** on open, move focus into the dialog; trap focus while it
+  is open; on close, return focus to the element that opened it. Prefer the
+  native `<dialog>` element or a well-tested library — focus trapping is easy to
+  get wrong. Give the dialog `role="dialog"` and `aria-modal="true"` with an
+  accessible name via `aria-labelledby`.
+- **Client-side route changes:** unlike a full page load, an SPA navigation does
+  not reset focus. On each route change, move focus to a logical landmark (the
+  new page's `<h1>` or main heading) and announce the new page title in a live
+  region, so screen-reader users know the view changed.
+
+### `prefers-reduced-motion`
+
+Respect users who have requested reduced motion at the OS level. Gate non-
+essential animation and transitions behind the media query:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+If you use [View Transitions](./view-transitions.md) or other JS-driven motion,
+read the same preference in JS and skip the animation:
+
+```ts
+const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+```
+
+See [SSR and reduced motion](#ssr-reduced-motion-and-fouc) for the server/client
+boundary caveat.
+
+### Touch targets
+
+Interactive targets should be at least **44×44 CSS pixels** (WCAG 2.1 AAA
+guidance, widely treated as a practical floor on touch devices). Apply minimum
+sizes with padding rather than shrinking the visible label, and keep adequate
+spacing between adjacent targets.
+
+### `eslint-plugin-jsx-a11y`
+
+React on Rails ships with
+[`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
+as a dev dependency, and the lint config exercises it. It is a fast static
+backstop that catches missing `alt` text, invalid ARIA, non-interactive elements
+with handlers, and similar mistakes at author time. Keep it in your own app's
+ESLint config and treat its warnings as bugs.
+
+**Caveat — `jsx-a11y/anchor-is-valid` is disabled in this repository.** In
+`eslint.config.ts` the rule is turned `off`:
+
+```ts
+'jsx-a11y/anchor-is-valid': 'off',
+```
+
+This is a project lint choice for the React on Rails codebase, not a
+recommendation that you disable it in your app. `anchor-is-valid` guards against
+the common anti-pattern of using `<a>` as a button (e.g. `<a href="#">` or an
+anchor with only an `onClick`). In application code, keep this rule **on**: use
+`<a href>` for navigation and `<button>` for actions. If you re-enable it and use
+a framework `<Link>` component, configure the rule's `components`/`specialLink`
+options instead of suppressing it.
+
+## Server Components
+
+[React Server Components](../../pro/react-server-components/index.md) (Pro)
+change how UI reaches the browser: the server streams an RSC payload, the shell
+and Suspense fallbacks render immediately, and slow boundaries stream in and
+hydrate independently
+([selective hydration](../../pro/react-server-components/selective-hydration-in-streamed-components.md)).
+This streaming, partially-hydrated model introduces accessibility failure modes
+that do not exist in a single synchronous render.
+
+### Progressive enhancement: accessible HTML before JS
+
+The strongest accessibility guarantee RSC gives you is that meaningful HTML
+exists **before** client JavaScript runs. Lean into it:
+
+- Ensure the server-rendered markup is usable on its own — real `<a href>`
+  links, real `<form action>` targets, headings and landmarks in place — so
+  keyboard and screen-reader users are not blocked while JS loads or if it never
+  loads.
+- Keep behavior that only exists after hydration (anything driven purely by
+  `onClick` in a Client Component) as an enhancement on top of a working server
+  baseline, not the only path.
+
+### Focus management across Suspense-streamed content
+
+When a [`<Suspense>`](../../pro/react-server-components/add-streaming-and-interactivity.md)
+boundary resolves, React swaps the fallback for the real content. If the user's
+focus was inside the fallback (or the streamed content should receive focus —
+e.g. it is the result of an action), that focus is not managed for you.
+
+- Do not auto-steal focus on every boundary resolution — content streaming in
+  below the fold should not yank a reader away from where they are.
+- When streamed content **is** the user's destination (a route's main content, a
+  submitted result), move focus to its heading once it mounts, and announce the
+  change in a live region.
+- Keep skeletons and their resolved content the same size where possible to avoid
+  layout shift that moves targets out from under a pointer or magnifier.
+
+### Avoiding `aria-live` double-announcements
+
+A live region that is present in the server-rendered HTML **and** re-rendered
+during hydration can announce its contents twice — once when the SSR'd DOM is
+read, and again when React reconciles. To avoid duplicate or spurious
+announcements across the server → client boundary:
+
+- Render live-region **containers** on the server, but treat them as empty at
+  first paint; populate them only in response to client-side events after
+  hydration.
+- Do not place already-rendered server content inside an `aria-live` region that
+  will re-mount on hydration. Reserve live regions for genuinely dynamic,
+  post-hydration updates.
+- For status messages that exist purely to be announced, gate them so they are
+  emitted once, on the client, after the component is interactive.
+
+### Keyboard navigability through partially-hydrated trees
+
+With selective hydration, parts of the page become interactive at different
+times. A control that is visible but whose Client Component has not yet hydrated
+can swallow or drop keyboard input.
+
+- Server-render interactive controls as real, natively-operable elements
+  (`<button>`, `<a href>`) so they work before hydration and stay in the tab
+  order throughout.
+- Avoid disabling controls "until hydrated" if the underlying action has a
+  server-side fallback — a disabled control is removed from the keyboard flow.
+- Test tab order on a throttled connection, where the gap between paint and
+  hydration is largest (see [Testing](#testing-accessibility)).
+
+### Loading and skeleton states (`role` / `aria-busy`)
+
+Suspense fallbacks and skeletons are not just visual placeholders — communicate
+their state to assistive tech:
+
+- Mark the region that is loading with `aria-busy="true"` while its content is
+  pending, and remove it (or set `false`) once resolved.
+- Give a meaningful status, e.g. a visually-hidden `role="status"` /
+  `aria-live="polite"` message like "Loading reviews", rather than an unlabeled
+  spinner.
+- Purely decorative skeleton shapes should be hidden from assistive tech with
+  `aria-hidden="true"`.
+
+Drive `aria-busy` from the loading state rather than hard-coding it, so it
+clears once the content resolves. Put the busy flag and the status message on the
+fallback (which is unmounted when the boundary resolves), and leave the resolved
+content with its normal semantics:
+
+```tsx
+import React, { Suspense } from 'react';
+
+function ReviewsFallback() {
+  return (
+    <div aria-busy="true">
+      <span role="status" className="sr-only">
+        Loading reviews
+      </span>
+      <ReviewsSkeleton aria-hidden="true" />
+    </div>
+  );
+}
+
+<Suspense fallback={<ReviewsFallback />}>
+  <Reviews />
+</Suspense>;
+```
+
+When the boundary resolves, React unmounts the fallback — so `aria-busy="true"`
+and the "Loading reviews" status go away with it, and `<Reviews />` renders
+without a stale busy flag.
+
+### SSR, reduced motion, and FOUC
+
+[`prefers-reduced-motion`](#prefers-reduced-motion) is only readable in the
+browser — the server cannot know the user's preference at render time. Drive
+motion suppression from **CSS media queries**, which apply in the server-rendered
+HTML before any JS runs, rather than from a JS check that only takes effect after
+hydration. A JS-gated animation can fire on first paint before the preference is
+read.
+
+Streaming SSR can also surface a flash of unstyled content (FOUC) as chunks
+arrive. Beyond the visual annoyance, FOUC can mean focus styles or contrast are
+briefly wrong. Make sure critical CSS (including focus indicators and the
+reduced-motion query) is available with the initial shell, not deferred. See the
+[Pro Streaming SSR guide](../../pro/streaming-ssr.md) for how the shell and
+script loading are ordered.
+
+## Testing accessibility
+
+Automated checks catch regressions cheaply; treat them as a floor, not a
+substitute for manual keyboard and screen-reader testing.
+
+### Playwright: ARIA and keyboard assertions
+
+React on Rails apps already run E2E tests against a real browser via
+[Playwright or Cypress](./dev-server-and-testing.md#playwright--cypress-e2e).
+Use accessible-role/name locators (which fail when the accessibility tree is
+wrong) and assert keyboard operability directly:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('dialog is keyboard accessible', async ({ page }) => {
+  await page.goto('/');
+
+  // Locate by role + accessible name, not by CSS — this exercises the a11y tree.
+  await page.getByRole('button', { name: 'Open settings' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Settings' });
+  await expect(dialog).toBeVisible();
+
+  // Focus should have moved into the dialog on open — assert the focused element
+  // is inside it, not merely that the dialog rendered.
+  await expect(dialog.locator(':focus')).toBeVisible();
+
+  // Escape closes and returns focus to the trigger.
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Open settings' })).toBeFocused();
+});
+
+test('main nav is reachable by keyboard', async ({ page }) => {
+  await page.goto('/');
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('link', { name: 'Home' })).toBeFocused();
+});
+```
+
+For an example of asserting React runtime behavior from a Playwright spec in this
+project, see
+`react_on_rails/spec/dummy/e2e/playwright/e2e/react_on_rails/root_error_callbacks.spec.js`
+(referenced from
+[Debugging hydration mismatches](./debugging-hydration-mismatches.md)).
+
+### Automated a11y tooling
+
+Layer a dedicated a11y scanner on top of role-based assertions to catch contrast,
+ARIA, and structural issues across whole pages. [axe-core](https://github.com/dequelabs/axe-core)
+is the standard engine; it is **not** a React on Rails dependency, so add it to
+your own app:
+
+- **Playwright:** [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright)
+  to scan rendered pages in your existing E2E suite.
+- **Component/unit tests:** [`jest-axe`](https://github.com/nickcolley/jest-axe)
+  (or the Vitest equivalent) to assert individual components have no violations.
+- **CI / static:** run the scan on your key routes so a11y regressions fail the
+  build the same way a broken test would.
+
+When testing RSC pages, scan **after** streaming and hydration have settled
+(wait for your loading state to clear / `aria-busy` to drop) so the scanner sees
+the final tree, and consider a second scan of the pre-hydration HTML to confirm
+the server baseline is accessible on its own.
+
+## Related documentation
+
+- [Forms and mutations with `useRailsForm`](./forms.md) — validation error shape
+  used in the live-region example above
+- [Styling with Tailwind](./styling-with-tailwind.md) — where to centralize
+  accessible color tokens
+- [View Transitions](./view-transitions.md) — JS-driven motion and reduced-motion
+- [Dev server and testing](./dev-server-and-testing.md) — Playwright / Cypress
+  setup
+- [React Server Components (Pro)](../../pro/react-server-components/index.md) —
+  streaming, Suspense, and selective hydration model
+- [Streaming SSR (Pro)](../../pro/streaming-ssr.md) — shell and script ordering

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -61,7 +61,10 @@ markup and update its contents — do not create the region at the moment the
 message appears, or the announcement may be missed.
 
 ```erb
-<%# app/views/layouts/application.html.erb %>
+<%# app/views/layouts/application.html.erb
+    This element is plain server-rendered ERB — it is not React-managed, so it
+    won't re-mount on hydration and won't trigger the double-announcement
+    described later for hydrated React live regions. %>
 <div aria-live="polite" aria-atomic="true" id="flash">
   <% flash.each do |type, message| %>
     <div class="flash flash--<%= type %>"><%= message %></div>
@@ -111,6 +114,19 @@ function EmailField() {
 After a submit that returns a 422, move focus to a summary of errors (or to the
 first invalid field) so keyboard and screen-reader users are taken to the
 problem rather than left at the submit button.
+
+The example above conditionally mounts the `role="alert"` element, which is the
+simplest pattern and works in most modern screen readers (a newly-inserted
+`role="alert"` is announced). If you need to support older AT pairings that only
+announce **mutations** of an already-present live region, render a persistent
+empty container in the initial markup and update its text instead:
+
+```tsx
+// Always rendered; only its contents change.
+<p id="email-error" role="alert" className="error">
+  {form.errors.email?.[0] ?? ''}
+</p>
+```
 
 ### Focus management on dialogs and route changes
 
@@ -274,6 +290,12 @@ their state to assistive tech:
   spinner.
 - Purely decorative skeleton shapes should be hidden from assistive tech with
   `aria-hidden="true"`.
+
+> The `sr-only` class used below visually hides text while keeping it available
+> to screen readers. It ships with [Tailwind](./styling-with-tailwind.md); without
+> Tailwind, define it yourself (see the
+> [WebAIM recipe](https://webaim.org/techniques/css/invisiblecontent/)):
+> `position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;`
 
 Drive `aria-busy` from the loading state rather than hard-coding it, so it
 clears once the content resolves. Put the busy flag and the status message on the

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -28,8 +28,8 @@ both). Where a practice is RSC-specific, it is called out in the
 Every text and interactive surface must meet WCAG AA contrast ratios:
 
 - **4.5:1** for normal text
-- **3:1** for large text (≥ 24px, or ≥ 19px bold) and for UI component
-  boundaries / focus indicators
+- **3:1** for large text (≥ 24px / 18pt, or ≥ 18.66px / 14pt bold) and for UI
+  component boundaries / focus indicators
 
 Contrast is a design-token concern, not a per-component one. If you use
 [Tailwind](./styling-with-tailwind.md), pin accessible color pairs in your theme
@@ -406,7 +406,24 @@ test('main nav is reachable by keyboard', async ({ page }) => {
 ```
 
 If your app has no skip link, the first `Tab` lands on the first nav item — but
-add the skip link: it is a Level A requirement.
+add one (it is a Level A requirement). A minimal skip link is a normal anchor to
+the main landmark, visually hidden until focused:
+
+```erb
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<%# ... %>
+<main id="main-content" tabindex="-1"><%= yield %></main>
+```
+
+```css
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+.skip-link:focus {
+  left: 0;
+}
+```
 
 For an example of asserting React runtime behavior from a Playwright spec in this
 project, see

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -83,6 +83,8 @@ associate each message with its field via `aria-describedby` so the error is
 announced when focus reaches the input:
 
 ```tsx
+import { useRailsForm } from 'react-on-rails/useRailsForm';
+
 function EmailField() {
   const form = useRailsForm({ email: '' });
 
@@ -146,7 +148,9 @@ server-rendered pages. Both transitions need explicit focus handling:
 - **Client-side route changes:** unlike a full page load, an SPA navigation does
   not reset focus. On each route change, move focus to a logical landmark (the
   new page's `<h1>` or main heading) and announce the new page title in a live
-  region, so screen-reader users know the view changed.
+  region, so screen-reader users know the view changed. Headings are not natively
+  focusable — add `tabIndex={-1}` to the target so `element.focus()` works
+  (`<h1 tabIndex={-1} ref={headingRef}>`), then focus it after the route renders.
 
 ### `prefers-reduced-motion`
 
@@ -181,7 +185,9 @@ boundary caveat.
 
 ### Touch targets
 
-The WCAG **AA** floor is **24×24 CSS pixels** (WCAG 2.2 SC 2.5.8). Aim higher:
+The WCAG 2.2 **AA** criterion (SC 2.5.8) effectively asks for **24×24 CSS
+pixels** — though a smaller target can still pass if it has enough spacing, since
+the rule is really about the target plus the gap to adjacent targets. Aim higher:
 **44×44 CSS pixels** (WCAG 2.1/2.2 AAA, SC 2.5.5) is widely treated as the
 practical minimum on touch devices. Apply minimum sizes with padding rather than
 shrinking the visible label, and keep adequate spacing between adjacent targets.
@@ -374,8 +380,10 @@ test('dialog is keyboard accessible', async ({ page }) => {
   const dialog = page.getByRole('dialog', { name: 'Settings' });
   await expect(dialog).toBeVisible();
 
-  // Focus should have moved into the dialog on open — assert the focused element
-  // is inside it, not merely that the dialog rendered.
+  // Focus should have moved into the dialog on open — assert a focused element
+  // is inside it, not merely that the dialog rendered. For a sharper failure,
+  // assert the specific control you expect, e.g.
+  // dialog.getByRole('button', { name: 'Close' }).
   await expect(dialog.locator(':focus')).toBeVisible();
 
   // Escape closes and returns focus to the trigger.

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -79,24 +79,32 @@ associate each message with its field via `aria-describedby` so the error is
 announced when focus reaches the input:
 
 ```tsx
-const form = useRailsForm({ email: '' });
+function EmailField() {
+  const form = useRailsForm({ email: '' });
 
-<div>
-  <label htmlFor="email">Email</label>
-  <input
-    id="email"
-    name="email"
-    aria-invalid={Boolean(form.errors.email)}
-    aria-describedby={form.errors.email ? 'email-error' : undefined}
-    value={form.data.email}
-    onChange={(e) => form.setData('email', e.target.value)}
-  />
-  {form.errors.email?.[0] && (
-    <p id="email-error" role="alert" className="error">
-      {form.errors.email[0]}
-    </p>
-  )}
-</div>;
+  // Use the same guard (`?.[0]`) for the attribute and the element it points to,
+  // so `aria-describedby` never references a `<p>` that isn't in the DOM.
+  const emailError = form.errors.email?.[0];
+
+  return (
+    <div>
+      <label htmlFor="email">Email</label>
+      <input
+        id="email"
+        name="email"
+        aria-invalid={Boolean(emailError)}
+        aria-describedby={emailError ? 'email-error' : undefined}
+        value={form.data.email}
+        onChange={(e) => form.setData('email', e.target.value)}
+      />
+      {emailError && (
+        <p id="email-error" role="alert" className="error">
+          {emailError}
+        </p>
+      )}
+    </div>
+  );
+}
 ```
 
 After a submit that returns a 422, move focus to a summary of errors (or to the
@@ -113,9 +121,11 @@ server-rendered pages. Both transitions need explicit focus handling:
 
 - **Dialogs / modals:** on open, move focus into the dialog; trap focus while it
   is open; on close, return focus to the element that opened it. Prefer the
-  native `<dialog>` element or a well-tested library — focus trapping is easy to
-  get wrong. Give the dialog `role="dialog"` and `aria-modal="true"` with an
-  accessible name via `aria-labelledby`.
+  native `<dialog>` element (opened with `showModal()`, which handles focus
+  trapping and the implicit `role="dialog"` for you) or a well-tested library —
+  hand-rolled focus trapping is easy to get wrong. Always give the dialog an
+  accessible name via `aria-labelledby`. On a custom (non-`<dialog>`) container,
+  add `role="dialog"` and `aria-modal="true"` yourself.
 - **Client-side route changes:** unlike a full page load, an SPA navigation does
   not reset focus. On each route change, move focus to a logical landmark (the
   new page's `<h1>` or main heading) and announce the new page title in a live
@@ -275,7 +285,12 @@ function ReviewsFallback() {
       <span role="status" className="sr-only">
         Loading reviews
       </span>
-      <ReviewsSkeleton aria-hidden="true" />
+      {/* Wrap in a real DOM element: a custom component only honors aria-hidden
+          if it forwards the prop to its root, so the wrapper is the reliable way
+          to hide decorative skeleton shapes from assistive tech. */}
+      <div aria-hidden="true">
+        <ReviewsSkeleton />
+      </div>
     </div>
   );
 }

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -416,12 +416,21 @@ the main landmark, visually hidden until focused:
 ```
 
 ```css
+/* Hidden until focused, using the direction-independent clip pattern so it
+   also works in RTL layouts. */
 .skip-link {
   position: absolute;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
 }
 .skip-link:focus {
-  left: 0;
+  position: static;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
 }
 ```
 

--- a/docs/oss/building-features/accessibility.md
+++ b/docs/oss/building-features/accessibility.md
@@ -10,9 +10,10 @@ streamed over the wire. Each path has its own failure modes for focus, live
 regions, and progressive enhancement.
 
 This guide collects the accessibility practices that matter for React on Rails
-specifically. The baseline target is **WCAG 2.1 Level AA**. Where a practice is
-RSC-specific, it is called out in the [Server Components](#server-components)
-section.
+specifically. The baseline target is **WCAG 2.1 Level AA** (WCAG 2.2, the current
+W3C Recommendation, is a backwards-compatible superset — the guidance here meets
+both). Where a practice is RSC-specific, it is called out in the
+[Server Components](#server-components) section.
 
 > **Scope note:** Most of the general guidance below is plain web a11y that
 > applies to any React on Rails app. The Server Components section assumes the
@@ -153,7 +154,10 @@ If you use [View Transitions](./view-transitions.md) or other JS-driven motion,
 read the same preference in JS and skip the animation:
 
 ```ts
-const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+// Browser-only — `window` is undefined during SSR / in a Server Component, so
+// guard it and prefer the CSS media query above, which applies before JS runs.
+const reduceMotion =
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 ```
 
 See [SSR and reduced motion](#ssr-reduced-motion-and-fouc) for the server/client
@@ -161,10 +165,10 @@ boundary caveat.
 
 ### Touch targets
 
-Interactive targets should be at least **44×44 CSS pixels** (WCAG 2.1 AAA
-guidance, widely treated as a practical floor on touch devices). Apply minimum
-sizes with padding rather than shrinking the visible label, and keep adequate
-spacing between adjacent targets.
+The WCAG **AA** floor is **24×24 CSS pixels** (WCAG 2.2 SC 2.5.8). Aim higher:
+**44×44 CSS pixels** (WCAG 2.1/2.2 AAA, SC 2.5.5) is widely treated as the
+practical minimum on touch devices. Apply minimum sizes with padding rather than
+shrinking the visible label, and keep adequate spacing between adjacent targets.
 
 ### `eslint-plugin-jsx-a11y`
 
@@ -295,9 +299,13 @@ function ReviewsFallback() {
   );
 }
 
-<Suspense fallback={<ReviewsFallback />}>
-  <Reviews />
-</Suspense>;
+function ReviewsSection() {
+  return (
+    <Suspense fallback={<ReviewsFallback />}>
+      <Reviews />
+    </Suspense>
+  );
+}
 ```
 
 When the boundary resolves, React unmounts the fallback — so `aria-busy="true"`
@@ -356,10 +364,19 @@ test('dialog is keyboard accessible', async ({ page }) => {
 
 test('main nav is reachable by keyboard', async ({ page }) => {
   await page.goto('/');
+
+  // A skip-navigation link is a WCAG 2.4.1 (Level A) requirement and the correct
+  // first tab stop, so assert it first, then the first nav item.
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('link', { name: /skip to main content/i })).toBeFocused();
+
   await page.keyboard.press('Tab');
   await expect(page.getByRole('link', { name: 'Home' })).toBeFocused();
 });
 ```
+
+If your app has no skip link, the first `Tab` lands on the first nav item — but
+add the skip link: it is a Level A requirement.
 
 For an example of asserting React runtime behavior from a Playwright spec in this
 project, see

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -108,6 +108,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'building-features/dev-server-and-testing',
             'building-features/testing-configuration',
+            'building-features/accessibility',
             'building-features/extensible-precompile-pattern',
             'building-features/process-managers',
             'building-features/debugging',

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11321,6 +11321,397 @@ When running tests in Docker, consider:
 - **Support:** [justin@shakacode.com](mailto:justin@shakacode.com)
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/building-features/accessibility
+SOURCE: docs/oss/building-features/accessibility.md
+================================================================================
+
+# Accessibility (a11y)
+
+Accessibility is not a feature you bolt on at the end — it is a property of every
+surface your app renders. React on Rails apps have an unusual accessibility
+surface area because the same UI can be produced three different ways: as
+server-rendered HTML (SSR), as client-hydrated React, and — in
+[React on Rails Pro](../../pro/react-on-rails-pro.md) — as
+[React Server Components (RSC)](../../pro/react-server-components/index.md)
+streamed over the wire. Each path has its own failure modes for focus, live
+regions, and progressive enhancement.
+
+This guide collects the accessibility practices that matter for React on Rails
+specifically. The baseline target is **WCAG 2.1 Level AA**. Where a practice is
+RSC-specific, it is called out in the [Server Components](#server-components)
+section.
+
+> **Scope note:** Most of the general guidance below is plain web a11y that
+> applies to any React on Rails app. The Server Components section assumes the
+> Pro RSC stack. Concrete RSC streaming/Suspense behavior referenced here is
+> documented in the
+> [Pro RSC docs](../../pro/react-server-components/index.md).
+
+## General React on Rails accessibility
+
+### Color contrast (WCAG AA)
+
+Every text and interactive surface must meet WCAG AA contrast ratios:
+
+- **4.5:1** for normal text
+- **3:1** for large text (≥ 24px, or ≥ 19px bold) and for UI component
+  boundaries / focus indicators
+
+Contrast is a design-token concern, not a per-component one. If you use
+[Tailwind](./styling-with-tailwind.md), pin accessible color pairs in your theme
+rather than reaching for arbitrary values per component, and audit them with a
+contrast checker (browser DevTools, or the axe tooling described
+[below](#automated-a11y-tooling)). Do not rely on color alone to convey state —
+pair color with text or an icon.
+
+### Keyboard navigation
+
+Everything actionable must be reachable and operable with the keyboard alone:
+
+- Use native interactive elements (`<button>`, `<a href>`, `<input>`) so you get
+  focusability, Enter/Space activation, and roles for free. A `<div onClick>` is
+  not keyboard-accessible.
+- Keep a visible focus indicator. Never `outline: none` without a replacement.
+- Maintain a logical tab order that follows the visual/reading order. Avoid
+  positive `tabIndex` values.
+
+Verify keyboard behavior in an E2E test rather than by hand — see
+[Testing](#testing-accessibility).
+
+### `aria-live` for Rails flash messages and form errors
+
+Content that appears asynchronously (flash messages after a Turbo navigation,
+validation errors after a failed submit) is invisible to screen readers unless
+it lands in a **live region**. Render the live region container in the initial
+markup and update its contents — do not create the region at the moment the
+message appears, or the announcement may be missed.
+
+```erb
+<%# app/views/layouts/application.html.erb %>
+<div aria-live="polite" aria-atomic="true" id="flash">
+  <% flash.each do |type, message| %>
+    <div class="flash flash--<%= type %>"><%= message %></div>
+  <% end %>
+</div>
+```
+
+Use `aria-live="polite"` for non-urgent updates (flash notices) and
+`aria-live="assertive"` (or `role="alert"`) for errors that need immediate
+attention.
+
+For React forms, the same rule applies. If you use
+[`useRailsForm`](./forms.md), the hook exposes a per-field `errors` object
+(`{ field: ["message", ...] }`). Surface validation errors in a live region and
+associate each message with its field via `aria-describedby` so the error is
+announced when focus reaches the input:
+
+```tsx
+const form = useRailsForm({ email: '' });
+
+<div>
+  <label htmlFor="email">Email</label>
+  <input
+    id="email"
+    name="email"
+    aria-invalid={Boolean(form.errors.email)}
+    aria-describedby={form.errors.email ? 'email-error' : undefined}
+    value={form.data.email}
+    onChange={(e) => form.setData('email', e.target.value)}
+  />
+  {form.errors.email?.[0] && (
+    <p id="email-error" role="alert" className="error">
+      {form.errors.email[0]}
+    </p>
+  )}
+</div>;
+```
+
+After a submit that returns a 422, move focus to a summary of errors (or to the
+first invalid field) so keyboard and screen-reader users are taken to the
+problem rather than left at the submit button.
+
+### Focus management on dialogs and route changes
+
+React on Rails apps commonly mix client-side routing
+([React Router](./react-router.md),
+[TanStack Router](./tanstack-router.md),
+[instant navigation](./client-side-routing-instant-navigation.md)) with
+server-rendered pages. Both transitions need explicit focus handling:
+
+- **Dialogs / modals:** on open, move focus into the dialog; trap focus while it
+  is open; on close, return focus to the element that opened it. Prefer the
+  native `<dialog>` element or a well-tested library — focus trapping is easy to
+  get wrong. Give the dialog `role="dialog"` and `aria-modal="true"` with an
+  accessible name via `aria-labelledby`.
+- **Client-side route changes:** unlike a full page load, an SPA navigation does
+  not reset focus. On each route change, move focus to a logical landmark (the
+  new page's `<h1>` or main heading) and announce the new page title in a live
+  region, so screen-reader users know the view changed.
+
+### `prefers-reduced-motion`
+
+Respect users who have requested reduced motion at the OS level. Gate non-
+essential animation and transitions behind the media query:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+If you use [View Transitions](./view-transitions.md) or other JS-driven motion,
+read the same preference in JS and skip the animation:
+
+```ts
+const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+```
+
+See [SSR and reduced motion](#ssr-reduced-motion-and-fouc) for the server/client
+boundary caveat.
+
+### Touch targets
+
+Interactive targets should be at least **44×44 CSS pixels** (WCAG 2.1 AAA
+guidance, widely treated as a practical floor on touch devices). Apply minimum
+sizes with padding rather than shrinking the visible label, and keep adequate
+spacing between adjacent targets.
+
+### `eslint-plugin-jsx-a11y`
+
+React on Rails ships with
+[`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
+as a dev dependency, and the lint config exercises it. It is a fast static
+backstop that catches missing `alt` text, invalid ARIA, non-interactive elements
+with handlers, and similar mistakes at author time. Keep it in your own app's
+ESLint config and treat its warnings as bugs.
+
+**Caveat — `jsx-a11y/anchor-is-valid` is disabled in this repository.** In
+`eslint.config.ts` the rule is turned `off`:
+
+```ts
+'jsx-a11y/anchor-is-valid': 'off',
+```
+
+This is a project lint choice for the React on Rails codebase, not a
+recommendation that you disable it in your app. `anchor-is-valid` guards against
+the common anti-pattern of using `<a>` as a button (e.g. `<a href="#">` or an
+anchor with only an `onClick`). In application code, keep this rule **on**: use
+`<a href>` for navigation and `<button>` for actions. If you re-enable it and use
+a framework `<Link>` component, configure the rule's `components`/`specialLink`
+options instead of suppressing it.
+
+## Server Components
+
+[React Server Components](../../pro/react-server-components/index.md) (Pro)
+change how UI reaches the browser: the server streams an RSC payload, the shell
+and Suspense fallbacks render immediately, and slow boundaries stream in and
+hydrate independently
+([selective hydration](../../pro/react-server-components/selective-hydration-in-streamed-components.md)).
+This streaming, partially-hydrated model introduces accessibility failure modes
+that do not exist in a single synchronous render.
+
+### Progressive enhancement: accessible HTML before JS
+
+The strongest accessibility guarantee RSC gives you is that meaningful HTML
+exists **before** client JavaScript runs. Lean into it:
+
+- Ensure the server-rendered markup is usable on its own — real `<a href>`
+  links, real `<form action>` targets, headings and landmarks in place — so
+  keyboard and screen-reader users are not blocked while JS loads or if it never
+  loads.
+- Keep behavior that only exists after hydration (anything driven purely by
+  `onClick` in a Client Component) as an enhancement on top of a working server
+  baseline, not the only path.
+
+### Focus management across Suspense-streamed content
+
+When a [`<Suspense>`](../../pro/react-server-components/add-streaming-and-interactivity.md)
+boundary resolves, React swaps the fallback for the real content. If the user's
+focus was inside the fallback (or the streamed content should receive focus —
+e.g. it is the result of an action), that focus is not managed for you.
+
+- Do not auto-steal focus on every boundary resolution — content streaming in
+  below the fold should not yank a reader away from where they are.
+- When streamed content **is** the user's destination (a route's main content, a
+  submitted result), move focus to its heading once it mounts, and announce the
+  change in a live region.
+- Keep skeletons and their resolved content the same size where possible to avoid
+  layout shift that moves targets out from under a pointer or magnifier.
+
+### Avoiding `aria-live` double-announcements
+
+A live region that is present in the server-rendered HTML **and** re-rendered
+during hydration can announce its contents twice — once when the SSR'd DOM is
+read, and again when React reconciles. To avoid duplicate or spurious
+announcements across the server → client boundary:
+
+- Render live-region **containers** on the server, but treat them as empty at
+  first paint; populate them only in response to client-side events after
+  hydration.
+- Do not place already-rendered server content inside an `aria-live` region that
+  will re-mount on hydration. Reserve live regions for genuinely dynamic,
+  post-hydration updates.
+- For status messages that exist purely to be announced, gate them so they are
+  emitted once, on the client, after the component is interactive.
+
+### Keyboard navigability through partially-hydrated trees
+
+With selective hydration, parts of the page become interactive at different
+times. A control that is visible but whose Client Component has not yet hydrated
+can swallow or drop keyboard input.
+
+- Server-render interactive controls as real, natively-operable elements
+  (`<button>`, `<a href>`) so they work before hydration and stay in the tab
+  order throughout.
+- Avoid disabling controls "until hydrated" if the underlying action has a
+  server-side fallback — a disabled control is removed from the keyboard flow.
+- Test tab order on a throttled connection, where the gap between paint and
+  hydration is largest (see [Testing](#testing-accessibility)).
+
+### Loading and skeleton states (`role` / `aria-busy`)
+
+Suspense fallbacks and skeletons are not just visual placeholders — communicate
+their state to assistive tech:
+
+- Mark the region that is loading with `aria-busy="true"` while its content is
+  pending, and remove it (or set `false`) once resolved.
+- Give a meaningful status, e.g. a visually-hidden `role="status"` /
+  `aria-live="polite"` message like "Loading reviews", rather than an unlabeled
+  spinner.
+- Purely decorative skeleton shapes should be hidden from assistive tech with
+  `aria-hidden="true"`.
+
+Drive `aria-busy` from the loading state rather than hard-coding it, so it
+clears once the content resolves. Put the busy flag and the status message on the
+fallback (which is unmounted when the boundary resolves), and leave the resolved
+content with its normal semantics:
+
+```tsx
+import React, { Suspense } from 'react';
+
+function ReviewsFallback() {
+  return (
+    <div aria-busy="true">
+      <span role="status" className="sr-only">
+        Loading reviews
+      </span>
+      <ReviewsSkeleton aria-hidden="true" />
+    </div>
+  );
+}
+
+<Suspense fallback={<ReviewsFallback />}>
+  <Reviews />
+</Suspense>;
+```
+
+When the boundary resolves, React unmounts the fallback — so `aria-busy="true"`
+and the "Loading reviews" status go away with it, and `<Reviews />` renders
+without a stale busy flag.
+
+### SSR, reduced motion, and FOUC
+
+[`prefers-reduced-motion`](#prefers-reduced-motion) is only readable in the
+browser — the server cannot know the user's preference at render time. Drive
+motion suppression from **CSS media queries**, which apply in the server-rendered
+HTML before any JS runs, rather than from a JS check that only takes effect after
+hydration. A JS-gated animation can fire on first paint before the preference is
+read.
+
+Streaming SSR can also surface a flash of unstyled content (FOUC) as chunks
+arrive. Beyond the visual annoyance, FOUC can mean focus styles or contrast are
+briefly wrong. Make sure critical CSS (including focus indicators and the
+reduced-motion query) is available with the initial shell, not deferred. See the
+[Pro Streaming SSR guide](../../pro/streaming-ssr.md) for how the shell and
+script loading are ordered.
+
+## Testing accessibility
+
+Automated checks catch regressions cheaply; treat them as a floor, not a
+substitute for manual keyboard and screen-reader testing.
+
+### Playwright: ARIA and keyboard assertions
+
+React on Rails apps already run E2E tests against a real browser via
+[Playwright or Cypress](./dev-server-and-testing.md#playwright--cypress-e2e).
+Use accessible-role/name locators (which fail when the accessibility tree is
+wrong) and assert keyboard operability directly:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('dialog is keyboard accessible', async ({ page }) => {
+  await page.goto('/');
+
+  // Locate by role + accessible name, not by CSS — this exercises the a11y tree.
+  await page.getByRole('button', { name: 'Open settings' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Settings' });
+  await expect(dialog).toBeVisible();
+
+  // Focus should have moved into the dialog on open — assert the focused element
+  // is inside it, not merely that the dialog rendered.
+  await expect(dialog.locator(':focus')).toBeVisible();
+
+  // Escape closes and returns focus to the trigger.
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Open settings' })).toBeFocused();
+});
+
+test('main nav is reachable by keyboard', async ({ page }) => {
+  await page.goto('/');
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('link', { name: 'Home' })).toBeFocused();
+});
+```
+
+For an example of asserting React runtime behavior from a Playwright spec in this
+project, see
+`react_on_rails/spec/dummy/e2e/playwright/e2e/react_on_rails/root_error_callbacks.spec.js`
+(referenced from
+[Debugging hydration mismatches](./debugging-hydration-mismatches.md)).
+
+### Automated a11y tooling
+
+Layer a dedicated a11y scanner on top of role-based assertions to catch contrast,
+ARIA, and structural issues across whole pages. [axe-core](https://github.com/dequelabs/axe-core)
+is the standard engine; it is **not** a React on Rails dependency, so add it to
+your own app:
+
+- **Playwright:** [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright)
+  to scan rendered pages in your existing E2E suite.
+- **Component/unit tests:** [`jest-axe`](https://github.com/nickcolley/jest-axe)
+  (or the Vitest equivalent) to assert individual components have no violations.
+- **CI / static:** run the scan on your key routes so a11y regressions fail the
+  build the same way a broken test would.
+
+When testing RSC pages, scan **after** streaming and hydration have settled
+(wait for your loading state to clear / `aria-busy` to drop) so the scanner sees
+the final tree, and consider a second scan of the pre-hydration HTML to confirm
+the server baseline is accessible on its own.
+
+## Related documentation
+
+- [Forms and mutations with `useRailsForm`](./forms.md) — validation error shape
+  used in the live-region example above
+- [Styling with Tailwind](./styling-with-tailwind.md) — where to centralize
+  accessible color tokens
+- [View Transitions](./view-transitions.md) — JS-driven motion and reduced-motion
+- [Dev server and testing](./dev-server-and-testing.md) — Playwright / Cypress
+  setup
+- [React Server Components (Pro)](../../pro/react-server-components/index.md) —
+  streaming, Suspense, and selective hydration model
+- [Streaming SSR (Pro)](../../pro/streaming-ssr.md) — shell and script ordering
+
+================================================================================
 PAGE: https://reactonrails.com/docs/building-features/extensible-precompile-pattern
 SOURCE: docs/oss/building-features/extensible-precompile-pattern.md
 ================================================================================

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11388,7 +11388,10 @@ markup and update its contents — do not create the region at the moment the
 message appears, or the announcement may be missed.
 
 ```erb
-<%# app/views/layouts/application.html.erb %>
+<%# app/views/layouts/application.html.erb
+    This element is plain server-rendered ERB — it is not React-managed, so it
+    won't re-mount on hydration and won't trigger the double-announcement
+    described later for hydrated React live regions. %>
 <div aria-live="polite" aria-atomic="true" id="flash">
   <% flash.each do |type, message| %>
     <div class="flash flash--<%= type %>"><%= message %></div>
@@ -11438,6 +11441,19 @@ function EmailField() {
 After a submit that returns a 422, move focus to a summary of errors (or to the
 first invalid field) so keyboard and screen-reader users are taken to the
 problem rather than left at the submit button.
+
+The example above conditionally mounts the `role="alert"` element, which is the
+simplest pattern and works in most modern screen readers (a newly-inserted
+`role="alert"` is announced). If you need to support older AT pairings that only
+announce **mutations** of an already-present live region, render a persistent
+empty container in the initial markup and update its text instead:
+
+```tsx
+// Always rendered; only its contents change.
+<p id="email-error" role="alert" className="error">
+  {form.errors.email?.[0] ?? ''}
+</p>
+```
 
 ### Focus management on dialogs and route changes
 
@@ -11601,6 +11617,12 @@ their state to assistive tech:
   spinner.
 - Purely decorative skeleton shapes should be hidden from assistive tech with
   `aria-hidden="true"`.
+
+> The `sr-only` class used below visually hides text while keeping it available
+> to screen readers. It ships with [Tailwind](./styling-with-tailwind.md); without
+> Tailwind, define it yourself (see the
+> [WebAIM recipe](https://webaim.org/techniques/css/invisiblecontent/)):
+> `position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;`
 
 Drive `aria-busy` from the loading state rather than hard-coding it, so it
 clears once the content resolves. Put the busy flag and the status message on the

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11406,24 +11406,32 @@ associate each message with its field via `aria-describedby` so the error is
 announced when focus reaches the input:
 
 ```tsx
-const form = useRailsForm({ email: '' });
+function EmailField() {
+  const form = useRailsForm({ email: '' });
 
-<div>
-  <label htmlFor="email">Email</label>
-  <input
-    id="email"
-    name="email"
-    aria-invalid={Boolean(form.errors.email)}
-    aria-describedby={form.errors.email ? 'email-error' : undefined}
-    value={form.data.email}
-    onChange={(e) => form.setData('email', e.target.value)}
-  />
-  {form.errors.email?.[0] && (
-    <p id="email-error" role="alert" className="error">
-      {form.errors.email[0]}
-    </p>
-  )}
-</div>;
+  // Use the same guard (`?.[0]`) for the attribute and the element it points to,
+  // so `aria-describedby` never references a `<p>` that isn't in the DOM.
+  const emailError = form.errors.email?.[0];
+
+  return (
+    <div>
+      <label htmlFor="email">Email</label>
+      <input
+        id="email"
+        name="email"
+        aria-invalid={Boolean(emailError)}
+        aria-describedby={emailError ? 'email-error' : undefined}
+        value={form.data.email}
+        onChange={(e) => form.setData('email', e.target.value)}
+      />
+      {emailError && (
+        <p id="email-error" role="alert" className="error">
+          {emailError}
+        </p>
+      )}
+    </div>
+  );
+}
 ```
 
 After a submit that returns a 422, move focus to a summary of errors (or to the
@@ -11440,9 +11448,11 @@ server-rendered pages. Both transitions need explicit focus handling:
 
 - **Dialogs / modals:** on open, move focus into the dialog; trap focus while it
   is open; on close, return focus to the element that opened it. Prefer the
-  native `<dialog>` element or a well-tested library — focus trapping is easy to
-  get wrong. Give the dialog `role="dialog"` and `aria-modal="true"` with an
-  accessible name via `aria-labelledby`.
+  native `<dialog>` element (opened with `showModal()`, which handles focus
+  trapping and the implicit `role="dialog"` for you) or a well-tested library —
+  hand-rolled focus trapping is easy to get wrong. Always give the dialog an
+  accessible name via `aria-labelledby`. On a custom (non-`<dialog>`) container,
+  add `role="dialog"` and `aria-modal="true"` yourself.
 - **Client-side route changes:** unlike a full page load, an SPA navigation does
   not reset focus. On each route change, move focus to a logical landmark (the
   new page's `<h1>` or main heading) and announce the new page title in a live
@@ -11602,7 +11612,12 @@ function ReviewsFallback() {
       <span role="status" className="sr-only">
         Loading reviews
       </span>
-      <ReviewsSkeleton aria-hidden="true" />
+      {/* Wrap in a real DOM element: a custom component only honors aria-hidden
+          if it forwards the prop to its root, so the wrapper is the reliable way
+          to hide decorative skeleton shapes from assistive tech. */}
+      <div aria-hidden="true">
+        <ReviewsSkeleton />
+      </div>
     </div>
   );
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11337,9 +11337,10 @@ streamed over the wire. Each path has its own failure modes for focus, live
 regions, and progressive enhancement.
 
 This guide collects the accessibility practices that matter for React on Rails
-specifically. The baseline target is **WCAG 2.1 Level AA**. Where a practice is
-RSC-specific, it is called out in the [Server Components](#server-components)
-section.
+specifically. The baseline target is **WCAG 2.1 Level AA** (WCAG 2.2, the current
+W3C Recommendation, is a backwards-compatible superset — the guidance here meets
+both). Where a practice is RSC-specific, it is called out in the
+[Server Components](#server-components) section.
 
 > **Scope note:** Most of the general guidance below is plain web a11y that
 > applies to any React on Rails app. The Server Components section assumes the
@@ -11480,7 +11481,10 @@ If you use [View Transitions](./view-transitions.md) or other JS-driven motion,
 read the same preference in JS and skip the animation:
 
 ```ts
-const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+// Browser-only — `window` is undefined during SSR / in a Server Component, so
+// guard it and prefer the CSS media query above, which applies before JS runs.
+const reduceMotion =
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 ```
 
 See [SSR and reduced motion](#ssr-reduced-motion-and-fouc) for the server/client
@@ -11488,10 +11492,10 @@ boundary caveat.
 
 ### Touch targets
 
-Interactive targets should be at least **44×44 CSS pixels** (WCAG 2.1 AAA
-guidance, widely treated as a practical floor on touch devices). Apply minimum
-sizes with padding rather than shrinking the visible label, and keep adequate
-spacing between adjacent targets.
+The WCAG **AA** floor is **24×24 CSS pixels** (WCAG 2.2 SC 2.5.8). Aim higher:
+**44×44 CSS pixels** (WCAG 2.1/2.2 AAA, SC 2.5.5) is widely treated as the
+practical minimum on touch devices. Apply minimum sizes with padding rather than
+shrinking the visible label, and keep adequate spacing between adjacent targets.
 
 ### `eslint-plugin-jsx-a11y`
 
@@ -11622,9 +11626,13 @@ function ReviewsFallback() {
   );
 }
 
-<Suspense fallback={<ReviewsFallback />}>
-  <Reviews />
-</Suspense>;
+function ReviewsSection() {
+  return (
+    <Suspense fallback={<ReviewsFallback />}>
+      <Reviews />
+    </Suspense>
+  );
+}
 ```
 
 When the boundary resolves, React unmounts the fallback — so `aria-busy="true"`
@@ -11683,10 +11691,19 @@ test('dialog is keyboard accessible', async ({ page }) => {
 
 test('main nav is reachable by keyboard', async ({ page }) => {
   await page.goto('/');
+
+  // A skip-navigation link is a WCAG 2.4.1 (Level A) requirement and the correct
+  // first tab stop, so assert it first, then the first nav item.
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('link', { name: /skip to main content/i })).toBeFocused();
+
   await page.keyboard.press('Tab');
   await expect(page.getByRole('link', { name: 'Home' })).toBeFocused();
 });
 ```
+
+If your app has no skip link, the first `Tab` lands on the first nav item — but
+add the skip link: it is a Level A requirement.
 
 For an example of asserting React runtime behavior from a Playwright spec in this
 project, see

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11410,6 +11410,8 @@ associate each message with its field via `aria-describedby` so the error is
 announced when focus reaches the input:
 
 ```tsx
+import { useRailsForm } from 'react-on-rails/useRailsForm';
+
 function EmailField() {
   const form = useRailsForm({ email: '' });
 
@@ -11473,7 +11475,9 @@ server-rendered pages. Both transitions need explicit focus handling:
 - **Client-side route changes:** unlike a full page load, an SPA navigation does
   not reset focus. On each route change, move focus to a logical landmark (the
   new page's `<h1>` or main heading) and announce the new page title in a live
-  region, so screen-reader users know the view changed.
+  region, so screen-reader users know the view changed. Headings are not natively
+  focusable — add `tabIndex={-1}` to the target so `element.focus()` works
+  (`<h1 tabIndex={-1} ref={headingRef}>`), then focus it after the route renders.
 
 ### `prefers-reduced-motion`
 
@@ -11508,7 +11512,9 @@ boundary caveat.
 
 ### Touch targets
 
-The WCAG **AA** floor is **24×24 CSS pixels** (WCAG 2.2 SC 2.5.8). Aim higher:
+The WCAG 2.2 **AA** criterion (SC 2.5.8) effectively asks for **24×24 CSS
+pixels** — though a smaller target can still pass if it has enough spacing, since
+the rule is really about the target plus the gap to adjacent targets. Aim higher:
 **44×44 CSS pixels** (WCAG 2.1/2.2 AAA, SC 2.5.5) is widely treated as the
 practical minimum on touch devices. Apply minimum sizes with padding rather than
 shrinking the visible label, and keep adequate spacing between adjacent targets.
@@ -11701,8 +11707,10 @@ test('dialog is keyboard accessible', async ({ page }) => {
   const dialog = page.getByRole('dialog', { name: 'Settings' });
   await expect(dialog).toBeVisible();
 
-  // Focus should have moved into the dialog on open — assert the focused element
-  // is inside it, not merely that the dialog rendered.
+  // Focus should have moved into the dialog on open — assert a focused element
+  // is inside it, not merely that the dialog rendered. For a sharper failure,
+  // assert the specific control you expect, e.g.
+  // dialog.getByRole('button', { name: 'Close' }).
   await expect(dialog.locator(':focus')).toBeVisible();
 
   // Escape closes and returns focus to the trigger.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11355,8 +11355,8 @@ both). Where a practice is RSC-specific, it is called out in the
 Every text and interactive surface must meet WCAG AA contrast ratios:
 
 - **4.5:1** for normal text
-- **3:1** for large text (≥ 24px, or ≥ 19px bold) and for UI component
-  boundaries / focus indicators
+- **3:1** for large text (≥ 24px / 18pt, or ≥ 18.66px / 14pt bold) and for UI
+  component boundaries / focus indicators
 
 Contrast is a design-token concern, not a per-component one. If you use
 [Tailwind](./styling-with-tailwind.md), pin accessible color pairs in your theme
@@ -11733,7 +11733,24 @@ test('main nav is reachable by keyboard', async ({ page }) => {
 ```
 
 If your app has no skip link, the first `Tab` lands on the first nav item — but
-add the skip link: it is a Level A requirement.
+add one (it is a Level A requirement). A minimal skip link is a normal anchor to
+the main landmark, visually hidden until focused:
+
+```erb
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<%# ... %>
+<main id="main-content" tabindex="-1"><%= yield %></main>
+```
+
+```css
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+.skip-link:focus {
+  left: 0;
+}
+```
 
 For an example of asserting React runtime behavior from a Playwright spec in this
 project, see

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11743,12 +11743,21 @@ the main landmark, visually hidden until focused:
 ```
 
 ```css
+/* Hidden until focused, using the direction-independent clip pattern so it
+   also works in RTL layouts. */
 .skip-link {
   position: absolute;
-  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
 }
 .skip-link:focus {
-  left: 0;
+  position: static;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
 }
 ```
 


### PR DESCRIPTION
## What

Adds a public accessibility best-practices guide for React on Rails, with a dedicated React Server Components section. Closes #3927.

React on Rails has had **no dedicated accessibility documentation** — the only a11y content lived in internal planning files. This publishes a proper WCAG 2.1 AA best-practices guide that addresses the unusual a11y surface of RoR apps, where the same UI can be produced as server-rendered HTML, client-hydrated React, or (Pro) RSC-streamed content, each with distinct focus, live-region, and progressive-enhancement failure modes.

## File location & rationale

`docs/guides/accessibility.md` (suggested in the issue) does not exist today — there is no `docs/guides/` tree. The docs are split into `docs/oss/**` and `docs/pro/**`, with the sidebar (`docs/sidebars.ts`) resolving OSS ids relative to `docs/oss/`.

I placed the guide at **`docs/oss/building-features/accessibility.md`** (sidebar: Building Features → Development & Ops, next to the testing/debugging docs):

- The **general** a11y guidance applies to every RoR app, so it belongs in OSS where the broadest audience finds it.
- The **RSC-specific** section cross-links into the Pro RSC docs, mirroring the existing pattern in `streaming-server-rendering.md`, which is an OSS doc that links readers to the Pro streaming/RSC material.

## Contents

**General RoR a11y:** WCAG AA contrast, keyboard navigation, `aria-live` for Rails flash messages + form errors, focus management on dialogs/route changes, `prefers-reduced-motion`, 44px touch targets, and `eslint-plugin-jsx-a11y`.

**Server Components:** progressive enhancement (accessible server HTML before JS), focus management across Suspense-streamed boundaries, avoiding `aria-live` double-announcements across SSR + hydration, keyboard nav through partially-hydrated trees, `role`/`aria-busy` loading states, and SSR + reduced-motion/FOUC across the server/client boundary.

**Testing:** Playwright role/keyboard assertion patterns and axe/jest-axe integration.

## Accuracy verifications (against the repo)

- **`jsx-a11y/anchor-is-valid` is disabled** — confirmed in `eslint.config.ts:169` (`'jsx-a11y/anchor-is-valid': 'off'`). The guide notes this is a repo lint choice and recommends apps keep the rule on.
- **`useRailsForm` signature** — confirmed in `docs/oss/building-features/forms.md` that the hook takes the initial data object directly (`useRailsForm({ email: '' })`) and exposes the `{ field: ["message"] }` error shape; the form example matches.
- **RSC Suspense/streaming/selective-hydration** concepts are grounded in and cross-linked to the existing Pro RSC docs.
- **axe-core / jest-axe** are presented as external tools to add, since they are **not** repo dependencies (only `eslint-plugin-jsx-a11y` is in `package.json`).
- All internal links and sidebar anchors were verified to resolve to existing files/headings.

## Also

- Linked the guide from `docs/sidebars.ts` and the docs README index (`docs/README.md`).
- Regenerated `llms-full.txt` via `script/generate-llms-full.mjs` (the generator reads sidebar order, so the new entry is included); `--check` mode is clean.

## Validation

- `prettier --check` clean on all changed files.
- `node script/generate-llms-full.mjs --check` reports files current.
- Internal links + sidebar anchors verified.
- `codex review --base origin/main` run; addressed all three findings (invalid `useRailsForm` init wrapper, `aria-busy` that never cleared, and a Playwright assertion that didn't actually verify focus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Adds **`docs/oss/building-features/accessibility.md`**, a WCAG 2.1 AA guide aimed at React on Rails apps across SSR, hydration, and Pro RSC streaming. It covers contrast and keyboard basics, `aria-live` for Rails flash and `useRailsForm` errors, dialog/route focus, reduced motion, touch targets, and notes that this repo disables `jsx-a11y/anchor-is-valid` while recommending apps keep it on.
> 
> A **Server Components** section documents RSC-specific pitfalls: progressive enhancement, Suspense focus, avoiding live-region double announcements on hydration, partial hydration tab order, and `aria-busy` / skeleton patterns, with links into Pro RSC docs.
> 
> A **testing** section adds Playwright role/keyboard examples, skip-link guidance, and optional axe integration. The page is wired into **`docs/sidebars.ts`** (Development & Ops) and **`docs/README.md`**, and **`llms-full.txt`** is regenerated to include the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621b658ca920a49608b8628b3819aa6c0cac8c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Accessibility (a11y) guide, including WCAG 2.1 Level AA targets for color contrast, keyboard navigation, focus management, dialogs, and reduced-motion support.
  * Covers React Server Components accessibility patterns, including progressive enhancement and safe live-region usage for Rails flash/validation.
  * Includes Playwright-based accessibility testing examples and recommendations for automated scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->