### PR TITLE
chore(deps): bump react-on-rails-rsc CI soak pin to 19.2.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "These force patched versions of transitive dev dependencies. Remove when upstream packages update.",
       "ajv overrides were intentionally excluded: ajv v8 breaks webpack's schema-utils/ajv-keywords.",
       "The 2 moderate ajv alerts (ReDoS in $data option) are tolerable — ajv only validates our own config files.",
-      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scopes the Pro/RSC dummy to the coordinated React 19.2.7 + react-on-rails-rsc 19.2.0-rc.3 pair so CI soak-tests the RSC path on React 19.2 (#3865; gate landed in #4026). The workspace-wide pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 — the published/default pin for 17.0.0 — until #3865 promotes 19.2 to the default."
+      "react_on_rails>react(-dom) scopes React 19.2 to the OSS dummy app (for the <Activity> demo, #3883). react_on_rails_pro_dummy>react(-dom)/react-on-rails-rsc scopes the Pro/RSC dummy to the coordinated React 19.2.7 + react-on-rails-rsc 19.2.0-rc.4 pair so CI soak-tests the RSC path on React 19.2 (#3865; gate landed in #4026). The workspace-wide pin stays at ~19.0.4 / react-on-rails-rsc 19.0.5 — the published/default pin for 17.0.0 — until #3865 promotes 19.2 to the default."
     ],
     "overrides": {
       "react": "$react",
@@ -140,7 +140,7 @@
       "react_on_rails>react-dom": "^19.2.0",
       "react_on_rails_pro_dummy>react": "^19.2.7",
       "react_on_rails_pro_dummy>react-dom": "^19.2.7",
-      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.0-rc.3",
+      "react_on_rails_pro_dummy>react-on-rails-rsc": "19.2.0-rc.4",
       "sentry-testkit>body-parser": "npm:empty-npm-package@1.0.0",
       "sentry-testkit>express": "npm:empty-npm-package@1.0.0",
       "lodash@>=4.0.0 <=4.17.22": ">=4.17.23 <5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   react_on_rails>react-dom: ^19.2.0
   react_on_rails_pro_dummy>react: ^19.2.7
   react_on_rails_pro_dummy>react-dom: ^19.2.7
-  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.0-rc.3
+  react_on_rails_pro_dummy>react-on-rails-rsc: 19.2.0-rc.4
   sentry-testkit>body-parser: npm:empty-npm-package@1.0.0
   sentry-testkit>express: npm:empty-npm-package@1.0.0
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23 <5'
@@ -762,8 +762,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-on-rails-pro-node-renderer
       react-on-rails-rsc:
-        specifier: 19.2.0-rc.3
-        version: 19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
+        specifier: 19.2.0-rc.4
+        version: 19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1)
       react-proptypes:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8469,8 +8469,8 @@ packages:
       react-dom: ~19.0.4
       webpack: ^5.59.0
 
-  react-on-rails-rsc@19.2.0-rc.3:
-    resolution: {integrity: sha512-lthw7rRbPdUOeZQMVR2rH1FdA3sp7wiZfMljmld1c/2epYtA7SYLLhg7jTn9FcVEIjWLZiyzC7GkNrNnLB4IOQ==}
+  react-on-rails-rsc@19.2.0-rc.4:
+    resolution: {integrity: sha512-Jm9822vmAvXPbQ3gyx8B5RwbGcmxEXZ1eMEoVxd3rsnnxuZ7B35dr11Ygy2FBPPq4v5sJa/PFWGir/m8Cg1b9Q==}
     peerDependencies:
       react: ~19.0.4
       react-dom: ~19.0.4
@@ -19131,7 +19131,7 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.3)
       webpack-sources: 3.3.3
 
-  react-on-rails-rsc@19.2.0-rc.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
+  react-on-rails-rsc@19.2.0-rc.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2

--- a/react_on_rails_pro/spec/dummy/package.json
+++ b/react_on_rails_pro/spec/dummy/package.json
@@ -56,7 +56,7 @@
     "react-intl": "^10",
     "react-on-rails-pro": "workspace:*",
     "react-on-rails-pro-node-renderer": "workspace:*",
-    "react-on-rails-rsc": "19.2.0-rc.3",
+    "react-on-rails-rsc": "19.2.0-rc.4",
     "react-proptypes": "^1.0.0",
     "react-redux": "^9.2.0",
     "react-refresh": "^0.11.0",


### PR DESCRIPTION
## What

Bumps the Pro/RSC dummy app's coordinated `react-on-rails-rsc` pin from `19.2.0-rc.3` to `19.2.0-rc.4`, so CI keeps soak-testing the RSC path on the latest React 19.2 prerelease.

## Changes

- `package.json` — the `react_on_rails_pro_dummy>react-on-rails-rsc` pnpm override → `19.2.0-rc.4`, plus the comment documenting that pin
- `react_on_rails_pro/spec/dummy/package.json` — direct dependency → `19.2.0-rc.4`
- `pnpm-lock.yaml` — regenerated via `pnpm install --lockfile-only` (fresh integrity hash for rc.4, no stale rc.3 pin)

## Scope / safety

- Only moves the **internal CI soak-test pin**. The user-facing default stays `react-on-rails-rsc@19.0.5`, so no CHANGELOG entry and no flagship-demo update (`AGENTS.md` external-demo coordination) are warranted.
- rc.4 declares the same `react` / `react-dom` peers as rc.3, so no new peer-dependency warnings are introduced.

## Intentionally NOT changed

Three docs (and their generated `llms-full.txt` mirrors) state the per-reference CSS-broadcast fix (PRs #108/#110/#113) **landed in / shipped in `19.2.0-rc.3`** — a historical fact that the rc.4 bump does not change. Rewriting them to rc.4 would make them false:

- `docs/oss/migrating/rsc-troubleshooting.md`
- `docs/oss/building-features/performance-tracks-and-profiling.md`

## Verification

- Both `package.json` files parse as valid JSON
- `npx prettier@3.6.2 --check` passes on all three changed files
- `grep` confirms no remaining `19.2.0-rc.3` pin references in the lockfile

Context: part of the React 19.2 RSC soak-testing tracked in #3865 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s React/RSC package pinning to a newer release.
  * Bumped the bundled Pro demo environment to match the same React/RSC version, helping keep local and workspace setups aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->