### PR TITLE
Fix vendored seam-doctor crash under a non-UTF-8 locale

### DIFF
--- a/.agents/bin/agent-workflow-seam-doctor
+++ b/.agents/bin/agent-workflow-seam-doctor
@@ -69,7 +69,9 @@ module AgentWorkflowSeamDoctor
 
     return ["missing AGENTS.md"] unless File.file?(agents_path)
 
-    config = parse_config(File.read(agents_path))
+    # Read as UTF-8 regardless of locale; a non-UTF-8 default external encoding
+    # (e.g. LANG=C) otherwise crashes the parser on non-ASCII bytes in AGENTS.md.
+    config = parse_config(File.binread(agents_path).force_encoding("UTF-8").scrub)
     if config.nil?
       issues << "missing AGENTS.md section: #{SECTION}"
     else

--- a/.agents/bin/agent-workflow-seam-doctor-test.rb
+++ b/.agents/bin/agent-workflow-seam-doctor-test.rb
@@ -677,3 +677,27 @@ class AgentWorkflowSeamDoctorSharedRootTest < Minitest::Test
     end
   end
 end
+
+class AgentWorkflowSeamDoctorEncodingTest < Minitest::Test
+  include AgentWorkflowSeamDoctorTestHelpers
+
+  def test_non_ascii_agents_md_parses_under_ascii_locale
+    with_repo do |root|
+      write_agents(root)
+      agents_path = File.join(root, "AGENTS.md")
+      body = File.read(agents_path)
+      # A real AGENTS.md carries non-ASCII bytes (em dashes, arrows). Reading it
+      # under a non-UTF-8 locale must not crash the config parser.
+      body.sub!("# AGENTS.md\n", "# AGENTS.md\n\nReact on Rails → SSR overview.\n")
+      File.write(agents_path, body)
+      write_skill(root, "No commands here.\n")
+
+      out, status = Open3.capture2e(
+        { "LC_ALL" => "C", "LANG" => "C" }, "ruby", SCRIPT, "--root", root
+      )
+
+      assert status.success?, out
+      assert_includes out, "PASS"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`.agents/bin/agent-workflow-seam-doctor` is the seam validation `AGENTS.md`
mandates before any issue / PR / batch work. It crashes under a non-UTF-8
locale:

```
$ LANG=C LC_ALL=C ruby .agents/bin/agent-workflow-seam-doctor --root .
agent-workflow-seam-doctor:122:in 'String#match?': invalid byte sequence in US-ASCII (ArgumentError)
```

`LANG=C` / `LC_ALL=C` is common in CI and headless agent shells; it passes
interactively only because dev shells default to `en_US.UTF-8`. This repo's
own `AGENTS.md` (em dashes, arrows) triggers it.

## Fix

`check` read `AGENTS.md` with `File.read`, decoding with the locale's default
external encoding. Read it as UTF-8 and `scrub` instead — the idiom already
used for skill/workflow markdown in `executable_placeholder_issues`. One line,
no behavior change under a UTF-8 locale.

## Provenance

Mirrors the shared-pack fix in shakacode/agent-workflows#1. Both files remain
**byte-identical to upstream**, preserving the vendoring invariant.

## Testing

- `LANG=C LC_ALL=C ruby .agents/bin/agent-workflow-seam-doctor --root .` now
  prints `PASS agent workflow seam is complete`.
- `ruby .agents/bin/agent-workflow-seam-doctor-test.rb` → `40 runs, 0 failures`
  (adds `AgentWorkflowSeamDoctorEncodingTest`, a `LC_ALL=C` regression test).
- `bundle exec rubocop` on both files → no offenses.
