### PR TITLE
Add canonical AI-agent prompts source (prompts.yml) (#3832 Part A)

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -56,6 +56,16 @@ prompts:
 - **`prompt`** — the verbatim body a user pastes. Use the `{{doc_url}}`
   placeholder anywhere the absolute docs URL should appear.
 
+### Versioning
+
+`schema_version` lets consumers (reactonrails.com#126, future tooling) react to
+structural changes:
+
+- **Bump it (breaking):** removing or renaming a field, changing a field's type,
+  or removing/renaming a category id or prompt id.
+- **Leave it (non-breaking):** adding optional fields, adding prompts or
+  categories, or editing prompt body / title text.
+
 ## Build-time URL resolution (single-source URLs)
 
 The absolute docs URL is **never hard-coded** in a prompt body. Consumers resolve
@@ -63,7 +73,7 @@ it at build time and substitute it for the placeholder:
 
 ```text
 doc_url = site_url + doc_route
-prompt_text = prompt.replace("{{doc_url}}", doc_url)
+prompt_text = prompt.replaceAll("{{doc_url}}", doc_url)   # replace ALL occurrences
 ```
 
 So the URL lives in exactly one place (`doc_route`) and cannot drift between the

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -1,0 +1,100 @@
+# Canonical AI-agent prompts (`prompts.yml`)
+
+[`prompts.yml`](./prompts.yml) is the single source of truth for the copy-able
+"paste into your AI agent" prompts that ground an assistant at the official
+React on Rails docs. [reactonrails.com](https://reactonrails.com) displays them
+(home Quick Start + the [`/prompts`](https://reactonrails.com/prompts) page) and
+publishes the machine-readable agent artifacts generated from this file.
+
+This is **Part A** of shakacode/react_on_rails#3832 (make the framework repo the
+canonical prompt source). The site-side sync + codegen that consumes this file is
+tracked in shakacode/reactonrails.com#126; the original site display shipped in
+shakacode/reactonrails.com#125. The empirical eval harness (Part B of #3832) is a
+separate initiative and is **not** part of this file.
+
+## Why the framework repo owns the prompts
+
+The prompts must move in lockstep with the framework's own docs, commands, and
+version requirements. Keeping them here (and having the site sync _from_ here)
+means a docs route rename or a version bump is a one-place change in the repo
+that already gates those docs, instead of drifting in a separate site constant.
+
+## Schema
+
+```yaml
+schema_version: 1
+site_url: https://reactonrails.com # canonical origin; matches the site's docusaurus url
+agent_note: <string> # one-liner shown once per surface
+
+categories: # display metadata, in display order
+  - id: <category-id>
+    eyebrow: <short label>
+    heading: <one-line heading>
+
+home_prompt_ids: # ordered subset for the home Quick Start
+  - <prompt-id>
+
+prompts:
+  - id: <stable-slug> # React key + selects the home subset; never reuse
+    title: <human title>
+    category: <one of categories[].id>
+    doc_route: <relative docs route> # e.g. /docs/pro/react-server-components
+    prompt: <prompt body, may contain {{doc_url}}>
+```
+
+### Field rules
+
+- **`id`** — stable slug. It is a public contract (React keys, `home_prompt_ids`,
+  per-prompt eval reports). Renaming one is a breaking change for downstream
+  consumers; prefer adding a new prompt.
+- **`category`** — must reference a `categories[].id`.
+- **`doc_route`** — a **relative** route only (starts with `/docs/`). This is the
+  single home for each prompt's URL.
+- **`prompt`** — the verbatim body a user pastes. Use the `{{doc_url}}`
+  placeholder anywhere the absolute docs URL should appear.
+
+## Build-time URL resolution (single-source URLs)
+
+The absolute docs URL is **never hard-coded** in a prompt body. Consumers resolve
+it at build time and substitute it for the placeholder:
+
+```
+doc_url = site_url + doc_route
+prompt_text = prompt.replace("{{doc_url}}", doc_url)
+```
+
+So the URL lives in exactly one place (`doc_route`) and cannot drift between the
+prompt text and the rendered "Open guide" link.
+
+## Artifact contract (consumed by reactonrails.com#126)
+
+From `prompts.yml`, the site is expected to generate:
+
+- **`prompts.json`** — the resolved prompt set (each prompt with `{{doc_url}}`
+  expanded and an absolute `doc_url` field), for programmatic / agent fetching.
+- **the site-published `llms.txt`** — the human-and-agent-readable prompt corpus
+  served at `https://reactonrails.com/llms.txt`.
+
+The site also regenerates its display component (`prompts.ts`) from this file so
+the live page matches the canonical set. This file does not itself emit those
+artifacts; generation lives with the consumer (the site, #126), and a future
+validator can assert round-trip fidelity.
+
+## `llms.txt` disambiguation
+
+There are two distinct `llms.txt` artifacts — do not conflate them:
+
+| Artifact                                    | Home           | Generated from                  | Purpose                                                          |
+| ------------------------------------------- | -------------- | ------------------------------- | ---------------------------------------------------------------- |
+| [`./llms.txt`](./llms.txt) (this repo root) | framework repo | `script/generate-llms-full.mjs` | machine-readable **doc route-map**, paired with `llms-full*.txt` |
+| `https://reactonrails.com/llms.txt`         | the website    | `prompts.yml` (this file)       | published **prompt corpus** for agents                           |
+
+The repo-root file is the framework's doc index; the site file is the prompt
+corpus. They share a filename and nothing else.
+
+## Editing prompts
+
+1. Edit `prompts.yml` (add/modify an entry; keep `id` stable).
+2. Use a **relative** `doc_route`; reference it in the body via `{{doc_url}}`.
+3. If adding a category, add it to `categories` first.
+4. The site (reactonrails.com#126) re-syncs and regenerates display + artifacts.

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -73,8 +73,13 @@ it at build time and substitute it for the placeholder:
 
 ```text
 doc_url = site_url + doc_route
-prompt_text = prompt.replaceAll("{{doc_url}}", doc_url)   # replace ALL occurrences
+prompt_text = prompt.replaceAll("{{doc_url}}", doc_url)   # ALL occurrences
 ```
+
+Use `replaceAll` (not a first-match `replace`): a body may reference
+`{{doc_url}}` more than once (e.g. an intro plus a closing "Full reference:
+{{doc_url}}"), and a first-match replace would silently leave the rest
+unresolved.
 
 So the URL lives in exactly one place (`doc_route`) and cannot drift between the
 prompt text and the rendered "Open guide" link.

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -24,7 +24,7 @@ that already gates those docs, instead of drifting in a separate site constant.
 ```yaml
 schema_version: 1
 site_url: https://reactonrails.com # canonical origin; matches the site's docusaurus url
-agent_note: <string> # one-liner shown once per surface
+agent_note: <string> # short description shown once per surface
 
 categories: # display metadata, in display order
   - id: <category-id>
@@ -100,4 +100,6 @@ corpus. They share a filename and nothing else.
 1. Edit `prompts.yml` (add/modify an entry; keep `id` stable).
 2. Use a **relative** `doc_route`; reference it in the body via `{{doc_url}}`.
 3. If adding a category, add it to `categories` first.
-4. The site (reactonrails.com#126) re-syncs and regenerates display + artifacts.
+4. Open a PR against the `reactonrails.com` repo to re-sync the site display and
+   regenerate artifacts (tracked in reactonrails.com#126; once that lands,
+   re-sync may be automated).

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -38,7 +38,7 @@ prompts:
   - id: <stable-slug> # React key + selects the home subset; never reuse
     title: <human title>
     category: <one of categories[].id>
-    doc_route: <relative docs route> # e.g. /docs/pro/react-server-components
+    doc_route: <relative docs route> # e.g. /docs/pro/react-server-components (may end in #fragment; quote if so)
     prompt: <prompt body, may contain {{doc_url}}>
 ```
 
@@ -48,8 +48,11 @@ prompts:
   per-prompt eval reports). Renaming one is a breaking change for downstream
   consumers; prefer adding a new prompt.
 - **`category`** — must reference a `categories[].id`.
-- **`doc_route`** — a **relative** route only (starts with `/docs/`). This is the
-  single home for each prompt's URL.
+- **`doc_route`** — a **relative** route only (starts with `/docs/`), optionally
+  ending in a `#fragment` anchor (e.g.
+  `/docs/api-reference/ruby-api-pro#async_react_component...`). This is the
+  single home for each prompt's URL. Quote any value containing `#` in YAML so
+  the fragment is never mistaken for a comment.
 - **`prompt`** — the verbatim body a user pastes. Use the `{{doc_url}}`
   placeholder anywhere the absolute docs URL should appear.
 
@@ -58,7 +61,7 @@ prompts:
 The absolute docs URL is **never hard-coded** in a prompt body. Consumers resolve
 it at build time and substitute it for the placeholder:
 
-```
+```text
 doc_url = site_url + doc_route
 prompt_text = prompt.replace("{{doc_url}}", doc_url)
 ```

--- a/prompts.yml
+++ b/prompts.yml
@@ -57,7 +57,7 @@ home_prompt_ids:
   - create-app
   - install-existing
 
-# The 11 canonical prompts, grouped by category in display order. Bodies are
+# The canonical prompts, grouped by category in display order. Bodies are
 # transcribed verbatim from the live site source (reactonrails.com
 # prototypes/docusaurus/src/constants/prompts.ts) with the inline absolute URL
 # replaced by the `{{doc_url}}` placeholder.

--- a/prompts.yml
+++ b/prompts.yml
@@ -91,8 +91,7 @@ prompts:
   - id: async-rendering
     title: Use async/Suspense rendering
     category: server-rendering
-    # Quoted because the value contains a '#' fragment anchor; unquoted it parses
-    # correctly (the '#' is not whitespace-preceded) but quoting makes that explicit.
+    # doc_route contains a '#' fragment anchor — must be quoted in YAML.
     doc_route: "/docs/api-reference/ruby-api-pro#async_react_componentcomponent_name-options--"
     prompt: "Set up async (Suspense) rendering for a React on Rails component. Follow {{doc_url}} exactly."
 

--- a/prompts.yml
+++ b/prompts.yml
@@ -91,7 +91,9 @@ prompts:
   - id: async-rendering
     title: Use async/Suspense rendering
     category: server-rendering
-    doc_route: /docs/api-reference/ruby-api-pro#async_react_componentcomponent_name-options--
+    # Quoted because the value contains a '#' fragment anchor; unquoted it parses
+    # correctly (the '#' is not whitespace-preceded) but quoting makes that explicit.
+    doc_route: "/docs/api-reference/ruby-api-pro#async_react_componentcomponent_name-options--"
     prompt: "Set up async (Suspense) rendering for a React on Rails component. Follow {{doc_url}} exactly."
 
   # --- migrate ---

--- a/prompts.yml
+++ b/prompts.yml
@@ -1,0 +1,134 @@
+# Canonical AI-agent prompts for React on Rails.
+#
+# This file is the SINGLE SOURCE OF TRUTH for the copy-able "paste into your AI
+# agent" prompts shown on reactonrails.com (home Quick Start + the /prompts
+# page). reactonrails.com syncs FROM this file and generates its display plus the
+# public agent artifacts (prompts.json and the site's published llms.txt). See
+# PROMPTS.md for the full schema and artifact contract.
+#
+# Why this lives in the framework repo: the prompts must stay in lockstep with
+# the framework's own docs and versions, so the framework repo owns them and the
+# site is a downstream consumer. Tracking: shakacode/react_on_rails#3832 (Part A);
+# site sync/codegen: shakacode/reactonrails.com#126; original display: #125.
+#
+# IMPORTANT — single-source URLs: each prompt stores only a relative `doc_route`.
+# The absolute docs URL is resolved at build time as `site_url + doc_route` and
+# substituted into the prompt body wherever the `{{doc_url}}` placeholder
+# appears, so the URL lives in exactly one place and cannot drift between the
+# prompt text and the "Open guide" link.
+#
+# NOTE — do not confuse this with the repo-root ./llms.txt: that file is the
+# framework's machine-readable doc route-map (paired with llms-full*.txt). The
+# prompt-corpus llms.txt referenced by #3832 is a DIFFERENT, site-published
+# artifact generated from this file. See PROMPTS.md → "llms.txt disambiguation".
+
+schema_version: 1
+
+# Canonical site origin; matches `url` in reactonrails.com docusaurus.config.ts.
+site_url: https://reactonrails.com
+
+# Shown once per surface (home Quick Start + /prompts hero).
+agent_note: >-
+  Paste into Cursor, Claude Code, Copilot, or any AI assistant. Each prompt
+  points the agent at the official docs so it doesn't guess.
+
+# Category display metadata, in site display order. The site renders one group
+# per category on /prompts using `eyebrow` + `heading`.
+categories:
+  - id: get-started
+    eyebrow: Get started
+    heading: Spin up React on Rails.
+  - id: server-rendering
+    eyebrow: Server rendering
+    heading: "Render on the server: RSC, SSR, streaming."
+  - id: migrate
+    eyebrow: Migrate
+    heading: Move an existing setup to React on Rails.
+  - id: features
+    eyebrow: Build features
+    heading: Add common capabilities.
+  - id: production
+    eyebrow: Optimize & go to production
+    heading: Tune performance and ship with Pro.
+
+# Ordered subset surfaced in the home Quick Start (RSC first — the marquee).
+home_prompt_ids:
+  - turn-on-rsc
+  - create-app
+  - install-existing
+
+# The 11 canonical prompts, grouped by category in display order. Bodies are
+# transcribed verbatim from the live site source (reactonrails.com
+# prototypes/docusaurus/src/constants/prompts.ts) with the inline absolute URL
+# replaced by the `{{doc_url}}` placeholder.
+prompts:
+  # --- get-started ---
+  - id: create-app
+    title: Start a new app
+    category: get-started
+    doc_route: /docs/getting-started/create-react-on-rails-app
+    prompt: "Set up a new Rails app with React on Rails, using TypeScript and server-side rendering. Follow the official guide at {{doc_url}} and use the exact commands and versions it specifies — don't improvise."
+
+  - id: install-existing
+    title: Add to an existing Rails app
+    category: get-started
+    doc_route: /docs/getting-started/existing-rails-app
+    prompt: "Add React on Rails to my existing Rails app with TypeScript, keeping my current routes and conventions. Follow {{doc_url}} and don't change any gem or package versions it doesn't tell you to."
+
+  # --- server-rendering ---
+  - id: turn-on-rsc
+    title: Turn on React Server Components
+    category: server-rendering
+    doc_route: /docs/pro/react-server-components
+    prompt: "Turn on React Server Components in my React on Rails app (no license required). Follow {{doc_url}} exactly, including the renderer and packer setup it specifies."
+
+  - id: streaming-ssr
+    title: Add streaming SSR
+    category: server-rendering
+    doc_route: /docs/pro/streaming-ssr
+    prompt: "Add streaming server-side rendering to my React on Rails app. Follow {{doc_url}} exactly and don't change versions it doesn't ask you to."
+
+  - id: async-rendering
+    title: Use async/Suspense rendering
+    category: server-rendering
+    doc_route: /docs/api-reference/ruby-api-pro#async_react_componentcomponent_name-options--
+    prompt: "Set up async (Suspense) rendering for a React on Rails component. Follow {{doc_url}} exactly."
+
+  # --- migrate ---
+  - id: migrate-react-rails
+    title: Migrate from react-rails
+    category: migrate
+    doc_route: /docs/migrating/migrating-from-react-rails
+    prompt: "Migrate my app from react-rails to React on Rails, keeping my existing components working. Follow {{doc_url}} and don't skip any step it lists."
+
+  # --- features ---
+  - id: code-splitting
+    title: Add code splitting
+    category: features
+    doc_route: /docs/building-features/code-splitting
+    prompt: "Add code splitting / lazy loading to my React on Rails components. Follow {{doc_url}} exactly."
+
+  # --- production ---
+  - id: oss-vs-pro
+    title: Evaluate OSS vs Pro
+    category: production
+    doc_route: /docs/getting-started/oss-vs-pro
+    prompt: "Review my React on Rails setup and tell me whether OSS or Pro fits my workload, citing the tradeoffs. Base your answer on {{doc_url}}."
+
+  - id: node-renderer
+    title: Set up the Node renderer
+    category: production
+    doc_route: /docs/pro/node-renderer
+    prompt: "Set up the React on Rails Pro Node renderer for server rendering. Follow {{doc_url}} exactly, including the configuration it specifies."
+
+  - id: fragment-caching
+    title: Add fragment caching
+    category: production
+    doc_route: /docs/pro/fragment-caching
+    prompt: "Add fragment caching to my server-rendered React on Rails components. Follow {{doc_url}} exactly."
+
+  - id: upgrade-to-pro
+    title: Get a production license / upgrade to Pro
+    category: production
+    doc_route: /docs/pro/upgrading-to-pro
+    prompt: "Walk me through upgrading my React on Rails app to Pro and getting a production license. Follow {{doc_url}}."


### PR DESCRIPTION
## Why

Make `react_on_rails` the **canonical source** of the 11 "paste-into-your-AI-agent" prompts that ground an assistant at the official docs. reactonrails.com already ships these prompts (home Quick Start + `/prompts`, shakacode/reactonrails.com#125), but the source-of-truth currently lives in a site constant. The prompts must move in lockstep with the framework's own docs/commands/versions, so the framework repo should own them and the site should sync *from* here (site sync/codegen tracked in shakacode/reactonrails.com#126).

This is **Part A** of #3832. Part B (the empirical eval harness) and the site-side codegen are explicitly out of scope.

## What

- **`prompts.yml`** — the canonical source: all 11 prompts (`id`, `title`, `category`, `doc_route`, `prompt`), category display metadata, and the home Quick Start subset.
  - Bodies are transcribed **verbatim** from the live, merged site source (`reactonrails.com` `prototypes/docusaurus/src/constants/prompts.ts` @ `main`), so generated output matches what's already live.
  - **Single-source URLs:** each prompt stores only a *relative* `doc_route`; the body references the docs URL via a `{{doc_url}}` placeholder resolved at build time as `site_url + doc_route`. The URL lives in exactly one place and can't drift between prompt text and the "Open guide" link — exactly as #3832 specifies.
- **`PROMPTS.md`** — schema, the build-time URL-resolution contract, the artifact contract the site generates (`prompts.json` + the site-published `llms.txt`), and explicit **disambiguation** from the repo-root `./llms.txt` (the framework doc route-map — a different artifact that happens to share a filename).

## Validation

- `ruby -ryaml` schema check: 11 prompts, 5 categories, home subset of 3, unique ids, every `category` declared, every `doc_route` relative + present, every body contains `{{doc_url}}`; sample resolution verified.
- `npx prettier --check PROMPTS.md prompts.yml` — clean (`*.yml` is prettier-ignored by repo config).
- `node script/generate-llms-full.mjs --check` — clean (root files are not under `docs/`, so the llms-full layer is untouched).
- Pre-commit hooks (markdown-links, trailing-newlines, prettier) — passed.
- `codex review --base origin/main` — no actionable issues; independently confirmed schema consistency and that `doc_route` values match published routes.

## Codex Decision Log

- **Non-blocking:** the batch plan suggested stubbing prompt bodies as TODO placeholders "pending the reactonrails.com#125 source."
  - **Decision:** seeded the real verbatim bodies instead.
  - **Why:** the source (`prompts.ts`) is merged and fetchable, and "seed it from the 11 prompts currently shipped so the site's generated output matches what's already live" is an explicit #3832 acceptance criterion. Real bodies make the file actually canonical; stubs would not.
  - **Review later:** None — bodies are a verbatim transcription; re-sync if the site constant changes before #126 wires the reverse sync.
- **Non-blocking:** file location.
  - **Decision:** `prompts.yml` + `PROMPTS.md` at repo root.
  - **Why:** mirrors the existing root-level machine-readable layer (`llms.txt`, `llms-full*.txt`, `AGENTS_USER_GUIDE.md`) and keeps the new files out of `docs/` so they don't feed llms-full generation.
  - **Review later:** if a future home (e.g. alongside Part B's `prompt-evals/`) is preferred.

## Follow-ups (not in this PR)

- reactonrails.com#126: consume `prompts.yml` — generate `prompts.json` + the published `llms.txt`, regenerate the display constant, and add a round-trip validator.
- #3832 Part B: the empirical eval harness.

Refs #3832

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and YAML metadata only; no runtime, auth, or build pipeline changes in this repo.
> 
> **Overview**
> Introduces **`prompts.yml`** as the framework repo’s single source of truth for the 11 copy-paste AI-agent prompts (plus category metadata and the home Quick Start `home_prompt_ids`), with prompt bodies using **`{{doc_url}}`** and relative **`doc_route`** values instead of hard-coded URLs.
> 
> Adds **`PROMPTS.md`** documenting the YAML schema, `schema_version` rules, build-time URL resolution (`site_url + doc_route`), expected downstream artifacts (`prompts.json`, site `llms.txt`, `prompts.ts`), and how that site file differs from repo-root **`llms.txt`**.
> 
> No application or gem code changes; site sync/codegen is explicitly deferred to reactonrails.com#126.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61da8528e4b2d73d7412220d8230db3b21b64989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `PROMPTS.md` with the canonical “paste into your AI agent” prompt specification, including the full prompt schema, category structure, and formatting/substitution rules (e.g., `doc_route` fragments and `{{doc_url}}` behavior).
  * Introduced `prompts.yml` as the single source of prompt metadata, covering both the Quick Start prompt set and the complete prompt collection.
  * Documented expected generated/published outputs (`prompts.json` and the website `llms.txt`) and the repo vs. website `llms.txt` difference, plus the update/re-sync workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->