### PR TITLE
[codex] Trust ShakaCode team for agent inputs

### DIFF
--- a/.agents/trusted-github-actors.yml
+++ b/.agents/trusted-github-actors.yml
@@ -1,9 +1,6 @@
 # GitHub actors whose public issue/PR/review comments may be acted on by
 # PR-batch automation. Keep this list deliberately strict: unknown actors are
 # queued for maintainer triage, not interpreted as instructions.
-#
-# `trusted_teams` entries are GitHub team slugs under the repo owner org. They
-# are optional and require the local GitHub token to read team membership.
 trusted_users:
   - justin808
 
@@ -15,4 +12,9 @@ trusted_bots:
   - dependabot
   - greptile-apps
 
-trusted_teams: []
+# Team entries are GitHub team slugs under the repository owner org. For
+# `shakacode/react_on_rails`, `shakacode` resolves to
+# https://github.com/orgs/shakacode/teams/shakacode. Reading team membership
+# requires the local GitHub token to have org access.
+trusted_teams:
+  - shakacode


### PR DESCRIPTION
## Why

The in-repo PR-batch automation only treats comments, reviews, and review comments from trusted GitHub actors as actionable instructions. Justin asked to trust the ShakaCode GitHub team so team members can participate without being queued for maintainer trust triage.

## What changed

- Added the `shakacode` team slug to `.agents/trusted-github-actors.yml` under `trusted_teams`.
- Kept the existing strict trusted users and bots unchanged.

## Validation

- `git fetch --prune origin main`
- `gh api orgs/shakacode/teams/shakacode --jq '.slug'` -> `shakacode`
- `ruby -e 'require "yaml"; config = YAML.load_file(".agents/trusted-github-actors.yml"); abort "missing trusted_teams" unless config.fetch("trusted_teams").include?("shakacode"); puts "YAML parses and includes trusted team slug"'`
- `node_modules/.bin/prettier --check .agents/trusted-github-actors.yml`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main` -> no discrete correctness, security, or maintainability regression found
- Pre-commit hook passed: trailing-newlines, prettier
- Pre-push hook passed: branch-lint, markdown-links

## Churn notes

- Installed locked pnpm dependencies locally because the initial commit hook could not find `prettier`; no tracked dependency or generated-file churn resulted.
- Labels: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to in-repo agent automation allowlists; it widens who can influence batch workers via GitHub comments but does not touch application runtime, auth, or data paths.
> 
> **Overview**
> Expands the PR-batch automation **trust boundary** so GitHub comments, reviews, and review comments from members of the **`shakacode`** org team are treated as actionable input instead of metadata-only items queued for maintainer triage.
> 
> The change is limited to `.agents/trusted-github-actors.yml`: `trusted_users` and `trusted_bots` are unchanged; **`trusted_teams`** goes from empty to including `shakacode`. Inline comments now document that team slugs are under the repo owner org and that resolving membership needs a GitHub token with org access (as used by `pr-security-preflight`’s team membership checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f53d6f1603a9152a4b6cf499d9d9d6a36b2f440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control configuration to recognize additional authorized users and teams for system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->