### PR TITLE
Add release forward-port helper

### DIFF
--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -211,7 +211,9 @@ git push   # or open a PR if main is protected / the fix needs review on main
   cherry-picked onto `main` (leaving a `-x` footer) and then **reverted**, the helper still treats it
   as present and skips it. If you reverted an eligible fix on `main` on purpose, re-pick it manually
   (`git cherry-pick -x <fix-sha>`); the patch-equivalence (`git cherry`) path already self-corrects
-  because a reverted change is no longer patch-equivalent.
+  because a reverted change is no longer patch-equivalent. The same history search can also
+  false-positive if a later target commit quotes the exact `(cherry picked from commit <sha>)` footer
+  in its message body.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).
@@ -302,16 +304,6 @@ git push origin --delete release/17.0.0
 > is not already.
 
 See [`releasing.md`](releasing.md) for the next-dev version bump details.
-
-> **Forward-port automation is a deliberate follow-up, not part of the promotion path.** The close-out
-> forward-port above (CHANGELOG collapse back to `main` + next-dev bump) is intentionally still manual
-> `git` because its safe shape is conditional — whether to take the version-bump commit at all depends on
-> how far `main` has drifted (see the caveat above), which is a judgment call a helper would have to
-> encode carefully. It is **not** a release blocker: unlike the stable-promotion guard (now resolved),
-> nothing aborts here. A `rake`/`script` helper that cherry-picks `-x` the fix/CHANGELOG commits while
-> skipping the rc version-bump commits can be added later without touching the promotion path; until then
-> follow the steps above. Track it as its own change rather than bundling speculative automation into the
-> release-critical `release.rake` promotion fix.
 
 Mark the release tracker released per [`rc-testing-plan.md`](rc-testing-plan.md), and clear the
 published phase for this line (the entry is removed when the branch is deleted) so agents stop applying

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -205,7 +205,8 @@ git push   # or open a PR if main is protected / the fix needs review on main
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
   evidence when available, unless the footer-bearing target commit has a later standard `git revert` commit
   on the target branch. For already-applied patches without the footer, it uses `git cherry` as the
-  candidate signal before verifying the source patch against the current target tree.
+  candidate signal before matching the source patch-id to target history and checking for a later standard
+  `git revert` of the matching target commit.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Known limitation: the "already forward-ported" skip still starts from history evidence. If a later

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -203,15 +203,16 @@ git push   # or open a PR if main is protected / the fix needs review on main
 ```
 
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
-  evidence when available, then verifies the source patch against the current target tree before skipping.
-  For already-applied patches without the footer, it uses `git cherry` as the candidate signal before the
-  same current-tree verification.
+  evidence when available, then verifies that the footer-bearing target commit's patch is still present in
+  the current target tree before skipping. For already-applied patches without the footer, it uses
+  `git cherry` as the candidate signal before verifying the source patch against the current target tree.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Known limitation: the "already forward-ported" skip still starts from history evidence. If a later
   target commit quotes the exact `(cherry picked from commit <sha>)` footer in its message body, that can
-  look like `-x` evidence. The helper still requires the source patch to be present in the current target
-  tree before skipping, so reverted picks are eligible to be picked again.
+  look like `-x` evidence. The helper still requires that footer-bearing target commit's patch to be
+  present in the current target tree before skipping, so reverted picks are eligible to be picked again;
+  inspect the dry-run plan before applying if a commit message intentionally quotes cherry-pick footers.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -227,6 +227,12 @@ git push   # or open a PR if main is protected / the fix needs review on main
   earlier picks in this run are already committed and safe. After fixing the conflict, rerun
   `script/release-forward-port` from the start: it is idempotent and skips commits already applied,
   then continues from the still-missing fix. Do not manually pick `Bump version to ...rc.N` commits.
+- Manual inspection fallback: if the helper reports `MANUAL` for a merge commit or a release-only
+  rollback, inspect whether any target hunks are needed. Apply those hunks manually if needed, then
+  rerun the helper. If the inspected commit still appears as `MANUAL` and no target hunks are needed,
+  rerun with `--ack-manual <sha>` for that commit so the helper can continue to later eligible picks.
+  `--ack-manual` only accepts commits that the current plan marks `MANUAL`; it is an acknowledgement,
+  not a blanket skip for normal `PICK` commits.
 - If a fix is _also_ wanted for ongoing `main` development and is low-risk, it is acceptable to author
   it on `main` first and cherry-pick it onto `release/X.Y.Z` (step 2 in reverse). Pick one direction
   per fix and record which in the PR so the other branch is not missed.

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -184,22 +184,35 @@ branch tip when maintainers want a new candidate to validate. Re-run the hard-ga
 ### 3. Forward-port stabilizing fixes back to `main`
 
 Every fix that lands on `release/X.Y.Z` must also reach `main`, or `main` regresses the moment the
-release branch is deleted. Forward-port with **`git cherry-pick -x`**, not a branch merge:
+release branch is deleted. Use `script/release-forward-port` first so the operation is dry-run-able,
+idempotent, and skips RC version-bump commits. The helper uses **`git cherry-pick -x`** for commits it
+applies; do not use a branch merge:
 
 ```bash
 git fetch origin
 git checkout main
 git pull --rebase
-# Cherry-pick the fix commit(s) — NOT the rc version-bump commits.
-git cherry-pick -x <fix-sha>
+
+# Inspect the plan first. Expect fix/CHANGELOG commits to be PICK and
+# Bump version to ...rc.N commits to be SKIP.
+script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
+
+# Apply the same plan. The helper checks out the local target branch and cherry-picks with -x.
+script/release-forward-port --source origin/release/17.0.0 --target main
 git push   # or open a PR if main is protected / the fix needs review on main
 ```
 
+- The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
+  evidence when available, and falls back to `git cherry` patch-equivalence for already-applied
+  patches without the footer.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
-  conflict resolution can see the relationship.
+  helper runs can see the relationship.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
-  Cherry-pick only the fix commits.
+  Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).
+- Manual fallback: if the helper reports a real conflict on an eligible fix, resolve that specific
+  cherry-pick with `git cherry-pick --continue` or abort and run `git cherry-pick -x <fix-sha>` for the
+  intended fix commit(s). Do not manually pick `Bump version to ...rc.N` commits.
 - If a fix is _also_ wanted for ongoing `main` development and is low-risk, it is acceptable to author
   it on `main` first and cherry-pick it onto `release/X.Y.Z` (step 2 in reverse). Pick one direction
   per fix and record which in the PR so the other branch is not missed.
@@ -255,22 +268,30 @@ and publish phase `final` for the release line during the promotion freeze.
 
 ```bash
 # After v17.0.0 is published and the GitHub release exists:
-# 1. Forward-port the final CHANGELOG collapse to main:
+# 1. Forward-port any remaining release-branch commits to main:
 git fetch origin
-git checkout main && git pull --rebase
-git cherry-pick -x <changelog-collapse-sha>  # the step-4 commit that collapsed the rc sections
-                                             # into ### [17.0.0]
+git checkout main
+git pull --rebase
+
+# The helper skips rc version bumps and already-forward-ported fixes.
+# It will also report and skip a version-bump commit when main has already
+# advanced past that version.
+script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
+script/release-forward-port --source origin/release/17.0.0 --target main
 git push   # or open a PR if main is protected
 # 2. Delete the ephemeral branch — the tags are the durable record.
 git push origin --delete release/17.0.0
 ```
 
-> **Caveat — do not blindly cherry-pick the version-bump commit.** If `main` has already advanced past the
-> release version (e.g. to `17.1.0.dev`), cherry-picking the bump-to-`17.0.0` commit will conflict on the
-> version artifacts and would regress `main`'s version. Only forward-port the version bump if `main` has
-> **not** yet been bumped past `17.0.0`; otherwise resolve to keep `main`'s newer version and take only the
-> CHANGELOG changes. Then bump `main` to the next dev version per [`releasing.md`](releasing.md) if it is
-> not already.
+> **Caveat — do not blindly cherry-pick version-bump commits.** The helper always skips
+> `Bump version to ...rc.N` commits. For non-RC version bumps, it compares `main`'s current version to
+> the commit subject and skips with an explicit version-drift message when `main` has already advanced
+> past the release version (e.g. to `17.1.0.dev`) or already has that version. If the skipped final
+> version-bump commit also contains the only CHANGELOG collapse you need on `main`, use the manual
+> fallback: cherry-pick that one commit, resolve version artifacts to keep `main`'s newer version, keep
+> only the intended CHANGELOG changes, and preserve a `(cherry picked from commit <sha>)` footer in the
+> final commit message. Then bump `main` to the next dev version per [`releasing.md`](releasing.md) if it
+> is not already.
 
 See [`releasing.md`](releasing.md) for the next-dev version bump details.
 

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -294,8 +294,7 @@ git checkout main
 git pull --rebase
 
 # The helper skips rc version bumps and already-forward-ported fixes.
-# It will also report and skip a version-bump commit when main has already
-# advanced past that version.
+# It reports stable final version bumps as MANUAL so CHANGELOG extraction is explicit.
 script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
 script/release-forward-port --source origin/release/17.0.0 --target main
 git push   # or open a PR if main is protected
@@ -304,14 +303,16 @@ git push origin --delete release/17.0.0
 ```
 
 > **Caveat — do not blindly cherry-pick version-bump commits.** The helper always skips
-> `Bump version to ...rc.N` commits. For non-RC version bumps, it compares `main`'s current version to
-> the commit subject and skips with an explicit version-drift message when `main` has already advanced
-> past the release version (e.g. to `17.1.0.dev`) or already has that version. If the skipped final
-> version-bump commit also contains the only CHANGELOG collapse you need on `main`, use the manual
-> fallback: cherry-pick that one commit, resolve version artifacts to keep `main`'s newer version, keep
-> only the intended CHANGELOG changes, and preserve a `(cherry picked from commit <sha>)` footer in the
-> final commit message. Then bump `main` to the next dev version per [`releasing.md`](releasing.md) if it
-> is not already.
+> `Bump version to ...rc.N` commits. For stable non-RC version bumps, the helper always marks the commit
+> `MANUAL`, regardless of `main`'s current version, so the operator explicitly decides whether to extract
+> only the CHANGELOG hunks. For prerelease non-RC bumps (for example `beta` or `dev`), it compares
+> `main`'s current version to the commit subject and skips with an explicit version-drift message when
+> `main` has already advanced past the release version (e.g. to `17.1.0.dev`) or already has that version.
+> If the skipped final version-bump commit also contains the only CHANGELOG collapse you need on `main`,
+> use the manual fallback: cherry-pick that one commit, resolve version artifacts to keep `main`'s newer
+> version, keep only the intended CHANGELOG changes, and preserve a `(cherry picked from commit <sha>)`
+> footer in the final commit message. Then bump `main` to the next dev version per
+> [`releasing.md`](releasing.md) if it is not already.
 
 See [`releasing.md`](releasing.md) for the next-dev version bump details.
 

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -207,12 +207,21 @@ git push   # or open a PR if main is protected / the fix needs review on main
   patches without the footer.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
+- Known limitation: the "already forward-ported" skip is history-based. If a fix was previously
+  cherry-picked onto `main` (leaving a `-x` footer) and then **reverted**, the helper still treats it
+  as present and skips it. If you reverted an eligible fix on `main` on purpose, re-pick it manually
+  (`git cherry-pick -x <fix-sha>`); the patch-equivalence (`git cherry`) path already self-corrects
+  because a reverted change is no longer patch-equivalent.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).
-- Manual fallback: if the helper reports a real conflict on an eligible fix, resolve that specific
-  cherry-pick with `git cherry-pick --continue` or abort and run `git cherry-pick -x <fix-sha>` for the
-  intended fix commit(s). Do not manually pick `Bump version to ...rc.N` commits.
+- Manual fallback: if the helper reports a real conflict on an eligible fix, prefer resolving that
+  specific cherry-pick in place with `git cherry-pick --continue` so the earlier successful picks are
+  kept. If you instead run `git cherry-pick --abort`, that rolls back **all** of the helper's earlier
+  picks in this run, so rerunning only `git cherry-pick -x <fix-sha>` would leave the forward-port
+  incomplete — after fixing the conflict, rerun `script/release-forward-port` from the start to replay
+  the full plan (it is idempotent and skips commits already applied). Do not manually pick
+  `Bump version to ...rc.N` commits.
 - If a fix is _also_ wanted for ongoing `main` development and is low-risk, it is acceptable to author
   it on `main` first and cherry-pick it onto `release/X.Y.Z` (step 2 in reverse). Pick one direction
   per fix and record which in the PR so the other branch is not missed.

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -194,7 +194,7 @@ git checkout main
 git pull --rebase
 
 # Inspect the plan first. Expect fix/CHANGELOG commits to be PICK and
-# Bump version to ...rc.N commits to be SKIP.
+# Bump version commits to be SKIP.
 script/release-forward-port --source origin/release/17.0.0 --target main --dry-run
 
 # Apply the same plan. The helper checks out the local target branch and cherry-picks with -x.
@@ -217,6 +217,9 @@ git push   # or open a PR if main is protected / the fix needs review on main
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).
+- Stable final `Bump version to X.Y.Z` commits are also skipped. If the release closeout needs their
+  CHANGELOG content on `main`, use the manual fallback to take only those hunks and leave release-branch
+  version-file changes behind.
 - Manual fallback: if the helper reports a real conflict on an eligible fix, prefer resolving that
   specific cherry-pick in place with `git cherry-pick --continue` so the earlier successful picks are
   kept. If you instead run `git cherry-pick --abort`, only the current conflicting commit is abandoned;

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -203,17 +203,17 @@ git push   # or open a PR if main is protected / the fix needs review on main
 ```
 
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
-  evidence when available, and falls back to `git cherry` patch-equivalence for already-applied
-  patches without the footer.
+  evidence when available. For already-applied patches without the footer, it uses `git cherry` as a
+  candidate signal, then verifies the source patch against the current target tree before skipping.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Known limitation: the "already forward-ported" skip is history-based. If a fix was previously
   cherry-picked onto `main` (leaving a `-x` footer) and then **reverted**, the helper still treats it
   as present and skips it. If you reverted an eligible fix on `main` on purpose, re-pick it manually
-  (`git cherry-pick -x <fix-sha>`); the patch-equivalence (`git cherry`) path already self-corrects
-  because a reverted change is no longer patch-equivalent. The same history search can also
-  false-positive if a later target commit quotes the exact `(cherry picked from commit <sha>)` footer
-  in its message body.
+  (`git cherry-pick -x <fix-sha>`). The no-footer fallback is stricter: it only skips when the source
+  patch is still present in the current target tree, so a no-footer pick that was later reverted is
+  eligible to be picked again. The history search can also false-positive if a later target commit quotes
+  the exact `(cherry picked from commit <sha>)` footer in its message body.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -203,16 +203,17 @@ git push   # or open a PR if main is protected / the fix needs review on main
 ```
 
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
-  evidence when available, then verifies that the footer-bearing target commit's patch is still present in
-  the current target tree before skipping. For already-applied patches without the footer, it uses
-  `git cherry` as the candidate signal before verifying the source patch against the current target tree.
+  evidence when available, unless the footer-bearing target commit has a later standard `git revert` commit
+  on the target branch. For already-applied patches without the footer, it uses `git cherry` as the
+  candidate signal before verifying the source patch against the current target tree.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
 - Known limitation: the "already forward-ported" skip still starts from history evidence. If a later
   target commit quotes the exact `(cherry picked from commit <sha>)` footer in its message body, that can
-  look like `-x` evidence. The helper still requires that footer-bearing target commit's patch to be
-  present in the current target tree before skipping, so reverted picks are eligible to be picked again;
-  inspect the dry-run plan before applying if a commit message intentionally quotes cherry-pick footers.
+  look like `-x` evidence. Standard `git revert` commits of the footer-bearing target commit prevent the
+  skip, so reverted picks are eligible to be picked again; inspect the dry-run plan before applying if a
+  commit message intentionally quotes cherry-pick footers or if a revert was done manually without
+  `git revert`.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -203,17 +203,15 @@ git push   # or open a PR if main is protected / the fix needs review on main
 ```
 
 - The helper skips commits already present on `main` using `(cherry picked from commit <sha>)`
-  evidence when available. For already-applied patches without the footer, it uses `git cherry` as a
-  candidate signal, then verifies the source patch against the current target tree before skipping.
+  evidence when available, then verifies the source patch against the current target tree before skipping.
+  For already-applied patches without the footer, it uses `git cherry` as the candidate signal before the
+  same current-tree verification.
 - `-x` appends `(cherry picked from commit <sha>)` so the forward-port is auditable and future
   helper runs can see the relationship.
-- Known limitation: the "already forward-ported" skip is history-based. If a fix was previously
-  cherry-picked onto `main` (leaving a `-x` footer) and then **reverted**, the helper still treats it
-  as present and skips it. If you reverted an eligible fix on `main` on purpose, re-pick it manually
-  (`git cherry-pick -x <fix-sha>`). The no-footer fallback is stricter: it only skips when the source
-  patch is still present in the current target tree, so a no-footer pick that was later reverted is
-  eligible to be picked again. The history search can also false-positive if a later target commit quotes
-  the exact `(cherry picked from commit <sha>)` footer in its message body.
+- Known limitation: the "already forward-ported" skip still starts from history evidence. If a later
+  target commit quotes the exact `(cherry picked from commit <sha>)` footer in its message body, that can
+  look like `-x` evidence. The helper still requires the source patch to be present in the current target
+  tree before skipping, so reverted picks are eligible to be picked again.
 - **Do not `git merge release/X.Y.Z` into `main`.** That drags the RC `Bump version to …rc.N` commits
   and the release-branch CHANGELOG layout onto `main`, which is exactly what we want to keep off `main`.
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -217,11 +217,10 @@ git push   # or open a PR if main is protected / the fix needs review on main
   Let the helper pick only eligible commits, or manually cherry-pick only the specific fix commit(s).
 - Manual fallback: if the helper reports a real conflict on an eligible fix, prefer resolving that
   specific cherry-pick in place with `git cherry-pick --continue` so the earlier successful picks are
-  kept. If you instead run `git cherry-pick --abort`, that rolls back **all** of the helper's earlier
-  picks in this run, so rerunning only `git cherry-pick -x <fix-sha>` would leave the forward-port
-  incomplete — after fixing the conflict, rerun `script/release-forward-port` from the start to replay
-  the full plan (it is idempotent and skips commits already applied). Do not manually pick
-  `Bump version to ...rc.N` commits.
+  kept. If you instead run `git cherry-pick --abort`, only the current conflicting commit is abandoned;
+  earlier picks in this run are already committed and safe. After fixing the conflict, rerun
+  `script/release-forward-port` from the start: it is idempotent and skips commits already applied,
+  then continues from the still-missing fix. Do not manually pick `Bump version to ...rc.N` commits.
 - If a fix is _also_ wanted for ongoing `main` development and is low-risk, it is acceptable to author
   it on `main` first and cherry-pick it onto `release/X.Y.Z` (step 2 in reverse). Pick one direction
   per fix and record which in the PR so the other branch is not missed.

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe "script/release-forward-port" do
   let(:script_path) { File.join(repo_root, "script/release-forward-port") }
 
   def git_env
-    { "GIT_CONFIG_COUNT" => "0" }
+    {
+      "GIT_CONFIG_COUNT" => "0",
+      "GIT_CONFIG_GLOBAL" => File::NULL,
+      "GIT_CONFIG_NOSYSTEM" => "1"
+    }
   end
 
   def git(repo, *args)
@@ -259,6 +263,28 @@ RSpec.describe "script/release-forward-port" do
       expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
       expect(second_stdout).to include("Nothing to cherry-pick")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "does not skip an -x cherry-pick that was later reverted" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+      git(repo, "revert", "--no-edit", "HEAD")
+      reverted_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("PICK")
+      expect(second_stdout).not_to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+      expect(git(repo, "rev-list", "--count", "main").strip.to_i).to eq(reverted_count.to_i + 1)
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -133,12 +133,13 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
-  it "skips commits already applied without an -x footer via git cherry patch-equivalence" do
+  it "skips commits already applied without an -x footer when the patch is still in the target tree" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
 
       # Apply the fix onto main WITHOUT -x so there is no
-      # "(cherry picked from commit ...)" footer; only git cherry can detect it.
+      # "(cherry picked from commit ...)" footer; the helper must confirm the
+      # patch is still present in the current target tree before skipping it.
       git(repo, "cherry-pick", fix_sha)
       latest_body = git(repo, "log", "-1", "--format=%B")
       expect(latest_body).not_to include("cherry picked from commit")
@@ -147,9 +148,31 @@ RSpec.describe "script/release-forward-port" do
       stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("patch already exists on main according to git cherry")
+      expect(stdout).to include("patch already exists on main according to the current target tree")
       expect(stdout).to include("Nothing to cherry-pick")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "does not skip a no-footer cherry-pick that was later reverted" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "cherry-pick", fix_sha)
+      git(repo, "revert", "--no-edit", "HEAD")
+      reverted_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(stdout).not_to include("patch already exists on main according to the current target tree")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+      expect(git(repo, "rev-list", "--count", "main").strip.to_i).to eq(reverted_count.to_i + 1)
+
+      latest_commit_body = git(repo, "log", "-1", "--format=%B")
+      expect(latest_commit_body).to include("(cherry picked from commit #{fix_sha})")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -704,6 +704,17 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "reports invalid acknowledged commits as usage errors" do
+    with_release_repo do |repo|
+      _stdout, stderr, status =
+        run_script(repo, "--source", "main", "--target", "main", "--dry-run", "--ack-manual", "not-a-sha")
+
+      expect(status.exitstatus).to eq(2)
+      expect(stderr).to include("Usage: script/release-forward-port")
+      expect(stderr).to include("--ack-manual \"not-a-sha\" is not a commit")
+    end
+  end
+
   it "does not skip an -x cherry-pick that was later reverted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -108,6 +108,51 @@ RSpec.describe "script/release-forward-port" do
     expect(stderr).not_to include("script/release-forward-port:")
   end
 
+  it "rejects an extra positional arg when --target is already set" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "typo", "--dry-run")
+
+      expect(status.exitstatus).to eq(2)
+      expect(stderr).to include("ERROR: too many arguments: typo")
+      expect(stderr).to include("Usage: script/release-forward-port")
+    end
+  end
+
+  it "uses a leftover positional as the target when only --source is set" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("target: main")
+      expect(stdout).to include("PICK")
+    end
+  end
+
+  it "skips commits already applied without an -x footer via git cherry patch-equivalence" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      # Apply the fix onto main WITHOUT -x so there is no
+      # "(cherry picked from commit ...)" footer; only git cherry can detect it.
+      git(repo, "cherry-pick", fix_sha)
+      latest_body = git(repo, "log", "-1", "--format=%B")
+      expect(latest_body).not_to include("cherry picked from commit")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to git cherry")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
   it "cherry-picks fixes with -x while excluding rc version bump commits" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+require_relative "spec_helper"
+
+RSpec.describe "script/release-forward-port" do
+  let(:repo_root) { File.expand_path("../../..", __dir__) }
+  let(:script_path) { File.join(repo_root, "script/release-forward-port") }
+
+  def git_env
+    { "GIT_CONFIG_COUNT" => "0" }
+  end
+
+  def git(repo, *args)
+    stdout, stderr, status = Open3.capture3(git_env, "git", *args, chdir: repo)
+    raise "git #{args.join(' ')} failed: #{stderr}#{stdout}" unless status.success?
+
+    stdout
+  end
+
+  def write_file(repo, path, contents)
+    full_path = File.join(repo, path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.write(full_path, contents)
+  end
+
+  def commit_all(repo, message)
+    git(repo, "add", ".")
+    git(repo, "commit", "--no-gpg-sign", "-m", message)
+    git(repo, "rev-parse", "HEAD").strip
+  end
+
+  def run_script(repo, *args)
+    Open3.capture3(git_env, RbConfig.ruby, script_path, *args, chdir: repo)
+  end
+
+  def run_script_from_repo_root(*args)
+    Open3.capture3(git_env, RbConfig.ruby, script_path, *args, chdir: repo_root)
+  end
+
+  def version_file(version)
+    <<~RUBY
+      # frozen_string_literal: true
+
+      module ReactOnRails
+        VERSION = "#{version}"
+      end
+    RUBY
+  end
+
+  def with_release_repo
+    Dir.mktmpdir("release-forward-port") do |repo|
+      git(repo, "init")
+      git(repo, "checkout", "-b", "main")
+      git(repo, "config", "user.email", "test@example.com")
+      git(repo, "config", "user.name", "Release Test")
+      git(repo, "config", "commit.gpgsign", "false")
+
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.0"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [Unreleased]\n")
+      write_file(repo, "app.txt", "base\n")
+      commit_all(repo, "Initial commit")
+
+      yield repo
+    end
+  end
+
+  def add_rc_bump_and_fix(repo)
+    git(repo, "checkout", "-b", "release/1.0.1")
+    write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc.1"))
+    write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1.rc.1]\n- RC notes\n")
+    rc_bump_sha = commit_all(repo, "Bump version to 1.0.1.rc.1")
+
+    write_file(repo, "app.txt", "base\nrelease fix\n")
+    fix_sha = commit_all(repo, "Fix release regression")
+    git(repo, "checkout", "main")
+
+    [rc_bump_sha, fix_sha]
+  end
+
+  it "dry-runs the forward-port plan without changing the target branch" do
+    with_release_repo do |repo|
+      rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stderr).to eq("")
+      expect(stdout).to include("DRY RUN")
+      expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
+      expect(stdout).to include("rc version bump commit")
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip).to eq("main")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
+      expect(File.read(File.join(repo, "react_on_rails/lib/react_on_rails/version.rb"))).to include("1.0.0")
+    end
+  end
+
+  it "prints usage without a stack trace for argument errors" do
+    _stdout, stderr, status = run_script_from_repo_root("--bogus")
+
+    expect(status.exitstatus).to eq(2)
+    expect(stderr).to include("ERROR: invalid option: --bogus")
+    expect(stderr).to include("Usage: script/release-forward-port")
+    expect(stderr).not_to include("script/release-forward-port:")
+  end
+
+  it "cherry-picks fixes with -x while excluding rc version bump commits" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("Forward-port complete")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+      expect(File.read(File.join(repo, "react_on_rails/lib/react_on_rails/version.rb"))).to include("1.0.0")
+
+      latest_commit_body = git(repo, "log", "-1", "--format=%B")
+      expect(latest_commit_body).to include("Fix release regression")
+      expect(latest_commit_body).to include("(cherry picked from commit #{fix_sha})")
+      expect(git(repo, "log", "--format=%s", "main")).not_to include("Bump version to 1.0.1.rc.1")
+    end
+  end
+
+  it "is idempotent when release commits were already forward-ported with -x" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      second_stdout, second_stderr, second_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "skips stable version bump commits when the target branch has already advanced" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1]\n- Final notes\n")
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.1.0.dev"))
+      commit_all(repo, "Start 1.1.0 development")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("target main is already at 1.1.0.dev")
+      expect(stdout).to include("manual fallback to take only the CHANGELOG hunks")
+    end
+  end
+end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe "script/release-forward-port" do
     File.binwrite(full_path, contents)
   end
 
+  def executable_file?(repo, path)
+    (File.stat(File.join(repo, path)).mode & 0o111).positive?
+  end
+
   def commit_all(repo, message)
     git(repo, "add", ".")
     git(repo, "commit", "--no-gpg-sign", "-m", message)
@@ -635,7 +639,7 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
-  it "skips stable version bump commits when the target branch has already advanced" do
+  it "marks stable version bump commits as manual when the target branch has already advanced" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
       write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
@@ -649,13 +653,13 @@ RSpec.describe "script/release-forward-port" do
       stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
       expect(stdout).to include("stable release version bump commit")
       expect(stdout).to include("manual fallback to take only the CHANGELOG hunks")
     end
   end
 
-  it "skips stable final version bumps when the target is still pre-release-cut" do
+  it "marks stable final version bumps as manual when the target is still pre-release-cut" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
       write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc.1"))
@@ -670,9 +674,29 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stdout).to include("target version: 1.0.0")
       expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
-      expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
       expect(stdout).to include("stable release version bump commit")
       expect(stdout).to include("manual fallback to take only the CHANGELOG hunks")
+    end
+  end
+
+  it "blocks normal mode on stable final version bumps so changelog extraction is explicit" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1]\n- Final notes\n")
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+      git(repo, "checkout", "main")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).not_to be_success
+      expect(stdout).to include("MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stderr).to include("Manual inspection required for #{stable_bump_sha}")
+      expect(stderr).to include("--ack-manual #{stable_bump_sha}")
+      expect(stdout).not_to include("Forward-port complete")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
     end
   end
 
@@ -710,7 +734,7 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stderr).to include("WARNING: VERSION constant not found")
       expect(stdout).to include("target version: UNKNOWN")
-      expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("MANUAL #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
       expect(stdout).to include("stable release version bump commit")
     end
   end
@@ -816,6 +840,29 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "picks mode-only commits instead of treating hunkless patch-id output as empty" do
+    with_release_repo do |repo|
+      write_file(repo, "script.sh", "#!/bin/sh\necho base\n")
+      commit_all(repo, "Add script")
+      expect(executable_file?(repo, "script.sh")).to be(false)
+
+      git(repo, "checkout", "-b", "release/1.0.1")
+      git(repo, "update-index", "--chmod=+x", "script.sh")
+      FileUtils.chmod(0o755, File.join(repo, "script.sh"))
+      git(repo, "commit", "--no-gpg-sign", "-m", "Make script executable")
+      mode_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+      expect(executable_file?(repo, "script.sh")).to be(false)
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{mode_fix_sha[0, 12]} Make script executable")
+      expect(stdout).to include("Forward-port complete")
+      expect(executable_file?(repo, "script.sh")).to be(true)
+    end
+  end
+
   it "does not suggest cherry-pick --continue when Git did not start a cherry-pick" do
     helper = ReleaseForwardPort.new([])
     entry = ReleaseForwardPort::PlanEntry.new(sha: "a" * 40, subject: "Fix release regression", action: :pick)
@@ -825,5 +872,19 @@ RSpec.describe "script/release-forward-port" do
     expect do
       helper.send(:warn_cherry_pick_failure, entry, completed: 0, remaining: 1)
     end.to output(/\A(?=.*Git did not leave a cherry-pick in progress)(?!.*--continue).*\z/m).to_stderr
+  end
+
+  it "rejects a pre-existing cherry-pick before checking worktree cleanliness" do
+    helper = ReleaseForwardPort.new([])
+
+    allow(helper).to receive(:cherry_pick_in_progress?).and_return(true)
+    expect(helper).not_to receive(:git).with("status", "--porcelain")
+
+    expect do
+      helper.send(:ensure_clean_worktree!)
+    end.to raise_error(
+      ReleaseForwardPort::GitError,
+      "a cherry-pick is already in progress; run git cherry-pick --continue or --abort first"
+    )
   end
 end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -122,6 +122,30 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips reverts of skipped rc version bump commits" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc.1"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1.rc.1]\n- RC notes\n")
+      rc_bump_sha = commit_all(repo, "Bump version to 1.0.1.rc.1")
+      git(repo, "revert", "--no-edit", "HEAD")
+      rc_revert_sha = git(repo, "rev-parse", "HEAD").strip
+
+      git(repo, "checkout", "main")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
+      expect(stdout).to include("SKIP #{rc_revert_sha[0, 12]} Revert \"Bump version to 1.0.1.rc.1\"")
+      expect(stdout).to include("reverts a release-only version bump that is skipped for main")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "react_on_rails/lib/react_on_rails/version.rb"))).to include("1.0.0")
+    end
+  end
+
   it "reports no commits when the source has nothing ahead of the target" do
     with_release_repo do |repo|
       stdout, stderr, status = run_script(repo, "--source", "main", "--target", "main", "--dry-run")
@@ -689,7 +713,9 @@ RSpec.describe "script/release-forward-port" do
     end
     allow(helper).to receive(:commit_descends_from?).and_return(true)
 
-    expect { helper.send(:standard_revert_on_target?, first_sha, "main") }.not_to raise_error
+    result = nil
+    expect { result = helper.send(:standard_revert_on_target?, first_sha, "main") }.not_to raise_error
+    expect(result).to be(false)
   end
 
   it "does not suggest cherry-pick --continue when Git did not start a cherry-pick" do

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -194,6 +194,31 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "omits release branch merge commits from the forward-port plan" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc.1"))
+      rc_bump_sha = commit_all(repo, "Bump version to 1.0.1.rc.1")
+
+      git(repo, "checkout", "-b", "release-fix")
+      write_file(repo, "app.txt", "base\nrelease fix\n")
+      fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "release/1.0.1")
+      git(repo, "merge", "--no-ff", "release-fix", "-m", "Merge release fix branch")
+      merge_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
+      expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(stdout).not_to include(merge_sha[0, 12])
+      expect(stdout).not_to include("Merge release fix branch")
+    end
+  end
+
   it "keeps earlier picks when a later cherry-pick is aborted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)
@@ -254,6 +279,24 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
       expect(stdout).to include("target main is already at 1.1.0.dev")
       expect(stdout).to include("manual fallback to take only the CHANGELOG hunks")
+    end
+  end
+
+  it "skips test prerelease version bumps when the target has advanced to a later prerelease" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.test.1"))
+      test_bump_sha = commit_all(repo, "Bump version to 1.0.1.test.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.beta.1"))
+      commit_all(repo, "Start 1.0.1 beta")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{test_bump_sha[0, 12]} Bump version to 1.0.1.test.1")
+      expect(stdout).to include("target main is already at 1.0.1.beta.1")
     end
   end
 end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -297,8 +297,34 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
       expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
-      expect(stdout).to include("SKIP #{merge_sha[0, 12]} Merge release fix branch")
+      expect(stdout).to include("MANUAL #{merge_sha[0, 12]} Merge release fix branch")
       expect(stdout).to include("merge commit; inspect manually for conflict-resolution hunks")
+    end
+  end
+
+  it "blocks normal mode when release branch merge commits need manual inspection" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "base\nrelease base\n")
+      base_fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "-b", "release-fix")
+      write_file(repo, "merge-only.txt", "merge-only fix\n")
+      commit_all(repo, "Fix merge-only regression")
+
+      git(repo, "checkout", "release/1.0.1")
+      git(repo, "merge", "--no-ff", "release-fix", "-m", "Merge release fix branch")
+      merge_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).not_to be_success
+      expect(stdout).to include("PICK #{base_fix_sha[0, 12]} Fix release regression")
+      expect(stdout).to include("MANUAL #{merge_sha[0, 12]} Merge release fix branch")
+      expect(stdout).not_to include("Forward-port complete")
+      expect(stderr).to include("Manual inspection required for #{merge_sha}")
+      expect(stderr).to include("Earlier successful picks from this run are already committed and safe")
     end
   end
 
@@ -447,12 +473,37 @@ RSpec.describe "script/release-forward-port" do
 
       stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
 
-      expect(status).to be_success, stderr
+      expect(status).not_to be_success
       expect(stdout).to include("SKIP #{release_pick_sha[0, 12]} Fix release regression")
       expect(stdout).to include("already forward-ported to main via cherry-pick -x evidence")
-      expect(stdout).to include("SKIP #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
-      expect(stdout).to include("reverts a release-only cherry-pick of a commit already live on main")
-      expect(stdout).to include("Nothing to cherry-pick")
+      expect(stdout).to include("MANUAL #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
+      expect(stdout).to include("reverts a release-only application of a commit already live on main")
+      expect(stderr).to include("Manual inspection required for #{release_revert_sha}")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
+    end
+  end
+
+  it "routes release-only reverts of no-footer reverse picks to manual handling" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      git(repo, "cherry-pick", main_fix_sha)
+      release_pick_body = git(repo, "log", "-1", "--format=%B")
+      expect(release_pick_body).not_to include("cherry picked from commit")
+      git(repo, "revert", "--no-edit", "HEAD")
+      release_revert_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).not_to be_success
+      expect(stdout).to include("MANUAL #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
+      expect(stdout).to include("reverts a release-only application of a commit already live on main")
+      expect(stderr).to include("Manual inspection required for #{release_revert_sha}")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
     end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -365,6 +365,36 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips release commits cherry-picked from a live target commit" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      write_file(repo, "app.txt", "base\nrelease-specific fix\n")
+      git(repo, "add", "app.txt")
+      git(
+        repo,
+        "commit",
+        "--no-gpg-sign",
+        "-m",
+        "Fix release regression",
+        "-m",
+        "(cherry picked from commit #{main_fix_sha})"
+      )
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{release_fix_sha[0, 12]} Fix release regression")
+      expect(stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
+    end
+  end
+
   it "does not skip an -x cherry-pick that was later reverted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -383,7 +383,28 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status).to be_success, stderr
       expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
-      expect(stdout).to include("target main is already at 1.1.0.dev")
+      expect(stdout).to include("stable release version bump commit")
+      expect(stdout).to include("manual fallback to take only the CHANGELOG hunks")
+    end
+  end
+
+  it "skips stable final version bumps when the target is still pre-release-cut" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc.1"))
+      rc_bump_sha = commit_all(repo, "Bump version to 1.0.1.rc.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      write_file(repo, "CHANGELOG.md", "# Change Log\n\n### [1.0.1]\n- Final notes\n")
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("target version: 1.0.0")
+      expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
+      expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("stable release version bump commit")
       expect(stdout).to include("manual fallback to take only the CHANGELOG hunks")
     end
   end
@@ -422,7 +443,8 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stderr).to include("WARNING: VERSION constant not found")
       expect(stdout).to include("target version: UNKNOWN")
-      expect(stdout).to include("PICK #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("SKIP #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+      expect(stdout).to include("stable release version bump commit")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -413,6 +413,32 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "routes release-only reverts of reverse cherry-picks to manual handling" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      git(repo, "cherry-pick", "-x", main_fix_sha)
+      release_pick_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "revert", "--no-edit", "HEAD")
+      release_revert_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{release_pick_sha[0, 12]} Fix release regression")
+      expect(stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(stdout).to include("SKIP #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
+      expect(stdout).to include("reverts a release-only cherry-pick of a commit already live on main")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
+    end
+  end
+
   it "does not skip an -x cherry-pick that was later reverted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe "script/release-forward-port" do
     File.write(full_path, contents)
   end
 
+  def write_binary_file(repo, path, contents)
+    full_path = File.join(repo, path)
+    FileUtils.mkdir_p(File.dirname(full_path))
+    File.binwrite(full_path, contents)
+  end
+
   def commit_all(repo, message)
     git(repo, "add", ".")
     git(repo, "commit", "--no-gpg-sign", "-m", message)
@@ -533,6 +539,57 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "allows acknowledged manual items to be skipped so later eligible commits can continue" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      git(repo, "cherry-pick", "-x", main_fix_sha)
+      git(repo, "revert", "--no-edit", "HEAD")
+      release_revert_sha = git(repo, "rev-parse", "HEAD").strip
+      write_file(repo, "later.txt", "later release fix\n")
+      later_fix_sha = commit_all(repo, "Fix later release regression")
+      git(repo, "checkout", "main")
+
+      first_stdout, first_stderr, first_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(first_status).not_to be_success
+      expect(first_stdout).to include("MANUAL #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
+      expect(first_stdout).to include("PICK #{later_fix_sha[0, 12]} Fix later release regression")
+      expect(first_stderr).to include("Manual inspection required for #{release_revert_sha}")
+      expect(first_stderr).to include("--ack-manual #{release_revert_sha}")
+      expect(first_stderr).to include("Note: 1 later eligible commit in this plan is not attempted after this failure")
+      expect(File).not_to exist(File.join(repo, "later.txt"))
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--ack-manual", release_revert_sha)
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("ACK-MANUAL #{release_revert_sha[0, 12]} Revert \"Fix release regression\"")
+      expect(second_stdout).to include("PICK #{later_fix_sha[0, 12]} Fix later release regression")
+      expect(second_stdout).to include("Forward-port complete")
+      expect(File.read(File.join(repo, "later.txt"))).to eq("later release fix\n")
+
+      latest_commit_body = git(repo, "log", "-1", "--format=%B")
+      expect(latest_commit_body).to include("(cherry picked from commit #{later_fix_sha})")
+    end
+  end
+
+  it "rejects acknowledged commits that are not manual items in the current plan" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      _stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run", "--ack-manual", fix_sha)
+
+      expect(status.exitstatus).to eq(2)
+      expect(stderr).to include("--ack-manual only accepts commits currently marked MANUAL")
+      expect(stderr).to include(fix_sha)
+    end
+  end
+
   it "does not skip an -x cherry-pick that was later reverted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)
@@ -716,6 +773,47 @@ RSpec.describe "script/release-forward-port" do
     result = nil
     expect { result = helper.send(:standard_revert_on_target?, first_sha, "main") }.not_to raise_error
     expect(result).to be(false)
+  end
+
+  it "does not crash when a standard revert footer references a missing commit" do
+    with_release_repo do |repo|
+      missing_sha = "a" * 40
+      git(repo, "checkout", "-b", "release/1.0.1")
+      git(
+        repo,
+        "commit",
+        "--allow-empty",
+        "--no-gpg-sign",
+        "-m",
+        "Revert \"Missing release commit\"",
+        "-m",
+        "This reverts commit #{missing_sha}."
+      )
+      revert_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stderr).not_to include("ERROR")
+      expect(stdout).to include("SKIP #{revert_sha[0, 12]} Revert \"Missing release commit\"")
+      expect(stdout).to include("empty commit; cherry-picking would only create a no-op commit on main")
+    end
+  end
+
+  it "handles invalid byte patches without encoding errors during patch-id checks" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_binary_file(repo, "invalid-bytes.txt", "\xffrelease bytes\n".b)
+      binary_fix_sha = commit_all(repo, "Fix release binary payload")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stderr).not_to include("ERROR")
+      expect(stdout).to include("PICK #{binary_fix_sha[0, 12]} Fix release binary payload")
+    end
   end
 
   it "does not suggest cherry-pick --continue when Git did not start a cherry-pick" do

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -520,6 +520,34 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "picks release commits cherry-picked from target merge commits that were later reverted" do
+    with_release_repo do |repo|
+      base_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "-b", "feature")
+      write_file(repo, "app.txt", "base\nmain merge fix\n")
+      commit_all(repo, "Fix regression through feature branch")
+
+      git(repo, "checkout", "main")
+      git(repo, "merge", "--no-ff", "feature", "-m", "Merge feature fix")
+      merge_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "revert", "-m", "1", "--no-edit", merge_sha)
+      merge_revert_body = git(repo, "log", "-1", "--format=%B")
+      expect(merge_revert_body).to include("This reverts commit #{merge_sha}, reversing")
+
+      git(repo, "checkout", "-b", "release/1.0.1", base_sha)
+      git(repo, "cherry-pick", "-x", "-m", "1", merge_sha)
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Merge feature fix")
+      expect(stdout).to include("Forward-port complete")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain merge fix\n")
+    end
+  end
+
   it "routes release-only reverts of reverse cherry-picks to manual handling" do
     with_release_repo do |repo|
       write_file(repo, "app.txt", "base\nmain fix\n")
@@ -810,14 +838,14 @@ RSpec.describe "script/release-forward-port" do
     first_sha = "a" * 40
     second_sha = "b" * 40
 
-    allow(helper).to receive(:git_lines) do |*args|
-      case args
-      when ["log", "main", "--fixed-strings", "--grep", "This reverts commit #{first_sha}.", "--format=%H"]
+    allow(helper).to receive(:standard_revert_shas_on_target) do |sha, target|
+      case [sha, target]
+      when [first_sha, "main"]
         [second_sha]
-      when ["log", "main", "--fixed-strings", "--grep", "This reverts commit #{second_sha}.", "--format=%H"]
+      when [second_sha, "main"]
         [first_sha]
       else
-        raise "unexpected git_lines call: #{args.inspect}"
+        raise "unexpected standard_revert_shas_on_target call: #{[sha, target].inspect}"
       end
     end
     allow(helper).to receive(:commit_descends_from?).and_return(true)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -137,6 +137,19 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "accepts positional source and target refs" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      stdout, stderr, status = run_script(repo, "release/1.0.1", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("source: release/1.0.1")
+      expect(stdout).to include("target: main")
+      expect(stdout).to include("PICK")
+    end
+  end
+
   it "skips commits already applied without an -x footer when the patch is still in the target tree" do
     with_release_repo do |repo|
       _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -98,6 +98,22 @@ RSpec.describe "script/release-forward-port" do
     [rc_bump_sha, fix_sha]
   end
 
+  def add_reverted_feature_merge(repo)
+    base_sha = git(repo, "rev-parse", "HEAD").strip
+    git(repo, "checkout", "-b", "feature")
+    write_file(repo, "app.txt", "base\nmain merge fix\n")
+    feature_sha = commit_all(repo, "Fix regression through feature branch")
+
+    git(repo, "checkout", "main")
+    git(repo, "merge", "--no-ff", "feature", "-m", "Merge feature fix")
+    merge_sha = git(repo, "rev-parse", "HEAD").strip
+    git(repo, "revert", "-m", "1", "--no-edit", merge_sha)
+    merge_revert_body = git(repo, "log", "-1", "--format=%B")
+    expect(merge_revert_body).to include("This reverts commit #{merge_sha}, reversing")
+
+    [base_sha, feature_sha, merge_sha]
+  end
+
   it "dry-runs the forward-port plan without changing the target branch" do
     with_release_repo do |repo|
       rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
@@ -543,6 +559,44 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status).to be_success, stderr
       expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Merge feature fix")
+      expect(stdout).to include("Forward-port complete")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain merge fix\n")
+    end
+  end
+
+  it "picks release commits cherry-picked from target feature commits whose merge was later reverted" do
+    with_release_repo do |repo|
+      base_sha, feature_sha = add_reverted_feature_merge(repo)
+
+      git(repo, "checkout", "-b", "release/1.0.1", base_sha)
+      git(repo, "cherry-pick", "-x", feature_sha)
+      release_fix_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix regression through feature branch")
+      expect(stdout).to include("Forward-port complete")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain merge fix\n")
+    end
+  end
+
+  it "picks no-footer release commits when the matching target merge was later reverted" do
+    with_release_repo do |repo|
+      base_sha, = add_reverted_feature_merge(repo)
+
+      git(repo, "checkout", "-b", "release/1.0.1", base_sha)
+      write_file(repo, "app.txt", "base\nmain merge fix\n")
+      release_fix_sha = commit_all(repo, "Fix release regression")
+      release_fix_body = git(repo, "log", "-1", "--format=%B")
+      expect(release_fix_body).not_to include("cherry picked from commit")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("PICK #{release_fix_sha[0, 12]} Fix release regression")
       expect(stdout).to include("Forward-port complete")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain merge fix\n")
     end

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "script/release-forward-port" do
 
       # Apply the fix onto main WITHOUT -x so there is no
       # "(cherry picked from commit ...)" footer; the helper must confirm the
-      # patch is still present in the current target tree before skipping it.
+      # equivalent target patch is still present in history before skipping it.
       git(repo, "cherry-pick", fix_sha)
       latest_body = git(repo, "log", "-1", "--format=%B")
       expect(latest_body).not_to include("cherry picked from commit")
@@ -175,9 +175,28 @@ RSpec.describe "script/release-forward-port" do
       stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
 
       expect(status).to be_success, stderr
-      expect(stdout).to include("patch already exists on main according to the current target tree")
+      expect(stdout).to include("patch already exists on main according to target history")
       expect(stdout).to include("Nothing to cherry-pick")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "skips no-footer cherry-picks after later target context changes" do
+    with_release_repo do |repo|
+      _rc_bump_sha, fix_sha = add_rc_bump_and_fix(repo)
+
+      git(repo, "cherry-pick", fix_sha)
+      write_file(repo, "app.txt", "base updated on main\nrelease fix\n")
+      commit_all(repo, "Adjust target context around release fix")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("patch already exists on main according to target history")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base updated on main\nrelease fix\n")
     end
   end
 
@@ -194,7 +213,7 @@ RSpec.describe "script/release-forward-port" do
 
       expect(status).to be_success, stderr
       expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
-      expect(stdout).not_to include("patch already exists on main according to the current target tree")
+      expect(stdout).not_to include("patch already exists on main according to target history")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
       expect(git(repo, "rev-list", "--count", "main").strip.to_i).to eq(reverted_count.to_i + 1)
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
-  it "omits release branch merge commits from the forward-port plan" do
+  it "reports release branch merge commits for manual handling" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
       write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc.1"))
@@ -278,8 +278,8 @@ RSpec.describe "script/release-forward-port" do
       expect(status).to be_success, stderr
       expect(stdout).to include("SKIP #{rc_bump_sha[0, 12]} Bump version to 1.0.1.rc.1")
       expect(stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
-      expect(stdout).not_to include(merge_sha[0, 12])
-      expect(stdout).not_to include("Merge release fix branch")
+      expect(stdout).to include("SKIP #{merge_sha[0, 12]} Merge release fix branch")
+      expect(stdout).to include("merge commit; inspect manually for conflict-resolution hunks")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -266,6 +266,40 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips conflict-resolved -x cherry-picks on rerun" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "app.txt", "release branch\n")
+      fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "app.txt", "main branch\n")
+      commit_all(repo, "Change same line on main")
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(first_status).not_to be_success
+      expect(first_stdout).to include("PICK #{fix_sha[0, 12]} Fix release regression")
+      expect(first_stderr).to include("Cherry-pick failed for #{fix_sha}")
+
+      write_file(repo, "app.txt", "main branch\nrelease branch\n")
+      git(repo, "add", "app.txt")
+      git(repo, "-c", "core.editor=true", "cherry-pick", "--continue")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+      latest_commit_body = git(repo, "log", "-1", "--format=%B")
+      expect(latest_commit_body).to include("(cherry picked from commit #{fix_sha})")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("main branch\nrelease branch\n")
+    end
+  end
+
   it "does not skip an -x cherry-pick that was later reverted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -103,6 +103,16 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "reports no commits when the source has nothing ahead of the target" do
+    with_release_repo do |repo|
+      stdout, stderr, status = run_script(repo, "--source", "main", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("No commits found in main..main.")
+      expect(stdout).to include("DRY RUN")
+    end
+  end
+
   it "prints usage without a stack trace for argument errors" do
     _stdout, stderr, status = run_script_from_repo_root("--bogus")
 
@@ -276,6 +286,29 @@ RSpec.describe "script/release-forward-port" do
       expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
       expect(second_stdout).to include("Nothing to cherry-pick")
       expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
+  it "skips -x cherry-picks after later target context changes" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      write_file(repo, "app.txt", "base updated on main\nrelease fix\n")
+      commit_all(repo, "Adjust target context around release fix")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base updated on main\nrelease fix\n")
     end
   end
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -171,6 +171,31 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "keeps earlier picks when a later cherry-pick is aborted" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+      git(repo, "checkout", "release/1.0.1")
+      write_file(repo, "conflict.txt", "release branch\n")
+      commit_all(repo, "Fix release conflict")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "conflict.txt", "main branch\n")
+      commit_all(repo, "Change conflict on main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).not_to be_success
+      expect(stdout).to include("Cherry-picking")
+      expect(stderr).to include("only the current conflicting commit is abandoned")
+      expect(git(repo, "log", "--format=%s", "main")).to include("Fix release regression")
+
+      git(repo, "cherry-pick", "--abort")
+
+      expect(git(repo, "log", "--format=%s", "main")).to include("Fix release regression")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+    end
+  end
+
   it "is idempotent when release commits were already forward-ported with -x" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -387,6 +387,29 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips an -x cherry-pick restored by reverting its revert" do
+    with_release_repo do |repo|
+      add_rc_bump_and_fix(repo)
+
+      first_stdout, first_stderr, first_status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+      expect(first_status).to be_success, first_stderr
+      expect(first_stdout).to include("Forward-port complete")
+
+      git(repo, "revert", "--no-edit", "HEAD")
+      git(repo, "revert", "--no-edit", "HEAD")
+      restored_count = git(repo, "rev-list", "--count", "main").strip
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nrelease fix\n")
+
+      second_stdout, second_stderr, second_status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(second_status).to be_success, second_stderr
+      expect(second_stdout).to include("already forward-ported to main via cherry-pick -x evidence")
+      expect(second_stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(restored_count)
+    end
+  end
+
   it "skips stable version bump commits when the target branch has already advanced" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -355,6 +355,44 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "picks version bumps when the target prerelease label is unknown" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.beta.1"))
+      beta_bump_sha = commit_all(repo, "Bump version to 1.0.1.beta.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.canary.1"))
+      commit_all(repo, "Start canary prerelease")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("target version: 1.0.1.canary.1")
+      expect(stdout).to include("PICK #{beta_bump_sha[0, 12]} Bump version to 1.0.1.beta.1")
+      expect(stdout).not_to include("target main is already at 1.0.1.canary.1")
+    end
+  end
+
+  it "warns when the target version file cannot be parsed" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1"))
+      stable_bump_sha = commit_all(repo, "Bump version to 1.0.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", "# version constant intentionally missing\n")
+      commit_all(repo, "Break target version file")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stderr).to include("WARNING: VERSION constant not found")
+      expect(stdout).to include("target version: UNKNOWN")
+      expect(stdout).to include("PICK #{stable_bump_sha[0, 12]} Bump version to 1.0.1")
+    end
+  end
+
   it "skips test prerelease version bumps when the target has advanced to a later prerelease" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -113,6 +113,24 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips initially empty release commits before cherry-picking" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      git(repo, "commit", "--allow-empty", "--no-gpg-sign", "-m", "Record release-only marker")
+      empty_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "checkout", "main")
+      commit_count = git(repo, "rev-list", "--count", "main").strip
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{empty_sha[0, 12]} Record release-only marker")
+      expect(stdout).to include("empty commit; cherry-picking would only create a no-op commit on main")
+      expect(stdout).to include("Nothing to cherry-pick")
+      expect(git(repo, "rev-list", "--count", "main").strip).to eq(commit_count)
+    end
+  end
+
   it "prints usage without a stack trace for argument errors" do
     _stdout, stderr, status = run_script_from_repo_root("--bogus")
 

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -362,6 +362,34 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "routes reverts of release-branch merge commits to manual handling" do
+    with_release_repo do |repo|
+      write_file(repo, "app.txt", "base\nmain fix\n")
+      main_fix_sha = commit_all(repo, "Fix release regression")
+
+      git(repo, "checkout", "-b", "release/1.0.1", "HEAD~1")
+      git(repo, "checkout", "-b", "release-fix", main_fix_sha)
+      git(repo, "checkout", "release/1.0.1")
+      git(repo, "merge", "--no-ff", "release-fix", "-m", "Merge release fix branch")
+      merge_sha = git(repo, "rev-parse", "HEAD").strip
+      git(repo, "revert", "-m", "1", "--no-edit", merge_sha)
+      merge_revert_sha = git(repo, "rev-parse", "HEAD").strip
+      merge_revert_body = git(repo, "log", "-1", "--format=%B")
+      expect(merge_revert_body).to include("This reverts commit #{merge_sha}, reversing")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status =
+        run_script(repo, "--source", "release/1.0.1", "--target", "main", "--ack-manual", merge_sha)
+
+      expect(status).not_to be_success
+      expect(stdout).to include("ACK-MANUAL #{merge_sha[0, 12]} Merge release fix branch")
+      expect(stdout).to include("MANUAL #{merge_revert_sha[0, 12]} Revert \"Merge release fix branch\"")
+      expect(stdout).to include("reverts a release-branch merge commit")
+      expect(stderr).to include("Manual inspection required for #{merge_revert_sha}")
+      expect(File.read(File.join(repo, "app.txt"))).to eq("base\nmain fix\n")
+    end
+  end
+
   it "keeps earlier picks when a later cherry-pick is aborted" do
     with_release_repo do |repo|
       add_rc_bump_and_fix(repo)

--- a/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
+++ b/react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb
@@ -6,6 +6,9 @@ require "rbconfig"
 require "tmpdir"
 require_relative "spec_helper"
 
+release_forward_port_script = File.expand_path("../../../script/release-forward-port", __dir__)
+load release_forward_port_script unless defined?(ReleaseForwardPort)
+
 RSpec.describe "script/release-forward-port" do
   let(:repo_root) { File.expand_path("../../..", __dir__) }
   let(:script_path) { File.join(repo_root, "script/release-forward-port") }
@@ -100,6 +103,22 @@ RSpec.describe "script/release-forward-port" do
       expect(git(repo, "rev-parse", "--abbrev-ref", "HEAD").strip).to eq("main")
       expect(File.read(File.join(repo, "app.txt"))).to eq("base\n")
       expect(File.read(File.join(repo, "react_on_rails/lib/react_on_rails/version.rb"))).to include("1.0.0")
+    end
+  end
+
+  it "skips bare rc version bump subjects before version-drift checks" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.rc"))
+      bare_rc_bump_sha = commit_all(repo, "Bump version to 1.0.1.rc")
+      git(repo, "checkout", "main")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stdout).to include("SKIP #{bare_rc_bump_sha[0, 12]} Bump version to 1.0.1.rc")
+      expect(stdout).to include("rc version bump commit")
+      expect(stdout).to include("Summary: 0 commits to cherry-pick, 1 commit skipped.")
     end
   end
 
@@ -564,6 +583,26 @@ RSpec.describe "script/release-forward-port" do
     end
   end
 
+  it "skips prerelease version bumps when the target version file cannot be parsed" do
+    with_release_repo do |repo|
+      git(repo, "checkout", "-b", "release/1.0.1")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", version_file("1.0.1.beta.1"))
+      beta_bump_sha = commit_all(repo, "Bump version to 1.0.1.beta.1")
+
+      git(repo, "checkout", "main")
+      write_file(repo, "react_on_rails/lib/react_on_rails/version.rb", "# version constant intentionally missing\n")
+      commit_all(repo, "Break target version file")
+
+      stdout, stderr, status = run_script(repo, "--source", "release/1.0.1", "--target", "main", "--dry-run")
+
+      expect(status).to be_success, stderr
+      expect(stderr).to include("WARNING: VERSION constant not found")
+      expect(stdout).to include("target version: UNKNOWN")
+      expect(stdout).to include("SKIP #{beta_bump_sha[0, 12]} Bump version to 1.0.1.beta.1")
+      expect(stdout).to include("prerelease version bump commit with target version UNKNOWN")
+    end
+  end
+
   it "skips test prerelease version bumps when the target has advanced to a later prerelease" do
     with_release_repo do |repo|
       git(repo, "checkout", "-b", "release/1.0.1")
@@ -580,5 +619,36 @@ RSpec.describe "script/release-forward-port" do
       expect(stdout).to include("SKIP #{test_bump_sha[0, 12]} Bump version to 1.0.1.test.1")
       expect(stdout).to include("target main is already at 1.0.1.beta.1")
     end
+  end
+
+  it "does not recurse forever when target revert messages reference each other" do
+    helper = ReleaseForwardPort.new([])
+    first_sha = "a" * 40
+    second_sha = "b" * 40
+
+    allow(helper).to receive(:git_lines) do |*args|
+      case args
+      when ["log", "main", "--fixed-strings", "--grep", "This reverts commit #{first_sha}.", "--format=%H"]
+        [second_sha]
+      when ["log", "main", "--fixed-strings", "--grep", "This reverts commit #{second_sha}.", "--format=%H"]
+        [first_sha]
+      else
+        raise "unexpected git_lines call: #{args.inspect}"
+      end
+    end
+    allow(helper).to receive(:commit_descends_from?).and_return(true)
+
+    expect { helper.send(:standard_revert_on_target?, first_sha, "main") }.not_to raise_error
+  end
+
+  it "does not suggest cherry-pick --continue when Git did not start a cherry-pick" do
+    helper = ReleaseForwardPort.new([])
+    entry = ReleaseForwardPort::PlanEntry.new(sha: "a" * 40, subject: "Fix release regression", action: :pick)
+
+    allow(helper).to receive(:cherry_pick_in_progress?).and_return(false)
+
+    expect do
+      helper.send(:warn_cherry_pick_failure, entry, completed: 0, remaining: 1)
+    end.to output(/\A(?=.*Git did not leave a cherry-pick in progress)(?!.*--continue).*\z/m).to_stderr
   end
 end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -417,6 +417,9 @@ class ReleaseForwardPort
   end
 
   def target_commit_reverted_through_merge?(sha, target)
+    # Intentionally conservative: if any merge that included this commit was
+    # reverted, treat the commit as not live. Re-picking a present change is
+    # safer than skipping a release fix that the target tree no longer has.
     @target_merge_revert_cache ||= {}
     cache_key = [sha, target]
     return @target_merge_revert_cache.fetch(cache_key) if @target_merge_revert_cache.key?(cache_key)
@@ -440,6 +443,9 @@ class ReleaseForwardPort
   end
 
   def patch_id_for_commit(sha)
+    # git show --format= emits diff-only output. git patch-id still hashes the
+    # hunk content and emits a commit field we discard; the first token is the
+    # content hash used for comparisons.
     patch = git("show", "--format=", "--full-index", "--find-renames", sha).b
     # Empty commits carry no file changes; cherry-picking them would only create
     # a no-op commit, so treat the patch as already present.
@@ -705,7 +711,7 @@ class ReleaseForwardPort
     @acknowledged_manual_shas = @options.fetch(:ack_manual).map do |sha|
       git("rev-parse", "--verify", "#{sha}^{commit}").strip
     rescue GitError => e
-      raise GitError, "--ack-manual #{sha.inspect} is not a commit: #{e.message}"
+      raise UsageError, "--ack-manual #{sha.inspect} is not a commit: #{e.message}"
     end.uniq
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -75,6 +75,7 @@ class ReleaseForwardPort
 
     ensure_clean_worktree!
     checkout_target!(target)
+    # This final expression is the process exit status.
     apply_plan(plan)
   rescue OptionParser::ParseError, UsageError => e
     warn "ERROR: #{e.message}"
@@ -163,7 +164,7 @@ class ReleaseForwardPort
     end
 
     if already_forward_ported_with_x?(sha, target)
-      return "already forward-ported to #{target} via cherry-pick -x evidence and current target tree"
+      return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert"
     end
 
     if patch_equivalent_commits[sha] && patch_present_on_target_tree?(sha, target)
@@ -198,15 +199,20 @@ class ReleaseForwardPort
     footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
     # This history search can false-positive if a later target commit quotes the
     # footer verbatim. The runbook documents that boundary for release operators.
-    forwarded_sha = git("log", target, "--fixed-strings", "--grep", footer, "--format=%H", "--max-count=1").strip
-    return false if forwarded_sha.empty?
+    forwarded_shas = git_lines("log", target, "--fixed-strings", "--grep", footer, "--format=%H")
+    return false if forwarded_shas.empty?
 
-    patch_present_on_target_tree?(forwarded_sha, target)
+    forwarded_shas.any? { |forwarded_sha| !standard_revert_on_target?(forwarded_sha, target) }
+  end
+
+  def standard_revert_on_target?(sha, target)
+    revert_message = "This reverts commit #{sha}."
+    !git("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H", "--max-count=1").strip.empty?
   end
 
   def patch_present_on_target_tree?(sha, target)
     patch = git("show", "--format=", "--binary", "--full-index", "--find-renames", sha)
-    return false if patch.strip.empty?
+    return true if patch.strip.empty?
 
     with_temporary_index(target) do |env|
       _stdout, _stderr, status =
@@ -313,6 +319,8 @@ class ReleaseForwardPort
     when :skip
       puts "SKIP #{entry.short_sha} #{entry.subject}"
       puts "     #{entry.reason}"
+    else
+      raise GitError, "unexpected plan entry action: #{entry.action.inspect}"
     end
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -134,7 +134,7 @@ class ReleaseForwardPort
   end
 
   def source_only_commits(source, target)
-    git_lines("rev-list", "--reverse", "--no-merges", "#{target}..#{source}")
+    git_lines("rev-list", "--reverse", "#{target}..#{source}")
   end
 
   def patch_equivalent_candidates(source, target)
@@ -163,6 +163,10 @@ class ReleaseForwardPort
       return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}"
     end
 
+    if merge_commit?(sha)
+      return "merge commit; inspect manually for conflict-resolution hunks before marking forward-port complete"
+    end
+
     if already_forward_ported_with_x?(sha, target)
       return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert"
     end
@@ -180,6 +184,10 @@ class ReleaseForwardPort
 
   def rc_version_bump?(subject)
     subject.match?(RC_VERSION_BUMP_SUBJECT)
+  end
+
+  def merge_commit?(sha)
+    git("rev-list", "--parents", "-n", "1", sha).split.length > 2
   end
 
   def version_bump_skip_reason(subject, target, target_version)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -7,6 +7,9 @@ require "open3"
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
   VERSION_FILE = "react_on_rails/lib/react_on_rails/version.rb"
+  # A trailing number after the `rc` marker is required (project convention is
+  # always `X.Y.Z.rc.N`). A versionless `1.0.0.rc` is intentionally NOT matched
+  # here; it falls through to the version-drift path in version_bump_skip_reason.
   RC_VERSION_BUMP_SUBJECT = /
     \Abump\s+version\s+to\s+v?\d+\.\d+\.\d+(?:[.-]rc[.-]?\d+|\.rc\.\d+)\b
   /ix
@@ -27,6 +30,7 @@ class ReleaseForwardPort
 
   def initialize(argv)
     @argv = argv.dup
+    @explicit_options = { source: false, target: false }
     @options = {
       dry_run: false,
       target: "main"
@@ -73,7 +77,13 @@ class ReleaseForwardPort
   def parse_options!
     argv = @argv.dup
     @parser.parse!(argv)
-    @options[:source] ||= argv.shift
+
+    # Only consume positional source/target when the corresponding flag was not
+    # supplied. A leftover positional after an explicit flag is an error, not a
+    # silent override of the flagged value.
+    @options[:source] = argv.shift unless @explicit_options[:source]
+    raise UsageError, "too many arguments: #{argv.join(' ')}" if @explicit_options[:target] && argv.any?
+
     @options[:target] = argv.shift if argv.any?
 
     raise UsageError, "source ref is required" if @options[:source].nil? || @options[:source].empty?
@@ -93,9 +103,11 @@ class ReleaseForwardPort
 
       parser.on("--source REF", "Release branch or ref to forward-port from") do |source|
         @options[:source] = source
+        @explicit_options[:source] = true
       end
       parser.on("--target REF", "Target local branch to forward-port onto (default: main)") do |target|
         @options[:target] = target
+        @explicit_options[:target] = true
       end
       parser.on("--dry-run", "Print the plan without checking out or cherry-picking") do
         @options[:dry_run] = true
@@ -233,7 +245,11 @@ class ReleaseForwardPort
       "beta" => 3,
       "pre" => 4,
       "rc" => 5
-    }.fetch(label, -1)
+      # Unknown labels rank as release-candidate (5) rather than below `dev`, so a
+      # novel marker like `1.0.0.snapshot` is treated as release-like instead of
+      # silently ranking below every known prerelease. Expand the table if the
+      # project adopts new prerelease markers.
+    }.fetch(label, 5)
   end
 
   def print_plan(source, target, target_version, plan)
@@ -294,20 +310,32 @@ class ReleaseForwardPort
       return 0
     end
 
-    picks.each do |entry|
+    picks.each_with_index do |entry, index|
       puts "\nCherry-picking #{entry.short_sha} #{entry.subject}"
       stdout, stderr, status = capture_git("cherry-pick", "-x", entry.sha)
       puts stdout unless stdout.empty?
       warn stderr unless stderr.empty?
       next if status.success?
 
-      warn "Cherry-pick failed for #{entry.sha}."
-      warn "Resolve the conflict and run git cherry-pick --continue, or run git cherry-pick --abort."
+      warn_cherry_pick_conflict(entry, remaining: picks.length - index - 1)
       return status.exitstatus || 1
     end
 
     puts "\nForward-port complete."
     0
+  end
+
+  def warn_cherry_pick_conflict(entry, remaining:)
+    warn "Cherry-pick failed for #{entry.sha}."
+    warn "Resolve the conflict and run git cherry-pick --continue to finish THIS commit."
+    if remaining.positive?
+      warn "Note: #{remaining} later eligible commit#{'s' unless remaining == 1} in this plan " \
+           "#{remaining == 1 ? 'is' : 'are'} not queued by --continue. Rerun " \
+           "script/release-forward-port after continuing to apply the rest " \
+           "(it is idempotent and skips commits already applied)."
+    end
+    warn "If you git cherry-pick --abort, earlier picks in this run are rolled back; " \
+         "rerun script/release-forward-port from the start after fixing the conflict."
   end
 
   def verify_ref!(ref, label:)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -1,0 +1,353 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "optparse"
+require "open3"
+
+# rubocop:disable Metrics/ClassLength
+class ReleaseForwardPort
+  VERSION_FILE = "react_on_rails/lib/react_on_rails/version.rb"
+  RC_VERSION_BUMP_SUBJECT = /
+    \Abump\s+version\s+to\s+v?\d+\.\d+\.\d+(?:[.-]rc[.-]?\d+|\.rc\.\d+)\b
+  /ix
+  VERSION_BUMP_SUBJECT = /
+    \Abump\s+version\s+to\s+v?
+    (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev)(?:[.-]?\d+)?)?)\b
+  /ix
+  CHERRY_PICK_FOOTER_PREFIX = "(cherry picked from commit "
+
+  PlanEntry = Struct.new(:sha, :subject, :action, :reason, keyword_init: true) do
+    def short_sha
+      sha[0, 12]
+    end
+  end
+
+  class UsageError < StandardError; end
+  class GitError < StandardError; end
+
+  def initialize(argv)
+    @argv = argv.dup
+    @options = {
+      dry_run: false,
+      target: "main"
+    }
+    @parser = build_parser
+  end
+
+  def run
+    parse_options!
+
+    source = @options.fetch(:source)
+    target = @options.fetch(:target)
+
+    verify_ref!(source, label: "source")
+    verify_ref!(target, label: "target")
+    ensure_local_target_branch!(target) unless @options[:dry_run]
+
+    commits = source_only_commits(source, target)
+    patch_equivalent_commits = patch_equivalent_commits(source, target)
+    target_version = version_at(target)
+    plan = build_plan(commits, target, target_version, patch_equivalent_commits)
+
+    print_plan(source, target, target_version, plan)
+
+    if @options[:dry_run]
+      puts "\nDRY RUN: no branches were checked out and no commits were cherry-picked."
+      return 0
+    end
+
+    ensure_clean_worktree!
+    checkout_target!(target)
+    apply_plan(plan)
+  rescue OptionParser::ParseError, UsageError => e
+    warn "ERROR: #{e.message}"
+    warn @parser
+    2
+  rescue GitError => e
+    warn "ERROR: #{e.message}"
+    1
+  end
+
+  private
+
+  def parse_options!
+    argv = @argv.dup
+    @parser.parse!(argv)
+    @options[:source] ||= argv.shift
+    @options[:target] = argv.shift if argv.any?
+
+    raise UsageError, "source ref is required" if @options[:source].nil? || @options[:source].empty?
+    raise UsageError, "too many arguments: #{argv.join(' ')}" unless argv.empty?
+  end
+
+  def build_parser
+    OptionParser.new do |parser|
+      parser.banner = <<~BANNER
+        Usage: script/release-forward-port --source release/X.Y.Z [--target main] [--dry-run]
+               script/release-forward-port release/X.Y.Z [main] [--dry-run]
+
+        Forward-port commits that are on a release branch but not on the target branch.
+        The helper cherry-picks with -x, skips commits already forward-ported with -x
+        evidence or equivalent patches, and excludes RC version bump commits.
+      BANNER
+
+      parser.on("--source REF", "Release branch or ref to forward-port from") do |source|
+        @options[:source] = source
+      end
+      parser.on("--target REF", "Target local branch to forward-port onto (default: main)") do |target|
+        @options[:target] = target
+      end
+      parser.on("--dry-run", "Print the plan without checking out or cherry-picking") do
+        @options[:dry_run] = true
+      end
+      parser.on("-h", "--help", "Show this help") do
+        puts parser
+        exit 0
+      end
+    end
+  end
+
+  def source_only_commits(source, target)
+    git_lines("rev-list", "--reverse", "#{target}..#{source}")
+  end
+
+  def patch_equivalent_commits(source, target)
+    git_lines("cherry", target, source).each_with_object({}) do |line, commits|
+      marker, sha = line.split(/\s+/, 2)
+      commits[sha] = true if marker == "-"
+    end
+  end
+
+  def build_plan(commits, target, target_version, patch_equivalent_commits)
+    commits.map do |sha|
+      full_sha = git("rev-parse", "#{sha}^{commit}").strip
+      subject = git("log", "-1", "--format=%s", full_sha).strip
+      reason = skip_reason(full_sha, subject, target, target_version, patch_equivalent_commits)
+
+      PlanEntry.new(
+        sha: full_sha,
+        subject:,
+        action: reason ? :skip : :pick,
+        reason:
+      )
+    end
+  end
+
+  def skip_reason(sha, subject, target, target_version, patch_equivalent_commits)
+    if rc_version_bump?(subject)
+      return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}"
+    end
+
+    if already_forward_ported_with_x?(sha, target)
+      return "already forward-ported to #{target} via cherry-pick -x evidence"
+    end
+
+    return "patch already exists on #{target} according to git cherry" if patch_equivalent_commits[sha]
+
+    version_bump_skip_reason(subject, target, target_version)
+  end
+
+  def rc_version_bump?(subject)
+    subject.match?(RC_VERSION_BUMP_SUBJECT)
+  end
+
+  def version_bump_skip_reason(subject, target, target_version)
+    version = version_from_bump_subject(subject)
+    return unless version && target_version
+
+    comparison = compare_versions(target_version, version)
+    return unless comparison && comparison >= 0
+
+    "target #{target} is already at #{target_version}; skipping version bump to #{version} to avoid " \
+      "regressing or duplicating the target version. If this commit also contains CHANGELOG changes, " \
+      "use the runbook's manual fallback to take only the CHANGELOG hunks."
+  end
+
+  def version_from_bump_subject(subject)
+    match = subject.match(VERSION_BUMP_SUBJECT)
+    match && match[:version].tr("-", ".")
+  end
+
+  def already_forward_ported_with_x?(sha, target)
+    footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
+    !git("log", target, "--fixed-strings", "--grep=#{footer}", "--format=%H", "--max-count=1").strip.empty?
+  end
+
+  def version_at(ref)
+    version_file = git("show", "#{ref}:#{VERSION_FILE}").strip
+    match = version_file.match(/VERSION\s*=\s*["'](?<version>[^"']+)["']/)
+    match && match[:version]
+  rescue GitError
+    nil
+  end
+
+  def compare_versions(left, right)
+    left_version = parse_version(left)
+    right_version = parse_version(right)
+    return unless left_version && right_version
+
+    base_comparison = left_version.fetch(:base) <=> right_version.fetch(:base)
+    return base_comparison unless base_comparison.zero?
+
+    compare_prerelease(left_version.fetch(:prerelease), right_version.fetch(:prerelease))
+  end
+
+  def parse_version(version)
+    normalized = version.to_s.delete_prefix("v").tr("-", ".")
+    match = normalized.match(
+      /\A(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:\.(?<label>[A-Za-z]+)(?:\.?(?<number>\d+))?)?\z/
+    )
+    return unless match
+
+    {
+      base: [match[:major].to_i, match[:minor].to_i, match[:patch].to_i],
+      prerelease: prerelease_from_match(match)
+    }
+  end
+
+  def prerelease_from_match(match)
+    return nil unless match[:label]
+
+    {
+      label: match[:label].downcase,
+      number: match[:number] ? match[:number].to_i : 0
+    }
+  end
+
+  def compare_prerelease(left, right)
+    return 0 if left.nil? && right.nil?
+    return 1 if left.nil?
+    return -1 if right.nil?
+
+    label_comparison = prerelease_rank(left.fetch(:label)) <=> prerelease_rank(right.fetch(:label))
+    return label_comparison unless label_comparison.zero?
+
+    left.fetch(:number) <=> right.fetch(:number)
+  end
+
+  def prerelease_rank(label)
+    {
+      "dev" => 0,
+      "test" => 1,
+      "alpha" => 2,
+      "beta" => 3,
+      "pre" => 4,
+      "rc" => 5
+    }.fetch(label, -1)
+  end
+
+  def print_plan(source, target, target_version, plan)
+    puts "Release forward-port plan"
+    puts "  source: #{source}"
+    puts "  target: #{target}"
+    puts "  target version: #{target_version || 'UNKNOWN'}"
+    puts
+
+    if plan.empty?
+      puts "No commits found in #{target}..#{source}."
+      return
+    end
+
+    plan.each { |entry| print_plan_entry(entry) }
+
+    picks = plan.count { |entry| entry.action == :pick }
+    skips = plan.length - picks
+    puts
+    puts "Summary: #{picks} commit#{'s' unless picks == 1} to cherry-pick, " \
+         "#{skips} commit#{'s' unless skips == 1} skipped."
+  end
+
+  def print_plan_entry(entry)
+    case entry.action
+    when :pick
+      puts "PICK #{entry.short_sha} #{entry.subject}"
+    when :skip
+      puts "SKIP #{entry.short_sha} #{entry.subject}"
+      puts "     #{entry.reason}"
+    end
+  end
+
+  def ensure_clean_worktree!
+    return if git("status", "--porcelain").strip.empty?
+
+    raise GitError, "working tree is not clean; commit, stash, or discard local changes before normal mode"
+  end
+
+  def ensure_local_target_branch!(target)
+    run_git("show-ref", "--verify", "--quiet", "refs/heads/#{target}") do |_stdout, stderr, status|
+      next if status.success?
+
+      raise GitError, "normal mode target must be a local branch (got #{target.inspect}): #{stderr.strip}"
+    end
+  end
+
+  def checkout_target!(target)
+    puts "\nChecking out #{target}..."
+    git!("checkout", target)
+  end
+
+  def apply_plan(plan)
+    picks = plan.select { |entry| entry.action == :pick }
+
+    if picks.empty?
+      puts "\nNothing to cherry-pick."
+      return 0
+    end
+
+    picks.each do |entry|
+      puts "\nCherry-picking #{entry.short_sha} #{entry.subject}"
+      stdout, stderr, status = capture_git("cherry-pick", "-x", entry.sha)
+      puts stdout unless stdout.empty?
+      warn stderr unless stderr.empty?
+      next if status.success?
+
+      warn "Cherry-pick failed for #{entry.sha}."
+      warn "Resolve the conflict and run git cherry-pick --continue, or run git cherry-pick --abort."
+      return status.exitstatus || 1
+    end
+
+    puts "\nForward-port complete."
+    0
+  end
+
+  def verify_ref!(ref, label:)
+    git("rev-parse", "--verify", "#{ref}^{commit}")
+  rescue GitError => e
+    raise GitError, "#{label} ref #{ref.inspect} is not a commit: #{e.message}"
+  end
+
+  def git_lines(*)
+    output = git(*)
+    output.lines.map(&:strip).reject(&:empty?)
+  end
+
+  def git!(*args)
+    stdout, stderr, status = capture_git(*args)
+    raise GitError, git_error(args, stdout, stderr, status) unless status.success?
+
+    stdout
+  end
+
+  def git(*)
+    git!(*)
+  end
+
+  def capture_git(*)
+    Open3.capture3("git", *)
+  end
+
+  def run_git(*)
+    stdout, stderr, status = capture_git(*)
+    yield(stdout, stderr, status)
+  end
+
+  def git_error(args, stdout, stderr, status)
+    message = ["git #{args.join(' ')} failed with status #{status.exitstatus}"]
+    message << stderr.strip unless stderr.strip.empty?
+    message << stdout.strip unless stdout.strip.empty?
+    message.join(": ")
+  end
+end
+# rubocop:enable Metrics/ClassLength
+
+exit ReleaseForwardPort.new(ARGV).run if $PROGRAM_NAME == __FILE__

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -12,11 +12,11 @@ class ReleaseForwardPort
   # always `X.Y.Z.rc.N`). A versionless `1.0.0.rc` is intentionally NOT matched
   # here; it falls through to the version-drift path in version_bump_skip_reason.
   RC_VERSION_BUMP_SUBJECT = /
-    \Abump\s+version\s+to\s+v?\d+\.\d+\.\d+(?:[.-]rc[.-]?\d+|\.rc\.\d+)\b
+    \Abump\s+version\s+to\s+v?\d+\.\d+\.\d+[.-]rc[.-]?\d+\b
   /ix
   VERSION_BUMP_SUBJECT = /
     \Abump\s+version\s+to\s+v?
-    (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev)(?:[.-]?\d+)?)?)\b
+    (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?)?)\b
   /ix
   CHERRY_PICK_FOOTER_PREFIX = "(cherry picked from commit "
 
@@ -121,7 +121,7 @@ class ReleaseForwardPort
   end
 
   def source_only_commits(source, target)
-    git_lines("rev-list", "--reverse", "#{target}..#{source}")
+    git_lines("rev-list", "--reverse", "--no-merges", "#{target}..#{source}")
   end
 
   def patch_equivalent_candidates(source, target)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -152,7 +152,7 @@ class ReleaseForwardPort
     end
 
     if already_forward_ported_with_x?(sha, target)
-      return "already forward-ported to #{target} via cherry-pick -x evidence"
+      return "already forward-ported to #{target} via cherry-pick -x evidence and current target tree"
     end
 
     if patch_equivalent_commits[sha] && patch_present_on_target_tree?(sha, target)
@@ -187,7 +187,9 @@ class ReleaseForwardPort
     footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
     # This history search can false-positive if a later target commit quotes the
     # footer verbatim. The runbook documents that boundary for release operators.
-    !git("log", target, "--fixed-strings", "--grep", footer, "--format=%H", "--max-count=1").strip.empty?
+    return false if git("log", target, "--fixed-strings", "--grep", footer, "--format=%H", "--max-count=1").strip.empty?
+
+    patch_present_on_target_tree?(sha, target)
   end
 
   def patch_present_on_target_tree?(sha, target)
@@ -206,6 +208,8 @@ class ReleaseForwardPort
     match = version_file.match(/VERSION\s*=\s*["'](?<version>[^"']+)["']/)
     match && match[:version]
   rescue GitError
+    warn "WARNING: unable to read #{VERSION_FILE} at #{ref}; " \
+         "version-drift guard is disabled for non-RC version bump commits."
     nil
   end
 
@@ -335,7 +339,7 @@ class ReleaseForwardPort
       next if status.success?
 
       warn_cherry_pick_conflict(entry, remaining: picks.length - index - 1)
-      return status.exitstatus || 1
+      return 1
     end
 
     puts "\nForward-port complete."

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -3,7 +3,6 @@
 
 require "optparse"
 require "open3"
-require "tmpdir"
 
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
@@ -26,6 +25,7 @@ class ReleaseForwardPort
     "pre" => 4,
     "rc" => 5
   }.freeze
+  EMPTY_PATCH_ID = "__empty_patch__"
   CHERRY_PICK_FOOTER_PREFIX = "(cherry picked from commit "
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, keyword_init: true) do
@@ -167,8 +167,8 @@ class ReleaseForwardPort
       return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert"
     end
 
-    if patch_equivalent_commits[sha] && patch_present_on_target_tree?(sha, target)
-      return "patch already exists on #{target} according to the current target tree"
+    if patch_equivalent_commits[sha] && patch_equivalent_commit_present_on_target?(sha, target)
+      return "patch already exists on #{target} according to target history with no later standard revert"
     end
 
     version_bump_skip_reason(subject, target, target_version)
@@ -218,17 +218,32 @@ class ReleaseForwardPort
     !git("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H", "--max-count=1").strip.empty?
   end
 
-  def patch_present_on_target_tree?(sha, target)
-    patch = git("show", "--format=", "--binary", "--full-index", "--find-renames", sha)
+  def patch_equivalent_commit_present_on_target?(sha, target)
+    source_patch_id = patch_id_for_commit(sha)
+    return true if source_patch_id == EMPTY_PATCH_ID
+
+    patch_equivalent_target_candidates(sha, target).any? do |target_sha|
+      patch_id_for_commit(target_sha) == source_patch_id && !standard_revert_on_target?(target_sha, target)
+    end
+  end
+
+  def patch_equivalent_target_candidates(sha, target)
+    paths = git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+    return [] if paths.empty?
+
+    git_lines("log", target, "--format=%H", "--no-merges", "--", *paths)
+  end
+
+  def patch_id_for_commit(sha)
+    patch = git("show", "--format=", "--full-index", "--find-renames", sha)
     # Empty commits carry no file changes; cherry-picking them would only create
     # a no-op commit, so treat the patch as already present.
-    return true if patch.strip.empty?
+    return EMPTY_PATCH_ID if patch.strip.empty?
 
-    with_temporary_index(target) do |env|
-      _stdout, _stderr, status =
-        capture_git(*%w[apply --cached --reverse --check], env:, stdin_data: patch)
-      status.success?
-    end
+    stdout, stderr, status = capture_git("patch-id", "--stable", stdin_data: patch)
+    raise GitError, git_error(["patch-id", "--stable", sha], stdout, stderr, status) unless status.success?
+
+    stdout.split.first
   end
 
   def version_at(ref)
@@ -396,17 +411,6 @@ class ReleaseForwardPort
     git("rev-parse", "--verify", "#{ref}^{commit}")
   rescue GitError => e
     raise GitError, "#{label} ref #{ref.inspect} is not a commit: #{e.message}"
-  end
-
-  def with_temporary_index(target)
-    Dir.mktmpdir("release-forward-port-index") do |dir|
-      index_path = File.join(dir, "index")
-      env = { "GIT_INDEX_FILE" => index_path }
-      stdout, stderr, status = capture_git("read-tree", target, env:)
-      raise GitError, git_error(["read-tree", target], stdout, stderr, status) unless status.success?
-
-      yield env
-    end
   end
 
   # The repo requires Ruby >= 3.3, so anonymous forwarding is valid and keeps

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -49,9 +49,9 @@ class ReleaseForwardPort
     ensure_local_target_branch!(target) unless @options[:dry_run]
 
     commits = source_only_commits(source, target)
-    equivalent_commits = patch_equivalent_commits(source, target)
+    equiv_commits = patch_equivalent_commits(source, target)
     target_version = version_at(target)
-    plan = build_plan(commits, target, target_version, equivalent_commits)
+    plan = build_plan(commits, target, target_version, equiv_commits)
 
     print_plan(source, target, target_version, plan)
 
@@ -182,6 +182,8 @@ class ReleaseForwardPort
 
   def already_forward_ported_with_x?(sha, target)
     footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
+    # This history search can false-positive if a later target commit quotes the
+    # footer verbatim. The runbook documents that boundary for release operators.
     !git("log", target, "--fixed-strings", "--grep=#{footer}", "--format=%H", "--max-count=1").strip.empty?
   end
 
@@ -245,10 +247,10 @@ class ReleaseForwardPort
       "beta" => 3,
       "pre" => 4,
       "rc" => 5
-      # Unknown labels rank as release-candidate (5) rather than below `dev`, so a
-      # novel marker like `1.0.0.snapshot` is treated as release-like instead of
-      # silently ranking below every known prerelease. Expand the table if the
-      # project adopts new prerelease markers.
+      # Unknown labels tie with `rc` instead of ranking below `dev`. That treats
+      # a novel marker like `1.0.0.snapshot` as a late-stage prerelease for
+      # version-drift detection. Expand the table if the project adopts new
+      # prerelease markers.
     }.fetch(label, 5)
   end
 
@@ -346,6 +348,8 @@ class ReleaseForwardPort
     raise GitError, "#{label} ref #{ref.inspect} is not a commit: #{e.message}"
   end
 
+  # The repo requires Ruby >= 3.3, so anonymous forwarding is valid and keeps
+  # these small git wrappers aligned with RuboCop's preferred style.
   def git_lines(*)
     output = git(*)
     output.lines.map(&:strip).reject(&:empty?)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -18,6 +18,14 @@ class ReleaseForwardPort
     \Abump\s+version\s+to\s+v?
     (?<version>\d+\.\d+\.\d+(?:(?:[.-])(?:alpha|beta|rc|pre|dev|test)(?:[.-]?\d+)?)?)\b
   /ix
+  PRERELEASE_RANKS = {
+    "dev" => 0,
+    "test" => 1,
+    "alpha" => 2,
+    "beta" => 3,
+    "pre" => 4,
+    "rc" => 5
+  }.freeze
   CHERRY_PICK_FOOTER_PREFIX = "(cherry picked from commit "
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, keyword_init: true) do
@@ -210,7 +218,13 @@ class ReleaseForwardPort
   def version_at(ref)
     version_file = git("show", "#{ref}:#{VERSION_FILE}").strip
     match = version_file.match(/VERSION\s*=\s*["'](?<version>[^"']+)["']/)
-    match && match[:version]
+    unless match
+      warn "WARNING: VERSION constant not found in #{VERSION_FILE} at #{ref}; " \
+           "version-drift guard is disabled for non-RC version bump commits."
+      return nil
+    end
+
+    match[:version]
   rescue GitError
     warn "WARNING: unable to read #{VERSION_FILE} at #{ref}; " \
          "version-drift guard is disabled for non-RC version bump commits."
@@ -255,25 +269,20 @@ class ReleaseForwardPort
     return 1 if left.nil?
     return -1 if right.nil?
 
-    label_comparison = prerelease_rank(left.fetch(:label)) <=> prerelease_rank(right.fetch(:label))
+    left_rank = prerelease_rank(left.fetch(:label))
+    right_rank = prerelease_rank(right.fetch(:label))
+    return unless left_rank && right_rank
+
+    label_comparison = left_rank <=> right_rank
     return label_comparison unless label_comparison.zero?
 
     left.fetch(:number) <=> right.fetch(:number)
   end
 
   def prerelease_rank(label)
-    {
-      "dev" => 0,
-      "test" => 1,
-      "alpha" => 2,
-      "beta" => 3,
-      "pre" => 4,
-      "rc" => 5
-      # Unknown labels tie with `rc` instead of ranking below `dev`. That treats
-      # a novel marker like `1.0.0.snapshot` as a late-stage prerelease for
-      # version-drift detection. Expand the table if the project adopts new
-      # prerelease markers.
-    }.fetch(label, 5)
+    # Unknown labels disable version-bump skipping. Picking an uncertain bump is
+    # safer than silently dropping a version commit that may still be needed.
+    PRERELEASE_RANKS[label]
   end
 
   def print_plan(source, target, target_version, plan)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -162,6 +162,8 @@ class ReleaseForwardPort
   end
 
   def patch_equivalent_candidates(source, target)
+    # git cherry uses patch-id, which covers content hunks but not mode-only
+    # changes. Mode-only commit idempotency is covered by the -x footer path.
     git_lines("cherry", target, source).each_with_object({}) do |line, commits|
       marker, sha = line.split(/\s+/, 2)
       commits[sha] = true if marker == "-"
@@ -226,6 +228,7 @@ class ReleaseForwardPort
     reason.start_with?(
       "merge commit; inspect manually",
       "reverts a release-only application",
+      "reverts a release-branch merge commit",
       "stable release version bump commit"
     )
   end
@@ -296,15 +299,20 @@ class ReleaseForwardPort
   def reverse_pick_revert_skip_reason(sha, target)
     reverted_sha = standard_revert_target(sha)
     return unless reverted_sha && commit_exists?(reverted_sha)
+    return merge_revert_skip_reason(target) if merge_commit?(reverted_sha)
     return unless reverted_commit_live_on_target?(reverted_sha, target)
 
     "reverts a release-only application of a commit already live on #{target}; inspect manually " \
       "before applying this rollback to #{target}"
   end
 
+  def merge_revert_skip_reason(target)
+    "reverts a release-branch merge commit; inspect manually before applying this rollback to #{target}"
+  end
+
   def standard_revert_target(sha)
     body = git("log", "-1", "--format=%B", sha)
-    match = body.match(/This reverts commit (?<sha>[0-9a-f]{40})\./)
+    match = body.match(/This reverts commit (?<sha>[0-9a-f]{40})[.,]/)
     match && match[:sha]
   end
 
@@ -713,9 +721,9 @@ class ReleaseForwardPort
     stdout
   end
 
-  def capture_git(*, env: {}, stdin_data: nil)
-    merged_env = { "GIT_TERMINAL_PROMPT" => "0", "GIT_PAGER" => "cat" }.merge(env)
-    Open3.capture3(merged_env, "git", *, stdin_data:)
+  def capture_git(*, stdin_data: nil)
+    git_env = { "GIT_TERMINAL_PROMPT" => "0", "GIT_PAGER" => "cat" }
+    Open3.capture3(git_env, "git", *, stdin_data:)
   end
 
   def run_git(*)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -3,7 +3,7 @@
 
 require "optparse"
 require "open3"
-require "tempfile"
+require "tmpdir"
 
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
@@ -50,7 +50,7 @@ class ReleaseForwardPort
     ensure_local_target_branch!(target) unless @options[:dry_run]
 
     commits = source_only_commits(source, target)
-    equiv_commits = patch_equivalent_commits(source, target)
+    equiv_commits = patch_equivalent_candidates(source, target)
     target_version = version_at(target)
     plan = build_plan(commits, target, target_version, equiv_commits)
 
@@ -124,10 +124,10 @@ class ReleaseForwardPort
     git_lines("rev-list", "--reverse", "#{target}..#{source}")
   end
 
-  def patch_equivalent_commits(source, target)
+  def patch_equivalent_candidates(source, target)
     git_lines("cherry", target, source).each_with_object({}) do |line, commits|
       marker, sha = line.split(/\s+/, 2)
-      commits[sha] = true if marker == "-" && patch_present_on_target_tree?(sha, target)
+      commits[sha] = true if marker == "-"
     end
   end
 
@@ -155,7 +155,9 @@ class ReleaseForwardPort
       return "already forward-ported to #{target} via cherry-pick -x evidence"
     end
 
-    return "patch already exists on #{target} according to the current target tree" if patch_equivalent_commits[sha]
+    if patch_equivalent_commits[sha] && patch_present_on_target_tree?(sha, target)
+      return "patch already exists on #{target} according to the current target tree"
+    end
 
     version_bump_skip_reason(subject, target, target_version)
   end
@@ -362,17 +364,13 @@ class ReleaseForwardPort
   end
 
   def with_temporary_index(target)
-    Tempfile.create("release-forward-port-index") do |file|
-      index_path = file.path
-      file.close
-      File.delete(index_path)
+    Dir.mktmpdir("release-forward-port-index") do |dir|
+      index_path = File.join(dir, "index")
       env = { "GIT_INDEX_FILE" => index_path }
       stdout, stderr, status = capture_git("read-tree", target, env:)
       raise GitError, git_error(["read-tree", target], stdout, stderr, status) unless status.success?
 
       yield env
-    ensure
-      File.delete(index_path) if index_path && File.exist?(index_path)
     end
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -204,6 +204,8 @@ class ReleaseForwardPort
   end
 
   def already_forward_ported_with_x?(sha, target)
+    return true if source_cherry_pick_origin_on_target?(sha, target)
+
     footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
     # This history search can false-positive if a later target commit quotes the
     # footer verbatim. The runbook documents that boundary for release operators.
@@ -216,10 +218,31 @@ class ReleaseForwardPort
     forwarded_shas.any? { |forwarded_sha| !standard_revert_on_target?(forwarded_sha, target) }
   end
 
+  def source_cherry_pick_origin_on_target?(sha, target)
+    origin_sha = cherry_pick_origin(sha)
+    origin_sha && commit_on_target?(origin_sha, target) && !standard_revert_on_target?(origin_sha, target)
+  end
+
+  def cherry_pick_origin(sha)
+    body = git("log", "-1", "--format=%B", sha)
+    match = body.match(/\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/)
+    match && match[:sha]
+  end
+
+  def commit_on_target?(sha, target)
+    _stdout, _stderr, status = capture_git("merge-base", "--is-ancestor", sha, target)
+    status.success?
+  end
+
   def standard_revert_on_target?(sha, target)
+    @standard_revert_cache ||= {}
+    cache_key = [sha, target]
+    return @standard_revert_cache.fetch(cache_key) if @standard_revert_cache.key?(cache_key)
+
     revert_message = "This reverts commit #{sha}."
     revert_shas = git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
-    revert_shas.any? { |revert_sha| !standard_revert_on_target?(revert_sha, target) }
+    @standard_revert_cache[cache_key] =
+      revert_shas.any? { |revert_sha| !standard_revert_on_target?(revert_sha, target) }
   end
 
   def patch_equivalent_commit_present_on_target?(sha, target)
@@ -245,7 +268,7 @@ class ReleaseForwardPort
     return EMPTY_PATCH_ID if patch.strip.empty?
 
     stdout, stderr, status = capture_git("patch-id", "--stable", stdin_data: patch)
-    raise GitError, git_error(["patch-id", "--stable", sha], stdout, stderr, status) unless status.success?
+    raise GitError, "#{git_error(['patch-id', '--stable'], stdout, stderr, status)} for #{sha}" unless status.success?
 
     patch_id = stdout.split.first
     raise GitError, "git patch-id produced no output for #{sha}" if patch_id.nil?

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -167,6 +167,9 @@ class ReleaseForwardPort
       return "merge commit; inspect manually for conflict-resolution hunks before marking forward-port complete"
     end
 
+    reverse_revert_reason = reverse_pick_revert_skip_reason(sha, target)
+    return reverse_revert_reason if reverse_revert_reason
+
     if already_forward_ported_with_x?(sha, target)
       return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert"
     end
@@ -213,6 +216,20 @@ class ReleaseForwardPort
   def version_from_bump_subject(subject)
     match = subject.match(VERSION_BUMP_SUBJECT)
     match && match[:version].tr("-", ".")
+  end
+
+  def reverse_pick_revert_skip_reason(sha, target)
+    reverted_sha = standard_revert_target(sha)
+    return unless reverted_sha && source_cherry_pick_origin_on_target?(reverted_sha, target)
+
+    "reverts a release-only cherry-pick of a commit already live on #{target}; inspect manually " \
+      "before applying this rollback to #{target}"
+  end
+
+  def standard_revert_target(sha)
+    body = git("log", "-1", "--format=%B", sha)
+    match = body.match(/This reverts commit (?<sha>[0-9a-f]{40})\./)
+    match && match[:sha]
   end
 
   def already_forward_ported_with_x?(sha, target)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -180,7 +180,15 @@ class ReleaseForwardPort
 
   def version_bump_skip_reason(subject, target, target_version)
     version = version_from_bump_subject(subject)
-    return unless version && target_version
+    return unless version
+
+    parsed_version = parse_version(version)
+    if parsed_version && parsed_version.fetch(:prerelease).nil?
+      return "stable release version bump commit; use the runbook's manual fallback to take only " \
+             "the CHANGELOG hunks and keep release branch version changes off #{target}"
+    end
+
+    return unless target_version
 
     comparison = compare_versions(target_version, version)
     return unless comparison && comparison >= 0
@@ -212,6 +220,8 @@ class ReleaseForwardPort
 
   def patch_present_on_target_tree?(sha, target)
     patch = git("show", "--format=", "--binary", "--full-index", "--find-renames", sha)
+    # Empty commits carry no file changes; cherry-picking them would only create
+    # a no-op commit, so treat the patch as already present.
     return true if patch.strip.empty?
 
     with_temporary_index(target) do |env|
@@ -359,7 +369,7 @@ class ReleaseForwardPort
       warn stderr unless stderr.empty?
       next if status.success?
 
-      warn_cherry_pick_conflict(entry, remaining: picks.length - index - 1)
+      warn_cherry_pick_conflict(entry, completed: index, remaining: picks.length - index - 1)
       return 1
     end
 
@@ -367,7 +377,7 @@ class ReleaseForwardPort
     0
   end
 
-  def warn_cherry_pick_conflict(entry, remaining:)
+  def warn_cherry_pick_conflict(entry, completed:, remaining:)
     warn "Cherry-pick failed for #{entry.sha}."
     warn "Resolve the conflict and run git cherry-pick --continue to finish THIS commit."
     if remaining.positive?
@@ -376,9 +386,9 @@ class ReleaseForwardPort
            "script/release-forward-port after continuing to apply the rest " \
            "(it is idempotent and skips commits already applied)."
     end
-    warn "If you run git cherry-pick --abort, only the current conflicting commit is abandoned; " \
-         "earlier picks from this run are already committed and safe. Rerun " \
-         "script/release-forward-port after fixing the conflict " \
+    warn "If you run git cherry-pick --abort, only the current conflicting commit is abandoned."
+    warn "Earlier successful picks from this run are already committed and safe." if completed.positive?
+    warn "Rerun script/release-forward-port after fixing the conflict " \
          "(it is idempotent and skips commits already applied)."
   end
 
@@ -415,7 +425,7 @@ class ReleaseForwardPort
   end
 
   def capture_git(*, env: {}, stdin_data: nil)
-    merged_env = { "GIT_TERMINAL_PROMPT" => "0" }.merge(env)
+    merged_env = { "GIT_TERMINAL_PROMPT" => "0", "GIT_PAGER" => "cat" }.merge(env)
     Open3.capture3(merged_env, "git", *, stdin_data:)
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -25,7 +25,9 @@ class ReleaseForwardPort
     "rc" => 5
   }.freeze
   EMPTY_PATCH_ID = "__empty_patch__"
-  CHERRY_PICK_FOOTER_PREFIX = "(cherry picked from commit "
+  CHERRY_PICK_FOOTER_FORMAT = "(cherry picked from commit %s)"
+  CHERRY_PICK_FOOTER_PATTERN = /\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/
+  ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
 
   PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
     def short_sha
@@ -45,6 +47,7 @@ class ReleaseForwardPort
     @explicit_options = { source: false, target: false }
     @options = {
       dry_run: false,
+      ack_manual: [],
       target: "main"
     }
     @parser = build_parser
@@ -58,6 +61,7 @@ class ReleaseForwardPort
 
     verify_ref!(source, label: "source")
     verify_ref!(target, label: "target")
+    normalize_acknowledged_manual_shas!
     ensure_local_target_branch!(target) unless @options[:dry_run]
 
     commits = source_only_commits(source, target)
@@ -68,6 +72,7 @@ class ReleaseForwardPort
     # guard, so normal mode and dry-run report the same plan before refusing to
     # checkout or cherry-pick.
     plan = build_plan(commits, target, target_version, equiv_commits)
+    validate_acknowledged_manual_shas!(plan)
 
     print_plan(source, target, target_version, plan)
 
@@ -109,14 +114,7 @@ class ReleaseForwardPort
 
   def build_parser
     OptionParser.new do |parser|
-      parser.banner = <<~BANNER
-        Usage: script/release-forward-port --source release/X.Y.Z [--target main] [--dry-run]
-               script/release-forward-port release/X.Y.Z [main] [--dry-run]
-
-        Forward-port commits that are on a release branch but not on the target branch.
-        The helper cherry-picks with -x, skips commits already forward-ported with -x
-        evidence or patches present in the target tree, and excludes RC version bump commits.
-      BANNER
+      parser.banner = usage_banner
 
       parser.on("--source REF", "Release branch or ref to forward-port from") do |source|
         @options[:source] = source
@@ -129,10 +127,31 @@ class ReleaseForwardPort
       parser.on("--dry-run", "Print the plan without checking out or cherry-picking") do
         @options[:dry_run] = true
       end
+      add_ack_manual_option(parser)
       parser.on("-h", "--help", "Show this help") do
         puts parser
         exit 0
       end
+    end
+  end
+
+  def usage_banner
+    <<~BANNER
+      Usage: script/release-forward-port --source release/X.Y.Z [--target main] [--dry-run]
+             script/release-forward-port release/X.Y.Z [main] [--dry-run]
+
+      Forward-port commits that are on a release branch but not on the target branch.
+      The helper cherry-picks with -x, skips commits already forward-ported with -x
+      evidence or patches present in the target tree, and excludes RC version bump commits.
+    BANNER
+  end
+
+  def add_ack_manual_option(parser)
+    parser.on(
+      "--ack-manual SHA",
+      "Acknowledge an inspected MANUAL commit and skip it in normal mode (repeatable)"
+    ) do |sha|
+      @options[:ack_manual] << sha
     end
   end
 
@@ -211,7 +230,9 @@ class ReleaseForwardPort
     reverted_sha = standard_revert_target(sha)
     return unless reverted_sha
 
-    reverted_subject = git("log", "-1", "--format=%s", reverted_sha).strip
+    reverted_subject = subject_for_commit(reverted_sha)
+    return unless reverted_subject
+
     return unless skipped_version_bump_subject?(reverted_subject, target, target_version)
 
     "reverts a release-only version bump that is skipped for #{target}; skipping this revert avoids " \
@@ -268,7 +289,8 @@ class ReleaseForwardPort
 
   def reverse_pick_revert_skip_reason(sha, target)
     reverted_sha = standard_revert_target(sha)
-    return unless reverted_sha && reverted_commit_live_on_target?(reverted_sha, target)
+    return unless reverted_sha && commit_exists?(reverted_sha)
+    return unless reverted_commit_live_on_target?(reverted_sha, target)
 
     "reverts a release-only application of a commit already live on #{target}; inspect manually " \
       "before applying this rollback to #{target}"
@@ -287,7 +309,7 @@ class ReleaseForwardPort
   def already_forward_ported_with_x?(sha, target)
     return true if source_cherry_pick_origin_on_target?(sha, target)
 
-    footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
+    footer = format(CHERRY_PICK_FOOTER_FORMAT, sha)
     # This history search can false-positive if a later target commit quotes the
     # footer verbatim. The runbook documents that boundary for release operators.
     forwarded_shas = git_lines("log", target, "--fixed-strings", "--grep", footer, "--format=%H")
@@ -310,7 +332,7 @@ class ReleaseForwardPort
 
   def cherry_pick_origin(sha)
     body = git("log", "-1", "--format=%B", sha)
-    match = body.match(/\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/)
+    match = body.match(CHERRY_PICK_FOOTER_PATTERN)
     match && match[:sha]
   end
 
@@ -355,10 +377,10 @@ class ReleaseForwardPort
   end
 
   def patch_id_for_commit(sha)
-    patch = git("show", "--format=", "--full-index", "--find-renames", sha)
+    patch = git("show", "--format=", "--full-index", "--find-renames", sha).b
     # Empty commits carry no file changes; cherry-picking them would only create
     # a no-op commit, so treat the patch as already present.
-    return EMPTY_PATCH_ID if patch.strip.empty?
+    return EMPTY_PATCH_ID if empty_patch?(patch)
 
     stdout, stderr, status = capture_git("patch-id", "--stable", stdin_data: patch)
     raise GitError, "#{git_error(['patch-id', '--stable'], stdout, stderr, status)} for #{sha}" unless status.success?
@@ -458,15 +480,36 @@ class ReleaseForwardPort
   end
 
   def plan_summary(plan)
+    counts = plan_counts(plan)
+    parts = [
+      "#{commit_count(counts.fetch(:picks))} to cherry-pick",
+      "#{commit_count(counts.fetch(:skips))} skipped"
+    ]
+    parts << "#{commit_count(counts.fetch(:acknowledged_manual))} acknowledged manual skipped" if
+      counts.fetch(:acknowledged_manual).positive?
+    parts << manual_inspection_summary(counts.fetch(:manual)) if counts.fetch(:manual).positive?
+    "Summary: #{parts.join(', ')}."
+  end
+
+  def plan_counts(plan)
     picks = plan.count { |entry| entry.action == :pick }
-    manual = plan.count(&:manual?)
-    skips = plan.length - picks - manual
-    summary = "Summary: #{picks} commit#{'s' unless picks == 1} to cherry-pick, " \
-              "#{skips} commit#{'s' unless skips == 1} skipped"
-    if manual.positive?
-      summary += ", #{manual} commit#{'s' unless manual == 1} need#{'s' if manual == 1} manual inspection"
-    end
-    "#{summary}."
+    acknowledged_manual = plan.count { |entry| acknowledged_manual_entry?(entry) }
+    manual = plan.count { |entry| entry.manual? && !acknowledged_manual_entry?(entry) }
+
+    {
+      picks:,
+      acknowledged_manual:,
+      manual:,
+      skips: plan.length - picks - manual - acknowledged_manual
+    }
+  end
+
+  def commit_count(count)
+    "#{count} commit#{'s' unless count == 1}"
+  end
+
+  def manual_inspection_summary(count)
+    "#{commit_count(count)} #{count == 1 ? 'needs' : 'need'} manual inspection"
   end
 
   def print_plan_entry(entry)
@@ -474,8 +517,10 @@ class ReleaseForwardPort
     when :pick
       puts "PICK #{entry.short_sha} #{entry.subject}"
     when :skip
-      puts "#{entry.manual? ? 'MANUAL' : 'SKIP'} #{entry.short_sha} #{entry.subject}"
+      puts "#{plan_entry_label(entry)} #{entry.short_sha} #{entry.subject}"
       puts "     #{entry.reason}"
+      puts "     acknowledged by --ack-manual; skipping after operator inspection" if
+        acknowledged_manual_entry?(entry)
     else
       raise GitError, "unexpected plan entry action: #{entry.action.inspect}"
     end
@@ -510,9 +555,10 @@ class ReleaseForwardPort
     completed_picks = 0
     plan.each_with_index do |entry, index|
       next if entry.action == :skip && !entry.manual?
+      next if acknowledged_manual_entry?(entry)
 
       if entry.manual?
-        warn_manual_entry(entry, completed: completed_picks, remaining: remaining_actionable_entries(plan, index))
+        warn_manual_entry(entry, completed: completed_picks, remaining: remaining_picks(plan, index))
         return 1
       end
 
@@ -530,11 +576,7 @@ class ReleaseForwardPort
   end
 
   def actionable_plan?(plan)
-    plan.any? { |entry| entry.action == :pick || entry.manual? }
-  end
-
-  def remaining_actionable_entries(plan, index)
-    plan[index + 1..].count { |entry| entry.action == :pick || entry.manual? }
+    plan.any? { |entry| entry.action == :pick || (entry.manual? && !acknowledged_manual_entry?(entry)) }
   end
 
   def remaining_picks(plan, index)
@@ -568,7 +610,9 @@ class ReleaseForwardPort
   def warn_manual_entry(entry, completed:, remaining:)
     warn "Manual inspection required for #{entry.sha}."
     warn entry.reason
-    warn_later_commits(remaining, "after resolving the manual item", continue_context: false)
+    warn "After inspection, apply any needed manual hunks so a rerun can skip this commit, or rerun with " \
+         "--ack-manual #{entry.sha} to record a no-hunks-needed decision and continue."
+    warn_later_commits(remaining, "after acknowledging the manual item", continue_context: false)
     warn "Earlier successful picks from this run are already committed and safe." if completed.positive?
   end
 
@@ -583,10 +627,55 @@ class ReleaseForwardPort
   end
 
   def cherry_pick_in_progress?
-    path = git("rev-parse", "--path-format=absolute", "--git-path", "CHERRY_PICK_HEAD").strip
+    git_dir = git("rev-parse", "--git-dir").strip
+    path = File.expand_path("CHERRY_PICK_HEAD", git_dir)
     File.exist?(path)
   rescue GitError
     false
+  end
+
+  def normalize_acknowledged_manual_shas!
+    @acknowledged_manual_shas = @options.fetch(:ack_manual).map do |sha|
+      git("rev-parse", "--verify", "#{sha}^{commit}").strip
+    rescue GitError => e
+      raise GitError, "--ack-manual #{sha.inspect} is not a commit: #{e.message}"
+    end.uniq
+  end
+
+  def validate_acknowledged_manual_shas!(plan)
+    return if @acknowledged_manual_shas.empty?
+
+    manual_shas = plan.select(&:manual?).map(&:sha)
+    unmatched = @acknowledged_manual_shas - manual_shas
+    return if unmatched.empty?
+
+    raise UsageError, "--ack-manual only accepts commits currently marked MANUAL in the plan; " \
+                      "unmatched: #{unmatched.join(', ')}"
+  end
+
+  def acknowledged_manual_entry?(entry)
+    entry.manual? && @acknowledged_manual_shas&.include?(entry.sha)
+  end
+
+  def plan_entry_label(entry)
+    return "ACK-MANUAL" if acknowledged_manual_entry?(entry)
+
+    entry.manual? ? "MANUAL" : "SKIP"
+  end
+
+  def subject_for_commit(sha)
+    git("log", "-1", "--format=%s", sha).strip
+  rescue GitError
+    nil
+  end
+
+  def commit_exists?(sha)
+    _stdout, _stderr, status = capture_git("cat-file", "-e", "#{sha}^{commit}")
+    status.success?
+  end
+
+  def empty_patch?(patch)
+    patch.each_byte.all? { |byte| ASCII_WHITESPACE_BYTES.include?(byte) }
   end
 
   def verify_ref!(ref, label:)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -3,6 +3,7 @@
 
 require "optparse"
 require "open3"
+require "tempfile"
 
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
@@ -98,7 +99,7 @@ class ReleaseForwardPort
 
         Forward-port commits that are on a release branch but not on the target branch.
         The helper cherry-picks with -x, skips commits already forward-ported with -x
-        evidence or equivalent patches, and excludes RC version bump commits.
+        evidence or patches present in the target tree, and excludes RC version bump commits.
       BANNER
 
       parser.on("--source REF", "Release branch or ref to forward-port from") do |source|
@@ -126,7 +127,7 @@ class ReleaseForwardPort
   def patch_equivalent_commits(source, target)
     git_lines("cherry", target, source).each_with_object({}) do |line, commits|
       marker, sha = line.split(/\s+/, 2)
-      commits[sha] = true if marker == "-"
+      commits[sha] = true if marker == "-" && patch_present_on_target_tree?(sha, target)
     end
   end
 
@@ -154,7 +155,7 @@ class ReleaseForwardPort
       return "already forward-ported to #{target} via cherry-pick -x evidence"
     end
 
-    return "patch already exists on #{target} according to git cherry" if patch_equivalent_commits[sha]
+    return "patch already exists on #{target} according to the current target tree" if patch_equivalent_commits[sha]
 
     version_bump_skip_reason(subject, target, target_version)
   end
@@ -184,7 +185,18 @@ class ReleaseForwardPort
     footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
     # This history search can false-positive if a later target commit quotes the
     # footer verbatim. The runbook documents that boundary for release operators.
-    !git("log", target, "--fixed-strings", "--grep=#{footer}", "--format=%H", "--max-count=1").strip.empty?
+    !git("log", target, "--fixed-strings", "--grep", footer, "--format=%H", "--max-count=1").strip.empty?
+  end
+
+  def patch_present_on_target_tree?(sha, target)
+    patch = git("show", "--format=", "--binary", "--full-index", "--find-renames", sha)
+    return false if patch.strip.empty?
+
+    with_temporary_index(target) do |env|
+      _stdout, _stderr, status =
+        capture_git(*%w[apply --cached --reverse --check], env:, stdin_data: patch)
+      status.success?
+    end
   end
 
   def version_at(ref)
@@ -293,9 +305,10 @@ class ReleaseForwardPort
 
   def ensure_local_target_branch!(target)
     run_git("show-ref", "--verify", "--quiet", "refs/heads/#{target}") do |_stdout, stderr, status|
-      next if status.success?
-
-      raise GitError, "normal mode target must be a local branch (got #{target.inspect}): #{stderr.strip}"
+      unless status.success?
+        raise GitError,
+              "normal mode target must be a local branch (got #{target.inspect}): #{stderr.strip}"
+      end
     end
   end
 
@@ -348,8 +361,25 @@ class ReleaseForwardPort
     raise GitError, "#{label} ref #{ref.inspect} is not a commit: #{e.message}"
   end
 
+  def with_temporary_index(target)
+    Tempfile.create("release-forward-port-index") do |file|
+      index_path = file.path
+      file.close
+      File.delete(index_path)
+      env = { "GIT_INDEX_FILE" => index_path }
+      stdout, stderr, status = capture_git("read-tree", target, env:)
+      raise GitError, git_error(["read-tree", target], stdout, stderr, status) unless status.success?
+
+      yield env
+    ensure
+      File.delete(index_path) if index_path && File.exist?(index_path)
+    end
+  end
+
   # The repo requires Ruby >= 3.3, so anonymous forwarding is valid and keeps
-  # these small git wrappers aligned with RuboCop's preferred style.
+  # these small git wrappers aligned with RuboCop's preferred style. Both git!
+  # and git raise on failure; capture_git/run_git are the non-raising escape
+  # hatches.
   def git_lines(*)
     output = git(*)
     output.lines.map(&:strip).reject(&:empty?)
@@ -366,8 +396,8 @@ class ReleaseForwardPort
     git!(*)
   end
 
-  def capture_git(*)
-    Open3.capture3("git", *)
+  def capture_git(*, env: {}, stdin_data: nil)
+    Open3.capture3(env, "git", *, stdin_data:)
   end
 
   def run_git(*)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -192,12 +192,14 @@ class ReleaseForwardPort
     special_reason = special_skip_reason(sha, subject, target, target_version)
     return special_reason if special_reason
 
-    return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert" if
+    return "already forward-ported to #{target} via cherry-pick -x evidence with no later target revert" if
       already_forward_ported_with_x?(sha, target)
 
     return "empty commit; cherry-picking would only create a no-op commit on #{target}" if
       patch_id_for_commit(sha) == EMPTY_PATCH_ID
 
+    # Origin was reverted on target: the fix was applied and then undone, so
+    # re-apply it even if git cherry reports a patch match.
     return if source_cherry_pick_origin_reverted_on_target?(sha, target)
 
     if patch_equivalent_commits[sha] &&
@@ -344,20 +346,20 @@ class ReleaseForwardPort
     forwarded_shas = git_lines("log", target, "--fixed-strings", "--grep", footer, "--format=%H")
     return false if forwarded_shas.empty?
 
-    # True if at least one copy of the cherry-pick is still live on the target
-    # (that is, not followed by a live standard git revert). Multiple copies are
-    # fine: pick -> revert -> re-pick is handled because the re-pick copy passes.
-    forwarded_shas.any? { |forwarded_sha| !standard_revert_on_target?(forwarded_sha, target) }
+    # True if at least one copy of the cherry-pick is still live on the target.
+    # Multiple copies are fine: pick -> revert -> re-pick is handled because the
+    # re-pick copy passes.
+    forwarded_shas.any? { |forwarded_sha| target_commit_live_on_target?(forwarded_sha, target) }
   end
 
   def source_cherry_pick_origin_on_target?(sha, target)
     origin_sha = cherry_pick_origin(sha)
-    origin_sha && commit_on_target?(origin_sha, target) && !standard_revert_on_target?(origin_sha, target)
+    origin_sha && commit_on_target?(origin_sha, target) && target_commit_live_on_target?(origin_sha, target)
   end
 
   def source_cherry_pick_origin_reverted_on_target?(sha, target)
     origin_sha = cherry_pick_origin(sha)
-    origin_sha && commit_on_target?(origin_sha, target) && standard_revert_on_target?(origin_sha, target)
+    origin_sha && commit_on_target?(origin_sha, target) && !target_commit_live_on_target?(origin_sha, target)
   end
 
   def reverted_commit_live_on_target?(sha, target)
@@ -395,6 +397,7 @@ class ReleaseForwardPort
   end
 
   def standard_revert_shas_on_target(sha, target)
+    # Git writes simple reverts as "sha." and merge reverts as "sha, reversing...".
     [".", ","].flat_map do |suffix|
       revert_message = "This reverts commit #{sha}#{suffix}"
       git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
@@ -405,8 +408,25 @@ class ReleaseForwardPort
     source_patch_id = patch_id_for_commit(sha)
 
     patch_equivalent_target_candidates(sha, target).any? do |target_sha|
-      patch_id_for_commit(target_sha) == source_patch_id && !standard_revert_on_target?(target_sha, target)
+      patch_id_for_commit(target_sha) == source_patch_id && target_commit_live_on_target?(target_sha, target)
     end
+  end
+
+  def target_commit_live_on_target?(sha, target)
+    !standard_revert_on_target?(sha, target) && !target_commit_reverted_through_merge?(sha, target)
+  end
+
+  def target_commit_reverted_through_merge?(sha, target)
+    @target_merge_revert_cache ||= {}
+    cache_key = [sha, target]
+    return @target_merge_revert_cache.fetch(cache_key) if @target_merge_revert_cache.key?(cache_key)
+
+    @target_merge_revert_cache[cache_key] =
+      target_merge_descendants(sha, target).any? { |merge_sha| standard_revert_on_target?(merge_sha, target) }
+  end
+
+  def target_merge_descendants(sha, target)
+    git_lines("log", target, "--merges", "--ancestry-path", "#{sha}..#{target}", "--format=%H")
   end
 
   def patch_equivalent_target_candidates(sha, target)
@@ -750,7 +770,7 @@ class ReleaseForwardPort
     stdout
   end
 
-  def capture_git(*, stdin_data: nil)
+  def capture_git(*, stdin_data: "")
     git_env = { "GIT_TERMINAL_PROMPT" => "0", "GIT_PAGER" => "cat" }
     Open3.capture3(git_env, "git", *, stdin_data:)
   end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -3,6 +3,7 @@
 
 require "optparse"
 require "open3"
+require "digest"
 
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
@@ -25,6 +26,7 @@ class ReleaseForwardPort
     "rc" => 5
   }.freeze
   EMPTY_PATCH_ID = "__empty_patch__"
+  HUNKLESS_PATCH_ID_PREFIX = "__hunkless_patch__:"
   CHERRY_PICK_FOOTER_FORMAT = "(cherry picked from commit %s)"
   CHERRY_PICK_FOOTER_PATTERN = /\(cherry picked from commit (?<sha>[0-9a-f]{40})\)/
   ASCII_WHITESPACE_BYTES = [9, 10, 11, 12, 13, 32].freeze
@@ -221,7 +223,11 @@ class ReleaseForwardPort
   def manual_skip_reason?(reason)
     return false unless reason
 
-    reason.start_with?("merge commit; inspect manually", "reverts a release-only application")
+    reason.start_with?(
+      "merge commit; inspect manually",
+      "reverts a release-only application",
+      "stable release version bump commit"
+    )
   end
 
   def skipped_version_bump_revert_skip_reason(sha, subject, target, target_version)
@@ -386,7 +392,7 @@ class ReleaseForwardPort
     raise GitError, "#{git_error(['patch-id', '--stable'], stdout, stderr, status)} for #{sha}" unless status.success?
 
     patch_id = stdout.split.first
-    raise GitError, "git patch-id produced no output for #{sha}" if patch_id.nil?
+    return hunkless_patch_id(patch) if patch_id.nil?
 
     patch_id
   end
@@ -527,6 +533,10 @@ class ReleaseForwardPort
   end
 
   def ensure_clean_worktree!
+    if cherry_pick_in_progress?
+      raise GitError, "a cherry-pick is already in progress; run git cherry-pick --continue or --abort first"
+    end
+
     return if git("status", "--porcelain").strip.empty?
 
     raise GitError, "working tree is not clean; commit, stash, or discard local changes before normal mode"
@@ -676,6 +686,10 @@ class ReleaseForwardPort
 
   def empty_patch?(patch)
     patch.each_byte.all? { |byte| ASCII_WHITESPACE_BYTES.include?(byte) }
+  end
+
+  def hunkless_patch_id(patch)
+    "#{HUNKLESS_PATCH_ID_PREFIX}#{Digest::SHA256.hexdigest(patch)}"
   end
 
   def verify_ref!(ref, label:)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -187,9 +187,10 @@ class ReleaseForwardPort
     footer = "#{CHERRY_PICK_FOOTER_PREFIX}#{sha})"
     # This history search can false-positive if a later target commit quotes the
     # footer verbatim. The runbook documents that boundary for release operators.
-    return false if git("log", target, "--fixed-strings", "--grep", footer, "--format=%H", "--max-count=1").strip.empty?
+    forwarded_sha = git("log", target, "--fixed-strings", "--grep", footer, "--format=%H", "--max-count=1").strip
+    return false if forwarded_sha.empty?
 
-    patch_present_on_target_tree?(sha, target)
+    patch_present_on_target_tree?(forwarded_sha, target)
   end
 
   def patch_present_on_target_tree?(sha, target)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -52,6 +52,10 @@ class ReleaseForwardPort
     commits = source_only_commits(source, target)
     equiv_commits = patch_equivalent_candidates(source, target)
     target_version = version_at(target)
+
+    # Build the operator-facing plan before the normal-mode dirty-worktree
+    # guard, so normal mode and dry-run report the same plan before refusing to
+    # checkout or cherry-pick.
     plan = build_plan(commits, target, target_version, equiv_commits)
 
     print_plan(source, target, target_version, plan)
@@ -133,12 +137,11 @@ class ReleaseForwardPort
 
   def build_plan(commits, target, target_version, patch_equivalent_commits)
     commits.map do |sha|
-      full_sha = git("rev-parse", "#{sha}^{commit}").strip
-      subject = git("log", "-1", "--format=%s", full_sha).strip
-      reason = skip_reason(full_sha, subject, target, target_version, patch_equivalent_commits)
+      subject = git("log", "-1", "--format=%s", sha).strip
+      reason = skip_reason(sha, subject, target, target_version, patch_equivalent_commits)
 
       PlanEntry.new(
-        sha: full_sha,
+        sha:,
         subject:,
         action: reason ? :skip : :pick,
         reason:
@@ -321,7 +324,7 @@ class ReleaseForwardPort
 
   def checkout_target!(target)
     puts "\nChecking out #{target}..."
-    git!("checkout", target)
+    git("checkout", target)
   end
 
   def apply_plan(plan)
@@ -380,27 +383,23 @@ class ReleaseForwardPort
   end
 
   # The repo requires Ruby >= 3.3, so anonymous forwarding is valid and keeps
-  # these small git wrappers aligned with RuboCop's preferred style. Both git!
-  # and git raise on failure; capture_git/run_git are the non-raising escape
-  # hatches.
+  # these small git wrappers aligned with RuboCop's preferred style. git raises
+  # on failure; capture_git/run_git are the non-raising escape hatches.
   def git_lines(*)
     output = git(*)
     output.lines.map(&:strip).reject(&:empty?)
   end
 
-  def git!(*args)
+  def git(*args)
     stdout, stderr, status = capture_git(*args)
     raise GitError, git_error(args, stdout, stderr, status) unless status.success?
 
     stdout
   end
 
-  def git(*)
-    git!(*)
-  end
-
   def capture_git(*, env: {}, stdin_data: nil)
-    Open3.capture3(env, "git", *, stdin_data:)
+    merged_env = { "GIT_TERMINAL_PROMPT" => "0" }.merge(env)
+    Open3.capture3(merged_env, "git", *, stdin_data:)
   end
 
   def run_git(*)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -167,6 +167,10 @@ class ReleaseForwardPort
       return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert"
     end
 
+    if patch_id_for_commit(sha) == EMPTY_PATCH_ID
+      return "empty commit; cherry-picking would only create a no-op commit on #{target}"
+    end
+
     if patch_equivalent_commits[sha] && patch_equivalent_commit_present_on_target?(sha, target)
       return "patch already exists on #{target} according to target history with no later standard revert"
     end

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -41,6 +41,8 @@ class ReleaseForwardPort
     end
   end
 
+  ManualSkipReason = Struct.new(:message, keyword_init: true)
+
   class UsageError < StandardError; end
   class GitError < StandardError; end
 
@@ -173,14 +175,15 @@ class ReleaseForwardPort
   def build_plan(commits, target, target_version, patch_equivalent_commits)
     commits.map do |sha|
       subject = git("log", "-1", "--format=%s", sha).strip
-      reason = skip_reason(sha, subject, target, target_version, patch_equivalent_commits)
+      skip_decision = skip_reason(sha, subject, target, target_version, patch_equivalent_commits)
+      reason = skip_reason_message(skip_decision)
 
       PlanEntry.new(
         sha:,
         subject:,
         action: reason ? :skip : :pick,
         reason:,
-        manual: manual_skip_reason?(reason)
+        manual: manual_skip_reason?(skip_decision)
       )
     end
   end
@@ -195,6 +198,8 @@ class ReleaseForwardPort
     return "empty commit; cherry-picking would only create a no-op commit on #{target}" if
       patch_id_for_commit(sha) == EMPTY_PATCH_ID
 
+    return if source_cherry_pick_origin_reverted_on_target?(sha, target)
+
     if patch_equivalent_commits[sha] &&
        patch_equivalent_commit_present_on_target?(sha, target)
       return "patch already exists on #{target} according to target history with no later standard revert"
@@ -207,8 +212,11 @@ class ReleaseForwardPort
     return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}" if
       rc_version_bump?(subject)
 
-    return "merge commit; inspect manually for conflict-resolution hunks before marking forward-port complete" if
-      merge_commit?(sha)
+    if merge_commit?(sha)
+      return manual_skip_reason(
+        "merge commit; inspect manually for conflict-resolution hunks before marking forward-port complete"
+      )
+    end
 
     skipped_version_bump_revert_skip_reason(sha, subject, target, target_version) ||
       reverse_pick_revert_skip_reason(sha, target)
@@ -223,14 +231,15 @@ class ReleaseForwardPort
   end
 
   def manual_skip_reason?(reason)
-    return false unless reason
+    reason.is_a?(ManualSkipReason)
+  end
 
-    reason.start_with?(
-      "merge commit; inspect manually",
-      "reverts a release-only application",
-      "reverts a release-branch merge commit",
-      "stable release version bump commit"
-    )
+  def skip_reason_message(reason)
+    reason.is_a?(ManualSkipReason) ? reason.message : reason
+  end
+
+  def manual_skip_reason(message)
+    ManualSkipReason.new(message:)
   end
 
   def skipped_version_bump_revert_skip_reason(sha, subject, target, target_version)
@@ -282,8 +291,10 @@ class ReleaseForwardPort
   end
 
   def stable_version_bump_skip_reason(target)
-    "stable release version bump commit; use the runbook's manual fallback to take only " \
+    manual_skip_reason(
+      "stable release version bump commit; use the runbook's manual fallback to take only " \
       "the CHANGELOG hunks and keep release branch version changes off #{target}"
+    )
   end
 
   def unknown_target_prerelease_skip_reason(target)
@@ -302,12 +313,16 @@ class ReleaseForwardPort
     return merge_revert_skip_reason(target) if merge_commit?(reverted_sha)
     return unless reverted_commit_live_on_target?(reverted_sha, target)
 
-    "reverts a release-only application of a commit already live on #{target}; inspect manually " \
+    manual_skip_reason(
+      "reverts a release-only application of a commit already live on #{target}; inspect manually " \
       "before applying this rollback to #{target}"
+    )
   end
 
   def merge_revert_skip_reason(target)
-    "reverts a release-branch merge commit; inspect manually before applying this rollback to #{target}"
+    manual_skip_reason(
+      "reverts a release-branch merge commit; inspect manually before applying this rollback to #{target}"
+    )
   end
 
   def standard_revert_target(sha)
@@ -340,6 +355,11 @@ class ReleaseForwardPort
     origin_sha && commit_on_target?(origin_sha, target) && !standard_revert_on_target?(origin_sha, target)
   end
 
+  def source_cherry_pick_origin_reverted_on_target?(sha, target)
+    origin_sha = cherry_pick_origin(sha)
+    origin_sha && commit_on_target?(origin_sha, target) && standard_revert_on_target?(origin_sha, target)
+  end
+
   def reverted_commit_live_on_target?(sha, target)
     source_cherry_pick_origin_on_target?(sha, target) || patch_equivalent_commit_present_on_target?(sha, target)
   end
@@ -365,14 +385,20 @@ class ReleaseForwardPort
     cache_key = [sha, target]
     return @standard_revert_cache.fetch(cache_key) if @standard_revert_cache.key?(cache_key)
 
-    revert_message = "This reverts commit #{sha}."
-    revert_shas = git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
+    revert_shas = standard_revert_shas_on_target(sha, target)
     # Seed the cache before recursive descent so mutual-revert cycles terminate.
     @standard_revert_cache[cache_key] = false
     @standard_revert_cache[cache_key] =
       revert_shas.any? do |revert_sha|
         commit_descends_from?(revert_sha, sha) && !standard_revert_on_target?(revert_sha, target)
       end
+  end
+
+  def standard_revert_shas_on_target(sha, target)
+    [".", ","].flat_map do |suffix|
+      revert_message = "This reverts commit #{sha}#{suffix}"
+      git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
+    end.uniq
   end
 
   def patch_equivalent_commit_present_on_target?(sha, target)
@@ -387,6 +413,9 @@ class ReleaseForwardPort
     paths = git_lines("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
     return [] if paths.empty?
 
+    # This path-history walk can be broad for high-churn files, but it only runs
+    # for no-footer patch-equivalent candidates after git cherry marks a commit
+    # equivalent. Normal helper reruns use the faster -x footer path.
     git_lines("log", target, "--format=%H", "--no-merges", "--", *paths)
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -27,9 +27,13 @@ class ReleaseForwardPort
   EMPTY_PATCH_ID = "__empty_patch__"
   CHERRY_PICK_FOOTER_PREFIX = "(cherry picked from commit "
 
-  PlanEntry = Struct.new(:sha, :subject, :action, :reason, keyword_init: true) do
+  PlanEntry = Struct.new(:sha, :subject, :action, :reason, :manual, keyword_init: true) do
     def short_sha
       sha[0, 12]
+    end
+
+    def manual?
+      !!manual
     end
   end
 
@@ -152,7 +156,8 @@ class ReleaseForwardPort
         sha:,
         subject:,
         action: reason ? :skip : :pick,
-        reason:
+        reason:,
+        manual: manual_skip_reason?(reason)
       )
     end
   end
@@ -190,6 +195,12 @@ class ReleaseForwardPort
 
   def merge_commit?(sha)
     git("rev-list", "--parents", "-n", "1", sha).split.length > 2
+  end
+
+  def manual_skip_reason?(reason)
+    return false unless reason
+
+    reason.start_with?("merge commit; inspect manually", "reverts a release-only")
   end
 
   def version_bump_skip_reason(subject, target, target_version)
@@ -238,9 +249,9 @@ class ReleaseForwardPort
 
   def reverse_pick_revert_skip_reason(sha, target)
     reverted_sha = standard_revert_target(sha)
-    return unless reverted_sha && source_cherry_pick_origin_on_target?(reverted_sha, target)
+    return unless reverted_sha && reverted_commit_live_on_target?(reverted_sha, target)
 
-    "reverts a release-only cherry-pick of a commit already live on #{target}; inspect manually " \
+    "reverts a release-only application of a commit already live on #{target}; inspect manually " \
       "before applying this rollback to #{target}"
   end
 
@@ -268,6 +279,10 @@ class ReleaseForwardPort
   def source_cherry_pick_origin_on_target?(sha, target)
     origin_sha = cherry_pick_origin(sha)
     origin_sha && commit_on_target?(origin_sha, target) && !standard_revert_on_target?(origin_sha, target)
+  end
+
+  def reverted_commit_live_on_target?(sha, target)
+    source_cherry_pick_origin_on_target?(sha, target) || patch_equivalent_commit_present_on_target?(sha, target)
   end
 
   def cherry_pick_origin(sha)
@@ -414,11 +429,20 @@ class ReleaseForwardPort
 
     plan.each { |entry| print_plan_entry(entry) }
 
-    picks = plan.count { |entry| entry.action == :pick }
-    skips = plan.length - picks
     puts
-    puts "Summary: #{picks} commit#{'s' unless picks == 1} to cherry-pick, " \
-         "#{skips} commit#{'s' unless skips == 1} skipped."
+    puts plan_summary(plan)
+  end
+
+  def plan_summary(plan)
+    picks = plan.count { |entry| entry.action == :pick }
+    manual = plan.count(&:manual?)
+    skips = plan.length - picks - manual
+    summary = "Summary: #{picks} commit#{'s' unless picks == 1} to cherry-pick, " \
+              "#{skips} commit#{'s' unless skips == 1} skipped"
+    if manual.positive?
+      summary += ", #{manual} commit#{'s' unless manual == 1} need#{'s' if manual == 1} manual inspection"
+    end
+    "#{summary}."
   end
 
   def print_plan_entry(entry)
@@ -426,7 +450,7 @@ class ReleaseForwardPort
     when :pick
       puts "PICK #{entry.short_sha} #{entry.subject}"
     when :skip
-      puts "SKIP #{entry.short_sha} #{entry.subject}"
+      puts "#{entry.manual? ? 'MANUAL' : 'SKIP'} #{entry.short_sha} #{entry.subject}"
       puts "     #{entry.reason}"
     else
       raise GitError, "unexpected plan entry action: #{entry.action.inspect}"
@@ -454,26 +478,51 @@ class ReleaseForwardPort
   end
 
   def apply_plan(plan)
-    picks = plan.select { |entry| entry.action == :pick }
-
-    if picks.empty?
+    unless actionable_plan?(plan)
       puts "\nNothing to cherry-pick."
       return 0
     end
 
-    picks.each_with_index do |entry, index|
-      puts "\nCherry-picking #{entry.short_sha} #{entry.subject}"
-      stdout, stderr, status = capture_git("cherry-pick", "-x", entry.sha)
-      puts stdout unless stdout.empty?
-      warn stderr unless stderr.empty?
-      next if status.success?
+    completed_picks = 0
+    plan.each_with_index do |entry, index|
+      next if entry.action == :skip && !entry.manual?
 
-      warn_cherry_pick_failure(entry, completed: index, remaining: picks.length - index - 1)
+      if entry.manual?
+        warn_manual_entry(entry, completed: completed_picks, remaining: remaining_actionable_entries(plan, index))
+        return 1
+      end
+
+      if cherry_pick_entry(entry)
+        completed_picks += 1
+        next
+      end
+
+      warn_cherry_pick_failure(entry, completed: completed_picks, remaining: remaining_picks(plan, index))
       return 1
     end
 
     puts "\nForward-port complete."
     0
+  end
+
+  def actionable_plan?(plan)
+    plan.any? { |entry| entry.action == :pick || entry.manual? }
+  end
+
+  def remaining_actionable_entries(plan, index)
+    plan[index + 1..].count { |entry| entry.action == :pick || entry.manual? }
+  end
+
+  def remaining_picks(plan, index)
+    plan[index + 1..].count { |entry| entry.action == :pick }
+  end
+
+  def cherry_pick_entry(entry)
+    puts "\nCherry-picking #{entry.short_sha} #{entry.subject}"
+    stdout, stderr, status = capture_git("cherry-pick", "-x", entry.sha)
+    puts stdout unless stdout.empty?
+    warn stderr unless stderr.empty?
+    status.success?
   end
 
   def warn_cherry_pick_failure(entry, completed:, remaining:)
@@ -489,6 +538,13 @@ class ReleaseForwardPort
       warn_later_commits(remaining, "after fixing the failed pick", continue_context: false)
     end
 
+    warn "Earlier successful picks from this run are already committed and safe." if completed.positive?
+  end
+
+  def warn_manual_entry(entry, completed:, remaining:)
+    warn "Manual inspection required for #{entry.sha}."
+    warn entry.reason
+    warn_later_commits(remaining, "after resolving the manual item", continue_context: false)
     warn "Earlier successful picks from this run are already committed and safe." if completed.positive?
   end
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -210,12 +210,16 @@ class ReleaseForwardPort
     forwarded_shas = git_lines("log", target, "--fixed-strings", "--grep", footer, "--format=%H")
     return false if forwarded_shas.empty?
 
+    # True if at least one copy of the cherry-pick is still live on the target
+    # (that is, not followed by a live standard git revert). Multiple copies are
+    # fine: pick -> revert -> re-pick is handled because the re-pick copy passes.
     forwarded_shas.any? { |forwarded_sha| !standard_revert_on_target?(forwarded_sha, target) }
   end
 
   def standard_revert_on_target?(sha, target)
     revert_message = "This reverts commit #{sha}."
-    !git("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H", "--max-count=1").strip.empty?
+    revert_shas = git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
+    revert_shas.any? { |revert_sha| !standard_revert_on_target?(revert_sha, target) }
   end
 
   def patch_equivalent_commit_present_on_target?(sha, target)
@@ -243,7 +247,10 @@ class ReleaseForwardPort
     stdout, stderr, status = capture_git("patch-id", "--stable", stdin_data: patch)
     raise GitError, git_error(["patch-id", "--stable", sha], stdout, stderr, status) unless status.success?
 
-    stdout.split.first
+    patch_id = stdout.split.first
+    raise GitError, "git patch-id produced no output for #{sha}" if patch_id.nil?
+
+    patch_id
   end
 
   def version_at(ref)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -163,30 +163,32 @@ class ReleaseForwardPort
   end
 
   def skip_reason(sha, subject, target, target_version, patch_equivalent_commits)
-    if rc_version_bump?(subject)
-      return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}"
-    end
+    special_reason = special_skip_reason(sha, subject, target, target_version)
+    return special_reason if special_reason
 
-    if merge_commit?(sha)
-      return "merge commit; inspect manually for conflict-resolution hunks before marking forward-port complete"
-    end
+    return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert" if
+      already_forward_ported_with_x?(sha, target)
 
-    reverse_revert_reason = reverse_pick_revert_skip_reason(sha, target)
-    return reverse_revert_reason if reverse_revert_reason
+    return "empty commit; cherry-picking would only create a no-op commit on #{target}" if
+      patch_id_for_commit(sha) == EMPTY_PATCH_ID
 
-    if already_forward_ported_with_x?(sha, target)
-      return "already forward-ported to #{target} via cherry-pick -x evidence with no later standard revert"
-    end
-
-    if patch_id_for_commit(sha) == EMPTY_PATCH_ID
-      return "empty commit; cherry-picking would only create a no-op commit on #{target}"
-    end
-
-    if patch_equivalent_commits[sha] && patch_equivalent_commit_present_on_target?(sha, target)
+    if patch_equivalent_commits[sha] &&
+       patch_equivalent_commit_present_on_target?(sha, target)
       return "patch already exists on #{target} according to target history with no later standard revert"
     end
 
     version_bump_skip_reason(subject, target, target_version)
+  end
+
+  def special_skip_reason(sha, subject, target, target_version)
+    return "rc version bump commit; release train forward-ports must keep prerelease bumps off #{target}" if
+      rc_version_bump?(subject)
+
+    return "merge commit; inspect manually for conflict-resolution hunks before marking forward-port complete" if
+      merge_commit?(sha)
+
+    skipped_version_bump_revert_skip_reason(sha, subject, target, target_version) ||
+      reverse_pick_revert_skip_reason(sha, target)
   end
 
   def rc_version_bump?(subject)
@@ -200,7 +202,24 @@ class ReleaseForwardPort
   def manual_skip_reason?(reason)
     return false unless reason
 
-    reason.start_with?("merge commit; inspect manually", "reverts a release-only")
+    reason.start_with?("merge commit; inspect manually", "reverts a release-only application")
+  end
+
+  def skipped_version_bump_revert_skip_reason(sha, subject, target, target_version)
+    return unless standard_revert_subject?(subject)
+
+    reverted_sha = standard_revert_target(sha)
+    return unless reverted_sha
+
+    reverted_subject = git("log", "-1", "--format=%s", reverted_sha).strip
+    return unless skipped_version_bump_subject?(reverted_subject, target, target_version)
+
+    "reverts a release-only version bump that is skipped for #{target}; skipping this revert avoids " \
+      "an empty or target-regressing cherry-pick"
+  end
+
+  def skipped_version_bump_subject?(subject, target, target_version)
+    !!(rc_version_bump?(subject) || version_bump_skip_reason(subject, target, target_version))
   end
 
   def version_bump_skip_reason(subject, target, target_version)
@@ -261,6 +280,10 @@ class ReleaseForwardPort
     match && match[:sha]
   end
 
+  def standard_revert_subject?(subject)
+    subject.start_with?("Revert ")
+  end
+
   def already_forward_ported_with_x?(sha, target)
     return true if source_cherry_pick_origin_on_target?(sha, target)
 
@@ -308,6 +331,7 @@ class ReleaseForwardPort
 
     revert_message = "This reverts commit #{sha}."
     revert_shas = git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
+    # Seed the cache before recursive descent so mutual-revert cycles terminate.
     @standard_revert_cache[cache_key] = false
     @standard_revert_cache[cache_key] =
       revert_shas.any? do |revert_sha|
@@ -559,7 +583,7 @@ class ReleaseForwardPort
   end
 
   def cherry_pick_in_progress?
-    path = git("rev-parse", "--git-path", "CHERRY_PICK_HEAD").strip
+    path = git("rev-parse", "--path-format=absolute", "--git-path", "CHERRY_PICK_HEAD").strip
     File.exist?(path)
   rescue GitError
     false

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -49,9 +49,9 @@ class ReleaseForwardPort
     ensure_local_target_branch!(target) unless @options[:dry_run]
 
     commits = source_only_commits(source, target)
-    patch_equivalent_commits = patch_equivalent_commits(source, target)
+    equivalent_commits = patch_equivalent_commits(source, target)
     target_version = version_at(target)
-    plan = build_plan(commits, target, target_version, patch_equivalent_commits)
+    plan = build_plan(commits, target, target_version, equivalent_commits)
 
     print_plan(source, target, target_version, plan)
 
@@ -334,8 +334,10 @@ class ReleaseForwardPort
            "script/release-forward-port after continuing to apply the rest " \
            "(it is idempotent and skips commits already applied)."
     end
-    warn "If you git cherry-pick --abort, earlier picks in this run are rolled back; " \
-         "rerun script/release-forward-port from the start after fixing the conflict."
+    warn "If you run git cherry-pick --abort, only the current conflicting commit is abandoned; " \
+         "earlier picks from this run are already committed and safe. Rerun " \
+         "script/release-forward-port after fixing the conflict " \
+         "(it is idempotent and skips commits already applied)."
   end
 
   def verify_ref!(ref, label:)

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -7,11 +7,10 @@ require "open3"
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
   VERSION_FILE = "react_on_rails/lib/react_on_rails/version.rb"
-  # A trailing number after the `rc` marker is required (project convention is
-  # always `X.Y.Z.rc.N`). A versionless `1.0.0.rc` is intentionally NOT matched
-  # here; it falls through to the version-drift path in version_bump_skip_reason.
+  # Project convention is `X.Y.Z.rc.N`, but a release branch can still contain a
+  # bare `X.Y.Z.rc` bump. Treat both as release-only version bumps.
   RC_VERSION_BUMP_SUBJECT = /
-    \Abump\s+version\s+to\s+v?\d+\.\d+\.\d+[.-]rc[.-]?\d+\b
+    \Abump\s+version\s+to\s+v?\d+\.\d+\.\d+[.-]rc(?:[.-]?\d+)?\b
   /ix
   VERSION_BUMP_SUBJECT = /
     \Abump\s+version\s+to\s+v?
@@ -198,9 +197,10 @@ class ReleaseForwardPort
     return unless version
 
     parsed_version = parse_version(version)
-    if parsed_version && parsed_version.fetch(:prerelease).nil?
-      return "stable release version bump commit; use the runbook's manual fallback to take only " \
-             "the CHANGELOG hunks and keep release branch version changes off #{target}"
+    return stable_version_bump_skip_reason(target) if stable_version_bump?(parsed_version)
+
+    if prerelease_version_bump?(parsed_version) && target_version.nil?
+      return unknown_target_prerelease_skip_reason(target)
     end
 
     return unless target_version
@@ -211,6 +211,24 @@ class ReleaseForwardPort
     "target #{target} is already at #{target_version}; skipping version bump to #{version} to avoid " \
       "regressing or duplicating the target version. If this commit also contains CHANGELOG changes, " \
       "use the runbook's manual fallback to take only the CHANGELOG hunks."
+  end
+
+  def stable_version_bump?(parsed_version)
+    parsed_version && parsed_version.fetch(:prerelease).nil?
+  end
+
+  def prerelease_version_bump?(parsed_version)
+    parsed_version&.fetch(:prerelease)
+  end
+
+  def stable_version_bump_skip_reason(target)
+    "stable release version bump commit; use the runbook's manual fallback to take only " \
+      "the CHANGELOG hunks and keep release branch version changes off #{target}"
+  end
+
+  def unknown_target_prerelease_skip_reason(target)
+    "prerelease version bump commit with target version UNKNOWN; use the runbook's manual fallback " \
+      "to take only the CHANGELOG hunks and keep release branch version changes off #{target}"
   end
 
   def version_from_bump_subject(subject)
@@ -263,6 +281,11 @@ class ReleaseForwardPort
     status.success?
   end
 
+  def commit_descends_from?(descendant_sha, ancestor_sha)
+    _stdout, _stderr, status = capture_git("merge-base", "--is-ancestor", ancestor_sha, descendant_sha)
+    status.success?
+  end
+
   def standard_revert_on_target?(sha, target)
     @standard_revert_cache ||= {}
     cache_key = [sha, target]
@@ -270,13 +293,15 @@ class ReleaseForwardPort
 
     revert_message = "This reverts commit #{sha}."
     revert_shas = git_lines("log", target, "--fixed-strings", "--grep", revert_message, "--format=%H")
+    @standard_revert_cache[cache_key] = false
     @standard_revert_cache[cache_key] =
-      revert_shas.any? { |revert_sha| !standard_revert_on_target?(revert_sha, target) }
+      revert_shas.any? do |revert_sha|
+        commit_descends_from?(revert_sha, sha) && !standard_revert_on_target?(revert_sha, target)
+      end
   end
 
   def patch_equivalent_commit_present_on_target?(sha, target)
     source_patch_id = patch_id_for_commit(sha)
-    return true if source_patch_id == EMPTY_PATCH_ID
 
     patch_equivalent_target_candidates(sha, target).any? do |target_sha|
       patch_id_for_commit(target_sha) == source_patch_id && !standard_revert_on_target?(target_sha, target)
@@ -443,7 +468,7 @@ class ReleaseForwardPort
       warn stderr unless stderr.empty?
       next if status.success?
 
-      warn_cherry_pick_conflict(entry, completed: index, remaining: picks.length - index - 1)
+      warn_cherry_pick_failure(entry, completed: index, remaining: picks.length - index - 1)
       return 1
     end
 
@@ -451,19 +476,37 @@ class ReleaseForwardPort
     0
   end
 
-  def warn_cherry_pick_conflict(entry, completed:, remaining:)
+  def warn_cherry_pick_failure(entry, completed:, remaining:)
     warn "Cherry-pick failed for #{entry.sha}."
-    warn "Resolve the conflict and run git cherry-pick --continue to finish THIS commit."
-    if remaining.positive?
-      warn "Note: #{remaining} later eligible commit#{'s' unless remaining == 1} in this plan " \
-           "#{remaining == 1 ? 'is' : 'are'} not queued by --continue. Rerun " \
-           "script/release-forward-port after continuing to apply the rest " \
-           "(it is idempotent and skips commits already applied)."
+
+    if cherry_pick_in_progress?
+      warn "Resolve the conflict and run git cherry-pick --continue to finish THIS commit."
+      warn_later_commits(remaining, "after continuing to apply the rest", continue_context: true)
+      warn "If you run git cherry-pick --abort, only the current conflicting commit is abandoned."
+    else
+      warn "Git did not leave a cherry-pick in progress; fix the git error above and rerun " \
+           "script/release-forward-port."
+      warn_later_commits(remaining, "after fixing the failed pick", continue_context: false)
     end
-    warn "If you run git cherry-pick --abort, only the current conflicting commit is abandoned."
+
     warn "Earlier successful picks from this run are already committed and safe." if completed.positive?
-    warn "Rerun script/release-forward-port after fixing the conflict " \
+  end
+
+  def warn_later_commits(remaining, rerun_after, continue_context:)
+    return unless remaining.positive?
+
+    queue_note = continue_context ? "not queued by --continue" : "not attempted after this failure"
+    warn "Note: #{remaining} later eligible commit#{'s' unless remaining == 1} in this plan " \
+         "#{remaining == 1 ? 'is' : 'are'} #{queue_note}. Rerun " \
+         "script/release-forward-port #{rerun_after} " \
          "(it is idempotent and skips commits already applied)."
+  end
+
+  def cherry_pick_in_progress?
+    path = git("rev-parse", "--git-path", "CHERRY_PICK_HEAD").strip
+    File.exist?(path)
+  rescue GitError
+    false
   end
 
   def verify_ref!(ref, label:)
@@ -493,6 +536,8 @@ class ReleaseForwardPort
   end
 
   def run_git(*)
+    raise ArgumentError, "run_git requires a block" unless block_given?
+
     stdout, stderr, status = capture_git(*)
     yield(stdout, stderr, status)
   end


### PR DESCRIPTION
## Summary

Closes #4162.

Adds `script/release-forward-port`, a release-train helper that plans and applies release-branch forward-ports back to `main` without merging the release branch.

## What changed

- Adds a dry-run-able helper that inspects `target..source`, prints `PICK`/`SKIP` decisions, and applies eligible commits with `git cherry-pick -x`.
- Surfaces release-line merge commits as manual `SKIP` entries, and skips initially empty commits, RC version bump commits, and stable final version bump commits that need manual CHANGELOG extraction.
- Routes release-only reverts of reverse cherry-picks to manual handling so a release rollback does not accidentally remove a live main fix.
- Keeps reruns idempotent across `-x` evidence, no-footer cherry-picks, target-only context edits, standard reverts, reverted reverts, and main-to-release backports being closed out later.
- Updates the release-train runbook to use the helper first while preserving manual fallback guidance for conflicts and version bump/CHANGELOG extraction.
- Adds hermetic temp-git-repo specs for dry-run behavior, normal cherry-pick behavior, idempotency, empty-commit skipping, RC/stable bump exclusion, version-drift messaging, usage errors, merge-commit manual surfacing, reverse-pick revert routing, conflict/abort guidance, and inherited Git signing config.

## Validation

- `.agents/bin/agent-workflow-seam-doctor` -> PASS
- `ruby -c script/release-forward-port` -> PASS
- `ruby -c react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb` -> PASS
- `cd react_on_rails && bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb` -> PASS, 25 examples
- `cd react_on_rails && env GIT_TEST_FORCE_SIGNING_FALLBACK=1 bundle exec rspec spec/react_on_rails/release_forward_port_script_spec.rb` -> PASS, 25 examples
- `BUNDLE_GEMFILE=$PWD/Gemfile bundle exec rubocop script/release-forward-port react_on_rails/spec/react_on_rails/release_forward_port_script_spec.rb` -> PASS, no offenses
- `git diff --check origin/main...HEAD` -> PASS
- `script/ci-changes-detector origin/main` -> recommends full hosted CI, no benchmarks
- Pre-push hooks -> PASS: branch RuboCop and online markdown-links
- `script/pr-merge-ledger 4181 --repo shakacode/react_on_rails --strict --finding-dispositions /tmp/pr4181-dispositions.json --changelog-classification not_user_visible` -> PASS, `complete_allowed: true`
- Live review-thread check -> PASS, 0 unresolved review threads after resolving current-head comments

## Merge Rationale

- Maintainer delegated merge authority in the 2026-06-25 Codex session as long as the merge reasons are documented here.
- This PR is the scoped follow-up after #4122 merged: it implements the dry-run-able/idempotent forward-port helper requested by #4162 without broad release-process redesign.
- The helper reduces release closeout risk by planning before applying, skipping unsafe version bump commits, detecting already-forward-ported fixes, and documenting when operators must use manual fallback.
- Changelog classification: `not_user_visible`; this adds internal release tooling and contributor runbook guidance, not a user-facing gem/npm behavior change.
- No lockfiles changed.
- I will merge only after current-head hosted CI and review checks pass on head `13960310e9e6c4f17afb46b32c97749e7a828438`.

Confidence note:
- Validated: focused syntax, RSpec, signing-fallback RSpec, targeted RuboCop, diff whitespace, CI detector, pre-push hooks, strict merge ledger, and live review-thread state.
- Evidence: current PR body, resolved review threads, current-head local validation on `13960310e9e6c4f17afb46b32c97749e7a828438`, and strict ledger `complete_allowed: true`.
- UNKNOWN: current-head hosted CI/review checks are still running after the latest rebase push.
- Residual risk: low-to-moderate until hosted CI completes; the helper intentionally leaves ambiguous release-version/CHANGELOG extraction to documented manual fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the release-line stabilization runbook to use automated forward-port steps, including a `--dry-run` planning phase and clearer conflict-resolution guidance.
  * Refreshed post-publication closure instructions to safely forward remaining release commits with a prior dry-run.

* **New Features**
  * Added a `release-forward-port` CLI that generates a PICK/SKIP plan and forwards eligible commits from a release line to `main`.
  * Supports dry-run, idempotent reruns, skipping RC/prerelease version bumps, and provides guidance on cherry-pick conflicts.

* **Tests**
  * Added comprehensive RSpec coverage for planning output, CLI validation, idempotency, patch-duplication detection, and conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
