### PR TITLE
Wrap generated demo file paths in onboarding page (Part 1 of #4062)

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/app/views/hello_world/index.html.erb.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/app/views/hello_world/index.html.erb.tt
@@ -129,6 +129,8 @@
     background: rgba(17, 32, 49, 0.06);
     color: var(--ink);
     font-size: 0.95em;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   @media (max-width: 900px) {


### PR DESCRIPTION
## What

Adds CSS wrapping to the `code` rule in the generated onboarding demo page so long file paths wrap instead of overflowing their container.

```diff
   code {
     padding: 2px 6px;
     border-radius: 8px;
     background: rgba(17, 32, 49, 0.06);
     color: var(--ink);
     font-size: 0.95em;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
```

File: `lib/generators/react_on_rails/templates/base/base/app/views/hello_world/index.html.erb.tt`

## Why

The generated `hello_world` onboarding page renders file paths inside `<code>` elements in the "Inspect these files next" card (`<code><%= hint[:path] %></code>`). The `code` CSS rule had no wrapping properties, so long file paths overflowed horizontally on narrow viewports (mobile / small windows), pushing the card out and creating horizontal scroll.

## Scope: Part 1 of #4062

This PR is **Part 1 only** — the CSS wrapping fix.

**Part 2 is intentionally deferred** as a separate, larger change: deriving the displayed source hints from the Shakapacker configuration (rather than hardcoding paths in the template). That work is broader and warrants its own PR. Using `Refs #4062` (not `Fixes`) so the issue stays open for Part 2.

## Codex Decision Log

- **Chose `overflow-wrap: anywhere` + `word-break: break-word` together.** `overflow-wrap: anywhere` allows breaking long unbreakable tokens (like slash-separated paths with no spaces) and, unlike `break-word`, is also considered when computing the min-content intrinsic size — preventing the container itself from overflowing. `word-break: break-word` is added as a defensive fallback for older engines. Both are minimal additions scoped strictly to the existing `code` rule; no other selectors were touched.

## Validation

- Ran `bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb`. The targeted landing-page example passes in isolation (`1 example, 0 failures`). The full-file run shows pre-existing failures caused by cross-example generated-directory state pollution ("Expected file ... to exist, but does not"), unrelated to this change — none reference the `code` rule, `overflow-wrap`, or `word-break`.
- No `.rb` files changed, so RuboCop was not required.
- ERB/HTML tags in the template are untouched; the change is confined to the CSS `code` block.

Refs #4062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in a generator ERB template; no runtime Ruby or app logic affected.
> 
> **Overview**
> Adds **`overflow-wrap: anywhere`** and **`word-break: break-word`** to the inline **`code`** styles in the generated hello world onboarding view template so long slash-separated file paths in the “Inspect these files next” hints wrap on narrow viewports instead of overflowing the card.
> 
> Scoped to the generator template only; new apps get the fix automatically. Part 1 of #4062 (Shakapacker-derived paths deferred).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f5e92688688523ad98dcf885cab6d06fcac0194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->