### PR TITLE
docs(agents): require per-worker worktree isolation in pr-batch

### DIFF
--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -290,8 +290,11 @@ advisory fallback state.
 
 Follow the canonical
 [Worker Rules](../../workflows/pr-processing.md#worker-rules) and keep one target
-or one disjoint lane per worker. The main agent owns final PR creation, status
-reporting, hosted-CI decisions, and merge sequencing.
+or one disjoint lane per worker. Every file-editing worker runs in its own
+worktree so two workers never share one working directory — Codex or
+multi-machine workers use `git worktree add`; in-process Claude Code
+`Agent`/`Workflow` subagents pass `isolation: 'worktree'`. The main agent owns
+final PR creation, status reporting, hosted-CI decisions, and merge sequencing.
 
 ## Coordinator Closeout Lane
 

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -593,7 +593,11 @@ When worker subagents are explicitly authorized:
 - Acquire the lane's `agent-coord claim` before creating the worker worktree or
   branch when the backend is available. If the claim is refused, the worker
   reports the holder and heartbeat liveness, then stops that lane.
-- Give each worker a separate worktree and branch.
+- Give each worker a separate worktree and branch. For in-process subagents
+  (Claude Code `Agent`/`Workflow` tools), "separate worktree" means passing
+  `isolation: 'worktree'`. Never run two file-editing workers in the same working
+  directory at the same time; sharing one checkout corrupts the git index,
+  branch, and working tree as workers overwrite each other.
 - Tell workers they are not alone in the codebase and must not revert others' edits.
 - Keep write scopes disjoint unless the main agent serializes integration.
 - Refresh that worker's heartbeat whenever it starts an item, pushes or updates a


### PR DESCRIPTION
## Problem

A recent parallel batch had worker subagents collide: multiple file-editing
workers ran in the **same working directory / git checkout** instead of each
getting its own isolated worktree, corrupting shared git state (index, branch,
working tree).

The rule to prevent this already exists in `pr-processing.md`
("Give each worker a separate worktree and branch"), so this was mostly an
adherence failure. But two real gaps in the skill made it easy to get wrong:

1. **The pr-batch skill's Worker Rules summary dropped the most failure-prone
   rule.** It restated only "one disjoint lane per worker" and "main agent owns
   PR creation," omitting "separate worktree per worker." An agent acting on the
   routing skill's own summary (without expanding the 75k-char workflow file)
   got a worker model with _no_ isolation requirement.
2. **Neither file named the Claude Code-native isolation mechanism.** "Separate
   worktree" was written for the Codex / multi-machine `git worktree add` flow.
   Nothing mapped it onto the in-process `Agent`/`Workflow` tool option
   `isolation: 'worktree'`, so an Agent-tool coordinator could follow the letter
   of "lanes" while putting every subagent in the same cwd.

## Fix

- **`.agents/workflows/pr-processing.md`** → Worker Rules: expand the worktree
  bullet to name `isolation: 'worktree'` for in-process subagents and explicitly
  forbid two file-editing workers sharing one working directory.
- **`.agents/skills/pr-batch/SKILL.md`** → Worker Rules: carry the isolation
  requirement in the routing skill's own summary so it no longer drops the
  critical rule when an agent reads only the skill.

Docs/process-only change to internal agent workflow files — no library code,
tests, or changelog impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to internal agent skills/workflows; no product code, CI, or security surface changes.
> 
> **Overview**
> Documents **mandatory per-worker worktree isolation** so parallel file-editing workers cannot share one git checkout.
> 
> **`.agents/workflows/pr-processing.md`** expands Worker Rules: in-process Claude `Agent`/`Workflow` subagents must use `isolation: 'worktree'` for “separate worktree,” and **two file-editing workers must not run in the same working directory** (shared checkout corrupts index, branch, and working tree).
> 
> **`.agents/skills/pr-batch/SKILL.md`** adds the same requirement to the routing skill’s Worker Rules summary (previously only “one lane per worker”), including Codex/multi-machine `git worktree add` vs Claude `isolation: 'worktree'`.
> 
> Internal agent workflow docs only; no library, test, or runtime changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9686675b3461c1688ec4d2b3167199dc39c8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated worker configuration guidance for batch processing and PR workflow management
  * Clarified that each worker must use its own separate git worktree and branch
  * Expanded best practices for concurrent worker execution across different environments
  * Reinforced isolation requirements to prevent git state corruption during multi-worker operations
  * Specified isolation modes and working directory separation constraints for various execution contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->