### PR TITLE
fix(test): target real rsc-css precedence in RSC FOUC release gate

### DIFF
--- a/test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts
+++ b/test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts
@@ -2,7 +2,12 @@ import { abTest, installRequestBlocking } from 'shaka-shared';
 
 const RSC_CSS_PROBE_SELECTOR = '[data-testid="rsc-css-probe"]';
 const RSC_CSS_PROBE_PATH = '/rsc_posts_page_over_http?posts_count=0';
-const RSC_STYLESHEET_SELECTOR = 'link[rel="stylesheet"][data-precedence="ror-rsc"]';
+// The Pro RSC renderer emits client-reference stylesheets as
+// `<link rel="stylesheet" data-precedence="rsc-css">` (see
+// packages/react-on-rails-pro/src/injectRSCPayload.ts). The earlier
+// `precedence="ror-rsc"` wrapper this gate originally targeted was reverted in
+// #3860; keep this selector in sync with the value the renderer actually emits.
+const RSC_STYLESHEET_SELECTOR = 'link[rel="stylesheet"][data-precedence="rsc-css"]';
 // A styled probe must have a real CSS-module background, not the default unstyled page background.
 // If the intended probe style ever matches one of these defaults, change the Pro dummy probe color first.
 // This avoids pinning the gate to cosmetic RGB changes in the dummy component.

--- a/test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts
+++ b/test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts
@@ -5,7 +5,7 @@ const RSC_CSS_PROBE_PATH = '/rsc_posts_page_over_http?posts_count=0';
 // The Pro RSC renderer emits client-reference stylesheets as
 // `<link rel="stylesheet" data-precedence="rsc-css">` (see
 // packages/react-on-rails-pro/src/injectRSCPayload.ts). The earlier
-// `precedence="ror-rsc"` wrapper this gate originally targeted was reverted in
+// `data-precedence="ror-rsc"` wrapper this gate originally targeted was reverted in
 // #3860; keep this selector in sync with the value the renderer actually emits.
 const RSC_STYLESHEET_SELECTOR = 'link[rel="stylesheet"][data-precedence="rsc-css"]';
 // A styled probe must have a real CSS-module background, not the default unstyled page background.


### PR DESCRIPTION
## Why

The **RSC FOUC ShakaPerf release gate** (`test/shakaperf/rsc-fouc/ab-tests/rsc-fouc-release-gate.abtest.ts`, run by `.github/workflows/shakaperf-release-gates.yml`) detects the injected RSC stylesheet with:

```ts
const RSC_STYLESHEET_SELECTOR = 'link[rel="stylesheet"][data-precedence="ror-rsc"]';
```

But the Pro RSC renderer emits `data-precedence="rsc-css"`, not `ror-rsc` — confirmed in `packages/react-on-rails-pro/src/injectRSCPayload.ts` (the only precedence value in package source). History explains the drift:

- **#3587** added a Pro-side React `<link precedence="ror-rsc">` FOUC wrapper; this gate (#3617/#3630) was written to match it.
- **#3860** reverted that `ror-rsc` wrapper.
- **#4047** introduced the current mechanism, which emits `data-precedence="rsc-css"`.

So the selector has matched **nothing** since #3860/#4047. The gate's `hasStylesheet` probe (`Boolean(document.querySelector(stylesheetSelector))`) is silently always-`false`, so its core assertion — *"RSC stylesheet present at first visible paint"* — is inert: it can only throw a false "stylesheet missing" error, never actually validate the FOUC-prevention pipeline.

## What changed

One-line fix: point the selector at the value the renderer actually emits (`rsc-css`), plus a comment pinning it to `injectRSCPayload.ts` and noting the #3860 revert so it doesn't drift again. The user-facing docs already tell readers to look for `data-precedence="rsc-css"` (`docs/pro/react-server-components/css-and-styling.md`), so this aligns the gate with both source and docs.

## Validation

- Value verified against `packages/react-on-rails-pro/src/injectRSCPayload.ts` (source of truth) and corroborated by `css-and-styling.md`.
- `prettier@3.6.2 --check` — clean.
- `codex review --base origin/main` — "No actionable correctness issues … the selector now matches the stylesheet marker emitted by the existing RSC payload injector."
- **Not run locally:** the gate is `workflow_dispatch`-only and needs the Pro license secret + full Pro dummy-app build + Playwright, so executing it requires CI. Recommend a manual `ShakaPerf Release Gates` dispatch to confirm the gate now exercises the stylesheet assertion end-to-end.

Found while documenting the rsc-css precedence behavior for #4138.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector and comment change; no production or runtime behavior is modified.
> 
> **Overview**
> The **RSC FOUC ShakaPerf release gate** was looking for `link[rel="stylesheet"][data-precedence="ror-rsc"]`, but Pro injects stylesheets with **`data-precedence="rsc-css"`** (see `injectRSCPayload.ts`). That mismatch meant `hasStylesheet` was always false, so the “stylesheet present at first visible paint” check never actually ran.
> 
> This PR updates `RSC_STYLESHEET_SELECTOR` to **`rsc-css`** and adds a short comment tying the gate to the injector and the #3860 revert, so the selector stays aligned with what the renderer emits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb3c16ebf1b7b1b42c4357fff2fd05330f9c35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test framework to ensure accurate validation of stylesheet rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->