### PR TITLE
Docs: point Pro license to purchase site

### DIFF
--- a/REACT-ON-RAILS-PRO-LICENSE.md
+++ b/REACT-ON-RAILS-PRO-LICENSE.md
@@ -89,6 +89,8 @@ The Organization may not remove or obfuscate this attribution.
 
 ## 7. Fees; Term; Termination
 
+Paid subscriptions may be purchased or renewed at [pro.reactonrails.com](https://pro.reactonrails.com/) or through another ShakaCode-approved order channel.
+
 Fees and billing terms are as agreed in the applicable order (e.g., GitHub Sponsors subscription or annual invoice).  
 For paid subscriptions, the license remains active only while fees are paid. ShakaCode may suspend or terminate for non-payment or material breach. Complimentary OSS Licenses remain active for the term specified in the grant, subject to the revocation terms in Section 4.1.  
 Upon termination, lapse, or revocation, the Organization must immediately cease use and remove the Software (including derivatives) from all Production systems and repositories, except for (a) non-commercial uses explicitly permitted in Section 4, or (b) Complimentary OSS Licenses revoked under Section 4.1(ii) for eligibility changes, in which case the Organization has thirty (30) days from written notice to comply.


### PR DESCRIPTION
## Summary

- Add a React on Rails Pro purchase/renewal link to Section 7 of the Pro EULA.
- Keep fee, billing, and term precedence tied to the applicable order.

## Rationale

The EULA already says Production Use requires a paid subscription, but it did not point readers to the purchase path. The README already uses https://pro.reactonrails.com/ for Pro pricing and sign-up, so this makes the license document easier to act on without changing the legal precedence language.

## Validation

- `git diff --check origin/main...HEAD`
- `pnpm install --frozen-lockfile`
- `pnpm dlx prettier@3.6.2 --check REACT-ON-RAILS-PRO-LICENSE.md`
- `ruby -e "require 'net/http'; uri = URI('https://pro.reactonrails.com/'); res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.head(uri.request_uri) }; puts [res.code, res.message, res['location']].compact.join(' ')"` -> `200 OK`
- Pre-commit hook: trailing-newlines passed; changed-file Markdown links passed offline; Prettier passed.
- Pre-push hook: branch-lint passed/skipped Ruby; branch Markdown links passed online with 2 OK, 0 errors, 1 excluded.

## Release / Merge Notes

- Release mode: `development` from release gate issue #3823.
- Changelog classification: `not_user_visible` for release notes; legal/docs-only pointer.
- Decision points: 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only EULA edit with no runtime, security, or billing logic changes.
> 
> **Overview**
> **Section 7 (Fees; Term; Termination)** of the React on Rails Pro EULA now states that paid subscriptions may be purchased or renewed at [pro.reactonrails.com](https://pro.reactonrails.com/) or through another ShakaCode-approved order channel.
> 
> Existing language on fees, billing, term, and order precedence is unchanged; this only adds an actionable purchase path consistent with the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e23adc20e488aa7a22dbe1797c78c7466ccdcca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license terms to clarify where paid subscriptions can be purchased or renewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->