### PR TITLE
Unskip Rspack RSC e2e tests on react-on-rails-rsc 19.2 (rc.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",
       "ajv overrides were intentionally excluded: ajv v8 breaks webpack's schema-utils/ajv-keywords.",
       "The 2 moderate ajv alerts (ReDoS in $data option) are tolerable — ajv only validates our own config files.",
-      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scopes the Pro/RSC dummy to the coordinated React 19.2.7 + react-on-rails-rsc 19.2.0-rc.1 pair so CI soak-tests the RSC path on React 19.2 (#3865; gate landed in #4026). The workspace-wide pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 — the published/default pin for 17.0.0 — until #3865 promotes 19.2 to the default."
+      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scopes the Pro/RSC dummy to the coordinated React 19.2.7 + react-on-rails-rsc 19.2.0-rc.3 pair so CI soak-tests the RSC path on React 19.2 (#3865; gate landed in #4026). The workspace-wide pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 — the published/default pin for 17.0.0 — until #3865 promotes 19.2 to the default."
     ],
     "overrides": {
       "react": "$react",
@@ -140,7 +140,7 @@
       "react_on_rails>react-dom": "^19.2.0",
       "react_on_rails_pro_dummy>react": "^19.2.7",
       "react_on_rails_pro_dummy>react-dom": "^19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.0-rc.1",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.0-rc.3",
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
       "lodash@>=4.0.0 <=4.17.22": ">=4.17.23 <5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   react_on_rails>react-dom: ^19.2.0
   react_on_rails_pro_dummy>react: ^19.2.7
   react_on_rails_pro_dummy>react-dom: ^19.2.7
-  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.0-rc.1
+  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.0-rc.3
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23 <5'
@@ -762,8 +762,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.2.0-rc.1
-        version: 19.2.0-rc.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
+        specifier: 19.2.0-rc.3
+        version: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8469,8 +8469,8 @@ packages:
       react-dom: ~19.0.4
       webpack: ^5.59.0
 
-  react-on-rails-rsc@19.2.0-rc.1:
-    resolution: {integrity: sha512-WcCFn522Zq8kN9Bl/KU8TvfdB/HiPu4kBdLyStLrWIm2CEpV7JNTrXWns2PgUngKizevdIS+FfCz+l/f6TbAsA==}
+  react-on-rails-rsc@19.2.0-rc.3:
+    resolution: {integrity: sha512-lthw7rRbPdUOeZQMVR2rH1FdA3sp7wiZfMljmld1c/2epYtA7SYLLhg7jTn9FcVEIjWLZiyzC7GkNrNnLB4IOQ==}
     peerDependencies:
       react: ~19.0.4
       react-dom: ~19.0.4
@@ -19131,7 +19131,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.2.0-rc.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
+  react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts
@@ -307,16 +307,6 @@ async function delayCompiledJavaScript(page: Page): Promise<JavaScriptController
   };
 }
 
-// Rspack RSC content does not render on react-on-rails-rsc@19.2.0-rc.1 (the Rspack
-// build cannot locate the client runtime, so the RSC module map is not created).
-// Tracked in react_on_rails_rsc#105. These skips fire ONLY under the Rspack gate
-// (SHAKAPACKER_ASSETS_BUNDLER=rspack); the webpack RSC path still runs them. The
-// client-only reveal tests below are unaffected and keep running. Remove the skips
-// when react-on-rails-rsc@19.2.0-rc.2 fixes the Rspack module map.
-const RSPACK_RSC_BROKEN_192 = process.env.SHAKAPACKER_ASSETS_BUNDLER === 'rspack';
-const RSPACK_RSC_SKIP_REASON =
-  'Rspack RSC content does not render on react-on-rails-rsc@19.2.0-rc.1 (module map not created) — react_on_rails_rsc#105; unskip at rc.2.';
-
 test.describe('RSC and streaming FOUC acceptance coverage', () => {
   test.describe('resource reveal ordering', () => {
     test.beforeEach(async ({ page }) => {
@@ -330,7 +320,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     test('streamed RSC content is visible and styled when its CSS is loaded, even while JS is delayed', async ({
       page,
     }) => {
-      test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
       const css = await controlCssBySentinel(page, RSC_SENTINEL);
       const scripts = await delayCompiledJavaScript(page);
 
@@ -346,7 +335,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     });
 
     test('streamed RSC content does not appear before its CSS when JS is available', async ({ page }) => {
-      test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
       const css = await controlCssBySentinel(page, RSC_SENTINEL, { holdTarget: true });
 
       await page.goto(RSC_FOUC_PATH, { waitUntil: 'commit' });
@@ -360,7 +348,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
     });
 
     test('streamed RSC content still waits for CSS if JS finishes first', async ({ page }) => {
-      test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
       const css = await controlCssBySentinel(page, RSC_SENTINEL, { holdTarget: true });
       const scripts = await delayCompiledJavaScript(page);
 
@@ -416,7 +403,6 @@ test.describe('RSC and streaming FOUC acceptance coverage', () => {
   });
 
   test('RSC and client-only probe pages only load the CSS chunks they use', async ({ browser }) => {
-    test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
     const rscPage = await browser.newPage();
     try {
       await recordProbePaints(rscPage, [RSC_PROBE_TARGET]);

--- a/react_on_rails_pro/spec/dummy/e2e-tests/rsc_route_ssr_false.spec.ts
+++ b/react_on_rails_pro/spec/dummy/e2e-tests/rsc_route_ssr_false.spec.ts
@@ -26,18 +26,8 @@ const UNWRAPPED_STREAM_PAYLOAD_KEY =
   'SimpleComponent-fun4a7ngv9-UnwrappedStreamRSCRouteDemo-react-component-0';
 const RSC_ROUTE_SSR_FALSE_BAILOUT_DIGEST = 'REACT_ON_RAILS_RSC_ROUTE_SSR_FALSE_BAILOUT';
 
-// Rspack RSC content does not render on react-on-rails-rsc@19.2.0-rc.1 (the Rspack
-// build cannot locate the client runtime, so the RSC module map is not created).
-// Tracked in react_on_rails_rsc#105. These skips fire ONLY under the Rspack gate
-// (SHAKAPACKER_ASSETS_BUNDLER=rspack); the webpack RSC path still runs them. Remove
-// the skips when react-on-rails-rsc@19.2.0-rc.2 fixes the Rspack module map.
-const RSPACK_RSC_BROKEN_192 = process.env.SHAKAPACKER_ASSETS_BUNDLER === 'rspack';
-const RSPACK_RSC_SKIP_REASON =
-  'Rspack RSC content does not render on react-on-rails-rsc@19.2.0-rc.1 (module map not created) — react_on_rails_rsc#105; unskip at rc.2.';
-
 test.describe('RSCRoute ssr=false', () => {
   test('server-renders sibling routes while deferring the ssr=false route', async ({ page, request }) => {
-    test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
     const response = await request.get(MIXED_ROUTE_PATH);
     expect(response.ok()).toBe(true);
     const html = await response.text();
@@ -85,7 +75,6 @@ test.describe('RSCRoute ssr=false', () => {
     page,
     request,
   }) => {
-    test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
     const response = await request.get(UNWRAPPED_ROUTE_PATH);
     expect(response.ok()).toBe(true);
     const html = await response.text();
@@ -136,7 +125,6 @@ test.describe('RSCRoute ssr=false', () => {
     page,
     request,
   }) => {
-    test.skip(RSPACK_RSC_BROKEN_192, RSPACK_RSC_SKIP_REASON);
     const response = await request.get(UNWRAPPED_STREAM_ROUTE_PATH);
     expect(response.ok()).toBe(true);
     const html = await response.text();

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.2.0-rc.1",
+    "react-on-rails-rsc": "19.2.0-rc.3",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",


### PR DESCRIPTION
## Summary

`react_on_rails_rsc#105` — the Rspack RSC build skipping the client-references module map on the 19.2 line, so RSC client content never rendered/hydrated under Rspack — is fixed in `react-on-rails-rsc@19.2.0-rc.2`. This re-enables the 7 Pro/RSC dummy e2e tests that were conditionally skipped under the Rspack gate (`RSPACK_RSC_BROKEN_192`) pending that fix.

## Changes

- Bump the Pro/RSC dummy dep and the `react_on_rails_pro_dummy>react-on-rails-rsc` pnpm override from `19.2.0-rc.1` → `19.2.0-rc.3` (rc.3 carries the rc.2 fix); refresh `pnpm-lock.yaml` and the override comment.
- Remove the `RSPACK_RSC_BROKEN_192` / `RSPACK_RSC_SKIP_REASON` guards and the now-unused constants:
  - `react_on_rails_pro/spec/dummy/e2e-tests/rsc_route_ssr_false.spec.ts` — 3 skips
  - `react_on_rails_pro/spec/dummy/e2e-tests/rsc_fouc.spec.ts` — 4 skips

## Why now

rc.2 (2026-06-17) and rc.3 (2026-06-21) shipped the Rspack module-map fix and `react_on_rails_rsc#105` is closed. Until now these tests were silently skipped under Rspack, so a regression on that path would not be caught during the 19.2 soak.

## Validation

- Local: prettier + eslint clean on the changed specs.
- The real proof is hosted CI: `rspack-dummy-app-tests` + `dummy-app-rspack-rsc-runtime-gate` now run the previously-skipped RSC-render assertions on rc.3. Requested `ready-for-hosted-ci`.

## Scope / risk

Test-only + dummy-app dependency change. The published **17.0.0 default RSC pin stays at stable `19.0.5`** (the 19.2 line remains opt-in, tracked by #3865). No published-package source is touched, so no CHANGELOG entry.

Context: `react_on_rails_rsc#105`, #3865, #4072.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `react-on-rails-rsc` dependency to version 19.2.0-rc.3.

* **Tests**
  * Enabled RSC streaming and route rendering tests that were previously skipped, improving test coverage for React Server Components functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->