### PR TITLE
Fix minimum dependency Pro test selection on Node 20

### DIFF
--- a/script/convert
+++ b/script/convert
@@ -123,6 +123,7 @@ minimum_pro_non_rsc_ignored_tests = %w[
   serverRenderReactComponent
   SuspenseHydration
   deferredRouteSsr
+  boundedCacheProvider[.]client[.]test
   imperativeRefetch[.]client[.]test
   inlineRefreshButton[.]client[.]test
   wrapServerComponentRenderer[.]client[.]test


### PR DESCRIPTION
## Why

`main` is red because the full main-push JS unit matrix ran the Node 20 minimum-dependency conversion after PR #4168 and then executed `packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx`. That test imports `@testing-library/react` and `@testing-library/jest-dom`, while `script/convert` intentionally removes `@testing-library/*` from the root minimum-dependency package set.

Follow-on docs PRs could still merge, but their main-push CI failed before useful docs checks because the docs-only safety guard refuses to validate docs-only pushes when the previous `main` SHA already has failed workflows. So the later docs merges are symptoms; the original poison is the unskipped Pro client test in the Node 20/minimum-dependency lane.

## What changed

Add `boundedCacheProvider[.]client[.]test` to the Pro `test:non-rsc` ignore pattern generated by `script/convert`, matching the existing minimum-dependency treatment for other Pro client/RSC tests that need React 19 or testing-library helpers.

## Why I Am Confident

- The failing main-only lane was reproduced at the routing level: `script/convert` removes `@testing-library/*`, and `boundedCacheProvider.client.test.tsx` imports `@testing-library/react` plus `@testing-library/jest-dom`, so it belongs with the existing converted-lane client/RSC test skips.
- The conversion output was checked in a temp worktree: after running `ruby script/convert`, the generated Pro `test:non-rsc` regex ignored `tests/boundedCacheProvider.client.test.tsx` and did not ignore an unrelated control test, `tests/buildCacheKey.test.ts`.
- The exact previously failing main lane passed after merge: `JS unit tests for Renderer package / build (20)` succeeded on main commit `a5b9e7e7d`, including the Pro JS tests after conversion.
- Full hosted PR CI passed before merge, including JS unit tests, Pro package tests, Pro integration, generator tests, integration tests, Playwright, lint, assets, CodeQL, and the long RSpec generator matrix.
- After merge, every latest-main push/dynamic workflow for `a5b9e7e7d` completed successfully.

## Validation

- `ruby -c script/convert`
- `bash -n script/ci-changes-detector && script/ci-changes-detector origin/main`
- Temp-worktree conversion assertion: ran `ruby script/convert`, confirmed converted `packages/react-on-rails-pro/package.json` ignores `tests/boundedCacheProvider.client.test.tsx`, and confirmed the same regex does not ignore `tests/buildCacheKey.test.ts`.
- `git diff --check && ruby -c script/convert && BUNDLE_GEMFILE=Gemfile bundle exec rubocop script/convert`
- `pnpm start format.listDifferent`
- `codex review --uncommitted`: no actionable correctness issues.
- `codex review --base origin/main`: clean.

`bin/ci-local --changed` was attempted. It failed in repo-wide RuboCop on pre-existing unrelated offenses under `react_on_rails/spike/3313_prism_gemfile_rewriter/*`; it had already passed setup/docs-sidebar before that unrelated lint failure.

## Changelog

Not user-visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded an internal test ignore list to prevent a specific Pro test suite from being included during the React 18 conversion process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
