### PR TITLE
[verification] Exercise generator required gate

### DIFF
--- a/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/generator_messages_spec.rb
@@ -5,6 +5,7 @@ require "tmpdir"
 require_relative "../support/generator_spec_helper"
 
 describe GeneratorMessages do
+  # Verification-only touch for #4150: this short-lived PR exercises generator-sensitive CI gating.
   it "has an empty messages array" do
     expect(described_class.messages).to be_empty
   end


### PR DESCRIPTION
## Verification-only PR

This draft PR exists only to collect evidence for issue #4150 after PR #4149 changed `.github/workflows/ci-required.yml`.

Do not merge this PR. After the required evidence is captured, this PR should be closed and the temporary branch may be deleted.

## Why

The issue needs a real ordinary `pull_request` run proving that generator-sensitive changes fail `ci-required / required-pr-gate` before hosted CI is requested, then pass after hosted CI is requested with the auditable `+ci-run-hosted` path.

## Implementation

- Adds one verification-only comment under `react_on_rails/spec/react_on_rails/generators/`.
- The file path is intentionally generator-sensitive so `script/ci-changes-detector origin/main` emits `run_generators=true`.
- No workflow files are edited.

## Validation

- `git diff --check` - passed.
- `script/ci-changes-detector origin/main` - passed; output includes `run_generators=true`.
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/generator_messages_spec.rb)` - 59 examples, 0 failures.
- `(cd react_on_rails && BUNDLE_GEMFILE=../Gemfile bundle exec rubocop)` - 226 files inspected, no offenses detected.
- `codex review --base origin/main` - no actionable findings.
- pre-commit hook - passed.
- pre-push hook - passed.

## CI Exercise Plan

1. Leave this PR without `ready-for-hosted-ci` first and capture the expected `ci-required / required-pr-gate` failure.
2. Comment `+ci-status`, then `+ci-run-hosted`.
3. Capture the required gate passing and hosted generator checks for the same head SHA.
4. Close this PR without merging and report the evidence on #4150.

## Labels

Labels: none initially. This is intentional so the ordinary PR required-gate failure path is exercised before hosted CI is requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edit in a generator spec for CI evidence collection; no runtime, auth, or workflow logic changes.
> 
> **Overview**
> **Verification-only change** — not intended to merge. Adds a single comment in `generator_messages_spec.rb` under `react_on_rails/spec/react_on_rails/generators/` so `script/ci-changes-detector` sets **`run_generators=true`** and a normal `pull_request` can prove the post-#4149 **`ci-required / required-pr-gate`** behavior (fail before hosted CI is requested, pass after `+ci-run-hosted`).
> 
> No workflow or generator implementation changes; behavior of the spec suite is unchanged aside from the comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1257fe707a360367036e46d706458fff1c685642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->