### PR TITLE
fix(benchmarks): collapse double slash in locale-prefixed route paths

### DIFF
--- a/benchmarks/lib/benchmark_routes.rb
+++ b/benchmarks/lib/benchmark_routes.rb
@@ -20,7 +20,10 @@ def route_has_required_params?(path)
 end
 
 def strip_optional_params(route)
-  route.gsub(/\([^)]*\)/, "")
+  # Collapse runs of "/" so removing an optional group adjacent to a leading slash
+  # (e.g. "/(/:locale)/dashboard" -> "//dashboard") doesn't leave a double slash.
+  # These are route paths, never full URLs, so collapsing "/+" to "/" is safe.
+  route.gsub(/\([^)]*\)/, "").squeeze("/")
 end
 
 def sanitize_route_name(route)

--- a/benchmarks/spec/benchmark_routes_spec.rb
+++ b/benchmarks/spec/benchmark_routes_spec.rb
@@ -204,6 +204,16 @@ RSpec.describe "benchmark route discovery helpers" do
       end
     end
 
+    it "collapses the double slash from a leading-slash locale-prefixed route" do
+      # "/(/:locale)/dashboard(.:format)" -> stripping the optional "(/:locale)"
+      # group leaves the leading slash adjacent to "/dashboard". Without collapsing
+      # runs of "/", the result is "//dashboard". Swapping the strip/normalize order
+      # does NOT help (both orders produce "//dashboard"); the fix collapses "/+".
+      expect(
+        benchmark_routes_for_app("unused", "/(/:locale)/dashboard(.:format)")
+      ).to eq(["/dashboard"])
+    end
+
     it "normalizes and strips optional params on explicit comma-split routes" do
       # Explicit ROUTES= inputs are copied from `rails routes` output, so they may
       # arrive with "(.:format)" suffixes, surrounding whitespace, missing leading
@@ -222,6 +232,10 @@ RSpec.describe "benchmark route discovery helpers" do
 
     it "removes an optional locale prefix group" do
       expect(strip_optional_params("(/:locale)/dashboard(.:format)")).to eq("/dashboard")
+    end
+
+    it "collapses the double slash left by a leading-slash locale prefix group" do
+      expect(strip_optional_params("/(/:locale)/dashboard(.:format)")).to eq("/dashboard")
     end
 
     it "leaves a route with no optional groups unchanged" do


### PR DESCRIPTION
## Problem

`benchmarks/lib/benchmark_routes.rb` mangles locale-prefixed route paths that
have a leading slash. `strip_optional_params` removes optional `(...)` groups
from a route path. For the input `/(/:locale)/dashboard(.:format)`, stripping
the optional `(/:locale)` group leaves the leading `/` directly adjacent to
`/dashboard`, producing a double slash: `//dashboard`.

Both code paths in the file are affected:

- `benchmark_routes_for_app` (explicit `ROUTES=` branch) does
  `strip_optional_params(normalize_route_path(route))`
- `benchmark_route_from_rails_output` does
  `normalize_route_path(strip_optional_params(path))`

Both yield `//dashboard`.

### Why the suggested order-swap fix is wrong

A reviewer might suggest swapping the strip/normalize call order. That does NOT
fix it — verified that both orders produce `//dashboard`. The leading slash is
already present in the input and the stripped group sits right after it, so the
double slash forms regardless of order.

## Fix

Collapse runs of `/` to a single `/` inside `strip_optional_params`:

```ruby
route.gsub(/\([^)]*\)/, "").squeeze("/")
```

These are route paths, never full URLs, so collapsing `/+` to `/` is safe.
Verified all four callers stay correct:

- `strip_optional_params` — now `/(/:locale)/dashboard(.:format)` -> `/dashboard`
- `benchmark_routes_for_app` (explicit ROUTES) — `/(/:locale)/dashboard(.:format)` -> `["/dashboard"]`
- `benchmark_route_from_rails_output` — unchanged for normal routes
- `sanitize_route_name` — `/` -> `root`, `/nested/path` -> `nested_path` (unaffected)

## Impact

Low. The benchmark suite's auto-discovery (`benchmark_route_from_rails_output`)
only keeps routes with no required params and simple paths, so this exact
locale-prefixed input is not exercised by the suite today. The bug surfaces only
via explicit `ROUTES=` requests copied verbatim from `rails routes` output. This
is CI/dev-internal tooling.

## Validation

- `bundle exec rubocop benchmarks/lib/benchmark_routes.rb benchmarks/spec/benchmark_routes_spec.rb` — no offenses.
- `bundle exec rspec benchmarks/spec` — 289 examples, 0 failures.

Added regression coverage:
- `strip_optional_params("/(/:locale)/dashboard(.:format)")` -> `/dashboard`
- `benchmark_routes_for_app("unused", "/(/:locale)/dashboard(.:format)")` -> `["/dashboard"]`

No CHANGELOG entry: CI/dev-internal tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dev benchmark tooling only; behavior change is localized to optional-route normalization with new specs.
> 
> **Overview**
> **`strip_optional_params`** now calls **`.squeeze("/")`** after stripping optional `(...)` groups so paths like `/(/:locale)/dashboard(.:format)` normalize to **`/dashboard`** instead of **`//dashboard`**. Reordering strip vs. normalize does not fix that case; collapsing slash runs is the intended fix (route paths only, not full URLs).
> 
> Regression specs cover **`strip_optional_params`** and explicit **`ROUTES=`** handling via **`benchmark_routes_for_app`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5d6741c97add087e008d57f7134eae3085eefa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where optional route segments could produce malformed paths with consecutive slashes. Route patterns are now properly normalized by collapsing adjacent slashes into a single separator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
