### PR TITLE
Local benchmark runner: raise server-boot timeout for slower machines (#4073)

### DIFF
--- a/benchmarks/run-local-benchmark.rb
+++ b/benchmarks/run-local-benchmark.rb
@@ -34,6 +34,12 @@ SERVER_PORT = 3001
 # Rails reaches it at REACT_RENDERER_URL. Pin both so a local override/stale renderer can't
 # desync them (see the pro server env + preflight below).
 RENDERER_PORT = 3800
+# How long to wait for the production server (and, for pro, the renderer) to bind. A cold
+# production Puma boot eager-loads the whole app before listening, which is slow on the first
+# run after a fresh build — observed ~83s on a 2021 M1 Max, vs ~2s warm. wait_for_port still
+# checks the process is alive each second, so a real crash fails fast; this generous ceiling
+# only affects a slow-but-alive boot. Override with BENCHMARK_SERVER_BOOT_TIMEOUT if needed.
+SERVER_BOOT_TIMEOUT = Integer(ENV.fetch("BENCHMARK_SERVER_BOOT_TIMEOUT", "240"))
 
 # Match CI, which runs benchmarks on the MINIMUM supported Ruby ("Ruby stays on minimum to
 # exercise gem compatibility"), not the repo's default. The default .tool-versions Ruby can
@@ -140,15 +146,15 @@ end
 
 def wait_for_port(pid, port, label)
   attempt = 0
-  while attempt < 30
+  while attempt < SERVER_BOOT_TIMEOUT
     raise "#{label} (pid #{pid}) exited during startup" unless process_alive?(pid)
     return if port_open?(port)
 
     attempt += 1
-    puts "  attempt #{attempt}/30: #{label} (port #{port}) not ready yet..."
+    puts "  attempt #{attempt}/#{SERVER_BOOT_TIMEOUT}: #{label} (port #{port}) not ready yet..."
     sleep 1
   end
-  raise "#{label} failed to start within 30s"
+  raise "#{label} failed to start within #{SERVER_BOOT_TIMEOUT}s"
 end
 
 def port_open?(port)

--- a/benchmarks/run-local-benchmark.rb
+++ b/benchmarks/run-local-benchmark.rb
@@ -39,7 +39,12 @@ RENDERER_PORT = 3800
 # run after a fresh build — observed ~83s on a 2021 M1 Max, vs ~2s warm. wait_for_port still
 # checks the process is alive each second, so a real crash fails fast; this generous ceiling
 # only affects a slow-but-alive boot. Override with BENCHMARK_SERVER_BOOT_TIMEOUT if needed.
-SERVER_BOOT_TIMEOUT = Integer(ENV.fetch("BENCHMARK_SERVER_BOOT_TIMEOUT", "240"))
+SERVER_BOOT_TIMEOUT = ENV.fetch("BENCHMARK_SERVER_BOOT_TIMEOUT", "240").then do |raw|
+  seconds = Integer(raw, exception: false)
+  next seconds if seconds&.positive?
+
+  abort "BENCHMARK_SERVER_BOOT_TIMEOUT must be a positive integer (seconds); got #{raw.inspect}."
+end
 
 # Match CI, which runs benchmarks on the MINIMUM supported Ruby ("Ruby stays on minimum to
 # exercise gem compatibility"), not the repo's default. The default .tool-versions Ruby can


### PR DESCRIPTION
## Why

Setting up the dedicated M1 nightly (#4073) surfaced a real bug: the local benchmark runner's `wait_for_port` had a **hardcoded 30s** server-boot timeout. A cold production Puma boot eager-loads the whole app before it starts listening, which took **~83–96s on a 2021 M1 Max** (vs ~2s warm on the M5). So the nightly failed at server startup:

```
=> Booting Puma
=> Rails 7.1.5.2 application starting in production
... attempt 30/30: Rails server (port 3001) not ready yet...
Rails server failed to start within 30s (RuntimeError)
```

A manual boot confirmed the server is healthy — it just binds slowly (`Listening on http://0.0.0.0:3001` after 83s).

## What

Make the ceiling generous and configurable:
- `SERVER_BOOT_TIMEOUT` default **240s** (env override `BENCHMARK_SERVER_BOOT_TIMEOUT`).
- `wait_for_port` still checks the process is alive every second, so a real crash still fails fast — the larger window only affects a slow-but-alive boot.

## Validation

- `ruby -c` + `rubocop` clean; constant resolves (default 240, override honored).
- **Confirmed on the M1**: with the fix, the server now binds at attempt 96/240 ("✅ server ready") and the run proceeds to benchmarking.
- `codex review` → no findings.

Surgical diff: 1 file, +9/−3. Relates to #4073.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only runner script; no production app, auth, or data-path changes.
> 
> **Overview**
> Fixes false failures when the local benchmark runner starts a cold production Puma server: the **30s** hard cap in `wait_for_port` is replaced with **`SERVER_BOOT_TIMEOUT`**, default **240s**, overridable via **`BENCHMARK_SERVER_BOOT_TIMEOUT`** (invalid values abort with a clear message).
> 
> Progress and failure messages now use that limit instead of `30`. The per-second “process still alive” check is unchanged, so a crashed server still fails quickly; only slow-but-successful boots get more time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5dda22f903cf9d46fac87f3b04e09aba5c0a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved benchmark startup reliability by waiting longer for the server to become available instead of using a short fixed timeout.
* **Chores**
  * Increased the default server boot timeout to 240 seconds, with an environment-variable override for customized runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->