### PR TITLE
Fix precompile hook crash under non-UTF-8 locale for Pro subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Fixed
+
+- **[Pro]** **Precompile hook no longer crashes under a non-UTF-8 (C/POSIX) locale**: The shared Shakapacker precompile hook now forces a UTF-8 locale on every `bundle exec` / shakapacker subprocess it spawns — pack generation, the i18n locale generation added in [PR 4128](https://github.com/shakacode/react_on_rails/pull/4128), and the RSC client-reference discovery build. Without `LANG`/`LC_ALL` set, those children inherited a US-ASCII default external encoding and died parsing Gemfiles containing non-ASCII bytes (e.g. `react_on_rails_pro/Gemfile.loader`: `invalid byte sequence in US-ASCII`), aborting the entire precompile. Extends the UTF-8 hardening from [PR 3949](https://github.com/shakacode/react_on_rails/pull/3949) from the hook's own file reads to the subprocess boundary. [PR 4169](https://github.com/shakacode/react_on_rails/pull/4169) by [justin808](https://github.com/justin808).
+
 ### [17.0.0.rc.6] - 2026-06-21
 
 #### Added

--- a/react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb
+++ b/react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb
@@ -101,6 +101,94 @@ RSpec.describe "Shakapacker precompile hook shared script" do
         expect(Dir).to have_received(:chdir).with(rails_root)
       end
     end
+
+    it "forces a UTF-8 locale for the i18n locale-generation subprocess" do
+      Dir.mktmpdir(nil, "/tmp") do |rails_root|
+        initializer_path = File.join(rails_root, "config", "initializers", "react_on_rails.rb")
+        FileUtils.mkdir_p(File.dirname(initializer_path))
+        File.write(initializer_path, <<~RUBY)
+          # ⚠️ i18n enabled
+          ReactOnRails.configure do |config|
+            config.i18n_dir = Rails.root.join("client", "app", "i18n", "generated")
+          end
+        RUBY
+
+        allow(self).to receive_messages(find_rails_root: rails_root, puts: nil)
+        # Run the chdir block so the subprocess invocation is reached, but stub `system`
+        # so we capture its env hash instead of actually shelling out to `bundle exec rake`.
+        allow(Dir).to receive(:chdir).and_yield
+        captured_env = nil
+        allow(self).to receive(:system) do |env, *_args|
+          captured_env = env
+          true
+        end
+
+        with_default_external(Encoding::US_ASCII) do
+          expect { generate_locales_if_needed }.not_to raise_error
+        end
+
+        # Without a forced UTF-8 locale, the spawned `bundle exec` dies parsing a Gemfile with
+        # non-ASCII bytes ("invalid byte sequence in US-ASCII"), aborting the whole precompile.
+        expect(captured_env).to include("RUBYOPT" => a_string_matching(/-EUTF-8/))
+        expect(captured_env).to include("LANG" => a_string_matching(/UTF-8/i))
+        expect(captured_env).to include("LC_ALL" => a_string_matching(/UTF-8/i))
+        expect(self).to have_received(:system).with(hash_including("RUBYOPT"), "bundle", "exec", "rake",
+                                                    "react_on_rails:locale", exception: true)
+      end
+    end
+
+    it "forces a UTF-8 locale for the pack-generation subprocess" do
+      Dir.mktmpdir(nil, "/tmp") do |rails_root|
+        initializer_path = File.join(rails_root, "config", "initializers", "react_on_rails.rb")
+        FileUtils.mkdir_p(File.dirname(initializer_path))
+        File.write(initializer_path, <<~RUBY)
+          # ⚠️ auto bundling enabled
+          ReactOnRails.configure do |config|
+            config.auto_load_bundle = true
+          end
+        RUBY
+
+        allow(self).to receive_messages(find_rails_root: rails_root, puts: nil)
+        allow(Dir).to receive(:chdir).and_yield
+        captured_env = nil
+        allow(self).to receive(:system) do |env, *_args|
+          captured_env = env
+          true
+        end
+
+        with_default_external(Encoding::US_ASCII) do
+          expect { generate_packs_if_needed }.not_to raise_error
+        end
+
+        expect(captured_env).to include("RUBYOPT" => a_string_matching(/-EUTF-8/))
+        expect(self).to have_received(:system).with(hash_including("RUBYOPT"), "bundle", "exec", "rails",
+                                                    "react_on_rails:generate_packs", exception: true)
+      end
+    end
+  end
+
+  describe "#utf8_subprocess_env" do
+    it "defaults LANG/LC_ALL to a UTF-8 locale and appends -EUTF-8 to RUBYOPT when unset" do
+      with_env("LANG" => nil, "LC_ALL" => nil, "RUBYOPT" => nil) do
+        env = utf8_subprocess_env
+        expect(env["LANG"]).to match(/UTF-8/i)
+        expect(env["LC_ALL"]).to match(/UTF-8/i)
+        expect(env["RUBYOPT"]).to eq("-EUTF-8")
+      end
+    end
+
+    it "preserves an existing UTF-8 locale and appends to an existing RUBYOPT" do
+      with_env("LANG" => "en_US.UTF-8", "LC_ALL" => "en_US.UTF-8", "RUBYOPT" => "-W0") do
+        env = utf8_subprocess_env
+        expect(env["LANG"]).to eq("en_US.UTF-8")
+        expect(env["LC_ALL"]).to eq("en_US.UTF-8")
+        expect(env["RUBYOPT"]).to eq("-W0 -EUTF-8")
+      end
+    end
+
+    it "merges and lets caller keys extend the base env" do
+      expect(utf8_subprocess_env("FOO" => "bar")).to include("FOO" => "bar", "RUBYOPT" => a_string_matching(/-EUTF-8/))
+    end
   end
 
   describe "valid_rsc_registration_entry_path?" do

--- a/react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb
+++ b/react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb
@@ -189,6 +189,12 @@ RSpec.describe "Shakapacker precompile hook shared script" do
     it "merges and lets caller keys extend the base env" do
       expect(utf8_subprocess_env("FOO" => "bar")).to include("FOO" => "bar", "RUBYOPT" => a_string_matching(/-EUTF-8/))
     end
+
+    it "does not duplicate -EUTF-8 when RUBYOPT already requests it" do
+      with_env("RUBYOPT" => "-EUTF-8") do
+        expect(utf8_subprocess_env["RUBYOPT"]).to eq("-EUTF-8")
+      end
+    end
   end
 
   describe "valid_rsc_registration_entry_path?" do
@@ -388,7 +394,10 @@ RSpec.describe "Shakapacker precompile hook shared script" do
           "CLIENT_BUNDLE_ONLY" => nil,
           "SERVER_BUNDLE_ONLY" => nil,
           "RSC_BUNDLE_ONLY" => "true",
-          "RSC_REFERENCE_DISCOVERY_BUILD" => "true"
+          "RSC_REFERENCE_DISCOVERY_BUILD" => "true",
+          # The discovery build also forces a UTF-8 locale so the shakapacker child does not crash
+          # under a C/POSIX locale parsing a Gemfile with non-ASCII bytes (see utf8_subprocess_env).
+          "RUBYOPT" => a_string_matching(/-EUTF-8/)
         ),
         "/rails/root/bin/shakapacker",
         exception: true

--- a/react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb
+++ b/react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb
@@ -46,10 +46,12 @@ end
 # set as a belt-and-suspenders for tools that read the locale directly. This is the subprocess-boundary
 # companion to the UTF-8-safe File.read calls in this script. `extra` keys override/extend the base env.
 def utf8_subprocess_env(extra = {})
+  rubyopt = ENV.fetch("RUBYOPT", "")
+  rubyopt = "#{rubyopt} -EUTF-8".strip unless rubyopt.include?("-EUTF-8")
   {
     "LANG" => ENV.fetch("LANG", "C.UTF-8"),
     "LC_ALL" => ENV.fetch("LC_ALL", "C.UTF-8"),
-    "RUBYOPT" => [ENV.fetch("RUBYOPT", nil), "-EUTF-8"].compact.join(" ").strip
+    "RUBYOPT" => rubyopt
   }.merge(extra)
 end
 

--- a/react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb
+++ b/react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb
@@ -37,6 +37,22 @@ def find_rails_root
   nil
 end
 
+# Build a subprocess env that forces a UTF-8 locale.
+#
+# Under a C/POSIX locale (no LANG/LC_ALL) the parent's Encoding.default_external is US-ASCII, and a
+# spawned `bundle exec` / shakapacker child inherits it, then dies parsing any Gemfile that contains
+# non-ASCII bytes (e.g. react_on_rails_pro/Gemfile.loader) with "invalid byte sequence in US-ASCII".
+# `-EUTF-8` pins the child Ruby's external/internal encodings regardless of locale; LANG/LC_ALL are
+# set as a belt-and-suspenders for tools that read the locale directly. This is the subprocess-boundary
+# companion to the UTF-8-safe File.read calls in this script. `extra` keys override/extend the base env.
+def utf8_subprocess_env(extra = {})
+  {
+    "LANG" => ENV.fetch("LANG", "C.UTF-8"),
+    "LC_ALL" => ENV.fetch("LC_ALL", "C.UTF-8"),
+    "RUBYOPT" => [ENV.fetch("RUBYOPT", nil), "-EUTF-8"].compact.join(" ").strip
+  }.merge(extra)
+end
+
 # Detect which package manager to use based on package.json's packageManager field,
 # falling back to checking system availability
 def detect_package_manager(package_json)
@@ -123,11 +139,11 @@ def generate_packs_if_needed
   puts "📦 Generating React on Rails packs..."
 
   Dir.chdir(rails_root) do
-    # Skip validation during precompile hook execution
-    ENV["REACT_ON_RAILS_SKIP_VALIDATION"] = "true"
-
-    # Run pack generation
-    system("bundle", "exec", "rails", "react_on_rails:generate_packs", exception: true)
+    # Skip validation during precompile hook execution.
+    # Force a UTF-8 locale for the child so `bundle exec` can parse Gemfiles with non-ASCII bytes
+    # under a C/POSIX locale (see utf8_subprocess_env).
+    system(utf8_subprocess_env("REACT_ON_RAILS_SKIP_VALIDATION" => "true"),
+           "bundle", "exec", "rails", "react_on_rails:generate_packs", exception: true)
     puts "✅ Pack generation completed successfully"
   end
 rescue Errno::ENOENT => e
@@ -222,13 +238,18 @@ def generate_rsc_manifest_client_references_if_needed
 
   puts "🔎 Generating RSC manifest client references..."
 
-  env = {
+  # Force a UTF-8 locale so the shakapacker child (which loads the Gemfile via bundler/setup) does
+  # not crash under a C/POSIX locale on Gemfiles with non-ASCII bytes (see utf8_subprocess_env).
+  env = utf8_subprocess_env(
+    # Set explicitly (rather than relying on the parent ENV that generate_packs_if_needed used to
+    # mutate) so this discovery build still skips React on Rails config validation.
+    "REACT_ON_RAILS_SKIP_VALIDATION" => "true",
     "SHAKAPACKER_SKIP_PRECOMPILE_HOOK" => "true",
     "RSC_REFERENCE_DISCOVERY_BUILD" => "true",
     "RSC_BUNDLE_ONLY" => "true",
     "CLIENT_BUNDLE_ONLY" => nil,
     "SERVER_BUNDLE_ONLY" => nil
-  }
+  )
 
   Dir.chdir(rails_root) do
     system(env, shakapacker_bin, exception: true)
@@ -261,13 +282,11 @@ def generate_locales_if_needed
   puts "🌐 Generating i18n locale files..."
 
   Dir.chdir(rails_root) do
-    # Run locale generation (idempotent - skips if up-to-date)
-    # Pass env to subprocess only, not globally
-    system(
-      { "REACT_ON_RAILS_SKIP_VALIDATION" => "true" },
-      "bundle", "exec", "rake", "react_on_rails:locale",
-      exception: true
-    )
+    # Run locale generation (idempotent - skips if up-to-date). Pass env to subprocess only, not
+    # globally. Force a UTF-8 locale so `bundle exec` can parse Gemfiles with non-ASCII bytes under
+    # a C/POSIX locale (see utf8_subprocess_env).
+    system(utf8_subprocess_env("REACT_ON_RAILS_SKIP_VALIDATION" => "true"),
+           "bundle", "exec", "rake", "react_on_rails:locale", exception: true)
     puts "✅ Locale generation completed successfully"
   end
 rescue StandardError => e


### PR DESCRIPTION
## Summary

The shared Shakapacker precompile hook (`react_on_rails/spec/support/shakapacker_precompile_hook_shared.rb`, loaded by both dummy apps' `bin/shakapacker-precompile-hook`) spawns `bundle exec` / shakapacker subprocesses for three steps:

1. **pack generation** — `bundle exec rails react_on_rails:generate_packs`
2. **i18n locale generation** — `bundle exec rake react_on_rails:locale` (added in #4128)
3. **RSC client-reference discovery** — the shakapacker binstub

Under a **C/POSIX locale** (no `LANG`/`LC_ALL`), the parent's `Encoding.default_external` is US-ASCII and each spawned child inherits it, then dies parsing any Gemfile containing non-ASCII bytes — e.g. `react_on_rails_pro/Gemfile.loader`:

```
[!] There was an error parsing `Gemfile.loader`: invalid byte sequence in US-ASCII. Bundler cannot continue.
```

The hook's `rescue` turns this into `exit 1`, **aborting the entire precompile** (e.g. `pnpm run build:test` in the Pro dummy).

#3949 hardened the hook's own `File.read`/`JSON.parse` against the C/POSIX locale but did **not** cover the subprocess boundary; #4128's new locale step made the gap visible for the Pro dummy. (For the OSS dummy the subprocesses load a Gemfile with no non-ASCII bytes, so OSS was unaffected — which is why #3949's tests passed.)

## Fix

Add a `utf8_subprocess_env` helper that forces a UTF-8 locale for child processes — `RUBYOPT=-EUTF-8` (pins the child Ruby's encodings regardless of locale) plus `LANG`/`LC_ALL` defaults — and apply it to all three subprocess spawns. This is the subprocess-boundary companion to #3949's UTF-8-safe reads.

The RSC discovery build now sets `REACT_ON_RAILS_SKIP_VALIDATION` **explicitly** in its env hash instead of relying on the parent-`ENV` mutation that `generate_packs_if_needed` used to perform (the global mutation is removed; each subprocess gets the skip flag through its own env hash).

## Validation

- `bundle exec rspec react_on_rails/spec/react_on_rails/shakapacker_precompile_hook_shared_spec.rb` → **21 examples, 0 failures** (adds regression specs for the locale and pack subprocess env, plus unit coverage for `utf8_subprocess_env`; the new tests fail on `main`).
- `bundle exec rubocop` on both changed files → no offenses.
- **End-to-end**: the full Pro dummy precompile hook under a C/POSIX locale —
  ```
  cd react_on_rails_pro/spec/dummy
  env -u LANG -u LC_ALL -u LC_CTYPE RAILS_ENV=test NODE_ENV=test bin/shakapacker-precompile-hook
  ```
  now exits **0** with `✅ Locale generation`, `✅ Pack generation`, and `✅ RSC manifest client references` all succeeding. On `main` it crashes at the locale step (and would crash again at pack generation) with `invalid byte sequence in US-ASCII`.

## Scope note

Found while verifying #4135 (whose `build:test` triggers the precompile hook). The narrow fix would be the locale step only, but pack generation and RSC discovery share the same C/POSIX fragility for Pro, so a locale-only fix would still leave the Pro precompile broken. This PR fixes all three; the change is a no-op for already-UTF-8 environments (CI, typical dev shells) and for the OSS dummy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-hook and subprocess env only; behavior unchanged under normal UTF-8 dev/CI shells.
> 
> **Overview**
> Fixes **[Pro]** precompile failures when the shell uses a C/POSIX locale (no `LANG`/`LC_ALL`): spawned `bundle exec` and `bin/shakapacker` children inherited US-ASCII and could abort parsing Gemfiles with non-ASCII bytes, killing the whole precompile.
> 
> Adds **`utf8_subprocess_env`** (`RUBYOPT` with `-EUTF-8`, default `LANG`/`LC_ALL`) and passes that env into **pack generation**, **i18n locale generation**, and **RSC client-reference discovery**. **`REACT_ON_RAILS_SKIP_VALIDATION`** is set on each subprocess env (including RSC discovery) instead of mutating parent `ENV` during pack generation.
> 
> Regression specs cover the helper and subprocess env; **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675756adc822242536fc1fe0c122c296e998306f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * [Pro] Fixed a crash in the shared Shakapacker precompile hook under non-UTF-8 locales (e.g., C/POSIX) when Gemfiles contain non-ASCII bytes. The hook now runs its subprocesses with forced UTF-8 locale settings during pack generation, i18n locale generation, and RSC client-reference discovery, preventing errors such as “invalid byte sequence in US-ASCII.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->