### PR TITLE
Docs: fix stale evaluate-issue gate cross-reference (#3910)

### DIFF
--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -347,8 +347,8 @@ language in an implementation PR, combined investigation PR, or no-PR evidence
 comment. Concrete corrective implementation PRs are not blocked merely because
 the target involves investigation or benchmark evidence.
 
-See the gate criteria in `.agents/skills/evaluate-issue/SKILL.md` (step 4d --
-"Evaluate the fix plan separately"). When the gate cannot be satisfied, carry
+See the gate criteria in `.agents/skills/evaluate-issue/SKILL.md` under the
+"Evaluate the fix plan separately" step. When the gate cannot be satisfied, carry
 only a caveated no-PR `park` disposition or a product-decision blocker.
 
 Workers should not turn product-decision blockers into speculative PRs. They should post or draft the evidence-backed question and stop that target.


### PR DESCRIPTION
## Why

`.agents/workflows/pr-processing.md` directs readers to the closing-evidence gate as **"step 4d"** in `.agents/skills/evaluate-issue/SKILL.md`. That skill has no `4d` sub-numbering — the gate lives under top-level **step 4, "Evaluate the fix plan separately."** The pointer is therefore stale/incorrect.

This is the exact `step 4d` reference flagged in #3985's review thread (`discussion_r3425505264`) that merged uncorrected. A few lines above (pr-processing.md:342-344), the same step is already referenced correctly *by name* with no number, so this just makes the second pointer consistent with the first.

## What

- pr-processing.md: `(step 4d -- "Evaluate the fix plan separately")` → `under the "Evaluate the fix plan separately" step`.

Docs-only; no behavior change. Verified the target skill: step 4 is "Evaluate the fix plan separately" (SKILL.md:47), with no `4d` sub-item; no other `step 4d` references remain anywhere under `.agents/` or `AGENTS.md`.

## Context

Closes the residual gap on #3910. The substantive ask in #3910 ("analysis/benchmark PRs need reproducible artifacts before closing issues") was already delivered by **#3985** — the closing-evidence gate exists in evaluate-issue (SKILL.md:52-67) and is enforced across pr-processing.md, post-merge-audit, and the evaluate-issue workflow mirror. Only this cosmetic stale cross-reference remained.

Resolves #3910.

## Codex Decision Log

- **Non-blocking:** whether to fix the stale pointer vs. close #3910 outright as "shipped by #3985."
  - **Decision:** ship the one-line consistency fix so the pointer is accurate, then the issue can close cleanly.
  - **Why:** trivial, zero-risk, and removes the documented loose end from #3985's review thread.
  - **Review later:** None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change; no runtime, CI, or agent behavior is modified.
> 
> **Overview**
> Updates **`.agents/workflows/pr-processing.md`** so the closing-evidence gate pointer no longer cites nonexistent **`step 4d`** in **`.agents/skills/evaluate-issue/SKILL.md`**.
> 
> The second reference now matches the first in the same section: it directs readers to the gate **under the "Evaluate the fix plan separately" step** (top-level step 4), not a numbered sub-step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9059489ecd39343aa113203d0a52d332a5fb802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow documentation to improve clarity and consistency in process instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Confidence

Merged by the batch coordinator under explicit maintainer authorization (repo owner @justin808 granted merge authority for this PR conditioned on documented confidence).

**Why confident — verified on head SHA `a9059489`:**
- Scope: 2-line, docs-only wording fix in an agent-process file (`.agents/workflows/pr-processing.md`). No code, runtime, build, CI, or dependency change.
- CI: `pr-ci-readiness` verdict `READY` — no failing, no pending; `required-pr-gate`, `markdown-format-check`, `markdown-link-check`, `detect-changes` all pass. Mergeable: CLEAN.
- Reviews on current head: CodeRabbit APPROVED; Greptile and Claude code-review summaries positive; **zero priority findings**; no changes-requested; 0 unresolved review threads.
- Merge ledger (`script/pr-merge-ledger 4104 --strict`): only flag is `unknown_review_decision`, which is structural — this repo has no branch-protection rule requiring a human approval object, so GitHub's `reviewDecision` is null. The maintainer's explicit authorization is the human decision that field represents. Waived on that basis; no correctness/security/regression/changelog finding remained.

Resolves #3910.
