### PR TITLE
fix(ci): build bundle-size base from PR merge commit's first parent

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -55,7 +55,46 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
-          fetch-depth: 1
+          # fetch-depth: 0 is required so the merge commit's parents are real
+          # (a shallow checkout grafts the tip and hides its parents, which would
+          # break base-SHA derivation below).
+          fetch-depth: 0
+
+      - name: Determine base SHA from the PR merge commit
+        id: base-sha
+        env:
+          MERGE_SHA: ${{ github.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # For pull_request events github.sha is the ephemeral merge commit
+          # (refs/pull/N/merge): the PR head merged into the base-branch tip. The
+          # PR-head sizes are built from this merge commit, so the base sizes must be
+          # built from its FIRST PARENT to share the exact same base-branch baseline.
+          #
+          # Using the live base tip (github.event.pull_request.base.sha) instead lets
+          # the two builds drift apart whenever the PR branch is behind the base
+          # branch: unrelated growth that landed on the base branch gets mis-attributed
+          # to the PR, producing uniform false-positive size increases across every
+          # tracked bundle (including OSS bundles the PR never touched).
+          if [ "$MERGE_SHA" = "$HEAD_SHA" ]; then
+            echo "::error::Bundle size check needs a mergeable PR: github.sha equals the PR head, so no merge commit exists (the branch likely conflicts with the base branch). Rebase / resolve conflicts and re-run."
+            exit 1
+          fi
+          read -ra parents <<< "$(git rev-list --parents -n 1 "$MERGE_SHA")"
+          # parents[0] = merge commit, [1] = first parent (base), [2] = second parent (head)
+          if [ "${#parents[@]}" -ne 3 ]; then
+            echo "::error::Expected github.sha ($MERGE_SHA) to be a 2-parent merge commit, found $(( ${#parents[@]} - 1 )) parent(s); cannot determine a matching base baseline. Ensure this job checks out with fetch-depth: 0."
+            exit 1
+          fi
+          base_sha="${parents[1]}"
+          head_parent="${parents[2]}"
+          if [ "$head_parent" != "$HEAD_SHA" ]; then
+            echo "::error::Merge commit second parent ($head_parent) does not match the PR head ($HEAD_SHA); unexpected merge structure."
+            exit 1
+          fi
+          echo "base-sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "Base baseline (merge commit first parent): $base_sha"
+          echo "PR head        (merge commit second parent): $head_parent"
 
       - name: Read runtime versions
         id: tool-versions
@@ -72,12 +111,15 @@ jobs:
       - name: Save size-limit config
         run: cp .size-limit.json /tmp/size-limit-config.json
 
-      # 2. Get base branch sizes.
+      # 2. Get base branch sizes from the merge commit's first parent so the base
+      #    and PR-head builds share the same base-branch baseline (see base-sha step).
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ steps.base-sha.outputs.base-sha }}
           persist-credentials: false
+          # fetch-depth: 0 so the (possibly older) base parent commit is fetchable.
+          fetch-depth: 0
 
       - name: Copy size-limit config to base branch
         run: cp /tmp/size-limit-config.json .size-limit.json

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -82,6 +82,10 @@ jobs:
           fi
           read -ra parents <<< "$(git rev-list --parents -n 1 "$MERGE_SHA")"
           # parents[0] = merge commit, [1] = first parent (base), [2] = second parent (head)
+          if [ "${#parents[@]}" -eq 0 ]; then
+            echo "::error::Could not read parents of github.sha ($MERGE_SHA); the commit is not reachable in this checkout. Ensure this job checks out with fetch-depth: 0."
+            exit 1
+          fi
           if [ "${#parents[@]}" -ne 3 ]; then
             echo "::error::Expected github.sha ($MERGE_SHA) to be a 2-parent merge commit, found $(( ${#parents[@]} - 1 )) parent(s); cannot determine a matching base baseline. Ensure this job checks out with fetch-depth: 0."
             exit 1
@@ -116,10 +120,11 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
+          # Only the working tree at the base parent is needed (not its history), so
+          # the default shallow fetch-depth is enough; checkout@v4 fetches this SHA
+          # directly since it is reachable from the base branch.
           ref: ${{ steps.base-sha.outputs.base-sha }}
           persist-credentials: false
-          # fetch-depth: 0 so the (possibly older) base parent commit is fetchable.
-          fetch-depth: 0
 
       - name: Copy size-limit config to base branch
         run: cp /tmp/size-limit-config.json .size-limit.json


### PR DESCRIPTION
## Problem

`check-bundle-size` produced false-positive failures for PRs whose branch had fallen behind the base branch. The job built **base** sizes from `github.event.pull_request.base.sha` but built **PR-head** sizes from `github.sha` — the `refs/pull/N/merge` commit (the head merged into the base-branch tip).

When the PR branch is several commits behind `main`, those two values reference **different base-branch baselines**. Growth that landed on `main` after the branch point gets absorbed into the delta and mis-attributed to the PR, producing a uniform ~700–1100 byte "increase" across **every** tracked bundle — including the OSS `react-on-rails/client` bundle a Pro-only PR never touched. Hit concretely by #4022 and #4023; the only workaround was a manual rebase onto current `main`.

## Root cause (verified)

For `pull_request` events `github.sha` is the ephemeral merge commit `refs/pull/N/merge`, which has two parents:
- **parent 1** = the base-branch commit the head was merged into
- **parent 2** = the PR head

The PR-head build already uses this merge commit, so its parent 1 is the *exact* base baseline the merge was computed against. Building base from the separate, frozen `base.sha` lets the two drift apart as `main` advances.

## Fix (Option 3, anchored to the merge commit)

Derive base from **`github.sha`'s first parent** instead of `base.sha`:

- Base and PR-head builds now share the same base-branch baseline **by construction** — skew is provably impossible, with no frozen-payload value trusted and no live-tip fetch (which would reintroduce a race).
- Self-heals stale branches: a behind-`main` PR is always measured against the baseline its own merge ref uses.

vs. the other options:
- **Option 1 (`git merge-base`)** pairs against the branch point, but the head build is the *merge ref* — so merge-base vs merge-ref still skews.
- **Option 2 (fail-soft "rebase and re-run")** leaves the manual toil in place.

### Changes (`.github/workflows/bundle-size.yml` only)

- PR-runtime checkout now uses `fetch-depth: 0` so the merge commit's parents are real (a shallow checkout grafts the tip and hides them).
- New **Determine base SHA** step validates `github.sha` is a 2-parent merge commit whose second parent matches the PR head, and fails with an actionable message when the PR is not mergeable (`github.sha == head sha`, i.e. base-branch conflicts).
- Base checkout consumes the derived SHA with `fetch-depth: 0`.

No changes to `scripts/bundle-size.mjs` or `.size-limit.json`; the `set-limits` flow is unchanged.

## Validation

- `actionlint .github/workflows/bundle-size.yml` — clean (SC2207 fixed via `read -ra`).
- Derivation logic unit-tested under bash against the real `refs/pull/4022/merge` ref:
  - real merge ref → base = correct first parent ✓
  - unmergeable (`github.sha == head`) → actionable error ✓
  - non-merge (1-parent) commit → caught ✓
  - merge ref with mismatched head → caught ✓
- `prettier --check` clean (and `*.yml` is prettier-ignored).

## Workflow Change Audit

- **Secret references:** none added/changed.
- **`permissions:`** unchanged (`contents: read`; job retains `pull-requests: write`).
- **`on:` triggers:** unchanged.
- **Third-party actions:** none added or version-changed (`actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v4`, `andresz1/size-limit-action@v1` all unchanged).
- **Command injection:** new `run:` block reads only SHAs, passed via `env:` and quoted (`"$MERGE_SHA"`, `"$HEAD_SHA"`); `ref:` consumes a git-validated SHA, not free text.

### New-gate / stale-base rollout note

This change does not add or broaden enforcement — it makes the existing gate **immune to stale-base skew by construction**, so it can only reduce false positives. Stale-based open PRs that touch `packages/**` will, on their next `check-bundle-size` run, be measured against their own merge-ref baseline and get accurate results (the fix is self-applying; re-running the check is the race control). No sweep of in-flight PRs is required to land safely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no secrets or app code; it should reduce false positives and only fails early on unmergeable PRs.
> 
> **Overview**
> Fixes **false-positive bundle size failures** when a PR branch is behind the base branch. The job used to measure the PR from `github.sha` (the ephemeral merge commit) but measured the baseline from `github.event.pull_request.base.sha`, so unrelated growth on `main` could look like a uniform increase across every tracked bundle.
> 
> The initial PR checkout now uses **`fetch-depth: 0`** so the merge commit’s parents are visible. A new **Determine base SHA** step reads the **first parent** of `github.sha`, checks it is a two-parent merge whose second parent matches the PR head, and fails with a clear message when the PR is not mergeable. The **base branch checkout** uses that derived SHA instead of `base.sha`, so base and PR-head builds share the same baseline by construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ae4bdb831db599faafc41cfb0ee14d1ca7f3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved bundle size checking accuracy and reliability by enhancing how the CI workflow determines and checks out the baseline SHA for pull requests.
  * Added validation and clearer failure messages when pull request merge structure is unexpected or not mergeable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Merge confidence note

Merged with delegated authority. Rationale:

- **Scope is contained and low-risk.** Single-file change to `.github/workflows/bundle-size.yml`; no product/runtime code, no `permissions:`/`on:`/secret/third-party-action changes (per the Workflow Change Audit comment). The gate only loosens — it removes a false-positive source and cannot make a real size regression pass (the `base + 0.5KB` threshold logic is unchanged).
- **Proven end-to-end, not just reasoned.** `check-bundle-size` ran green on this PR's own head, exercising the new merge-commit-first-parent base derivation and the base checkout at default depth. Root cause was verified empirically against the real `refs/pull/4022/merge` ref (parent1 = base, parent2 = head).
- **Full required gate green:** `required-pr-gate`, `check-bundle-size`, `actionlint`, `zizmor`, `CodeQL`, `Analyze (ruby/js)` all SUCCESS.
- **Independent review satisfied:** CodeRabbit approved; Cursor Bugbot green; `claude-review` green for the current head; both inline review findings (error-message underflow, base `fetch-depth`) addressed in `52ae4bdb8` and replied to. No unresolved actionable feedback.
- **Stale-base rollout handled:** the change is self-applying — open behind-`main` PRs touching `packages/**` get accurate results on their next `check-bundle-size` run; no pre-land sweep required.
