### PR TITLE
Fix main generator pretend spec isolation

### DIFF
--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3717,12 +3717,20 @@ describe InstallGenerator, type: :generator do
     it "does not read the copied Redux Tailwind entry in pretend mode" do
       redux_generator = redux_generator_fixture(pretend: true, tailwind: true)
       client_entry = "app/javascript/src/HelloWorldApp/ror_components/HelloWorldApp.client.jsx"
+      simulate_existing_file("config/shakapacker.yml", <<~YAML)
+        default: &default
+          source_path: app/javascript
+
+        development:
+          <<: *default
+      YAML
 
       allow(redux_generator).to receive(:copy_file)
       allow(redux_generator).to receive(:gsub_file)
       allow(redux_generator).to receive(:prepend_to_file)
+      allow(File).to receive(:read).and_call_original
 
-      expect(File).not_to receive(:read)
+      expect(File).not_to receive(:read).with(File.join(destination_root, client_entry))
       expect(redux_generator).to receive(:say_status)
         .with(:pretend, "Would add Tailwind stylesheet import to #{client_entry}", :yellow)
 


### PR DESCRIPTION
## Why

The default branch is currently failing `Rspec test for gem` on `main` in the generator shard:

- Run: https://github.com/shakacode/react_on_rails/actions/runs/27869267839
- Failed jobs: `rspec-package-tests (4.0, latest, generators)` and `rspec-package-tests (3.3, minimum, generators)`
- Failed example: `spec/react_on_rails/generators/install_generator_spec.rb:3717`

The failure was not caused by the most recent Pro streaming PR. The same generator failure appears on the prior pushed commit and traces back to the custom Shakapacker-root generator work in #4130. A focused ordered repro showed the issue:

```bash
cd react_on_rails && bundle exec rspec \
  spec/react_on_rails/generators/install_generator_spec.rb:564 \
  spec/react_on_rails/generators/install_generator_spec.rb:590 \
  spec/react_on_rails/generators/install_generator_spec.rb:3717
```

Before this patch, that sequence failed because earlier examples left `config/shakapacker.yml` in the shared generator destination. The pretend-mode example used `expect(File).not_to receive(:read)`, which accidentally forbade the legitimate config read used to resolve Shakapacker paths. The behavior the test meant to protect is narrower: pretend mode must not read the copied Redux Tailwind client entry, because pretend mode does not create that file.

## What changed

- Adds an explicit `config/shakapacker.yml` fixture to the pretend-mode example.
- Allows normal `File.read` calls while asserting the generated Redux client entry is not read.
- Keeps the production generator code unchanged.

## Validation

- `git diff --check` -> passed.
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb:564 spec/react_on_rails/generators/install_generator_spec.rb:590 spec/react_on_rails/generators/install_generator_spec.rb:3717` -> 4 examples, 0 failures.
- `cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop spec/react_on_rails/generators/install_generator_spec.rb` -> 1 file inspected, no offenses.
- `codex review --uncommitted` -> no actionable correctness issues.
- Pre-commit hook -> trailing-newlines, Ruby autofix/RuboCop passed for the changed spec.
- Pre-push hook -> branch Ruby RuboCop and markdown-links passed.

## Process triage

Process Gap Disposition: `checklist+replay`.

- Motivating miss: #4130 recorded focused validation for `install_generator_spec.rb:3717`, but the default-branch failure required replaying that example after earlier custom-root generator examples that leave `config/shakapacker.yml` in the shared destination.
- Replay evidence: the ordered repro above failed on `main` before this patch and passed after this patch.
- Non-goal: do not add a broad prose-only rule or a full generator-suite requirement for every small generator PR.

Merge queue would reduce stale-base/concurrency merges, but it would not have caught this exact issue unless the queue runs the same generator shard before landing. The actionable process improvement is to include ordered replay when adding generator examples that share `dummy-for-generators`, especially when new examples leave Shakapacker config or other shared files behind.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to generator spec isolation; runtime install/generator behavior is unchanged.
> 
> **Overview**
> Fixes a flaky failure in **`install_generator_spec`** for the Redux + Tailwind **`--pretend`** example when earlier examples leave **`config/shakapacker.yml`** in the shared **`dummy-for-generators`** destination.
> 
> The example now seeds its own minimal Shakapacker config, stubs **`File.read`** with **`and_call_original`**, and asserts only that the generated **`HelloWorldApp.client.jsx`** path is not read—matching the generator’s early return in pretend mode before it would read the copied client entry. **No generator production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace88048d62a3f2acac5637dbd3e39ad23a36289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced generator test precision for improved reliability in verifying expected file handling behavior during generator operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->