### PR TITLE
Document batch audit issue coverage

### DIFF
--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -67,11 +67,13 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    rows marked `UNKNOWN`, and report the batch metadata correction needed before
    reducing the audit to the merged-PR range only.
 
-5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to
-   PRs through coordination branch names, linked PRs, PR bodies, labels,
-   comments, authors, merge timing, and git history. Keep PR-range inclusion
-   separate from worked-issue coverage so no-PR, blocked, parked, and unmerged
-   lanes are still evaluated.
+5. Batch PR subset: only when `worked_issue_scope` is verified from
+   coordination state, map worked issues to PRs through coordination branch
+   names, linked PRs, PR bodies, labels, comments, authors, merge timing, and
+   git history. Treat `not applicable`, `UNKNOWN (...)`, and `empty (...)` as
+   merged-PR-range-only or advisory scope states, not verified batch subsets.
+   Keep PR-range inclusion separate from worked-issue coverage so no-PR,
+   blocked, parked, and unmerged lanes are still evaluated.
 
 Show included worked issues, included PRs, excluded near-matches, base/head SHAs, coordination status evidence, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.
 

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -38,10 +38,12 @@ For private coordination backend setup and CLI discovery, see
 3. Merged PR list: every PR merged between base and head.
 4. Worked issue list: when a batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
    then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
-   primary worked-issue scope. If `agent-coord` is missing, unavailable, or either command fails,
-   record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
-   completeness from merged PRs.
-5. Batch PR subset: map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.
+   primary worked-issue scope. If `agent-coord` is missing or `agent-coord doctor` fails,
+   record `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
+   `agent-coord doctor` passes but `agent-coord status` fails, record
+   `worked_issue_scope: UNKNOWN (access)` with the exact command/error. In both cases,
+   continue with merged PR range evidence only and do not infer completeness from merged PRs.
+5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.
 
 Show included worked issues, included PRs, excluded near-matches, base/head SHAs, coordination status evidence, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.
 

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -36,9 +36,9 @@ For private coordination backend setup and CLI discovery, see
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.
 3. Merged PR list: every PR merged between base and head.
-4. Worked issue list: when a batch/run id is known, run `agent-coord doctor` and
-   `agent-coord status`, then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
-   primary worked-issue scope. If `agent-coord` is missing, unavailable, or the status command fails,
+4. Worked issue list: when a batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
+   then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
+   primary worked-issue scope. If `agent-coord` is missing, unavailable, or either command fails,
    record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
    completeness from merged PRs.
 5. Batch PR subset: map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -30,13 +30,16 @@ When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-au
 
 The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Open finding markers create carry-over PRs that are subtracted from `to_audit`; closed markers remain fingerprint context only. Use the output as the initial merged-PR scope table, then verify assumptions before deep audit.
 
-For private coordination backend setup and CLI discovery, see
-`internal/contributor-info/agent-coordination-backend.md`.
-
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.
 3. Merged PR list: every PR merged between base and head.
-4. Worked issue list: when a batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
+4. Worked issue list: for private coordination backend setup and CLI discovery,
+   see `internal/contributor-info/agent-coordination-backend.md`. If no
+   coordinated batch/run is in scope, record `worked_issue_scope: not
+applicable`. If batch work is in scope but the batch/run id is unknown, run
+   `agent-coord doctor` then `agent-coord status` to list candidate batch/run
+   ids and lanes, but ask for confirmation before treating any candidate as the
+   worked-issue scope. When a batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
    then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
    primary worked-issue scope. If `agent-coord` is missing or `agent-coord doctor` fails,
    record `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -52,6 +52,11 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    fallback for possible no-PR, blocked, parked, or done-unmerged lanes before
    reducing scope to merged PRs. Keep advisory rows marked `UNKNOWN` as needed,
    and do not infer confirmed completeness from merged PRs.
+   If `agent-coord doctor` and `agent-coord status` both succeed but the named
+   batch entry contains no worked issues or lanes, record
+   `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
+   continue with the merged-PR range only, and report the batch metadata
+   correction needed.
 5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.
 
 Show included worked issues, included PRs, excluded near-matches, base/head SHAs, coordination status evidence, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.
@@ -149,13 +154,17 @@ The audit should usually produce an issue plan for non-OK findings, but not crea
   checked.
 - **Changelog only**: for missing changelog entries; prefer one bundled changelog issue or a recommendation to run `/update-changelog`, not one issue per entry.
 - **One child issue**: for each independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
-- **Parent issue**: create one parent issue only to group two or more related _child fix_ issues from the
-  same audit. Do **not** create a standalone audit-snapshot tracker (a `Post-<range> audit` /
-  `Post-rc.N catch-up audit` issue): per `AGENTS.md` → _Tracking Issues And Handoffs_, the audit
-  report is a point-in-time snapshot — append it to the standing release audit ledger in place, and
-  include that ledger comment URL in every approved parent or child issue created from the audit.
-  Genuine non-OK findings still become real child issues; only the snapshot/report is what goes to
-  the ledger instead of a new issue.
+- **Parent issue**: create one parent issue only to group two or more related
+  _child fix_ issues from the same audit. Do **not** create a standalone
+  audit-snapshot tracker (a `Post-<range> audit` / `Post-rc.N catch-up audit`
+  issue): per `AGENTS.md` → _Tracking Issues And Handoffs_, the audit report is
+  a point-in-time snapshot. For release-gate audits, append that snapshot to the
+  standing release audit ledger in place and include the ledger comment URL in
+  every approved parent or child issue created from the audit. For non-release
+  audits with no release-gate ledger, record
+  `Audit ledger: not applicable (non-release audit)` in every approved parent or
+  child issue. Genuine non-OK findings still become real child issues; only the
+  snapshot/report is what goes to the ledger instead of a new issue.
 
 For process findings, the issue plan must include a Process Gap Disposition
 before issue creation:

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -54,11 +54,13 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
    `agent-coord doctor` passes but
    `agent-coord status` fails, record `worked_issue_scope: UNKNOWN (access)`
-   with the exact command/error. In both UNKNOWN cases, use structured public
-   `codex-claim` comments as an advisory fallback for possible no-PR, blocked,
-   parked, or done-unmerged lanes before reducing scope to merged PRs. Keep
-   advisory rows marked `UNKNOWN` as needed, and do not infer confirmed
-   completeness from merged PRs.
+   with the exact command/error. A structured public `codex-claim` comment is a
+   GitHub issue/PR comment containing a `codex-claim` JSON block in the format
+   documented by `internal/contributor-info/agent-coordination-backend.md`. In
+   both UNKNOWN cases, use structured public `codex-claim` comments as an
+   advisory fallback for possible no-PR, blocked, parked, or done-unmerged lanes
+   before reducing scope to merged PRs. Keep advisory rows marked `UNKNOWN` as
+   needed, and do not infer confirmed completeness from merged PRs.
 
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
@@ -68,7 +70,11 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    rows marked `UNKNOWN`, report the batch metadata correction needed, and ask
    for confirmation before reducing the audit to the merged-PR range only. If
    the user confirms no lanes were worked, record the empty-batch finding and
-   proceed to the merged-PR range.
+   proceed to the merged-PR range. If the user indicates lanes were worked
+   despite the empty entry, record
+   `worked_issue_scope: UNKNOWN (empty batch, lanes expected)`, collect a manual
+   lane list from the user or advisory `codex-claim` comments, and keep
+   recovered rows advisory `UNKNOWN` until coordination state is corrected.
 
 5. Batch PR subset: only when `worked_issue_scope` is verified from
    coordination state, map worked issues to PRs through coordination branch

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -22,6 +22,10 @@ Use `.agents/workflows/post-merge-audit.md` for reusable copy-paste prompts, inc
 Start by resolving the exact audit range and, when auditing a named agent
 batch/run, the exact worked-issue scope:
 
+Term: a structured public `codex-claim` comment is a GitHub issue/PR comment
+containing a `codex-claim` JSON block in the "Public claim comment" format from
+`.agents/workflows/pr-processing.md`.
+
 When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-audit-scope`, run it first:
 
 ```bash
@@ -54,13 +58,11 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
    `agent-coord doctor` passes but
    `agent-coord status` fails, record `worked_issue_scope: UNKNOWN (access)`
-   with the exact command/error. A structured public `codex-claim` comment is a
-   GitHub issue/PR comment containing a `codex-claim` JSON block in the format
-   documented by `internal/contributor-info/agent-coordination-backend.md`. In
-   both UNKNOWN cases, use structured public `codex-claim` comments as an
-   advisory fallback for possible no-PR, blocked, parked, or done-unmerged lanes
-   before reducing scope to merged PRs. Keep advisory rows marked `UNKNOWN` as
-   needed, and do not infer confirmed completeness from merged PRs.
+   with the exact command/error. In both UNKNOWN cases, use structured public
+   `codex-claim` comments as an advisory fallback for possible no-PR, blocked,
+   parked, or done-unmerged lanes before reducing scope to merged PRs. Keep
+   advisory rows marked `UNKNOWN` as needed, and do not infer confirmed
+   completeness from merged PRs.
 
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
@@ -174,11 +176,11 @@ lane was evaluated, even when the issue produced no merged PR:
 The audit should usually produce an issue plan for non-OK findings, but not create issues until approval.
 
 - **No issue**: for `OK`, duplicate findings, findings fully resolved by the
-  audit evidence, or healthy `in_progress` lanes; include `in_progress` lanes
-  in the worked-issue coverage table so the coordinator can see they were
-  checked.
+  audit evidence, evidenced `realized` lanes, or healthy `in_progress` lanes;
+  include `realized` and `in_progress` lanes in the worked-issue coverage table
+  so the coordinator can see they were checked.
 - **Changelog only**: for missing changelog entries; prefer one bundled changelog issue or a recommendation to run `/update-changelog`, not one issue per entry.
-- **One child issue**: for each independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
+- **One child issue**: for each independently actionable fix PR, revert consideration, maintainer question, follow-up task, or non-OK worked-issue outcome (`partial`, `missed`, `regressed`, or `unknown`) that needs follow-up.
 - **Parent issue**: create one parent issue only to group two or more related
   _child fix_ issues from the same audit. Do **not** create a standalone
   audit-snapshot tracker (a `Post-<range> audit` / `Post-rc.N catch-up audit`

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -217,7 +217,8 @@ Return high-risk findings first, then:
 4. A deduped issue plan with parent/child recommendations and fingerprints.
 5. A worked-issue coverage table with issue number, coordination lane/branch,
    linked PR or no-PR/blocker evidence, final state, intent-achievement
-   classification, and `UNKNOWN` facts.
+   classification, and `UNKNOWN` facts (see the example in
+   `.agents/workflows/post-merge-audit.md`).
 6. A PR-by-PR table.
 7. Exact commands and data sources used, including `agent-coord status` output
    for the named batch or the exact reason coordination state was `UNKNOWN`.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -35,17 +35,23 @@ The resolver is read-only. It resolves the default release-candidate base, the h
 3. Merged PR list: every PR merged between base and head.
 4. Worked issue list: for private coordination backend setup and CLI discovery,
    see `internal/contributor-info/agent-coordination-backend.md`. If no
-   coordinated batch/run is in scope, record `worked_issue_scope: not
-applicable`. If batch work is in scope but the batch/run id is unknown, run
+   coordinated batch/run is in scope, record
+   `worked_issue_scope: not applicable`. If batch work is in scope but the
+   batch/run id is unknown, record
+   `worked_issue_scope: UNKNOWN (needs batch confirmation)`, run
    `agent-coord doctor` then `agent-coord status` to list candidate batch/run
-   ids and lanes, but ask for confirmation before treating any candidate as the
-   worked-issue scope. When a batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
-   then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
-   primary worked-issue scope. If `agent-coord` is missing or `agent-coord doctor` fails,
-   record `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
+   ids and lanes, and ask for confirmation before treating any candidate as the
+   worked-issue scope. When a batch/run id is known, run `agent-coord doctor`
+   then `agent-coord status`, then inspect the named batch entry; use claims,
+   heartbeats, and batch metadata as the primary worked-issue scope. If
+   `agent-coord` is missing or `agent-coord doctor` fails, record
+   `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
    `agent-coord doctor` passes but `agent-coord status` fails, record
-   `worked_issue_scope: UNKNOWN (access)` with the exact command/error. In both cases,
-   continue with merged PR range evidence only and do not infer completeness from merged PRs.
+   `worked_issue_scope: UNKNOWN (access)` with the exact command/error. In both
+   UNKNOWN cases, use structured public `codex-claim` comments as an advisory
+   fallback for possible no-PR, blocked, parked, or done-unmerged lanes before
+   reducing scope to merged PRs. Keep advisory rows marked `UNKNOWN` as needed,
+   and do not infer confirmed completeness from merged PRs.
 5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.
 
 Show included worked issues, included PRs, excluded near-matches, base/head SHAs, coordination status evidence, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -19,7 +19,8 @@ Use `.agents/workflows/post-merge-audit.md` for reusable copy-paste prompts, inc
 
 ## Scope Gate
 
-Start by resolving the exact audit range:
+Start by resolving the exact audit range and, when auditing a named agent
+batch/run, the exact worked-issue scope:
 
 When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-audit-scope`, run it first:
 
@@ -27,14 +28,19 @@ When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-au
 .agents/skills/post-merge-audit/bin/post-merge-audit-scope --json
 ```
 
-The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Open finding markers create carry-over PRs that are subtracted from `to_audit`; closed markers remain fingerprint context only. Use the output as the initial scope table, then verify assumptions before deep audit.
+The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Open finding markers create carry-over PRs that are subtracted from `to_audit`; closed markers remain fingerprint context only. Use the output as the initial merged-PR scope table, then verify assumptions before deep audit.
 
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.
 3. Merged PR list: every PR merged between base and head.
-4. Batch subset: PRs that appear to be from agent batch work by branch name, PR body, labels, comments, author, merge timing, or linked issues.
+4. Worked issue list: when a batch/run id is known, run `agent-coord status` after `agent-coord
+doctor`, then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
+   primary worked-issue scope. If `agent-coord` is missing, unavailable, or the status command fails,
+   record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
+   completeness from merged PRs.
+5. Batch PR subset: map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.
 
-Show included PRs, excluded near-matches, base/head SHAs, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.
+Show included worked issues, included PRs, excluded near-matches, base/head SHAs, coordination status evidence, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.
 
 ## Audit Checks
 
@@ -55,6 +61,25 @@ For each included PR:
 - Validation: compare changed areas with the validation evidence in the PR body or comments.
 - Cross-PR interactions: compare changed files, shared behavior, assumptions, and release-sensitive areas across the batch.
 - Decision log: inspect any `Codex Decision Log` or equivalent section and verify the decisions still hold after the merge.
+
+For each worked issue from coordination state, including no-PR, blocked,
+parked, done-unmerged, or still-open lanes:
+
+- Intent coverage: compare the issue intent and acceptance criteria with the PR
+  diff, no-PR evidence comment, branch state, or blocker note.
+- Final state: verify whether the issue was merged, closed, parked, blocked,
+  left open intentionally, or remains `UNKNOWN`.
+- Handoff expectations: check validation evidence, decision-point count,
+  confidence notes, review/comment triage, and any Process Gap Disposition
+  fields required by `.agents/workflows/pr-processing.md`.
+- Classification: reuse the intent-achievement classes from
+  `.agents/workflows/continuous-evaluation-loop.md` (`realized`, `partial`,
+  `missed`, `regressed`, `stalled`, or `unknown`) and explain any `UNKNOWN`
+  evidence needed to resolve the issue outcome.
+- Post-merge intake: route merged non-OK issue outcomes into the issue plan
+  below; route active/stalled lanes back to the batch coordinator as
+  resume/reassign/drop decisions instead of treating them as merged-PR audit
+  findings.
 
 ## Codex And Claude Coordination
 
@@ -77,6 +102,18 @@ Classify each PR:
 - **Needs fix PR**: a real defect, missing test, missing compatibility note, or bad interaction should be fixed before release.
 - **Needs revert consideration**: the merge appears risky enough that reverting may be safer than patching.
 
+Classify each worked issue separately so the audit can prove every coordinated
+lane was evaluated, even when the issue produced no merged PR:
+
+- **Realized**: the issue intent was satisfied and the final state is supported
+  by evidence.
+- **Partial / missed / regressed**: the issue intent was incompletely addressed,
+  not addressed, or harmed by the result.
+- **Stalled**: the lane needs a coordinator decision to resume, reassign, or
+  drop.
+- **Unknown**: the auditor cannot verify the issue outcome from available
+  coordination, GitHub, and git evidence.
+
 ## Issue Plan
 
 The audit should usually produce an issue plan for non-OK findings, but not create issues until approval.
@@ -84,7 +121,13 @@ The audit should usually produce an issue plan for non-OK findings, but not crea
 - **No issue**: for `OK`, duplicate findings, or findings fully resolved by the audit evidence.
 - **Changelog only**: for missing changelog entries; prefer one bundled changelog issue or a recommendation to run `/update-changelog`, not one issue per entry.
 - **One child issue**: for each independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
-- **Parent issue**: create one parent issue only to group two or more related _child fix_ issues from the same audit. Do **not** create a standalone audit-snapshot tracker (a `Post-<range> audit` / `Post-rc.N catch-up audit` issue): per `AGENTS.md` → _Tracking Issues And Handoffs_, the audit report is a point-in-time snapshot — append it to the standing release audit ledger in place. Genuine non-OK findings still become real child issues; only the snapshot/report is what goes to the ledger instead of a new issue.
+- **Parent issue**: create one parent issue only to group two or more related _child fix_ issues from the
+  same audit. Do **not** create a standalone audit-snapshot tracker (a `Post-<range> audit` /
+  `Post-rc.N catch-up audit` issue): per `AGENTS.md` → _Tracking Issues And Handoffs_, the audit
+  report is a point-in-time snapshot — append it to the standing release audit ledger in place, and
+  include that ledger comment URL in every approved parent or child issue created from the audit.
+  Genuine non-OK findings still become real child issues; only the snapshot/report is what goes to
+  the ledger instead of a new issue.
 
 For process findings, the issue plan must include a Process Gap Disposition
 before issue creation:
@@ -116,7 +159,11 @@ Return high-risk findings first, then:
 2. Missing changelog candidates, with a single recommendation to run `/update-changelog` when any are found.
 3. Cross-PR interaction risks.
 4. A deduped issue plan with parent/child recommendations and fingerprints.
-5. A PR-by-PR table.
-6. Exact commands and data sources used.
+5. A worked-issue coverage table with issue number, coordination lane/branch,
+   linked PR or no-PR/blocker evidence, final state, intent-achievement
+   classification, and `UNKNOWN` facts.
+6. A PR-by-PR table.
+7. Exact commands and data sources used, including `agent-coord status` output
+   for the named batch or the exact reason coordination state was `UNKNOWN`.
 
 Do not create fixes, comments, labels, issues, changelog edits, reverts, or PRs until the user approves the audit report.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -23,7 +23,8 @@ Start by resolving the exact audit range and, when auditing a named agent
 batch/run, the exact worked-issue scope:
 
 Term: a structured public `codex-claim` comment is a GitHub issue/PR comment
-containing a `codex-claim` JSON block in the "Public claim comment" format from
+containing a `codex-claim` HTML comment (`<!-- codex-claim v1 ... -->`) with
+key/value fields in the "Public claim comment" format from
 `.agents/workflows/pr-processing.md`.
 
 When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-audit-scope`, run it first:
@@ -63,6 +64,10 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    parked, or done-unmerged lanes before reducing scope to merged PRs. Keep
    advisory rows marked `UNKNOWN` as needed, and do not infer confirmed
    completeness from merged PRs.
+   When the batch/run id itself is unknown, scope that advisory scan to issues
+   and open PRs active within the audit time window; use each claim's `batch:`
+   field to surface candidate batch ids, not to filter as confirmed scope until
+   the user confirms the id.
 
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
@@ -187,8 +192,11 @@ The audit should usually produce an issue plan for non-OK findings, but not crea
   issue): per `AGENTS.md` → _Tracking Issues And Handoffs_, the audit report is
   a point-in-time snapshot. For release-gate audits, append that snapshot to the
   standing release audit ledger in place and include the ledger comment URL in
-  every approved parent or child issue created from the audit. For non-release
-  audits with no release-gate ledger, record
+  every approved parent or child issue created from the audit. Locate the ledger
+  with the release-mode preflight search: open issues with the `release` and
+  `TRACKING` labels, plus `Release gate:` title matches. If no release-gate
+  ledger exists for a release audit, surface that absence as a blocker before
+  creating follow-up issues. For non-release audits with no release-gate ledger, record
   `Audit ledger: not applicable (non-release audit)` in every approved parent or
   child issue. Genuine non-OK findings still become real child issues; only the
   snapshot/report is what goes to the ledger instead of a new issue.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -45,13 +45,14 @@ The resolver is read-only. It resolves the default release-candidate base, the h
      scope
 
    If candidate discovery cannot verify backend setup or access,
-   `UNKNOWN (setup)` or `UNKNOWN (access)` takes precedence; also report that
-   batch id confirmation is still needed after backend recovery. When a
-   batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
-   then inspect the named batch entry; use claims, heartbeats, and batch
-   metadata as the primary worked-issue scope. If `agent-coord` is missing or
-   `agent-coord doctor` fails, record `worked_issue_scope: UNKNOWN (setup)` with
-   the exact command/error. If `agent-coord doctor` passes but
+   `UNKNOWN (setup)` or `UNKNOWN (access)` takes precedence over
+   `UNKNOWN (needs batch confirmation)`; also report that batch id confirmation
+   is still needed after backend recovery. When a batch/run id is known, run
+   `agent-coord doctor` then `agent-coord status`, then inspect the named batch
+   entry; use claims, heartbeats, and batch metadata as the primary worked-issue
+   scope. If `agent-coord` is missing or `agent-coord doctor` fails, record
+   `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
+   `agent-coord doctor` passes but
    `agent-coord status` fails, record `worked_issue_scope: UNKNOWN (access)`
    with the exact command/error. In both UNKNOWN cases, use structured public
    `codex-claim` comments as an advisory fallback for possible no-PR, blocked,
@@ -64,8 +65,10 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
    scan structured public `codex-claim` comments as advisory recovery rows for
    possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
-   rows marked `UNKNOWN`, and report the batch metadata correction needed before
-   reducing the audit to the merged-PR range only.
+   rows marked `UNKNOWN`, report the batch metadata correction needed, and ask
+   for confirmation before reducing the audit to the merged-PR range only. If
+   the user confirms no lanes were worked, record the empty-batch finding and
+   proceed to the merged-PR range.
 
 5. Batch PR subset: only when `worked_issue_scope` is verified from
    coordination state, map worked issues to PRs through coordination branch

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -116,19 +116,20 @@ Classify each PR:
 Classify each worked issue separately so the audit can prove every coordinated
 lane was evaluated, even when the issue produced no merged PR:
 
-- **In progress**: the lane is healthy active/live work with recent heartbeat,
+- `in_progress`: the lane is healthy active/live work with recent heartbeat,
   commits, or review activity and no stalled, regressed, partial, missed, or
   unknown signal; record it as a no-action item.
-- **Realized**: the issue intent was satisfied and the final state is supported
+- `realized`: the issue intent was satisfied and the final state is supported
   by evidence.
-- **Partial**: the issue intent was incompletely addressed; some acceptance
+- `partial`: the issue intent was incompletely addressed; some acceptance
   criteria landed and others did not.
-- **Missed**: the issue intent was not addressed; no meaningful implementation
+- `missed`: the issue intent was not addressed; no meaningful implementation
   or evidence comment exists.
-- **Regressed**: the merge harmed an outcome that was previously satisfied.
-- **Stalled**: the lane needs a coordinator decision to resume, reassign, or
-  drop.
-- **Unknown**: the auditor cannot verify the issue outcome from available
+- `regressed`: the merge harmed an outcome that was previously satisfied.
+- `stalled`: the lane needs a coordinator decision to resume, reassign, or
+  drop. Includes `stale` and `dead` lost-heartbeat operational states; see
+  `continuous-evaluation-loop.md` for the operational-to-intent mapping.
+- `unknown`: the auditor cannot verify the issue outcome from available
   coordination, GitHub, and git evidence.
 
 ## Issue Plan

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -76,8 +76,9 @@ For each included PR:
 - Cross-PR interactions: compare changed files, shared behavior, assumptions, and release-sensitive areas across the batch.
 - Decision log: inspect any `Codex Decision Log` or equivalent section and verify the decisions still hold after the merge.
 
-For each worked issue from coordination state, including no-PR, blocked,
-parked, done-unmerged, or still-open lanes:
+For each worked issue from coordination state or advisory `codex-claim`
+recovery rows, including no-PR, blocked, parked, done-unmerged, or still-open
+lanes:
 
 - Intent coverage: compare the issue intent and acceptance criteria with the PR
   diff, no-PR evidence comment, branch state, or blocker note.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -76,13 +76,14 @@ parked, done-unmerged, or still-open lanes:
   confidence notes, review/comment triage, and any Process Gap Disposition
   fields required by `.agents/workflows/pr-processing.md`.
 - Classification: reuse the intent-achievement classes from
-  `.agents/workflows/continuous-evaluation-loop.md` (`realized`, `partial`,
-  `missed`, `regressed`, `stalled`, or `unknown`) and explain any `UNKNOWN`
-  evidence needed to resolve the issue outcome.
+  `.agents/workflows/continuous-evaluation-loop.md` (`in_progress`,
+  `realized`, `partial`, `missed`, `regressed`, `stalled`, or `unknown`) and
+  explain any `UNKNOWN` evidence needed to resolve the issue outcome.
 - Post-merge intake: route merged non-OK issue outcomes into the issue plan
-  below; route active/stalled lanes back to the batch coordinator as
-  resume/reassign/drop decisions instead of treating them as merged-PR audit
-  findings.
+  below; record healthy `in_progress` lanes in the worked-issue table as
+  no-action items; route `stalled` lanes back to the batch coordinator as
+  resume/reassign/drop decisions in the audit report instead of treating them
+  as merged-PR audit findings.
 
 ## Codex And Claude Coordination
 
@@ -108,10 +109,16 @@ Classify each PR:
 Classify each worked issue separately so the audit can prove every coordinated
 lane was evaluated, even when the issue produced no merged PR:
 
+- **In progress**: the lane is healthy active/live work with recent heartbeat,
+  commits, or review activity and no stalled, regressed, partial, missed, or
+  unknown signal; record it as a no-action item.
 - **Realized**: the issue intent was satisfied and the final state is supported
   by evidence.
-- **Partial / missed / regressed**: the issue intent was incompletely addressed,
-  not addressed, or harmed by the result.
+- **Partial**: the issue intent was incompletely addressed; some acceptance
+  criteria landed and others did not.
+- **Missed**: the issue intent was not addressed; no meaningful implementation
+  or evidence comment exists.
+- **Regressed**: the merge harmed an outcome that was previously satisfied.
 - **Stalled**: the lane needs a coordinator decision to resume, reassign, or
   drop.
 - **Unknown**: the auditor cannot verify the issue outcome from available
@@ -121,7 +128,10 @@ lane was evaluated, even when the issue produced no merged PR:
 
 The audit should usually produce an issue plan for non-OK findings, but not create issues until approval.
 
-- **No issue**: for `OK`, duplicate findings, or findings fully resolved by the audit evidence.
+- **No issue**: for `OK`, duplicate findings, findings fully resolved by the
+  audit evidence, or healthy `in_progress` lanes; include `in_progress` lanes
+  in the worked-issue coverage table so the coordinator can see they were
+  checked.
 - **Changelog only**: for missing changelog entries; prefer one bundled changelog issue or a recommendation to run `/update-changelog`, not one issue per entry.
 - **One child issue**: for each independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
 - **Parent issue**: create one parent issue only to group two or more related _child fix_ issues from the

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -58,9 +58,15 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
-   continue with the merged-PR range only, and report the batch metadata
-   correction needed.
-5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to PRs through coordination branch names, linked PRs, PR bodies, labels, comments, authors, merge timing, and git history. Keep PR-range inclusion separate from worked-issue coverage so no-PR, blocked, parked, and unmerged lanes are still evaluated.
+   scan structured public `codex-claim` comments as advisory recovery rows for
+   possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
+   rows marked `UNKNOWN`, and report the batch metadata correction needed before
+   reducing the audit to the merged-PR range only.
+5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to
+   PRs through coordination branch names, linked PRs, PR bodies, labels,
+   comments, authors, merge timing, and git history. Keep PR-range inclusion
+   separate from worked-issue coverage so no-PR, blocked, parked, and unmerged
+   lanes are still evaluated.
 
 Show included worked issues, included PRs, excluded near-matches, base/head SHAs, coordination status evidence, and assumptions. Ask for confirmation before deep audit unless the user explicitly asks to proceed without confirmation.
 

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -37,24 +37,28 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    see `internal/contributor-info/agent-coordination-backend.md`. If no
    coordinated batch/run is in scope, record
    `worked_issue_scope: not applicable`. If batch work is in scope but the
-   batch/run id is unknown, record
-   `worked_issue_scope: UNKNOWN (needs batch confirmation)`, run
-   `agent-coord doctor` then `agent-coord status` to list candidate batch/run
-   ids and lanes, and ask for confirmation before treating any candidate as the
-   worked-issue scope. If candidate discovery cannot verify backend setup or
-   access, `UNKNOWN (setup)` or `UNKNOWN (access)` takes precedence; also report
-   that batch id confirmation is still needed after backend recovery. When a
-   batch/run id is known, run `agent-coord doctor`
-   then `agent-coord status`, then inspect the named batch entry; use claims,
-   heartbeats, and batch metadata as the primary worked-issue scope. If
-   `agent-coord` is missing or `agent-coord doctor` fails, record
-   `worked_issue_scope: UNKNOWN (setup)` with the exact command/error. If
-   `agent-coord doctor` passes but `agent-coord status` fails, record
-   `worked_issue_scope: UNKNOWN (access)` with the exact command/error. In both
-   UNKNOWN cases, use structured public `codex-claim` comments as an advisory
-   fallback for possible no-PR, blocked, parked, or done-unmerged lanes before
-   reducing scope to merged PRs. Keep advisory rows marked `UNKNOWN` as needed,
-   and do not infer confirmed completeness from merged PRs.
+   batch/run id is unknown:
+   - run `agent-coord doctor` then `agent-coord status` to list candidate
+     batch/run ids and lanes
+   - record `worked_issue_scope: UNKNOWN (needs batch confirmation)`
+   - ask for confirmation before treating any candidate as the worked-issue
+     scope
+
+   If candidate discovery cannot verify backend setup or access,
+   `UNKNOWN (setup)` or `UNKNOWN (access)` takes precedence; also report that
+   batch id confirmation is still needed after backend recovery. When a
+   batch/run id is known, run `agent-coord doctor` then `agent-coord status`,
+   then inspect the named batch entry; use claims, heartbeats, and batch
+   metadata as the primary worked-issue scope. If `agent-coord` is missing or
+   `agent-coord doctor` fails, record `worked_issue_scope: UNKNOWN (setup)` with
+   the exact command/error. If `agent-coord doctor` passes but
+   `agent-coord status` fails, record `worked_issue_scope: UNKNOWN (access)`
+   with the exact command/error. In both UNKNOWN cases, use structured public
+   `codex-claim` comments as an advisory fallback for possible no-PR, blocked,
+   parked, or done-unmerged lanes before reducing scope to merged PRs. Keep
+   advisory rows marked `UNKNOWN` as needed, and do not infer confirmed
+   completeness from merged PRs.
+
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
@@ -62,6 +66,7 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
    rows marked `UNKNOWN`, and report the batch metadata correction needed before
    reducing the audit to the merged-PR range only.
+
 5. Batch PR subset: when `worked_issue_scope` is known, map worked issues to
    PRs through coordination branch names, linked PRs, PR bodies, labels,
    comments, authors, merge timing, and git history. Keep PR-range inclusion

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -30,11 +30,14 @@ When this repository includes `.agents/skills/post-merge-audit/bin/post-merge-au
 
 The resolver is read-only. It resolves the default release-candidate base, the head SHA, squash-aware merged PRs, prior `post-merge-audit-finding` fingerprints, PRs with open finding markers, and the `to_audit` list. Open finding markers create carry-over PRs that are subtracted from `to_audit`; closed markers remain fingerprint context only. Use the output as the initial merged-PR scope table, then verify assumptions before deep audit.
 
+For private coordination backend setup and CLI discovery, see
+`internal/contributor-info/agent-coordination-backend.md`.
+
 1. Base: the user-supplied tag/commit, or the most recent release candidate tag when the user says "since the last RC".
 2. Head: usually `origin/main` or the current release branch.
 3. Merged PR list: every PR merged between base and head.
-4. Worked issue list: when a batch/run id is known, run `agent-coord status` after `agent-coord
-doctor`, then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
+4. Worked issue list: when a batch/run id is known, run `agent-coord doctor` and
+   `agent-coord status`, then inspect the named batch entry; use claims, heartbeats, and batch metadata as the
    primary worked-issue scope. If `agent-coord` is missing, unavailable, or the status command fails,
    record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
    completeness from merged PRs.

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -41,7 +41,10 @@ The resolver is read-only. It resolves the default release-candidate base, the h
    `worked_issue_scope: UNKNOWN (needs batch confirmation)`, run
    `agent-coord doctor` then `agent-coord status` to list candidate batch/run
    ids and lanes, and ask for confirmation before treating any candidate as the
-   worked-issue scope. When a batch/run id is known, run `agent-coord doctor`
+   worked-issue scope. If candidate discovery cannot verify backend setup or
+   access, `UNKNOWN (setup)` or `UNKNOWN (access)` takes precedence; also report
+   that batch id confirmation is still needed after backend recovery. When a
+   batch/run id is known, run `agent-coord doctor`
    then `agent-coord status`, then inspect the named batch entry; use claims,
    heartbeats, and batch metadata as the primary worked-issue scope. If
    `agent-coord` is missing or `agent-coord doctor` fails, record

--- a/.agents/skills/post-merge-audit/SKILL.md
+++ b/.agents/skills/post-merge-audit/SKILL.md
@@ -79,11 +79,13 @@ parked, done-unmerged, or still-open lanes:
   `.agents/workflows/continuous-evaluation-loop.md` (`in_progress`,
   `realized`, `partial`, `missed`, `regressed`, `stalled`, or `unknown`) and
   explain any `UNKNOWN` evidence needed to resolve the issue outcome.
-- Post-merge intake: route merged non-OK issue outcomes into the issue plan
-  below; record healthy `in_progress` lanes in the worked-issue table as
-  no-action items; route `stalled` lanes back to the batch coordinator as
-  resume/reassign/drop decisions in the audit report instead of treating them
-  as merged-PR audit findings.
+- Post-merge intake: record healthy `in_progress` lanes and evidenced
+  `realized` outcomes in the worked-issue table as no-action items; route
+  `stalled` lanes back to the batch coordinator as resume/reassign/drop
+  decisions unless the user explicitly approves tracking the stalled lane as an
+  issue; route every other non-OK worked-issue class (`partial`, `missed`,
+  `regressed`, or `unknown`), merged or not, into the issue plan or an explicit
+  coordinator action that names the missing evidence or decision.
 
 ## Codex And Claude Coordination
 

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -4,6 +4,11 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 
 ## Coordination Rules
 
+These prompts intentionally repeat the worked-issue scope state machine from
+`.agents/skills/post-merge-audit/SKILL.md` so copy-paste audits stay
+self-contained. Keep state-machine changes mirrored across this workflow,
+`SKILL.md`, and `.agents/workflows/pr-processing.md`.
+
 - Use one exact audit id, base, and head for every agent, for example `audit: <YYYY-MM-DD>-post-rc`.
 - Format `<AUDIT_ID>` as `<YYYY-MM-DD>-<short-purpose>`, for example `<YYYY-MM-DD>-post-rc` or `<YYYY-MM-DD>-agent-batch-audit`.
 - Run Codex and Claude independently first. Do not give either agent the other agent's report until both reports are complete.
@@ -34,12 +39,11 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   `agent-coord status`, and inspect the named batch entry as the primary
   worked-issue scope when available. If coordination state cannot be verified,
   record `worked_issue_scope: UNKNOWN (setup)` or
-  `worked_issue_scope: UNKNOWN (access)` with the exact command/error. A
-  structured public `codex-claim` comment is a GitHub issue/PR comment
-  containing a `codex-claim` JSON block in the format documented by
-  `internal/contributor-info/agent-coordination-backend.md`. Use structured
-  public `codex-claim` comments as advisory recovery evidence when available
-  before reducing unknown scope to merged PRs.
+  `worked_issue_scope: UNKNOWN (access)` with the exact command/error. Use
+  structured public `codex-claim` comments (GitHub comments containing a
+  `codex-claim` JSON block in the "Public claim comment" format from
+  `.agents/workflows/pr-processing.md`) as advisory recovery evidence when
+  available before reducing unknown scope to merged PRs.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
 

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -18,8 +18,9 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   ledger append after the permission, quota, or transient API issue is resolved
   without regenerating the audit unless the base, head, or approved report
   changed.
-- If multiple child issues are needed, create one parent issue for the audit and one child issue per
-  independently actionable fix/revert/question. For release-gate audits, link
+- If multiple child issues are needed, create one parent issue for the audit
+  and one child issue per independently actionable fix/revert/question. For
+  release-gate audits, link
   the release-gate audit ledger comment from every approved parent or child
   issue created from the audit. For non-release audits with no ledger, record
   `Audit ledger: not applicable (non-release audit)` in approved issue bodies.
@@ -80,11 +81,14 @@ Use git, GitHub, and agent-coord ground truth. Do not rely on prior chat memory.
 
 Scope:
 - Repository: <OWNER>/<REPO>
-- Batch id: <BATCH_ID, UNKNOWN if batch work is in scope but the id was not supplied, or not applicable>
+- Batch id: <BATCH_ID | UNKNOWN | not applicable>
 - Base: resolve the most recent release candidate tag/commit unless I provide one explicitly
 - Head: current main
 - Focus: PRs that appear to be from recent high-concurrency agent/Codex/Claude batch work
 - Audit id: <AUDIT_ID>
+
+BATCH_ID = the known batch run id; UNKNOWN = batch work is in scope but the id
+was not supplied; not applicable = no coordinated batch is in scope.
 
 First, produce the exact worked-issue scope and merged-PR range:
 - when no coordinated batch/run is in scope, skip `agent-coord` and record
@@ -112,8 +116,10 @@ First, produce the exact worked-issue scope and merged-PR range:
 - if `agent-coord doctor` and `agent-coord status` both succeed but the named
   batch entry contains no worked issues or lanes, record
   `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
-  continue with the merged-PR range only, and report the batch metadata
-  correction needed
+  scan structured public `codex-claim` comments as advisory recovery rows for
+  possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
+  rows marked `UNKNOWN`, and report the batch metadata correction needed before
+  reducing the audit to the merged-PR range only
 
 Then produce the exact merged-PR range and, only when `worked_issue_scope` is
 known, the batch-subset list:
@@ -250,6 +256,10 @@ Pay special attention to disagreements:
     `worked_issue_scope: UNKNOWN`, treat the verified coordination data as the
     candidate worked-issue scope and record the UNKNOWN report as a setup/access
     gap to resolve, not as evidence that no worked-issue scope exists
+  - when both reports record `worked_issue_scope: UNKNOWN`, consolidate the
+    command/error evidence from both reports and surface a single unresolved
+    `worked_issue_scope: UNKNOWN` finding that names the command or permission
+    needed before any worked-issue audit can proceed
 - different intent-achievement classifications for the same worked issue
 - different PR inclusion lists
 - different release-candidate base

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -10,8 +10,14 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 - During independent audits, agents may draft issue bodies but must not create issues, comments, labels, fixes, reverts, branches, or PRs.
 - Use one coordinator to compare reports, dedupe findings, and propose the issue plan.
 - Create GitHub issues only after the user approves the deduped issue plan.
-- If multiple child issues are needed, create one parent issue for the audit and one child issue per independently actionable fix/revert/question.
+- If multiple child issues are needed, create one parent issue for the audit and one child issue per
+  independently actionable fix/revert/question. Link the release-gate audit ledger comment from every
+  approved parent or child issue created from the audit.
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
+- For named batch/run audits, run `agent-coord status` and inspect the named
+  batch entry as the primary worked-issue scope when available. If coordination
+  state cannot be verified, record `worked_issue_scope: UNKNOWN` with the exact
+  command/error instead of silently reducing the audit to merged PRs.
 
 Suggested hidden fingerprint:
 
@@ -49,18 +55,31 @@ If you do not know or cannot verify an item from GitHub/local git, say UNKNOWN r
 Run this separately in Codex and Claude. Do not share one agent's output with the other until both are done.
 
 ```text
-Run an independent post-merge audit of merged PRs since the last release candidate.
+Run an independent post-merge audit of a batch/run and its merged PRs since the last release candidate.
 
-Use git and GitHub ground truth. Do not rely on prior chat memory.
+Use git, GitHub, and agent-coord ground truth. Do not rely on prior chat memory.
 
 Scope:
 - Repository: <OWNER>/<REPO>
+- Batch id: <BATCH_ID or UNKNOWN>
 - Base: resolve the most recent release candidate tag/commit unless I provide one explicitly
 - Head: current main
 - Focus: PRs that appear to be from recent high-concurrency agent/Codex/Claude batch work
 - Audit id: <AUDIT_ID>
 
-First, produce the exact merged-PR range and batch-subset list:
+First, produce the exact worked-issue scope and merged-PR range:
+- run `agent-coord doctor` and `agent-coord status` when a batch id is known,
+  then inspect `<BATCH_ID>` in the status output
+- list every worked issue/lane from claims, heartbeats, branches, and dependency
+  metadata
+- for each worked issue, include the lane owner, branch, heartbeat/final state,
+  linked PR if known, and whether the final state is merged, open, blocked,
+  parked, no-PR, done-unmerged, or UNKNOWN
+- if agent-coord is missing, unavailable, or status fails, record
+  `worked_issue_scope: UNKNOWN` with the exact command/error and continue with
+  GitHub/git evidence for the merged-PR range only
+
+Then produce the exact merged-PR range and batch-subset list:
 - merged PR number and URL
 - merge commit
 - branch name
@@ -70,9 +89,24 @@ First, produce the exact merged-PR range and batch-subset list:
 - why you think it is or is not part of the batch
 
 List every PR merged between base and head, not only the PRs that look like
-batch work. Ask me to confirm the included and excluded PRs before deep audit.
+batch work. Ask me to confirm the included/excluded worked issues and PRs before
+deep audit.
 
-After confirmation, audit each included PR for:
+After confirmation, audit each worked issue for:
+- whether the implementation, no-PR comment, blocker, or parked disposition
+  satisfied the issue intent and acceptance criteria
+- whether the final issue state is correct: merged, closed, still open,
+  parked, blocked, no-PR, done-unmerged, or UNKNOWN
+- whether review comments, handoff expectations, confidence notes, validation
+  evidence, decision-point count, and Process Gap Disposition fields were
+  handled when required
+- classify each worked issue as `realized`, `partial`, `missed`, `regressed`,
+  `stalled`, or `unknown`, using `.agents/workflows/continuous-evaluation-loop.md`
+  for the intent-achievement definitions
+- for `stalled` lanes, recommend resume, reassign, or drop; for merged non-OK
+  findings, prepare post-merge audit issue-plan entries
+
+Also audit each included merged PR for:
 - risky behavior change
 - missing or weak validation
 - missing lockfile content-diff evidence when committed lockfiles changed, using
@@ -114,7 +148,10 @@ For every non-OK finding, include a draft issue entry but do not create it:
   `checklist+replay`, or `park`), `Motivating miss`, `Replay evidence or park
   reason`, and `Non-goal`
 
-Return high-risk findings first, then a PR-by-PR table. Include exact commands and data sources used. Do not make code changes, comments, labels, issues, reverts, or PRs without approval.
+Return high-risk findings first, then a worked-issue coverage table and a
+PR-by-PR table. Include exact commands and data sources used, plus any remaining
+`UNKNOWN` facts and the command or permission needed to resolve them. Do not
+make code changes, comments, labels, issues, reverts, or PRs without approval.
 ```
 
 ## Comparison Prompt
@@ -168,6 +205,7 @@ Rules:
 - Do not create duplicate child issues. If an issue already exists, link it in the parent issue plan instead.
 - If there are two or more related child issues, create one parent issue first.
 - Create one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
+- Include the release-gate audit ledger comment URL in every parent and child issue body.
 - For missing changelog findings, prefer one bundled changelog issue or recommend `/update-changelog`; do not create one issue per missing entry unless explicitly approved.
 - For process findings, preserve the approved Process Gap Disposition fields:
   `Mechanism target`, `Motivating miss`, `Replay evidence or park reason`, and

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -14,7 +14,10 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   audit ledger first.
 - If a required release-gate ledger append fails, do not create issues; report
   the exact command/API error and the ledger issue or permission needed to
-  unblock issue creation.
+  unblock issue creation. The approved audit report remains valid; retry the
+  ledger append after the permission, quota, or transient API issue is resolved
+  without regenerating the audit unless the base, head, or approved report
+  changed.
 - If multiple child issues are needed, create one parent issue for the audit and one child issue per
   independently actionable fix/revert/question. For release-gate audits, link
   the release-gate audit ledger comment from every approved parent or child
@@ -101,6 +104,11 @@ First, produce the exact worked-issue scope and merged-PR range:
   `worked_issue_scope: UNKNOWN (access)` with the exact command/error and
   use structured public `codex-claim` comments as advisory coverage when
   available before continuing with GitHub/git evidence for the merged-PR range
+- if `agent-coord doctor` and `agent-coord status` both succeed but the named
+  batch entry contains no worked issues or lanes, record
+  `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
+  continue with the merged-PR range only, and report the batch metadata
+  correction needed
 
 Then produce the exact merged-PR range and, only when `worked_issue_scope` is
 known, the batch-subset list:
@@ -124,10 +132,10 @@ alongside the merged PR range, and include a `worked_issue_scope: UNKNOWN`
 finding with the command or permission needed to recover the missing issue/lane
 list.
 
-Ask me to confirm the included/excluded worked issues and PRs before deep audit
-when `worked_issue_scope` is known. When the scope is `UNKNOWN (needs batch
-confirmation)`, ask me to choose the candidate batch/run id before any
-worked-issue audit.
+Ask me to confirm the included/excluded worked issues, advisory `codex-claim`
+rows, and PR range before deep audit unless I explicitly say to proceed. When
+the scope is `UNKNOWN (needs batch confirmation)`, ask me to choose the
+candidate batch/run id before any worked-issue audit.
 
 After confirmation, audit each known worked issue or advisory `codex-claim` row
 for:
@@ -247,13 +255,14 @@ Pay special attention to disagreements:
 
 Return:
 1. consensus high-risk findings
-2. disputed findings needing human review
-3. reconciled worked-issue coverage table with issue number, coordination
+2. reconciled review-gate violations
+3. disputed findings needing human review
+4. reconciled worked-issue coverage table with issue number, coordination
    lane/branch, linked PR or no-PR/blocker evidence, final state,
    intent-achievement classification, and any unresolved `UNKNOWN` facts
-4. PRs both agents consider OK
-5. deduped issue plan
-6. recommended next actions
+5. PRs both agents consider OK
+6. deduped issue plan
+7. recommended next actions
 
 Do not create issues or PRs yet.
 ```

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -23,8 +23,9 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
 - For named batch/run audits, run `agent-coord doctor`, then `agent-coord status`, and inspect the named
   batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
-  record `worked_issue_scope: UNKNOWN` with the exact command/error instead of silently reducing the audit
-  to merged PRs.
+  record `worked_issue_scope: UNKNOWN (setup)` or `worked_issue_scope: UNKNOWN (access)` with the exact
+  command/error. Use structured public claim comments as advisory recovery evidence when available before
+  reducing unknown scope to merged PRs.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
 

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -9,14 +9,17 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 - Run Codex and Claude independently first. Do not give either agent the other agent's report until both reports are complete.
 - During independent audits, agents may draft issue bodies but must not create issues, comments, labels, fixes, reverts, branches, or PRs.
 - Use one coordinator to compare reports, dedupe findings, and propose the issue plan.
-- Create GitHub issues only after the user approves the deduped issue plan and
-  the approved audit report has been appended to the release-gate audit ledger.
-- If appending to the release-gate audit ledger fails, do not create issues;
-  report the exact command/API error and the ledger issue or permission needed
-  to unblock issue creation.
+- Create GitHub issues only after the user approves the deduped issue plan. For
+  release-gate audits, append the approved audit report to the release-gate
+  audit ledger first.
+- If a required release-gate ledger append fails, do not create issues; report
+  the exact command/API error and the ledger issue or permission needed to
+  unblock issue creation.
 - If multiple child issues are needed, create one parent issue for the audit and one child issue per
-  independently actionable fix/revert/question. Link the release-gate audit ledger comment from every
-  approved parent or child issue created from the audit.
+  independently actionable fix/revert/question. For release-gate audits, link
+  the release-gate audit ledger comment from every approved parent or child
+  issue created from the audit. For non-release audits with no ledger, record
+  `Audit ledger: not applicable (non-release audit)` in approved issue bodies.
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
 - For named batch/run audits, run `agent-coord doctor`, then `agent-coord status`, and inspect the named
   batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
@@ -68,15 +71,20 @@ Use git, GitHub, and agent-coord ground truth. Do not rely on prior chat memory.
 
 Scope:
 - Repository: <OWNER>/<REPO>
-- Batch id: <BATCH_ID, or UNKNOWN if not applicable>
+- Batch id: <BATCH_ID, UNKNOWN if batch work is in scope but the id was not supplied, or not applicable>
 - Base: resolve the most recent release candidate tag/commit unless I provide one explicitly
 - Head: current main
 - Focus: PRs that appear to be from recent high-concurrency agent/Codex/Claude batch work
 - Audit id: <AUDIT_ID>
 
 First, produce the exact worked-issue scope and merged-PR range:
-- when a batch id is `UNKNOWN` or not applicable, skip `agent-coord` and record
+- when no coordinated batch/run is in scope, skip `agent-coord` and record
   `worked_issue_scope: not applicable`
+- when batch work is in scope but the batch id is `UNKNOWN`, run
+  `agent-coord doctor`, then `agent-coord status` to list candidate batch/run
+  ids and lanes. Record `worked_issue_scope: UNKNOWN (needs batch
+  confirmation)` and ask me to confirm a candidate batch/run id before treating
+  any candidate lane list as the worked-issue scope.
 - when a batch id is known, run `agent-coord doctor`, then `agent-coord status`,
   then inspect `<BATCH_ID>` in the status output
 - list every worked issue/lane from claims, heartbeats, branches, and dependency
@@ -103,14 +111,18 @@ known, the batch-subset list:
 - why it is or is not part of the batch, only when `worked_issue_scope` is known
 
 List every PR merged between base and head, not only the PRs that look like
-batch work. Ask me to confirm the included/excluded worked issues and PRs before
-deep audit.
+batch work.
 
 If `worked_issue_scope` is `UNKNOWN`, do not invent a worked-issue list from the
 merged PR range and do not identify an included/excluded batch subset from PR
 links or heuristics. After confirmation, audit the merged PR range only and
 include a `worked_issue_scope: UNKNOWN` finding with the command or permission
 needed to recover the missing issue/lane list.
+
+Ask me to confirm the included/excluded worked issues and PRs before deep audit
+when `worked_issue_scope` is known. When the scope is `UNKNOWN (needs batch
+confirmation)`, ask me to choose the candidate batch/run id before any
+worked-issue audit.
 
 After confirmation, audit each known worked issue for:
 - whether the implementation, no-PR comment, blocker, or parked disposition
@@ -252,11 +264,15 @@ Rules:
 - Do not create duplicate child issues. If an issue already exists, link it in the parent issue plan instead.
 - If there are two or more related child issues, create one parent issue first.
 - Create one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
-- Append the audit report to the release-gate audit ledger before creating approved follow-up issues; include the
-  resulting ledger comment URL in every parent and child issue body.
-- If the ledger append fails, do not create parent or child issues. Report the
-  exact command/API error and the ledger issue, permission, or retry needed
-  before issue creation can proceed.
+- For release-gate audits, append the audit report to the release-gate audit
+  ledger before creating approved follow-up issues; include the resulting ledger
+  comment URL in every parent and child issue body.
+- If a required release-gate ledger append fails, do not create parent or child
+  issues. Report the exact command/API error and the ledger issue, permission,
+  or retry needed before issue creation can proceed.
+- For non-release audits with no release-gate ledger, include
+  `Audit ledger: not applicable (non-release audit)` in every parent and child
+  issue body.
 - For missing changelog findings, prefer one bundled changelog issue or recommend `/update-changelog`; do not create one issue per missing entry unless explicitly approved.
 - For process findings, preserve the approved Process Gap Disposition fields:
   `Mechanism target`, `Motivating miss`, `Replay evidence or park reason`, and

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -183,7 +183,8 @@ The worked-issue coverage table must include issue number, coordination
 lane/branch, linked PR or no-PR/blocker evidence, final state,
 intent-achievement classification, and `UNKNOWN` facts.
 
-Example worked-issue coverage table:
+Example worked-issue coverage table (`batch-abc` and issue numbers are
+placeholders; replace them with the real batch id and issues):
 | Issue | Lane/branch | Evidence | Final state | Classification | UNKNOWN facts |
 | --- | --- | --- | --- | --- | --- |
 | #1234 | batch-abc:issue-1234 / codex/example | PR #2345 merged | merged | realized | none |
@@ -214,6 +215,10 @@ Pay special attention to disagreements:
 - one agent flags risk and the other misses it
 - different worked-issue inclusion lists, including one agent having
   coordination data while the other records `worked_issue_scope: UNKNOWN`
+  - when one report has verified coordination data and another has
+    `worked_issue_scope: UNKNOWN`, treat the verified coordination data as the
+    candidate worked-issue scope and record the UNKNOWN report as a setup/access
+    gap to resolve, not as evidence that no worked-issue scope exists
 - different intent-achievement classifications for the same worked issue
 - different PR inclusion lists
 - different release-candidate base
@@ -249,6 +254,9 @@ Rules:
 - Create one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
 - Append the audit report to the release-gate audit ledger before creating approved follow-up issues; include the
   resulting ledger comment URL in every parent and child issue body.
+- If the ledger append fails, do not create parent or child issues. Report the
+  exact command/API error and the ledger issue, permission, or retry needed
+  before issue creation can proceed.
 - For missing changelog findings, prefer one bundled changelog issue or recommend `/update-changelog`; do not create one issue per missing entry unless explicitly approved.
 - For process findings, preserve the approved Process Gap Disposition fields:
   `Mechanism target`, `Motivating miss`, `Replay evidence or park reason`, and

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -41,9 +41,12 @@ self-contained. Keep state-machine changes mirrored across this workflow,
   record `worked_issue_scope: UNKNOWN (setup)` or
   `worked_issue_scope: UNKNOWN (access)` with the exact command/error. Use
   structured public `codex-claim` comments (GitHub comments containing a
-  `codex-claim` JSON block in the "Public claim comment" format from
-  `.agents/workflows/pr-processing.md`) as advisory recovery evidence when
-  available before reducing unknown scope to merged PRs.
+  `codex-claim` HTML comment with key/value fields in the "Public claim
+  comment" format from `.agents/workflows/pr-processing.md`) as advisory
+  recovery evidence when available before reducing unknown scope to merged PRs.
+  If the batch id itself is unknown, scope advisory public-claim discovery to
+  issues and open PRs active within the audit time window; use claim `batch:`
+  fields to surface candidate ids until the user confirms one.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
 
@@ -307,7 +310,8 @@ Return:
 6. reconciled worked-issue coverage table with issue number, coordination
    lane/branch, linked PR or no-PR/blocker evidence, final state,
    intent-achievement classification, and any unresolved `UNKNOWN` facts
-7. recommended next actions
+7. recommended next actions, including a coordinator resume/reassign/drop
+   decision for `stalled` lanes instead of defaulting to issue creation
 
 Do not create issues or PRs yet.
 ```

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -240,6 +240,8 @@ placeholders; replace them with the real batch id and issues):
 | --- | --- | --- | --- | --- | --- |
 | #1234 | batch-abc:issue-1234 / codex/example | PR #2345 merged | merged | realized | none |
 | #1235 | batch-abc:issue-1235 / no branch | blocker comment URL | blocked | stalled | owner decision needed |
+| #1236 | batch-abc:issue-1236 / codex/partial-example | PR #2346 merged | merged | partial | acceptance criteria C not addressed |
+| #1237 | UNKNOWN (advisory) / no coord data | codex-claim comment URL (advisory) | UNKNOWN | unknown | coordination state needed to confirm |
 ```
 
 ## Comparison Prompt

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -18,6 +18,8 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   batch entry as the primary worked-issue scope when available. If coordination
   state cannot be verified, record `worked_issue_scope: UNKNOWN` with the exact
   command/error instead of silently reducing the audit to merged PRs.
+- For private coordination backend setup and CLI discovery, see
+  `internal/contributor-info/agent-coordination-backend.md`.
 
 Suggested hidden fingerprint:
 

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -69,41 +69,48 @@ Use git, GitHub, and agent-coord ground truth. Do not rely on prior chat memory.
 Scope:
 - Repository: <OWNER>/<REPO>
 - Batch id: <BATCH_ID, or UNKNOWN if not applicable>
-  (if UNKNOWN or not applicable, skip the agent-coord lookup below)
 - Base: resolve the most recent release candidate tag/commit unless I provide one explicitly
 - Head: current main
 - Focus: PRs that appear to be from recent high-concurrency agent/Codex/Claude batch work
 - Audit id: <AUDIT_ID>
 
 First, produce the exact worked-issue scope and merged-PR range:
-- run `agent-coord doctor`, then `agent-coord status` when a batch id is known,
+- when a batch id is `UNKNOWN` or not applicable, skip `agent-coord` and record
+  `worked_issue_scope: not applicable`
+- when a batch id is known, run `agent-coord doctor`, then `agent-coord status`,
   then inspect `<BATCH_ID>` in the status output
 - list every worked issue/lane from claims, heartbeats, branches, and dependency
   metadata
 - for each worked issue, include the lane owner, branch, heartbeat/final state,
   linked PR if known, and whether the final state is merged, open, blocked,
   parked, no-PR, done-unmerged, or UNKNOWN
-- if agent-coord is missing, unavailable, or either command fails, record
-  `worked_issue_scope: UNKNOWN` with the exact command/error and continue with
-  GitHub/git evidence for the merged-PR range only
+- if `agent-coord` is missing or `agent-coord doctor` fails, record
+  `worked_issue_scope: UNKNOWN (setup)` with the exact command/error and
+  continue with GitHub/git evidence for the merged-PR range only
+- if `agent-coord doctor` passes but `agent-coord status` fails, record
+  `worked_issue_scope: UNKNOWN (access)` with the exact command/error and
+  continue with GitHub/git evidence for the merged-PR range only
 
-Then produce the exact merged-PR range and batch-subset list:
+Then produce the exact merged-PR range and, only when `worked_issue_scope` is
+known, the batch-subset list:
 - merged PR number and URL
 - merge commit
 - branch name
 - author
 - linked issue
-- included or excluded from the batch subset
-- why you think it is or is not part of the batch
+- included or excluded from the batch subset, only when `worked_issue_scope` is
+  known
+- why it is or is not part of the batch, only when `worked_issue_scope` is known
 
 List every PR merged between base and head, not only the PRs that look like
 batch work. Ask me to confirm the included/excluded worked issues and PRs before
 deep audit.
 
 If `worked_issue_scope` is `UNKNOWN`, do not invent a worked-issue list from the
-merged PR range. After confirmation, audit the merged PR range only and include
-a `worked_issue_scope: UNKNOWN` finding with the command or permission needed to
-recover the missing issue/lane list.
+merged PR range and do not identify an included/excluded batch subset from PR
+links or heuristics. After confirmation, audit the merged PR range only and
+include a `worked_issue_scope: UNKNOWN` finding with the command or permission
+needed to recover the missing issue/lane list.
 
 After confirmation, audit each known worked issue for:
 - whether the implementation, no-PR comment, blocker, or parked disposition
@@ -218,8 +225,9 @@ Pay special attention to disagreements:
 Return:
 1. consensus high-risk findings
 2. disputed findings needing human review
-3. reconciled worked-issue coverage table with consensus classification and any
-   unresolved `UNKNOWN` facts
+3. reconciled worked-issue coverage table with issue number, coordination
+   lane/branch, linked PR or no-PR/blocker evidence, final state,
+   intent-achievement classification, and any unresolved `UNKNOWN` facts
 4. PRs both agents consider OK
 5. deduped issue plan
 6. recommended next actions

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -57,13 +57,14 @@ If you do not know or cannot verify an item from GitHub/local git, say UNKNOWN r
 Run this separately in Codex and Claude. Do not share one agent's output with the other until both are done.
 
 ```text
-Run an independent post-merge audit of a batch/run and its merged PRs since the last release candidate.
+Run an independent post-merge audit of merged PRs (and, when a batch id is known, its worked-issue scope)
+since the last release candidate.
 
 Use git, GitHub, and agent-coord ground truth. Do not rely on prior chat memory.
 
 Scope:
 - Repository: <OWNER>/<REPO>
-- Batch id: <BATCH_ID or UNKNOWN>
+- Batch id: <BATCH_ID, or UNKNOWN if not applicable>
 - Base: resolve the most recent release candidate tag/commit unless I provide one explicitly
 - Head: current main
 - Focus: PRs that appear to be from recent high-concurrency agent/Codex/Claude batch work
@@ -77,7 +78,7 @@ First, produce the exact worked-issue scope and merged-PR range:
 - for each worked issue, include the lane owner, branch, heartbeat/final state,
   linked PR if known, and whether the final state is merged, open, blocked,
   parked, no-PR, done-unmerged, or UNKNOWN
-- if agent-coord is missing, unavailable, or status fails, record
+- if agent-coord is missing, unavailable, or either command fails, record
   `worked_issue_scope: UNKNOWN` with the exact command/error and continue with
   GitHub/git evidence for the merged-PR range only
 
@@ -154,6 +155,9 @@ Return high-risk findings first, then a worked-issue coverage table and a
 PR-by-PR table. Include exact commands and data sources used, plus any remaining
 `UNKNOWN` facts and the command or permission needed to resolve them. Do not
 make code changes, comments, labels, issues, reverts, or PRs without approval.
+The worked-issue coverage table must include issue number, coordination
+lane/branch, linked PR or no-PR/blocker evidence, final state,
+intent-achievement classification, and `UNKNOWN` facts.
 ```
 
 ## Comparison Prompt
@@ -207,7 +211,8 @@ Rules:
 - Do not create duplicate child issues. If an issue already exists, link it in the parent issue plan instead.
 - If there are two or more related child issues, create one parent issue first.
 - Create one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task.
-- Include the release-gate audit ledger comment URL in every parent and child issue body.
+- Append the audit report to the release-gate audit ledger before creating approved follow-up issues; include the
+  resulting ledger comment URL in every parent and child issue body.
 - For missing changelog findings, prefer one bundled changelog issue or recommend `/update-changelog`; do not create one issue per missing entry unless explicitly approved.
 - For process findings, preserve the approved Process Gap Disposition fields:
   `Mechanism target`, `Motivating miss`, `Replay evidence or park reason`, and

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -34,9 +34,12 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   `agent-coord status`, and inspect the named batch entry as the primary
   worked-issue scope when available. If coordination state cannot be verified,
   record `worked_issue_scope: UNKNOWN (setup)` or
-  `worked_issue_scope: UNKNOWN (access)` with the exact command/error. Use
-  structured public `codex-claim` comments as advisory recovery evidence when
-  available before reducing unknown scope to merged PRs.
+  `worked_issue_scope: UNKNOWN (access)` with the exact command/error. A
+  structured public `codex-claim` comment is a GitHub issue/PR comment
+  containing a `codex-claim` JSON block in the format documented by
+  `internal/contributor-info/agent-coordination-backend.md`. Use structured
+  public `codex-claim` comments as advisory recovery evidence when available
+  before reducing unknown scope to merged PRs.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
 
@@ -128,7 +131,11 @@ First, produce the exact worked-issue scope and merged-PR range:
   rows marked `UNKNOWN`, report the batch metadata correction needed, and ask
   for confirmation before reducing the audit to the merged-PR range only. If
   the user confirms no lanes were worked, record the empty-batch finding and
-  proceed to the merged-PR range.
+  proceed to the merged-PR range. If the user indicates lanes were worked
+  despite the empty entry, record
+  `worked_issue_scope: UNKNOWN (empty batch, lanes expected)`, collect a manual
+  lane list from the user or advisory `codex-claim` comments, and keep
+  recovered rows advisory `UNKNOWN` until coordination state is corrected.
 
 Then produce the exact merged-PR range and, only when `worked_issue_scope` is
 verified from coordination state, the batch-subset list:
@@ -242,6 +249,7 @@ placeholders; replace them with the real batch id and issues):
 | #1235 | batch-abc:issue-1235 / no branch | blocker comment URL | blocked | stalled | owner decision needed |
 | #1236 | batch-abc:issue-1236 / codex/partial-example | PR #2346 merged | merged | partial | acceptance criteria C not addressed |
 | #1237 | UNKNOWN (advisory) / no coord data | codex-claim comment URL (advisory) | UNKNOWN | unknown | coordination state needed to confirm |
+| #1238 | batch-abc:issue-1238 / codex/done-no-merge | no-PR evidence comment URL | done-unmerged | realized | none |
 ```
 
 ## Comparison Prompt

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -14,10 +14,10 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   independently actionable fix/revert/question. Link the release-gate audit ledger comment from every
   approved parent or child issue created from the audit.
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
-- For named batch/run audits, run `agent-coord status` and inspect the named
-  batch entry as the primary worked-issue scope when available. If coordination
-  state cannot be verified, record `worked_issue_scope: UNKNOWN` with the exact
-  command/error instead of silently reducing the audit to merged PRs.
+- For named batch/run audits, run `agent-coord doctor` and `agent-coord status` and inspect the named
+  batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
+  record `worked_issue_scope: UNKNOWN` with the exact command/error instead of silently reducing the audit
+  to merged PRs.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
 

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -24,7 +24,7 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 - For named batch/run audits, run `agent-coord doctor`, then `agent-coord status`, and inspect the named
   batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
   record `worked_issue_scope: UNKNOWN (setup)` or `worked_issue_scope: UNKNOWN (access)` with the exact
-  command/error. Use structured public claim comments as advisory recovery evidence when available before
+  command/error. Use structured public `codex-claim` comments as advisory recovery evidence when available before
   reducing unknown scope to merged PRs.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
@@ -95,10 +95,12 @@ First, produce the exact worked-issue scope and merged-PR range:
   parked, no-PR, done-unmerged, or UNKNOWN
 - if `agent-coord` is missing or `agent-coord doctor` fails, record
   `worked_issue_scope: UNKNOWN (setup)` with the exact command/error and
-  continue with GitHub/git evidence for the merged-PR range only
+  use structured public `codex-claim` comments as advisory coverage when
+  available before continuing with GitHub/git evidence for the merged-PR range
 - if `agent-coord doctor` passes but `agent-coord status` fails, record
   `worked_issue_scope: UNKNOWN (access)` with the exact command/error and
-  continue with GitHub/git evidence for the merged-PR range only
+  use structured public `codex-claim` comments as advisory coverage when
+  available before continuing with GitHub/git evidence for the merged-PR range
 
 Then produce the exact merged-PR range and, only when `worked_issue_scope` is
 known, the batch-subset list:
@@ -116,16 +118,19 @@ batch work.
 
 If `worked_issue_scope` is `UNKNOWN`, do not invent a worked-issue list from the
 merged PR range and do not identify an included/excluded batch subset from PR
-links or heuristics. After confirmation, audit the merged PR range only and
-include a `worked_issue_scope: UNKNOWN` finding with the command or permission
-needed to recover the missing issue/lane list.
+links or heuristics. Use structured public `codex-claim` comments as advisory
+worked-issue rows when available, keep those rows marked `UNKNOWN`, audit them
+alongside the merged PR range, and include a `worked_issue_scope: UNKNOWN`
+finding with the command or permission needed to recover the missing issue/lane
+list.
 
 Ask me to confirm the included/excluded worked issues and PRs before deep audit
 when `worked_issue_scope` is known. When the scope is `UNKNOWN (needs batch
 confirmation)`, ask me to choose the candidate batch/run id before any
 worked-issue audit.
 
-After confirmation, audit each known worked issue for:
+After confirmation, audit each known worked issue or advisory `codex-claim` row
+for:
 - whether the implementation, no-PR comment, blocker, or parked disposition
   satisfied the issue intent and acceptance criteria
 - whether the final issue state is correct: merged, closed, still open,

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -122,15 +122,16 @@ First, produce the exact worked-issue scope and merged-PR range:
   reducing the audit to the merged-PR range only
 
 Then produce the exact merged-PR range and, only when `worked_issue_scope` is
-known, the batch-subset list:
+verified from coordination state, the batch-subset list:
 - merged PR number and URL
 - merge commit
 - branch name
 - author
 - linked issue
 - included or excluded from the batch subset, only when `worked_issue_scope` is
-  known
-- why it is or is not part of the batch, only when `worked_issue_scope` is known
+  verified from coordination state
+- why it is or is not part of the batch, only when `worked_issue_scope` is
+  verified from coordination state
 
 List every PR merged between base and head, not only the PRs that look like
 batch work.
@@ -143,10 +144,14 @@ alongside the merged PR range, and include a `worked_issue_scope: UNKNOWN`
 finding with the command or permission needed to recover the missing issue/lane
 list.
 
+Treat `worked_issue_scope: not applicable`, `worked_issue_scope: UNKNOWN (...)`,
+and `worked_issue_scope: empty (...)` as merged-PR-range-only or advisory scope
+states, not verified batch subsets.
+
 Ask me to confirm the included/excluded worked issues, advisory `codex-claim`
 rows, and PR range before deep audit unless I explicitly say to proceed. When
 the scope is `UNKNOWN (needs batch confirmation)`, ask me to choose the
-candidate batch/run id before any worked-issue audit.
+candidate batch/run id before any confirmed worked-issue audit.
 
 After confirmation, audit each known worked issue or advisory `codex-claim` row
 for:
@@ -259,7 +264,9 @@ Pay special attention to disagreements:
   - when both reports record `worked_issue_scope: UNKNOWN`, consolidate the
     command/error evidence from both reports and surface a single unresolved
     `worked_issue_scope: UNKNOWN` finding that names the command or permission
-    needed before any worked-issue audit can proceed
+    needed before any confirmed worked-issue audit can proceed; continue
+    auditing advisory `codex-claim` rows alongside the merged PR range, keeping
+    those rows marked `UNKNOWN`
 - different intent-achievement classifications for the same worked issue
 - different PR inclusion lists
 - different release-candidate base

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -20,9 +20,9 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   changed.
 - If multiple child issues are needed, create one parent issue for the audit
   and one child issue per independently actionable fix/revert/question. For
-  release-gate audits, link
-  the release-gate audit ledger comment from every approved parent or child
-  issue created from the audit. For non-release audits with no ledger, record
+  release-gate audits, include the release-gate audit ledger comment URL in
+  every approved parent or child issue created from the audit. For non-release
+  audits with no ledger, record
   `Audit ledger: not applicable (non-release audit)` in approved issue bodies.
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
 - When batch work is in scope but the batch/run id was not supplied, record
@@ -288,8 +288,8 @@ Return:
 1. consensus high-risk findings
 2. reconciled review-gate violations
 3. disputed findings needing human review
-4. deduped issue plan
-5. PRs both agents consider OK
+4. PRs both agents consider OK
+5. deduped issue plan
 6. reconciled worked-issue coverage table with issue number, coordination
    lane/branch, linked PR or no-PR/blocker evidence, final state,
    intent-achievement classification, and any unresolved `UNKNOWN` facts

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -9,12 +9,13 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 - Run Codex and Claude independently first. Do not give either agent the other agent's report until both reports are complete.
 - During independent audits, agents may draft issue bodies but must not create issues, comments, labels, fixes, reverts, branches, or PRs.
 - Use one coordinator to compare reports, dedupe findings, and propose the issue plan.
-- Create GitHub issues only after the user approves the deduped issue plan.
+- Create GitHub issues only after the user approves the deduped issue plan and
+  the approved audit report has been appended to the release-gate audit ledger.
 - If multiple child issues are needed, create one parent issue for the audit and one child issue per
   independently actionable fix/revert/question. Link the release-gate audit ledger comment from every
   approved parent or child issue created from the audit.
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
-- For named batch/run audits, run `agent-coord doctor` and `agent-coord status` and inspect the named
+- For named batch/run audits, run `agent-coord doctor`, then `agent-coord status`, and inspect the named
   batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
   record `worked_issue_scope: UNKNOWN` with the exact command/error instead of silently reducing the audit
   to merged PRs.
@@ -65,13 +66,14 @@ Use git, GitHub, and agent-coord ground truth. Do not rely on prior chat memory.
 Scope:
 - Repository: <OWNER>/<REPO>
 - Batch id: <BATCH_ID, or UNKNOWN if not applicable>
+  (if UNKNOWN or not applicable, skip the agent-coord lookup below)
 - Base: resolve the most recent release candidate tag/commit unless I provide one explicitly
 - Head: current main
 - Focus: PRs that appear to be from recent high-concurrency agent/Codex/Claude batch work
 - Audit id: <AUDIT_ID>
 
 First, produce the exact worked-issue scope and merged-PR range:
-- run `agent-coord doctor` and `agent-coord status` when a batch id is known,
+- run `agent-coord doctor`, then `agent-coord status` when a batch id is known,
   then inspect `<BATCH_ID>` in the status output
 - list every worked issue/lane from claims, heartbeats, branches, and dependency
   metadata
@@ -108,10 +110,12 @@ After confirmation, audit each known worked issue for:
 - whether review comments, handoff expectations, confidence notes, validation
   evidence, decision-point count, and Process Gap Disposition fields were
   handled when required
-- classify each worked issue as `realized`, `partial`, `missed`, `regressed`,
-  `stalled`, or `unknown`, using `.agents/workflows/continuous-evaluation-loop.md`
-  for the intent-achievement definitions
-- for `stalled` lanes, recommend resume, reassign, or drop; for merged non-OK
+- classify each worked issue as `in_progress`, `realized`, `partial`,
+  `missed`, `regressed`, `stalled`, or `unknown`, using
+  `.agents/workflows/continuous-evaluation-loop.md` for the intent-achievement
+  definitions
+- for healthy `in_progress` lanes, record no action in the worked-issue table;
+  for `stalled` lanes, recommend resume, reassign, or drop; for merged non-OK
   findings, prepare post-merge audit issue-plan entries
 
 Also audit each included merged PR for:
@@ -187,6 +191,9 @@ For each finding:
 
 Pay special attention to disagreements:
 - one agent flags risk and the other misses it
+- different worked-issue inclusion lists, including one agent having
+  coordination data while the other records `worked_issue_scope: UNKNOWN`
+- different intent-achievement classifications for the same worked issue
 - different PR inclusion lists
 - different release-candidate base
 - different interpretation of validation evidence
@@ -197,9 +204,11 @@ Pay special attention to disagreements:
 Return:
 1. consensus high-risk findings
 2. disputed findings needing human review
-3. PRs both agents consider OK
-4. deduped issue plan
-5. recommended next actions
+3. reconciled worked-issue coverage table with consensus classification and any
+   unresolved `UNKNOWN` facts
+4. PRs both agents consider OK
+5. deduped issue plan
+6. recommended next actions
 
 Do not create issues or PRs yet.
 ```

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -95,7 +95,12 @@ List every PR merged between base and head, not only the PRs that look like
 batch work. Ask me to confirm the included/excluded worked issues and PRs before
 deep audit.
 
-After confirmation, audit each worked issue for:
+If `worked_issue_scope` is `UNKNOWN`, do not invent a worked-issue list from the
+merged PR range. After confirmation, audit the merged PR range only and include
+a `worked_issue_scope: UNKNOWN` finding with the command or permission needed to
+recover the missing issue/lane list.
+
+After confirmation, audit each known worked issue for:
 - whether the implementation, no-PR comment, blocker, or parked disposition
   satisfied the issue intent and acceptance criteria
 - whether the final issue state is correct: merged, closed, still open,

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -24,6 +24,11 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   issue created from the audit. For non-release audits with no ledger, record
   `Audit ledger: not applicable (non-release audit)` in approved issue bodies.
 - Before creating any issue, search existing open issues for the affected PR number and the hidden fingerprint.
+- When batch work is in scope but the batch/run id was not supplied, record
+  `worked_issue_scope: UNKNOWN (needs batch confirmation)`. If candidate
+  discovery cannot verify backend setup or access, record `UNKNOWN (setup)` or
+  `UNKNOWN (access)` with the exact command/error and report that batch id
+  confirmation is still needed after backend recovery.
 - For named batch/run audits, run `agent-coord doctor`, then `agent-coord status`, and inspect the named
   batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
   record `worked_issue_scope: UNKNOWN (setup)` or `worked_issue_scope: UNKNOWN (access)` with the exact

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -30,11 +30,13 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
   discovery cannot verify backend setup or access, record `UNKNOWN (setup)` or
   `UNKNOWN (access)` with the exact command/error and report that batch id
   confirmation is still needed after backend recovery.
-- For named batch/run audits, run `agent-coord doctor`, then `agent-coord status`, and inspect the named
-  batch entry as the primary worked-issue scope when available. If coordination state cannot be verified,
-  record `worked_issue_scope: UNKNOWN (setup)` or `worked_issue_scope: UNKNOWN (access)` with the exact
-  command/error. Use structured public `codex-claim` comments as advisory recovery evidence when available before
-  reducing unknown scope to merged PRs.
+- For named batch/run audits, run `agent-coord doctor`, then
+  `agent-coord status`, and inspect the named batch entry as the primary
+  worked-issue scope when available. If coordination state cannot be verified,
+  record `worked_issue_scope: UNKNOWN (setup)` or
+  `worked_issue_scope: UNKNOWN (access)` with the exact command/error. Use
+  structured public `codex-claim` comments as advisory recovery evidence when
+  available before reducing unknown scope to merged PRs.
 - For private coordination backend setup and CLI discovery, see
   `internal/contributor-info/agent-coordination-backend.md`.
 
@@ -98,13 +100,18 @@ First, produce the exact worked-issue scope and merged-PR range:
   ids and lanes. Record `worked_issue_scope: UNKNOWN (needs batch
   confirmation)` and ask me to confirm a candidate batch/run id before treating
   any candidate lane list as the worked-issue scope.
-- when a batch id is known, run `agent-coord doctor`, then `agent-coord status`,
-  then inspect `<BATCH_ID>` in the status output
-- list every worked issue/lane from claims, heartbeats, branches, and dependency
-  metadata
-- for each worked issue, include the lane owner, branch, heartbeat/final state,
-  linked PR if known, and whether the final state is merged, open, blocked,
-  parked, no-PR, done-unmerged, or UNKNOWN
+  If candidate discovery cannot verify backend setup or access, record
+  `worked_issue_scope: UNKNOWN (setup)` or
+  `worked_issue_scope: UNKNOWN (access)` instead of
+  `UNKNOWN (needs batch confirmation)`, with the exact command/error.
+- when a batch id is known:
+  - run `agent-coord doctor`, then `agent-coord status`, then inspect
+    `<BATCH_ID>` in the status output
+  - list every worked issue/lane from claims, heartbeats, branches, and
+    dependency metadata
+  - for each worked issue, include the lane owner, branch, heartbeat/final
+    state, linked PR if known, and whether the final state is merged, open,
+    blocked, parked, no-PR, done-unmerged, or UNKNOWN
 - if `agent-coord` is missing or `agent-coord doctor` fails, record
   `worked_issue_scope: UNKNOWN (setup)` with the exact command/error and
   use structured public `codex-claim` comments as advisory coverage when
@@ -118,8 +125,10 @@ First, produce the exact worked-issue scope and merged-PR range:
   `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
   scan structured public `codex-claim` comments as advisory recovery rows for
   possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
-  rows marked `UNKNOWN`, and report the batch metadata correction needed before
-  reducing the audit to the merged-PR range only
+  rows marked `UNKNOWN`, report the batch metadata correction needed, and ask
+  for confirmation before reducing the audit to the merged-PR range only. If
+  the user confirms no lanes were worked, record the empty-batch finding and
+  proceed to the merged-PR range.
 
 Then produce the exact merged-PR range and, only when `worked_issue_scope` is
 verified from coordination state, the batch-subset list:
@@ -279,11 +288,11 @@ Return:
 1. consensus high-risk findings
 2. reconciled review-gate violations
 3. disputed findings needing human review
-4. reconciled worked-issue coverage table with issue number, coordination
+4. deduped issue plan
+5. PRs both agents consider OK
+6. reconciled worked-issue coverage table with issue number, coordination
    lane/branch, linked PR or no-PR/blocker evidence, final state,
    intent-achievement classification, and any unresolved `UNKNOWN` facts
-5. PRs both agents consider OK
-6. deduped issue plan
 7. recommended next actions
 
 Do not create issues or PRs yet.

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -114,9 +114,13 @@ After confirmation, audit each known worked issue for:
   `missed`, `regressed`, `stalled`, or `unknown`, using
   `.agents/workflows/continuous-evaluation-loop.md` for the intent-achievement
   definitions
-- for healthy `in_progress` lanes, record no action in the worked-issue table;
-  for `stalled` lanes, recommend resume, reassign, or drop; for merged non-OK
-  findings, prepare post-merge audit issue-plan entries
+- for healthy `in_progress` lanes and evidenced `realized` outcomes, record no
+  action in the worked-issue table; for `stalled` lanes, recommend resume,
+  reassign, or drop unless the user explicitly approves tracking the stalled
+  lane as an issue; for any other non-OK worked-issue class (`partial`,
+  `missed`, `regressed`, or `unknown`), merged or not, prepare a post-merge
+  audit issue-plan entry or an explicit coordinator action naming the missing
+  evidence or decision
 
 Also audit each included merged PR for:
 - risky behavior change
@@ -160,10 +164,11 @@ For every non-OK finding, include a draft issue entry but do not create it:
   `checklist+replay`, or `park`), `Motivating miss`, `Replay evidence or park
   reason`, and `Non-goal`
 
-Return high-risk findings first, then a worked-issue coverage table and a
-PR-by-PR table. Include exact commands and data sources used, plus any remaining
-`UNKNOWN` facts and the command or permission needed to resolve them. Do not
-make code changes, comments, labels, issues, reverts, or PRs without approval.
+Return high-risk findings first, then review-gate violations, missing changelog
+candidates, cross-PR interaction risks, the issue plan, a worked-issue coverage
+table, a PR-by-PR table, and exact commands/data sources. Include any remaining
+`UNKNOWN` facts and the command or permission needed to resolve them. Do not make
+code changes, comments, labels, issues, reverts, or PRs without approval.
 The worked-issue coverage table must include issue number, coordination
 lane/branch, linked PR or no-PR/blocker evidence, final state,
 intent-achievement classification, and `UNKNOWN` facts.

--- a/.agents/workflows/post-merge-audit.md
+++ b/.agents/workflows/post-merge-audit.md
@@ -11,6 +11,9 @@ Use these prompts with `.agents/skills/post-merge-audit/SKILL.md` when auditing 
 - Use one coordinator to compare reports, dedupe findings, and propose the issue plan.
 - Create GitHub issues only after the user approves the deduped issue plan and
   the approved audit report has been appended to the release-gate audit ledger.
+- If appending to the release-gate audit ledger fails, do not create issues;
+  report the exact command/API error and the ledger issue or permission needed
+  to unblock issue creation.
 - If multiple child issues are needed, create one parent issue for the audit and one child issue per
   independently actionable fix/revert/question. Link the release-gate audit ledger comment from every
   approved parent or child issue created from the audit.
@@ -172,6 +175,12 @@ code changes, comments, labels, issues, reverts, or PRs without approval.
 The worked-issue coverage table must include issue number, coordination
 lane/branch, linked PR or no-PR/blocker evidence, final state,
 intent-achievement classification, and `UNKNOWN` facts.
+
+Example worked-issue coverage table:
+| Issue | Lane/branch | Evidence | Final state | Classification | UNKNOWN facts |
+| --- | --- | --- | --- | --- | --- |
+| #1234 | batch-abc:issue-1234 / codex/example | PR #2345 merged | merged | realized | none |
+| #1235 | batch-abc:issue-1235 / no branch | blocker comment URL | blocked | stalled | owner decision needed |
 ```
 
 ## Comparison Prompt

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1182,8 +1182,10 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - after user approval, append the audit report to the release-gate audit
      ledger before creating issues, then include the resulting ledger comment
      URL in every approved parent or child issue body
-10. Return high-risk findings first, then review-gate violations, cross-PR
-    risks, missing changelog candidates, the issue plan, a worked-issue coverage
-    table, a PR-by-PR table, and exact commands/data sources.
+10. Return high-risk findings first, then review-gate violations, missing
+    changelog candidates, cross-PR risks, the issue plan, a worked-issue
+    coverage table (issue number, coordination lane/branch, linked PR or
+    no-PR/blocker evidence, final state, intent-achievement classification,
+    `UNKNOWN` facts), a PR-by-PR table, and exact commands/data sources.
 
 Do not create fixes, issues, comments, labels, changelog edits, reverts, or PRs until the user approves the audit report and issue plan.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1139,25 +1139,30 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
 2. Resolve worked-issue scope from coordination state when coordinated batch
    work is in scope. If no coordinated batch/run is in scope, record
    `worked_issue_scope: not applicable`. If batch work is in scope but the
-   batch/run id is unknown, run `agent-coord doctor` and `agent-coord status` to
-   list candidate batch/run ids and lanes, record
-   `worked_issue_scope: UNKNOWN (needs batch confirmation)`, and ask the user to confirm a candidate before
-   treating any candidate lane list as worked-issue scope. When the batch/run id
-   is known, run `agent-coord doctor` and `agent-coord status`, then inspect the
-   named batch entry to identify the worked issue set from claims, heartbeats,
-   branches, and dependency metadata. If `agent-coord` is missing or
-   `agent-coord doctor` fails, record `worked_issue_scope: UNKNOWN (setup)`. If
-   `agent-coord doctor` passes but `agent-coord status` fails, record
-   `worked_issue_scope: UNKNOWN (access)`. In all UNKNOWN cases, include the
-   exact command/error and use structured public `codex-claim` comments as an
-   advisory fallback for possible no-PR, blocked, parked, or done-unmerged lanes
-   before reducing scope to merged PRs. If candidate discovery cannot verify
-   backend setup or access, `UNKNOWN (setup)` or `UNKNOWN (access)` takes
-   precedence over `UNKNOWN (needs batch confirmation)`; also report that batch
-   id confirmation is still needed after backend recovery. Keep advisory claim
-   rows marked `UNKNOWN` as needed, and report the command, permission, or batch
-   id confirmation needed to recover the worked issue list instead of identifying
-   a confirmed batch subset from PR links or heuristics.
+   batch/run id is unknown:
+   - run `agent-coord doctor` and `agent-coord status` to list candidate
+     batch/run ids and lanes
+   - record `worked_issue_scope: UNKNOWN (needs batch confirmation)`
+   - ask the user to confirm a candidate before treating any candidate lane list
+     as worked-issue scope
+
+   When the batch/run id is known, run `agent-coord doctor` and
+   `agent-coord status`, then inspect the named batch entry to identify the
+   worked issue set from claims, heartbeats, branches, and dependency metadata.
+   If `agent-coord` is missing or `agent-coord doctor` fails, record
+   `worked_issue_scope: UNKNOWN (setup)`. If `agent-coord doctor` passes but
+   `agent-coord status` fails, record `worked_issue_scope: UNKNOWN (access)`. In
+   all UNKNOWN cases, include the exact command/error and use structured public
+   `codex-claim` comments as an advisory fallback for possible no-PR, blocked,
+   parked, or done-unmerged lanes before reducing scope to merged PRs. If
+   candidate discovery cannot verify backend setup or access, `UNKNOWN (setup)`
+   or `UNKNOWN (access)` takes precedence over
+   `UNKNOWN (needs batch confirmation)`; also report that batch id confirmation
+   is still needed after backend recovery. Keep advisory claim rows marked
+   `UNKNOWN` as needed, and report the command, permission, or batch id
+   confirmation needed to recover the worked issue list instead of identifying a
+   confirmed batch subset from PR links or heuristics.
+
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
@@ -1165,6 +1170,7 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
    rows marked `UNKNOWN`, and report the batch metadata correction needed before
    reducing the audit to the merged PR range only.
+
 3. List every PR merged in the range. When `worked_issue_scope` is known,
    identify the batch subset by coordination state, branch names, PR bodies,
    labels, comments, authors, merge timing, and linked issues. When

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1145,11 +1145,13 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    the merged PR range and report the command or permission needed to recover
    the worked issue list instead of identifying a batch subset from PR links or
    heuristics.
-3. When `worked_issue_scope` is known, list every PR merged in the range, then identify the batch subset by
-   coordination state, branch names, PR bodies, labels, comments, authors,
-   merge timing, and linked issues. Keep no-PR, blocked, parked, and
-   done-unmerged worked issues in the audit scope even when they have no merged
-   PR.
+3. List every PR merged in the range. When `worked_issue_scope` is known,
+   identify the batch subset by coordination state, branch names, PR bodies,
+   labels, comments, authors, merge timing, and linked issues. When
+   `worked_issue_scope` is `UNKNOWN`, keep this as a merged-PR range only and
+   do not classify PRs as included/excluded batch work from PR links or
+   heuristics. Keep no-PR, blocked, parked, and done-unmerged worked issues in
+   the audit scope even when they have no merged PR.
 4. Ask for confirmation of included and excluded worked issues and PRs before
    deep audit unless the user explicitly says to proceed.
 5. For each known worked issue, evaluate whether the implementation, no-PR
@@ -1187,7 +1189,9 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
      filing issues
    - after user approval, append the audit report to the release-gate audit
      ledger before creating issues, then include the resulting ledger comment
-     URL in every approved parent or child issue body
+     URL in every approved parent or child issue body; if the ledger append
+     fails, do not create issues and report the exact command/API error plus the
+     ledger issue, permission, or retry needed
 10. Return high-risk findings first, then review-gate violations, missing
     changelog candidates, cross-PR risks, the issue plan, a worked-issue
     coverage table (issue number, coordination lane/branch, linked PR or

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1141,8 +1141,6 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    heartbeats, branches, and dependency metadata. If coordination state is unavailable,
    record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
    completeness from merged PRs.
-   For private coordination backend setup and CLI discovery, see
-   `internal/contributor-info/agent-coordination-backend.md`.
 3. List every PR merged in the range, then identify the batch subset by
    coordination state, branch names, PR bodies, labels, comments, authors,
    merge timing, and linked issues. Keep no-PR, blocked, parked, and

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1158,18 +1158,20 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
 3. List every PR merged in the range. When `worked_issue_scope` is known,
    identify the batch subset by coordination state, branch names, PR bodies,
    labels, comments, authors, merge timing, and linked issues. When
-   `worked_issue_scope` is `UNKNOWN`, keep this as a merged-PR range only and
-   do not classify PRs as included/excluded batch work from PR links or
-   heuristics. Keep no-PR, blocked, parked, and done-unmerged worked issues in
-   the audit scope even when they have no merged PR.
+   `worked_issue_scope` is `UNKNOWN`, keep the confirmed PR subset as a
+   merged-PR range only and do not classify PRs as included/excluded batch work
+   from PR links or heuristics. Use advisory public `codex-claim` rows from step
+   2 for possible no-PR, blocked, parked, and done-unmerged lanes, but keep
+   those rows marked `UNKNOWN` until coordination state is recovered.
 4. Ask for confirmation of included and excluded worked issues and PRs before
    deep audit when `worked_issue_scope` is known unless the user explicitly says
    to proceed. When the scope is `UNKNOWN (needs batch confirmation)`, ask the
    user to choose the candidate batch/run id before any worked-issue audit.
-5. For each known worked issue, evaluate whether the implementation, no-PR
-   evidence, blocker, or parked disposition satisfied the issue intent; verify
-   the final state; and classify it as `in_progress`, `realized`, `partial`,
-   `missed`, `regressed`, `stalled`, or `unknown` using
+5. For each known worked issue or advisory public `codex-claim` row, evaluate
+   whether the implementation, no-PR evidence, blocker, or parked disposition
+   satisfied the issue intent; verify the final state; and classify it as
+   `in_progress`, `realized`, `partial`, `missed`, `regressed`, `stalled`, or
+   `unknown` using
    `.agents/workflows/continuous-evaluation-loop.md`. Treat healthy active/live
    lanes as `in_progress` no-action items unless they have a stalled, regressed,
    partial, missed, or unknown signal.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1140,8 +1140,8 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    work is in scope. If no coordinated batch/run is in scope, record
    `worked_issue_scope: not applicable`. If batch work is in scope but the
    batch/run id is unknown, run `agent-coord doctor` and `agent-coord status` to
-   list candidate batch/run ids and lanes, record `worked_issue_scope: UNKNOWN
-(needs batch confirmation)`, and ask the user to confirm a candidate before
+   list candidate batch/run ids and lanes, record
+   `worked_issue_scope: UNKNOWN (needs batch confirmation)`, and ask the user to confirm a candidate before
    treating any candidate lane list as worked-issue scope. When the batch/run id
    is known, run `agent-coord doctor` and `agent-coord status`, then inspect the
    named batch entry to identify the worked issue set from claims, heartbeats,

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1150,9 +1150,11 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    deep audit unless the user explicitly says to proceed.
 5. For each worked issue, evaluate whether the implementation, no-PR evidence,
    blocker, or parked disposition satisfied the issue intent; verify the final
-   state; and classify it as `realized`, `partial`, `missed`, `regressed`,
-   `stalled`, or `unknown` using
-   `.agents/workflows/continuous-evaluation-loop.md`.
+   state; and classify it as `in_progress`, `realized`, `partial`, `missed`,
+   `regressed`, `stalled`, or `unknown` using
+   `.agents/workflows/continuous-evaluation-loop.md`. Treat healthy active/live
+   lanes as `in_progress` no-action items unless they have a stalled,
+   regressed, partial, missed, or unknown signal.
 6. For each included merged PR, inspect reviews, comments, checks, merge time,
    changed files, validation evidence, changelog coverage, and cross-PR
    interactions.
@@ -1165,16 +1167,23 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - requested adversarial review that did not finish before merge, finished on an older head SHA, or left untriaged `BLOCKING`/`DISCUSS` findings
 8. Flag user-visible changes missing from `CHANGELOG.md`; if any are found, recommend running `/update-changelog` before the next release candidate.
 9. Produce a deduped issue plan for non-OK findings:
-   - no issue for OK, duplicates, or fully resolved findings
+   - no issue for OK, duplicates, fully resolved findings, or healthy
+     `in_progress` lanes
    - one bundled changelog issue or a `/update-changelog` recommendation for missing changelog entries
    - one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task
    - one parent issue when there are two or more related child issues from the same audit
+   - a coordinator action entry, not a follow-up issue, for each `stalled` lane
+     that needs a resume/reassign/drop decision unless the user explicitly
+     approves tracking it as an issue
    - hidden `post-merge-audit-finding` fingerprints so duplicate child issues can be detected
    - for process findings, include the Process Gap Disposition fields above,
      especially `Mechanism target` and `Replay evidence or park reason`, before
      filing issues
-10. Return high-risk findings first, then cross-PR risks, missing changelog
-    candidates, the issue plan, a worked-issue coverage table, a PR-by-PR
-    table, and exact commands/data sources.
+   - after user approval, append the audit report to the release-gate audit
+     ledger before creating issues, then include the resulting ledger comment
+     URL in every approved parent or child issue body
+10. Return high-risk findings first, then review-gate violations, cross-PR
+    risks, missing changelog candidates, the issue plan, a worked-issue coverage
+    table, a PR-by-PR table, and exact commands/data sources.
 
 Do not create fixes, issues, comments, labels, changelog edits, reverts, or PRs until the user approves the audit report and issue plan.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1136,13 +1136,15 @@ For a manual multi-PR landing plan:
 Use this section when reviewing already-merged PRs from concurrent agent work, especially before a release candidate.
 
 1. Resolve the base release candidate tag/commit and head SHA.
-2. When auditing a named batch/run, run `agent-coord doctor` and `agent-coord status`,
-   then inspect the named batch entry to identify the worked issue set from claims,
-   heartbeats, branches, and dependency metadata. If coordination state is unavailable,
-   record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
-   completeness from merged PRs; when scope is `UNKNOWN`, audit only the merged
-   PR range and report the command or permission needed to recover the worked
-   issue list instead of identifying a batch subset from PR links or heuristics.
+2. When auditing a named batch/run and the batch/run id is known, run
+   `agent-coord doctor` and `agent-coord status`, then inspect the named batch
+   entry to identify the worked issue set from claims, heartbeats, branches, and
+   dependency metadata. If coordination state is unavailable, record
+   `worked_issue_scope: UNKNOWN` with the exact command/error instead of
+   inferring completeness from merged PRs; when scope is `UNKNOWN`, audit only
+   the merged PR range and report the command or permission needed to recover
+   the worked issue list instead of identifying a batch subset from PR links or
+   heuristics.
 3. When `worked_issue_scope` is known, list every PR merged in the range, then identify the batch subset by
    coordination state, branch names, PR bodies, labels, comments, authors,
    merge timing, and linked issues. Keep no-PR, blocked, parked, and
@@ -1174,6 +1176,8 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - one bundled changelog issue or a `/update-changelog` recommendation for missing changelog entries
    - one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task
    - one parent issue when there are two or more related child issues from the same audit
+   - include healthy `in_progress` lanes in the worked-issue coverage table so
+     the coordinator can verify complete coverage
    - a coordinator action entry, not a follow-up issue, for each `stalled` lane
      that needs a resume/reassign/drop decision unless the user explicitly
      approves tracking it as an issue

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1171,19 +1171,20 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    rows marked `UNKNOWN`, and report the batch metadata correction needed before
    reducing the audit to the merged PR range only.
 
-3. List every PR merged in the range. When `worked_issue_scope` is known,
-   identify the batch subset by coordination state, branch names, PR bodies,
-   labels, comments, authors, merge timing, and linked issues. When
-   `worked_issue_scope` is `UNKNOWN`, keep the confirmed PR subset as a
-   merged-PR range only and do not classify PRs as included/excluded batch work
-   from PR links or heuristics. Use advisory public `codex-claim` rows from step
-   2 for possible no-PR, blocked, parked, and done-unmerged lanes, but keep
-   those rows marked `UNKNOWN` until coordination state is recovered.
+3. List every PR merged in the range. When `worked_issue_scope` is verified
+   from coordination state, identify the batch subset by coordination state,
+   branch names, PR bodies, labels, comments, authors, merge timing, and linked
+   issues. When `worked_issue_scope` is `not applicable`, `UNKNOWN (...)`, or
+   `empty (...)`, keep the confirmed PR list as a merged-PR range only and do
+   not classify PRs as included/excluded batch work from PR links or heuristics.
+   Use advisory public `codex-claim` rows from step 2 for possible no-PR,
+   blocked, parked, and done-unmerged lanes, but keep those rows marked
+   `UNKNOWN` until coordination state is recovered.
 4. Ask for confirmation of included and excluded worked issues, advisory public
    `codex-claim` rows, and the PR range before deep audit unless the user
    explicitly says to proceed. When the scope is
    `UNKNOWN (needs batch confirmation)`, ask the user to choose the candidate
-   batch/run id before any worked-issue audit.
+   batch/run id before any confirmed worked-issue audit.
 5. For each known worked issue or advisory public `codex-claim` row, evaluate
    whether the implementation, no-PR evidence, blocker, or parked disposition
    satisfied the issue intent; verify the final state; and classify it as

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1141,6 +1141,8 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    heartbeats, branches, and dependency metadata. If coordination state is unavailable,
    record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
    completeness from merged PRs.
+   For private coordination backend setup and CLI discovery, see
+   `internal/contributor-info/agent-coordination-backend.md`.
 3. List every PR merged in the range, then identify the batch subset by
    coordination state, branch names, PR bodies, labels, comments, authors,
    merge timing, and linked issues. Keep no-PR, blocked, parked, and

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1161,8 +1161,10 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
-   audit the merged PR range only, and report the batch metadata correction
-   needed.
+   scan structured public `codex-claim` comments as advisory recovery rows for
+   possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
+   rows marked `UNKNOWN`, and report the batch metadata correction needed before
+   reducing the audit to the merged PR range only.
 3. List every PR merged in the range. When `worked_issue_scope` is known,
    identify the batch subset by coordination state, branch names, PR bodies,
    labels, comments, authors, merge timing, and linked issues. When

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1140,7 +1140,7 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    work is in scope. If no coordinated batch/run is in scope, record
    `worked_issue_scope: not applicable`. If batch work is in scope but the
    batch/run id is unknown:
-   - run `agent-coord doctor` and `agent-coord status` to list candidate
+   - run `agent-coord doctor`, then `agent-coord status` to list candidate
      batch/run ids and lanes
    - record `worked_issue_scope: UNKNOWN (needs batch confirmation)`
    - ask the user to confirm a candidate before treating any candidate lane list
@@ -1168,8 +1168,10 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
    scan structured public `codex-claim` comments as advisory recovery rows for
    possible no-PR, blocked, parked, or done-unmerged lanes, keep any recovered
-   rows marked `UNKNOWN`, and report the batch metadata correction needed before
-   reducing the audit to the merged PR range only.
+   rows marked `UNKNOWN`, report the batch metadata correction needed, and ask
+   for confirmation before reducing the audit to the merged PR range only. If
+   the user confirms no lanes were worked, record the empty-batch finding and
+   proceed to the merged PR range.
 
 3. List every PR merged in the range. When `worked_issue_scope` is verified
    from coordination state, identify the batch subset by coordination state,

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1136,18 +1136,35 @@ For a manual multi-PR landing plan:
 Use this section when reviewing already-merged PRs from concurrent agent work, especially before a release candidate.
 
 1. Resolve the base release candidate tag/commit and head SHA.
-2. List every PR merged in the range, then identify the batch subset by branch names, PR bodies, labels, comments, authors, merge timing, and linked issues.
-3. Ask for confirmation of included and excluded PRs before deep audit unless the user explicitly says to proceed.
-4. For each included PR, inspect reviews, comments, checks, merge time, changed files, validation evidence, changelog coverage, and cross-PR interactions.
-5. Flag review-gate violations:
+2. When auditing a named batch/run, run `agent-coord doctor` and `agent-coord status`,
+   then inspect the named batch entry to identify the worked issue set from claims,
+   heartbeats, branches, and dependency metadata. If coordination state is unavailable,
+   record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
+   completeness from merged PRs.
+3. List every PR merged in the range, then identify the batch subset by
+   coordination state, branch names, PR bodies, labels, comments, authors,
+   merge timing, and linked issues. Keep no-PR, blocked, parked, and
+   done-unmerged worked issues in the audit scope even when they have no merged
+   PR.
+4. Ask for confirmation of included and excluded worked issues and PRs before
+   deep audit unless the user explicitly says to proceed.
+5. For each worked issue, evaluate whether the implementation, no-PR evidence,
+   blocker, or parked disposition satisfied the issue intent; verify the final
+   state; and classify it as `realized`, `partial`, `missed`, `regressed`,
+   `stalled`, or `unknown` using
+   `.agents/workflows/continuous-evaluation-loop.md`.
+6. For each included merged PR, inspect reviews, comments, checks, merge time,
+   changed files, validation evidence, changelog coverage, and cross-PR
+   interactions.
+7. Flag review-gate violations:
    - review checks, reviews, or comments that landed after merge
    - review checks that were queued, in progress, stale, or asynchronous at merge time
    - pre-merge `Must Fix`, `MUST-FIX`, `Should Fix`, `DISCUSS`, `Changes Requested`, or similar actionable comments with no later evidence they were fixed, waived, or classified
    - AI reviewer approvals, positive issue comments, or "no actionable comments" summaries that were incorrectly treated as required maintainer approval or special approval gates
    - AI review findings that were ignored even though they identified a confirmed blocker such as a correctness regression, failing test, security issue, API contract break, data-loss risk, or missing required maintainer approval
    - requested adversarial review that did not finish before merge, finished on an older head SHA, or left untriaged `BLOCKING`/`DISCUSS` findings
-6. Flag user-visible changes missing from `CHANGELOG.md`; if any are found, recommend running `/update-changelog` before the next release candidate.
-7. Produce a deduped issue plan for non-OK findings:
+8. Flag user-visible changes missing from `CHANGELOG.md`; if any are found, recommend running `/update-changelog` before the next release candidate.
+9. Produce a deduped issue plan for non-OK findings:
    - no issue for OK, duplicates, or fully resolved findings
    - one bundled changelog issue or a `/update-changelog` recommendation for missing changelog entries
    - one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task
@@ -1156,6 +1173,8 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - for process findings, include the Process Gap Disposition fields above,
      especially `Mechanism target` and `Replay evidence or park reason`, before
      filing issues
-8. Return high-risk findings first, then cross-PR risks, missing changelog candidates, the issue plan, a PR-by-PR table, and exact commands/data sources.
+10. Return high-risk findings first, then cross-PR risks, missing changelog
+    candidates, the issue plan, a worked-issue coverage table, a PR-by-PR
+    table, and exact commands/data sources.
 
 Do not create fixes, issues, comments, labels, changelog edits, reverts, or PRs until the user approves the audit report and issue plan.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1136,15 +1136,22 @@ For a manual multi-PR landing plan:
 Use this section when reviewing already-merged PRs from concurrent agent work, especially before a release candidate.
 
 1. Resolve the base release candidate tag/commit and head SHA.
-2. When auditing a named batch/run and the batch/run id is known, run
-   `agent-coord doctor` and `agent-coord status`, then inspect the named batch
-   entry to identify the worked issue set from claims, heartbeats, branches, and
-   dependency metadata. If coordination state is unavailable, record
-   `worked_issue_scope: UNKNOWN` with the exact command/error instead of
-   inferring completeness from merged PRs; when scope is `UNKNOWN`, audit only
-   the merged PR range and report the command or permission needed to recover
-   the worked issue list instead of identifying a batch subset from PR links or
-   heuristics.
+2. Resolve worked-issue scope from coordination state when coordinated batch
+   work is in scope. If no coordinated batch/run is in scope, record
+   `worked_issue_scope: not applicable`. If batch work is in scope but the
+   batch/run id is unknown, run `agent-coord doctor` and `agent-coord status` to
+   list candidate batch/run ids and lanes, record `worked_issue_scope: UNKNOWN
+(needs batch confirmation)`, and ask the user to confirm a candidate before
+   treating any candidate lane list as worked-issue scope. When the batch/run id
+   is known, run `agent-coord doctor` and `agent-coord status`, then inspect the
+   named batch entry to identify the worked issue set from claims, heartbeats,
+   branches, and dependency metadata. If `agent-coord` is missing or
+   `agent-coord doctor` fails, record `worked_issue_scope: UNKNOWN (setup)`. If
+   `agent-coord doctor` passes but `agent-coord status` fails, record
+   `worked_issue_scope: UNKNOWN (access)`. In all UNKNOWN cases, include the
+   exact command/error, audit only the merged PR range, and report the command,
+   permission, or batch id confirmation needed to recover the worked issue list
+   instead of identifying a batch subset from PR links or heuristics.
 3. List every PR merged in the range. When `worked_issue_scope` is known,
    identify the batch subset by coordination state, branch names, PR bodies,
    labels, comments, authors, merge timing, and linked issues. When
@@ -1153,7 +1160,9 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    heuristics. Keep no-PR, blocked, parked, and done-unmerged worked issues in
    the audit scope even when they have no merged PR.
 4. Ask for confirmation of included and excluded worked issues and PRs before
-   deep audit unless the user explicitly says to proceed.
+   deep audit when `worked_issue_scope` is known unless the user explicitly says
+   to proceed. When the scope is `UNKNOWN (needs batch confirmation)`, ask the
+   user to choose the candidate batch/run id before any worked-issue audit.
 5. For each known worked issue, evaluate whether the implementation, no-PR
    evidence, blocker, or parked disposition satisfied the issue intent; verify
    the final state; and classify it as `in_progress`, `realized`, `partial`,
@@ -1187,11 +1196,14 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - for process findings, include the Process Gap Disposition fields above,
      especially `Mechanism target` and `Replay evidence or park reason`, before
      filing issues
-   - after user approval, append the audit report to the release-gate audit
-     ledger before creating issues, then include the resulting ledger comment
-     URL in every approved parent or child issue body; if the ledger append
-     fails, do not create issues and report the exact command/API error plus the
-     ledger issue, permission, or retry needed
+   - for release-gate audits, after user approval, append the audit report to
+     the release-gate audit ledger before creating issues, then include the
+     resulting ledger comment URL in every approved parent or child issue body;
+     if the required ledger append fails, do not create issues and report the
+     exact command/API error plus the ledger issue, permission, or retry needed
+   - for non-release audits with no release-gate ledger, include
+     `Audit ledger: not applicable (non-release audit)` in every approved parent
+     or child issue body
 10. Return high-risk findings first, then review-gate violations, missing
     changelog candidates, cross-PR risks, the issue plan, a worked-issue
     coverage table (issue number, coordination lane/branch, linked PR or

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1151,10 +1151,13 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    `worked_issue_scope: UNKNOWN (access)`. In all UNKNOWN cases, include the
    exact command/error and use structured public `codex-claim` comments as an
    advisory fallback for possible no-PR, blocked, parked, or done-unmerged lanes
-   before reducing scope to merged PRs. Keep advisory claim rows marked
-   `UNKNOWN` as needed, and report the command, permission, or batch id
-   confirmation needed to recover the worked issue list instead of identifying a
-   confirmed batch subset from PR links or heuristics.
+   before reducing scope to merged PRs. If candidate discovery cannot verify
+   backend setup or access, `UNKNOWN (setup)` or `UNKNOWN (access)` takes
+   precedence over `UNKNOWN (needs batch confirmation)`; also report that batch
+   id confirmation is still needed after backend recovery. Keep advisory claim
+   rows marked `UNKNOWN` as needed, and report the command, permission, or batch
+   id confirmation needed to recover the worked issue list instead of identifying
+   a confirmed batch subset from PR links or heuristics.
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
    `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
@@ -1221,4 +1224,7 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
     no-PR/blocker evidence, final state, intent-achievement classification,
     `UNKNOWN` facts), a PR-by-PR table, and exact commands/data sources.
 
-Do not create fixes, issues, comments, labels, changelog edits, reverts, or PRs until the user approves the audit report and issue plan.
+Do not create fixes, issues, comments, labels, changelog edits, reverts, or PRs
+until the user approves the audit report and issue plan. For release-gate
+audits, also append the approved audit report to the release-gate ledger
+successfully before issue creation.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -39,7 +39,8 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      checked, report private state as `UNKNOWN` and use structured public
      `codex-claim` comments as an advisory fallback. A structured public
      `codex-claim` comment is a GitHub issue/PR comment containing a
-     `codex-claim` JSON block; see the "Public claim comment" format below.
+     `codex-claim` HTML comment (`<!-- codex-claim v1 ... -->`) with key/value
+     fields; see the "Public claim comment" format below.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
@@ -554,7 +555,11 @@ Before merge or final readiness, scan the PR description for the decision log an
 > And Handoffs_: record the handoff below on the relevant parent tracking issue
 > (or the agent-coordination repo if one is in use), or in the batch's own PR
 > comment/description when there is no parent umbrella; and append point-in-time
-> audits to the standing release audit ledger in place. Never spawn a standalone
+> audits to the standing release audit ledger in place. Locate that ledger with
+> the release-mode preflight search: open issues with the `release` and
+> `TRACKING` labels, plus `Release gate:` title matches; if no release-gate
+> ledger exists for a release audit, surface that absence before creating
+> follow-up issues. Never spawn a standalone
 > `Handoff: ...` or `Post-rc.N audit` issue. Close superseded process issues on
 > sight; closure follows the work, not whoever opened the tracker.
 
@@ -1164,6 +1169,9 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    `UNKNOWN` as needed, and report the command, permission, or batch id
    confirmation needed to recover the worked issue list instead of identifying a
    confirmed batch subset from PR links or heuristics.
+   If the batch id itself is unknown, scope advisory public-claim discovery to
+   issues and open PRs active within the audit time window, and use each claim's
+   `batch:` field only to surface candidate ids until the user confirms one.
 
    If `agent-coord doctor` and `agent-coord status` both succeed but the named
    batch entry contains no worked issues or lanes, record
@@ -1178,6 +1186,10 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    `worked_issue_scope: UNKNOWN (empty batch, lanes expected)`, collect a manual
    lane list from the user or advisory `codex-claim` comments, and keep
    recovered rows advisory `UNKNOWN` until coordination state is corrected.
+
+   Sync note: this scope algorithm is intentionally mirrored in
+   `.agents/skills/post-merge-audit/SKILL.md` and
+   `.agents/workflows/post-merge-audit.md`; update all copies together.
 
 3. List every PR merged in the range. When `worked_issue_scope` is verified
    from coordination state, identify the batch subset by coordination state,

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1140,21 +1140,23 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    then inspect the named batch entry to identify the worked issue set from claims,
    heartbeats, branches, and dependency metadata. If coordination state is unavailable,
    record `worked_issue_scope: UNKNOWN` with the exact command/error instead of inferring
-   completeness from merged PRs.
-3. List every PR merged in the range, then identify the batch subset by
+   completeness from merged PRs; when scope is `UNKNOWN`, audit only the merged
+   PR range and report the command or permission needed to recover the worked
+   issue list instead of identifying a batch subset from PR links or heuristics.
+3. When `worked_issue_scope` is known, list every PR merged in the range, then identify the batch subset by
    coordination state, branch names, PR bodies, labels, comments, authors,
    merge timing, and linked issues. Keep no-PR, blocked, parked, and
    done-unmerged worked issues in the audit scope even when they have no merged
    PR.
 4. Ask for confirmation of included and excluded worked issues and PRs before
    deep audit unless the user explicitly says to proceed.
-5. For each worked issue, evaluate whether the implementation, no-PR evidence,
-   blocker, or parked disposition satisfied the issue intent; verify the final
-   state; and classify it as `in_progress`, `realized`, `partial`, `missed`,
-   `regressed`, `stalled`, or `unknown` using
+5. For each known worked issue, evaluate whether the implementation, no-PR
+   evidence, blocker, or parked disposition satisfied the issue intent; verify
+   the final state; and classify it as `in_progress`, `realized`, `partial`,
+   `missed`, `regressed`, `stalled`, or `unknown` using
    `.agents/workflows/continuous-evaluation-loop.md`. Treat healthy active/live
-   lanes as `in_progress` no-action items unless they have a stalled,
-   regressed, partial, missed, or unknown signal.
+   lanes as `in_progress` no-action items unless they have a stalled, regressed,
+   partial, missed, or unknown signal.
 6. For each included merged PR, inspect reviews, comments, checks, merge time,
    changed files, validation evidence, changelog coverage, and cross-PR
    interactions.

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -39,7 +39,7 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      checked, report private state as `UNKNOWN` and use structured public
      `codex-claim` comments as an advisory fallback. A structured public
      `codex-claim` comment is a GitHub issue/PR comment containing a
-     `codex-claim` JSON block; see the public claim comment format below.
+     `codex-claim` JSON block; see the "Public claim comment" format below.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
@@ -1213,8 +1213,8 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - requested adversarial review that did not finish before merge, finished on an older head SHA, or left untriaged `BLOCKING`/`DISCUSS` findings
 8. Flag user-visible changes missing from `CHANGELOG.md`; if any are found, recommend running `/update-changelog` before the next release candidate.
 9. Produce a deduped issue plan for non-OK findings:
-   - no issue for OK, duplicates, fully resolved findings, or healthy
-     `in_progress` lanes
+   - no issue for OK, duplicates, fully resolved findings, evidenced `realized`
+     lanes, or healthy `in_progress` lanes
    - one bundled changelog issue or a `/update-changelog` recommendation for missing changelog entries
    - one child issue per independently actionable fix PR, revert consideration, maintainer question, or follow-up task
    - one parent issue when there are two or more related child issues from the same audit
@@ -1223,6 +1223,8 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    - a coordinator action entry, not a follow-up issue, for each `stalled` lane
      that needs a resume/reassign/drop decision unless the user explicitly
      approves tracking it as an issue
+   - one child issue or approved coordinator action for each `partial`, `missed`,
+     `regressed`, or `unknown` worked-issue outcome that needs follow-up
    - hidden `post-merge-audit-finding` fingerprints so duplicate child issues can be detected
    - for process findings, include the Process Gap Disposition fields above,
      especially `Mechanism target` and `Replay evidence or park reason`, before

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -36,8 +36,8 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      liveness. `agent-coord status` is a preflight view; the claim operation is
      the backend's compare-and-swap gate, so the claim result is the source of
      truth for races. If `agent-coord doctor` or `agent-coord status` cannot be
-     checked, report private state as `UNKNOWN` and use structured public claim
-     comments as an advisory fallback.
+     checked, report private state as `UNKNOWN` and use structured public
+     `codex-claim` comments as an advisory fallback.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
@@ -1155,6 +1155,11 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    `UNKNOWN` as needed, and report the command, permission, or batch id
    confirmation needed to recover the worked issue list instead of identifying a
    confirmed batch subset from PR links or heuristics.
+   If `agent-coord doctor` and `agent-coord status` both succeed but the named
+   batch entry contains no worked issues or lanes, record
+   `worked_issue_scope: empty (no coordination lanes found for <BATCH_ID>)`,
+   audit the merged PR range only, and report the batch metadata correction
+   needed.
 3. List every PR merged in the range. When `worked_issue_scope` is known,
    identify the batch subset by coordination state, branch names, PR bodies,
    labels, comments, authors, merge timing, and linked issues. When
@@ -1163,10 +1168,11 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    from PR links or heuristics. Use advisory public `codex-claim` rows from step
    2 for possible no-PR, blocked, parked, and done-unmerged lanes, but keep
    those rows marked `UNKNOWN` until coordination state is recovered.
-4. Ask for confirmation of included and excluded worked issues and PRs before
-   deep audit when `worked_issue_scope` is known unless the user explicitly says
-   to proceed. When the scope is `UNKNOWN (needs batch confirmation)`, ask the
-   user to choose the candidate batch/run id before any worked-issue audit.
+4. Ask for confirmation of included and excluded worked issues, advisory public
+   `codex-claim` rows, and the PR range before deep audit unless the user
+   explicitly says to proceed. When the scope is
+   `UNKNOWN (needs batch confirmation)`, ask the user to choose the candidate
+   batch/run id before any worked-issue audit.
 5. For each known worked issue or advisory public `codex-claim` row, evaluate
    whether the implementation, no-PR evidence, blocker, or parked disposition
    satisfied the issue intent; verify the final state; and classify it as

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -37,7 +37,9 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
      the backend's compare-and-swap gate, so the claim result is the source of
      truth for races. If `agent-coord doctor` or `agent-coord status` cannot be
      checked, report private state as `UNKNOWN` and use structured public
-     `codex-claim` comments as an advisory fallback.
+     `codex-claim` comments as an advisory fallback. A structured public
+     `codex-claim` comment is a GitHub issue/PR comment containing a
+     `codex-claim` JSON block; see the public claim comment format below.
    - For lanes declared in `batches/<batch-id>.json` with `depends_on`, run
      `agent-coord status` at lane start and before rebase or push. If the lane
      shows unmet `blocked_on` refs, set that lane's heartbeat status to
@@ -1171,7 +1173,11 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    rows marked `UNKNOWN`, report the batch metadata correction needed, and ask
    for confirmation before reducing the audit to the merged PR range only. If
    the user confirms no lanes were worked, record the empty-batch finding and
-   proceed to the merged PR range.
+   proceed to the merged PR range. If the user indicates lanes were worked
+   despite the empty entry, record
+   `worked_issue_scope: UNKNOWN (empty batch, lanes expected)`, collect a manual
+   lane list from the user or advisory `codex-claim` comments, and keep
+   recovered rows advisory `UNKNOWN` until coordination state is corrected.
 
 3. List every PR merged in the range. When `worked_issue_scope` is verified
    from coordination state, identify the batch subset by coordination state,

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -1149,9 +1149,12 @@ Use this section when reviewing already-merged PRs from concurrent agent work, e
    `agent-coord doctor` fails, record `worked_issue_scope: UNKNOWN (setup)`. If
    `agent-coord doctor` passes but `agent-coord status` fails, record
    `worked_issue_scope: UNKNOWN (access)`. In all UNKNOWN cases, include the
-   exact command/error, audit only the merged PR range, and report the command,
-   permission, or batch id confirmation needed to recover the worked issue list
-   instead of identifying a batch subset from PR links or heuristics.
+   exact command/error and use structured public `codex-claim` comments as an
+   advisory fallback for possible no-PR, blocked, parked, or done-unmerged lanes
+   before reducing scope to merged PRs. Keep advisory claim rows marked
+   `UNKNOWN` as needed, and report the command, permission, or batch id
+   confirmation needed to recover the worked issue list instead of identifying a
+   confirmed batch subset from PR links or heuristics.
 3. List every PR merged in the range. When `worked_issue_scope` is known,
    identify the batch subset by coordination state, branch names, PR bodies,
    labels, comments, authors, merge timing, and linked issues. When

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -169,7 +169,7 @@ exclude_path = [
 ]
 
 # Don't check fragments/anchors (can be flaky)
-include_fragments = "none"
+include_fragments = false
 
 # Keep CI cache entries short-lived so transient external failures do not
 # linger across otherwise valid PRs.

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -169,7 +169,7 @@ exclude_path = [
 ]
 
 # Don't check fragments/anchors (can be flaky)
-include_fragments = false
+include_fragments = "none"
 
 # Keep CI cache entries short-lived so transient external failures do not
 # linger across otherwise valid PRs.


### PR DESCRIPTION
## Why

Fixes #4126.
Refs #4010.

Batch/post-merge audits were centered on merged PR ranges, which can miss worked issues that ended as no-PR, blocked, parked, or done-unmerged lanes. Release-audit follow-up issues also need a durable backlink to the release-gate audit ledger entry that approved them.

## What changed

- Updates the post-merge audit skill and workflow to resolve worked-issue scope from `agent-coord doctor` / `agent-coord status` for named batch/run audits.
- Treats missing/unavailable `agent-coord`, `doctor` failures, and `status` failures as `worked_issue_scope: UNKNOWN` with exact command/error evidence.
- Keeps `worked_issue_scope: UNKNOWN` as a hard boundary: use structured public `codex-claim` comments only as advisory recovery evidence, then record the missing command/permission instead of reconstructing confirmed worked issues from PR links.
- Adds per-issue intent/final-state classification so no-PR, blocked, parked, and unmerged lanes stay in audit scope.
- Routes non-OK worked-issue outcomes, including no-PR/unmerged lanes, to an issue plan or explicit coordinator action; stalled lanes remain coordinator actions unless the user approves an issue.
- Updates PR-processing post-merge audit guidance to keep worked-issue coverage separate from merged-PR coverage and to include consistent output ordering/table columns.
- Clarifies the independent audit prompt, worked-issue coverage table columns, comparison prompt, and ledger-before-follow-up-issue ordering.
- Requires approved release-gate post-merge audit parent/child issues to include the release-gate audit ledger comment URL, while non-release audits record `Audit ledger: not applicable (non-release audit)`.

## Validation

- `git diff --check origin/main...HEAD` -> pass
- `/Users/justin/.codex/worktrees/b2d0/react_on_rails/node_modules/.bin/prettier --check .agents/skills/post-merge-audit/SKILL.md .agents/workflows/post-merge-audit.md .agents/workflows/pr-processing.md` -> pass
- `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> 3 links checked, 0 errors
- Current-head review follow-up validation: `git diff --check origin/main...HEAD`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Second review-wave validation: `git diff --check origin/main...HEAD`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Final review-wave validation after `d2387221f`: `git diff --check origin/main...HEAD`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Advisory-row review validation after `c89147e45`: `git diff --check origin/main...HEAD`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Empty-batch/ledger retry review validation after `416f4e1d4`: `git diff --check origin/main...HEAD`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- UNKNOWN-precedence review validation after `1afb5d5bd`: `git diff --check origin/main...HEAD`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Advisory-scope review validation after `100fe7797`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Verified-scope review validation after `1ee5183d6`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Scope-confirmation review validation after `2e8f20297`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Output-wording review validation after `dc09b82fb`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Coverage-example review validation after `a9df867a2`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Empty-batch recovery review validation after `93faaf203`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- Issue-plan routing review validation after `1ca39a730`: `git diff --check`, shared Prettier check, and `PATH=/tmp/lychee-v0.23.0:$PATH bin/lefthook/markdown-link-lint branch` -> pass
- `PATH=/tmp/lychee-v0.23.0:$PATH bin/check-links` -> 2,955 links checked, 0 errors after restoring CI-compatible Lychee config syntax
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` -> 226 files inspected, no offenses
- pre-commit/pre-push hooks passed on the pushed branch; pre-push used the CI-compatible Lychee v0.23.0 binary.

## Notes

Current head `1ca39a730` is pushed after final review-thread follow-up. Hosted checks restarted after the latest push; local Markdown validation is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated post-merge audit skill and workflow guidance to be squash-aware and derive audit scope from coordination lanes, including blocked/parked/done-unmerged (non-PR) work.
  * Strengthened sequencing with pre-issue search and confirmation gating; when lane scope can’t be verified, auditors must record an explicit `UNKNOWN` with the exact command/error.
  * Expanded outputs with worked-issue coverage (including unresolved `UNKNOWN` facts) and PR-by-PR tables, and requires linking approved parent/child issues to the release-gate audit ledger.
* **Chores**
  * Refreshed batch audit evaluation for lane-based outcomes, improved review-gate violation detection, added missing-changelog recommendations, and revised issue-plan/stalled routing with higher-risk-first output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only agent workflow documentation; no runtime, auth, or application code changes.
> 
> **Overview**
> Post-merge audit guidance no longer stops at merged PRs. **Worked-issue scope** is resolved via `agent-coord doctor` / `status` (with explicit `UNKNOWN` states and advisory `codex-claim` recovery), and each lane is classified (`in_progress`, `realized`, `partial`, `missed`, `regressed`, `stalled`, `unknown`) including no-PR, blocked, parked, and done-unmerged outcomes.
> 
> The skill, workflow prompts, and `pr-processing.md` post-merge section are aligned on scope gates, output ordering, a **worked-issue coverage table**, and issue-plan routing (stalled → coordinator action; non-OK lanes → issues). **Release-gate** audits must append the report to the release audit ledger before follow-up issues and link that comment URL in approved parent/child issues; non-release audits record ledger N/A.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc747f90a107ab0d3ff537216132996dc1a96fc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->









