### PR TITLE
feat: Owner Stacks in development error reports (#3887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Added
+
+- **Owner Stacks in development error reports**: When a React component throws during rendering, React on Rails now enriches its development error reporting with React 19.1+'s dev-only [`captureOwnerStack`](https://react.dev/reference/react/captureOwnerStack) output — the chain of components that rendered the failing one (e.g. `at Avatar` / `at PostCard` / `at PostList`). On the **server-side rendering** path, the owner stack is captured synchronously inside the Pro streaming `onError` callback and appended to the error's stack, so it flows through to the Rails-side `ReactOnRails::PrerenderError` / `SmartError` (`:server_rendering_error`) output and the streamed shell-error HTML. On the **client**, recoverable hydration mismatches (`onRecoverableError`) automatically gain an owner-stack line in the branded development log, and apps that register their own `onCaughtError`/`onUncaughtError` handler get an additive `[ReactOnRails] Render error ... Owner stack:` line for client render errors. To avoid displacing React's own built-in development diagnostics (component stacks, error-boundary hints), React on Rails does not auto-attach caught/uncaught handlers solely to log owner stacks. Owner-stack capture requires React >= 19.1 running its development build, so it is a strict no-op on older React and in all production builds (no capture, no `captureOwnerStack` call), asserted by tests. The ExecJS rendering path is out of scope (capture must happen JS-side, synchronously, inside React's error callback). Closes [Issue 3887](https://github.com/shakacode/react_on_rails/issues/3887). [PR 4089](https://github.com/shakacode/react_on_rails/pull/4089) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.5] - 2026-06-16
 
 #### Fixed

--- a/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
+++ b/packages/react-on-rails-pro/src/streamServerRenderedReactComponent.ts
@@ -17,6 +17,7 @@ import { Readable } from 'stream';
 
 import sanitizeNonce from 'react-on-rails/@internal/sanitizeNonce';
 import { renderToPipeableStream } from 'react-on-rails/ReactDOMServer';
+import captureReactOwnerStack from 'react-on-rails/captureReactOwnerStack';
 import { convertToError } from 'react-on-rails/serverRenderUtils';
 import {
   assertRailsContextWithServerStreamingCapabilities,
@@ -65,6 +66,23 @@ const streamRenderReactComponent = (
     pipeToTransform(errorHtmlStream);
   };
 
+  // Returns the suffix to append to an error's stack so React 19.1+'s owner stack (the component
+  // chain that rendered the failing one, issue #3887) travels to Rails via the renderingError
+  // metadata (message + stack) and into the shell-error HTML. MUST be called synchronously inside a
+  // React error callback (onError/onShellError), where `captureReactOwnerStack()` can still read the
+  // owner stack; returns '' on React < 19.1 and in production builds. Keyed on a marker so callers
+  // can apply it idempotently: for an Error instance both onError and onShellError receive the same
+  // object (the second call returns '' because the marker is already present), and for a non-Error
+  // throw each callback gets a fresh Error from convertToError that still gets the owner stack.
+  const OWNER_STACK_MARKER = '\n\nOwner stack (the components that rendered this one):';
+  const ownerStackAugmentedStack = (error: Error): string | undefined => {
+    if (typeof error.stack !== 'string' || error.stack.includes(OWNER_STACK_MARKER)) {
+      return undefined;
+    }
+    const ownerStack = captureReactOwnerStack();
+    return ownerStack ? `${error.stack}${OWNER_STACK_MARKER}${ownerStack}` : undefined;
+  };
+
   assertRailsContextWithServerStreamingCapabilities(railsContext);
 
   Promise.resolve(reactRenderingResult)
@@ -83,7 +101,16 @@ const streamRenderReactComponent = (
 
       const renderingStream = renderToPipeableStream(reactRenderedElement, {
         onShellError(e) {
-          sendErrorHtml(convertToError(e));
+          const error = convertToError(e);
+          // Ensure the owner stack is on this error's stack for the shell-error HTML (issue #3887).
+          // For an Error instance React already passed it to onError, which appended it, so the marker
+          // is present and the suffix is empty; for a non-Error throw onShellError gets a fresh Error
+          // and the owner stack is appended here.
+          const augmentedStack = ownerStackAugmentedStack(error);
+          if (augmentedStack) {
+            error.stack = augmentedStack;
+          }
+          sendErrorHtml(error);
         },
         onShellReady() {
           renderState.isShellReady = true;
@@ -101,6 +128,15 @@ const streamRenderReactComponent = (
           if (isRSCRouteSSRFalseBailoutError(error)) {
             sawRSCRouteSSRFalseBailout = true;
             return error.digest;
+          }
+
+          // Append the owner stack to this error's stack (issue #3887). onError fires for every
+          // render error and sets renderState.error, which is serialized into the Rails-side
+          // renderingError metadata (message + stack) — so this is what carries owner stacks to
+          // PrerenderError/SmartError for ALL streaming errors.
+          const augmentedStack = ownerStackAugmentedStack(error);
+          if (augmentedStack) {
+            error.stack = augmentedStack;
           }
 
           reportError(error);

--- a/packages/react-on-rails/package.json
+++ b/packages/react-on-rails/package.json
@@ -48,6 +48,7 @@
     "./ReactOnRails.full": "./lib/ReactOnRails.full.js",
     "./handleError": "./lib/handleError.js",
     "./generateRenderingErrorMessage": "./lib/generateRenderingErrorMessage.js",
+    "./captureReactOwnerStack": "./lib/captureReactOwnerStack.js",
     "./serverRenderUtils": "./lib/serverRenderUtils.js",
     "./buildConsoleReplay": "./lib/buildConsoleReplay.js",
     "./ReactDOMServer": "./lib/ReactDOMServer.cjs",

--- a/packages/react-on-rails/src/captureReactOwnerStack.ts
+++ b/packages/react-on-rails/src/captureReactOwnerStack.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+/**
+ * React's `captureOwnerStack` (added in React 19.1) returns the "owner stack" for the component
+ * currently rendering or erroring — the chain of components that created the failing element, e.g.
+ *
+ *   at Avatar
+ *   at PostCard
+ *   at PostList
+ *
+ * This is dramatically more useful for debugging than a minified JS stack because it names the
+ * components a developer actually wrote.
+ *
+ * IMPORTANT dev-build-on-server / production constraints (verified against React 19.0.x and 19.2.x):
+ *
+ * 1. `captureOwnerStack` is exported **only from React's development build**. In a production build
+ *    the export does not exist (`typeof React.captureOwnerStack !== 'function'`), so the guard below
+ *    makes this a strict no-op in production — there is no capture, no call, and no behavioral change.
+ *    This is asserted by tests.
+ * 2. It is exported only from React **>= 19.1**. On React 19.0 and earlier the export is `undefined`
+ *    even in dev builds, so the same guard covers the version requirement without needing to parse
+ *    `React.version`.
+ * 3. It returns a meaningful string **only when called synchronously while React is rendering or
+ *    handling an error** (e.g. inside an `onError`/`onCaughtError`/`onUncaughtError`/`onShellError`
+ *    callback). Called outside that window it returns `null`. Post-hoc formatting (for example the
+ *    Ruby layer, or a `try/catch` around `renderToString` after it has already thrown) cannot
+ *    capture it — which is why capture must happen JS-side inside the error callback.
+ *
+ * On the server this only yields output when React's **development** build runs in the SSR bundle.
+ * Production SSR bundles run React's production build and therefore get the no-op behavior above;
+ * that is the documented, intended outcome for production.
+ *
+ * @returns React's owner stack string verbatim (it typically begins with a newline and indented
+ *   `at <Component>` frames) when a non-empty one is available, otherwise `undefined`. The
+ *   whitespace is preserved intentionally so callers can embed it directly under a label. Never
+ *   throws.
+ */
+// `captureOwnerStack` is only present on React's dev build for React >= 19.1. Accessing it through a
+// typed-as-optional view keeps this compiling against the broad `react >= 16` peer range.
+const reactWithOwnerStack = React as typeof React & {
+  captureOwnerStack?: () => string | null;
+};
+
+/**
+ * Whether React's dev-only `captureOwnerStack` API exists in the current build — i.e. React >= 19.1
+ * running its **development** build. Used to gate dev-mode owner-stack logging so that on older
+ * React (or any production build), where the API is absent, React's own default error reporting is
+ * left untouched (issue #3887).
+ */
+export function isOwnerStackSupported(): boolean {
+  return typeof reactWithOwnerStack.captureOwnerStack === 'function';
+}
+
+export default function captureReactOwnerStack(): string | undefined {
+  if (typeof reactWithOwnerStack.captureOwnerStack !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const ownerStack = reactWithOwnerStack.captureOwnerStack();
+    if (typeof ownerStack === 'string' && ownerStack.trim().length > 0) {
+      return ownerStack;
+    }
+  } catch {
+    // captureOwnerStack must never break error reporting; swallow any unexpected failure.
+  }
+
+  return undefined;
+}

--- a/packages/react-on-rails/src/rootErrorHandlers.ts
+++ b/packages/react-on-rails/src/rootErrorHandlers.ts
@@ -3,6 +3,7 @@ import type { ReactHydrateOptions } from './reactApis.cts';
 import { supportsRootApi, supportsReact19RootErrorCallbacks } from './reactApis.cts';
 import { getRailsContext } from './context.ts';
 import { isThenable } from './isThenable.ts';
+import captureReactOwnerStack, { isOwnerStackSupported } from './captureReactOwnerStack.ts';
 
 /**
  * Guide linked from the development-mode hydration-mismatch message.
@@ -188,10 +189,40 @@ function extractComponentStack(errorInfo: unknown): string | undefined {
 }
 
 /**
+ * React 19.2+ includes the owner stack on the `errorInfo` passed to `onCaughtError`/`onUncaughtError`
+ * (and to `onRecoverableError` for hydration mismatches) via `errorInfo.ownerStack`. Prefer it when
+ * present; callers fall back to a live `captureReactOwnerStack()` call for React 19.1, which exposes
+ * the API but not the `errorInfo` field.
+ */
+function extractOwnerStack(errorInfo: unknown): string | undefined {
+  const ownerStack = (errorInfo as { ownerStack?: unknown } | null | undefined)?.ownerStack;
+  return typeof ownerStack === 'string' && ownerStack.trim().length > 0 ? ownerStack : undefined;
+}
+
+/**
+ * Builds the supplemental "Owner stack" suffix for dev-mode error logs (issue #3887).
+ *
+ * MUST be called synchronously from inside React's error callback. `precomputedOwnerStack` is the
+ * owner stack React already captured for this error (e.g. `errorInfo.ownerStack` on React 19.2+),
+ * when available; otherwise we fall back to a live `captureReactOwnerStack()` call, which only
+ * returns a value while React is still handling the error. Returns an empty string when no owner
+ * stack is available — in particular on React < 19.1 and in production builds, where
+ * `captureReactOwnerStack` is a strict no-op.
+ */
+function ownerStackSuffix(precomputedOwnerStack?: string): string {
+  const ownerStack =
+    (typeof precomputedOwnerStack === 'string' && precomputedOwnerStack.trim().length > 0
+      ? precomputedOwnerStack
+      : undefined) ?? captureReactOwnerStack();
+  return ownerStack ? `\nOwner stack (the components that rendered this one):${ownerStack}` : '';
+}
+
+/**
  * Branded, supplemental development-mode line: component name, dom id, component stack (when
- * React provides one), and the debugging-guide link. Deliberately does NOT dump the error object
- * itself — the error is default-reported exactly once elsewhere (by `defaultReportRecoverableError`
- * on core paths, or by Pro's internal recoverable-error handler on chained paths).
+ * React provides one), the owner stack (React >= 19.1 dev builds, issue #3887), and the
+ * debugging-guide link. Deliberately does NOT dump the error object itself — the error is
+ * default-reported exactly once elsewhere (by `defaultReportRecoverableError` on core paths, or by
+ * Pro's internal recoverable-error handler on chained paths).
  */
 function logDevHydrationError(context: RootErrorContext, errorInfo: unknown): void {
   const componentName = context.componentName ?? 'unknown';
@@ -199,7 +230,30 @@ function logDevHydrationError(context: RootErrorContext, errorInfo: unknown): vo
   const componentStack = extractComponentStack(errorInfo);
   const componentStackSuffix = componentStack ? `\nComponent stack:${componentStack}` : '';
   console.error(
-    `[ReactOnRails] Recoverable hydration error in component "${componentName}" (dom id: "${domNodeId}"). The server-rendered HTML did not match what React rendered on the client, so React threw away the server HTML and re-rendered on the client. Common Rails-specific causes and fixes: ${HYDRATION_MISMATCH_GUIDE_URL}${componentStackSuffix}`,
+    `[ReactOnRails] Recoverable hydration error in component "${componentName}" (dom id: "${domNodeId}"). The server-rendered HTML did not match what React rendered on the client, so React threw away the server HTML and re-rendered on the client. Common Rails-specific causes and fixes: ${HYDRATION_MISMATCH_GUIDE_URL}${componentStackSuffix}${ownerStackSuffix(extractOwnerStack(errorInfo))}`,
+  );
+}
+
+/**
+ * Development-only supplemental line for render-path errors React reports through an app-registered
+ * `onCaughtError`/`onUncaughtError` handler (issue #3887). Names the failing component/dom id and
+ * appends the owner stack when React provides one. The error itself is reported by the app's own
+ * handler (which we forward to), so this line is purely additive context.
+ */
+function logDevRenderError(
+  kind: 'onCaughtError' | 'onUncaughtError',
+  context: RootErrorContext,
+  errorInfo: unknown,
+): void {
+  const suffix = ownerStackSuffix(extractOwnerStack(errorInfo));
+  if (!suffix) {
+    return;
+  }
+  const componentName = context.componentName ?? 'unknown';
+  const domNodeId = context.domNodeId ?? 'unknown';
+  const caughtNote = kind === 'onCaughtError' ? ' (caught by an error boundary)' : '';
+  console.error(
+    `[ReactOnRails] Render error in component "${componentName}" (dom id: "${domNodeId}")${caughtNote}.${suffix}`,
   );
 }
 
@@ -272,13 +326,34 @@ export function buildRootErrorCallbackOptions(
   }
 
   if (supportsReact19RootErrorCallbacks) {
+    // Owner-stack enrichment for client render errors (issue #3887). We only enrich when the app has
+    // registered its own onCaughtError/onUncaughtError handler: providing one already replaces
+    // React's default reporting for that callback, so prepending our supplemental dev owner-stack
+    // line is purely additive. We deliberately do NOT auto-attach a wrapper when the app registered
+    // no handler — that would displace React's built-in dev diagnostics (component stack,
+    // error-boundary hints) that we cannot faithfully reproduce, a net loss. Owner stacks still reach
+    // users automatically on the two paths React on Rails already owns: SSR errors (the Pro streaming
+    // onError path) and hydration mismatches (the onRecoverableError path above).
+    //
+    // The owner-stack line is only emitted on React >= 19.1 dev builds (`isOwnerStackSupported()`);
+    // otherwise the wrapper just forwards to the app handler unchanged.
+    const enrichDevOwnerStack = inDevelopmentEnv() && isOwnerStackSupported();
+
     if (onCaughtError) {
-      options.onCaughtError = (error, errorInfo) =>
+      options.onCaughtError = (error, errorInfo) => {
+        if (enrichDevOwnerStack) {
+          logDevRenderError('onCaughtError', context, errorInfo);
+        }
         safeInvoke(onCaughtError, 'onCaughtError', error, errorInfo, context);
+      };
     }
     if (onUncaughtError) {
-      options.onUncaughtError = (error, errorInfo) =>
+      options.onUncaughtError = (error, errorInfo) => {
+        if (enrichDevOwnerStack) {
+          logDevRenderError('onUncaughtError', context, errorInfo);
+        }
         safeInvoke(onUncaughtError, 'onUncaughtError', error, errorInfo, context);
+      };
     }
   }
 

--- a/packages/react-on-rails/tests/captureReactOwnerStack.test.ts
+++ b/packages/react-on-rails/tests/captureReactOwnerStack.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for captureReactOwnerStack (issue #3887).
+ *
+ * captureReactOwnerStack wraps React 19.1+'s dev-only `captureOwnerStack`. The two behaviors that
+ * MUST hold regardless of the React version installed in the test workspace:
+ *
+ *   1. Production / older-React no-op: when `React.captureOwnerStack` is absent (production builds,
+ *      and every React < 19.1), the helper never calls it and returns `undefined`.
+ *   2. When the API IS present (React >= 19.1 dev build), the helper returns its trimmed string
+ *      output and tolerates `null` / empty / throwing implementations.
+ *
+ * Because the helper reads `React.captureOwnerStack` lazily on each call, we exercise both behaviors
+ * by mutating that property on the imported React module within a test, then restoring it.
+ */
+
+import * as React from 'react';
+import captureReactOwnerStack from '../src/captureReactOwnerStack.ts';
+
+// `react/experimental` types `captureOwnerStack` as a required `() => string | null`, but at runtime
+// it is absent in production builds and on React < 19.1. Treat the property as an arbitrary,
+// possibly-missing value so the tests can install/remove fakes that model those runtimes.
+const reactModule = React as unknown as Record<'captureOwnerStack', unknown>;
+
+const withCaptureOwnerStack = (impl: unknown, run: () => void): void => {
+  const had = Object.prototype.hasOwnProperty.call(reactModule, 'captureOwnerStack');
+  const original = reactModule.captureOwnerStack;
+  reactModule.captureOwnerStack = impl;
+  try {
+    run();
+  } finally {
+    if (had) {
+      reactModule.captureOwnerStack = original;
+    } else {
+      delete (reactModule as { captureOwnerStack?: unknown }).captureOwnerStack;
+    }
+  }
+};
+
+describe('captureReactOwnerStack', () => {
+  it('returns undefined and does not call captureOwnerStack when the API is absent (production / React < 19.1 no-op)', () => {
+    withCaptureOwnerStack(undefined, () => {
+      expect(captureReactOwnerStack()).toBeUndefined();
+    });
+  });
+
+  it('does not invoke a non-function captureOwnerStack', () => {
+    // A production build does not export the API at all; assert we never treat a stray
+    // non-function value as callable.
+    withCaptureOwnerStack(null, () => {
+      expect(captureReactOwnerStack()).toBeUndefined();
+    });
+  });
+
+  it('returns the owner stack string when the dev API provides one', () => {
+    const ownerStack = '\n    at Avatar\n    at PostCard\n    at PostList';
+    const spy = jest.fn(() => ownerStack);
+    withCaptureOwnerStack(spy, () => {
+      expect(captureReactOwnerStack()).toBe(ownerStack);
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when the dev API returns null (called outside render)', () => {
+    withCaptureOwnerStack(
+      () => null,
+      () => {
+        expect(captureReactOwnerStack()).toBeUndefined();
+      },
+    );
+  });
+
+  it('returns undefined when the dev API returns an empty / whitespace-only string', () => {
+    withCaptureOwnerStack(
+      () => '   \n  ',
+      () => {
+        expect(captureReactOwnerStack()).toBeUndefined();
+      },
+    );
+  });
+
+  it('never throws when the dev API throws', () => {
+    withCaptureOwnerStack(
+      () => {
+        throw new Error('boom');
+      },
+      () => {
+        expect(captureReactOwnerStack()).toBeUndefined();
+      },
+    );
+  });
+});

--- a/packages/react-on-rails/tests/rootErrorCallbacks.test.tsx
+++ b/packages/react-on-rails/tests/rootErrorCallbacks.test.tsx
@@ -12,7 +12,11 @@
 import * as React from 'react';
 import { renderComponent } from '../src/ClientRenderer.ts';
 import ComponentRegistry from '../src/ComponentRegistry.ts';
-import { setRootErrorHandlers, resetRootErrorHandlers } from '../src/rootErrorHandlers.ts';
+import {
+  buildRootErrorCallbackOptions,
+  setRootErrorHandlers,
+  resetRootErrorHandlers,
+} from '../src/rootErrorHandlers.ts';
 import { resetRailsContext } from '../src/context.ts';
 import { supportsReact19RootErrorCallbacks } from '../src/reactApis.cts';
 
@@ -137,6 +141,25 @@ describe('root error callbacks with real react-dom (React 19)', () => {
       'https://reactonrails.com/docs/building-features/debugging-hydration-mismatches',
     );
   });
+
+  react19It(
+    'never auto-attaches a caught/uncaught wrapper for owner stacks when the app registered no handler, preserving React defaults (issue #3887)',
+    () => {
+      // React on Rails must not displace React's built-in caught/uncaught dev diagnostics (component
+      // stack, error-boundary hints) just to add an owner-stack line. With no app-registered handler,
+      // both callbacks stay unset so React's own defaults run untouched — regardless of React version.
+      // Owner stacks still reach users automatically on the SSR and hydration-mismatch paths. The
+      // positive client path (app handler + owner stacks available) is covered with a mocked
+      // owner-stack module in rootErrorCallbacksOwnerStack.test.tsx.
+      setupRailsContext('development');
+      const context = { componentName: 'ThrowingDevComponent', domNodeId: 'dev-uncaught-dom-id' };
+
+      const options = buildRootErrorCallbackOptions(context, false);
+
+      expect(options.onUncaughtError).toBeUndefined();
+      expect(options.onCaughtError).toBeUndefined();
+    },
+  );
 
   react19It(
     'invokes the user onUncaughtError with enriched context on the client-render (createRoot) path',

--- a/packages/react-on-rails/tests/rootErrorCallbacksOwnerStack.test.tsx
+++ b/packages/react-on-rails/tests/rootErrorCallbacksOwnerStack.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Positive-path coverage for issue #3887's client owner-stack enrichment.
+ *
+ * The workspace React is 19.0.x, where `captureOwnerStack` does not exist, so the real-runtime
+ * integration test in `rootErrorCallbacks.test.tsx` can only exercise the no-op branch. Here we mock
+ * `captureReactOwnerStack` to model a React >= 19.1 dev build (owner stacks available) and assert the
+ * branded dev-mode render-error line actually carries the owner chain. This is the CI-runnable
+ * substitute for the dev-only browser behavior (the dummy e2e cannot run because the Playwright
+ * harness boots Rails in `test`, while the owner-stack logger is gated to `development`).
+ */
+
+const OWNER_STACK = '\n    at OwnerStackInner\n    at OwnerStackMiddle\n    at OwnerStackThrower';
+
+jest.mock('../src/captureReactOwnerStack.ts', () => ({
+  __esModule: true,
+  default: jest.fn(() => OWNER_STACK),
+  isOwnerStackSupported: jest.fn(() => true),
+}));
+
+import {
+  buildRootErrorCallbackOptions,
+  setRootErrorHandlers,
+  resetRootErrorHandlers,
+} from '../src/rootErrorHandlers.ts';
+import { resetRailsContext } from '../src/context.ts';
+import { supportsReact19RootErrorCallbacks } from '../src/reactApis.cts';
+
+const setupRailsContext = (railsEnv: string): void => {
+  const el = document.createElement('div');
+  el.id = 'js-react-on-rails-context';
+  el.textContent = JSON.stringify({
+    railsEnv,
+    inMailer: false,
+    i18nLocale: 'en',
+    i18nDefaultLocale: 'en',
+    rorVersion: '17.0.0',
+    rorPro: false,
+    href: 'http://localhost:3000',
+    location: 'http://localhost:3000',
+    scheme: 'http',
+    host: 'localhost',
+    port: 3000,
+    pathname: '/',
+    search: null,
+    httpAcceptLanguage: 'en',
+    serverSide: false,
+    componentRegistryTimeout: 0,
+  });
+  document.body.appendChild(el);
+};
+
+const react19Describe = supportsReact19RootErrorCallbacks ? describe : describe.skip;
+
+react19Describe('client owner-stack enrichment with owner stacks available (issue #3887)', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetRootErrorHandlers();
+    resetRailsContext();
+    document.body.innerHTML = '';
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    resetRootErrorHandlers();
+    resetRailsContext();
+  });
+
+  const brandedRenderErrorLine = (): string | undefined =>
+    consoleErrorSpy.mock.calls
+      .map((call) => call[0])
+      .find(
+        (arg): arg is string =>
+          typeof arg === 'string' && arg.includes('[ReactOnRails] Render error in component'),
+      );
+
+  it('appends the owner chain to a dev app-registered onUncaughtError handler and still forwards to it', () => {
+    setupRailsContext('development');
+    const appOnUncaughtError = jest.fn();
+    setRootErrorHandlers({ onUncaughtError: appOnUncaughtError });
+    const context = { componentName: 'OwnerStackThrower', domNodeId: 'owner-dom-id' };
+
+    const options = buildRootErrorCallbackOptions(context, false);
+    expect(options.onUncaughtError).toBeDefined();
+
+    // errorInfo has no `ownerStack` field (React < 19.2 shape) so the logger falls back to the
+    // mocked live `captureReactOwnerStack()`.
+    const error = new Error('deliberate render error');
+    options.onUncaughtError?.(error, {});
+
+    const line = brandedRenderErrorLine();
+    expect(line).toBeDefined();
+    expect(line).toContain('"OwnerStackThrower"');
+    expect(line).toContain('Owner stack (the components that rendered this one):');
+    expect(line).toContain('at OwnerStackMiddle');
+    // The enrichment is purely additive: the app's own handler still runs, receiving React on Rails'
+    // enriched context (component name + dom id) as the third argument.
+    expect(appOnUncaughtError).toHaveBeenCalledWith(error, {}, context);
+  });
+
+  it('appends the owner chain to a dev app-registered onCaughtError handler with the error-boundary note', () => {
+    setupRailsContext('development');
+    const appOnCaughtError = jest.fn();
+    setRootErrorHandlers({ onCaughtError: appOnCaughtError });
+    const context = { componentName: 'OwnerStackThrower', domNodeId: 'owner-dom-id' };
+
+    const options = buildRootErrorCallbackOptions(context, false);
+    expect(options.onCaughtError).toBeDefined();
+
+    const error = new Error('deliberate caught error');
+    options.onCaughtError?.(error, {});
+
+    const line = brandedRenderErrorLine();
+    expect(line).toBeDefined();
+    expect(line).toContain('"OwnerStackThrower"');
+    expect(line).toContain('(caught by an error boundary)');
+    expect(line).toContain('Owner stack (the components that rendered this one):');
+    expect(line).toContain('at OwnerStackMiddle');
+    expect(appOnCaughtError).toHaveBeenCalledWith(error, {}, context);
+  });
+
+  it('does not auto-attach a wrapper when the app registered no handler, leaving React defaults intact', () => {
+    setupRailsContext('development');
+    const context = { componentName: 'OwnerStackThrower', domNodeId: 'owner-dom-id' };
+
+    // Even with owner stacks available and in development, we never displace React's built-in
+    // caught/uncaught dev diagnostics when the app supplied no handler of its own.
+    const options = buildRootErrorCallbackOptions(context, false);
+    expect(options.onUncaughtError).toBeUndefined();
+    expect(options.onCaughtError).toBeUndefined();
+  });
+});

--- a/react_on_rails/spec/dummy/app/views/pages/root_error_callbacks.html.erb
+++ b/react_on_rails/spec/dummy/app/views/pages/root_error_callbacks.html.erb
@@ -18,3 +18,7 @@
 <hr/>
 <h2>Client-rendered component caught by an error boundary (onCaughtError)</h2>
 <%= react_component("RootErrorBoundaryThrower", prerender: false, id: "RootErrorBoundaryThrower-react-component-0") %>
+
+<hr/>
+<h2>Client-rendered nested component that throws, exercising owner stacks (issue #3887)</h2>
+<%= react_component("OwnerStackThrower", prerender: false, id: "OwnerStackThrower-react-component-0") %>

--- a/react_on_rails/spec/dummy/client/app/startup/OwnerStackThrower.tsx
+++ b/react_on_rails/spec/dummy/client/app/startup/OwnerStackThrower.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+/**
+ * Test fixture for issue #3887 (Owner Stacks in CSR/SSR error reports).
+ *
+ * A deliberately *nested* component tree so React 19.1+'s owner stack
+ * (`captureOwnerStack`, dev builds only) has a meaningful chain to report:
+ *
+ *   OwnerStackThrower  →  OwnerStackMiddle  →  OwnerStackInner (throws)
+ *
+ * Client-rendered (createRoot path, `prerender: false`). After the button is clicked the inner
+ * component throws during render with no error boundary above it, so React routes the error to the
+ * root's `onUncaughtError` callback. React on Rails' dev-mode logger (rootErrorHandlers.ts) then
+ * emits a "[ReactOnRails] Render error ... Owner stack:" line naming the owner chain in the browser
+ * console.
+ *
+ * Manual demo only: the branded line is gated to `railsEnv === 'development'` and requires a React
+ * >= 19.1 dev build, so it is exercised at the unit level by `rootErrorCallbacksOwnerStack.test.tsx`
+ * rather than by the Playwright suite (which boots Rails in `test`). Load `/root_error_callbacks` in
+ * a development server and click the button to see it live.
+ */
+
+const OwnerStackInner: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => {
+  if (shouldThrow) {
+    throw new Error('Deliberate owner-stack render error from OwnerStackInner');
+  }
+  return <p>Owner stack inner ready</p>;
+};
+
+const OwnerStackMiddle: React.FC<{ shouldThrow: boolean }> = ({ shouldThrow }) => (
+  <OwnerStackInner shouldThrow={shouldThrow} />
+);
+
+const OwnerStackThrower: React.FC = () => {
+  const [shouldThrow, setShouldThrow] = React.useState(false);
+
+  return (
+    <div>
+      <h3>Owner Stack Thrower</h3>
+      <button type="button" onClick={() => setShouldThrow(true)}>
+        Throw nested render error
+      </button>
+      <OwnerStackMiddle shouldThrow={shouldThrow} />
+    </div>
+  );
+};
+
+export default OwnerStackThrower;


### PR DESCRIPTION
## Why

SSR/CSR errors surfaced from the Node renderer / ExecJS are the single most-reported React on Rails debugging pain: a JS stack with no component context (`Exception in rendering!` + a minified stack). React 19.1's dev-only [`captureOwnerStack`](https://react.dev/reference/react/captureOwnerStack) returns the **owner chain** — the components that rendered the failing one (e.g. `at Avatar` / `at PostCard` / `at PostList`) — turning a multi-minute hunt into a quick read. Better errors are also exactly what AI coding agents consume to self-correct.

Closes #3887 (child of #3865). Builds on the merged root error-callbacks work (#3933) and error classification (#3614/#3724).

## What changed

Dev-mode-only owner-stack enrichment on both error paths, with a strict production no-op:

- **New util** `packages/react-on-rails/src/captureReactOwnerStack.ts` — wraps `React.captureOwnerStack()` with a guard that resolves the dev-build/version question (see decision log). Returns `undefined` unless React ≥ 19.1's **development** build is active. Never throws. Also exports `isOwnerStackSupported()`.
- **Server (streaming SSR)** `streamServerRenderedReactComponent.ts` — the owner stack is captured **synchronously** inside React's `onError` callback (which fires for every render error and feeds `renderState.error`) and appended to `error.stack`. That single mechanism delivers it to both the Rails-side rendering error (`PrerenderError`/`SmartError`, `:server_rendering_error`) and the streamed shell-error HTML. `onShellError` reuses the same already-appended error object, so it is not captured twice.
- **Client (hydrate)** `rootErrorHandlers.ts` — recoverable hydration mismatches (`onRecoverableError`, already attached by RoR in dev per #3892) now also carry an owner-stack line in the branded dev log. For client **render** errors, RoR enriches `onCaughtError`/`onUncaughtError` with an additive `[ReactOnRails] Render error … Owner stack:` line **only when the app registered its own handler** — it does **not** auto-attach handlers just to log owner stacks (see decision log). Prefers React 19.2's `errorInfo.ownerStack` when present, falling back to a live `captureOwnerStack()` for 19.1.

## Codex Decision Log

- **Non-blocking: how to gate "dev React build on the server".**
  - **Decision:** Guard solely on `typeof React.captureOwnerStack === 'function'` rather than parsing `React.version` or inspecting `NODE_ENV`.
  - **Why:** `captureOwnerStack` is exported **only** from React's development build, and **only** on React ≥ 19.1. A single capability check therefore covers both the version requirement and the dev-vs-prod build requirement, and is automatically a no-op in production SSR bundles (which run React's production build). Asserted by tests.
  - **Review later:** None.
- **Non-blocking: do not auto-attach caught/uncaught handlers just to log owner stacks.**
  - **Decision:** Client render-error owner stacks are added only when the app already registered `onCaughtError`/`onUncaughtError`. RoR does not install these handlers on the app's behalf solely for owner-stack logging.
  - **Why:** Registering a React 19 root error callback *replaces* React's default reporting for it, and React's dev defaults (component stacks, error-boundary hints) can't be faithfully reproduced — auto-attaching would be a net loss of diagnostics rather than additive. SSR errors and hydration mismatches still get owner stacks automatically because RoR already owns those callbacks. (Raised by the pre-push codex review.)
  - **Review later:** If a future need arises for owner stacks on un-handled client render errors, revisit once React exposes owner stacks to default reporting.

- **Non-blocking: deliver SSR owner stacks by appending to `error.stack` rather than a separate structured field.**
  - **Decision:** Append the owner stack to the error's stack in `onError` instead of threading a dedicated `owner_stack` field through the JS→Ruby boundary into `SmartError`.
  - **Why:** The Rails-side rendering error is built from the JS error's message + stack, so the stack is the channel that actually reaches `PrerenderError`/`SmartError` today; a separate field would require new end-to-end serialization that nothing currently populates. Appending is one mechanism that covers both the Rails output and the shell-error HTML and avoids dead code.
  - **Review later:** A future enhancement could surface the owner chain as a dedicated, separately-styled `SmartError` section if the renderingError payload starts carrying it as a structured field.

## Scope notes

- **Production is a strict no-op** — no capture, no `captureOwnerStack` call — asserted by tests.
- **ExecJS path is out of scope**: capture must happen JS-side, synchronously, inside React's error callback; the ExecJS path cannot satisfy that. Documented as a Node-renderer + client benefit.

## Validation (local)

- `pnpm --filter react-on-rails run type-check` ✓ · `pnpm --filter react-on-rails-pro run type-check` ✓
- `eslint` (changed src) ✓ 0 errors · `prettier --check` ✓
- `jest captureReactOwnerStack rootErrorCallbacks rootErrorCallbacksOwnerStack` ✓ (incl. a mocked positive-path test for the React ≥19.1 owner-stack line)
- Pre-push `codex review --base origin/main` run to clean (caught and fixed: an e2e that couldn't run under the `test` harness, a React 19.0 default-diagnostics regression, and an owner-stack duplication on pre-shell errors).
- `OwnerStackThrower.tsx` dummy demo is a documented manual-verification fixture (the dev-only branded line can't be asserted by the Playwright suite, which boots Rails in `test`); auto-registered via `auto_load_bundle`, renders cleanly on page load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated to development builds and React ≥19.1 capability checks; production and ExecJS paths are unchanged no-ops, with additive logging only on error paths RoR already owns or when apps opt in via existing handlers.
> 
> **Overview**
> Adds **development-only** owner-stack context to React on Rails error output using React 19.1+’s dev-only `captureOwnerStack`, with a strict no-op on older React and in production.
> 
> A new **`captureReactOwnerStack`** helper (exported from the package) wraps the API behind a `typeof captureOwnerStack === 'function'` guard and never throws. **Pro streaming SSR** appends the owner chain to `error.stack` synchronously inside `onError` / `onShellError` (idempotent via a marker), so it flows through existing `renderingError` metadata to Rails `PrerenderError` / `SmartError` and shell-error HTML. **Client** dev logs gain owner stacks on recoverable hydration errors (`onRecoverableError`), and when the app already registers `onCaughtError` / `onUncaughtError`, an additive `[ReactOnRails] Render error … Owner stack:` line is logged without replacing React’s default diagnostics when no app handler exists.
> 
> Tests cover the capture helper, the no-auto-wrap behavior, and mocked positive paths; the dummy app adds an `OwnerStackThrower` manual demo fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922d6065d8fbb764bdac7db944a920bc219de231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced React 19.1+ development error reporting by appending React owner stacks to render/shipping error logs (including streaming server render errors in Pro).
  * Improved hydration mismatch and root error logging to include “Owner stack” context.
  * App `onCaughtError`/`onUncaughtError` handlers now receive enriched error context with owner stack details.
  * Safe no-op on older React versions and in production builds (no manual configuration needed).
* **Documentation**
  * Updated changelog describing the new owner stack behavior.
* **Tests**
  * Added coverage for owner-stack capture and the dev logging/callback enrichment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->