### PR TITLE
Fix pr-merge-ledger UTF-8 crash under non-UTF-8 locale

### DIFF
--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4909,6 +4909,159 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
+  # Regression: GitHub review/comment bodies from bot reviewers (coderabbitai,
+  # codex) routinely contain UTF-8 such as em-dashes and emoji. The script is a
+  # standalone tool run outside any bundle, so it resolves the Ruby-shipped json
+  # gem. Modern json (>= ~2.8) raises Encoding::InvalidByteSequenceError ("\xE2"
+  # on US-ASCII) when JSON.parse receives UTF-8 bytes tagged US-ASCII -- which is
+  # what happens under a non-UTF-8 locale (LANG/LC_ALL unset). The script must
+  # pin UTF-8 regardless of locale.
+  #
+  # These tests deliberately run the script with Bundler.with_unbundled_env so it
+  # uses the system json (the strict one users hit), not this suite's pinned json
+  # 2.7.2, which silently tolerates the mistagged bytes and would mask the bug.
+  # When the unbundled json is too old to be strict, the regression cannot be
+  # reproduced, so the test skips rather than passing as a no-op.
+  def ascii_locale_env
+    {
+      "LANG" => "C",
+      "LC_ALL" => "C",
+      "LC_CTYPE" => nil
+    }.freeze
+  end
+
+  def with_unbundled_env(&)
+    require "bundler"
+    Bundler.with_unbundled_env(&)
+  end
+
+  def unbundled_json_rejects_mistagged_utf8?
+    # {"k":"<em-dash>"} as raw UTF-8 bytes, deliberately mislabeled US-ASCII.
+    probe = <<~RUBY
+      require "json"
+      bytes = [0x7b, 0x22, 0x6b, 0x22, 0x3a, 0x22, 0xe2, 0x80, 0x94, 0x22, 0x7d]
+      mistagged = bytes.pack("C*").force_encoding("US-ASCII")
+      begin
+        JSON.parse(mistagged)
+        print "tolerant"
+      rescue EncodingError
+        print "strict"
+      end
+    RUBY
+    with_unbundled_env do
+      out, = Open3.capture2(ascii_locale_env, "ruby", "-e", probe)
+      out == "strict"
+    end
+  end
+
+  it "parses non-ASCII GraphQL review-thread bodies under a US-ASCII locale" do
+    skip "system json tolerates mistagged UTF-8; cannot reproduce" unless unbundled_json_rejects_mistagged_utf8?
+
+    fake_gh = <<~SH
+      #!/bin/sh
+      query=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|-F)
+            shift
+            case "$1" in
+              query=*) query=${1#query=} ;;
+            esac
+            ;;
+        esac
+        shift
+      done
+
+      if printf '%s' "$query" | grep -q 'files(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"number":1,"title":"PR 1","url":"https://example.com/pr/1","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"branch-1","headRefOid":"head-1","mergedAt":null,"reviewDecision":"APPROVED","files":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviewThreads'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"isOutdated":false,"path":"script/pr-merge-ledger","line":1,"comments":{"nodes":[{"id":"comment-1","databaseId":1,"body":"Consider this — it has an em-dash and an emoji 🎉 from coderabbitai.","author":{"login":"coderabbitai"},"url":"https://example.com/comment-1","path":"script/pr-merge-ledger","line":1,"createdAt":"2026-06-01T00:00:00Z","outdated":false,"commit":{"oid":"head-1"},"pullRequestReview":{"id":"review-1","state":"COMMENTED","submittedAt":"2026-06-01T00:00:00Z","commit":{"oid":"head-1"},"author":{"login":"coderabbitai"}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      elif printf '%s' "$query" | grep -q 'reviews(first'; then
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"reviews":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      else
+        cat <<'JSON'
+      {"data":{"repository":{"pullRequest":{"comments":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+      JSON
+      fi
+    SH
+
+    with_unbundled_env do
+      with_fake_gh(fake_gh) do |env|
+        stdout, stderr, status = Open3.capture3(
+          env.merge(ascii_locale_env),
+          script_path,
+          "1",
+          "--repo",
+          "shakacode/react_on_rails",
+          "--changelog-classification",
+          "not_user_visible",
+          chdir: repo_root
+        )
+
+        expect(status).to be_success, stderr
+        expect(stderr).not_to include("InvalidByteSequenceError")
+
+        report = JSON.parse(stdout)
+        excerpt = report.dig(
+          "pull_requests", 0, "unresolved_current_head_review_threads", "threads", 0, "body_excerpt"
+        )
+        expect(excerpt).to include("em-dash")
+        expect(excerpt).to include("—")
+        expect(excerpt).to include("🎉")
+      end
+    end
+  end
+
+  it "parses non-ASCII fixture bodies under a US-ASCII locale" do
+    skip "system json tolerates mistagged UTF-8; cannot reproduce" unless unbundled_json_rejects_mistagged_utf8?
+
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 4106,
+        "title" => "Wrap generated demo file paths — with em-dash 🎉",
+        "headRefOid" => "abc123",
+        "reviewDecision" => "APPROVED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [],
+      "comments" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-non-ascii", ".json"]) do |file|
+      file.binmode
+      file.write(JSON.generate(fixture).b)
+      file.flush
+
+      stdout, stderr, status = with_unbundled_env do
+        Open3.capture3(
+          ascii_locale_env,
+          script_path,
+          "--fixture",
+          file.path,
+          "--changelog-classification",
+          "not_user_visible",
+          "--strict",
+          chdir: repo_root
+        )
+      end
+
+      expect(status).to be_success, stderr
+      expect(stderr).not_to include("InvalidByteSequenceError")
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "title")).to include("—")
+      expect(report.dig("pull_requests", 0, "pr", "title")).to include("🎉")
+    end
+  end
+
   it "prints the fixed JSON schema" do
     stdout, stderr, status = Open3.capture3(script_path, "--schema", chdir: repo_root)
 

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4936,6 +4936,13 @@ RSpec.describe "script/pr-merge-ledger" do
   end
 
   def unbundled_json_rejects_mistagged_utf8?
+    # The probe result is process-wide (it only depends on the system json gem),
+    # so spawn at most one subprocess per suite run. RSpec runs each example in a
+    # fresh instance, so memoize on the example-group class -- which is shared --
+    # rather than an instance variable, which would not persist across examples.
+    memo = self.class.instance_variable_get(:@unbundled_json_rejects_mistagged_utf8)
+    return memo unless memo.nil?
+
     # {"k":"<em-dash>"} as raw UTF-8 bytes, deliberately mislabeled US-ASCII.
     probe = <<~RUBY
       require "json"
@@ -4948,10 +4955,11 @@ RSpec.describe "script/pr-merge-ledger" do
         print "strict"
       end
     RUBY
-    with_unbundled_env do
+    result = with_unbundled_env do
       out, = Open3.capture2(ascii_locale_env, "ruby", "-e", probe)
       out == "strict"
     end
+    self.class.instance_variable_set(:@unbundled_json_rejects_mistagged_utf8, result)
   end
 
   it "parses non-ASCII GraphQL review-thread bodies under a US-ASCII locale" do

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -4941,6 +4941,7 @@ RSpec.describe "script/pr-merge-ledger" do
     # fresh instance, so memoize on the example-group class -- which is shared --
     # rather than an instance variable, which would not persist across examples.
     memo = self.class.instance_variable_get(:@unbundled_json_rejects_mistagged_utf8)
+    # Three-state: nil = not probed yet, false = tolerant json, true = strict json.
     return memo unless memo.nil?
 
     # {"k":"<em-dash>"} as raw UTF-8 bytes, deliberately mislabeled US-ASCII.

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -6,6 +6,17 @@ require "open3"
 require "optparse"
 require "time"
 
+# GitHub returns UTF-8 (em-dashes, emoji, etc. from bot reviewers like
+# coderabbitai/codex), and our JSON fixtures are UTF-8. When the process runs
+# under a non-UTF-8 locale (e.g. LANG/LC_ALL unset, defaulting to US-ASCII),
+# both subprocess pipes and File.read would otherwise tag bytes as US-ASCII and
+# JSON.parse raises Encoding::InvalidByteSequenceError on the first multibyte
+# sequence. Pin the default external encoding to UTF-8 so the script is
+# encoding-robust regardless of locale. This must run before any Open3 pipe is
+# created or any file is read, since pipes inherit the default external encoding
+# at creation time.
+Encoding.default_external = Encoding::UTF_8
+
 # rubocop:disable Metrics/ClassLength
 class PrMergeLedger
   SCHEMA_VERSION = "pr-merge-ledger/v1"

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -9,7 +9,7 @@ require "time"
 # Pipes and File.read inherit the default external encoding at creation time, so
 # this must run before any Open3 call or file read. Without it, a non-UTF-8
 # locale (e.g. LANG/LC_ALL unset) leaves GitHub's UTF-8 bytes tagged US-ASCII and
-# JSON.parse raises on the first multibyte sequence. See PR #4123 for details.
+# JSON.parse raises on the first multibyte sequence.
 Encoding.default_external = Encoding::UTF_8
 
 # rubocop:disable Metrics/ClassLength

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -6,15 +6,10 @@ require "open3"
 require "optparse"
 require "time"
 
-# GitHub returns UTF-8 (em-dashes, emoji, etc. from bot reviewers like
-# coderabbitai/codex), and our JSON fixtures are UTF-8. When the process runs
-# under a non-UTF-8 locale (e.g. LANG/LC_ALL unset, defaulting to US-ASCII),
-# both subprocess pipes and File.read would otherwise tag bytes as US-ASCII and
-# JSON.parse raises Encoding::InvalidByteSequenceError on the first multibyte
-# sequence. Pin the default external encoding to UTF-8 so the script is
-# encoding-robust regardless of locale. This must run before any Open3 pipe is
-# created or any file is read, since pipes inherit the default external encoding
-# at creation time.
+# Pipes and File.read inherit the default external encoding at creation time, so
+# this must run before any Open3 call or file read. Without it, a non-UTF-8
+# locale (e.g. LANG/LC_ALL unset) leaves GitHub's UTF-8 bytes tagged US-ASCII and
+# JSON.parse raises on the first multibyte sequence. See PR #4123 for details.
 Encoding.default_external = Encoding::UTF_8
 
 # rubocop:disable Metrics/ClassLength


### PR DESCRIPTION
## Problem

`script/pr-merge-ledger` crashes with `Encoding::InvalidByteSequenceError: "\xE2" on US-ASCII` whenever a PR's GitHub review-thread or comment bodies contain non-ASCII UTF-8 bytes — em-dashes or emoji from bot reviewers like coderabbitai/codex.

Repro:
```
script/pr-merge-ledger 4106 --repo shakacode/react_on_rails --changelog-classification not_user_visible --strict --pretty
```

The crash traces to `JSON.parse` of the `gh api graphql` response (and equally `File.read` for `--fixture`). The only known workaround was `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 RUBYOPT="-Eutf-8"`.

## Root cause

When the process default external encoding is US-ASCII (LANG/LC_ALL unset), both the `Open3` subprocess pipes and `File.read` tag the captured UTF-8 bytes as US-ASCII, and `JSON.parse` raises on the first multibyte sequence.

This only surfaces with the strict `json` gem shipped in modern Ruby (the standalone script resolves the system default gem, json 2.19.x). The version pinned in the test bundle (json 2.7.2) silently tolerates the mistagged bytes — which is exactly why the existing suite never caught it (a local/CI parity gap).

## Fix

Pin `Encoding.default_external = Encoding::UTF_8` at startup, before any `Open3` pipe is created or any file is read, so the script is encoding-robust regardless of locale. Pipes inherit the default external encoding at creation time, so this single change covers both the GraphQL and fixture read paths.

## Tests

Two regression tests cover the GraphQL (`gh` subprocess) and fixture (`File.read`) paths under a forced US-ASCII locale. They deliberately run the script via `Bundler.with_unbundled_env` so it resolves the strict **system** `json` (the one users actually hit) instead of the suite's tolerant pinned `json` 2.7.2 that would mask the bug. When the available `json` is too old to be strict, they `skip` rather than passing as a no-op.

Verified the tests fail with the exact `InvalidByteSequenceError` when the fix is reverted, and pass with it. Full `pr_merge_ledger_script_spec.rb` suite (107 examples) green; RuboCop clean. Confirmed end-to-end against live GitHub under `LANG=C LC_ALL=C` with no encoding error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early encoding assignment in a standalone script with targeted regression tests; no auth, data, or merge-gate logic changes.
> 
> **Overview**
> Fixes **`script/pr-merge-ledger`** crashing with `Encoding::InvalidByteSequenceError` when GitHub review/comment bodies contain UTF-8 (em-dashes, emoji) and the process runs under a **US-ASCII locale** (`LANG=C`, unset `LC_ALL`). Under those conditions, **`Open3`** pipes and **`File.read`** mistag UTF-8 bytes as US-ASCII, and strict system **`json`** gems fail on **`JSON.parse`**.
> 
> The script now sets **`Encoding.default_external = Encoding::UTF_8`** at startup, **before** any subprocess pipe or fixture read, so both live GraphQL and **`--fixture`** paths stay locale-independent.
> 
> Adds **regression specs** that force a C locale and run the script via **`Bundler.with_unbundled_env`** (system **`json`**, not the suite’s tolerant pin). They **`skip`** when the environment cannot reproduce strict parsing; otherwise they assert success and preserved non-ASCII in output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9fc114a870ca433383efe6937e826c788c2e685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode handling in the PR merge ledger script by forcing UTF-8 encoding up front, reducing failures when PR data includes non-ASCII characters (e.g., emojis and em-dashes).

* **Tests**
  * Added regression coverage to verify the script correctly parses UTF-8 content under locale/encoding variations.
  * Ensures the ledger output includes the expected characters and that encoding-related errors are not emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->