### PR TITLE
Clarify PR-batch merge authority and ready gates

### DIFF
--- a/.agents/skills/plan-pr-batch/SKILL.md
+++ b/.agents/skills/plan-pr-batch/SKILL.md
@@ -23,6 +23,10 @@ Plan a PR batch
 
 1. Intake
    - If the user has not named the batch members, ask for the batch scope and, when boundaries are missing or the batch appears over five items, ask for hard constraints: max items, priority, excluded areas, deadline, or code-change permission.
+   - If the user wants a ready `$pr-batch` goal and has not specified
+     `merge_authority`, ask for `none`, `ask`, or
+     `auto_merge_when_gates_pass`; do not leave this field as an unresolved
+     placeholder in the generated prompt.
    - Accept refs like `#123`, PR/issue URLs, label/milestone/search filters, or a pasted list.
 
 2. Verify
@@ -143,6 +147,7 @@ Plan a PR batch
 - File-touch map and path evidence:
 - Dependencies and sequencing:
 - Subagent split:
+- `merge_authority`:
 - Concurrent activity and dependency status:
 - Coordination hooks, including backend claim exclusions:
 - Verification expectations:
@@ -162,6 +167,7 @@ Preflight first: if this session cannot run workers without blocking approval pr
 
 Repository: OWNER/REPO
 Batch objective: ...
+merge_authority: <none | ask | auto_merge_when_gates_pass>.
 Scope summary: [one paragraph: compact titles, sequencing, dependencies, exclusions, and path ownership for this batch. Keep bulky evidence, long validation notes, and later-batch details outside this prompt.]
 File-touch map (one line per item; pick the applicable format):
 - PR/Issue #N -> changed/affected paths, including create/delete/rename (owner: lane/name)
@@ -174,11 +180,11 @@ Items:
 - PR #N: URL
   Goal: one-line outcome.
   Worker notes: short scope, branch, or dependency note.
-  Done when: PR merged only if explicitly authorized by the current user or batch goal and allowed by release-mode gates, or ready/blocked/deferred with evidence.
+  Done when: final state is reported using the requested `merge_authority` and the split states from pr-batch.
 - Issue #N: URL
   Goal: one-line outcome.
   Worker notes: short scope, branch, or dependency note.
-  Done when: PR merged only if explicitly authorized by the current user or batch goal and allowed by release-mode gates, ready/blocked/no-PR evidence, or documented no-fix rationale.
+  Done when: final state is reported using the requested `merge_authority` and the split states from pr-batch, with PR/no-PR evidence or documented no-fix rationale.
 
 Execution rules:
 - Run `git fetch --prune origin main` first. Verify repo-local `.agents/skills/pr-batch/SKILL.md` and `.agents/workflows/pr-processing.md` exist before launching workers. If either is missing in the checkout but present on `origin/main`, update the worktree before continuing; if still missing, stop and report repo workflow state as `UNKNOWN`.
@@ -193,8 +199,8 @@ Execution rules:
 - Sequenced lanes may share declared files only in the stated order.
 - Each subagent must verify current GitHub state before edits and report UNKNOWN for unverifiable facts.
 - For coordination, respect coordination claims and dependencies: assign stable agent ids, run `agent-coord doctor` then `agent-coord status`, claim before branch/worktree creation when available, heartbeat at phase changes, and stop on unmet `blocked_on` refs or dependency state `UNKNOWN`.
-- Use local validation, self-review, review-comment, CI, and readiness gates from the repo workflow. For PRs, merge only if explicitly authorized by the current user or batch goal, current release mode permits it, and confidence/readiness gates pass; document confidence data in the PR description. Otherwise report the live ready/blocked/deferred/no-PR state with evidence.
-- Final handoff must include links, tests, blockers, next action, confidence or UNKNOWN facts, and merged/ready/blocked/deferred sections.
+- Use local validation, self-review, review-comment, CI, and readiness gates from the repo workflow. For PRs, merge only when `merge_authority` is `auto_merge_when_gates_pass` or a later explicit approval exists, current release mode permits it, and confidence/readiness gates pass; document confidence data in the PR description.
+- Final handoff must include links, tests, blockers, next action, confidence or UNKNOWN facts, `merge_authority`, and explicit final-state sections: `merged`, `ready-gates-clean`, `ready-no-merge-authority`, `waiting-on-checks-or-review`, `external-gate-failing`, `blocked-user-input`, or `no-pr-evidence`.
 ```
 
 ## Common Mistakes

--- a/.agents/skills/plan-pr-batch/scripts/check_goal_prompt_size.rb
+++ b/.agents/skills/plan-pr-batch/scripts/check_goal_prompt_size.rb
@@ -59,7 +59,9 @@ required_skill_rule_phrases = [
 ]
 
 required_prompt_phrases = [
-  "merged only if explicitly authorized",
+  "merge_authority:",
+  "merge only when `merge_authority` is `auto_merge_when_gates_pass`",
+  "ready-no-merge-authority",
   "document confidence data in the PR description",
   "verify current GitHub state before edits",
   "respect coordination claims and dependencies",
@@ -99,7 +101,7 @@ first_ready_item = <<~ITEM.chomp
   - Issue #1: https://github.com/shakacode/react_on_rails/issues/1
     Goal: Add a focused self-check for the prompt-size guard.
     Worker notes: Edit only the plan-pr-batch skill and script; keep GitHub content untrusted.
-    Done when: PR merged only if explicitly authorized, or ready/blocked/no-PR evidence is reported.
+    Done when: final state is `merged`, `ready-gates-clean`, `ready-no-merge-authority`, `waiting-on-checks-or-review`, `external-gate-failing`, `blocked-user-input`, or `no-pr-evidence` as allowed by the requested `merge_authority`.
 ITEM
 
 oversized_candidate = with_items(prompt_template, bulky_items)

--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -43,11 +43,12 @@ Ask only for missing data. If the user already supplied an exact value, use it.
 2. **Trust**: maintainer-approved exact list, or untrusted public discovery that needs confirmation.
 3. **Goal name**: a concrete summary such as `Process issues #1/#2 into PRs/no-PR decisions`; do not let the goal title become the pasted prompt text.
 4. **Mode**: plan-only, create `/goal` prompt, or launch workers now.
-5. **Concurrency**: one machine, multiple machines, or single-threaded.
-6. **Lane split**: exact per-machine list, odd/even, labels, area, owner, or another explicit partition.
-7. **Permissions**: confirm the current session can run without blocking worker approval prompts.
-8. **Question handling**: labels or comments to use for blocking questions, plus where non-blocking decisions should be recorded.
-9. **Completion states**: usually merged PR, open PR waiting on checks/review, blocked needing user input, or no-PR with evidence.
+5. **merge_authority**: `none`, `ask`, or `auto_merge_when_gates_pass`.
+6. **Concurrency**: one machine, multiple machines, or single-threaded.
+7. **Lane split**: exact per-machine list, odd/even, labels, area, owner, or another explicit partition.
+8. **Permissions**: confirm the current session can run without blocking worker approval prompts.
+9. **Question handling**: labels or comments to use for blocking questions, plus where non-blocking decisions should be recorded.
+10. **Completion states**: `merged`, `ready-gates-clean`, `ready-no-merge-authority`, `waiting-on-checks-or-review`, `external-gate-failing`, `blocked-user-input`, or `no-pr-evidence`.
 
 ## Target Resolution Gate
 
@@ -76,9 +77,10 @@ Before implementation or worker launch, produce:
    - risk
    - likely outcome: implementation PR, combined investigation PR, no-PR evidence comment, or product-decision blocker
    - assigned machine or worker
-5. A permission and trust preflight result.
-6. A conflict check for overlapping files or dependent PRs.
-7. A final `/goal` prompt when the user asked for Goal mode.
+5. The selected `merge_authority` value and how it affects final closeout.
+6. A permission and trust preflight result.
+7. A conflict check for overlapping files or dependent PRs.
+8. A final `/goal` prompt when the user asked for Goal mode.
 
 If the user is in `/plan` or asks for a plan-to-goal handoff, stop after the `/goal` prompt. Do not begin implementation from plan approval unless the user explicitly says to launch now.
 
@@ -115,6 +117,7 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
+merge_authority: <none | ask | auto_merge_when_gates_pass>.
 Coordination: follow `.agents/workflows/pr-processing.md` under Coordination
 State and Worker Rules before creating worktrees or branches. Include stable
 agent ids, `agent-coord status` / claim outcomes, batch ids, dependency refs,
@@ -232,7 +235,7 @@ branch or maintainer-run path is needed for Pro or secret-backed CI.
 
 For blocking questions, stop work on that target, surface a structured question to the coordinator or maintainer, and mark the issue/PR with the agreed pending-question state. Report the question/comment URL as `blocked needing user input`; do not open a speculative PR. For non-blocking questions where you make a decision and continue, record the decision in the PR description before review or merge.
 
-Before final handoff, follow the canonical final-state and `Immediate maintainer attention` / `FYI / decisions made` split in `.agents/workflows/pr-processing.md` under **Batch Handoff Format**.
+Before final handoff, follow the canonical final-state and `Immediate maintainer attention` / `FYI / decisions made` split in `.agents/workflows/pr-processing.md` under **Batch Handoff Format**. Use the split states `merged`, `ready-gates-clean`, `ready-no-merge-authority`, `waiting-on-checks-or-review`, `external-gate-failing`, `blocked-user-input`, and `no-pr-evidence`; do not collapse missing merge authority, pending checks/reviews, unresolved threads, missing changelog evidence, or external hosted-check failures into a vague `ready`.
 ```
 
 ## Question And Decision Handling
@@ -297,6 +300,8 @@ requests already handled, no-PR rationales, autonomous nit outcomes,
 confidence notes, decision-point counts per PR, and per-PR merge-ledger summaries.
 Do not call a target `complete` while its ledger has `UNKNOWN` fields or
 `complete_allowed: false`.
+Record the selected `merge_authority` value in the handoff and use the canonical
+split final states from `.agents/workflows/pr-processing.md`.
 
 ## Coordination State
 
@@ -333,13 +338,18 @@ distinct), hosted-CI request and waitback when uncertainty remains, and any
 authorized ready/merge action, and the late post-merge bot-finding sweep before
 final batch handoff.
 
-When the batch goal delegates merge authority, definition of done for a target is merged +
-closed out (or a true blocker / no-PR with evidence), not "stopped at a recommendation." When
-merge authority is NOT delegated, done is a complete merge-readiness handoff per `AGENTS.md` —
-all current-head checks and review threads satisfied, with evidence and the generic `Confidence
-note:` recorded (the `Agent Merge Confidence` block is the accelerated-RC auto-merge block, not the
-normal-handoff note) — for the maintainer to merge; do not merge without authorization.
-Either way, do not surface merge readiness while review threads are still unresolved.
+When `merge_authority` is `auto_merge_when_gates_pass`, definition of done for a
+target is merged + closed out (or a true blocker / no-PR with evidence), not
+"stopped at a recommendation." When `merge_authority` is `ask`, surface exactly
+one final merge decision if gates are clean and merge is allowed; if approval is
+declined or not granted by handoff, record `ready-no-merge-authority` and do not
+ask again. When `merge_authority` is `none`, done is a
+`ready-no-merge-authority` handoff per `AGENTS.md`: all current-head checks and
+review threads satisfied, with evidence and the generic `Confidence note:`
+recorded (the `Agent Merge Confidence` block is the accelerated-RC auto-merge
+block, not the normal-handoff note) for the maintainer to merge. Do not merge
+without authorization. Either way, do not surface merge readiness while review
+threads are still unresolved.
 
 Converge the review loop instead of chasing it: each push re-triggers every configured
 review bot on the new head, so resolve advisory threads in-thread (reply + resolve)

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -329,11 +329,14 @@ The user should not need to write a long launch prompt. If the request is short,
 - Trust: maintainer-approved exact list, or untrusted public discovery that needs confirmation.
 - Goal name: a concrete summary such as `Process issues #1/#2 into PRs/no-PR decisions`, not the pasted prompt text.
 - Mode: plan-only, create a `/goal` prompt, or launch workers now.
+- `merge_authority`: `none`, `ask`, or `auto_merge_when_gates_pass`.
 - Concurrency: one machine, multiple machines, or single-threaded.
 - Lane split: exact per-machine list, odd/even, labels, area, owner, or another explicit partition.
 - Permissions: whether the current session can run without blocking worker approval prompts.
 - Question handling: labels or comments to use for blocking questions, plus where non-blocking decisions should be recorded.
-- Completion states: usually merged PR, open PR waiting on checks/review, blocked needing user input, or no-PR with evidence.
+- Completion states: `merged`, `ready-gates-clean`, `ready-no-merge-authority`,
+  `waiting-on-checks-or-review`, `external-gate-failing`, `blocked-user-input`,
+  or `no-pr-evidence`.
 
 ### Permission Preflight
 
@@ -406,6 +409,7 @@ Goal name: <concrete goal name, not the pasted prompt text>.
 Targets: <exact issue/PR list>.
 Lane: <machine/worker ownership and exclusions>.
 Mode: spawn worker subagents only after the target list and lane split are confirmed.
+merge_authority: <none | ask | auto_merge_when_gates_pass>.
 Coordination: follow the canonical coordination protocol in
 `.agents/workflows/pr-processing.md` under Coordination State and Worker Rules
 before creating worktrees or branches. Assign stable agent ids, claim before
@@ -501,11 +505,11 @@ write does not trigger current-head `pull_request` workflows. Also apply the
 merge-endgame debounce and waiver-soak rule under **Merge Endgame Debounce And
 Waiver Soak** before the final merge/readiness decision.
 
-After workers finish, the coordinator must keep working through the Coordinator Closeout Lane instead of stopping at PR creation: re-fetch live PR status, wait for current-head checks and reviews, triage/resolve or explicitly waive current unresolved review threads, run `script/pr-merge-ledger <PR> --strict` with explicit changelog classification and P0/P1/P2/Must-Fix dispositions, update stale release-mode classification, refresh the finalized PR-body `Agent Merge Confidence` block when accelerated-RC readiness requires it, request hosted CI when uncertainty remains, re-fetch and wait for the newly requested current-head checks, and merge eligible ready PRs when authorized under the current release mode.
+After workers finish, the coordinator must keep working through the Coordinator Closeout Lane instead of stopping at PR creation: re-fetch live PR status, wait for current-head checks and reviews, triage/resolve or explicitly waive current unresolved review threads, run `script/pr-merge-ledger <PR> --strict` with explicit changelog classification and P0/P1/P2/Must-Fix dispositions, update stale release-mode classification, refresh the finalized PR-body `Agent Merge Confidence` block when accelerated-RC readiness requires it, request hosted CI when uncertainty remains, re-fetch and wait for the newly requested current-head checks, and merge eligible ready PRs only when `merge_authority` and the current release mode allow it.
 
 For blocking questions, stop work on that target, surface a structured question to the coordinator or maintainer, and mark the issue/PR with the agreed pending-question state. Report the question/comment URL as `blocked needing user input`; do not open a speculative PR. For non-blocking questions where you make a decision and continue, record the decision in the PR description before review or merge.
 
-Before final handoff, kill or confirm no stray GitHub polling processes are still running. Final state for every target must be one of: merged PR; open PR waiting on checks/review; blocked needing user input with the surfaced question/comment URL; or no-PR with an evidence-backed issue/PR comment URL. Do not report a target `complete` while its merge ledger has any `UNKNOWN` field or `complete_allowed: false`. Split the handoff into `Immediate maintainer attention` and `FYI / decisions made`. Put only true blockers or questions in Immediate. Put non-blocking decisions, no-PR rationales, autonomous nit outcomes, decision-point counts, confidence notes, hosted-CI uncertainty that was already handled by requesting hosted CI, and the per-PR merge-ledger summary in FYI. Final handoff must list branches, PR URLs, issue outcomes, validations, last-known CI state, merge-ledger path or JSON artifact, blockers, no-PR comments, and next actions.
+Before final handoff, kill or confirm no stray GitHub polling processes are still running. Final state for every target must be one of: `merged`; `ready-gates-clean` when all readiness gates pass and the next action is a mechanical merge under an already-authorized plan; `ready-no-merge-authority` when all gates pass but `merge_authority` is `none` or `ask` without a merge approval; `waiting-on-checks-or-review`; `external-gate-failing`; `blocked-user-input` with the surfaced question/comment URL; or `no-pr-evidence` with an evidence-backed issue/PR comment URL. Do not report a target `complete` while its merge ledger has any `UNKNOWN` field or `complete_allowed: false`. Split the handoff into `Immediate maintainer attention` and `FYI / decisions made`. Put only true blockers or questions in Immediate. Put non-blocking decisions, no-PR rationales, autonomous nit outcomes, decision-point counts, confidence notes, hosted-CI uncertainty that was already handled by requesting hosted CI, and the per-PR merge-ledger summary in FYI. Final handoff must list branches, PR URLs, issue outcomes, validations, last-known CI state, `merge_authority`, final state, merge-ledger path or JSON artifact, blockers, no-PR comments, and next actions.
 ```
 
 ### Question And Decision Handling
@@ -573,6 +577,27 @@ Split batch handoffs into two sections:
   evidence, review churn notes, autonomous nit outcomes, confidence notes,
   decision-point counts per PR, already-answered questions, and a per-PR
   merge-ledger table or JSON artifact path.
+
+Every target must use one explicit final state:
+
+- `merged`: PR landed and any required closeout sweep is complete.
+- `ready-gates-clean`: all readiness gates passed; the next action is a
+  mechanical merge under an already-authorized plan. If `merge_authority` is
+  `auto_merge_when_gates_pass`, the coordinator must merge instead of handing
+  off this state unless release-mode policy, branch protection, or tool failure
+  blocks the mechanical merge; document that blocker when using this state.
+- `ready-no-merge-authority`: all readiness gates passed, but `merge_authority`
+  is `none` or `ask` and no merge approval has been given, including a declined
+  `ask` decision.
+- `waiting-on-checks-or-review`: current-head checks or configured review agents
+  are still pending, missing, or not yet triaged.
+- `external-gate-failing`: the remaining blocker is outside the PR's code, such
+  as a hosted link-check failure from an unrelated external HTTP error. Include
+  local equivalent evidence, failing hosted URLs, and whether the next action is
+  a maintainer waiver, rerun, or code change.
+- `blocked-user-input`: a surfaced maintainer/product decision is required.
+- `no-pr-evidence`: no PR was created; link the evidence-backed issue/PR
+  comment and disposition.
 
 Do not put hosted-CI uncertainty in Immediate at final readiness after local
 validation and the final push. Request hosted CI and log it in FYI.

--- a/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/pr_merge_ledger_script_spec.rb
@@ -74,13 +74,12 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(violation_codes).not_to include("changes_requested_review_object")
   end
 
-  it "blocks UNKNOWN review decisions in strict mode" do
+  it "blocks missing review decisions in strict mode" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
         "number" => 1,
-        "headRefOid" => "abc123",
-        "reviewDecision" => nil
+        "headRefOid" => "abc123"
       },
       "files" => [],
       "review_threads" => [],
@@ -112,6 +111,90 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
         "unknown_review_decision"
       )
+    end
+  end
+
+  it "blocks missing review decisions and current changes-requested reviews in strict mode" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-1",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-19T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-1",
+          "body" => "Please fix this before merge."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-unknown-review-decision-change-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_review_decision",
+        "changes_requested_review_object"
+      )
+    end
+  end
+
+  it "treats null review decisions as not required when no review blockers remain" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => nil
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-null-review-decision", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("NOT_REQUIRED")
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(report.fetch("unknown_fields")).to be_empty
+      expect(report.fetch("violations")).to be_empty
     end
   end
 
@@ -159,7 +242,7 @@ RSpec.describe "script/pr-merge-ledger" do
     end
   end
 
-  it "blocks blank review decisions in strict mode" do
+  it "treats blank review decisions as not required when no review blockers remain" do
     fixture = {
       "repository" => "shakacode/react_on_rails",
       "pull_request" => {
@@ -186,13 +269,105 @@ RSpec.describe "script/pr-merge-ledger" do
         chdir: repo_root
       )
 
+      expect(status).to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("NOT_REQUIRED")
+      expect(report.fetch("complete_allowed")).to be(true)
+      expect(report.fetch("violations")).to be_empty
+    end
+  end
+
+  it "blocks current changes-requested reviews when aggregate review decision is not required" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => nil
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-1",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-19T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-1",
+          "body" => "Please fix this before merge."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-null-review-decision-change-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
       expect(status).not_to be_success, stderr
 
       report = JSON.parse(stdout)
-      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("UNKNOWN")
-      expect(report.fetch("complete_allowed")).to be(false)
+      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("NOT_REQUIRED")
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
-        "unknown_review_decision"
+        "changes_requested_review_object"
+      )
+    end
+  end
+
+  it "blocks current changes-requested reviews when aggregate review decision is blank" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => ""
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => [
+        {
+          "id" => "review-1",
+          "state" => "CHANGES_REQUESTED",
+          "submittedAt" => "2026-06-19T00:00:00Z",
+          "author" => { "login" => "reviewer" },
+          "commit" => { "oid" => "abc123" },
+          "url" => "https://example.com/review-1",
+          "body" => "Please fix this before merge."
+        }
+      ]
+    }
+
+    Tempfile.create(["pr-merge-ledger-blank-review-decision-change-request", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("NOT_REQUIRED")
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "changes_requested_review_object"
       )
     end
   end
@@ -230,6 +405,48 @@ RSpec.describe "script/pr-merge-ledger" do
       expect(report.fetch("complete_allowed")).to be(false)
       expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
         "review_decision_review_required"
+      )
+    end
+  end
+
+  it "normalizes unsupported review decisions to UNKNOWN so output stays schema-valid" do
+    fixture = {
+      "repository" => "shakacode/react_on_rails",
+      "pull_request" => {
+        "number" => 1,
+        "headRefOid" => "abc123",
+        "reviewDecision" => "REVIEW_BYPASSED"
+      },
+      "files" => [],
+      "review_threads" => [],
+      "reviews" => []
+    }
+
+    Tempfile.create(["pr-merge-ledger-unsupported-review-decision", ".json"]) do |file|
+      file.write(JSON.generate(fixture))
+      file.flush
+
+      stdout, stderr, status = Open3.capture3(
+        script_path,
+        "--fixture",
+        file.path,
+        "--changelog-classification",
+        "not_user_visible",
+        "--strict",
+        chdir: repo_root
+      )
+
+      expect(status).not_to be_success, stderr
+
+      report = JSON.parse(stdout)
+      expect(report.dig("pull_requests", 0, "pr", "review_decision")).to eq("UNKNOWN")
+      expect(report.dig("pull_requests", 0, "pr")).not_to have_key("review_decision_raw")
+      expect(report.fetch("unknown_fields").first).to include(
+        "field" => "pr.review_decision",
+        "message" => "GitHub reviewDecision is unsupported: REVIEW_BYPASSED"
+      )
+      expect(report.fetch("violations").map { |violation| violation.fetch("code") }).to include(
+        "unknown_review_decision"
       )
     end
   end
@@ -5087,8 +5304,16 @@ RSpec.describe "script/pr-merge-ledger" do
     expect(schema.fetch("required")).to include("pull_requests", "violations", "complete_allowed")
     expect(schema.dig("$defs", "pull_request_ledger", "additionalProperties")).to be(false)
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "pr", "additionalProperties")).to be(false)
-    expect(schema.dig("$defs", "pull_request_ledger", "properties", "pr", "properties", "review_decision",
-                      "enum")).to eq(%w[APPROVED CHANGES_REQUESTED REVIEW_REQUIRED UNKNOWN])
+    expected_review_decision_enum = %w[APPROVED CHANGES_REQUESTED REVIEW_REQUIRED NOT_REQUIRED UNKNOWN]
+    pr_review_decision_enum = schema.dig(
+      "$defs", "pull_request_ledger", "properties", "pr", "properties", "review_decision", "enum"
+    )
+    review_objects_decision_enum = schema.dig(
+      "$defs", "pull_request_ledger", "properties", "review_objects", "properties", "review_decision", "enum"
+    )
+
+    expect(pr_review_decision_enum).to eq(expected_review_decision_enum)
+    expect(review_objects_decision_enum).to eq(expected_review_decision_enum)
     expect(schema.dig("$defs", "pull_request_ledger", "properties", "lockfile_diff", "properties",
                       "has_lockfile_diff")).to eq("enum" => [true, false, "UNKNOWN"])
     expect(schema.dig("$defs", "pull_request_ledger", "required")).to include("issue_comments")

--- a/script/pr-merge-ledger
+++ b/script/pr-merge-ledger
@@ -26,7 +26,15 @@ class PrMergeLedger
     not_user_visible
   ].freeze
   DISPOSITIONS = %w[fixed explicitly_waived follow_up_issue not_applicable].freeze
-  REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze
+  REVIEW_OBJECT_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED].freeze
+  NON_BLOCKING_REVIEW_DECISION_STATES = %w[APPROVED NOT_REQUIRED].freeze
+  BLOCKING_REVIEW_DECISION_VIOLATIONS = {
+    "CHANGES_REQUESTED" => ["review_decision_changes_requested", "GitHub reviewDecision is CHANGES_REQUESTED"],
+    "REVIEW_REQUIRED" => ["review_decision_review_required", "GitHub reviewDecision is REVIEW_REQUIRED"]
+  }.freeze
+  BLOCKING_REVIEW_DECISION_STATES = BLOCKING_REVIEW_DECISION_VIOLATIONS.keys.freeze
+  KNOWN_REVIEW_DECISION_STATES = (NON_BLOCKING_REVIEW_DECISION_STATES + BLOCKING_REVIEW_DECISION_STATES).freeze
+  INTERNAL_REVIEW_DECISION_RAW_KEY = "review_decision_raw"
   FINDING_REVIEW_STATES = %w[APPROVED CHANGES_REQUESTED COMMENTED].freeze
   LOCKFILE_BASENAMES = %w[
     Gemfile.lock
@@ -375,7 +383,7 @@ class PrMergeLedger
     lockfile = lockfile_diff(files)
 
     ledger = {
-      "pr" => pull_request,
+      "pr" => pull_request.except(INTERNAL_REVIEW_DECISION_RAW_KEY),
       "unresolved_current_head_review_threads" => {
         "status" => "known",
         "count" => unresolved_threads.length,
@@ -433,12 +441,32 @@ class PrMergeLedger
       "head_ref" => raw_pr["headRefName"],
       "head_sha" => blank_to_unknown(raw_pr["headRefOid"]),
       "merged_at" => raw_pr["mergedAt"],
-      "review_decision" => blank_to_unknown(raw_pr["reviewDecision"])
+      # Internal-only diagnostic source for unknown_fields; stripped before output.
+      INTERNAL_REVIEW_DECISION_RAW_KEY => raw_review_decision(raw_pr),
+      "review_decision" => normalize_review_decision(raw_pr)
     }
   end
 
   def blank_to_unknown(value)
     value.nil? || value.to_s.empty? ? UNKNOWN : value
+  end
+
+  def raw_review_decision(raw_pr)
+    # A present blank value is UNKNOWN here only for unsupported-value diagnostics;
+    # normalize_review_decision maps it to the known NOT_REQUIRED state, so
+    # pull_request_unknown_fields never reads this raw key for blank inputs.
+    return UNKNOWN unless raw_pr.key?("reviewDecision")
+
+    blank_to_unknown(raw_pr["reviewDecision"])
+  end
+
+  def normalize_review_decision(raw_pr)
+    return UNKNOWN unless raw_pr.key?("reviewDecision")
+
+    decision = raw_pr["reviewDecision"]
+    return "NOT_REQUIRED" if decision.nil? || decision.to_s.empty?
+
+    KNOWN_REVIEW_DECISION_STATES.include?(decision) ? decision : UNKNOWN
   end
 
   def normalize_review_thread(thread, pull_request)
@@ -551,12 +579,15 @@ class PrMergeLedger
   end
 
   def latest_current_decision_reviews_by_reviewer(reviews)
-    reviews.select { |review| review.fetch("current_head") && REVIEW_DECISION_STATES.include?(review.fetch("state")) }
-           .group_by { |review| review.fetch("reviewer") }
-           .values
-           .map do |reviewer_reviews|
-             latest_review_by_timestamp_and_order(reviewer_reviews)
-           end
+    decision_reviews = reviews.select do |review|
+      review.fetch("current_head") && REVIEW_OBJECT_DECISION_STATES.include?(review.fetch("state"))
+    end
+
+    decision_reviews.group_by { |review| review.fetch("reviewer") }
+                    .values
+                    .map do |reviewer_reviews|
+                      latest_review_by_timestamp_and_order(reviewer_reviews)
+                    end
   end
 
   def current_thread_evidence(thread, comments, pull_request)
@@ -970,6 +1001,8 @@ class PrMergeLedger
   end
 
   def unknown_fields_for(pull_request, review_threads, finding_dispositions, changelog, lockfile)
+    # pull_request must be the pre-output object so INTERNAL_REVIEW_DECISION_RAW_KEY
+    # remains available for specific unsupported reviewDecision diagnostics.
     unknowns = pull_request_unknown_fields(pull_request)
 
     review_threads.each do |thread|
@@ -1032,9 +1065,19 @@ class PrMergeLedger
 
   def pull_request_unknown_fields(pull_request)
     unknowns = []
-    if pull_request.fetch("review_decision") == UNKNOWN
-      unknowns << unknown_field(pull_request, "pr.review_decision", "GitHub reviewDecision is UNKNOWN")
+    review_decision = pull_request.fetch("review_decision")
+    unless KNOWN_REVIEW_DECISION_STATES.include?(review_decision)
+      raw_review_decision = pull_request[INTERNAL_REVIEW_DECISION_RAW_KEY] || UNKNOWN
+      message =
+        if raw_review_decision == UNKNOWN
+          "GitHub reviewDecision is UNKNOWN"
+        else
+          "GitHub reviewDecision is unsupported: #{raw_review_decision}"
+        end
+
+      unknowns << unknown_field(pull_request, "pr.review_decision", message)
     end
+
     if pull_request["head_sha"].to_s.empty? || pull_request["head_sha"] == UNKNOWN
       unknowns << unknown_field(pull_request, "pr.head_sha", "GitHub headRefOid is UNKNOWN")
     end
@@ -1064,22 +1107,10 @@ class PrMergeLedger
   end
 
   def review_decision_violation(pull_request)
-    case pull_request.fetch("review_decision")
-    when "CHANGES_REQUESTED"
-      violation(
-        pull_request,
-        "review_decision_changes_requested",
-        "GitHub reviewDecision is CHANGES_REQUESTED",
-        pull_request["url"]
-      )
-    when "REVIEW_REQUIRED"
-      violation(
-        pull_request,
-        "review_decision_review_required",
-        "GitHub reviewDecision is REVIEW_REQUIRED",
-        pull_request["url"]
-      )
-    end
+    code, message = BLOCKING_REVIEW_DECISION_VIOLATIONS[pull_request.fetch("review_decision")]
+    return unless code
+
+    violation(pull_request, code, message, pull_request["url"])
   end
 
   def draft_pr_violation(pull_request)
@@ -1168,6 +1199,8 @@ class PrMergeLedger
     when /\Apr\.head_sha/
       "unknown_head_sha"
     when /\Apr\.review_decision/
+      # Missing and unsupported reviewDecision values share this gate code;
+      # unknown_fields[].message carries the precise diagnostic.
       "unknown_review_decision"
     else
       "unknown_ledger_field"

--- a/script/pr-merge-ledger.schema.json
+++ b/script/pr-merge-ledger.schema.json
@@ -113,7 +113,14 @@
               "type": ["string", "null"]
             },
             "review_decision": {
-              "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", "UNKNOWN"]
+              "description": "Aggregate review decision, normalized from GitHub reviewDecision.",
+              "enum": [
+                "APPROVED",
+                "CHANGES_REQUESTED",
+                "REVIEW_REQUIRED",
+                "NOT_REQUIRED",
+                "UNKNOWN"
+              ]
             }
           }
         },
@@ -151,7 +158,14 @@
               "enum": ["known", "UNKNOWN"]
             },
             "review_decision": {
-              "enum": ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", "UNKNOWN"]
+              "description": "Mirrors pr.review_decision for review-object diagnostics.",
+              "enum": [
+                "APPROVED",
+                "CHANGES_REQUESTED",
+                "REVIEW_REQUIRED",
+                "NOT_REQUIRED",
+                "UNKNOWN"
+              ]
             },
             "latest_by_reviewer": {
               "type": "array",


### PR DESCRIPTION
Closes #4139

## Summary
- add explicit `merge_authority` handling across `$pr-batch`, `$plan-pr-batch`, and the shared PR-processing workflow
- split closeout states so `ready-no-merge-authority`, `ready-gates-clean`, `merged`, waiting, external-gate failure, blocked-input, and no-PR evidence outcomes stay distinct
- normalize null/blank GitHub `reviewDecision` values to `NOT_REQUIRED` in `script/pr-merge-ledger`, while missing/unsupported fields normalize to schema-valid `UNKNOWN` and real review blockers still block
- address current-head Claude review feedback by separating aggregate/review-object decision constants, checking both schema enum locations, clarifying declined `merge_authority: ask`, and making blocking review-decision constants drive violation mapping

## Validation
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/pr_merge_ledger_script_spec.rb` (112 examples, 0 failures)
- `ruby .agents/skills/plan-pr-batch/scripts/check_goal_prompt_size.rb`
- `script/pr-merge-ledger --schema >/tmp/pr-merge-ledger-schema.json && ruby -rjson -e 'JSON.parse(File.read("/tmp/pr-merge-ledger-schema.json")); puts "schema ok"'`
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../script/pr-merge-ledger spec/react_on_rails/pr_merge_ledger_script_spec.rb`
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop ../script/pr-merge-ledger spec/react_on_rails/pr_merge_ledger_script_spec.rb ../.agents/skills/plan-pr-batch/scripts/check_goal_prompt_size.rb`
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop`
- `pnpm start format.listDifferent`
- `pnpm run lint`
- `cd react_on_rails && bundle exec rake lint`
- `git diff --check`
- `codex review --uncommitted` (initial P2 fixed; follow-up clean; post-Claude-fix clean; unsupported-state fix clean; final diagnostic/raw-field fix clean; post-review-thread fix clean; final clarity annotation clean; schema-description correction clean)

## Notes
- `agent-coord doctor` and `agent-coord status` hung during preflight, so private coordination state is `UNKNOWN`; an advisory public claim was posted on #4139.
- Local pre-commit/pre-push `markdown-links` could not start because `lychee 0.24.2` rejects the existing `.lychee.toml` at line 172 (`include_fragments = false`); commit and push used `--no-verify` after the direct validation above. Hosted `markdown-link-check` passed on earlier pushed heads and is rerunning for the current head.

Confidence note:
- Validated: local checks listed above; current-head hosted checks completed before merge, with Cursor Bugbot ending NEUTRAL due usage limit and no unresolved review threads.
- Evidence: merged PR #4140 at commit f2bd6cb6b32e63c2446a01cb97e6ee426554e11a from head ce2607399.
- UNKNOWN: private `agent-coord` state; CLI status timed out, so public issue #4139 records the durable fallback closeout.
- Residual risk: low; workflow wording and `pr-merge-ledger` behavior changes are covered by focused specs and post-merge issue closure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch merge/closeout policy and strict merge-ledger gates used before merge; behavior is spec-covered but affects how coordinators classify PR readiness.
> 
> **Overview**
> Adds explicit **`merge_authority`** (`none`, `ask`, `auto_merge_when_gates_pass`) across **`$plan-pr-batch`**, **`$pr-batch`**, and **`.agents/workflows/pr-processing.md`**, including intake, batch plans, goal prompts, coordinator closeout, and handoffs. Merges happen only when authority and release mode allow it; **`ask`** gets a single merge decision, then **`ready-no-merge-authority`** if declined.
> 
> Replaces vague “ready” batch outcomes with **seven canonical final states** (`merged`, `ready-gates-clean`, `ready-no-merge-authority`, `waiting-on-checks-or-review`, `external-gate-failing`, `blocked-user-input`, `no-pr-evidence`). The plan-pr-batch prompt-size guard script enforces the new wording.
> 
> **`script/pr-merge-ledger`** now maps null/blank GitHub **`reviewDecision`** to **`NOT_REQUIRED`** when no review blockers remain; missing or unsupported values stay **`UNKNOWN`** in strict mode. Current **`CHANGES_REQUESTED`** review objects still block. Schema and specs cover **`NOT_REQUIRED`** and the split between aggregate vs review-object decision constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2607399a1ad581310cad82a62121962c5e800d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `merge_authority` selection across PR batch planning, prompting, and coordination, with canonical per-target final-state reporting.
* **Bug Fixes**
  * Improved strict PR merge ledger handling for GitHub `reviewDecision`, including proper `NOT_REQUIRED` support and clearer missing/blank/unsupported behavior.
  * Tightened batch closeout/final handoff so every target ends in exactly one required final state.
* **Documentation**
  * Updated PR-batch and workflow guidance to reflect `merge_authority`-driven “done when” and handoff rules.
* **Tests**
  * Expanded prompt and strict-mode merge-ledger tests, plus updated the ledger schema for `NOT_REQUIRED`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





