### PR TITLE
Apply Capacity AI posture to Pro Control Plane template

### DIFF
--- a/react_on_rails_pro/.controlplane/postgres.yml 
+++ b/react_on_rails_pro/.controlplane/postgres.yml 
@@ -21,9 +21,14 @@ spec:
         - path: /var/lib/postgresql/data
           recoveryPolicy: retain
           uri: 'scratch://postgres-vol'
-  # Important that postgres does not scaling because disk storage is local to one server!
+  # Keep Postgres on one manual replica because disk storage is local to one server.
+  # Capacity AI may restart the workload when adjusting resources; for Postgres
+  # that can disrupt the database despite the retained local volume.
+  # Keep the single-replica manual posture explicit instead of relying on platform defaults.
   defaultOptions:
     autoscaling:
+      metric: disabled
+      minScale: 1
       maxScale: 1
     capacityAI: false
   # This firewall configuration corresponds to using a simple, hard-coded password for postgres

--- a/react_on_rails_pro/.controlplane/rails.yml
+++ b/react_on_rails_pro/.controlplane/rails.yml
@@ -47,11 +47,12 @@ spec:
         - number: 3800
           protocol: http
   defaultOptions:
-    # Start out like this for "test apps"
+    # Public/staging test apps keep one warm replica while Capacity AI right-sizes CPU and memory.
     autoscaling:
-      # Max of 1 effectively disables autoscaling, so a like a Heroku dyno count of 1
+      metric: disabled
+      minScale: 1
       maxScale: 1
-    capacityAI: false
+    capacityAI: true
   firewallConfig:
     external:
       # Default to allow public access to Rails server

--- a/react_on_rails_pro/.controlplane/rails.yml
+++ b/react_on_rails_pro/.controlplane/rails.yml
@@ -47,8 +47,9 @@ spec:
         - number: 3800
           protocol: http
   defaultOptions:
-    # Public/staging test apps keep one warm replica while Capacity AI right-sizes CPU and memory.
-    # For production, increase maxScale and review Capacity AI suitability.
+    # Public/staging test apps keep one warm replica while Capacity AI right-sizes both containers.
+    # Capacity AI may restart that replica when applying resource changes.
+    # For production or high-availability staging, increase maxScale and review Capacity AI suitability.
     autoscaling:
       metric: disabled
       minScale: 1

--- a/react_on_rails_pro/.controlplane/rails.yml
+++ b/react_on_rails_pro/.controlplane/rails.yml
@@ -48,6 +48,7 @@ spec:
           protocol: http
   defaultOptions:
     # Public/staging test apps keep one warm replica while Capacity AI right-sizes CPU and memory.
+    # For production, increase maxScale and review Capacity AI suitability.
     autoscaling:
       metric: disabled
       minScale: 1

--- a/react_on_rails_pro/.controlplane/rails.yml
+++ b/react_on_rails_pro/.controlplane/rails.yml
@@ -47,7 +47,8 @@ spec:
         - number: 3800
           protocol: http
   defaultOptions:
-    # Public/staging test apps keep one warm replica while Capacity AI right-sizes both containers.
+    # Public/staging test apps keep one warm replica while Capacity AI right-sizes both workload
+    # containers (rails and node-renderer).
     # Capacity AI may restart that replica when applying resource changes.
     # For production or high-availability staging, increase maxScale and review Capacity AI suitability.
     autoscaling:

--- a/react_on_rails_pro/.controlplane/redis.yml
+++ b/react_on_rails_pro/.controlplane/redis.yml
@@ -22,9 +22,11 @@ spec:
         - number: 6379
           protocol: tcp
   defaultOptions:
-    # Redis keeps Capacity AI off: right-sizing restarts are a poor default for a cache.
+    # Capacity AI may restart the workload when adjusting resources; for Redis
+    # that can disrupt cache state and connections.
     # Review cache restart tolerance before copying the Rails Capacity AI posture here.
     autoscaling:
+      minScale: 1
       maxScale: 1
     capacityAI: false
   # This firewall configuration corresponds to using no password for Redis in the gvc.yml template.

--- a/react_on_rails_pro/.controlplane/redis.yml
+++ b/react_on_rails_pro/.controlplane/redis.yml
@@ -22,6 +22,8 @@ spec:
         - number: 6379
           protocol: tcp
   defaultOptions:
+    # Redis keeps Capacity AI off: right-sizing restarts are a poor default for a cache.
+    # Review cache restart tolerance before copying the Rails Capacity AI posture here.
     autoscaling:
       maxScale: 1
     capacityAI: false

--- a/react_on_rails_pro/.controlplane/redis.yml
+++ b/react_on_rails_pro/.controlplane/redis.yml
@@ -25,6 +25,7 @@ spec:
     # Capacity AI may restart the workload when adjusting resources; for Redis
     # that can disrupt cache state and connections.
     # Review cache restart tolerance before copying the Rails Capacity AI posture here.
+    # Keep the single-replica manual posture explicit instead of relying on platform defaults.
     autoscaling:
       metric: disabled
       minScale: 1

--- a/react_on_rails_pro/.controlplane/redis.yml
+++ b/react_on_rails_pro/.controlplane/redis.yml
@@ -26,6 +26,7 @@ spec:
     # that can disrupt cache state and connections.
     # Review cache restart tolerance before copying the Rails Capacity AI posture here.
     autoscaling:
+      metric: disabled
       minScale: 1
       maxScale: 1
     capacityAI: false


### PR DESCRIPTION
## Why

Refs #3999.

The in-repo Pro Control Plane template still had the older autoscaling posture. This brings the Pro Rails workload template in line with the fixed-size Capacity AI posture used by the current demo/starter direction, without editing external repositories from this batch lane.

## What changed

- Updates `react_on_rails_pro/.controlplane/rails.yml` to use `autoscaling.metric: disabled`.
- Sets `minScale: 1` and `maxScale: 1` for the Rails workload template.
- Enables `capacityAI: true` for the Rails workload template.
- Clarifies that Capacity AI right-sizes both workload containers and may restart the single replica when applying resource changes.
- Adds a production/high-availability staging note to increase `maxScale` and review Capacity AI suitability.
- Documents why the sibling Redis and Postgres templates keep Capacity AI disabled by default and now spell out `metric: disabled`, `minScale: 1`, and `maxScale: 1` explicitly.

## Validation

- `git diff --check origin/main...HEAD` -> pass
- YAML parse for `rails.yml`, `redis.yml`, and the existing trailing-space `postgres.yml ` template -> pass
- `/Users/justin/.codex/worktrees/b2d0/react_on_rails/node_modules/.bin/prettier --check react_on_rails_pro/.controlplane/rails.yml react_on_rails_pro/.controlplane/redis.yml` and `--parser yaml --check 'react_on_rails_pro/.controlplane/postgres.yml '` -> pass
- `script/check-pro-license-headers --check` -> pass
- `script/ci-changes-detector origin/main` -> YAML change reported as uncategorized/full-suite
- Current-head review follow-up validation: `git diff --check origin/main...HEAD`, shared Prettier check, YAML parse, `script/check-pro-license-headers --check`, and `script/ci-changes-detector origin/main` -> pass
- Review-thread resolution validation after `4a00ef957`: Postgres template now explicitly sets `metric: disabled`, `minScale: 1`, `maxScale: 1`, and `capacityAI: false`; unresolved review threads -> 0
- `pnpm start format.listDifferent` -> pass before the review-fix comment-only commits
- pre-commit/pre-push hooks passed on the pushed branch.

## Remaining scope

Issue #3999 records a live flagship demo verification for the intended fixed-replica Rails posture: `type: standard`, `autoscaling.metric: disabled`, `minScale: 1`, `maxScale: 1`, and `capacityAI: true`. This PR applies that posture only to the in-repo Pro template; existing deployments must opt in by reapplying templates.

External starter/demo repos still need separate follow-up PRs or no-PR decisions. This lane did not make cross-repo edits.

Current head `4a00ef957` is pushed after current-head review follow-up. Hosted checks are green and review threads are resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Rails workload now maintains a single warm replica with CapacityAI optimization enabled for improved resource efficiency
  * Added guidance regarding Redis cache behavior under CapacityAI, including documentation on potential service restarts and cache disruptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Template-only, but turning on Capacity AI for Rails changes how new/applied deployments behave (possible replica restarts during resource tuning); Postgres/Redis behavior is unchanged aside from explicit scale settings.
> 
> **Overview**
> Updates the in-repo **Pro Control Plane** workload templates so autoscaling is explicit (`metric: disabled`, `minScale: 1`, `maxScale: 1`) instead of implied by `maxScale: 1` alone.
> 
> **Rails** turns on **`capacityAI: true`** for the fixed single-replica staging/test posture and documents that Capacity AI may restart the one replica (and right-size both `rails` and `node-renderer`) when resources change, with a note to raise `maxScale` and reconsider Capacity AI for production HA.
> 
> **Postgres** and **Redis** keep **`capacityAI: false`** but gain matching comments explaining why restarts are risky (local disk for Postgres, cache/connections for Redis) and why the single-replica manual posture is spelled out explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a00ef957ec5438c29b25686054f0e1528fe1e75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
