### PR TITLE
Docs(generator): note Pro production devtool for source-mapped SSR stacks (#3893)

### DIFF
--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
@@ -224,11 +224,14 @@ const configureServer = () => {
   // The Pro Node renderer can remap bundled stack frames back to your original
   // source files (see docs/oss/building-features/node-renderer/debugging.md). This
   // needs source maps in the *production* server bundle, which the default above
-  // disables (`devtool: false`). To opt in, set a production devtool, e.g.:
-  //   serverWebpackConfig.devtool = 'source-map';        // external .map (smaller bundle; stage the .map next to the uploaded bundle)
-  //   serverWebpackConfig.devtool = 'inline-source-map'; // simplest; map travels inside the bundle
-  // The server bundle is never served to browsers, but never serve server-bundle
-  // source maps publicly.
+  // disables (`devtool: false`). To opt in, replace the devtool line above with a
+  // production-aware variant (keep the dev setting so development is unaffected), e.g.:
+  //   serverWebpackConfig.devtool = process.env.NODE_ENV === 'production' ? 'source-map' : 'cheap-module-source-map';
+  //     // 'source-map' — external .map (smaller bundle; stage the .map next to the uploaded bundle)
+  //   serverWebpackConfig.devtool = process.env.NODE_ENV === 'production' ? 'inline-source-map' : 'cheap-module-source-map';
+  //     // 'inline-source-map' — simplest; map travels inside the bundle (larger file)
+  // The server bundle is never served to browsers; still, never expose
+  // server-bundle source maps publicly.
 <% else -%>
   // If using the default 'web', then libraries like Emotion and loadable-components
   // break with SSR. The fix is to use a node renderer and change the target.

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
@@ -219,6 +219,16 @@ const configureServer = () => {
 
   // Disable Node.js polyfills - not needed when targeting Node
   serverWebpackConfig.node = false;
+
+  // Source-mapped SSR stack traces in production:
+  // The Pro Node renderer can remap bundled stack frames back to your original
+  // source files (see docs/oss/building-features/node-renderer/debugging.md). This
+  // needs source maps in the *production* server bundle, which the default above
+  // disables (`devtool: false`). To opt in, set a production devtool, e.g.:
+  //   serverWebpackConfig.devtool = 'source-map';        // external .map (smaller bundle; stage the .map next to the uploaded bundle)
+  //   serverWebpackConfig.devtool = 'inline-source-map'; // simplest; map travels inside the bundle
+  // The server bundle is never served to browsers, but never serve server-bundle
+  // source maps publicly.
 <% else -%>
   // If using the default 'web', then libraries like Emotion and loadable-components
   // break with SSR. The fix is to use a node renderer and change the target.

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/serverWebpackConfig.js.tt
@@ -224,14 +224,17 @@ const configureServer = () => {
   // The Pro Node renderer can remap bundled stack frames back to your original
   // source files (see docs/oss/building-features/node-renderer/debugging.md). This
   // needs source maps in the *production* server bundle, which the default above
-  // disables (`devtool: false`). To opt in, replace the devtool line above with a
-  // production-aware variant (keep the dev setting so development is unaffected), e.g.:
+  // disables (`devtool: false`). To opt in, replace only the `serverWebpackConfig.devtool`
+  // assignment above (keep the eval-devtool note) with a production-aware variant so
+  // development is unaffected. Both examples below use non-`eval` devtools, satisfying
+  // that constraint. E.g.:
   //   serverWebpackConfig.devtool = process.env.NODE_ENV === 'production' ? 'source-map' : 'cheap-module-source-map';
   //     // 'source-map' — external .map (smaller bundle; stage the .map next to the uploaded bundle)
   //   serverWebpackConfig.devtool = process.env.NODE_ENV === 'production' ? 'inline-source-map' : 'cheap-module-source-map';
   //     // 'inline-source-map' — simplest; map travels inside the bundle (larger file)
   // The server bundle is never served to browsers; still, never expose
   // server-bundle source maps publicly.
+
 <% else -%>
   // If using the default 'web', then libraries like Emotion and loadable-components
   // break with SSR. The fix is to use a node renderer and change the target.


### PR DESCRIPTION
## Why

Part of the closeout of #3893 (SSR debugging & profiling). The core feature — source-mapped Node-renderer stack traces — shipped in #3940, and the profiling/`--inspect` docs in #3961. This PR closes one small residual: the generated `serverWebpackConfig.js` template gave **no guidance** on the `devtool` setting needed to actually get those source-mapped stack traces **in production**.

The template default is:

```js
serverWebpackConfig.devtool = process.env.NODE_ENV === 'production' ? false : 'cheap-module-source-map';
```

i.e. source maps are **disabled in production**. That's a reasonable default (no `.map` files generated/uploaded), but it silently defeats the #3940 feature for Pro users in production: without a production server-bundle source map, the Node renderer has nothing to remap frames against, so production SSR error stacks stay anonymous/minified. Nothing in the generated config tells a Pro user how to opt in.

## What

Adds a comment (Pro branch of the template only) documenting how to enable production source maps for source-mapped SSR stack traces, mirroring the existing prose guidance in `docs/oss/building-features/node-renderer/debugging.md`:

- `devtool: 'source-map'` — external `.map` (smaller bundle; stage the `.map` next to the uploaded bundle), or
- `devtool: 'inline-source-map'` — simplest; map travels inside the bundle.
- Plus the "never serve server-bundle source maps publicly" caveat.

**Comment-only. No behavior change** — the default stays `false` in production; this just documents the opt-in. Scoped to the `use_pro?` branch because the remapping is a Pro Node-renderer capability.

## Scope / what's intentionally NOT here

- The other #3893 residual — a Rails-side RSpec asserting mapped `.tsx` frames in `PrerenderError` — is **environment-heavy** (needs the test SSR bundle built+staged with source maps, currently UNKNOWN) and is tracked as a separate P3 follow-up: #4112 (not forced into this PR).
- I did **not** change the production `devtool` default. Flipping it to emit maps for all Pro users would add `.map` generation/upload and privacy considerations; an opt-in comment is the correct, behavior-preserving scope.

## Validation

- Comment-only change inside the existing `<% if use_pro? -%>` block; no ERB interpolation introduced (the `install_generator_spec.rb` `.tt`-interpolation regression remains satisfied).
- Generator specs assert generated `serverWebpackConfig.js` content via `include(...)` substring checks (`pro_generator_spec.rb`, `rsc_generator_spec.rb`), and `pro_server_webpack_content` in `generator_spec_helper.rb` is a hand-written input fixture independent of this template — so added comments don't affect them.

## Merge confidence

- **Risk: very low.** Comment-only template addition; no runtime, API, or generated-behavior change.
- **Authorization:** maintainer (justin808) explicitly authorized merge for confident, documented changes in this batch.
- Merge gate: pending hosted-CI green on required checks for the current head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only template change with no runtime or generated-config behavior change.
> 
> **Overview**
> Adds **comment-only** guidance in the Pro `serverWebpackConfig.js` generator template so users know production SSR stack remapping needs non-default `devtool` settings.
> 
> The new block sits after the existing `target: 'node'` / `node: false` lines and explains that the default `devtool: false` in production blocks source-mapped frames, points to `debugging.md`, and shows opt-in examples (`source-map` vs `inline-source-map`) plus a warning not to expose server-bundle maps publicly. **No generated webpack behavior changes** — production still disables source maps by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2fe4054ccadbf270993ff8aedb1bface4adbd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Pro server webpack configuration guidance with clearer instructions on enabling production server source maps, noting how this affects the underlying build setting.
  * Included security-focused clarification that the server bundle is not meant to be served to browsers and that source maps should not be exposed publicly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->