### PR TITLE
Fix git diff base fallback test fixture

### DIFF
--- a/script/lib/git-diff-base-test.bash
+++ b/script/lib/git-diff-base-test.bash
@@ -660,7 +660,10 @@ test_resolve_logs_deepen_progress() {
   # is not opaque between the initial fetch and the eventual unshallow. This
   # checks each deepen depth in the 2 -> 4 -> 8 sequence and verifies the
   # fallback still fires after the deepen budget is exhausted.
-  setup_repo_fixture shallow 1 20
+  # Keep the merge base far enough behind the main tip that Git versions which
+  # deepen repository history more aggressively still exhaust this small
+  # 2 -> 4 -> 8 test budget before resolving it.
+  setup_repo_fixture shallow 1 60
   local err_file
   err_file="$(mktemp resolve-err.XXXXXX)"
   if ! GIT_DIFF_BASE_FETCH_DEPTH=2 GIT_DIFF_BASE_MAX_ATTEMPTS=3 \


### PR DESCRIPTION
## Why

The post-merge hosted-CI audit in #4055 found that `bash script/lib/git-diff-base-test.bash` failed on current `main` in `test_resolve_logs_deepen_progress`. The helper behavior was still correct; the fixture was no longer far enough behind `main` to force the intended `--unshallow` fallback on newer Git/deepen behavior.

## What changed

- Increase the `test_resolve_logs_deepen_progress` fixture from 20 to 60 extra `main` commits.
- Add a short comment explaining that the fixture must stay beyond the small `2 -> 4 -> 8` deepen budget across Git versions.

## Validation

- `bash script/lib/git-diff-base-test.bash` -> 41 run, 0 failed
- `bash -n script/lib/git-diff-base script/lib/git-diff-base-test.bash script/ci-changes-detector script/ci-changes-detector-test.bash` -> passed
- `git diff --check` -> passed
- `script/ci-changes-detector origin/main` -> classified as CI infrastructure, full test suite/no benchmarks
- `bash script/ci-changes-detector-test.bash` -> 49 run, 0 failed
- `shellcheck script/lib/git-diff-base-test.bash script/lib/git-diff-base script/ci-changes-detector script/ci-changes-detector-test.bash` -> passed
- `codex review --base origin/main` -> no actionable regressions
- pre-commit hook -> passed
- pre-push hook -> passed

Refs #4055

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and comment change; no production `git-diff-base` behavior is modified.
> 
> **Overview**
> Fixes a flaky/failing `test_resolve_logs_deepen_progress` on current Git by making the shallow-repo fixture keep the merge base beyond what a **2 → 4 → 8** deepen budget can reach.
> 
> **`test_resolve_logs_deepen_progress`** now calls `setup_repo_fixture shallow 1 60` instead of `20`, with a short comment that newer Git versions may deepen history more aggressively so the test must still exhaust the budget and hit the `--unshallow` fallback (and the expected stderr progress lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80bca76d5483f99340eaafc4d1eeaffb21a1f483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness for Git version compatibility in deepen-progress assertions by adjusting fixture parameters and adding clarifying comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->