### PR TITLE
docs: add "Consuming an Unreleased Build" getting-started page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ The examples below are for the `main` branch of `react-on-rails` package.
 See [this issue](https://github.com/pnpm/pnpm/issues/4765).
 
 ```shell
-pnpm add "github:shakacode/react_on_rails/repo#main&path:packages/react-on-rails"
+pnpm add "github:shakacode/react_on_rails#main&path:packages/react-on-rails"
 ```
 
 #### Yarn Berry

--- a/docs/oss/getting-started/consuming-an-unreleased-build.md
+++ b/docs/oss/getting-started/consuming-an-unreleased-build.md
@@ -111,6 +111,7 @@ When you consume an unreleased build, bump the related packages **together** so
 versions stay compatible:
 
 - `react_on_rails` (gem)
+- `react-on-rails` (npm)
 - `react_on_rails_pro` (gem)
 - `react-on-rails-pro-node-renderer` (npm)
 - `react-on-rails-rsc` (npm), if you use React Server Components — see

--- a/docs/oss/getting-started/consuming-an-unreleased-build.md
+++ b/docs/oss/getting-started/consuming-an-unreleased-build.md
@@ -113,6 +113,7 @@ versions stay compatible:
 - `react_on_rails` (gem)
 - `react-on-rails` (npm)
 - `react_on_rails_pro` (gem)
+- `react-on-rails-pro` (npm)
 - `react-on-rails-pro-node-renderer` (npm)
 - `react-on-rails-rsc` (npm), if you use React Server Components — see
   [shakacode/react_on_rails_rsc#109](https://github.com/shakacode/react_on_rails_rsc/issues/109)

--- a/docs/oss/getting-started/consuming-an-unreleased-build.md
+++ b/docs/oss/getting-started/consuming-an-unreleased-build.md
@@ -1,0 +1,127 @@
+---
+slug: consuming-an-unreleased-build
+---
+
+# Consuming an Unreleased Build
+
+Use this page when you need to test an unreleased version of React on Rails in
+your own application — before it is published to RubyGems or npm.
+
+> [!NOTE]
+> **Summary for AI agents:** This is the adopter-facing version of the
+> "Testing your changes in an external application" section of
+> [CONTRIBUTING.md](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md).
+> It covers pointing a downstream app at a Git branch (gems) and at the
+> per-package npm subdirectories. The two non-obvious gotchas are the
+> OSS-vs-Pro `glob:` asymmetry for gems and the fact that bare
+> `owner/repo#ref` npm refs do not work for the subdirectory packages.
+
+## When you need this
+
+React on Rails ships the gem and several npm packages from a single monorepo.
+When a fix or feature has landed on `main` (or another branch) but has not yet
+been released, you can still consume it directly from Git so you can validate it
+in a real application before the next release.
+
+This is useful when you want to:
+
+- Verify a bug fix against your app before it is published.
+- Try a feature on an upcoming branch.
+- Reproduce or confirm behavior reported in an issue or PR.
+
+## Ruby gems
+
+Point your `Gemfile` at the Git repository and branch:
+
+```ruby
+gem 'react_on_rails',
+  git: 'https://github.com/shakacode/react_on_rails',
+  branch: 'main'
+gem 'react_on_rails_pro',
+  git: 'https://github.com/shakacode/react_on_rails',
+  glob: 'react_on_rails_pro/react_on_rails_pro.gemspec',
+  branch: 'main'
+```
+
+Note the asymmetry: the open-source `react_on_rails` gem needs **no** `glob:`
+option — its gemspec lives at the repository root and Bundler finds it
+automatically. Only `react_on_rails_pro` needs an explicit
+`glob: 'react_on_rails_pro/react_on_rails_pro.gemspec'` because its gemspec
+lives in a subdirectory. Run `bundle install` afterward, and use
+`bundle update react_on_rails react_on_rails_pro` to pull newer commits from the
+branch.
+
+## npm packages
+
+The npm packages live in subdirectories of the monorepo
+(`packages/react-on-rails`, `packages/react-on-rails-pro`,
+`packages/react-on-rails-pro-node-renderer`). Not every package manager can
+depend on a single subdirectory of a Git repo, so the recommended path depends
+on your manager.
+
+### pnpm (recommended, v9+)
+
+pnpm can install a subdirectory of a Git repo directly:
+
+```shell
+pnpm add "github:shakacode/react_on_rails/repo#main&path:packages/react-on-rails"
+```
+
+For Pro, add the additional packages the same way, substituting
+`packages/react-on-rails-pro` and
+`packages/react-on-rails-pro-node-renderer` for the `path:` value.
+
+### Yarn Berry
+
+Yarn Berry supports the Git protocol with a workspace selector:
+
+```shell
+yarn add "git@github.com:shakacode/react_on_rails.git#workspace=react-on-rails&head=main"
+```
+
+### npm (and managers that can't resolve a Git subdirectory)
+
+npm does not support depending on a subdirectory of a Git repo, so build a
+tarball with `pnpm pack` and install that:
+
+```shell
+# In the React on Rails checkout
+pnpm install && pnpm run build
+cd packages/react-on-rails && pnpm pack   # creates react-on-rails-<version>.tgz
+
+# In your app
+npm install <path-to-tarball>
+```
+
+For rapid iteration, [yalc](https://github.com/whitecolor/yalc) is an
+alternative: after `pnpm run build`, run `yalc publish` from each
+`packages/*` directory you changed, then `yalc add <package>` in your app.
+
+> [!TIP]
+> **Why a bare `owner/repo#ref` fails for these packages:** a bare Git ref
+> resolves the workspace **root**, not the publishable subdirectory you want.
+> In addition, each package's `lib/` output is gitignored (`packages/*/lib/`)
+> and produced by the package's `prepare`/build script — which some package
+> managers skip for Git dependencies — so you would end up without the built
+> output. The pnpm `path:` selector and the tarball both avoid this.
+
+## Version pairing
+
+When you consume an unreleased build, bump the related packages **together** so
+versions stay compatible:
+
+- `react_on_rails` (gem)
+- `react_on_rails_pro` (gem)
+- `react-on-rails-pro-node-renderer` (npm)
+- `react-on-rails-rsc` (npm), if you use React Server Components — see
+  [shakacode/react_on_rails_rsc#109](https://github.com/shakacode/react_on_rails_rsc/issues/109)
+
+Mixing a new gem with old npm packages (or vice versa) is the most common cause
+of confusing failures when testing an unreleased build.
+
+## See also
+
+For the contributor-oriented version — including local `path:` dependencies and
+testing changes against the in-repo dummy apps — see
+[Testing your changes in an external application](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md#testing-your-changes-in-an-external-application)
+in `CONTRIBUTING.md`.

--- a/docs/oss/getting-started/consuming-an-unreleased-build.md
+++ b/docs/oss/getting-started/consuming-an-unreleased-build.md
@@ -64,7 +64,7 @@ on your manager.
 pnpm can install a subdirectory of a Git repo directly:
 
 ```shell
-pnpm add "github:shakacode/react_on_rails/repo#main&path:packages/react-on-rails"
+pnpm add "github:shakacode/react_on_rails#main&path:packages/react-on-rails"
 ```
 
 For Pro, add the additional packages the same way, substituting

--- a/docs/oss/getting-started/examples-and-references.md
+++ b/docs/oss/getting-started/examples-and-references.md
@@ -38,6 +38,8 @@ source, while others require React on Rails Pro.
 - Upstream branch testing: the starter documents how to validate unreleased
   `react_on_rails` and `react_on_rails_rsc` branches in
   [Testing Upstream Branches](https://github.com/shakacode/react-on-rails-starter-tanstack/blob/main/docs/12-upstream-branch-testing.md).
+  For the general gem/npm recipes, see
+  [Consuming an Unreleased Build](./consuming-an-unreleased-build.md).
 - Note: this repo uses React on Rails Pro. See [OSS vs Pro](./oss-vs-pro.md)
   for evaluation guidance.
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/create-react-on-rails-app',
         'getting-started/tutorial',
         'getting-started/installation-into-an-existing-rails-app',
+        'getting-started/consuming-an-unreleased-build',
         'getting-started/project-structure',
         'getting-started/using-react-on-rails',
         'getting-started/oss-vs-pro',

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1451,6 +1451,7 @@ versions stay compatible:
 - `react_on_rails` (gem)
 - `react-on-rails` (npm)
 - `react_on_rails_pro` (gem)
+- `react-on-rails-pro` (npm)
 - `react-on-rails-pro-node-renderer` (npm)
 - `react-on-rails-rsc` (npm), if you use React Server Components — see
   [shakacode/react_on_rails_rsc#109](https://github.com/shakacode/react_on_rails_rsc/issues/109)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1402,7 +1402,7 @@ on your manager.
 pnpm can install a subdirectory of a Git repo directly:
 
 ```shell
-pnpm add "github:shakacode/react_on_rails/repo#main&path:packages/react-on-rails"
+pnpm add "github:shakacode/react_on_rails#main&path:packages/react-on-rails"
 ```
 
 For Pro, add the additional packages the same way, substituting

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -655,6 +655,8 @@ source, while others require React on Rails Pro.
 - Upstream branch testing: the starter documents how to validate unreleased
   `react_on_rails` and `react_on_rails_rsc` branches in
   [Testing Upstream Branches](https://github.com/shakacode/react-on-rails-starter-tanstack/blob/main/docs/12-upstream-branch-testing.md).
+  For the general gem/npm recipes, see
+  [Consuming an Unreleased Build](./consuming-an-unreleased-build.md).
 - Note: this repo uses React on Rails Pro. See [OSS vs Pro](./oss-vs-pro.md)
   for evaluation guidance.
 
@@ -1332,6 +1334,135 @@ Review these changes before adapting them to your actual application structure.
 - **Enable server-side rendering** — [SSR guide](../core-concepts/react-server-rendering.md)
 - **Compare OSS and Pro** — [OSS vs Pro](./oss-vs-pro.md)
 - **Upgrade to Pro** — [3-step upgrade guide](../../pro/upgrading-to-pro.md)
+
+================================================================================
+PAGE: https://reactonrails.com/docs/getting-started/consuming-an-unreleased-build
+SOURCE: docs/oss/getting-started/consuming-an-unreleased-build.md
+================================================================================
+
+# Consuming an Unreleased Build
+
+Use this page when you need to test an unreleased version of React on Rails in
+your own application — before it is published to RubyGems or npm.
+
+> [!NOTE]
+> **Summary for AI agents:** This is the adopter-facing version of the
+> "Testing your changes in an external application" section of
+> [CONTRIBUTING.md](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md).
+> It covers pointing a downstream app at a Git branch (gems) and at the
+> per-package npm subdirectories. The two non-obvious gotchas are the
+> OSS-vs-Pro `glob:` asymmetry for gems and the fact that bare
+> `owner/repo#ref` npm refs do not work for the subdirectory packages.
+
+## When you need this
+
+React on Rails ships the gem and several npm packages from a single monorepo.
+When a fix or feature has landed on `main` (or another branch) but has not yet
+been released, you can still consume it directly from Git so you can validate it
+in a real application before the next release.
+
+This is useful when you want to:
+
+- Verify a bug fix against your app before it is published.
+- Try a feature on an upcoming branch.
+- Reproduce or confirm behavior reported in an issue or PR.
+
+## Ruby gems
+
+Point your `Gemfile` at the Git repository and branch:
+
+```ruby
+gem 'react_on_rails',
+  git: 'https://github.com/shakacode/react_on_rails',
+  branch: 'main'
+gem 'react_on_rails_pro',
+  git: 'https://github.com/shakacode/react_on_rails',
+  glob: 'react_on_rails_pro/react_on_rails_pro.gemspec',
+  branch: 'main'
+```
+
+Note the asymmetry: the open-source `react_on_rails` gem needs **no** `glob:`
+option — its gemspec lives at the repository root and Bundler finds it
+automatically. Only `react_on_rails_pro` needs an explicit
+`glob: 'react_on_rails_pro/react_on_rails_pro.gemspec'` because its gemspec
+lives in a subdirectory. Run `bundle install` afterward, and use
+`bundle update react_on_rails react_on_rails_pro` to pull newer commits from the
+branch.
+
+## npm packages
+
+The npm packages live in subdirectories of the monorepo
+(`packages/react-on-rails`, `packages/react-on-rails-pro`,
+`packages/react-on-rails-pro-node-renderer`). Not every package manager can
+depend on a single subdirectory of a Git repo, so the recommended path depends
+on your manager.
+
+### pnpm (recommended, v9+)
+
+pnpm can install a subdirectory of a Git repo directly:
+
+```shell
+pnpm add "github:shakacode/react_on_rails/repo#main&path:packages/react-on-rails"
+```
+
+For Pro, add the additional packages the same way, substituting
+`packages/react-on-rails-pro` and
+`packages/react-on-rails-pro-node-renderer` for the `path:` value.
+
+### Yarn Berry
+
+Yarn Berry supports the Git protocol with a workspace selector:
+
+```shell
+yarn add "git@github.com:shakacode/react_on_rails.git#workspace=react-on-rails&head=main"
+```
+
+### npm (and managers that can't resolve a Git subdirectory)
+
+npm does not support depending on a subdirectory of a Git repo, so build a
+tarball with `pnpm pack` and install that:
+
+```shell
+# In the React on Rails checkout
+pnpm install && pnpm run build
+cd packages/react-on-rails && pnpm pack   # creates react-on-rails-<version>.tgz
+
+# In your app
+npm install <path-to-tarball>
+```
+
+For rapid iteration, [yalc](https://github.com/whitecolor/yalc) is an
+alternative: after `pnpm run build`, run `yalc publish` from each
+`packages/*` directory you changed, then `yalc add <package>` in your app.
+
+> [!TIP]
+> **Why a bare `owner/repo#ref` fails for these packages:** a bare Git ref
+> resolves the workspace **root**, not the publishable subdirectory you want.
+> In addition, each package's `lib/` output is gitignored (`packages/*/lib/`)
+> and produced by the package's `prepare`/build script — which some package
+> managers skip for Git dependencies — so you would end up without the built
+> output. The pnpm `path:` selector and the tarball both avoid this.
+
+## Version pairing
+
+When you consume an unreleased build, bump the related packages **together** so
+versions stay compatible:
+
+- `react_on_rails` (gem)
+- `react_on_rails_pro` (gem)
+- `react-on-rails-pro-node-renderer` (npm)
+- `react-on-rails-rsc` (npm), if you use React Server Components — see
+  [shakacode/react_on_rails_rsc#109](https://github.com/shakacode/react_on_rails_rsc/issues/109)
+
+Mixing a new gem with old npm packages (or vice versa) is the most common cause
+of confusing failures when testing an unreleased build.
+
+## See also
+
+For the contributor-oriented version — including local `path:` dependencies and
+testing changes against the in-repo dummy apps — see
+[Testing your changes in an external application](https://github.com/shakacode/react_on_rails/blob/main/CONTRIBUTING.md#testing-your-changes-in-an-external-application)
+in `CONTRIBUTING.md`.
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/getting-started/project-structure

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1449,6 +1449,7 @@ When you consume an unreleased build, bump the related packages **together** so
 versions stay compatible:
 
 - `react_on_rails` (gem)
+- `react-on-rails` (npm)
 - `react_on_rails_pro` (gem)
 - `react-on-rails-pro-node-renderer` (npm)
 - `react-on-rails-rsc` (npm), if you use React Server Components — see


### PR DESCRIPTION
## Motivation

Downstream adopters frequently need to test an **unreleased** React on Rails fix or feature in their own application before the next release. The repo already documents how to do this in `CONTRIBUTING.md` ("Testing your changes in an external application"), but that guidance is **not surfaced on the published Docusaurus docs site**, so adopters don't discover it.

This PR adds a concise, adopter-facing getting-started page that surfaces the monorepo gem `glob:` trick and the npm subdirectory / tarball / yalc paths, and cross-links back to `CONTRIBUTING.md` instead of duplicating it.

## Corrects two inaccuracies from the issue body

- **OSS-vs-Pro `glob:` asymmetry.** The issue showed `glob: "react_on_rails/*.gemspec"` for the OSS gem. That's wrong: the open-source `react_on_rails` gem needs **no** `glob:` (its gemspec is at the repo root and Bundler finds it automatically). Only `react_on_rails_pro` needs `glob: 'react_on_rails_pro/react_on_rails_pro.gemspec'`. Verified against `CONTRIBUTING.md` lines 154–162.
- **pnpm vs "yarn classic".** The issue framed npm consumption around yarn classic. This repo uses **pnpm**, which supports Git subdirectory dependencies directly (no yalc needed). yalc/tarball is the fallback for managers that can't (npm; older yarn). The page presents pnpm as the recommended path.

## Files touched

- `docs/oss/getting-started/consuming-an-unreleased-build.md` (new page)
- `docs/sidebars.ts` (sidebar entry, immediately after `installation-into-an-existing-rails-app`)
- `docs/oss/getting-started/examples-and-references.md` (one cross-link line under the existing "Upstream branch testing" bullet)

## Validation

```
$ npx prettier --check docs/oss/getting-started/consuming-an-unreleased-build.md docs/oss/getting-started/examples-and-references.md docs/sidebars.ts
Checking formatting...
All matched files use Prettier code style!

$ script/check-docs-sidebar    # after staging the new file
Checking new docs against docs/sidebars.ts...
  ✓ getting-started/consuming-an-unreleased-build
✓ All 1 new doc(s) have sidebar entries

$ lychee --offline docs/oss/getting-started/consuming-an-unreleased-build.md docs/oss/getting-started/examples-and-references.md
🔍 23 Total ✅ 4 OK 🚫 0 Errors 👻 19 Excluded
```

Notes:
- `sidebars.ts`: my edit adds one string literal inside the existing `items` array; `tsc` reports only the pre-existing "Cannot find module '@docusaurus/...'" type-resolution error (the Docusaurus deps aren't installed in this repo), no syntax error.
- The lefthook pre-commit `eslint`/`prettier` steps could not run in this worktree (binaries not installed: `Command "eslint"/"prettier" not found`); Prettier was validated independently via `npx prettier --check` (passed), and the offline markdown-link + trailing-newline hooks passed.

Fixes #4114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or dependency behavior impact.
> 
> **Overview**
> Adds a **Getting Started** doc for adopters who need to test unreleased React on Rails in their own apps, surfacing workflows that previously lived mainly in `CONTRIBUTING.md`.
> 
> The new page covers **Git-based gem** setup (including OSS vs Pro `glob:` behavior), **npm monorepo subdirectory** installs (pnpm `path:`, Yarn Berry workspace, tarball/yalc fallbacks), why bare `owner/repo#ref` fails, and **version pairing** across related gems/packages. It links back to the contributor-oriented external-app testing section instead of duplicating local `path:` and dummy-app guidance.
> 
> **Navigation and discoverability:** the page is registered in `docs/sidebars.ts` after installation, cross-linked from the TanStack starter’s upstream-branch testing bullet in `examples-and-references.md`, and mirrored in `llms-full.txt`. **CONTRIBUTING.md** corrects the pnpm Git example to `github:shakacode/react_on_rails#main&path:…` (drops an invalid `/repo/` segment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411d3d501c447adb8b582dc2121a192ab5656d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Added a new “Consuming an Unreleased Build” guide for testing unreleased React on Rails directly from the Git monorepo, including Ruby gem Git branch installs, monorepo npm subdirectory consumption (pnpm/Yarn Berry), an npm tarball fallback, and an iterative `yalc` workflow.
* Added compatibility/version pairing guidance and explained why bare `owner/repo#ref` doesn’t work for these subdirectory packages.
* Linked the guide from existing recipes and included it in the Getting Started sidebar.
* Corrected a pnpm Git dependency snippet in CONTRIBUTING.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->