### PR TITLE
fix(pro-license): check untracked new files, not just tracked ones

### DIFF
--- a/script/check-pro-license-headers
+++ b/script/check-pro-license-headers
@@ -8,9 +8,9 @@
 # against the header silently drifting away as files are added or moved.
 #
 # Usage:
-#   script/check-pro-license-headers           # check; non-zero exit lists offenders
+#   script/check-pro-license-headers           # check working tree, incl. new untracked files; lists offenders
 #   script/check-pro-license-headers --check-staged  # check staged/index contents
-#   script/check-pro-license-headers --fix     # insert/upgrade headers in place
+#   script/check-pro-license-headers --fix     # insert/upgrade headers in place (tracked + new untracked)
 #   script/check-pro-license-headers --list    # print the in-scope file set and exit
 #   script/check-pro-license-headers --self-test  # run the in-memory unit tests
 #
@@ -243,6 +243,28 @@ def tracked_in_scope_files
   out.split("\x00").reject(&:empty?).select { |p| in_scope?(p) }.sort
 end
 
+# New Pro files that exist in the working tree but are not yet tracked (not
+# `git add`-ed) and are not gitignored. `git ls-files` lists only tracked
+# paths, so without this a brand-new headerless Pro file is invisible to a
+# local `--check`/`--fix`: the run reports a false pass and the missing header
+# only surfaces in hosted CI (which sees the file once it is committed).
+# `--exclude-standard` honors .gitignore, so build artifacts and node_modules
+# under the Pro trees are skipped.
+def untracked_in_scope_files
+  out, status = Open3.capture2("git", "ls-files", "-z", "--others", "--exclude-standard", *PRO_TREES)
+  abort "git ls-files (untracked) failed" unless status.success?
+
+  out.split("\x00").reject(&:empty?).select { |p| in_scope?(p) }.sort
+end
+
+# Files to validate against the working tree: tracked Pro files plus not-yet-
+# staged new ones, so a missing header fails locally before commit instead of
+# in hosted CI. (--check-staged stays tracked-only by design: it inspects the
+# index via `git show :path`, and an unstaged file is not part of the commit.)
+def working_tree_in_scope_files
+  (tracked_in_scope_files + untracked_in_scope_files).uniq.sort
+end
+
 def index_file_content(path)
   out, err, status = Open3.capture3("git", "show", ":#{path}")
   message = "git show :#{path} failed (exit #{status.exitstatus}): #{err.strip}"
@@ -252,7 +274,7 @@ def index_file_content(path)
 end
 
 def run_check
-  files = tracked_in_scope_files
+  files = working_tree_in_scope_files
   missing = files.reject { |p| File.read(p).include?(render_header(comment_style(p))) }
   if missing.empty?
     puts "All #{files.size} in-scope Pro files have the current license header."
@@ -285,7 +307,7 @@ end
 
 def run_fix
   changed = []
-  tracked_in_scope_files.each do |path|
+  working_tree_in_scope_files.each do |path|
     original = File.read(path)
     updated = apply_header(path, original)
     next if updated == original
@@ -303,7 +325,7 @@ def run_fix
 end
 
 def run_list
-  files = tracked_in_scope_files
+  files = working_tree_in_scope_files
   files.each { |p| puts p }
   warn "#{files.size} in-scope Pro files."
   0


### PR DESCRIPTION
## Problem

`script/check-pro-license-headers` enforces the proprietary per-file
license header on React on Rails Pro source. Its scope came from
`git ls-files <PRO_TREES>` — **tracked files only**. A brand-new Pro file
that hasn't been `git add`-ed yet is invisible to a local `--check`/`--fix`,
so the run reports a **false pass**. The missing header only surfaces in
hosted CI, which runs `--check` against the committed (now-tracked) tree.

This is the "the local check inspects *changed* files but not newly *added*
ones" gap that let two new Pro test files ship without headers and get
caught only by hosted CI.

### Reproduction (before this change)

```
$ printf '# frozen_string_literal: true\n\nputs "x"\n' > react_on_rails_pro/probe.rb
$ ruby script/check-pro-license-headers --check
All 805 in-scope Pro files have the current license header.   # exit 0  ← false pass
$ git add react_on_rails_pro/probe.rb
$ ruby script/check-pro-license-headers --check
Missing or outdated Pro license header in 1 file(s): ...      # exit 1  (only once tracked)
```

## Fix

- Add `untracked_in_scope_files` using
  `git ls-files --others --exclude-standard <PRO_TREES>`, so untracked
  **new** files are included while `.gitignore`'d build output /
  `node_modules` under the Pro trees stay excluded.
- Route the working-tree modes (`--check`, `--fix`, `--list`) through a
  combined `working_tree_in_scope_files` (tracked + new untracked, deduped).
- Leave `--check-staged` tracked/index-only **by design**: it inspects
  `git show :path`, and an unstaged file is not part of the commit (the
  pre-commit lefthook path already catches a staged new file via the
  index).

## Impact

- A new headerless Pro file now **fails `--check` locally before staging**,
  and `--fix` repairs it — closing the loop the `--check` message points to.
- **Hosted CI is unchanged**: clean checkouts have no untracked in-scope
  files, so `untracked_in_scope_files` is empty there. The change can only
  catch *more*, never fewer.
- The pre-commit lefthook hook (`--check-staged`) is unchanged.

## Verification

- `ruby script/check-pro-license-headers --self-test` — passes
- `bundle exec rubocop --force-exclusion script/check-pro-license-headers` — clean
- Reproduction above now exits non-zero on the untracked file and is fixed by `--fix`
- Clean tree still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only enforcement script change that only expands local detection; hosted CI and `--check-staged` behavior are unchanged.
> 
> **Overview**
> **Closes a false-pass gap** where new, unstaged Pro files were skipped because scope came only from `git ls-files` (tracked paths).
> 
> The script now discovers **untracked but not gitignored** in-scope files under the Pro trees via `git ls-files --others --exclude-standard`, merges them with tracked paths in `working_tree_in_scope_files`, and uses that set for default **`--check`**, **`--fix`**, and **`--list`**. **`--check-staged`** still validates **index-only** tracked files via `git show :path`, unchanged for pre-commit behavior.
> 
> Usage comments at the top of the script were updated to describe working-tree coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05feffdd1bb227bcc5ef0c828ee0d02229514e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pro license header checker now validates newly created and untracked Pro files in the working tree, catching missing or outdated headers before changes are committed. This enables developers to identify and fix license header issues immediately during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->