### PR TITLE
Docs: centralize simplify gate guidance

### DIFF
--- a/.agents/skills/pr-batch/SKILL.md
+++ b/.agents/skills/pr-batch/SKILL.md
@@ -125,7 +125,8 @@ whose committed lockfiles change.
 Keep this template aligned with the matching plan-to-goal prompt in
 `.agents/workflows/pr-processing.md`, including the review/audit gate
 paragraphs. The `Coordination:` line below intentionally points at the canonical
-workflow rules instead of duplicating them.
+workflow rules instead of duplicating them. Keep sync-maintenance comments
+outside the fenced prompt so they are not copied into generated `/goal` text.
 
 Use this template when creating the `/goal` text:
 
@@ -166,7 +167,7 @@ and include decision-point counts plus confidence notes in handoffs.
 
 Run `git fetch --prune origin main` first, confirm the expected repo root, verify repo-local workflow files, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
-For issue targets, create one focused branch and PR unless exact same-file overlap makes a bundle safer. Start new issue branches from updated origin/main. For existing PR, review-fix, or merge-readiness targets, work on the existing PR head branch and do not create replacement PRs; if the branch cannot be updated safely, report the blocker. Follow local validation, pre-push review/simplify, CI backpressure, and merge-readiness gates.
+For issue targets, create one focused branch and PR unless exact same-file overlap makes a bundle safer. Start new issue branches from updated origin/main. For existing PR, review-fix, or merge-readiness targets, work on the existing PR head branch and do not create replacement PRs; if the branch cannot be updated safely, report the blocker. Follow local validation, the pre-push review gate, CI backpressure, and merge-readiness gates.
 
 Every PR body must include a self-contained why/rationale summary. Link the
 target issue when one exists, but do not make reviewers open the issue to
@@ -192,17 +193,14 @@ controls. For lockfile changes, include Dependabot ecosystem and
 directory/directories compatibility and the lockfile content-diff evidence
 required by the Handoff Contract in `.agents/skills/pr-batch/SKILL.md`.
 
-For high-risk cases above, run Claude's `/simplify` after all required review passes for that case are clean, including Claude Code review when required, and before the final push or readiness report.
-
-<!-- Keep this /simplify block in sync with .agents/workflows/pr-processing.md and the Goal Prompt Template below. -->
-
-- Preferred invocation: `claude -p '/simplify origin/<base>' --model <default-simplify-model> --max-budget-usd 20`, substituting the Default simplify model from `AGENTS.md`, adjusting `<base>` to the PR's real base branch, and using it only when that command targets the current branch diff. This maintainer-requested default pins Opus for deep simplification; update it only by maintainer request and do not silently substitute another model.
-- Fallback target form: if the preferred command cannot target the diff correctly, use the local Claude-supported range form, such as `/simplify origin/<base>...HEAD`. The target must be the PR/branch diff, for example `origin/main...HEAD`, not an empty uncommitted diff.
-- Mode: do not use plan mode unless the surrounding workflow explicitly requires a no-edit review-only run.
-- Acceptance: treat `/simplify` output as advisory. Accept only simplifications that reduce real complexity without changing behavior or widening scope; reject speculative rewrites, style churn, broad abstractions, and changes outside the PR's target issue/scope.
-- Validation loop: if accepted simplifications change files, rerun targeted validation and the review/simplify gate as appropriate.
-- Skip evidence: if `/simplify` is unavailable, times out, hits budget, rejects the pinned model flag, or cannot target the PR diff correctly, record it as skipped with exact evidence instead of blocking indefinitely.
-- Evidence/churn notes: record the primary review gate, Claude review pass if run or skipped, whether `/simplify` was run/skipped/accepted/rejected and why, and any automated review findings waived, deferred, or classified as noise.
+For `/simplify`, follow `.agents/workflows/pr-processing.md` under
+**Pre-Push AI Review And Simplify Gate** and **Canonical `/simplify` Policy**.
+Non-trivial changes require the primary local/adversarial review gate, but
+`/simplify` applies only when the change also matches the canonical
+high-risk/extra-review cases or a maintainer requests it. Use the `AGENTS.md`
+Default simplify model, target the PR/branch diff, treat output as advisory,
+rerun targeted validation for accepted changes, and record exact run/skip
+evidence.
 
 Before merge, verify the current head SHA, then wait for requested or configured
 review agents such as Claude, CodeRabbit, Greptile, Cursor Bugbot, and Codex

--- a/.agents/workflows/pr-processing.md
+++ b/.agents/workflows/pr-processing.md
@@ -85,7 +85,9 @@ For adversarial pre-merge or post-merge PR review, use `.agents/skills/adversari
    - Do not push "hopeful" fixes just to let CI discover basic failures.
 5. Self-review before every push or PR-ready signal.
 6. Run local validation based on changed areas.
-7. Run the pre-push AI review and simplify gate when the change is non-trivial or high-risk.
+7. Run the pre-push AI review gate when the change is non-trivial,
+   high-risk, or repeatedly churny; run the `/simplify` subgate only for the
+   canonical high-risk/extra-review cases below.
 8. Update the PR body, issue, or one concise PR comment with exact verification evidence, churn notes, and remaining gaps. Every PR body must include a self-contained why/rationale summary; link issues as supporting context, but do not require reviewers to open an issue to understand why the PR exists.
 9. Only then request review, hosted CI, or merge readiness.
 
@@ -641,7 +643,8 @@ Examples:
 If the user is using `/plan`, or asks to prepare a `/goal`, stop after producing the approved plan and exact `/goal` text. Do not begin implementation just because the plan was approved unless the user explicitly says to launch now.
 
 Keep this goal prompt aligned with `.agents/skills/pr-batch/SKILL.md`,
-including the review/audit gate paragraphs.
+including the review/audit gate paragraphs. Keep sync-maintenance comments
+outside the fenced prompt so they are not copied into generated `/goal` text.
 
 The `$pr-batch` skill links to this canonical `Coordination:` paragraph instead
 of duplicating it.
@@ -695,7 +698,7 @@ plus confidence notes in handoffs.
 
 Fetch/prune main first, confirm the expected repo root, and verify any nested repo paths before assigning work. Classify each target as an implementation PR, combined investigation PR, deliberate no-PR evidence comment, or product-decision blocker.
 
-For issue targets, create one focused branch and PR unless exact same-file overlap makes a bundle safer. Start new issue branches from updated origin/main and target `main` by default. **Release-phase override:** when the work is a stabilizing fix for an active RC (the applicable release line is in the `rc`/`final` phase and the fix belongs on the release branch), branch from and open the PR against `origin/release/X.Y.Z` instead of `main`, then forward-port to `main` with `git cherry-pick -x <sha>` per the runbook — do not open the fix against `main` and rely on someone noticing it needs cherry-picking onto the RC. For existing PR, review-fix, or merge-readiness targets, work on the existing PR head branch and do not create replacement PRs; if the branch cannot be updated safely, report the blocker. Follow local validation, pre-push review/simplify, CI backpressure, and merge-readiness gates.
+For issue targets, create one focused branch and PR unless exact same-file overlap makes a bundle safer. Start new issue branches from updated origin/main and target `main` by default. **Release-phase override:** when the work is a stabilizing fix for an active RC (the applicable release line is in the `rc`/`final` phase and the fix belongs on the release branch), branch from and open the PR against `origin/release/X.Y.Z` instead of `main`, then forward-port to `main` with `git cherry-pick -x <sha>` per the runbook — do not open the fix against `main` and rely on someone noticing it needs cherry-picking onto the RC. For existing PR, review-fix, or merge-readiness targets, work on the existing PR head branch and do not create replacement PRs; if the branch cannot be updated safely, report the blocker. Follow local validation, the pre-push review gate, CI backpressure, and merge-readiness gates.
 
 For non-trivial, high-risk, hosted-CI-labeled, force-full, benchmark-labeled,
 workflow/build-config, dependency/runtime-version, or broad refactor PRs (labels per `AGENTS.md` → **Agent Workflow Configuration**), commit the intended
@@ -717,17 +720,14 @@ controls. For lockfile changes, include Dependabot ecosystem and
 directory/directories compatibility, then apply the lockfile content-diff
 evidence requirement from the Handoff Contract in `.agents/skills/pr-batch/SKILL.md`.
 
-For high-risk cases above, run Claude's `/simplify` after all required review passes for that case are clean, including Claude Code review when required, and before the final push or readiness report.
-
-<!-- Keep this /simplify block in sync with .agents/skills/pr-batch/SKILL.md and its Goal Prompt Template. -->
-
-- Preferred invocation: `claude -p '/simplify origin/<base>' --model <default-simplify-model> --max-budget-usd 20`, substituting the Default simplify model from `AGENTS.md`, adjusting `<base>` to the PR's real base branch, and using it only when that command targets the current branch diff. This maintainer-requested default pins Opus for deep simplification; update it only by maintainer request and do not silently substitute another model.
-- Fallback target form: if the preferred command cannot target the diff correctly, use the local Claude-supported range form, such as `/simplify origin/<base>...HEAD`. The target must be the PR/branch diff, for example `origin/main...HEAD`, not an empty uncommitted diff.
-- Mode: do not use plan mode unless the surrounding workflow explicitly requires a no-edit review-only run.
-- Acceptance: treat `/simplify` output as advisory. Accept only simplifications that reduce real complexity without changing behavior or widening scope; reject speculative rewrites, style churn, broad abstractions, and changes outside the PR's target issue/scope.
-- Validation loop: if accepted simplifications change files, rerun targeted validation and the review/simplify gate as appropriate.
-- Skip evidence: if `/simplify` is unavailable, times out, hits budget, rejects the pinned model flag, or cannot target the PR diff correctly, record it as skipped with exact evidence instead of blocking indefinitely.
-- Evidence/churn notes: record the primary review gate, Claude review pass if run or skipped, whether `/simplify` was run/skipped/accepted/rejected and why, and any automated review findings waived, deferred, or classified as noise.
+For `/simplify`, follow `.agents/workflows/pr-processing.md` under
+**Pre-Push AI Review And Simplify Gate** and **Canonical `/simplify` Policy**.
+Non-trivial changes require the primary local/adversarial review gate, but
+`/simplify` applies only when the change also matches the canonical
+high-risk/extra-review cases or a maintainer requests it. Use the `AGENTS.md`
+Default simplify model, target the PR/branch diff, treat output as advisory,
+rerun targeted validation for accepted changes, and record exact run/skip
+evidence.
 
 Before merge, verify the current head SHA, then wait for requested or configured
 review agents such as Claude, CodeRabbit, Greptile, Cursor Bugbot, and Codex
@@ -1165,27 +1165,69 @@ If self-review finds a real issue, fix it locally before pushing. Do not post se
 For non-trivial, high-risk, or repeatedly churny changes, do more local review before
 asking GitHub reviewers or CI to spend another cycle.
 
+### Canonical `/simplify` Policy
+
+This subsection is the canonical `/simplify` source of truth. Goal templates and
+skill docs should point here instead of duplicating command details. Keep any
+sync-maintenance comments outside generated `/goal` fenced text.
+
+Applicability:
+
+- Always run the primary local/adversarial self-review gate for non-trivial,
+  high-risk, or repeatedly churny changes.
+- Run Claude's `/simplify` only when a maintainer asks for it or when the change
+  is one of the high-risk/extra-review cases: high-risk,
+  `ready-for-hosted-ci`, `force-full-hosted-ci`, benchmark labels (`benchmark`,
+  `benchmark-core`, `benchmark-pro`, or `benchmark-pro-node-renderer`),
+  workflow/build-config, dependency/runtime-version, or broad-refactor scoped.
+  A non-trivial or repeatedly churny change alone does not require `/simplify`.
+
+Execution:
+
+- Preferred invocation for a PR targeting `main`: `claude -p '/simplify origin/main' --model claude-opus-4-8 --max-budget-usd 20`. The model value is the Default simplify model from `AGENTS.md` in this checkout; update this example only when that value changes by maintainer request, and do not silently substitute another model.
+- For another base branch, replace `origin/main` with the PR's real base, for
+  example `origin/release/X.Y.Z`. Use the preferred command only when it targets
+  the current branch diff.
+- Fallback target form: if the preferred command cannot target the diff
+  correctly, use the local Claude-supported range form, such as
+  `/simplify origin/<base>...HEAD`. The target must be the PR/branch diff, for
+  example `origin/main...HEAD`, not an empty uncommitted diff.
+- Mode: do not use plan mode unless the surrounding workflow explicitly
+  requires a no-edit review-only run.
+- Acceptance: treat `/simplify` output as advisory. Accept only simplifications
+  that reduce real complexity without changing behavior or widening scope;
+  reject speculative rewrites, style churn, broad abstractions, and changes
+  outside the PR's target issue/scope.
+- Validation loop: if accepted simplifications change files, rerun targeted
+  validation and the review/simplify gate as appropriate.
+- Skip evidence: if `/simplify` is unavailable, times out, hits budget, rejects
+  the pinned model flag, or cannot target the PR diff correctly, record it as
+  skipped with exact evidence instead of blocking indefinitely.
+- Evidence/churn notes: record the primary review gate, Claude review pass if
+  run or skipped, whether `/simplify` was run/skipped/accepted/rejected and why,
+  and any automated review findings waived, deferred, or classified as noise.
+
 1. Commit the intended implementation batch locally first so every later suggestion has a
    clean before/after diff. Do not push only to trigger review.
 2. Apply the local/adversarial self-review gate on the committed branch diff, normally via
    `.agents/skills/autoreview/SKILL.md`. The default engine is `codex review --base origin/main` or
    the PR's real base.
-3. When the maintainer asks for Claude review, or when the change is high-risk, hosted-CI-labeled,
-   force-full, benchmark-labeled, workflow/build-config, dependency/runtime-version, or broad-refactor scoped, run
+3. When the maintainer asks for Claude review, or when the change is high-risk,
+   `ready-for-hosted-ci`, `force-full-hosted-ci`, benchmark labels (`benchmark`,
+   `benchmark-core`, `benchmark-pro`, or `benchmark-pro-node-renderer`),
+   workflow/build-config, dependency/runtime-version, or broad-refactor scoped, run
    one additional Claude Code review pass if the current environment provides it, for example
    `/code-review` or `/code-review ultra`. If Claude review tooling is unavailable, state that in
    the PR evidence instead of substituting an unrelated tool.
 4. Verify every Codex or Claude finding against the real code before acting. Accept only concrete
    blockers or clear simplifications that preserve behavior; reject speculative rewrites, broad
    refactors, and style churn.
-5. For those high-risk cases, run `/simplify` after all required review passes for that case are
-   clean, including Claude Code review when required, and before the final push or readiness report.
-   Keep this checklist summary in sync with the canonical `/simplify` block above. Preferred
-   invocation: `claude -p '/simplify origin/<base>' --model <default-simplify-model> --max-budget-usd 20`,
-   substituting the Default simplify model from `AGENTS.md`, adjusting `<base>` to the PR's real base branch, and only if the command targets the current branch diff.
-   Otherwise use a local range form such as `/simplify origin/<base>...HEAD`. Accept only
-   behavior-preserving simplifications that reduce real complexity; record unavailable, timed-out,
-   over-budget, stale-model, or bad-target runs as skipped with exact evidence.
+5. For the canonical high-risk/extra-review cases above, run `/simplify` after
+   all required review passes for that case are clean, including Claude Code
+   review when required, and before the final push or readiness report. Use the
+   **Canonical `/simplify` Policy** in this section for the exact command,
+   fallback target form, acceptance, validation, skip-evidence, and churn-note
+   rules.
 6. After accepting any review or `/simplify` change, rerun the targeted validation for the changed
    surface and rerun the relevant review gate before pushing, continuing until there are no
    accepted/actionable findings.

--- a/internal/contributor-info/agent-pr-batch-skills.md
+++ b/internal/contributor-info/agent-pr-batch-skills.md
@@ -17,7 +17,16 @@ drills. This file stays focused on skill selection and per-batch sizing.
 | `$plan-pr-batch`     | The user wants to choose, verify, or shape issues/PRs before launching workers.                             | A concise Batch Plan plus a ready `$pr-batch` goal prompt under 4000 characters.      |
 | `$pr-batch`          | The target list is exact, trusted, and ready to run or convert into a `/goal` prompt.                       | A launch plan, worker split, or final `/goal` prompt for processing the batch.        |
 
-The `agents/openai.yaml` file under a skill is optional Codex UI metadata for skill picker display text and the default prompt. Add it only for skills that need Codex picker metadata; it is not required for every skill.
+The `agents/openai.yaml` file under a skill is optional Codex UI metadata, not a
+runtime workflow requirement. This guide is the repo convention for that file:
+add it only when a skill needs Codex picker display text or a default prompt.
+The currently meaningful fields live under `interface:`:
+`display_name`, `short_description`, and `default_prompt`. Keep
+`default_prompt` short and copy-paste safe, usually by telling Codex which skill
+to invoke and what context to provide; do not embed generated `/goal` templates,
+sync-maintenance comments, or repo policy copies there. Skills without
+`agents/openai.yaml` remain valid and callable through their `SKILL.md`
+metadata.
 
 ## Issue Audit Prompt Flow
 
@@ -51,7 +60,13 @@ omit the queue summary and note that queue state is unavailable.
 2. If exact candidate issues are already known and may be hypothetical, AI/code-analysis-only, over-scoped, or better handled with a no-PR evidence comment, start with `$evaluate-issue` directly.
 3. Verify every candidate through GitHub. Use `UNKNOWN` for facts that cannot be checked.
 4. After `$plan-pr-batch` resolves exact candidates, use `$evaluate-issue` for speculative, AI/code-analysis-only, over-scoped, or unclear items before assigning implementation work.
-5. Shape the batch into independent worker lanes. Cap each batch at 8 items when files or risk overlap, or 10 fully independent items; otherwise propose a smaller first batch. For multiple concurrent batches, keep this as a per-batch cap and apply the cross-batch routing guidance in [Multi-Batch Operations](multi-batch-operations.md) before launching.
+5. Shape the batch into independent worker lanes. Use the `$plan-pr-batch`
+   File-touch map before applying the cap: use 10 items only when every item has
+   verified file-disjoint, low-risk paths; use 8 or fewer when paths are
+   `UNKNOWN`, files/risk overlap, a rename reserves multiple trees, or a serial
+   discovery lane is needed. For multiple concurrent batches, keep this as a
+   per-batch cap and apply the cross-batch routing guidance in
+   [Multi-Batch Operations](multi-batch-operations.md) before launching.
 6. Give the user the Batch Plan and fenced `$pr-batch` goal prompt. Do not launch workers yet.
 7. When the user says to run it, use `$pr-batch` with the fenced goal prompt.
 
@@ -69,7 +84,15 @@ The `$pr-batch` prompt must preserve the preflight/trust rules from [.agents/ski
 ## Review And Readiness
 
 - Existing PR targets with review feedback should route workers through [.agents/workflows/address-review.md](../../.agents/workflows/address-review.md) or [.agents/skills/address-review/SKILL.md](../../.agents/skills/address-review/SKILL.md).
-- Non-trivial, high-risk, `ready-for-hosted-ci`, `force-full-hosted-ci`, `benchmark`, workflow/build-config, dependency/runtime-version, and broad-refactor PRs must follow the `$pr-batch` review and `/simplify` gates before final push or readiness reporting.
+- Non-trivial, high-risk, or repeatedly churny PRs must follow the `$pr-batch`
+  review gate before final push or readiness reporting. `/simplify` applies
+  when a maintainer asks for it or when the PR also matches the canonical
+  high-risk/extra-review cases in
+  [.agents/workflows/pr-processing.md](../../.agents/workflows/pr-processing.md):
+  high-risk, `ready-for-hosted-ci`, `force-full-hosted-ci`, benchmark labels
+  (`benchmark`, `benchmark-core`, `benchmark-pro`, or
+  `benchmark-pro-node-renderer`), workflow/build-config,
+  dependency/runtime-version, or broad-refactor scoped.
 - Hosted CI requests belong at the final readiness gate after local validation,
   review-thread triage, and the final push. Agents should use `+ci-status` and
   `+ci-run-hosted` for optimized hosted CI. Use `+ci-force-full` only when a


### PR DESCRIPTION
## Summary

Closes #4153.

This docs cleanup makes `.agents/workflows/pr-processing.md` the canonical source for `/simplify` policy details, while the `$pr-batch` goal template and contributor guide point at that source instead of duplicating command details. It also clarifies the optional `agents/openai.yaml` / `interface:` metadata convention and tightens batch sizing guidance around file-touch maps.

## Changes

- Added a canonical `/simplify` policy section with applicability, command, fallback target, advisory acceptance, validation, and evidence rules.
- Replaced duplicated `/simplify` command blocks in generated goal text with references to the canonical policy, keeping sync-maintenance comments outside copy-paste prompt fences.
- Documented `agents/openai.yaml` as optional Codex UI metadata with `display_name`, `short_description`, and `default_prompt` under `interface:`.
- Tightened batch cap guidance to require verified file-disjoint, low-risk paths for 10-item batches and smaller/serial batches when path data is `UNKNOWN` or overlapping.

## Validation

- `git fetch --prune origin main`
- `.agents/skills/pr-batch/bin/pr-security-preflight --repo shakacode/react_on_rails 4153` -> `SECURITY_PREFLIGHT_OK`
- `git diff --check origin/main...HEAD && git diff --check`
- `.agents/bin/agent-workflow-seam-doctor` -> pass
- `bin/check-links` -> 3022 total, 0 errors
- `pnpm start format.listDifferent` -> pass
- `ruby .agents/skills/plan-pr-batch/scripts/check_goal_prompt_size.rb` -> pass (`goal_prompt_template_chars=3673`, `split_fallback_goal_prompt_chars=3721`)
- `script/ci-changes-detector origin/main` -> documentation-only, recommended CI jobs: none
- Pre-commit hooks -> trailing newlines, changed-file markdown links, Prettier passed
- Pre-push hooks -> branch-lint skipped Ruby lint; online changed-file markdown links passed
- Address-review closeout -> Claude review threads fixed or explicitly declined, all three review threads resolved, summary checkpoint posted

## Review / Simplify Evidence

- `codex review --base origin/main` accepted two P2 wording findings and the branch was patched.
- Final `codex review --base origin/main` on `ffd7a0904` result: no actionable regressions in the modified workflow text.
- `claude -p '/code-review ultra origin/main' --max-budget-usd 20` completed once; accepted the exact-label wording finding and rejected the hardcoded model concern because the canonical policy intentionally keeps a copy-pasteable command tied to `AGENTS.md`'s Default simplify model.
- Final Claude review retry hung with no output for over 5 minutes and was interrupted; recorded as unavailable for the final post-fix retry.
- `claude -p '/simplify origin/main' --model claude-opus-4-8 --max-budget-usd 20` hung with no output for over 5 minutes and was interrupted; recorded as skipped due to timeout/hang.

## QA Evidence

- QA lane: none; QA not required.
- Scope checked: docs-only internal agent-workflow/process guidance, no runtime, generated output, CI workflow, or user-facing behavior changes.
- Tested at: branch head `ffd7a0904`.
- Automated checks: listed above.
- Manual checks: reviewed generated prompt fence boundaries and source-of-truth references.
- Findings: Codex/Claude wording findings fixed; no remaining blocker.
- QA required: no.
- QA required rationale: low-risk docs-only internal process cleanup outside required QA categories.
- QA lane status: not_applicable.
- Release-blocking status: not_applicable.
- Process-gap disposition: not applicable (this implements existing follow-up #4153; no new recurring process miss found).

## Changelog

Not user-visible.

## Labels

Labels: none. `script/ci-changes-detector origin/main` classifies the branch as documentation-only with no CI jobs recommended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the internal PR pre-push workflow guidance to separate the general review gate from the `/simplify` subgate.
  * Clarified when `/simplify` is applicable, how advisory output should be handled, and the required rerun/validation + evidence recording loop.
  * Refined batch goal prompt instructions to avoid copying certain maintenance notes into generated goal content.
* **Chores**
  * Improved internal contributor guidance around batch planning and review/readiness criteria, including expanded high-risk/extra-review case definitions.

Note: No user-facing changes—documentation-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
