### PR TITLE
AGENTS: add Tracking Issues And Handoffs hygiene policy

### DIFF
--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -78,7 +78,7 @@ The audit should usually produce an issue plan for non-OK findings, but not crea
 - **No issue**: for `OK`, duplicate findings, or findings fully resolved by the audit evidence.
 - **Changelog only**: for missing changelog entries; prefer one bundled changelog issue or a recommendation to run `/update-changelog`, not one issue per entry.
 - **One child issue**: for each independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
-- **Parent issue**: create one parent issue when there are two or more related child issues from the same audit or when the audit spans a release-candidate readiness decision.
+- **Parent issue**: create one parent issue only to group two or more related _child fix_ issues from the same audit. Do **not** create a standalone audit-snapshot tracker (a `Post-<range> audit` / `Post-rc.N catch-up audit` issue): per `AGENTS.md` → _Tracking Issues And Handoffs_, the audit report is a point-in-time snapshot — append it to the standing release audit ledger in place. Genuine non-OK findings still become real child issues; only the snapshot/report is what goes to the ledger instead of a new issue.
 
 For process findings, the issue plan must include a Process Gap Disposition
 before issue creation:

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -261,11 +261,12 @@ detailed policy belongs in the canonical workflow.
 
 ## Batch Handoff Format
 
-> **Do not file a standalone handoff or audit issue.** Per `AGENTS.md` →
-> _Tracking Issues And Handoffs_: record a handoff as a comment on the relevant
-> parent tracking issue (or the agent-coordination repo if one is in use), and
-> append audits to the release audit ledger in place — never spawn a
-> `Handoff: ...` / `Post-rc.N audit` issue. Close superseded process issues on
+> **A handoff is a comment, not a new issue.** Per `AGENTS.md` → _Tracking Issues
+> And Handoffs_: record a handoff on the relevant parent tracking issue (or the
+> agent-coordination repo if one is in use), or — when there is no parent umbrella
+> — in the batch's own PR comment/description; and append point-in-time audits to
+> the standing release audit ledger in place. Never spawn a standalone
+> `Handoff: ...` or `Post-rc.N audit` issue. Close superseded process issues on
 > sight; closure follows the work, not whoever opened the tracker.
 
 <!-- Keep this handoff summary in sync with `.agents/workflows/pr-processing.md` -> `### Batch Handoff Format`. -->

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -261,6 +261,13 @@ detailed policy belongs in the canonical workflow.
 
 ## Batch Handoff Format
 
+> **Do not file a standalone handoff or audit issue.** Per `AGENTS.md` →
+> _Tracking Issues And Handoffs_: record a handoff as a comment on the relevant
+> parent tracking issue (or the agent-coordination repo if one is in use), and
+> append audits to the release audit ledger in place — never spawn a
+> `Handoff: ...` / `Post-rc.N audit` issue. Close superseded process issues on
+> sight; closure follows the work, not whoever opened the tracker.
+
 <!-- Keep this handoff summary in sync with `.agents/workflows/pr-processing.md` -> `### Batch Handoff Format`. -->
 
 Use the canonical Batch Handoff Format in

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -501,6 +501,13 @@ Before merge or final readiness, scan the PR description for the decision log an
 
 <!-- Canonical batch handoff copy. `.agents/skills/pr-batch/SKILL.md` should point here instead of duplicating this section. -->
 
+> **A handoff is a comment, not a new issue.** Per `AGENTS.md` → _Tracking Issues
+> And Handoffs_: record the handoff below on the relevant parent tracking issue
+> (or the agent-coordination repo if one is in use), or in the batch's own PR
+> comment/description when there is no parent umbrella — never spawn a standalone
+> `Handoff: ...` or `Post-rc.N audit` issue. Close superseded process issues on
+> sight; closure follows the work, not whoever opened the tracker.
+
 Split batch handoffs into two sections:
 
 - **Immediate maintainer attention**: true blockers and questions only, such as

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -504,7 +504,8 @@ Before merge or final readiness, scan the PR description for the decision log an
 > **A handoff is a comment, not a new issue.** Per `AGENTS.md` → _Tracking Issues
 > And Handoffs_: record the handoff below on the relevant parent tracking issue
 > (or the agent-coordination repo if one is in use), or in the batch's own PR
-> comment/description when there is no parent umbrella — never spawn a standalone
+> comment/description when there is no parent umbrella; and append point-in-time
+> audits to the standing release audit ledger in place. Never spawn a standalone
 > `Handoff: ...` or `Post-rc.N audit` issue. Close superseded process issues on
 > sight; closure follows the work, not whoever opened the tracker.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,36 @@ contract unless a maintainer explicitly narrows the run.
   - Residual risk: <one-line risk summary, or "none">
   ```
 
+## Tracking Issues And Handoffs
+
+Keep the issue tracker for durable work — product features, real bugs, release
+gates — not for transient agent-process state. Process state accretes into
+clutter because "open a tracker" has no matching "close it" step.
+
+- **Do not open a new issue for a session handoff or a point-in-time audit.** A
+  handoff is transient coordination and an audit is a snapshot; neither is
+  durable backlog. Record a handoff as a comment on the relevant parent tracking
+  issue (for example the roadmap umbrella), and append an audit to the standing
+  release audit ledger (#4010) in place. If a dedicated agent-coordination repo
+  is in use, route handoffs there instead. Never spawn a standalone
+  `Handoff: ...` or `Post-rc.N audit` issue.
+- **One durable ledger per recurring concern, updated in place.** Release audits
+  append to the ledger (#4010); cross-agent coordination state lives in the
+  coordination layer (#3974). Do not create a sibling issue each cycle.
+- **Closure follows the work, not the opener.** A tracking issue closes when its
+  underlying PR/work lands, done by whoever finishes the work — not by whoever
+  opened the tracker. "I opened it" does not mean "I must close it": WIP can
+  outlive a session (lost chat, unanswered question, disconnect). The heartbeat
+  detects abandonment, and an unfinished PR is the real signal of remaining work
+  — act on the PR, not on a stale tracker.
+- **The 30-day test.** Before opening any tracking or meta issue, ask whether it
+  will still matter in 30 days. If not, it is a comment or a ledger entry, not an
+  issue.
+- **Sweep on sight.** When you encounter a resolved or superseded
+  handoff/audit/process-snapshot issue, close it — consolidating any still-live
+  finding into the durable ledger or a real backlog issue — rather than leaving
+  it open.
+
 ## Release Mode And Auto-Merge Coordination
 
 Use the current release tracker to decide whether PRs are in normal development, accelerated RC, strict RC, or final-release mode. The tracker is the live source of truth for the mode; committed docs define how to interpret it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,26 +343,35 @@ clutter because "open a tracker" has no matching "close it" step.
 - **Do not open a new issue for a session handoff or a point-in-time audit.** A
   handoff is transient coordination and an audit is a snapshot; neither is
   durable backlog. Record a handoff as a comment on the relevant parent tracking
-  issue (for example the roadmap umbrella), and append an audit to the standing
-  release audit ledger (#4010) in place. If a dedicated agent-coordination repo
-  is in use, route handoffs there instead. Never spawn a standalone
-  `Handoff: ...` or `Post-rc.N audit` issue.
+  issue (for example the roadmap umbrella), or — if a dedicated agent-coordination
+  repo is in use — there. If the work has no parent umbrella (a standalone PR or a
+  one-off batch), put the handoff in the PR's final comment or description rather
+  than creating an issue to hold it. Append a point-in-time audit to the standing
+  release audit ledger in place. Never spawn a standalone `Handoff: ...` or
+  `Post-rc.N audit` issue.
 - **One durable ledger per recurring concern, updated in place.** Release audits
-  append to the ledger (#4010); cross-agent coordination state lives in the
-  coordination layer (#3974). Do not create a sibling issue each cycle.
+  append to the standing release audit ledger; cross-agent coordination state —
+  the heartbeats and leases that signal which agent is live on which lane — lives
+  in the coordination-layer tracker. Do not create a sibling issue each cycle.
+  (At time of writing these are #4010 and #3974, but treat any such number as a
+  movable pointer: confirm it is still the live ledger before relying on it, and
+  update the pointer if it has been superseded — the same staleness this policy
+  guards against applies to the ledgers themselves.)
 - **Closure follows the work, not the opener.** A tracking issue closes when its
   underlying PR/work lands, done by whoever finishes the work — not by whoever
   opened the tracker. "I opened it" does not mean "I must close it": WIP can
-  outlive a session (lost chat, unanswered question, disconnect). The heartbeat
-  detects abandonment, and an unfinished PR is the real signal of remaining work
-  — act on the PR, not on a stale tracker.
+  outlive a session (lost chat, unanswered question, disconnect). The heartbeat —
+  the coordination layer's liveness signal that flags when no agent is active on a
+  lane — detects abandonment, and an unfinished PR is the real signal of remaining
+  work; act on the PR, not on a stale tracker.
 - **The 30-day test.** Before opening any tracking or meta issue, ask whether it
   will still matter in 30 days. If not, it is a comment or a ledger entry, not an
   issue.
-- **Sweep on sight.** When you encounter a resolved or superseded
-  handoff/audit/process-snapshot issue, close it — consolidating any still-live
-  finding into the durable ledger or a real backlog issue — rather than leaving
-  it open.
+- **Sweep on sight.** When a handoff/audit/process-snapshot issue's underlying
+  work has landed or its snapshot is obsolete, close it — first consolidating any
+  still-live finding into the durable ledger or a real backlog issue. Verify it is
+  actually resolved or superseded before closing; never close a tracker that still
+  fronts unfinished work.
 
 ## Release Mode And Auto-Merge Coordination
 


### PR DESCRIPTION
## What

Adds a **Tracking Issues And Handoffs** policy section to `AGENTS.md` (the canonical agent policy) plus a pointer in the `pr-batch` skill.

## Why

The agent-batch workflow accreted ~10 standalone handoff / audit / process-snapshot issues (closed in a sweep alongside this change) because "open a tracker" had no matching "close it" step, and transient coordination state was being filed as durable issues. This codifies how to prevent the re-accumulation.

## The policy

- **No standalone handoff or point-in-time audit issues.** Handoffs → a comment on the parent tracking issue (or the agent-coordination repo if one is in use); audits → appended to the release audit ledger (#4010) in place.
- **One durable ledger per recurring concern**, updated in place (release audits → #4010; coordination state → #3974) — no sibling issue each cycle.
- **Closure follows the work, not the opener.** A tracking issue closes when its underlying PR/work lands, by whoever finishes it — not by whoever opened it. WIP outlives sessions (lost chat, disconnect); the heartbeat detects abandonment and an unfinished PR is the real signal.
- **30-day test** before opening any meta issue; **sweep superseded process issues on sight.**

## Scope

Docs-only (`AGENTS.md` + skill); no runtime/CI impact. `AGENTS.md` is not a `check-llms-full` input, so no `llms-full` regen. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent policy and skills; no runtime, CI, or application code paths affected.
> 
> **Overview**
> Adds canonical **Tracking Issues And Handoffs** rules to `AGENTS.md` so transient agent work (session handoffs, point-in-time audits, process snapshots) stops accumulating as standalone GitHub issues.
> 
> **Policy highlights:** handoffs belong in parent-tracker comments, the coordination repo, or the batch PR—not new `Handoff: ...` issues; audit reports append to the standing release audit ledger in place, not `Post-rc.N audit` issues; one durable ledger per recurring concern; close trackers when the underlying work lands (any finisher, not only the opener); apply a **30-day test** before meta issues; sweep obsolete process issues after consolidating live findings.
> 
> **Wiring:** identical callouts in `.agents/workflows/pr-processing.md` and `.agents/skills/pr-batch/SKILL.md` under Batch Handoff Format; `post-merge-audit` narrows parent-issue creation to grouping real child fix issues and explicitly forbids audit-snapshot tracker issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2872debdf61b6c825b55babec66a7d8149d936ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance section **“Tracking Issues And Handoffs”** to standardize how transient handoffs and audits are recorded.
  * Updated batch “Process Gap / handoff” instructions to require handoffs be logged as comments on the relevant parent (or an appropriate fallback) and to avoid standalone “Handoff: …” or “Post-rc.N audit” issues.
  * Refined post-merge audit instructions to append reports to the standing release audit ledger and create parent issues only when bundling multiple related fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->