### PR TITLE
Add High-Risk Mode to adversarial-pr-review (#4050)

### DIFF
--- a/.agents/skills/adversarial-pr-review/SKILL.md
+++ b/.agents/skills/adversarial-pr-review/SKILL.md
@@ -54,3 +54,29 @@ special merge gate; require only that advisory findings are complete, current,
 and triaged.
 If the PR already merged before this gate ran, include the finding in the next
 post-merge audit issue plan instead of editing GitHub state without approval.
+
+## High-Risk Mode
+
+Apply this stricter mode when a PR touches release-sensitive surfaces:
+release-candidate or version-bump changes, SSR/RSC/hydration behavior, streaming
+or asset-timing, CI/workflow/build-config, generated output, benchmark-sensitive
+code, Pro/core boundaries, or concurrent batch work. It adds three demands on top
+of the steps above; see `.agents/workflows/adversarial-pr-review.md` under
+**High-Risk Mode** for the full checklist, adversarial-question seed, the
+`pending_maintainer_action` dashboard block, and the #4047 retrospective fixture.
+
+1. **Prove the bug, then prove the fix.** When feasible, reproduce the reported
+   failure on the base (without the fix) and confirm it disappears on the current
+   head. Then check the fix waits for the _minimum_ required condition and is the
+   simplest plausible location for the invariant — not an over-broad wait or a
+   policy duplicated across layers.
+2. **Separate implementation confidence from merge-gate readiness.** Strong test
+   evidence does not mean the merge gate is satisfied.
+3. **Report merge-gate state without conflating the three approval concepts.** A
+   maintainer approval _comment_, a formal GitHub _review object_ (`reviewDecision`),
+   and the local `script/pr-merge-ledger --strict` result (`complete_allowed`) are
+   distinct. Report each separately and classify every remaining blocker by type:
+   policy gate, GitHub API state, CI/check failure, or real code concern. If a
+   plain maintainer comment is intended to suffice for a lane, that waiver must be
+   stated explicitly in the handoff — never silently treat an "approved" comment
+   as a formal review object.

--- a/.agents/skills/adversarial-pr-review/SKILL.md
+++ b/.agents/skills/adversarial-pr-review/SKILL.md
@@ -64,20 +64,28 @@ code, Pro/core boundaries, or concurrent batch work. It adds three demands on to
 of the steps above; see `.agents/workflows/adversarial-pr-review.md` under
 **High-Risk Mode** for the full checklist, adversarial-question seed, the
 `pending_maintainer_action` dashboard block, and the #4047 retrospective fixture.
+For high-risk or concurrent-batch PRs, the review is required before readiness
+only in the sense that its `BLOCKING` and `DISCUSS` findings must be fixed,
+explicitly decided, or waived; it remains report-only and is not a GitHub
+approval object.
 
 1. **Prove the bug, then prove the fix.** When feasible, reproduce the reported
    failure on the base (without the fix) and confirm it disappears on the current
    head. Then check the fix waits for the _minimum_ required condition and is the
    simplest plausible location for the invariant — not an over-broad wait or a
    policy duplicated across layers. If the bug cannot be reproduced, report that
-   explicitly and classify the fix as `DISCUSS` rather than `BLOCKING`.
+   explicitly and classify the fix as `DISCUSS` rather than `BLOCKING`. Treat
+   proof as infeasible only for concrete reasons: missing historical repro
+   artifacts, a base that cannot build/run after reasonable setup, external
+   secrets or prod-only systems, destructive/unsafe operations, or cost/time
+   beyond the lane budget; name the reason and evidence.
 2. **Separate implementation confidence from merge-gate readiness.** Strong test
    evidence does not mean the merge gate is satisfied.
 3. **Report merge-gate state without conflating the three approval concepts.** A
    maintainer approval _comment_, a formal GitHub _review object_ (`reviewDecision`),
-   and the local `script/pr-merge-ledger --strict` result (`complete_allowed`) are
-   distinct. Report each separately and classify every remaining blocker by type:
-   policy gate, GitHub API state, CI/check failure, or real code concern. If a
-   plain maintainer comment is intended to suffice for a lane, that waiver must be
-   stated explicitly in the handoff — never silently treat an "approved" comment
-   as a formal review object.
+   and the local `script/pr-merge-ledger <PR> --strict` result
+   (`complete_allowed`) are distinct. Report each separately and classify every
+   remaining blocker by type: policy gate, GitHub API state, CI/check failure, or
+   real code concern. If a plain maintainer comment is intended to suffice for a
+   lane, that waiver must be stated explicitly in the handoff — never silently
+   treat an "approved" comment as a formal review object.

--- a/.agents/skills/adversarial-pr-review/SKILL.md
+++ b/.agents/skills/adversarial-pr-review/SKILL.md
@@ -69,7 +69,8 @@ of the steps above; see `.agents/workflows/adversarial-pr-review.md` under
    failure on the base (without the fix) and confirm it disappears on the current
    head. Then check the fix waits for the _minimum_ required condition and is the
    simplest plausible location for the invariant — not an over-broad wait or a
-   policy duplicated across layers.
+   policy duplicated across layers. If the bug cannot be reproduced, report that
+   explicitly and classify the fix as `DISCUSS` rather than `BLOCKING`.
 2. **Separate implementation confidence from merge-gate readiness.** Strong test
    evidence does not mean the merge gate is satisfied.
 3. **Report merge-gate state without conflating the three approval concepts.** A

--- a/.agents/workflows/adversarial-pr-review.md
+++ b/.agents/workflows/adversarial-pr-review.md
@@ -171,10 +171,12 @@ a strong-looking handoff cannot hide an unsatisfied gate.
 ### Extra Steps
 
 1. **Prove the bug without the fix.** When feasible, reproduce the reported
-   failure against the base branch (or `HEAD~` of the PR) using the same repro,
-   test, or script the PR adds, and capture the failing evidence. Then confirm it
-   passes on the current PR head. If the bug cannot be reproduced, say so and
-   downgrade confidence — a fix for an unprovable bug is itself a `DISCUSS`.
+   failure against a merge-base/base checkout, or against a verified
+   test-only/pre-fix fixture commit that is known not to contain the fix, using
+   the same repro, test, or script the PR adds, and capture the failing evidence.
+   Then confirm it passes on the current PR head. If the bug cannot be
+   reproduced, say so and downgrade confidence — a fix for an unprovable bug is
+   itself a `DISCUSS`.
 2. **Verify the fix is correct and minimal.** Check that it waits for the
    _minimum_ required condition (not an over-broad wait that masks races), that
    the invariant lives in the simplest single place rather than being duplicated
@@ -239,12 +241,12 @@ agent, or code change remains.
 pending_maintainer_action:
   required: true # false only when state is ready_to_merge
   state: waiting_maintainer_review # | waiting_ci | waiting_review_agent | waiting_code_change | ready_to_merge
-  owner: maintainer # who must act: maintainer | author | none
+  owner: maintainer # who must act: maintainer | author | review-agent | none
   action: 'Submit formal GitHub review for current head'
   reason: 'reviewDecision is null'
   blocks_merge: true
   evidence:
-    pr: 4047
+    pr: <PR_NUMBER>
     head_sha: '<sha>'
     review_decision: null # APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | null
     maintainer_approval_comment: true # a human comment exists, but is not a review object

--- a/.agents/workflows/adversarial-pr-review.md
+++ b/.agents/workflows/adversarial-pr-review.md
@@ -158,3 +158,108 @@ Return:
 
 Do not create issues, comments, labels, fixes, or PRs.
 ```
+
+## High-Risk Mode
+
+Use this stricter mode when a PR touches release-sensitive surfaces:
+release-candidate or version-bump changes, SSR/RSC/hydration behavior, streaming
+or asset-timing, CI/workflow/build-config, generated output, benchmark-sensitive
+code, Pro/core boundaries, or concurrent batch work. It does not replace the
+steps above; it adds proof-of-bug, simplicity, and merge-gate-clarity demands so
+a strong-looking handoff cannot hide an unsatisfied gate.
+
+### Extra Steps
+
+1. **Prove the bug without the fix.** When feasible, reproduce the reported
+   failure against the base branch (or `HEAD~` of the PR) using the same repro,
+   test, or script the PR adds, and capture the failing evidence. Then confirm it
+   passes on the current PR head. If the bug cannot be reproduced, say so and
+   downgrade confidence — a fix for an unprovable bug is itself a `DISCUSS`.
+2. **Verify the fix is correct and minimal.** Check that it waits for the
+   _minimum_ required condition (not an over-broad wait that masks races), that
+   the invariant lives in the simplest single place rather than being duplicated
+   across layers, and that it does not regress app-authored behavior (for FOUC/RSC
+   work: preload/style attributes, split stream chunks, encoding boundaries).
+3. **Separate implementation confidence from merge-gate readiness, and report the
+   three approval concepts distinctly** (see Approval And Merge-Gate Clarity).
+
+### Approval And Merge-Gate Clarity
+
+The #4047/#4045 closeout was confusing because three similar-looking concepts
+were conflated. Always report them separately for a high-risk PR:
+
+- **Maintainer approval comment** — a human comment in the PR discussion. It is
+  evidence of intent, but it is _not_ a formal GitHub review object and does not
+  populate `reviewDecision`.
+- **GitHub `reviewDecision`** — the formal review-object state
+  (`APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` / null). This is the only
+  thing branch protection enforces.
+- **`script/pr-merge-ledger --strict`** — the local mechanical gate; check whether
+  it currently returns `complete_allowed: true` for the current head SHA.
+
+Then classify every remaining blocker by _type_ so the reader knows who/what
+clears it:
+
+- **policy gate** — repo policy requires a formal review object for this PR/lane.
+- **GitHub API state** — e.g. `reviewDecision` is null or stale vs the head SHA.
+- **CI/check failure** — a required or configured check is failing or pending.
+- **real code concern** — a `BLOCKING`/`DISCUSS` finding from this review.
+
+If a plain maintainer comment is intended to be sufficient for a specific lane,
+that waiver/decision must be stated explicitly in the handoff and reflected in
+whatever policy or ledger input supports it. Never silently treat an "approved"
+comment and a formal GitHub review object as the same thing.
+
+### Suggested Adversarial Questions
+
+Seed the review with questions such as:
+
+- Can we prove the bug exists without the fix using the same repro or test?
+- Does the fix wait for the minimum required thing, or accidentally wait for too
+  much?
+- What happens on timeout, missing assets, malformed streams, split chunks, or
+  encoding boundaries?
+- Does this preserve app-authored preload/style behavior?
+- Are review-agent results current-head evidence or stale advisory history?
+- Are benchmarks required because the change touches streaming, hydration, SSR,
+  or asset timing?
+- Is there a simpler location to enforce the invariant without duplicating policy
+  across layers?
+- What is the failure mode if inferred metadata is absent or wrong?
+- Are we conflating human confidence, GitHub review state, and local ledger state?
+
+### Dashboard-Friendly Pending-Action Block
+
+End a high-risk report with a stable block an agent-coordination dashboard can
+parse. Emit exactly one `state` from the allowed set so the dashboard can route
+the PR. Use `state: ready_to_merge` only when no maintainer action, CI, review
+agent, or code change remains.
+
+```yaml
+pending_maintainer_action:
+  required: true # false only when state is ready_to_merge
+  state: waiting_maintainer_review # | waiting_ci | waiting_review_agent | waiting_code_change | ready_to_merge
+  owner: maintainer # who must act: maintainer | author | none
+  action: 'Submit formal GitHub review for current head'
+  reason: 'reviewDecision is null'
+  blocks_merge: true
+  evidence:
+    pr: 4047
+    head_sha: '<sha>'
+    review_decision: null # APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | null
+    maintainer_approval_comment: true # a human comment exists, but is not a review object
+    ledger_complete_allowed: false # script/pr-merge-ledger --strict
+    ci_readiness: NOT_READY # from pr-ci-readiness: READY | NOT_READY | UNKNOWN
+```
+
+### Retrospective Fixture: #4047
+
+`#4047` (Fix Pro FOUC reveal gating, merged 2026-06-16) is the canonical replay
+fixture for this mode — it touches FOUC/RSC streaming, hydration, benchmarks, and
+formal review state. Replaying it should surface: (a) the proof-before/after via
+its FOUC Playwright coverage, (b) the simplicity question about _where_ stylesheet
+readiness is gated, and (c) a pending-action block that distinguished a maintainer
+approval comment from a populated `reviewDecision` and from the ledger's
+`complete_allowed` — the exact conflation that motivated this mode. Use it to
+sanity-check that a new high-risk report keeps those three approval concepts
+separate.

--- a/.agents/workflows/adversarial-pr-review.md
+++ b/.agents/workflows/adversarial-pr-review.md
@@ -168,6 +168,11 @@ code, Pro/core boundaries, or concurrent batch work. It does not replace the
 steps above; it adds proof-of-bug, simplicity, and merge-gate-clarity demands so
 a strong-looking handoff cannot hide an unsatisfied gate.
 
+For high-risk or concurrent-batch PRs, this review is required before readiness
+only in the sense that its `BLOCKING` and `DISCUSS` findings must be fixed,
+explicitly decided, or waived. It remains report-only; it is not a GitHub
+approval object and does not replace maintainer review or branch protection.
+
 ### Extra Steps
 
 1. **Prove the bug without the fix.** When feasible, reproduce the reported
@@ -177,6 +182,10 @@ a strong-looking handoff cannot hide an unsatisfied gate.
    Then confirm it passes on the current PR head. If the bug cannot be
    reproduced, say so and downgrade confidence — a fix for an unprovable bug is
    itself a `DISCUSS`.
+   Accepted infeasibility reasons are limited to missing historical repro
+   artifacts, a base that cannot build/run after reasonable setup, external
+   secrets or prod-only systems, destructive/unsafe operations, or cost/time
+   beyond the lane budget. Name the reason, evidence, and confidence impact.
 2. **Verify the fix is correct and minimal.** Check that it waits for the
    _minimum_ required condition (not an over-broad wait that masks races), that
    the invariant lives in the simplest single place rather than being duplicated
@@ -196,8 +205,8 @@ were conflated. Always report them separately for a high-risk PR:
 - **GitHub `reviewDecision`** — the formal review-object state
   (`APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` / null). This is the only
   thing branch protection enforces.
-- **`script/pr-merge-ledger --strict`** — the local mechanical gate; check whether
-  it currently returns `complete_allowed: true` for the current head SHA.
+- **`script/pr-merge-ledger <PR> --strict`** — the local mechanical gate; check
+  whether it currently returns `complete_allowed: true` for the current head SHA.
 
 Then classify every remaining blocker by _type_ so the reader knows who/what
 clears it:
@@ -237,6 +246,9 @@ parse. Emit exactly one `state` from the allowed set so the dashboard can route
 the PR. Use `state: ready_to_merge` only when no maintainer action, CI, review
 agent, or code change remains.
 
+Allowed `state` values are `waiting_maintainer_review`, `waiting_ci`,
+`waiting_review_agent`, `waiting_code_change`, and `ready_to_merge`.
+
 ```yaml
 pending_maintainer_action:
   required: true # false only when state is ready_to_merge
@@ -250,7 +262,7 @@ pending_maintainer_action:
     head_sha: '<sha>'
     review_decision: null # APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED | null
     maintainer_approval_comment: true # a human comment exists, but is not a review object
-    ledger_complete_allowed: false # script/pr-merge-ledger --strict
+    ledger_complete_allowed: false # script/pr-merge-ledger <PR> --strict
     ci_readiness: NOT_READY # from pr-ci-readiness: READY | NOT_READY | UNKNOWN
 ```
 


### PR DESCRIPTION
## Why

High-risk PRs sometimes need more than a normal review pass. In the #4047/#4045 closeout the implementation evidence was strong, but the handoff conflated three similar-looking concepts: a maintainer approval *comment*, a formal GitHub *review object* (`reviewDecision`), and the local `script/pr-merge-ledger --strict` result (`complete_allowed`). #4050 asked for a repeatable way to red-team high-risk PRs, prove the bug exists without the fix, verify the fix is simple, and report exactly what human approval or mechanical gate remains.

## Decision: extend, don't duplicate

The issue proposed a new `.agents/skills/tough-adversarial-review/SKILL.md`. Evaluation found ~75% of the "Required Behavior" already lives in `adversarial-pr-review` (untrusted-input handling, live ground-truth fetch, the 5-way BLOCKING/DISCUSS/FOLLOWUP/NON_BLOCKING_DECISION/NOISE classification, AI-review-as-advisory, release-sensitive surfaces, merge gate). The maintainer chose to **extend the existing skill** rather than ship a near-duplicate. This intentionally does not satisfy the issue's "new file exists" acceptance criterion; the equivalent functionality is delivered in the existing skill + workflow, which the issue itself said should be complemented, not replaced.

## What changed

Both files gain a **High-Risk Mode** section (additive only, no existing lines removed):

- `.agents/skills/adversarial-pr-review/SKILL.md` — lean entry point: when to apply, the three extra demands, and a pointer to the workflow for detail.
- `.agents/workflows/adversarial-pr-review.md` — full detail:
  - **Extra steps:** prove the bug without the fix, then verify the fix is correct and *minimal* (minimum-required wait, single simplest location, no app-behavior regression).
  - **Approval and merge-gate clarity:** keep maintainer comment vs `reviewDecision` vs `pr-merge-ledger --strict` distinct; classify every remaining blocker by type (policy gate / GitHub API state / CI failure / real code concern); require explicit waivers.
  - **Suggested adversarial questions** seed list.
  - **Dashboard-friendly `pending_maintainer_action` block** with a single routable `state`.
  - **#4047 retrospective fixture** as the canonical replay scenario.

## Validation

- `prettier --check` (the `markdown-format-check` CI gate, printWidth 110) — clean on both files after `--write`.
- Diff is 131 insertions, 0 deletions across exactly the 2 intended files.
- lychee `markdown-link-check` is scoped to `docs/` + root `*.md` (not `.agents/`); additions contain no external URLs.

## Codex Decision Log

- **Non-blocking:** new standalone skill vs extend existing.
  - **Decision:** extend `adversarial-pr-review`.
  - **Why:** maintainer chose extend (~75% overlap); avoids a duplicate skill and policy drift across two files.
  - **Review later:** if a distinct high-risk skill is later wanted, this content lifts cleanly into one.

Closes #4050.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent review guidance; no runtime, auth, or product behavior.
> 
> **Overview**
> Extends the existing **adversarial-pr-review** skill and workflow with **High-Risk Mode** for release-sensitive PRs (SSR/RSC, CI, benchmarks, Pro boundaries, concurrent batches, etc.) instead of adding a separate skill.
> 
> The skill adds a short entry point: when to apply the mode, three extra demands (prove bug then fix, separate test confidence from merge readiness, keep approval concepts distinct), and a pointer to the workflow. The workflow documents the full checklist: repro on base vs pass on head, minimal-fix checks, explicit separation of maintainer comments vs `reviewDecision` vs `script/pr-merge-ledger --strict`, blocker typing, adversarial question seeds, a parseable `pending_maintainer_action` YAML block for dashboards, and **#4047** as a retrospective replay fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee87cce50c19fa383bb7187afd4a05c77f488c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Documentation**
  * Introduced a new **High-Risk Mode** in the adversarial PR review guidance for release-sensitive and behavior-critical changes, keeping the workflow report-only while tightening expectations.
  * Added **extra proof requirements** (attempt base-without-fix reproduction when feasible, downgrade confidence when not) and **minimum-condition verification** to encourage minimal, correct fixes.
  * Improved **approval vs merge-gate clarity** by separating maintainer approval evidence, formal merge-gate state, and local readiness; enhanced blocker classification and dashboard-ready pending-action reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Merge Criteria

Status: ready to merge under maintainer-delegated merge authority from the Codex thread on 2026-06-20.

- Head SHA verified: `ee87cce50c19fa383bb7187afd4a05c77f488c1d`.
- Base / release gate: targets `main`; release tracker #3823 `Agent Release Mode` block reads `Mode: development`. `agent-coord doctor/status` timed out, so backend phase was not used.
- CI: `.agents/skills/pr-batch/bin/pr-ci-readiness 4115 --repo shakacode/react_on_rails` returned `READY`; `gh pr checks` showed 22 pass / 18 skipping and no failing or pending checks.
- Reviews: current-head review-thread scan found 0 unresolved threads and 0 changes-requested review objects.
- Ledger: `script/pr-merge-ledger 4115 --repo shakacode/react_on_rails --changelog-classification not_user_visible --strict` passed with `complete_allowed: true`, 0 unknown fields, and 0 violations.
- Changelog: not required; this updates internal agent review workflow documentation only.
- Merge method: repository allows squash only; merge should use `--squash --match-head-commit ee87cce50c19fa383bb7187afd4a05c77f488c1d`.
