### PR TITLE
docs: fix dead undici link and silence flaky GitHub links in lychee check

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -143,6 +143,8 @@ exclude = [
   '^https://github\.com/K4sku$',  # Intermittent 502 from GitHub user page in CI
   '^https://github\.com/npm/cli/issues/6253$',  # Intermittent 502 from GitHub issue pages in CI
   '^https://github\.com/search\?q=gem\+react_on_rails&ref=advsearch&type=repositories&utf8=%E2%9C%93$',  # Intermittent 502 from GitHub search in CI
+  '^https://github\.com/shakacode/react_on_rails/issues/1457(#.*)?$',  # Intermittent 500 from GitHub issue pages in CI
+  '^https://github\.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/dummy/client/app/components/Loadable/routes/Routes\.imports-hmr\.jsx(#.*)?$',  # Intermittent 500 from GitHub blob pages in CI
 
   # ============================================================================
   # EXTERNAL DOC PAGES WITH CI CONNECTIVITY FAILURES


### PR DESCRIPTION
## Why

The whole-tree `markdown-link-check` (lychee) job is failing on PRs whose diffs don't touch the offending links — e.g. it went red on #4143 (rsc-css docs) over links in `code-splitting.md`, `js-configuration.md`, and two core-concepts files. The same job **passed** on the sibling #4142, so the failures are environmental/rot, not PR-specific. Two distinct causes:

1. **Dead link (rot):** `https://undici.nodejs.org/` now returns **404** — the undici docsify site is gone. The "undici's compatibility notes" link in `js-configuration.md` is repointed to the undici GitHub README (`https://github.com/nodejs/undici#readme`, 200), which covers the same runtime/version compatibility guidance.
2. **Flaky GitHub 5xx under CI load:** `react_on_rails/issues/1457#issuecomment-…` and the `Routes.imports-hmr.jsx` blob both return **200 normally** but **500 from CI** (verified: both 200 via curl; the blob file exists on `main`). Added to the existing *"Intermittent 5xx from GitHub … in CI"* exclude group in `.lychee.toml`, matching the established convention (which already lists issues/2766, npm/cli/6253, rack SPEC, etc.).

This makes the advisory link-check reliably green repo-wide instead of intermittently red on unrelated PRs.

## What changed

- `docs/oss/building-features/node-renderer/js-configuration.md` — undici link repointed (table re-padded by prettier as a side effect).
- `.lychee.toml` — two URLs added to the intermittent-5xx exclude list, with matching comments.
- `llms-full.txt` — regenerated for the doc change.

## Validation

- `taplo lint .lychee.toml` — clean; exclude regexes verified to match the two failing URLs.
- Both excluded GitHub links confirmed `200` when not rate-limited; the `Routes.imports-hmr.jsx` target exists on `main`. undici URL confirmed `404`; replacement `200`.
- `prettier@3.6.2 --check` — clean. `node script/generate-llms-full.mjs --check` — current.
- `codex review --base origin/main` — one [P1] (stale llms-full after the table reflow) found and fixed.

Found while landing the RSC docs batch (#4142/#4143); kept as a separate PR since these links are unrelated to that content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI link-check configuration only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Stops unrelated PRs from failing the repo-wide **lychee** markdown link check by fixing one dead doc URL and excluding two GitHub links that only flake under CI.
> 
> In **`js-configuration.md`** (and mirrored **`llms-full.txt`**), the undici compatibility link is repointed from the removed **`undici.nodejs.org`** site to **`https://github.com/nodejs/undici#readme`**. The fetch decision table is re-padded after formatting.
> 
> **`.lychee.toml`** adds exclude patterns for **`react_on_rails/issues/1457`** (with optional fragment) and the **`Routes.imports-hmr.jsx`** blob on `main`, following the existing intermittent GitHub 5xx convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdafae4fcd624713d9d5f982bfbdd00e0751d8dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated link checker configuration to reduce false CI failures caused by intermittent GitHub timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->