### PR TITLE
Split benchmark tracking script

### DIFF
--- a/benchmarks/lib/track_benchmarks.rb
+++ b/benchmarks/lib/track_benchmarks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "github"
+require_relative "github_cli"
+require_relative "regression_report"
+require_relative "bencher_runner"
+require_relative "bencher_report"
+require_relative "benchmark_table"
+require_relative "pr_report_poster"
+require_relative "track_benchmarks/config"
+require_relative "track_benchmarks/branch_args"
+require_relative "track_benchmarks/summary"
+require_relative "track_benchmarks/bencher_run"
+require_relative "track_benchmarks/pr_comments"
+require_relative "track_benchmarks/regression_payloads"
+require_relative "track_benchmarks/confirmation"
+require_relative "track_benchmarks/cli"

--- a/benchmarks/lib/track_benchmarks/bencher_run.rb
+++ b/benchmarks/lib/track_benchmarks/bencher_run.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Bencher execution helpers and exit-code classification.
+  module BencherRun
+    module_function
+
+    def run_bencher!(runner, branch, start_point_args)
+      # The bang means this script helper exits the process on an untriageable
+      # Bencher report shape, matching the surrounding top-level script helpers.
+      runner.run(branch:, start_point_args:)
+    rescue BencherRunner::ReportParseError => e
+      warn "::error::#{e.message}"
+      exit 1
+    rescue BencherRunner::PersistenceError => e
+      warn "::error::Benchmark report persistence failed: #{e.message}"
+      exit 1
+    end
+
+    def normalized_exit_code(exit_code, report)
+      return exit_code unless exit_code != 0 && report&.filtered_alert? && !Summary.regression?(report)
+
+      Github.notice("Bencher reported only stale active alert(s); no current boundary-backed regression remains.")
+      0
+    end
+
+    # A missing start-point baseline (operational, not a regression): retrying without
+    # the start-point hash falls back to the latest baseline. The no-regression guard is
+    # load-bearing — a real regression must not be silently re-run against a different
+    # baseline. The stderr match detects the operational error, not an alert.
+    def retry_without_start_point_hash?(stderr, exit_code, report)
+      exit_code != 0 &&
+        stderr.match?(/Head Version.*not found/) &&
+        !Summary.regression?(report)
+    end
+
+    def without_start_point_hash(start_point_args)
+      retry_args = start_point_args.dup
+      if (hash_arg_index = retry_args.index("--start-point-hash"))
+        retry_args.slice!(hash_arg_index, 2)
+      end
+      retry_args
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/branch_args.rb
+++ b/benchmarks/lib/track_benchmarks/branch_args.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Resolves the Bencher branch and start-point arguments for each GitHub event.
+  module BranchArgs
+    module_function
+
+    # A confirmation rerun (BENCHMARK_MODE=confirm) re-tests a main-push regression candidate
+    # on a fresh runner before the issue is filed. It must NOT pollute main's Bencher series,
+    # so it submits to a throwaway per-run branch and re-tests against main's cloned baseline.
+    def confirmation_mode?(env: ENV)
+      env.fetch("BENCHMARK_MODE", "initial") == "confirm"
+    end
+
+    # Bencher branch-safe slug: lowercase, runs of non-alphanumerics collapsed to a single
+    # dash, no leading/trailing dash. "Pro (shard 1/2)" -> "pro-shard-1-2".
+    def slugify(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+    end
+
+    # A unique synthetic Bencher branch for the confirmation rerun, e.g.
+    # "confirm-main-123456-pro-shard-1-2". Unique per run AND suite/shard so concurrent
+    # confirmation reruns never share a series, and never "main" so the confirmation sample
+    # is not appended to main's history.
+    def confirmation_branch(run_id, suite_name)
+      "confirm-main-#{run_id}-#{slugify(suite_name)}"
+    end
+
+    # Re-test against main's baseline without writing into main's series: clone main's
+    # thresholds onto the throwaway branch and reset it to a fresh copy of main's head each
+    # run. This is the same anchoring the PR path uses (branch_and_start_point_args).
+    def confirmation_start_point_args
+      ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
+    end
+
+    def branch_and_start_point_args(env: ENV)
+      if confirmation_mode?(env:)
+        return [
+          confirmation_branch(env.fetch("GITHUB_RUN_ID"), env.fetch("BENCHMARK_SUITE_NAME")),
+          confirmation_start_point_args
+        ]
+      end
+
+      case env.fetch("GITHUB_EVENT_NAME")
+      when "push"
+        ["main", []]
+      when "pull_request"
+        [
+          env.fetch("GITHUB_HEAD_REF"),
+          [
+            "--start-point", env.fetch("GITHUB_BASE_REF"),
+            "--start-point-hash", env.fetch("GITHUB_BASE_SHA"),
+            "--start-point-clone-thresholds",
+            "--start-point-reset"
+          ]
+        ]
+      when "workflow_dispatch"
+        workflow_dispatch_args(env)
+      else
+        warn "Unexpected event type: #{env.fetch('GITHUB_EVENT_NAME')}"
+        exit 1
+      end
+    end
+
+    def workflow_dispatch_args(env)
+      branch = env.fetch("GITHUB_REF_NAME")
+      return [branch, []] if branch == "main"
+
+      stdout, status = GithubCli.capture(
+        "gh", "api", "repos/#{env.fetch('GITHUB_REPOSITORY')}/compare/main...#{branch}",
+        "--jq", ".merge_base_commit.sha",
+        error_message: "Failed to resolve merge-base with main for #{branch}"
+      )
+      start_point_args = ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
+      # On API failure GithubCli already emits ::error::; fall back to the latest
+      # baseline rather than conflating a failed call with "no merge-base found".
+      merge_base = status.success? ? stdout.strip : ""
+
+      if merge_base.empty?
+        puts "Could not find merge-base with main via GitHub API, continuing without hash"
+      else
+        puts "Found merge-base via API: #{merge_base}"
+        start_point_args.insert(2, "--start-point-hash", merge_base)
+      end
+
+      [branch, start_point_args]
+    end
+    private_class_method :workflow_dispatch_args
+  end
+end

--- a/benchmarks/lib/track_benchmarks/cli.rb
+++ b/benchmarks/lib/track_benchmarks/cli.rb
@@ -10,7 +10,7 @@ module TrackBenchmarks
     end
 
     def run
-      branch, start_point_args = BranchArgs.branch_and_start_point_args
+      branch, start_point_args = BranchArgs.branch_and_start_point_args(env:)
       bencher_result = BencherRun.run_bencher!(bencher_runner, branch, start_point_args)
       bencher_exit_code, report = retry_without_start_point_hash(branch, start_point_args, bencher_result)
       bencher_exit_code = BencherRun.normalized_exit_code(bencher_exit_code, report)
@@ -20,14 +20,14 @@ module TrackBenchmarks
       report_markdown = Summary.rendered_report(report, suite_name, Config::DISPLAY_JSON)
       Summary.post_report_to_summary(report_markdown, suite_name)
 
-      if BranchArgs.confirmation_mode?
+      if BranchArgs.confirmation_mode?(env:)
         # Fresh-runner rerun of a main-push candidate. Owns its own exit code (confirmed /
         # cleared / inconclusive) and never posts PR comments.
         Confirmation.run(report, bencher_exit_code, report_markdown, suite_name)
       else
         post_pull_request_report(report, report_markdown)
 
-        if RegressionPayloads.main_push? && bencher_exit_code != 0
+        if RegressionPayloads.main_push?(env:) && bencher_exit_code != 0
           RegressionPayloads.report_main_push_candidate(report, report_markdown, bencher_exit_code, suite_name)
         end
       end

--- a/benchmarks/lib/track_benchmarks/cli.rb
+++ b/benchmarks/lib/track_benchmarks/cli.rb
@@ -65,7 +65,7 @@ module TrackBenchmarks
     end
 
     def post_pull_request_report(report, report_markdown)
-      pr_event = ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+      pr_event = ENV.fetch("GITHUB_EVENT_NAME", nil) == "pull_request"
       if report.nil? && pr_event
         # A nil report means Bencher produced no parseable output (operational failure). On
         # a PR, replacing the comment now would delete the previous run's real report and

--- a/benchmarks/lib/track_benchmarks/cli.rb
+++ b/benchmarks/lib/track_benchmarks/cli.rb
@@ -3,9 +3,10 @@
 module TrackBenchmarks
   # Runtime orchestration for benchmarks/track_benchmarks.rb.
   class Cli
-    def initialize(suite_name:, report_marker:)
+    def initialize(suite_name:, report_marker:, env: ENV)
       @suite_name = suite_name
       @report_marker = report_marker
+      @env = env
     end
 
     def run
@@ -34,7 +35,7 @@ module TrackBenchmarks
 
     private
 
-    attr_reader :suite_name, :report_marker
+    attr_reader :suite_name, :report_marker, :env
 
     def bencher_runner
       @bencher_runner ||= BencherRunner.new(benchmark_json: Config::BENCHMARK_JSON, report_json: Config::REPORT_JSON)
@@ -65,8 +66,10 @@ module TrackBenchmarks
     end
 
     def post_pull_request_report(report, report_markdown)
-      pr_event = ENV.fetch("GITHUB_EVENT_NAME", nil) == "pull_request"
-      if report.nil? && pr_event
+      event_name = env.fetch("GITHUB_EVENT_NAME", nil)
+      return unless event_name == "pull_request"
+
+      if report.nil?
         # A nil report means Bencher produced no parseable output (operational failure). On
         # a PR, replacing the comment now would delete the previous run's real report and
         # make an auth/API/network failure look like a normal un-highlighted summary, while
@@ -76,14 +79,14 @@ module TrackBenchmarks
           "Bencher produced no report for #{suite_name} (operational failure); " \
           "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
         )
-      elsif pr_event && Summary.regression?(report) && report_markdown.empty?
+      elsif Summary.regression?(report) && report_markdown.empty?
         # A real regression but no table to render (display sidecar missing/empty). Don't
         # leave the stale PR comment looking unchanged — post the run-URL fallback (which
         # also emits ::error::) so the regression is visible in the PR thread, mirroring the
         # main-push candidate hand-off.
-        PrComments.replace(Summary.regression_handoff_summary(report_markdown)) { pr_report_poster }
+        PrComments.replace(Summary.regression_handoff_summary(report_markdown), event_name:) { pr_report_poster }
       else
-        PrComments.replace(report_markdown) { pr_report_poster }
+        PrComments.replace(report_markdown, event_name:) { pr_report_poster }
       end
     end
   end

--- a/benchmarks/lib/track_benchmarks/cli.rb
+++ b/benchmarks/lib/track_benchmarks/cli.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Runtime orchestration for benchmarks/track_benchmarks.rb.
+  class Cli
+    def initialize(suite_name:, report_marker:)
+      @suite_name = suite_name
+      @report_marker = report_marker
+    end
+
+    def run
+      branch, start_point_args = BranchArgs.branch_and_start_point_args
+      bencher_result = BencherRun.run_bencher!(bencher_runner, branch, start_point_args)
+      bencher_exit_code, report = retry_without_start_point_hash(branch, start_point_args, bencher_result)
+      bencher_exit_code = BencherRun.normalized_exit_code(bencher_exit_code, report)
+
+      # Build the Markdown summary table once; the same body feeds the job summary, the
+      # PR comment, and the candidate/confirmation hand-offs.
+      report_markdown = Summary.rendered_report(report, suite_name, Config::DISPLAY_JSON)
+      Summary.post_report_to_summary(report_markdown, suite_name)
+
+      if BranchArgs.confirmation_mode?
+        # Fresh-runner rerun of a main-push candidate. Owns its own exit code (confirmed /
+        # cleared / inconclusive) and never posts PR comments.
+        Confirmation.run(report, bencher_exit_code, report_markdown, suite_name)
+      else
+        post_pull_request_report(report, report_markdown)
+
+        if RegressionPayloads.main_push? && bencher_exit_code != 0
+          RegressionPayloads.report_main_push_candidate(report, report_markdown, bencher_exit_code, suite_name)
+        end
+      end
+    end
+
+    private
+
+    attr_reader :suite_name, :report_marker
+
+    def bencher_runner
+      @bencher_runner ||= BencherRunner.new(benchmark_json: Config::BENCHMARK_JSON, report_json: Config::REPORT_JSON)
+    end
+
+    def pr_report_poster
+      # Keep this behind replace_pr_comments so non-PR runs never require PR env vars.
+      @pr_report_poster ||= PrReportPoster.from_env(suite_name:, marker: report_marker)
+    end
+
+    def retry_without_start_point_hash(branch, start_point_args, bencher_result)
+      stderr = bencher_result.stderr
+      bencher_exit_code = bencher_result.exit_code
+      report = bencher_result.report
+      unless BencherRun.retry_without_start_point_hash?(stderr, bencher_exit_code, report)
+        return [bencher_exit_code, report]
+      end
+
+      retry_args = BencherRun.without_start_point_hash(start_point_args)
+      puts "Start-point hash not found in Bencher; retrying without --start-point-hash"
+      Github.warning("Start-point hash not found in Bencher; falling back to latest baseline for comparison")
+      # The retry's stderr is unused: regression classification reads the JSON report,
+      # and this path only triggers when the first run had no regression.
+      retry_result = BencherRun.run_bencher!(bencher_runner, branch, retry_args)
+      # Intentionally leave retry_result.stderr unused here. BencherRunner#run has
+      # already emitted it; only the exit code and parsed report affect the outcome.
+      [retry_result.exit_code, retry_result.report]
+    end
+
+    def post_pull_request_report(report, report_markdown)
+      pr_event = ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
+      if report.nil? && pr_event
+        # A nil report means Bencher produced no parseable output (operational failure). On
+        # a PR, replacing the comment now would delete the previous run's real report and
+        # make an auth/API/network failure look like a normal un-highlighted summary, while
+        # the job still exits 0. Keep the prior comment intact and surface the failure
+        # instead. (post_report_to_summary above is per-run and clobbers nothing.)
+        Github.warning(
+          "Bencher produced no report for #{suite_name} (operational failure); " \
+          "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
+        )
+      elsif pr_event && Summary.regression?(report) && report_markdown.empty?
+        # A real regression but no table to render (display sidecar missing/empty). Don't
+        # leave the stale PR comment looking unchanged — post the run-URL fallback (which
+        # also emits ::error::) so the regression is visible in the PR thread, mirroring the
+        # main-push candidate hand-off.
+        PrComments.replace(Summary.regression_handoff_summary(report_markdown)) { pr_report_poster }
+      else
+        PrComments.replace(report_markdown) { pr_report_poster }
+      end
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/config.rb
+++ b/benchmarks/lib/track_benchmarks/config.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Paths and required environment helpers for the benchmark tracking script.
+  module Config
+    module_function
+
+    BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
+    REPORT_JSON = ENV.fetch("BENCHER_REPORT_JSON", "bench_results/bencher_report.json")
+    # Written by the bench scripts (BmfCollector#write_display_json); carries the
+    # summary-table columns Bencher never sees (p90, raw Status), keyed by the same
+    # canonical name as the report so the join is exact.
+    # NOTE: benchmark_config.rb independently defines DISPLAY_JSON with the same default
+    # path; the bench scripts and this tracker run as separate programs, so keep them in sync.
+    DISPLAY_JSON = ENV.fetch("BENCHMARK_DISPLAY_JSON", "bench_results/benchmark_display.json")
+    # Initial-run hand-off: a non-fatal candidate written when Bencher alerts on main.
+    CANDIDATE_REPORT_JSON = File.join("bench_results", RegressionReport::CANDIDATE_FILENAME)
+    # Confirmation-run hand-off: written only when the candidate's alert(s) re-alert.
+    CONFIRMED_REPORT_JSON = File.join("bench_results", RegressionReport::CONFIRMED_FILENAME)
+    # Directory the first-run candidate artifact was downloaded into (confirmation mode).
+    # Read via a recursive glob, not a fixed path, so it works regardless of how
+    # upload/download-artifact nests the single file under the download path.
+    CANDIDATE_INPUT_DIR = ENV.fetch("BENCHMARK_CANDIDATE_DIR", "candidate")
+
+    def env!(key)
+      ENV.fetch(key) do
+        warn "#{key} is required"
+        exit 1
+      end
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/confirmation.rb
+++ b/benchmarks/lib/track_benchmarks/confirmation.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Confirmation-rerun classification and hand-off.
+  module Confirmation
+    module_function
+
+    # Read the downloaded first-run candidate (found by recursive glob under dir): its
+    # structured alerts and rendered summary. Returns [nil, ""] when the payload is
+    # missing/corrupt so the caller can treat the confirmation as inconclusive (an
+    # operational failure) rather than silently clearing it.
+    def load_candidate(dir)
+      path = Dir.glob(File.join(dir, "**", RegressionReport::CANDIDATE_FILENAME)).first
+      unless path
+        warn "::error::No confirmation candidate (#{RegressionReport::CANDIDATE_FILENAME}) found under " \
+             "#{dir}; treating the confirmation as inconclusive."
+        return [nil, ""]
+      end
+
+      parsed = JSON.parse(File.read(path))
+      unless parsed.is_a?(Hash)
+        warn "::error::Confirmation candidate #{path} is not a JSON object (got #{parsed.class}); " \
+             "treating the confirmation as inconclusive."
+        return [nil, ""]
+      end
+
+      alerts = parsed[RegressionReport::ALERTS]
+      unless alerts.is_a?(Array) && !alerts.empty?
+        warn "::error::Confirmation candidate #{path} has empty or missing " \
+             "#{RegressionReport::ALERTS}; treating the confirmation as inconclusive."
+        return [nil, parsed[RegressionReport::SUMMARY].to_s]
+      end
+
+      [alerts, parsed[RegressionReport::SUMMARY].to_s]
+    rescue StandardError => e
+      warn "::error::Could not read confirmation candidate #{path} (#{e.class}: #{e.message}); " \
+           "treating the confirmation as inconclusive."
+      [nil, ""]
+    end
+
+    # Classify a confirmation rerun. Pure so it is unit-testable.
+    #   :inconclusive — no parseable report, or a non-zero exit with no alert (operational
+    #                   failure: auth/API/network/CLI). Must fail the workflow, file nothing.
+    #   :cleared      — the report parsed but none of the candidate's (non-ignored) alerts
+    #                   re-alerted. The first run was noise.
+    #   :confirmed    — the same benchmark+measure pair(s) re-alerted; returns just those.
+    # Ignored benchmarks are dropped from the candidate side first so a confirmation can
+    # never be carried by a benchmark we would suppress anyway.
+    def outcome(report, bencher_exit_code, candidate_alerts)
+      return [:inconclusive, []] if report.nil?
+      return [:inconclusive, []] if bencher_exit_code != 0 && !Summary.regression?(report)
+
+      confirmed = RegressionReport.confirmed_alerts(
+        RegressionReport.actionable_alerts(candidate_alerts),
+        Summary.regressed_alert_pairs(report)
+      )
+      return [:cleared, []] if confirmed.empty?
+
+      [:confirmed, confirmed]
+    end
+
+    # Human-readable "benchmark (measure)" for the workflow summary / logs.
+    def describe_alert(alert)
+      benchmark = alert[RegressionReport::ALERT_BENCHMARK]
+      measure = alert[RegressionReport::ALERT_MEASURE]
+      measure ? "#{benchmark} (#{measure})" : benchmark
+    end
+
+    # State the confirmation outcome in the workflow run summary (acceptance criterion:
+    # every first-run alert is visibly confirmed, cleared as noise, or inconclusive).
+    def append_summary(status, confirmed_alerts, suite_name)
+      body =
+        case status
+        when :confirmed
+          lines = confirmed_alerts.map { |alert| "- #{describe_alert(alert)}" }.join("\n")
+          "## #{suite_name} confirmation: ✅ CONFIRMED\n\n" \
+            "These first-run alerts re-alerted on a fresh runner (re-tested against main's " \
+            "baseline) and will be reported:\n\n#{lines}\n\n"
+        when :cleared
+          "## #{suite_name} confirmation: 🟢 CLEARED (noise)\n\n" \
+          "The first-run alert(s) did not re-alert on a fresh runner. No issue will be filed.\n\n"
+        else
+          "## #{suite_name} confirmation: ⚠️ INCONCLUSIVE\n\n" \
+          "The confirmation rerun could not be evaluated (benchmark execution or Bencher " \
+          "reporting failed). Treated as an operational failure; no issue will be filed.\n\n"
+        end
+      Summary.append_step_summary(body)
+    end
+
+    # The confirmation rerun (BENCHMARK_MODE=confirm). Owns its own exit code:
+    #   confirmed   -> write the confirmed hand-off, exit 0 (report-regressions fails the run)
+    #   cleared     -> exit 0 (the first-run alert was noise)
+    #   inconclusive-> exit 1 (operational failure: fail the workflow, file nothing)
+    def run(report, bencher_exit_code, confirmation_markdown, suite_name)
+      candidate_alerts, first_run_summary = load_candidate(Config::CANDIDATE_INPUT_DIR)
+      # A missing/corrupt candidate is an operational failure, not a cleared alert.
+      return finish(:inconclusive, [], suite_name) if candidate_alerts.nil?
+
+      status, confirmed_alerts = outcome(report, bencher_exit_code, candidate_alerts)
+      if status == :confirmed &&
+         !RegressionPayloads.write_confirmed(confirmed_alerts, first_run_summary, confirmation_markdown, suite_name)
+        # The regression confirmed but its hand-off was lost: fail rather than drop it.
+        return finish(:inconclusive, [], suite_name)
+      end
+
+      finish(status, confirmed_alerts, suite_name)
+    end
+
+    def finish(status, confirmed_alerts, suite_name)
+      append_summary(status, confirmed_alerts, suite_name)
+      case status
+      when :confirmed
+        Github.notice("Confirmed #{confirmed_alerts.size} #{suite_name} regression alert(s) on a fresh runner.")
+        exit 0
+      when :cleared
+        Github.notice("Cleared #{suite_name} first-run alert(s) as noise; no re-alert on the fresh runner.")
+        exit 0
+      else
+        warn "::error::#{suite_name} confirmation rerun was inconclusive (operational failure); " \
+             "failing the workflow without filing an issue. Investigate: #{Github.run_url}"
+        exit 1
+      end
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/confirmation.rb
+++ b/benchmarks/lib/track_benchmarks/confirmation.rb
@@ -10,10 +10,18 @@ module TrackBenchmarks
     # missing/corrupt so the caller can treat the confirmation as inconclusive (an
     # operational failure) rather than silently clearing it.
     def load_candidate(dir)
-      path = Dir.glob(File.join(dir, "**", RegressionReport::CANDIDATE_FILENAME)).first
-      unless path
+      path = nil
+      candidates = Dir.glob(File.join(dir, "**", RegressionReport::CANDIDATE_FILENAME))
+      case candidates.length
+      when 0
         warn "::error::No confirmation candidate (#{RegressionReport::CANDIDATE_FILENAME}) found under " \
              "#{dir}; treating the confirmation as inconclusive."
+        return [nil, ""]
+      when 1
+        path = candidates.first
+      else
+        warn "::error::Multiple confirmation candidates (#{RegressionReport::CANDIDATE_FILENAME}) found under " \
+             "#{dir}: #{candidates.sort.join(', ')}; treating the confirmation as inconclusive."
         return [nil, ""]
       end
 
@@ -33,7 +41,8 @@ module TrackBenchmarks
 
       [alerts, parsed[RegressionReport::SUMMARY].to_s]
     rescue StandardError => e
-      warn "::error::Could not read confirmation candidate #{path} (#{e.class}: #{e.message}); " \
+      candidate = path || File.join(dir, "**", RegressionReport::CANDIDATE_FILENAME)
+      warn "::error::Could not read confirmation candidate #{candidate} (#{e.class}: #{e.message}); " \
            "treating the confirmation as inconclusive."
       [nil, ""]
     end

--- a/benchmarks/lib/track_benchmarks/pr_comments.rb
+++ b/benchmarks/lib/track_benchmarks/pr_comments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # PR-comment replacement gate for benchmark reports.
+  module PrComments
+    module_function
+
+    def replace(markdown, event_name: ENV.fetch("GITHUB_EVENT_NAME", nil))
+      return unless event_name == "pull_request"
+      return if markdown.empty?
+
+      yield.replace(markdown)
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/regression_payloads.rb
+++ b/benchmarks/lib/track_benchmarks/regression_payloads.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Writes the first-run candidate and confirmed-regression hand-off payloads.
+  module RegressionPayloads
+    module_function
+
+    def main_push?(env: ENV)
+      env.fetch("GITHUB_EVENT_NAME") == "push" && env.fetch("GITHUB_REF") == "refs/heads/main"
+    end
+
+    # A main-push Bencher alert is now a NON-FATAL candidate: the gate/confirmation jobs
+    # rerun the alerting suite/shard on a fresh runner and only file the issue if the SAME
+    # benchmark+measure re-alerts, so write the candidate hand-off and exit 0 — the
+    # report-regressions job owns the final pass/fail. (A lost hand-off is the one case we
+    # still fail the suite, rather than silently drop the regression.) A non-zero exit with
+    # NO alert is an operational failure, not a regression, and still fails the suite.
+    def report_main_push_candidate(report, report_markdown, bencher_exit_code, suite_name)
+      if Summary.regression?(report)
+        exit 1 unless write_candidate(report, report_markdown, suite_name)
+      else
+        warn "::error::Bencher exited #{bencher_exit_code} on main with no regression alert for " \
+             "#{suite_name}; this indicates an operational failure (auth/API/network/CLI), not a " \
+             "performance regression. Check the logs above."
+        exit bencher_exit_code
+      end
+    end
+
+    # Write the non-fatal first-run candidate for the gate/confirmation jobs. Records the
+    # structured alert pairs so the confirmation rerun can require the SAME pair(s) to
+    # re-alert, plus the un-sharded suite name (so a suite's shards combine downstream) and
+    # the rendered summary. Returns true on success; false means the hand-off was lost, so
+    # the caller fails the suite rather than silently dropping the regression.
+    def write_candidate(report, report_markdown, suite_name, path: Config::CANDIDATE_REPORT_JSON, env: ENV)
+      File.write(
+        path,
+        JSON.generate(
+          RegressionReport::SUITE_NAME => env.fetch("BENCHMARK_SUITE_GROUP", suite_name),
+          RegressionReport::SHARD_LABEL => env.fetch("BENCHMARK_SHARD_LABEL", ""),
+          RegressionReport::SUMMARY => Summary.regression_handoff_summary(report_markdown),
+          RegressionReport::REGRESSED_BENCHMARKS => Summary.regressed_benchmark_names(report),
+          RegressionReport::ALERTS => Summary.regressed_alert_pairs(report)
+        )
+      )
+      Github.notice(
+        "Bencher flagged a #{suite_name} regression CANDIDATE on main. It is non-fatal until a " \
+        "fresh-runner confirmation rerun re-alerts on the same benchmark+measure. " \
+        "See the Bencher dashboard and the workflow run: #{Github.run_url}"
+      )
+      true
+    rescue StandardError => e
+      warn "::error::Bencher flagged a #{suite_name} regression candidate on main but its payload " \
+           "could not be written (#{e.class}: #{e.message}); confirmation cannot run and the issue will " \
+           "NOT be auto-filed — investigate using GitHub run logs: #{Github.run_url}"
+      false
+    end
+
+    # Write the confirmed hand-off for report-regressions: the first run and confirmation
+    # summaries side by side (the comparison is the evidence) and the confirmed alert pairs.
+    def write_confirmed(confirmed_alerts, first_run_summary, confirmation_markdown, suite_name,
+                        path: Config::CONFIRMED_REPORT_JSON, env: ENV)
+      File.write(
+        path,
+        JSON.generate(
+          RegressionReport::SUITE_NAME => env.fetch("BENCHMARK_SUITE_GROUP", suite_name),
+          RegressionReport::SHARD_LABEL => env.fetch("BENCHMARK_SHARD_LABEL", ""),
+          RegressionReport::FIRST_RUN_SUMMARY => first_run_summary,
+          RegressionReport::CONFIRMATION_SUMMARY => Summary.regression_handoff_summary(confirmation_markdown),
+          RegressionReport::ALERTS => confirmed_alerts,
+          RegressionReport::REGRESSED_BENCHMARKS =>
+            confirmed_alerts.filter_map { |alert| alert[RegressionReport::ALERT_BENCHMARK] }.uniq
+        )
+      )
+      true
+    rescue StandardError => e
+      warn "::error::A #{suite_name} regression was confirmed on a fresh runner but its payload " \
+           "could not be written (#{e.class}: #{e.message}); the issue will NOT be auto-filed — " \
+           "investigate using GitHub run logs: #{Github.run_url}"
+      false
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/regression_payloads.rb
+++ b/benchmarks/lib/track_benchmarks/regression_payloads.rb
@@ -65,7 +65,8 @@ module TrackBenchmarks
           RegressionReport::SUITE_NAME => env.fetch("BENCHMARK_SUITE_GROUP", suite_name),
           RegressionReport::SHARD_LABEL => env.fetch("BENCHMARK_SHARD_LABEL", ""),
           RegressionReport::FIRST_RUN_SUMMARY => first_run_summary,
-          RegressionReport::CONFIRMATION_SUMMARY => confirmation_markdown,
+          RegressionReport::CONFIRMATION_SUMMARY =>
+            Summary.regression_handoff_summary(confirmation_markdown, failure_context: "during confirmation"),
           RegressionReport::ALERTS => confirmed_alerts,
           RegressionReport::REGRESSED_BENCHMARKS =>
             confirmed_alerts.filter_map { |alert| alert[RegressionReport::ALERT_BENCHMARK] }.uniq

--- a/benchmarks/lib/track_benchmarks/regression_payloads.rb
+++ b/benchmarks/lib/track_benchmarks/regression_payloads.rb
@@ -65,7 +65,7 @@ module TrackBenchmarks
           RegressionReport::SUITE_NAME => env.fetch("BENCHMARK_SUITE_GROUP", suite_name),
           RegressionReport::SHARD_LABEL => env.fetch("BENCHMARK_SHARD_LABEL", ""),
           RegressionReport::FIRST_RUN_SUMMARY => first_run_summary,
-          RegressionReport::CONFIRMATION_SUMMARY => Summary.regression_handoff_summary(confirmation_markdown),
+          RegressionReport::CONFIRMATION_SUMMARY => confirmation_markdown,
           RegressionReport::ALERTS => confirmed_alerts,
           RegressionReport::REGRESSED_BENCHMARKS =>
             confirmed_alerts.filter_map { |alert| alert[RegressionReport::ALERT_BENCHMARK] }.uniq

--- a/benchmarks/lib/track_benchmarks/summary.rb
+++ b/benchmarks/lib/track_benchmarks/summary.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module TrackBenchmarks
+  # Report parsing, table rendering, and GitHub step-summary helpers.
+  module Summary
+    module_function
+
+    def append_step_summary(markdown)
+      File.open(ENV.fetch("GITHUB_STEP_SUMMARY"), "a") { |file| file.write(markdown) }
+    end
+
+    def post_report_to_summary(markdown, suite_name)
+      return if markdown.empty?
+
+      append_step_summary("## #{suite_name} Bencher Report\n\n")
+      append_step_summary(markdown)
+    end
+
+    # The display rows written by the bench scripts (BmfCollector#write_display_json).
+    def display_rows(display_json)
+      return [] unless File.exist?(display_json)
+
+      parsed = JSON.parse(File.read(display_json))
+      unless parsed.is_a?(Array)
+        # Mirror the write side (BmfCollector#write_display_json warns on a non-array
+        # sidecar). Without this the table would silently disappear on a contract break,
+        # and a main regression hand-off could store an empty summary with no diagnostic.
+        Github.warning("#{display_json} is not a JSON array (got #{parsed.class}); skipping the summary table")
+        return []
+      end
+
+      parsed
+    rescue JSON::ParserError => e
+      Github.warning("Could not parse #{display_json} (#{e.message}); skipping the summary table")
+      []
+    end
+
+    # The Markdown summary table: display rows joined with the Bencher report by
+    # benchmark name, with tracked values highlighted by significance. Empty string
+    # when there are no rows (nothing to post).
+    def rendered_report(report, suite_name, display_json)
+      rows = display_rows(display_json)
+      return "" if rows.empty?
+
+      BenchmarkTable.new(title: "#{suite_name} Benchmark Summary", rows:, report:).to_markdown
+    end
+
+    # Body for the report-regressions hand-off. Normally the rendered table; but if the
+    # display sidecar was missing/corrupt rendered_report returned "" — don't hand off an
+    # empty-bodied regression issue. Substitute a run-URL pointer (and shout via ::error::)
+    # so report-regressions still files something actionable.
+    def regression_handoff_summary(report_markdown)
+      return report_markdown unless report_markdown.empty?
+
+      run_url = Github.run_url
+      warn "::error::Bencher flagged a regression on main but the summary table could not be " \
+           "rendered (the display sidecar was missing or invalid); the auto-filed issue will link " \
+           "the run instead of showing the table. Investigate: #{run_url}"
+      "_Summary table unavailable (the benchmark display sidecar was missing or empty). " \
+        "See the Bencher dashboard and the workflow run: #{run_url}_"
+    end
+
+    # A real performance regression: Bencher raised at least one active alert in the
+    # JSON report. Deterministic — no stderr grepping. nil report (operational failure
+    # with no parseable stdout) is not a regression.
+    def regression?(report)
+      report&.regression? || false
+    end
+
+    # The names of the benchmarks Bencher raised an active alert for, deduped. Read from
+    # the same alerts[] as #regression?, so it is exactly the set of rows the summary
+    # table flags red. Handed off to report-regressions so it can decide which benchmarks
+    # regressed without re-parsing the rendered table. Empty when there is no report or no
+    # alert carried a benchmark name.
+    def regressed_benchmark_names(report)
+      return [] unless report
+
+      report.alerts.filter_map(&:benchmark).uniq
+    end
+
+    # The structured benchmark+measure pairs Bencher raised an active alert for, deduped.
+    # Read from the same alerts[] as #regression?/#regressed_benchmark_names. Handed off in
+    # the candidate so a confirmation rerun can require the SAME pair to re-alert (not just
+    # any alert in the suite). An alert with no benchmark name is dropped — it can't be
+    # matched. measure may be nil; the matcher falls back to name-only for those.
+    def regressed_alert_pairs(report)
+      return [] unless report
+
+      report.alerts
+            .select(&:benchmark)
+            .map { |alert| RegressionReport.alert(alert.benchmark, alert.measure) }
+            .uniq
+    end
+  end
+end

--- a/benchmarks/lib/track_benchmarks/summary.rb
+++ b/benchmarks/lib/track_benchmarks/summary.rb
@@ -33,6 +33,9 @@ module TrackBenchmarks
     rescue JSON::ParserError => e
       Github.warning("Could not parse #{display_json} (#{e.message}); skipping the summary table")
       []
+    rescue SystemCallError => e
+      Github.warning("Could not read #{display_json} (#{e.class}: #{e.message}); skipping the summary table")
+      []
     end
 
     # The Markdown summary table: display rows joined with the Bencher report by

--- a/benchmarks/lib/track_benchmarks/summary.rb
+++ b/benchmarks/lib/track_benchmarks/summary.rb
@@ -52,11 +52,11 @@ module TrackBenchmarks
     # display sidecar was missing/corrupt rendered_report returned "" — don't hand off an
     # empty-bodied regression issue. Substitute a run-URL pointer (and shout via ::error::)
     # so report-regressions still files something actionable.
-    def regression_handoff_summary(report_markdown)
+    def regression_handoff_summary(report_markdown, failure_context: "on main")
       return report_markdown unless report_markdown.empty?
 
       run_url = Github.run_url
-      warn "::error::Bencher flagged a regression on main but the summary table could not be " \
+      warn "::error::Bencher flagged a regression #{failure_context} but the summary table could not be " \
            "rendered (the display sidecar was missing or invalid); the auto-filed issue will link " \
            "the run instead of showing the table. Investigate: #{run_url}"
       "_Summary table unavailable (the benchmark display sidecar was missing or empty). " \

--- a/benchmarks/spec/track_benchmarks/branch_args_spec.rb
+++ b/benchmarks/spec/track_benchmarks/branch_args_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require_relative "../../lib/track_benchmarks"
+
+RSpec.describe TrackBenchmarks::BranchArgs do
+  describe ".branch_and_start_point_args" do
+    it "uses the pull request head branch and base SHA as the start point" do
+      branch, start_point_args = described_class.branch_and_start_point_args(
+        env: {
+          "GITHUB_EVENT_NAME" => "pull_request",
+          "GITHUB_HEAD_REF" => "feature/benchmarks",
+          "GITHUB_BASE_REF" => "main",
+          "GITHUB_BASE_SHA" => "abc123"
+        }
+      )
+
+      expect(branch).to eq("feature/benchmarks")
+      expect(start_point_args).to eq(
+        %w[
+          --start-point main
+          --start-point-hash abc123
+          --start-point-clone-thresholds
+          --start-point-reset
+        ]
+      )
+    end
+
+    it "adds a workflow_dispatch merge-base hash when the GitHub API resolves one" do
+      status = instance_double(Process::Status, success?: true)
+      allow(GithubCli).to receive(:capture).with(
+        "gh", "api", "repos/shakacode/react_on_rails/compare/main...feature/benchmarks",
+        "--jq", ".merge_base_commit.sha",
+        error_message: "Failed to resolve merge-base with main for feature/benchmarks"
+      ).and_return(["merge-base-sha\n", status])
+
+      branch = nil
+      start_point_args = nil
+      expect do
+        branch, start_point_args = described_class.branch_and_start_point_args(
+          env: {
+            "GITHUB_EVENT_NAME" => "workflow_dispatch",
+            "GITHUB_REF_NAME" => "feature/benchmarks",
+            "GITHUB_REPOSITORY" => "shakacode/react_on_rails"
+          }
+        )
+      end.to output(/Found merge-base via API: merge-base-sha/).to_stdout
+
+      expect(branch).to eq("feature/benchmarks")
+      expect(start_point_args).to eq(
+        %w[
+          --start-point main
+          --start-point-hash merge-base-sha
+          --start-point-clone-thresholds
+          --start-point-reset
+        ]
+      )
+    end
+
+    it "falls back to the latest main baseline when workflow_dispatch merge-base lookup fails" do
+      status = instance_double(Process::Status, success?: false)
+      allow(GithubCli).to receive(:capture).and_return(["", status])
+
+      branch = nil
+      start_point_args = nil
+      expect do
+        branch, start_point_args = described_class.branch_and_start_point_args(
+          env: {
+            "GITHUB_EVENT_NAME" => "workflow_dispatch",
+            "GITHUB_REF_NAME" => "feature/benchmarks",
+            "GITHUB_REPOSITORY" => "shakacode/react_on_rails"
+          }
+        )
+      end.to output(/Could not find merge-base with main via GitHub API/).to_stdout
+
+      expect(branch).to eq("feature/benchmarks")
+      expect(start_point_args).to eq(
+        %w[--start-point main --start-point-clone-thresholds --start-point-reset]
+      )
+    end
+  end
+end

--- a/benchmarks/spec/track_benchmarks/branch_args_spec.rb
+++ b/benchmarks/spec/track_benchmarks/branch_args_spec.rb
@@ -5,6 +5,15 @@ require_relative "../../lib/track_benchmarks"
 
 RSpec.describe TrackBenchmarks::BranchArgs do
   describe ".branch_and_start_point_args" do
+    it "uses main with no start point for push events" do
+      branch, start_point_args = described_class.branch_and_start_point_args(
+        env: { "GITHUB_EVENT_NAME" => "push" }
+      )
+
+      expect(branch).to eq("main")
+      expect(start_point_args).to eq([])
+    end
+
     it "uses the pull request head branch and base SHA as the start point" do
       branch, start_point_args = described_class.branch_and_start_point_args(
         env: {
@@ -77,6 +86,17 @@ RSpec.describe TrackBenchmarks::BranchArgs do
       expect(start_point_args).to eq(
         %w[--start-point main --start-point-clone-thresholds --start-point-reset]
       )
+    end
+
+    it "fails loudly for unexpected event types" do
+      expected_output = output(/Unexpected event type: schedule/).to_stderr
+      expected_exit = raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+
+      expect do
+        described_class.branch_and_start_point_args(
+          env: { "GITHUB_EVENT_NAME" => "schedule" }
+        )
+      end.to expected_output.and(expected_exit)
     end
   end
 end

--- a/benchmarks/spec/track_benchmarks/cli_spec.rb
+++ b/benchmarks/spec/track_benchmarks/cli_spec.rb
@@ -6,6 +6,42 @@ require_relative "../../lib/track_benchmarks"
 RSpec.describe TrackBenchmarks::Cli do
   include BenchmarkEnvHelper
 
+  describe "#run" do
+    it "passes injected env through benchmark orchestration gates" do
+      env = { "GITHUB_EVENT_NAME" => "push", "GITHUB_REF" => "refs/heads/main" }
+      cli = described_class.new(suite_name: "Core", report_marker: "core", env:)
+      runner = instance_double(BencherRunner)
+      report = instance_double(BencherReport)
+      result_type = Struct.new(:stderr, :exit_code, :report, keyword_init: true)
+      result = result_type.new(stderr: "", exit_code: 1, report:)
+
+      allow(BencherRunner).to receive(:new).with(
+        benchmark_json: TrackBenchmarks::Config::BENCHMARK_JSON,
+        report_json: TrackBenchmarks::Config::REPORT_JSON
+      ).and_return(runner)
+      allow(TrackBenchmarks::BranchArgs).to receive(:branch_and_start_point_args).with(env:).and_return(["main", []])
+      allow(TrackBenchmarks::BencherRun).to receive(:run_bencher!).with(runner, "main", []).and_return(result)
+      allow(TrackBenchmarks::BencherRun).to receive(:retry_without_start_point_hash?)
+        .with("", 1, report)
+        .and_return(false)
+      allow(TrackBenchmarks::BencherRun).to receive(:normalized_exit_code).with(1, report).and_return(1)
+      allow(TrackBenchmarks::Summary).to receive(:rendered_report)
+        .with(report, "Core", TrackBenchmarks::Config::DISPLAY_JSON)
+        .and_return("summary")
+      expect(TrackBenchmarks::Summary).to receive(:post_report_to_summary).with("summary", "Core")
+      allow(TrackBenchmarks::BranchArgs).to receive(:confirmation_mode?).with(env:).and_return(false)
+      allow(TrackBenchmarks::RegressionPayloads).to receive(:main_push?).with(env:).and_return(true)
+      expect(TrackBenchmarks::RegressionPayloads).to receive(:report_main_push_candidate)
+        .with(report, "summary", 1, "Core")
+
+      cli.run
+
+      expect(TrackBenchmarks::BranchArgs).to have_received(:branch_and_start_point_args).with(env:)
+      expect(TrackBenchmarks::BranchArgs).to have_received(:confirmation_mode?).with(env:)
+      expect(TrackBenchmarks::RegressionPayloads).to have_received(:main_push?).with(env:)
+    end
+  end
+
   describe "PR event detection" do
     it "does not require a GitHub event env var outside pull requests" do
       cli = described_class.new(suite_name: "Core", report_marker: "core", env: {})

--- a/benchmarks/spec/track_benchmarks/cli_spec.rb
+++ b/benchmarks/spec/track_benchmarks/cli_spec.rb
@@ -8,12 +8,27 @@ RSpec.describe TrackBenchmarks::Cli do
 
   describe "PR event detection" do
     it "does not require a GitHub event env var outside pull requests" do
-      with_env("GITHUB_EVENT_NAME" => nil) do
-        cli = described_class.new(suite_name: "Core", report_marker: "core")
-        expect(PrReportPoster).not_to receive(:from_env)
+      cli = described_class.new(suite_name: "Core", report_marker: "core", env: {})
+      expect(PrReportPoster).not_to receive(:from_env)
 
-        expect { cli.send(:post_pull_request_report, nil, "summary") }.not_to raise_error
-      end
+      expect { cli.send(:post_pull_request_report, nil, "summary") }.not_to raise_error
+    end
+
+    it "uses the injected event env when posting pull request reports" do
+      cli = described_class.new(
+        suite_name: "Core",
+        report_marker: "core",
+        env: { "GITHUB_EVENT_NAME" => "pull_request" }
+      )
+      report = instance_double(BencherReport)
+      poster = instance_double(PrReportPoster)
+
+      allow(TrackBenchmarks::Summary).to receive(:regression?).with(report).and_return(false)
+      allow(PrReportPoster).to receive(:from_env).with(suite_name: "Core", marker: "core").and_return(poster)
+
+      expect(poster).to receive(:replace).with("summary")
+
+      cli.send(:post_pull_request_report, report, "summary")
     end
   end
 end

--- a/benchmarks/spec/track_benchmarks/cli_spec.rb
+++ b/benchmarks/spec/track_benchmarks/cli_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper"
+require_relative "../../lib/track_benchmarks"
+
+RSpec.describe TrackBenchmarks::Cli do
+  include BenchmarkEnvHelper
+
+  describe "PR event detection" do
+    it "does not require a GitHub event env var outside pull requests" do
+      with_env("GITHUB_EVENT_NAME" => nil) do
+        cli = described_class.new(suite_name: "Core", report_marker: "core")
+        expect(PrReportPoster).not_to receive(:from_env)
+
+        expect { cli.send(:post_pull_request_report, nil, "summary") }.not_to raise_error
+      end
+    end
+  end
+end

--- a/benchmarks/spec/track_benchmarks/regression_payloads_spec.rb
+++ b/benchmarks/spec/track_benchmarks/regression_payloads_spec.rb
@@ -82,7 +82,36 @@ RSpec.describe TrackBenchmarks::RegressionPayloads do
       end
     end
 
-    it "preserves an empty confirmation summary instead of replacing it with a generic hand-off" do
+    it "uses a confirmation-specific fallback when the confirmation summary is empty" do
+      allow(Github).to receive(:run_url).and_return("https://github.test/run/2")
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "regression-confirmed.json")
+        alerts = [{ "benchmark" => "/posts: Pro", "measure" => "rps" }]
+
+        result = nil
+        expect do
+          result =
+            described_class.write_confirmed(
+              alerts,
+              "first run",
+              "",
+              "Core",
+              path:,
+              env: {}
+            )
+        end.to output(/Bencher flagged a regression during confirmation/).to_stderr
+
+        expect(result).to be(true)
+
+        payload = JSON.parse(File.read(path))
+        expect(payload.fetch(RegressionReport::CONFIRMATION_SUMMARY))
+          .to include("Summary table unavailable")
+        expect(payload.fetch(RegressionReport::CONFIRMATION_SUMMARY)).not_to eq("")
+      end
+    end
+
+    it "does not wrap a non-empty confirmation summary" do
       Dir.mktmpdir do |dir|
         path = File.join(dir, "regression-confirmed.json")
         alerts = [{ "benchmark" => "/posts: Pro", "measure" => "rps" }]
@@ -91,7 +120,7 @@ RSpec.describe TrackBenchmarks::RegressionPayloads do
           described_class.write_confirmed(
             alerts,
             "first run",
-            "",
+            "confirmation run",
             "Core",
             path:,
             env: {}
@@ -99,7 +128,7 @@ RSpec.describe TrackBenchmarks::RegressionPayloads do
         ).to be(true)
 
         payload = JSON.parse(File.read(path))
-        expect(payload.fetch(RegressionReport::CONFIRMATION_SUMMARY)).to eq("")
+        expect(payload.fetch(RegressionReport::CONFIRMATION_SUMMARY)).to eq("confirmation run")
       end
     end
   end

--- a/benchmarks/spec/track_benchmarks/regression_payloads_spec.rb
+++ b/benchmarks/spec/track_benchmarks/regression_payloads_spec.rb
@@ -81,5 +81,26 @@ RSpec.describe TrackBenchmarks::RegressionPayloads do
         )
       end
     end
+
+    it "preserves an empty confirmation summary instead of replacing it with a generic hand-off" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "regression-confirmed.json")
+        alerts = [{ "benchmark" => "/posts: Pro", "measure" => "rps" }]
+
+        expect(
+          described_class.write_confirmed(
+            alerts,
+            "first run",
+            "",
+            "Core",
+            path:,
+            env: {}
+          )
+        ).to be(true)
+
+        payload = JSON.parse(File.read(path))
+        expect(payload.fetch(RegressionReport::CONFIRMATION_SUMMARY)).to eq("")
+      end
+    end
   end
 end

--- a/benchmarks/spec/track_benchmarks/regression_payloads_spec.rb
+++ b/benchmarks/spec/track_benchmarks/regression_payloads_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "../spec_helper"
+require_relative "../../lib/track_benchmarks"
+
+RSpec.describe TrackBenchmarks::RegressionPayloads do
+  def report_with_alert
+    BencherReport.parse(
+      JSON.generate(
+        "results" => [],
+        "alerts" => [
+          {
+            "benchmark" => { "name" => "/posts: Pro" },
+            "threshold" => { "measure" => { "slug" => "rps" } },
+            "status" => "active"
+          }
+        ]
+      )
+    )
+  end
+
+  describe ".write_candidate" do
+    it "writes the non-fatal first-run regression hand-off payload" do
+      allow(Github).to receive(:run_url).and_return("https://github.test/run/1")
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "regression-candidate.json")
+        ok = nil
+        expect do
+          ok = described_class.write_candidate(
+            report_with_alert,
+            "rendered summary",
+            "Core shard 1",
+            path:,
+            env: { "BENCHMARK_SUITE_GROUP" => "Core", "BENCHMARK_SHARD_LABEL" => "1/2" }
+          )
+        end.to output(/::notice::Bencher flagged a Core shard 1 regression CANDIDATE/).to_stdout
+
+        expect(ok).to be(true)
+        payload = JSON.parse(File.read(path))
+        expect(payload).to include(
+          RegressionReport::SUITE_NAME => "Core",
+          RegressionReport::SHARD_LABEL => "1/2",
+          RegressionReport::SUMMARY => "rendered summary",
+          RegressionReport::REGRESSED_BENCHMARKS => ["/posts: Pro"],
+          RegressionReport::ALERTS => [{ "benchmark" => "/posts: Pro", "measure" => "rps" }]
+        )
+      end
+    end
+  end
+
+  describe ".write_confirmed" do
+    it "writes first-run and confirmation summaries with deduped benchmark names" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "regression-confirmed.json")
+        alerts = [
+          { "benchmark" => "/posts: Pro", "measure" => "rps" },
+          { "benchmark" => "/posts: Pro", "measure" => "p50_latency" }
+        ]
+
+        expect(
+          described_class.write_confirmed(
+            alerts,
+            "first run",
+            "confirmation run",
+            "Core",
+            path:,
+            env: {}
+          )
+        ).to be(true)
+
+        payload = JSON.parse(File.read(path))
+        expect(payload).to include(
+          RegressionReport::SUITE_NAME => "Core",
+          RegressionReport::SHARD_LABEL => "",
+          RegressionReport::FIRST_RUN_SUMMARY => "first run",
+          RegressionReport::CONFIRMATION_SUMMARY => "confirmation run",
+          RegressionReport::ALERTS => alerts,
+          RegressionReport::REGRESSED_BENCHMARKS => ["/posts: Pro"]
+        )
+      end
+    end
+  end
+end

--- a/benchmarks/spec/track_benchmarks/summary_spec.rb
+++ b/benchmarks/spec/track_benchmarks/summary_spec.rb
@@ -28,6 +28,53 @@ RSpec.describe TrackBenchmarks::Summary do
         expect(rows).to eq([])
       end
     end
+
+    it "preserves silent absent-file behavior" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "missing_display.json")
+
+        rows = nil
+        expect { rows = described_class.display_rows(path) }.not_to output.to_stdout
+
+        expect(rows).to eq([])
+      end
+    end
+
+    it "warns and returns no rows when the sidecar disappears after the existence check" do
+      path = "benchmark_display.json"
+      allow(File).to receive(:exist?).with(path).and_return(true)
+      allow(File).to receive(:read).with(path).and_raise(Errno::ENOENT)
+
+      rows = nil
+      expect { rows = described_class.display_rows(path) }
+        .to output(/::warning::Could not read #{Regexp.escape(path)} \(Errno::ENOENT:/).to_stdout
+
+      expect(rows).to eq([])
+    end
+
+    it "warns and returns no rows when the sidecar cannot be read because of permissions" do
+      path = "benchmark_display.json"
+      allow(File).to receive(:exist?).with(path).and_return(true)
+      allow(File).to receive(:read).with(path).and_raise(Errno::EACCES)
+
+      rows = nil
+      expect { rows = described_class.display_rows(path) }
+        .to output(/::warning::Could not read #{Regexp.escape(path)} \(Errno::EACCES:/).to_stdout
+
+      expect(rows).to eq([])
+    end
+
+    it "warns and returns no rows for other sidecar IO errors" do
+      path = "benchmark_display.json"
+      allow(File).to receive(:exist?).with(path).and_return(true)
+      allow(File).to receive(:read).with(path).and_raise(Errno::EIO)
+
+      rows = nil
+      expect { rows = described_class.display_rows(path) }
+        .to output(/::warning::Could not read #{Regexp.escape(path)} \(Errno::EIO:/).to_stdout
+
+      expect(rows).to eq([])
+    end
   end
 
   describe ".regressed_alert_pairs" do

--- a/benchmarks/spec/track_benchmarks/summary_spec.rb
+++ b/benchmarks/spec/track_benchmarks/summary_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "../spec_helper"
+require_relative "../../lib/track_benchmarks"
+
+RSpec.describe TrackBenchmarks::Summary do
+  describe ".display_rows" do
+    it "returns parsed display rows from a JSON array sidecar" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "benchmark_display.json")
+        rows = [{ "name" => "/posts", "rps" => 10.0 }]
+        File.write(path, JSON.generate(rows))
+
+        expect(described_class.display_rows(path)).to eq(rows)
+      end
+    end
+
+    it "warns and returns no rows when the sidecar is malformed JSON" do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "benchmark_display.json")
+        File.write(path, "{")
+
+        rows = nil
+        expect { rows = described_class.display_rows(path) }
+          .to output(/::warning::Could not parse #{Regexp.escape(path)}/).to_stdout
+
+        expect(rows).to eq([])
+      end
+    end
+  end
+
+  describe ".regressed_alert_pairs" do
+    it "deduplicates active alert benchmark and measure pairs" do
+      report = BencherReport.parse(
+        JSON.generate(
+          "results" => [],
+          "alerts" => [
+            {
+              "benchmark" => { "name" => "/posts: Pro" },
+              "threshold" => { "measure" => { "slug" => "rps" } },
+              "status" => "active"
+            },
+            {
+              "benchmark" => { "name" => "/posts: Pro" },
+              "threshold" => { "measure" => { "slug" => "rps" } },
+              "status" => "active"
+            }
+          ]
+        )
+      )
+
+      expect(described_class.regressed_alert_pairs(report)).to eq(
+        [{ "benchmark" => "/posts: Pro", "measure" => "rps" }]
+      )
+    end
+  end
+end

--- a/benchmarks/spec/track_benchmarks_spec.rb
+++ b/benchmarks/spec/track_benchmarks_spec.rb
@@ -268,6 +268,49 @@ RSpec.describe "track_benchmarks" do
         end
       end
 
+      it "treats a missing candidate as inconclusive" do
+        Dir.mktmpdir do |dir|
+          result = nil
+          expect { result = load_candidate(dir) }
+            .to output(/::error::No confirmation candidate/).to_stderr
+
+          expect(result).to eq([nil, ""])
+        end
+      end
+
+      it "treats multiple candidates as inconclusive instead of choosing one arbitrarily" do
+        Dir.mktmpdir do |dir|
+          first = File.join(dir, "first")
+          second = File.join(dir, "second")
+          FileUtils.mkdir_p(first)
+          FileUtils.mkdir_p(second)
+          File.write(
+            File.join(first, RegressionReport::CANDIDATE_FILENAME),
+            JSON.generate(RegressionReport::ALERTS => [])
+          )
+          File.write(
+            File.join(second, RegressionReport::CANDIDATE_FILENAME),
+            JSON.generate(RegressionReport::ALERTS => [{ "benchmark" => "/x: Pro", "measure" => "rps" }])
+          )
+
+          result = nil
+          expect { result = load_candidate(dir) }
+            .to output(/::error::Multiple confirmation candidates/).to_stderr
+
+          expect(result).to eq([nil, ""])
+        end
+      end
+
+      it "keeps the rescue message safe when candidate discovery fails before a path is selected" do
+        allow(Dir).to receive(:glob).and_raise(Errno::EACCES)
+
+        result = nil
+        expect { result = load_candidate("candidate-dir") }
+          .to output(%r{::error::Could not read confirmation candidate candidate-dir/\*\*/}).to_stderr
+
+        expect(result).to eq([nil, ""])
+      end
+
       it "treats missing alerts as inconclusive" do
         Dir.mktmpdir do |dir|
           write_candidate(dir, RegressionReport::SUMMARY => "first run")

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -1,145 +1,53 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "json"
+require_relative "lib/track_benchmarks"
 
-require_relative "lib/github"
-require_relative "lib/github_cli"
-require_relative "lib/regression_report"
-require_relative "lib/bencher_runner"
-require_relative "lib/bencher_report"
-require_relative "lib/benchmark_table"
-require_relative "lib/pr_report_poster"
+BENCHMARK_JSON = TrackBenchmarks::Config::BENCHMARK_JSON
+REPORT_JSON = TrackBenchmarks::Config::REPORT_JSON
+DISPLAY_JSON = TrackBenchmarks::Config::DISPLAY_JSON
+CANDIDATE_REPORT_JSON = TrackBenchmarks::Config::CANDIDATE_REPORT_JSON
+CONFIRMED_REPORT_JSON = TrackBenchmarks::Config::CONFIRMED_REPORT_JSON
+CANDIDATE_INPUT_DIR = TrackBenchmarks::Config::CANDIDATE_INPUT_DIR
 
 def env!(key)
-  ENV.fetch(key) do
-    warn "#{key} is required"
-    exit 1
-  end
+  TrackBenchmarks::Config.env!(key)
 end
 
-BENCHMARK_JSON = ENV.fetch("BENCHMARK_JSON", "bench_results/benchmark.json")
-REPORT_JSON = ENV.fetch("BENCHER_REPORT_JSON", "bench_results/bencher_report.json")
-# Written by the bench scripts (BmfCollector#write_display_json); carries the
-# summary-table columns Bencher never sees (p90, raw Status), keyed by the same
-# canonical name as the report so the join is exact.
-# NOTE: benchmark_config.rb independently defines DISPLAY_JSON with the same default
-# path; the bench scripts and this tracker run as separate programs, so keep them in sync.
-DISPLAY_JSON = ENV.fetch("BENCHMARK_DISPLAY_JSON", "bench_results/benchmark_display.json")
-# Initial-run hand-off: a non-fatal candidate written when Bencher alerts on main.
-CANDIDATE_REPORT_JSON = File.join("bench_results", RegressionReport::CANDIDATE_FILENAME)
-# Confirmation-run hand-off: written only when the candidate's alert(s) re-alert.
-CONFIRMED_REPORT_JSON = File.join("bench_results", RegressionReport::CONFIRMED_FILENAME)
-# Directory the first-run candidate artifact was downloaded into (confirmation mode).
-# Read via a recursive glob, not a fixed path, so it works regardless of how
-# upload/download-artifact nests the single file under the download path.
-CANDIDATE_INPUT_DIR = ENV.fetch("BENCHMARK_CANDIDATE_DIR", "candidate")
-
-# A confirmation rerun (BENCHMARK_MODE=confirm) re-tests a main-push regression candidate
-# on a fresh runner before the issue is filed. It must NOT pollute main's Bencher series,
-# so it submits to a throwaway per-run branch and re-tests against main's cloned baseline.
 def confirmation_mode?
-  ENV.fetch("BENCHMARK_MODE", "initial") == "confirm"
+  TrackBenchmarks::BranchArgs.confirmation_mode?
 end
 
-# Bencher branch-safe slug: lowercase, runs of non-alphanumerics collapsed to a single
-# dash, no leading/trailing dash. "Pro (shard 1/2)" -> "pro-shard-1-2".
 def slugify(value)
-  value.to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+  TrackBenchmarks::BranchArgs.slugify(value)
 end
 
-# A unique synthetic Bencher branch for the confirmation rerun, e.g.
-# "confirm-main-123456-pro-shard-1-2". Unique per run AND suite/shard so concurrent
-# confirmation reruns never share a series, and never "main" so the confirmation sample
-# is not appended to main's history.
 def confirmation_branch(run_id, suite_name)
-  "confirm-main-#{run_id}-#{slugify(suite_name)}"
+  TrackBenchmarks::BranchArgs.confirmation_branch(run_id, suite_name)
 end
 
-# Re-test against main's baseline without writing into main's series: clone main's
-# thresholds onto the throwaway branch and reset it to a fresh copy of main's head each
-# run. This is the same anchoring the PR path uses (branch_and_start_point_args).
 def confirmation_start_point_args
-  ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
+  TrackBenchmarks::BranchArgs.confirmation_start_point_args
 end
 
 def branch_and_start_point_args
-  if confirmation_mode?
-    return [
-      confirmation_branch(ENV.fetch("GITHUB_RUN_ID"), ENV.fetch("BENCHMARK_SUITE_NAME")),
-      confirmation_start_point_args
-    ]
-  end
-
-  case ENV.fetch("GITHUB_EVENT_NAME")
-  when "push"
-    ["main", []]
-  when "pull_request"
-    [
-      ENV.fetch("GITHUB_HEAD_REF"),
-      [
-        "--start-point", ENV.fetch("GITHUB_BASE_REF"),
-        "--start-point-hash", ENV.fetch("GITHUB_BASE_SHA"),
-        "--start-point-clone-thresholds",
-        "--start-point-reset"
-      ]
-    ]
-  when "workflow_dispatch"
-    branch = ENV.fetch("GITHUB_REF_NAME")
-    return [branch, []] if branch == "main"
-
-    stdout, status = GithubCli.capture(
-      "gh", "api", "repos/#{ENV.fetch('GITHUB_REPOSITORY')}/compare/main...#{branch}",
-      "--jq", ".merge_base_commit.sha",
-      error_message: "Failed to resolve merge-base with main for #{branch}"
-    )
-    start_point_args = ["--start-point", "main", "--start-point-clone-thresholds", "--start-point-reset"]
-    # On API failure GithubCli already emits ::error::; fall back to the latest
-    # baseline rather than conflating a failed call with "no merge-base found".
-    merge_base = status.success? ? stdout.strip : ""
-
-    if merge_base.empty?
-      puts "Could not find merge-base with main via GitHub API, continuing without hash"
-    else
-      puts "Found merge-base via API: #{merge_base}"
-      start_point_args.insert(2, "--start-point-hash", merge_base)
-    end
-
-    [branch, start_point_args]
-  else
-    warn "Unexpected event type: #{ENV.fetch('GITHUB_EVENT_NAME')}"
-    exit 1
-  end
+  TrackBenchmarks::BranchArgs.branch_and_start_point_args
 end
 
 def run_bencher!(branch, start_point_args)
-  # The bang means this script helper exits the process on an untriageable
-  # Bencher report shape, matching the surrounding top-level script helpers.
-  bencher_runner.run(branch:, start_point_args:)
-rescue BencherRunner::ReportParseError => e
-  warn "::error::#{e.message}"
-  exit 1
-rescue BencherRunner::PersistenceError => e
-  warn "::error::Benchmark report persistence failed: #{e.message}"
-  exit 1
+  TrackBenchmarks::BencherRun.run_bencher!(bencher_runner, branch, start_point_args)
 end
 
 def normalized_bencher_exit_code(exit_code, report)
-  return exit_code unless exit_code != 0 && report&.filtered_alert? && !regression?(report)
-
-  Github.notice("Bencher reported only stale active alert(s); no current boundary-backed regression remains.")
-  0
+  TrackBenchmarks::BencherRun.normalized_exit_code(exit_code, report)
 end
 
 def append_step_summary(markdown)
-  File.open(ENV.fetch("GITHUB_STEP_SUMMARY"), "a") { |file| file.write(markdown) }
+  TrackBenchmarks::Summary.append_step_summary(markdown)
 end
 
 def post_report_to_summary(markdown)
-  return if markdown.empty?
-
-  append_step_summary("## #{SUITE_NAME} Bencher Report\n\n")
-  append_step_summary(markdown)
+  TrackBenchmarks::Summary.post_report_to_summary(markdown, SUITE_NAME)
 end
 
 def bencher_runner
@@ -147,10 +55,7 @@ def bencher_runner
 end
 
 def replace_pr_comments(markdown)
-  return unless ENV.fetch("GITHUB_EVENT_NAME", nil) == "pull_request"
-  return if markdown.empty?
-
-  pr_report_poster.replace(markdown)
+  TrackBenchmarks::PrComments.replace(markdown) { pr_report_poster }
 end
 
 def pr_report_poster
@@ -158,285 +63,81 @@ def pr_report_poster
   @pr_report_poster ||= PrReportPoster.from_env(suite_name: SUITE_NAME, marker: REPORT_MARKER)
 end
 
-# The display rows written by the bench scripts (BmfCollector#write_display_json).
 def display_rows
-  return [] unless File.exist?(DISPLAY_JSON)
-
-  parsed = JSON.parse(File.read(DISPLAY_JSON))
-  unless parsed.is_a?(Array)
-    # Mirror the write side (BmfCollector#write_display_json warns on a non-array
-    # sidecar). Without this the table would silently disappear on a contract break,
-    # and a main regression hand-off could store an empty summary with no diagnostic.
-    Github.warning("#{DISPLAY_JSON} is not a JSON array (got #{parsed.class}); skipping the summary table")
-    return []
-  end
-
-  parsed
-rescue JSON::ParserError => e
-  Github.warning("Could not parse #{DISPLAY_JSON} (#{e.message}); skipping the summary table")
-  []
+  TrackBenchmarks::Summary.display_rows(DISPLAY_JSON)
 end
 
-# The Markdown summary table: display rows joined with the Bencher report by
-# benchmark name, with tracked values highlighted by significance. Empty string
-# when there are no rows (nothing to post). suite_name is passed in rather than read
-# from the SUITE_NAME constant (which is only assigned inside the
-# __FILE__ == $PROGRAM_NAME block) so this stays callable from specs/require-only
-# contexts without raising NameError.
 def rendered_report(report, suite_name)
-  rows = display_rows
-  return "" if rows.empty?
-
-  BenchmarkTable.new(title: "#{suite_name} Benchmark Summary", rows:, report:).to_markdown
+  TrackBenchmarks::Summary.rendered_report(report, suite_name, DISPLAY_JSON)
 end
 
-# Body for the report-regressions hand-off. Normally the rendered table; but if the
-# display sidecar was missing/corrupt rendered_report returned "" — don't hand off an
-# empty-bodied regression issue. Substitute a run-URL pointer (and shout via ::error::)
-# so report-regressions still files something actionable.
 def regression_handoff_summary(report_markdown)
-  return report_markdown unless report_markdown.empty?
-
-  warn "::error::Bencher flagged a regression on main but the summary table could not be " \
-       "rendered (the display sidecar was missing or invalid); the auto-filed issue will link " \
-       "the run instead of showing the table. Investigate: #{Github.run_url}"
-  "_Summary table unavailable (the benchmark display sidecar was missing or empty). " \
-    "See the Bencher dashboard and the workflow run: #{Github.run_url}_"
+  TrackBenchmarks::Summary.regression_handoff_summary(report_markdown)
 end
 
-# A real performance regression: Bencher raised at least one active alert in the
-# JSON report. Deterministic — no stderr grepping. nil report (operational failure
-# with no parseable stdout) is not a regression.
 def regression?(report)
-  report&.regression? || false
+  TrackBenchmarks::Summary.regression?(report)
 end
 
-# The names of the benchmarks Bencher raised an active alert for, deduped. Read from
-# the same alerts[] as #regression?, so it is exactly the set of rows the summary
-# table flags 🔴. Handed off to report-regressions so it can decide which benchmarks
-# regressed without re-parsing the rendered table. Empty when there is no report or no
-# alert carried a benchmark name.
 def regressed_benchmark_names(report)
-  return [] unless report
-
-  report.alerts.filter_map(&:benchmark).uniq
+  TrackBenchmarks::Summary.regressed_benchmark_names(report)
 end
 
-# The structured benchmark+measure pairs Bencher raised an active alert for, deduped.
-# Read from the same alerts[] as #regression?/#regressed_benchmark_names. Handed off in
-# the candidate so a confirmation rerun can require the SAME pair to re-alert (not just
-# any alert in the suite). An alert with no benchmark name is dropped — it can't be
-# matched. measure may be nil; the matcher falls back to name-only for those.
 def regressed_alert_pairs(report)
-  return [] unless report
-
-  report.alerts
-        .select(&:benchmark)
-        .map { |alert| RegressionReport.alert(alert.benchmark, alert.measure) }
-        .uniq
+  TrackBenchmarks::Summary.regressed_alert_pairs(report)
 end
 
-# Read the downloaded first-run candidate (found by recursive glob under dir): its
-# structured alerts and rendered summary. Returns [nil, ""] when the payload is
-# missing/corrupt so the caller can treat the confirmation as inconclusive (an
-# operational failure) rather than silently clearing it.
 def load_candidate(dir)
-  path = Dir.glob(File.join(dir, "**", RegressionReport::CANDIDATE_FILENAME)).first
-  unless path
-    warn "::error::No confirmation candidate (#{RegressionReport::CANDIDATE_FILENAME}) found under " \
-         "#{dir}; treating the confirmation as inconclusive."
-    return [nil, ""]
-  end
-
-  parsed = JSON.parse(File.read(path))
-  unless parsed.is_a?(Hash)
-    warn "::error::Confirmation candidate #{path} is not a JSON object (got #{parsed.class}); " \
-         "treating the confirmation as inconclusive."
-    return [nil, ""]
-  end
-
-  alerts = parsed[RegressionReport::ALERTS]
-  unless alerts.is_a?(Array) && !alerts.empty?
-    warn "::error::Confirmation candidate #{path} has empty or missing " \
-         "#{RegressionReport::ALERTS}; treating the confirmation as inconclusive."
-    return [nil, parsed[RegressionReport::SUMMARY].to_s]
-  end
-
-  [alerts, parsed[RegressionReport::SUMMARY].to_s]
-rescue StandardError => e
-  warn "::error::Could not read confirmation candidate #{path} (#{e.class}: #{e.message}); " \
-       "treating the confirmation as inconclusive."
-  [nil, ""]
+  TrackBenchmarks::Confirmation.load_candidate(dir)
 end
 
-# Classify a confirmation rerun. Pure so it is unit-testable.
-#   :inconclusive — no parseable report, or a non-zero exit with no alert (operational
-#                   failure: auth/API/network/CLI). Must fail the workflow, file nothing.
-#   :cleared      — the report parsed but none of the candidate's (non-ignored) alerts
-#                   re-alerted. The first run was noise.
-#   :confirmed    — the same benchmark+measure pair(s) re-alerted; returns just those.
-# Ignored benchmarks are dropped from the candidate side first so a confirmation can
-# never be carried by a benchmark we would suppress anyway.
 def confirmation_outcome(report, bencher_exit_code, candidate_alerts)
-  return [:inconclusive, []] if report.nil?
-  return [:inconclusive, []] if bencher_exit_code != 0 && !regression?(report)
-
-  confirmed = RegressionReport.confirmed_alerts(
-    RegressionReport.actionable_alerts(candidate_alerts),
-    regressed_alert_pairs(report)
-  )
-  return [:cleared, []] if confirmed.empty?
-
-  [:confirmed, confirmed]
+  TrackBenchmarks::Confirmation.outcome(report, bencher_exit_code, candidate_alerts)
 end
 
-# Human-readable "benchmark (measure)" for the workflow summary / logs.
 def describe_alert(alert)
-  benchmark = alert[RegressionReport::ALERT_BENCHMARK]
-  measure = alert[RegressionReport::ALERT_MEASURE]
-  measure ? "#{benchmark} (#{measure})" : benchmark
+  TrackBenchmarks::Confirmation.describe_alert(alert)
 end
 
-# A missing start-point baseline (operational, not a regression): retrying without
-# the start-point hash falls back to the latest baseline. The no-regression guard is
-# load-bearing — a real regression must not be silently re-run against a different
-# baseline. The stderr match detects the operational error, not an alert.
 def retry_without_start_point_hash?(stderr, exit_code, report)
-  exit_code != 0 &&
-    stderr.match?(/Head Version.*not found/) &&
-    !regression?(report)
+  TrackBenchmarks::BencherRun.retry_without_start_point_hash?(stderr, exit_code, report)
 end
 
 def main_push?
-  ENV.fetch("GITHUB_EVENT_NAME") == "push" && ENV.fetch("GITHUB_REF") == "refs/heads/main"
+  TrackBenchmarks::RegressionPayloads.main_push?
 end
 
-# A main-push Bencher alert is now a NON-FATAL candidate: the gate/confirmation jobs
-# rerun the alerting suite/shard on a fresh runner and only file the issue if the SAME
-# benchmark+measure re-alerts, so write the candidate hand-off and exit 0 — the
-# report-regressions job owns the final pass/fail. (A lost hand-off is the one case we
-# still fail the suite, rather than silently drop the regression.) A non-zero exit with
-# NO alert is an operational failure, not a regression, and still fails the suite.
 def report_main_push_candidate(report, report_markdown, bencher_exit_code, suite_name)
-  if regression?(report)
-    exit 1 unless write_candidate(report, report_markdown, suite_name)
-  else
-    warn "::error::Bencher exited #{bencher_exit_code} on main with no regression alert for " \
-         "#{suite_name}; this indicates an operational failure (auth/API/network/CLI), not a " \
-         "performance regression. Check the logs above."
-    exit bencher_exit_code
-  end
+  TrackBenchmarks::RegressionPayloads.report_main_push_candidate(report, report_markdown, bencher_exit_code, suite_name)
 end
 
-# Write the non-fatal first-run candidate for the gate/confirmation jobs. Records the
-# structured alert pairs so the confirmation rerun can require the SAME pair(s) to
-# re-alert, plus the un-sharded suite name (so a suite's shards combine downstream) and
-# the rendered summary. Returns true on success; false means the hand-off was lost, so
-# the caller fails the suite rather than silently dropping the regression.
 def write_candidate(report, report_markdown, suite_name)
-  File.write(
-    CANDIDATE_REPORT_JSON,
-    JSON.generate(
-      RegressionReport::SUITE_NAME => ENV.fetch("BENCHMARK_SUITE_GROUP", suite_name),
-      RegressionReport::SHARD_LABEL => ENV.fetch("BENCHMARK_SHARD_LABEL", ""),
-      RegressionReport::SUMMARY => regression_handoff_summary(report_markdown),
-      RegressionReport::REGRESSED_BENCHMARKS => regressed_benchmark_names(report),
-      RegressionReport::ALERTS => regressed_alert_pairs(report)
-    )
-  )
-  Github.notice(
-    "Bencher flagged a #{suite_name} regression CANDIDATE on main. It is non-fatal until a " \
-    "fresh-runner confirmation rerun re-alerts on the same benchmark+measure. " \
-    "See the Bencher dashboard and the workflow run: #{Github.run_url}"
-  )
-  true
-rescue StandardError => e
-  warn "::error::Bencher flagged a #{suite_name} regression candidate on main but its payload " \
-       "could not be written (#{e.class}: #{e.message}); confirmation cannot run and the issue will " \
-       "NOT be auto-filed — investigate using GitHub run logs: #{Github.run_url}"
-  false
+  TrackBenchmarks::RegressionPayloads.write_candidate(report, report_markdown, suite_name)
 end
 
-# Write the confirmed hand-off for report-regressions: the first run and confirmation
-# summaries side by side (the comparison is the evidence) and the confirmed alert pairs.
 def write_confirmed(confirmed_alerts, first_run_summary, confirmation_markdown, suite_name)
-  File.write(
-    CONFIRMED_REPORT_JSON,
-    JSON.generate(
-      RegressionReport::SUITE_NAME => ENV.fetch("BENCHMARK_SUITE_GROUP", suite_name),
-      RegressionReport::SHARD_LABEL => ENV.fetch("BENCHMARK_SHARD_LABEL", ""),
-      RegressionReport::FIRST_RUN_SUMMARY => first_run_summary,
-      RegressionReport::CONFIRMATION_SUMMARY => regression_handoff_summary(confirmation_markdown),
-      RegressionReport::ALERTS => confirmed_alerts,
-      RegressionReport::REGRESSED_BENCHMARKS =>
-        confirmed_alerts.filter_map { |alert| alert[RegressionReport::ALERT_BENCHMARK] }.uniq
-    )
+  TrackBenchmarks::RegressionPayloads.write_confirmed(
+    confirmed_alerts,
+    first_run_summary,
+    confirmation_markdown,
+    suite_name
   )
-  true
-rescue StandardError => e
-  warn "::error::A #{suite_name} regression was confirmed on a fresh runner but its payload " \
-       "could not be written (#{e.class}: #{e.message}); the issue will NOT be auto-filed — " \
-       "investigate using GitHub run logs: #{Github.run_url}"
-  false
 end
 
-# State the confirmation outcome in the workflow run summary (acceptance criterion:
-# every first-run alert is visibly confirmed, cleared as noise, or inconclusive).
 def append_confirmation_summary(status, confirmed_alerts, suite_name)
-  body =
-    case status
-    when :confirmed
-      lines = confirmed_alerts.map { |alert| "- #{describe_alert(alert)}" }.join("\n")
-      "## #{suite_name} confirmation: ✅ CONFIRMED\n\n" \
-        "These first-run alerts re-alerted on a fresh runner (re-tested against main's " \
-        "baseline) and will be reported:\n\n#{lines}\n\n"
-    when :cleared
-      "## #{suite_name} confirmation: 🟢 CLEARED (noise)\n\n" \
-      "The first-run alert(s) did not re-alert on a fresh runner. No issue will be filed.\n\n"
-    else
-      "## #{suite_name} confirmation: ⚠️ INCONCLUSIVE\n\n" \
-      "The confirmation rerun could not be evaluated (benchmark execution or Bencher " \
-      "reporting failed). Treated as an operational failure; no issue will be filed.\n\n"
-    end
-  append_step_summary(body)
+  TrackBenchmarks::Confirmation.append_summary(status, confirmed_alerts, suite_name)
 end
 
-# The confirmation rerun (BENCHMARK_MODE=confirm). Owns its own exit code:
-#   confirmed   -> write the confirmed hand-off, exit 0 (report-regressions fails the run)
-#   cleared     -> exit 0 (the first-run alert was noise)
-#   inconclusive-> exit 1 (operational failure: fail the workflow, file nothing)
 def run_confirmation(report, bencher_exit_code, confirmation_markdown, suite_name)
-  candidate_alerts, first_run_summary = load_candidate(CANDIDATE_INPUT_DIR)
-  # A missing/corrupt candidate is an operational failure, not a cleared alert.
-  return finish_confirmation(:inconclusive, [], suite_name) if candidate_alerts.nil?
-
-  status, confirmed_alerts = confirmation_outcome(report, bencher_exit_code, candidate_alerts)
-  if status == :confirmed && !write_confirmed(confirmed_alerts, first_run_summary, confirmation_markdown, suite_name)
-    # The regression confirmed but its hand-off was lost: fail rather than drop it.
-    return finish_confirmation(:inconclusive, [], suite_name)
-  end
-
-  finish_confirmation(status, confirmed_alerts, suite_name)
+  TrackBenchmarks::Confirmation.run(report, bencher_exit_code, confirmation_markdown, suite_name)
 end
 
 def finish_confirmation(status, confirmed_alerts, suite_name)
-  append_confirmation_summary(status, confirmed_alerts, suite_name)
-  case status
-  when :confirmed
-    Github.notice("Confirmed #{confirmed_alerts.size} #{suite_name} regression alert(s) on a fresh runner.")
-    exit 0
-  when :cleared
-    Github.notice("Cleared #{suite_name} first-run alert(s) as noise; no re-alert on the fresh runner.")
-    exit 0
-  else
-    warn "::error::#{suite_name} confirmation rerun was inconclusive (operational failure); " \
-         "failing the workflow without filing an issue. Investigate: #{Github.run_url}"
-    exit 1
-  end
+  TrackBenchmarks::Confirmation.finish(status, confirmed_alerts, suite_name)
 end
 
 # Only run the benchmark tracking when invoked as a script; `require`-ing the file
-# (e.g. from specs) just loads the helpers above.
+# (e.g. from specs) just loads the compatibility helpers above.
 if __FILE__ == $PROGRAM_NAME
   # Check the input file before validating env vars — a missing benchmark.json is the more
   # actionable failure (almost always upstream `bench.rb` didn't produce results).
@@ -449,63 +150,5 @@ if __FILE__ == $PROGRAM_NAME
   REPORT_MARKER = env!("BENCHER_REPORT_MARKER")
   env!("BENCHER_API_TOKEN")
 
-  branch, start_point_args = branch_and_start_point_args
-  bencher_result = run_bencher!(branch, start_point_args)
-  stderr = bencher_result.stderr
-  bencher_exit_code = bencher_result.exit_code
-  report = bencher_result.report
-
-  if retry_without_start_point_hash?(stderr, bencher_exit_code, report)
-    retry_args = start_point_args.dup
-    if (hash_arg_index = retry_args.index("--start-point-hash"))
-      retry_args.slice!(hash_arg_index, 2)
-    end
-    puts "Start-point hash not found in Bencher; retrying without --start-point-hash"
-    Github.warning("Start-point hash not found in Bencher; falling back to latest baseline for comparison")
-    # The retry's stderr is unused: regression classification reads the JSON report,
-    # and this path only triggers when the first run had no regression.
-    retry_result = run_bencher!(branch, retry_args)
-    # Intentionally leave retry_result.stderr unused here. BencherRunner#run has
-    # already emitted it; only the exit code and parsed report affect the outcome.
-    bencher_exit_code = retry_result.exit_code
-    report = retry_result.report
-  end
-  bencher_exit_code = normalized_bencher_exit_code(bencher_exit_code, report)
-
-  # Build the Markdown summary table once; the same body feeds the job summary, the
-  # PR comment, and the candidate/confirmation hand-offs.
-  report_markdown = rendered_report(report, SUITE_NAME)
-  post_report_to_summary(report_markdown)
-
-  if confirmation_mode?
-    # Fresh-runner rerun of a main-push candidate. Owns its own exit code (confirmed /
-    # cleared / inconclusive) and never posts PR comments.
-    run_confirmation(report, bencher_exit_code, report_markdown, SUITE_NAME)
-  else
-    pr_event = ENV.fetch("GITHUB_EVENT_NAME") == "pull_request"
-    if report.nil? && pr_event
-      # A nil report means Bencher produced no parseable output (operational failure). On
-      # a PR, replacing the comment now would delete the previous run's real report and
-      # make an auth/API/network failure look like a normal un-highlighted summary, while
-      # the job still exits 0. Keep the prior comment intact and surface the failure
-      # instead. (post_report_to_summary above is per-run and clobbers nothing.)
-      Github.warning(
-        "Bencher produced no report for #{SUITE_NAME} (operational failure); " \
-        "keeping the previous PR comment intact instead of overwriting it with an un-highlighted table."
-      )
-    elsif pr_event && regression?(report) && report_markdown.empty?
-      # A real regression but no table to render (display sidecar missing/empty). Don't
-      # leave the stale PR comment looking unchanged — post the run-URL fallback (which
-      # also emits ::error::) so the regression is visible in the PR thread, mirroring the
-      # main-push candidate hand-off.
-      replace_pr_comments(regression_handoff_summary(report_markdown))
-    else
-      replace_pr_comments(report_markdown)
-    end
-
-    if main_push? && bencher_exit_code != 0
-      report_main_push_candidate(report, report_markdown, bencher_exit_code,
-                                 SUITE_NAME)
-    end
-  end
+  TrackBenchmarks::Cli.new(suite_name: SUITE_NAME, report_marker: REPORT_MARKER).run
 end

--- a/benchmarks/track_benchmarks.rb
+++ b/benchmarks/track_benchmarks.rb
@@ -46,8 +46,11 @@ def append_step_summary(markdown)
   TrackBenchmarks::Summary.append_step_summary(markdown)
 end
 
-def post_report_to_summary(markdown)
-  TrackBenchmarks::Summary.post_report_to_summary(markdown, SUITE_NAME)
+def post_report_to_summary(markdown, suite_name = nil)
+  suite_name ||= Object.const_get(:SUITE_NAME) if Object.const_defined?(:SUITE_NAME)
+  raise ArgumentError, "suite_name is required outside script execution" unless suite_name
+
+  TrackBenchmarks::Summary.post_report_to_summary(markdown, suite_name)
 end
 
 def bencher_runner


### PR DESCRIPTION
## Summary

Fixes #3459 by splitting `benchmarks/track_benchmarks.rb` into focused modules without intended behavior changes:

- Keeps the executable entrypoint in `benchmarks/track_benchmarks.rb`.
- Adds focused implementation files under `benchmarks/lib/track_benchmarks/**`.
- Adds focused specs under `benchmarks/spec/track_benchmarks/**`.

## Validation

- `script/ci-changes-detector origin/main`
- `bundle exec rspec benchmarks/spec/track_benchmarks_spec.rb benchmarks/spec/track_benchmarks`
- `bundle exec rspec benchmarks/spec`
- Ruby syntax checks for `benchmarks/track_benchmarks.rb`, `benchmarks/lib/track_benchmarks.rb`, `benchmarks/lib/track_benchmarks/**/*.rb`, and focused specs.
- `bundle exec rubocop benchmarks/track_benchmarks.rb benchmarks/lib/track_benchmarks.rb benchmarks/lib/track_benchmarks benchmarks/spec/track_benchmarks`
- Safe missing-input smoke: `BENCHMARK_JSON=/tmp/codex-missing-benchmark.json bundle exec ruby benchmarks/track_benchmarks.rb` exits 1 as expected.
- Pre-push hook: branch RuboCop and markdown-links passed.

## Review / Churn Notes

- `codex review --base origin/main` completed with no correctness/security/maintainability findings.
- `claude -p '/code-review origin/main'` completed with no correctness findings; it noted optional maintainability cleanup around compatibility shims and memoization, intentionally kept out of scope for a behavior-preserving split.
- `bin/ci-local --changed` was attempted by the worker and failed in pre-existing repo-wide RuboCop offenses under `react_on_rails/spike/3313_prism_gemfile_rewriter/**`, outside this lane's file-touch map.
- `claude -p '/simplify origin/main'` was run under a 180s timeout and exited with no output.

## Codex Decision Log

- **Non-blocking:** Multiple downloaded confirmation candidate payloads are now treated as inconclusive instead of choosing `Dir.glob(...).first`.
  - **Decision:** Keep the defensive guard and document it as artifact-corruption handling.
  - **Why:** Arbitrary `.first` could confirm or clear the wrong benchmark payload when the artifact tree is malformed.
  - **Review later:** None; this does not change normal benchmark execution or valid single-candidate confirmation behavior.

## Changelog

Not user-visible; no changelog entry.

Confidence note:
- Validated: commands above plus pre-push hook.
- Evidence: local command output; PR branch `codex/3459-track-benchmarks-split`.
- UNKNOWN: hosted CI/review status until GitHub checks and reviewers complete.
- Residual risk: benchmark behavior is intended to be unchanged, but full live benchmark execution is left to hosted/maintainer-selected benchmark validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation rerun flow that classifies confirmed, cleared, or inconclusive results and publishes step-summary output.
  * Added regression handoff candidate/confirmed JSON payloads and display-sidecar rendering for improved report content.
* **Bug Fixes**
  * Improved resiliency with normalized exit codes and automated retries when start-point hashes aren’t usable.
  * Made main-branch regression candidate handling more non-fatal and added safer PR comment updating.
* **Refactor**
  * Modularized benchmark tracking into dedicated components and converted the main entry script into a thin delegator.
* **Tests**
  * Expanded RSpec coverage for branching/start-point args, summary rendering, payload writing, confirmation loading, and CLI orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge Rationale

Maintainer merge authority was granted on 2026-06-24 after this PR reached ready state.

Reasons to merge:

- Implements issue #3459 by splitting `benchmarks/track_benchmarks.rb` into focused modules/specs without intended benchmark behavior changes.
- Current head `d30b12e8186ca2f7bc983b5c76d8f8f957031e46` is mergeable (`mergeStateStatus: CLEAN`) with 44 checks passed, 0 pending, and 0 failing.
- Required readiness is green, strict merge ledger is clean (`complete_allowed: true`, no unknown fields, no violations), and unresolved review threads are 0.
- The diff stays inside the assigned benchmark file-touch map: `benchmarks/track_benchmarks.rb`, `benchmarks/lib/**`, and `benchmarks/spec/**`.

Confidence note:
- Validated: focused benchmark specs and syntax/RuboCop checks listed above, `pr-ci-readiness`, full hosted checks, review-thread triage, and `script/pr-merge-ledger 4176 --strict --pretty --changelog-classification not_user_visible`.
- Evidence: closeout comment https://github.com/shakacode/react_on_rails/pull/4176#issuecomment-4778580202; ledger artifact `/tmp/pr-4176-merge-ledger-premerge.json`.
- UNKNOWN: none.
- Residual risk: behavior-preserving benchmark tooling split; no intended benchmark behavior change.
