### PR TITLE
docs: add Mermaid diagrams to release-train runbook

### DIFF
--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -312,6 +312,7 @@ flowchart TD
     PR["Agent-merged PR"] --> T{"Target branch?"}
     T -->|"main"| BETA["beta gate · lowest<br/>confidence note<br/>+ green required checks"]
     T -->|"release/*"| AC{"agent-coord phase?<br/>doctor + status exit 0"}
+    T -->|"cannot determine"| NOAM["report UNKNOWN<br/>do not auto-merge<br/>maintainer decision"]
     AC -->|"rc"| RC["rc gate · higher<br/>confidence note<br/>+ adversarial-pr-review<br/>+ zero open MUST-FIX"]
     AC -->|"final"| FINAL["final gate · highest<br/>rc gate + cherry-picked<br/>verified fixes only<br/>+ no new features<br/>+ human sign-off"]
     AC -->|"UNKNOWN / no entry"| FB{"tracker in<br/>final-release mode?"}

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -114,7 +114,7 @@ flowchart TD
     C -->|"yes"| D["4 · Promote in place<br/>drop -rc at release tip<br/>tag vX.Y.Z — no re-cut"]
     D --> E["5 · Close out<br/>forward-port CHANGELOG collapse<br/>delete release/X.Y.Z (tags persist)"]
     B -.->|"3 · cherry-pick -x each fix"| M(["main — never freezes"])
-    E -.-> M
+    E -.->|"5 · forward-port CHANGELOG"| M
 ```
 
 > **Note:** Worked examples use the concrete version `17.0.0` (and branch `release/17.0.0`, tags
@@ -310,11 +310,11 @@ flowchart TD
     PR["Agent-merged PR"] --> T{"Target branch?"}
     T -->|"main"| BETA["beta gate · lowest<br/>confidence note<br/>+ green required checks"]
     T -->|"release/*"| AC{"agent-coord phase?<br/>doctor + status exit 0"}
-    AC -->|"rc"| RC
-    AC -->|"final"| FINAL
+    AC -->|"rc"| RC["rc gate · higher<br/>confidence note<br/>+ adversarial-pr-review<br/>+ zero open MUST-FIX"]
+    AC -->|"final"| FINAL["final gate · highest<br/>rc gate + cherry-picked<br/>verified fixes only<br/>+ no new features<br/>+ human sign-off"]
     AC -->|"UNKNOWN / no entry"| FB{"tracker in<br/>final-release mode?"}
-    FB -->|"no"| RC["rc gate · higher<br/>confidence note<br/>+ adversarial-pr-review<br/>+ zero open MUST-FIX"]
-    FB -->|"yes"| FINAL["final gate · highest<br/>rc gate + cherry-picked<br/>verified fixes only<br/>+ no new features<br/>+ human sign-off"]
+    FB -->|"no"| RC
+    FB -->|"yes"| FINAL
 ```
 
 Reading the gate is mechanical:

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -31,6 +31,27 @@ The release train separates "keep merging" from "stabilize a release":
 - **Final = promote the last good RC**, not a re-cut from `main`. Extra `main` commits since the RC
   roll into the next version automatically.
 
+The whole train at a glance — `main` keeps moving while `release/17.0.0` stabilizes, every fix is
+cherry-picked back to `main`, and the final is the last good RC promoted in place (no re-cut):
+
+```mermaid
+gitGraph
+    commit id: "batch work"
+    commit id: "feature A"
+    branch release/17.0.0
+    commit id: "rc.0 bump" tag: "v17.0.0.rc.0"
+    checkout main
+    commit id: "feature B"
+    checkout release/17.0.0
+    commit id: "SSR fix"
+    commit id: "rc.1 bump" tag: "v17.0.0.rc.1"
+    checkout main
+    cherry-pick id: "SSR fix"
+    commit id: "feature C"
+    checkout release/17.0.0
+    commit id: "final bump" tag: "v17.0.0"
+```
+
 ## Decision: ephemeral `release/X.Y.Z`, not one long-lived `releases` branch
 
 We use an **ephemeral per-version `release/X.Y.Z` branch**, cut at RC time and deleted after the final
@@ -81,6 +102,20 @@ the auto-merge automation _within_ a phase. See
 
 The git mechanics below were validated end-to-end with a local dry-run (see
 [Dry-run](#dry-run-validate-the-mechanics)).
+
+The five steps and how they map onto the two branches — solid arrows are the release-branch
+progression; dotted arrows are what reaches `main` (which never freezes):
+
+```mermaid
+flowchart TD
+    A["1 · Cut RC<br/>branch release/X.Y.Z from origin/main<br/>tag vX.Y.Z.rc.0"] --> B["2 · Stabilize<br/>only fixes target release/X.Y.Z<br/>re-tag rc.1, rc.2 …"]
+    B --> C{"Hard gates pass?<br/>rc-testing-plan.md"}
+    C -->|"no"| B
+    C -->|"yes"| D["4 · Promote in place<br/>drop -rc at release tip<br/>tag vX.Y.Z — no re-cut"]
+    D --> E["5 · Close out<br/>forward-port CHANGELOG collapse<br/>delete release/X.Y.Z (tags persist)"]
+    B -.->|"3 · cherry-pick -x each fix"| M(["main — never freezes"])
+    E -.-> M
+```
 
 > **Note:** Worked examples use the concrete version `17.0.0` (and branch `release/17.0.0`, tags
 > `v17.0.0.rc.N` / `v17.0.0`) for clarity, because the repo is on `v17.0.0.rc.3` as this runbook lands.
@@ -266,6 +301,22 @@ judgment; everything machine-checkable is handled autonomously with evidence.
 | **rc**    | `release/*`       | **Higher.** Confidence note + adversarial-pr-review + **zero open MUST-FIX**. Only stabilizing fixes reach `release/*`; features still allowed on `main`.                                                                                  |
 | **final** | `release/*` → tag | **Highest.** Everything `rc` requires (adversarial-pr-review + **zero open MUST-FIX**) **plus**: only cherry-picked, fully-verified fixes; **no new features**; **human sign-off on the promotion itself**. No confidence-only auto-merge. |
 
+The same selection as the decision an agent runs per PR — the table above is the canonical wording;
+this diagram mirrors it (`agent-coord` first, the deterministic branch-derived fallback when it is
+`UNKNOWN`):
+
+```mermaid
+flowchart TD
+    PR["Agent-merged PR"] --> T{"Target branch?"}
+    T -->|"main"| BETA["beta gate · lowest<br/>confidence note<br/>+ green required checks"]
+    T -->|"release/*"| AC{"agent-coord phase?<br/>doctor + status exit 0"}
+    AC -->|"rc"| RC
+    AC -->|"final"| FINAL
+    AC -->|"UNKNOWN / no entry"| FB{"tracker in<br/>final-release mode?"}
+    FB -->|"no"| RC["rc gate · higher<br/>confidence note<br/>+ adversarial-pr-review<br/>+ zero open MUST-FIX"]
+    FB -->|"yes"| FINAL["final gate · highest<br/>rc gate + cherry-picked<br/>verified fixes only<br/>+ no new features<br/>+ human sign-off"]
+```
+
 Reading the gate is mechanical:
 
 1. Determine the PR's **target branch**.
@@ -314,7 +365,8 @@ Agents that act on the gate: `pr-batch`, `address-review` (nit-autonomy + MUST-F
 skill-level phase **table** of its own — the table lives only in `AGENTS.md` and this runbook. `pr-batch`
 and `adversarial-pr-review` add a one-line pointer back here and to `AGENTS.md`; `address-review` and
 `pr-processing` inherit the same gate through the `AGENTS.md` Maintainer Attention Contract they already
-follow. If the gate tiers ever change, update `AGENTS.md` and this runbook (the canonical source) rather
+follow. If the gate tiers ever change, update `AGENTS.md` and this runbook (the canonical source) —
+including the gate-selection diagram above, which mirrors the table and is illustrative only — rather
 than adding per-skill phase tables.
 
 ### Phase vs. release mode

--- a/internal/contributor-info/release-train-runbook.md
+++ b/internal/contributor-info/release-train-runbook.md
@@ -103,8 +103,10 @@ the auto-merge automation _within_ a phase. See
 The git mechanics below were validated end-to-end with a local dry-run (see
 [Dry-run](#dry-run-validate-the-mechanics)).
 
-The five steps and how they map onto the two branches — solid arrows are the release-branch
-progression; dotted arrows are what reaches `main` (which never freezes):
+The five steps mapped onto the two branches. The solid path is the release branch (1 → 2 → 4 → 5);
+step 3 is not a separate stage — it runs _during_ stabilization, so it appears as a dotted
+forward-port arrow to `main` rather than a node in the main flow. The step-5 close-out likewise
+forward-ports the CHANGELOG. `main` never freezes:
 
 ```mermaid
 flowchart TD
@@ -114,7 +116,7 @@ flowchart TD
     C -->|"yes"| D["4 · Promote in place<br/>drop -rc at release tip<br/>tag vX.Y.Z — no re-cut"]
     D --> E["5 · Close out<br/>forward-port CHANGELOG collapse<br/>delete release/X.Y.Z (tags persist)"]
     B -.->|"3 · cherry-pick -x each fix"| M(["main — never freezes"])
-    E -.->|"5 · forward-port CHANGELOG"| M
+    E -.->|"forward-port CHANGELOG"| M
 ```
 
 > **Note:** Worked examples use the concrete version `17.0.0` (and branch `release/17.0.0`, tags


### PR DESCRIPTION
### Summary

Adds three Mermaid diagrams to [`internal/contributor-info/release-train-runbook.md`](internal/contributor-info/release-train-runbook.md) so the release-train model is easier to grasp at a glance. No prose was rewritten — each diagram sits next to the section/table it illustrates.

- **Release-train topology (`gitGraph`)** — under _Why a release train_: `main` never freezes, `release/X.Y.Z` carries the RCs, each fix is cherry-picked back to `main`, and the final is the last good RC promoted in place (no re-cut).
- **Runbook flow (`flowchart`)** — top of _Runbook_: the five steps and how they map onto the two branches (solid = release-branch progression, dotted = what reaches `main`).
- **Per-PR merge-gate selection (`flowchart`)** — in _Phase-tiered merge gating_: target branch → phase → gate tier, including the `agent-coord` `UNKNOWN` fallback. Mirrors the canonical phase→gate table.

Why Mermaid: it is already the repo convention (`internal/analysis/` uses it) and renders natively on GitHub, where these contributor-only docs are viewed (they are not published via Docusaurus). Text-based, so the diagrams are diffable and add no binary assets.

**Do we need agent instructions for this?** No new `AGENTS.md` policy or skill instruction is required. The diagrams are illustrative; the phase→gate table in `AGENTS.md` and this runbook stays canonical. To prevent drift, the gate diagram's caption marks it as mirroring the table, and the runbook's existing _"if gate tiers ever change, update `AGENTS.md` and this runbook"_ rule now explicitly covers the diagram.

### Pull Request checklist

- [x] ~Add/update test to cover these changes~ (docs-only change)
- [x] Update documentation
- [x] ~Update CHANGELOG file~ (internal contributor doc, not a user-facing library change)

### Other Information

- All three diagrams were validated by rendering with `mermaid-cli` (Mermaid 11, the version GitHub renders with); each produced a clean SVG/PNG.
- Pre-commit hooks pass: Prettier 3.6.2 (unchanged), Lychee offline link check (6/6 OK), trailing-newline check.
- Scope is a single file: +56 / −1.

### Merge rationale

Merging on maintainer authorization (@justin808: "merge if confident and all review comments are addressed"). Basis for confidence:

- **Low risk:** docs-only change to one internal contributor file (`internal/contributor-info/release-train-runbook.md`) — no runtime code, no user-facing behavior, and no effect on the in-flight 17.0.0 release artifacts.
- **Release gate satisfied:** tracker #3823 mode is `development`, and this PR targets `main` (beta phase → lowest gate: confidence note + green required checks). The accelerated-RC confidence block / independent finalizer does not apply.
- **All review feedback resolved:** 7 threads, 0 unresolved, across 3 rounds from `claude`/`greptile`/CodeRabbit. Genuine findings were fixed (symmetric edge labels, first-reference node definitions, the step-3/step-5 labeling nuance, and the missing "cannot determine target" fallback exit on the gate diagram); redundant/decorative nits were declined with a rationale in-thread rather than churning the diagram.
- **CI green where it counts:** required docs checks pass (`markdown-format-check`, `markdown-link-check`); `mergeable=MERGEABLE` and the branch is up to date with `main`. The `UNSTABLE` state reflects only non-required long-running jobs (benchmarks, CodeQL), which do not gate a docs-only change.
- **Diagrams validated:** all three render cleanly with `mermaid-cli` (Mermaid 11, GitHub's renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three Mermaid diagrams to the release-train runbook, including a gitGraph-style overview of RC branch creation through final promotion, a workflow map of release vs. forward-port behavior across steps, and a phase-tiered merge-gating flowchart with branch-based phase selection and an unknown-mode fallback.
  * Updated the agent-skills/gate-tier guidance to remove a duplicated sentence fragment and improve clarity/consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
