### PR TITLE
fix(ci): send browser-like User-Agent in lychee link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,6 +12,13 @@ retry_wait_time = 20
 # Timeout for each request
 timeout = 20
 
+# Send a browser-like User-Agent so anti-bot defenses don't return false 403s.
+# Some hosts (e.g. webaim.org) block lychee's default crawler UA via anti-bot
+# rules even though the link is live. Presenting a current Chrome UA stops these
+# false positives across all docs without per-host excludes. A genuine 403
+# (real access failure) still fails the run, so this does not hide dead links.
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+
 # Exclude patterns (migrated from markdown-link-check-config.json)
 exclude = [
   # ============================================================================

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -17,7 +17,9 @@ timeout = 20
 # rules even though the link is live. Presenting a current Chrome UA stops these
 # false positives across all docs without per-host excludes. A genuine 403
 # (real access failure) still fails the run, so this does not hide dead links.
-user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+# Keep the Chrome version reasonably current (bump every ~6-12 months): some
+# anti-bot systems fingerprint the UA version and may flag a stale one.
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
 
 # Exclude patterns (migrated from markdown-link-check-config.json)
 exclude = [


### PR DESCRIPTION
## Problem

The `markdown-link-check` CI job (lychee) fails on `docs/oss/building-features/accessibility.md` because `https://webaim.org/techniques/css/invisiblecontent/` returns **HTTP 403**. This is webaim.org's anti-bot rule blocking lychee's default crawler User-Agent — the link is live, not dead.

## Fix (root cause, not a per-host exclude)

Configure lychee in `.lychee.toml` to send a browser-like (current Chrome) `user_agent`. This stops anti-bot false-positive 403s across **all** docs rather than excluding webaim specifically, and avoids accreting an ever-growing per-host exclude list. A genuine 403 (real access failure) still fails the run, so this does not hide dead links.

## Verification

- `lychee 0.23.0` (matching the workflow's pinned version) installed locally.
- Ran the exact workflow command on the affected file:
  ```
  lychee --config .lychee.toml docs/oss/building-features/accessibility.md
  🔍 24 Total ✅ 24 OK 🚫 0 Errors
  ```
- Config parses cleanly with the new `user_agent` key.

Note: webaim does not 403 from a local IP, so the block is environment-specific (CI datacenter IP + default UA). The UA change addresses the documented anti-bot mechanism directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs tooling only; no runtime, auth, or application code changes, with limited blast radius beyond link-check behavior.
> 
> **Overview**
> **Fixes false 403 failures** in the markdown link-check CI job by configuring lychee to send a **current Chrome `user_agent`** in `.lychee.toml`, instead of its default crawler UA that some sites (e.g. webaim.org) block via anti-bot rules.
> 
> This is a **global config change** for all doc link checks—not a one-off host exclude—so live external links are less likely to fail CI while real access failures (genuine 403s) still fail the run. Inline comments note that the Chrome version string should be bumped periodically so anti-bot fingerprinting does not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30571b018ab1cf3d55010d7ef6ac65b9edb3341f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the link-checker configuration to send a browser-like Chrome User-Agent, helping reduce anti-bot false-positive 403 errors when validating external documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->