### PR TITLE
Add plan-qa-batch design: behavioral QA planner + qa-batch runner

### DIFF
--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -65,12 +65,12 @@ This is the same selection/interview/dispatch gap that `plan-pr-batch` →
 
 ### 1. Trigger and invocation
 
-- **Default (release-gate sweep):** `$plan-qa-batch` with no args resolves
-  "merged through `HEAD`, looking back to the last RC tag." The RC tag is only a
-  _performance bound_ on how far back to scan — see §2.
-- **Override (on-demand):** `$plan-qa-batch <base..head>`, `--full` (no lower
-  bound — reconciles pre-RC PRs, §3), a label/milestone filter, or an explicit
-  PR list.
+- **Default (release-gate sweep):** `$plan-qa-batch` with no args runs the
+  authoritative unbounded backlog query (§3) and uses the last-RC window only to
+  order/prioritize what it surfaces — never to filter (§2).
+- **Override (on-demand):** `$plan-qa-batch <base..head>`, `--full` (drop the
+  since-RC ordering window and present the entire backlog flat, §3), a
+  label/milestone filter, or an explicit PR list.
 - **Idempotent:** re-invoke any time. PRs already carrying a terminal QA label
   (`qa-verified` or `qa-skipped`, §5) drop out automatically, so the skill always
   shows exactly what still needs QA.
@@ -88,31 +88,39 @@ backlog = (all merged PRs through HEAD)
 ```
 
 Every merged PR ends in exactly one terminal state — `qa-verified` or
-`qa-skipped` — so the unverified set is precisely the PRs with neither label. A
-start point (commit, PR, tag, RC) is only a **default scan window** for the
-common case; it is never a correctness filter. A periodic `--full` sweep (no
-lower bound) reconciles anything older than the window, so a PR merged before the
-last RC that was never QA'd still resurfaces. The labels — not the range —
-guarantee no gaps, and because a `qa-skipped` PR is never re-presented, the
-excluded list also stays bounded.
+`qa-skipped` — so the unverified set is precisely the PRs with neither label.
+**The authoritative, unbounded label query (§3) runs on every invocation**, so a
+PR merged before the last RC that was never QA'd is never dropped — the RC window
+is only an ordering/prioritization hint, never a filter that removes unlabeled
+PRs. The labels — not the range — guarantee no gaps, and because a `qa-skipped`
+PR is never re-presented, the **backlog** (future work) stays bounded to
+unlabeled PRs only. (The `qa-skipped` _set_ itself grows monotonically with the
+repo's formatting/typo history; that is harmless because it never re-enters the
+backlog, but it is not "bounded.")
 
-### 3. Scope resolution (reuse, do not duplicate)
+### 3. Scope resolution — label query is authoritative, resolver is an optimization
 
-Call the existing read-only resolver
-`.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` to get the
-squash-aware merged-PR set, shared with `post-merge-audit`. **Important:** that
-resolver's default base is the most recent RC, so on its own it would _filter
-out_ older un-QA'd PRs and break the §2 guarantee. It therefore supplies the
-**default scan window only**; the authoritative backlog is the label query
+The authoritative backlog is always the **unbounded, paginated** label query, run
+on every invocation (not just `--full`):
 
+```sh
+gh pr list --state merged --search "-label:qa-verified -label:qa-skipped" \
+  --limit 9999   # iterate pages if the repo can exceed the search cap (~1000)
 ```
-gh pr list --state merged --search "-label:qa-verified -label:qa-skipped" …
-```
 
-The skill reconciles the two: the RC window is the fast common path, and a
-`--full` run (or a periodic reconciliation) drops the lower bound so nothing
-older than the RC is silently lost. `plan-qa-batch` then layers QA classification
-(§4) on the resulting set.
+`gh pr list` defaults to `--state open` and `--limit 30` and the search backend
+caps at ~1000 results, so the skill MUST set `--state merged`, a high `--limit`,
+and page explicitly — otherwise the "gap-free" promise silently truncates.
+
+The read-only resolver
+`.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` is then used
+**only as an optimization** to order/prioritize the common since-RC window, never
+to filter the backlog. Two real constraints when calling it (verified against the
+script): it **hard-fails (`return 1`)** when no `*.rc.*` tag is in head history
+and `--base` is omitted, so `plan-qa-batch` always passes `--base origin/main`
+explicitly and treats any non-zero exit as "optimization unavailable" — the label
+query above remains the unconditional source of truth. `plan-qa-batch` then
+layers QA classification (§4) on the resulting set.
 
 ### 4. Classify by QA _method_, not include-vs-skip
 
@@ -155,11 +163,16 @@ PR), so it is explicit, not ad hoc:
    to a provisional method.
 2. **LLM adjudication** for anything ambiguous, reading the diff + linked issue
    against the §4 table. The prompt and its tie-breaks live in the SKILL.md so
-   every run applies the same rule, not an implementer's invention.
+   every run applies the same rule, not an implementer's invention. This step
+   emits **three** artifacts per PR — QA method, env profile, and a **provisional
+   `repro tactic`** (e.g. `git checkout <fix>~1 -- <file>` + spec, or "boot Pro
+   dummy, hit route X"). The tactic is provisional: `verify-pr-fix` finalizes it
+   at execution time, so the plan is actionable before launch without over-fitting.
 3. **No silent "nothing to verify".** A PR routed to the `qa-skipped` lane is
    surfaced in the interview (§7) with its one-line reason and is labeled only
-   after the developer acknowledges the excluded list — so the exclusion is
-   deliberate and auditable, never automatic.
+   after acknowledgment (developer in an attended run; auto-acknowledged with an
+   audit-trail note in an unattended run — §7) — so the exclusion is deliberate
+   and auditable, never silent.
 
 ### 5. Dedup and persistence — two terminal labels
 
@@ -169,8 +182,7 @@ so the backlog (§2) is a pure query:
 - **`qa-verified`** — applied on a **passing** QA run (any method: behavioral
   pass, docs OK, code-check OK).
 - **`qa-skipped`** — applied after the "nothing to verify" glance (§4), symmetric
-  with `qa-verified`, so those PRs never resurface and the excluded list stays
-  bounded.
+  with `qa-verified`, so those PRs never re-enter the backlog.
 
 Properties:
 
@@ -181,10 +193,13 @@ Properties:
   the merged set minus the two labels on each run — no local file, no `.context`
   (Conductor-only, non-portable), no tracker issue. Works identically on every
   platform and machine.
-- **Self-healing label setup.** `gh pr edit --add-label` does **not** create a
-  missing label (it errors / no-ops), which would silently break dedup. So the
-  writer first ensures the label exists (`gh label list` → `gh label create` if
-  absent) before adding it — no manual one-time setup step to forget.
+- **Self-healing, idempotent label setup.** `gh pr edit --add-label` does **not**
+  create a missing label (it errors / no-ops), which would silently break dedup.
+  So the writer first ensures the label exists, then adds it — no manual one-time
+  setup to forget. Because `qa-batch` lanes run concurrently, the ensure step is
+  **idempotent**: two lanes can race on the same missing label, so a
+  `gh label create` that returns "already exists" is treated as **success**, not a
+  lane failure (equivalently, a single serialized bootstrap before fan-out).
 - **Write-ordering is an invariant, not a description.** `qa-verified` MUST be the
   **final** write: apply it only after `gh pr comment` returns success for the
   evidence comment. If the evidence post fails, the label step is aborted — so a
@@ -214,27 +229,44 @@ rules live in `.agents/workflows/pr-processing.md` and
 
 This is two-way conflict-avoidance: QA will not run on a PR being actively
 re-edited, and other batches see QA in flight. The **same integration is added to
-`post-merge-audit`** so audit passes coordinate too. When the backend is
-unavailable, report private state as `UNKNOWN` and fall back to advisory public
-claim comments, exactly as the implementation batches already do.
+`post-merge-audit`** so audit passes coordinate too.
+
+**Degraded-backend fallback (exit-code-aware).** The backend doc distinguishes
+exit 3 (`CLAIM_REFUSED`, hard stop) from exit 2 (`UNKNOWN` / degraded). Because QA
+lanes are dependency-sensitive by definition (point 1 — must not verify a moving
+target), an exit-2 `UNKNOWN` status for a PR that **could** carry an invisible
+live implementation claim is treated as **blocked/deferred**, _not_ proceeded on
+advisory public comments. (Advisory-comment fallback is only acceptable for a PR
+with no plausible concurrent claimant.) This matches the canonical rule in
+`agent-coordination-backend.md`; proceeding on UNKNOWN would let QA verify an
+in-progress state.
 
 **Repeated-contention escalation.** A PR skipped for a live claim (point 1) is
 retried next run, but a PR under perpetual edit would be skipped forever and the
 coverage gap would be invisible. After **3** consecutive contention skips the
-planner surfaces it in its output as `blocked — repeated contention`, so the
-maintainer can schedule a QA window or override rather than let it silently fall
-out of coverage.
+planner surfaces it as `blocked — repeated contention` so the maintainer can
+schedule a QA window or override. The skip count needs durable, file-free storage
+across invocations, so it lives on the PR's `agent-coord` coordination record (the
+backend already in use), incremented on each contention skip and cleared when QA
+finally claims the PR — not in a local file (ruled out, §5) and not encodable in a
+terminal label.
 
 ### 7. The interview
 
 Present the auto-ranked candidate list plus a collapsed "nothing to verify" list,
 then ask only for what cannot be inferred:
 
-1. Confirm base/range (default: last-RC scan window; offer `--full` to reconcile
-   older PRs per §2/§3).
-2. **Acknowledge the `qa-skipped` list.** The "nothing to verify" PRs are shown
-   with per-PR reasons; `qa-skipped` is applied only after the developer confirms,
-   so no PR is silently retired (§4 classification mechanism).
+1. Confirm base/range (default: the since-RC ordering window; the authoritative
+   backlog query is unbounded regardless, §2/§3).
+2. **Acknowledge the `qa-skipped` list.** Only the **newly classified** "nothing
+   to verify" PRs from this run are shown (already-`qa-skipped` PRs are filtered
+   out by §2 and never reappear), each with its one-line reason. `qa-skipped` is
+   applied only after acknowledgment, so no PR is silently retired. In an
+   **unattended run** there is no developer to confirm, so the runner
+   auto-acknowledges and records the per-PR reasons in the batch output as the
+   audit trail (symmetric with unattended issue creation, §10) — otherwise
+   "nothing to verify" PRs could never reach a terminal label and would resurface
+   forever.
 3. **Environment availability now** — Redis + Pro license + Pro renderer up?
    Browser available? Candidates whose **actual** env profile (§4b) is
    unavailable are deferred and clearly listed, not silently dropped.
@@ -260,21 +292,30 @@ unless asked. It emits, to session output:
 
 The `qa-batch` runner dispatches **one subagent per QA lane**, each claiming its
 PR(s), running the routed method, posting evidence, and closing out. Concurrency
-is bounded by **two** constraints, with a liveness exit so a stuck lane cannot
-wedge the batch — note these are _not_ `pr-batch`'s file-touch collision model,
-which is irrelevant here because QA workers do not edit source:
+is bounded by **three** constraints, with a liveness exit so a stuck lane cannot
+wedge the batch:
 
 - **(a) `agent-coord` claims** — never two lanes (or a lane and an implementation
   batch) on the same PR.
 - **(b) Environment-resource contention** — only **one** consumer of the Pro
   renderer / Redis / license / dummy-app DB at a time. Lanes whose env profile
-  needs the shared Pro stack **serialize**; spec-only and docs lanes
+  needs the shared Pro stack **serialize**; docs and pure-read lanes
   **parallelize** freely.
-- **Liveness — timeout / deadlock exit.** The serialized Pro-stack slot has a wall-clock
-  timeout. A lane that exceeds it (hung renderer, crashed agent, stale
-  `agent-coord` claim, never-exiting test) is marked **failed — not labeled**, its
-  claim released, and it is deferred to the next batch and surfaced to the
-  maintainer — the same fail-open posture as the `agent-coord`-unavailable
+- **(c) Working-tree isolation.** QA mostly does not edit source, but the
+  documented spec-only "before" tactic (`git checkout <fix>~1 -- <file>`, §4 /
+  `verify-pr-fix`) **does mutate the shared checkout** — two such lanes in one
+  working directory can run against, or restore, each other's pre-fix file and
+  corrupt the before/after evidence. So any lane using that tactic runs in its
+  **own git worktree** (`isolation: 'worktree'`), exactly as `pr-batch` workers
+  do; only that subset needs it, not docs/read lanes. (This is the one place
+  `pr-batch`'s isolation model does apply.)
+- **Liveness — timeout / deadlock exit.** The serialized Pro-stack slot has a
+  wall-clock timeout, recommended **~20 min** (Pro cold-start alone — license
+  check + renderer boot — can take ~5 min before a test starts), tunable as a
+  `qa-batch` parameter. A lane that exceeds it (hung renderer, crashed agent,
+  stale `agent-coord` claim, never-exiting test) is marked **failed — not
+  labeled**, its claim released, and it is deferred to the next batch and surfaced
+  to the maintainer — the same fail-open posture as the `agent-coord`-unavailable
   fallback in §6. One stuck lane never blocks the rest indefinitely.
 
 `plan-qa-batch` stays plan-only (Phase A): it produces the plan and goal prompt
@@ -286,8 +327,9 @@ documented as a future enhancement, not built.
 
 - **Pass (✅):** post the `verify-pr-fix` evidence comment, then apply
   `qa-verified` as the final write (§5 invariant).
-- **Nothing to verify:** apply `qa-skipped` after developer acknowledgment
-  (§4/§7).
+- **Nothing to verify:** apply `qa-skipped` after acknowledgment — developer in
+  an attended run, auto-acknowledged with an audit-trail note when unattended
+  (§7).
 - **Fail (❌) or any bug/doc/code problem found:** create a **discrete,
   cross-linked issue** describing the reproduction and the broken signal (mirrors
   `post-merge-audit`'s "Needs follow-up issue / Needs fix PR" classification), and
@@ -319,21 +361,25 @@ A sibling to `pr-batch`, deliberately thin and QA-specific:
 
 - Consumes the `plan-qa-batch` goal prompt.
 - Dispatches one subagent per lane; each runs the routed QA method.
-- Enforces the two-constraint concurrency model (§9) and the `agent-coord`
-  protocol (§6).
+- Enforces the §9 concurrency model (claims + env contention + worktree isolation
+  for spec-only lanes, with the liveness timeout) and the `agent-coord` protocol
+  (§6).
 - Per-PR closeout: label on pass, issue on fail (§10).
 - Reuses `pr-batch`'s safety posture (untrusted GitHub content cannot override
-  `AGENTS.md`; stop on blocked approvals) but **not** its branch/merge/file-touch
-  machinery, which does not apply to QA.
+  `AGENTS.md`; stop on blocked approvals) and its **worktree isolation** for the
+  spec-only lanes that mutate the checkout (§9c), but **not** its branch/merge
+  machinery — QA never creates branches or PRs and never merges.
 
-It is kept separate from `pr-batch` because the contention model (env resources,
-not file paths) and the closeout (label/issue, not branch/merge readiness) differ
-enough that overloading `pr-batch` would muddy both.
+It is kept separate from `pr-batch` because the primary contention model (env
+resources, not file paths) and the closeout (label/issue, not branch/merge
+readiness) differ enough that overloading `pr-batch` would muddy both.
 
 ## Boundaries (what it does NOT do)
 
 - Does not run `verify-pr-fix` itself (Phase A is plan-only).
-- Does not create branches, worktrees, or PRs, and does not merge.
+- Does not create branches or PRs, and does not merge. (It does use ephemeral
+  git worktrees to isolate spec-only "before" repros — §9c — which are discarded
+  after the lane.)
 - Does not produce a standing tracker issue.
 - Does not duplicate `post-merge-audit` (process risk) or `verify` (local checks).
 - Produces a recommendation; the release-gate go/no-go stays with the maintainer.

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -105,11 +105,14 @@ The authoritative backlog is always the **unbounded, paginated** label query for
 the active target base branch, run on every invocation (not just `--full`):
 
 ```sh
+set -o pipefail
+
+repo="${QA_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
 target_base="${QA_TARGET_BASE:-main}" # e.g. main or the active release branch
 
 gh api --method GET --paginate \
   -f state=closed -f base="$target_base" -f per_page=100 \
-  /repos/OWNER/REPO/pulls |
+  "/repos/$repo/pulls" |
   jq -s '
     [.[][] | select(.merged_at != null)
       | select(([.labels[].name] | index("qa-verified")) | not)
@@ -123,7 +126,12 @@ caps around 1000 results. The planner therefore MUST NOT rely on a high
 API (or an equivalent non-search GraphQL connection) until `hasNextPage` /
 `Link: rel="next"` is exhausted, filter `merged_at != null`, and constrain the
 query to the active target base branch so a release sweep does not mix `main`
-and `release/*` PRs.
+and `release/*` PRs. The `repo` value is derived from the trusted local checkout
+or an explicit trusted override and reused anywhere this document shows
+`OWNER/REPO`-style placeholders. The implementation MUST preserve `pipefail` (or
+capture the API exit code explicitly) and abort on API/auth/rate-limit/network
+errors before using the `jq` output; a failed page fetch is UNKNOWN, not an empty
+backlog.
 
 The read-only resolver
 `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` is then used
@@ -215,11 +223,13 @@ Properties:
   setup to forget. Because `qa-batch` lanes run concurrently, the ensure step is
   **idempotent**: read the full label set first (for example,
   `gh label list --limit 1000 --json name`, or `gh api --paginate` over
-  `/repos/OWNER/REPO/labels` if the repo can exceed that), create the missing
-  label if absent, and if a concurrent `gh label create` returns the GitHub 422
-  validation error, re-read the full label set and treat it as success only when
-  the expected label is now present. Any other create failure stays loud
-  (equivalently, a single serialized bootstrap before fan-out).
+  `/repos/$repo/labels` if the repo can exceed that), create the missing label if
+  absent, and if a concurrent `gh label create` returns the GitHub 422 validation
+  error, re-read the full label set and treat it as success only when the
+  expected label is now present. A failed re-read after a 422 is also a loud
+  failure: abort the label step and surface the error rather than proceeding
+  silently. Any other create failure stays loud (equivalently, a single
+  serialized bootstrap before fan-out).
 - **Write-ordering is an invariant, not a description.** `qa-verified` MUST be the
   **final** write: apply it only after `gh pr comment` returns success for the
   evidence comment. If the evidence post fails, the label step is aborted — so a
@@ -240,7 +250,7 @@ rules live in `.agents/workflows/pr-processing.md` and
 `internal/contributor-info/agent-coordination-backend.md`. Per QA lane:
 
 1. `agent-coord doctor` + targeted
-   `agent-coord status --repo OWNER/REPO --target <pr>` per candidate — if a
+   `agent-coord status --repo "$repo" --target <pr>` per candidate — if a
    candidate PR has a **live claim** from another (implementation/review) batch,
    **skip it this round** and report why; QA must not verify a moving target.
 2. `agent-coord claim` the PR's QA lane before starting (compare-and-swap gate;
@@ -344,15 +354,16 @@ wedge the batch:
   **own git worktree** (`isolation: 'worktree'`), exactly as `pr-batch` workers
   do; only that subset needs it, not docs/read lanes. (This is the one place
   `pr-batch`'s isolation model does apply.)
-- **Liveness — timeout / deadlock exit.** The serialized Pro-stack slot has a
-  wall-clock timeout, recommended **~20 min** (Pro cold-start alone — license
-  check + renderer boot — can take ~5 min before a test starts), tunable as a
-  `qa-batch` parameter. A lane that exceeds it (hung renderer, crashed agent,
-  stale `agent-coord` claim, never-exiting test) is marked **failed — not
-  labeled**, its claim released, and it is deferred to the next batch and surfaced
-  to the maintainer — the same blocked/deferred posture as the
-  `agent-coord`-unavailable fallback in §6. One stuck lane never blocks the rest
-  indefinitely.
+- **Liveness — timeout / deadlock exit.** Every lane, regardless of method, has a
+  wall-clock timeout. Pro-stack lanes use a recommended floor of **~20 min** (Pro
+  cold-start alone — license check + renderer boot — can take ~5 min before a
+  test starts); docs/read lanes can use a shorter value, but they still need a
+  hard cap. The timeout is tunable as a `qa-batch` parameter. A lane that exceeds
+  it (hung renderer, crashed agent, stale `agent-coord` claim, never-exiting
+  test) is marked **failed — not labeled**, its claim released, and it is deferred
+  to the next batch and surfaced to the maintainer — the same blocked/deferred
+  posture as the `agent-coord`-unavailable fallback in §6. One stuck lane never
+  blocks the rest indefinitely.
 
 `plan-qa-batch` stays plan-only (Phase A): it produces the plan and goal prompt
 and launches `qa-batch` only when the user asks. **Phase B** (the planner

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -68,45 +68,63 @@ This is the same selection/interview/dispatch gap that `plan-pr-batch` →
 - **Default (release-gate sweep):** `$plan-qa-batch` with no args resolves
   "merged through `HEAD`, looking back to the last RC tag." The RC tag is only a
   _performance bound_ on how far back to scan — see §2.
-- **Override (on-demand):** `$plan-qa-batch <base..head>`, a label/milestone
-  filter, or an explicit PR list.
-- **Idempotent:** re-invoke any time. PRs already carrying `qa-verified` drop
-  out automatically, so the skill always shows exactly what still needs QA.
+- **Override (on-demand):** `$plan-qa-batch <base..head>`, `--full` (no lower
+  bound — reconciles pre-RC PRs, §3), a label/milestone filter, or an explicit
+  PR list.
+- **Idempotent:** re-invoke any time. PRs already carrying a terminal QA label
+  (`qa-verified` or `qa-skipped`, §5) drop out automatically, so the skill always
+  shows exactly what still needs QA.
 
-### 2. Range is always through HEAD — gap-free by construction
+### 2. Backlog is defined by labels, not the range — gap-free by construction
 
-`HEAD` (`origin/main` / the release branch) is always the upper bound. A
-start point (commit, PR, tag, RC) is an **optional performance bound**, never the
-correctness boundary, because selection is **per-PR**:
+`HEAD` (`origin/main` / the release branch) is always the upper bound. The QA
+backlog is defined **only** by terminal labels, so the range can never silently
+drop a PR:
 
 ```
-candidates = (all merged PRs through HEAD)
-             − (PRs carrying the `qa-verified` label)
-             − (PRs with genuinely nothing to verify)
+backlog = (all merged PRs through HEAD)
+          − (PRs labeled `qa-verified`)   ← passed QA (§5)
+          − (PRs labeled `qa-skipped`)    ← reviewed, nothing to verify (§5)
 ```
 
-Anything left unverified before an arbitrary start point resurfaces on the next
-full sweep. The `qa-verified` label — not the range — guarantees no gaps.
+Every merged PR ends in exactly one terminal state — `qa-verified` or
+`qa-skipped` — so the unverified set is precisely the PRs with neither label. A
+start point (commit, PR, tag, RC) is only a **default scan window** for the
+common case; it is never a correctness filter. A periodic `--full` sweep (no
+lower bound) reconciles anything older than the window, so a PR merged before the
+last RC that was never QA'd still resurfaces. The labels — not the range —
+guarantee no gaps, and because a `qa-skipped` PR is never re-presented, the
+excluded list also stays bounded.
 
 ### 3. Scope resolution (reuse, do not duplicate)
 
 Call the existing read-only resolver
 `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` to get the
-squash-aware merged-PR set and the last-RC base. One source of truth for "what
-merged since the RC," shared with `post-merge-audit`. `plan-qa-batch` layers QA
-classification (§4) and label dedup (§5) on top of that list.
+squash-aware merged-PR set, shared with `post-merge-audit`. **Important:** that
+resolver's default base is the most recent RC, so on its own it would _filter
+out_ older un-QA'd PRs and break the §2 guarantee. It therefore supplies the
+**default scan window only**; the authoritative backlog is the label query
+
+```
+gh pr list --state merged --search "-label:qa-verified -label:qa-skipped" …
+```
+
+The skill reconciles the two: the RC window is the fast common path, and a
+`--full` run (or a periodic reconciliation) drops the lower bound so nothing
+older than the RC is silently lost. `plan-qa-batch` then layers QA classification
+(§4) on the resulting set.
 
 ### 4. Classify by QA _method_, not include-vs-skip
 
 Nothing merged is dropped silently — every PR is routed to the right verification
 method. Each candidate is classified by reading its diff and linked issue:
 
-| Merged change                                      | QA method                                                                                             |
-| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Behavioral fix / feature                           | `verify-pr-fix` — reproduce before/after, post evidence                                               |
-| **Docs**                                           | Read it: does it make sense, are commands/links/examples correct, does it match the code it describes |
-| Refactor / types / config / other code             | "Does it do what it claims, nothing broke" — confirm behavior unchanged + coverage                    |
-| Truly nothing to verify (formatting, comment typo) | Glance + note — the only "excluded" lane, near-empty                                                  |
+| Merged change                                      | QA method                                                                                                 |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Behavioral fix / feature                           | `verify-pr-fix` — reproduce before/after, post evidence                                                   |
+| **Docs**                                           | Read it: does it make sense, are commands/links/examples correct, does it match the code it describes     |
+| Refactor / types / config / other code             | "Does it do what it claims, nothing broke" — confirm behavior unchanged + coverage                        |
+| Truly nothing to verify (formatting, comment typo) | Glance + note, then apply `qa-skipped` (§5) so it never resurfaces — the only "excluded" lane, near-empty |
 
 Each candidate carries **three independent attributes** (deliberately _not_
 collapsed into a single "tier"):
@@ -127,21 +145,57 @@ The skip filter from `verify-pr-fix`'s "When NOT to use" still applies to the
 repro), but it no longer removes the PR from QA — the PR is routed to the docs or
 code-check method instead.
 
-### 5. Dedup and persistence — one signal
+#### Classification mechanism
 
-- **`qa-verified` label** on the PR, applied by `verify-pr-fix` on a **passing**
-  run (`gh pr edit <n> --add-label qa-verified`, which works on already-merged
-  PRs). Created once in the repo.
-- **Dedup** is a single `gh pr list --search "… label:qa-verified"` query rather
-  than scanning every candidate's comment body.
+Classification is the correctness boundary (a wrong "nothing to verify" silences a
+PR), so it is explicit, not ad hoc:
+
+1. **Heuristic first pass** on the file-touch set (reuse `plan-pr-batch`'s
+   `pr-file-touch-map`): docs-only, comment/format-only, and code path sets route
+   to a provisional method.
+2. **LLM adjudication** for anything ambiguous, reading the diff + linked issue
+   against the §4 table. The prompt and its tie-breaks live in the SKILL.md so
+   every run applies the same rule, not an implementer's invention.
+3. **No silent "nothing to verify".** A PR routed to the `qa-skipped` lane is
+   surfaced in the interview (§7) with its one-line reason and is labeled only
+   after the developer acknowledges the excluded list — so the exclusion is
+   deliberate and auditable, never automatic.
+
+### 5. Dedup and persistence — two terminal labels
+
+Every merged PR reaches exactly one terminal QA state, recorded as a GitHub label
+so the backlog (§2) is a pure query:
+
+- **`qa-verified`** — applied on a **passing** QA run (any method: behavioral
+  pass, docs OK, code-check OK).
+- **`qa-skipped`** — applied after the "nothing to verify" glance (§4), symmetric
+  with `qa-verified`, so those PRs never resurface and the excluded list stays
+  bounded.
+
+Properties:
+
+- **Dedup** is a single
+  `gh pr list --state merged --search "-label:qa-verified -label:qa-skipped"`
+  query rather than scanning every candidate's comment body.
 - **GitHub is the persistence.** The plan is a _derived view_ reconstructed from
-  the merged set minus the label on each run — no local file, no `.context`
+  the merged set minus the two labels on each run — no local file, no `.context`
   (Conductor-only, non-portable), no tracker issue. Works identically on every
   platform and machine.
-- **Failures stay loud.** A failing verification gets **no** label — it routes to
-  a discrete issue (§10), never a quiet success marker. (A hidden marker comment
-  to machine-locate the exact evidence comment is intentionally deferred; the
-  label plus the human-readable `verify-pr-fix` comment is enough for v1.)
+- **Self-healing label setup.** `gh pr edit --add-label` does **not** create a
+  missing label (it errors / no-ops), which would silently break dedup. So the
+  writer first ensures the label exists (`gh label list` → `gh label create` if
+  absent) before adding it — no manual one-time setup step to forget.
+- **Write-ordering is an invariant, not a description.** `qa-verified` MUST be the
+  **final** write: apply it only after `gh pr comment` returns success for the
+  evidence comment. If the evidence post fails, the label step is aborted — so a
+  PR can never carry `qa-verified` without its supporting evidence (no silent
+  false positive). A crash between a successful evidence post and the label is
+  survivable: the next run simply re-verifies.
+- **Failures stay loud.** A failing verification (❌) gets **neither** label and a
+  discrete issue (§10); it deliberately remains in the backlog so re-runs keep
+  re-verifying until the fix lands, with the open issue as the human signal. (A
+  hidden marker comment to machine-locate the exact evidence is deferred; the
+  labels plus the human-readable `verify-pr-fix` comment are enough for v1.)
 
 ### 6. Coordination — same heartbeat as the implementation batches
 
@@ -164,18 +218,29 @@ re-edited, and other batches see QA in flight. The **same integration is added t
 unavailable, report private state as `UNKNOWN` and fall back to advisory public
 claim comments, exactly as the implementation batches already do.
 
+**Repeated-contention escalation.** A PR skipped for a live claim (point 1) is
+retried next run, but a PR under perpetual edit would be skipped forever and the
+coverage gap would be invisible. After **3** consecutive contention skips the
+planner surfaces it in its output as `blocked — repeated contention`, so the
+maintainer can schedule a QA window or override rather than let it silently fall
+out of coverage.
+
 ### 7. The interview
 
 Present the auto-ranked candidate list plus a collapsed "nothing to verify" list,
 then ask only for what cannot be inferred:
 
-1. Confirm base/range (default: look back to last RC, through `HEAD`).
-2. **Environment availability now** — Redis + Pro license + Pro renderer up?
+1. Confirm base/range (default: last-RC scan window; offer `--full` to reconcile
+   older PRs per §2/§3).
+2. **Acknowledge the `qa-skipped` list.** The "nothing to verify" PRs are shown
+   with per-PR reasons; `qa-skipped` is applied only after the developer confirms,
+   so no PR is silently retired (§4 classification mechanism).
+3. **Environment availability now** — Redis + Pro license + Pro renderer up?
    Browser available? Candidates whose **actual** env profile (§4b) is
    unavailable are deferred and clearly listed, not silently dropped.
-3. Cap — max items this batch.
-4. Methods/areas to include or exclude.
-5. Concurrency — how many lanes / subagents to plan for.
+4. Cap — max items this batch.
+5. Methods/areas to include or exclude.
+6. Concurrency — how many lanes / subagents to plan for.
 
 ### 8. Output — the QA Batch Plan + goal prompt
 
@@ -195,8 +260,9 @@ unless asked. It emits, to session output:
 
 The `qa-batch` runner dispatches **one subagent per QA lane**, each claiming its
 PR(s), running the routed method, posting evidence, and closing out. Concurrency
-is bounded by **two** constraints — note these are _not_ `pr-batch`'s file-touch
-collision model, which is irrelevant here because QA workers do not edit source:
+is bounded by **two** constraints, with a liveness exit so a stuck lane cannot
+wedge the batch — note these are _not_ `pr-batch`'s file-touch collision model,
+which is irrelevant here because QA workers do not edit source:
 
 - **(a) `agent-coord` claims** — never two lanes (or a lane and an implementation
   batch) on the same PR.
@@ -204,6 +270,12 @@ collision model, which is irrelevant here because QA workers do not edit source:
   renderer / Redis / license / dummy-app DB at a time. Lanes whose env profile
   needs the shared Pro stack **serialize**; spec-only and docs lanes
   **parallelize** freely.
+- **Liveness — timeout / deadlock exit.** The serialized Pro-stack slot has a wall-clock
+  timeout. A lane that exceeds it (hung renderer, crashed agent, stale
+  `agent-coord` claim, never-exiting test) is marked **failed — not labeled**, its
+  claim released, and it is deferred to the next batch and surfaced to the
+  maintainer — the same fail-open posture as the `agent-coord`-unavailable
+  fallback in §6. One stuck lane never blocks the rest indefinitely.
 
 `plan-qa-batch` stays plan-only (Phase A): it produces the plan and goal prompt
 and launches `qa-batch` only when the user asks. **Phase B** (the planner
@@ -212,20 +284,32 @@ documented as a future enhancement, not built.
 
 ### 10. Findings → issues
 
-- **Pass (✅):** apply `qa-verified`; post the `verify-pr-fix` evidence comment.
+- **Pass (✅):** post the `verify-pr-fix` evidence comment, then apply
+  `qa-verified` as the final write (§5 invariant).
+- **Nothing to verify:** apply `qa-skipped` after developer acknowledgment
+  (§4/§7).
 - **Fail (❌) or any bug/doc/code problem found:** create a **discrete,
-  cross-linked issue** describing the reproduction and the broken signal
-  (mirrors `post-merge-audit`'s "Needs follow-up issue / Needs fix PR"
-  classification, approval-gated before creation), and post the failing evidence
-  on the PR. **No** `qa-verified` label.
+  cross-linked issue** describing the reproduction and the broken signal (mirrors
+  `post-merge-audit`'s "Needs follow-up issue / Needs fix PR" classification), and
+  post the failing evidence on the PR. **Neither** label is applied.
 - **No standing umbrella tracker issue** for the QA effort itself — that is the
   only thing #3952 ruled out. Per-bug issues are expected and encouraged.
 
+**Issue-creation approval.** Creating an issue is outward-facing, so it is gated:
+
+- **Attended run:** synchronous confirm in-session before creation (the default).
+- **Unattended run** (e.g. scheduled `qa-batch` with no operator): do **not**
+  block. Create the issue with a `needs-human-review` label, or — if issue
+  auto-creation is disabled for the run — record the finding in the batch output
+  for later filing. The mode is a `qa-batch` invocation flag, recorded in the
+  handoff.
+
 ## Coordinated edits to existing skills
 
-1. **`verify-pr-fix`** — on a passing verification, add `qa-verified`
-   (`gh pr edit <n> --add-label qa-verified`) after posting evidence. One-time:
-   create the label in the repo. No other change to its flow.
+1. **`verify-pr-fix`** — after a passing verification, ensure the label exists
+   (`gh label list` → `gh label create qa-verified` if absent) and add it as the
+   **final** write, only after the evidence comment posts successfully (§5
+   invariant). No other change to its flow.
 2. **`post-merge-audit`** — register `agent-coord` claims/heartbeats for audit
    passes so audits coordinate with implementation and QA batches (§6).
 
@@ -269,20 +353,23 @@ enough that overloading `pr-batch` would muddy both.
 - `.agents/skills/verify-pr-fix/SKILL.md` — add the `qa-verified` label step.
 - `.agents/skills/post-merge-audit/SKILL.md` — add `agent-coord` coordination.
 
-**One-time repo setup:**
+**Labels** (created on demand by the writers — no manual pre-step, see §5):
 
-- Create the `qa-verified` GitHub label.
+- `qa-verified`, `qa-skipped`, and `needs-human-review` (the last for unattended
+  issue creation, §10).
 
 ## Open questions / risks
 
-- **`qa-verified` label semantics over time.** A PR superseded by a later change
-  could carry a stale `qa-verified`. Acceptable for v1 (the label means "the fix
-  as merged was proven once"); revisit if churn makes it misleading.
+- **Terminal-label semantics over time.** A PR superseded by a later change could
+  carry a stale `qa-verified`/`qa-skipped`. Acceptable for v1 (a label means "the
+  change as merged reached this state once"); revisit if churn makes it
+  misleading.
 - **Docs/other-code QA depth.** The non-behavioral methods (§4) are lighter and
   more subjective than `verify-pr-fix`. v1 keeps them as a structured read +
   note; they may warrant their own mini-rubric later.
 - **Resolver coupling.** Reusing `post-merge-audit-scope` ties `plan-qa-batch` to
-  that script's contract; a change there must keep the `--json` shape stable.
+  that script's contract (its `--json` shape, and the last-RC default base that
+  §3 deliberately overrides with the label query as the authoritative backlog).
 - **Mislocated existing specs (separate task).** Three design docs sit under
   public `docs/superpowers/specs/`; by the "`docs/` is public, internal design
   goes to `internal/planning/`" rule they should move. Out of scope for this

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -69,8 +69,8 @@ This is the same selection/interview/dispatch gap that `plan-pr-batch` →
   authoritative unbounded backlog query (§3) and uses the last-RC window only to
   order/prioritize what it surfaces — never to filter (§2).
 - **Override (on-demand):** `$plan-qa-batch <base..head>`, `--full` (drop the
-  since-RC ordering window and present the entire backlog flat, §3), a
-  label/milestone filter, or an explicit PR list.
+  since-RC ordering window; backlog coverage is always unbounded regardless —
+  §2), a label/milestone filter, or an explicit PR list.
 - **Idempotent:** re-invoke any time. PRs already carrying a terminal QA label
   (`qa-verified` or `qa-skipped`, §5) drop out automatically, so the skill always
   shows exactly what still needs QA.
@@ -107,7 +107,10 @@ the active target base branch, run on every invocation (not just `--full`):
 ```sh
 set -o pipefail
 
-repo="${QA_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+repo="${QA_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}" || {
+  echo "ERROR: could not determine repository name" >&2
+  exit 1
+}
 target_base="${QA_TARGET_BASE:-main}" # e.g. main or the active release branch
 
 gh api --method GET --paginate \
@@ -128,13 +131,14 @@ API (or an equivalent non-search GraphQL connection) until `hasNextPage` /
 query to the active target base branch so a release sweep does not mix `main`
 and `release/*` PRs. The `repo` value is derived from the trusted local checkout
 or an explicit trusted override and reused anywhere this document shows
-`OWNER/REPO`-style placeholders. The implementation MUST preserve `pipefail` (or
-capture the API exit code explicitly) and abort on API/auth/rate-limit/network
-errors before using the `jq` output; a failed page fetch is UNKNOWN, not an empty
-backlog. The `jq -s` example buffers all returned pages before filtering; that is
-acceptable for React on Rails' current PR volume, but the SKILL.md should switch
-to per-page/streaming processing if a target repo's merged PR count makes that
-memory trade-off unsafe.
+`OWNER/REPO`-style placeholders. Repository derivation failure is also UNKNOWN:
+abort before making the backlog API call. The implementation MUST preserve
+`pipefail` (or capture the API exit code explicitly) and abort on
+API/auth/rate-limit/network errors before using the `jq` output; a failed page
+fetch is UNKNOWN, not an empty backlog. The `jq -s` example buffers all returned
+pages before filtering; that is acceptable for React on Rails' current PR volume,
+but the SKILL.md should switch to per-page/streaming processing if a target
+repo's merged PR count makes that memory trade-off unsafe.
 
 The read-only resolver
 `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` is then used

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -111,15 +111,18 @@ repo="${QA_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}" || {
   echo "ERROR: could not determine repository name" >&2
   exit 1
 }
-target_base="${QA_TARGET_BASE:-main}" # e.g. main or the active release branch
+target_bases="${QA_TARGET_BASES:-main}" # e.g. "main release/v4.1"
 
-gh api --method GET --paginate \
-  -f state=closed -f base="$target_base" -f per_page=100 \
-  "/repos/$repo/pulls" |
+for target_base in $target_bases; do
+  gh api --method GET --paginate \
+    -f state=closed -f base="$target_base" -f per_page=100 \
+    "/repos/$repo/pulls"
+done |
   jq -s '
     [.[][] | select(.merged_at != null)
       | select(([.labels[].name] | index("qa-verified")) | not)
       | select(([.labels[].name] | index("qa-skipped")) | not)]
+    | unique_by(.number)
   '
 ```
 
@@ -128,17 +131,23 @@ caps around 1000 results. The planner therefore MUST NOT rely on a high
 `--limit` over search to prove "gap-free" coverage. It must page the pull-request
 API (or an equivalent non-search GraphQL connection) until `hasNextPage` /
 `Link: rel="next"` is exhausted, filter `merged_at != null`, and constrain the
-query to the active target base branch so a release sweep does not mix `main`
-and `release/*` PRs. The `repo` value is derived from the trusted local checkout
-or an explicit trusted override and reused anywhere this document shows
-`OWNER/REPO`-style placeholders. Repository derivation failure is also UNKNOWN:
-abort before making the backlog API call. The implementation MUST preserve
-`pipefail` (or capture the API exit code explicitly) and abort on
-API/auth/rate-limit/network errors before using the `jq` output; a failed page
-fetch is UNKNOWN, not an empty backlog. The `jq -s` example buffers all returned
-pages before filtering; that is acceptable for React on Rails' current PR volume,
-but the SKILL.md should switch to per-page/streaming processing if a target
-repo's merged PR count makes that memory trade-off unsafe.
+query to the trusted target-base set. That set is usually one branch (`main` or
+the active release branch), but a main sweep in a release-branch workflow must
+include release branches whose PRs can reach `HEAD` via release → main merges;
+otherwise PRs originally targeted at `release/*` are invisible to a
+`base=main`-only query. If the planner cannot enumerate the relevant base set, it
+stops with UNKNOWN instead of narrowing the "gap-free" guarantee.
+
+The `repo` value is derived from the trusted local checkout or an explicit
+trusted override and reused anywhere this document shows `OWNER/REPO`-style
+placeholders. Repository derivation failure is also UNKNOWN: abort before making
+the backlog API call. The implementation MUST preserve `pipefail` (or capture the
+API exit code explicitly) and abort on API/auth/rate-limit/network errors before
+using the `jq` output; a failed page fetch is UNKNOWN, not an empty backlog. The
+`jq -s` example buffers all returned pages before filtering; that is acceptable
+for React on Rails' current PR volume, but the SKILL.md should switch to
+per-page/streaming processing if a target repo's merged PR count makes that
+memory trade-off unsafe.
 
 The read-only resolver
 `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` is then used

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -131,7 +131,10 @@ or an explicit trusted override and reused anywhere this document shows
 `OWNER/REPO`-style placeholders. The implementation MUST preserve `pipefail` (or
 capture the API exit code explicitly) and abort on API/auth/rate-limit/network
 errors before using the `jq` output; a failed page fetch is UNKNOWN, not an empty
-backlog.
+backlog. The `jq -s` example buffers all returned pages before filtering; that is
+acceptable for React on Rails' current PR volume, but the SKILL.md should switch
+to per-page/streaming processing if a target repo's merged PR count makes that
+memory trade-off unsafe.
 
 The read-only resolver
 `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` is then used
@@ -221,15 +224,14 @@ Properties:
   create a missing label (it errors / no-ops), which would silently break dedup.
   So the writer first ensures the label exists, then adds it — no manual one-time
   setup to forget. Because `qa-batch` lanes run concurrently, the ensure step is
-  **idempotent**: read the full label set first (for example,
-  `gh label list --limit 1000 --json name`, or `gh api --paginate` over
-  `/repos/$repo/labels` if the repo can exceed that), create the missing label if
-  absent, and if a concurrent `gh label create` returns the GitHub 422 validation
-  error, re-read the full label set and treat it as success only when the
-  expected label is now present. A failed re-read after a 422 is also a loud
-  failure: abort the label step and surface the error rather than proceeding
-  silently. Any other create failure stays loud (equivalently, a single
-  serialized bootstrap before fan-out).
+  **idempotent**: read the full label set first via the paginated labels API
+  (for example, `gh api --method GET --paginate "/repos/$repo/labels"` with
+  `--jq '.[].name'`), create the missing label if absent, and if a concurrent
+  `gh label create` returns the GitHub 422 validation error, re-read the full
+  label set and treat it as success only when the expected label is now present.
+  A failed re-read after a 422 is also a loud failure: abort the label step and
+  surface the error rather than proceeding silently. Any other create failure
+  stays loud (equivalently, a single serialized bootstrap before fan-out).
 - **Write-ordering is an invariant, not a description.** `qa-verified` MUST be the
   **final** write: apply it only after `gh pr comment` returns success for the
   evidence comment. If the evidence post fails, the label step is aborted — so a
@@ -382,9 +384,10 @@ documented as a future enhancement, not built.
   `post-merge-audit`'s "Needs follow-up issue / Needs fix PR" classification), and
   post the failing evidence on the PR. **Neither** label is applied.
 - **Infra/tooling stall:** do not create a duplicate product bug issue. Post or
-  record the blocker evidence, leave the PR unlabeled, and create at most one
-  maintainer-approved tooling follow-up if the failure is durable and not already
-  tracked.
+  record the blocker evidence, leave the PR unlabeled (so it re-enters the
+  backlog on the next run, matching the §5 failure posture), and create at most
+  one maintainer-approved tooling follow-up if the failure is durable and not
+  already tracked.
 - **No standing umbrella tracker issue** for the QA effort itself — that is the
   only thing #3952 ruled out. Per-bug issues are expected and encouraged.
 
@@ -435,7 +438,8 @@ readiness) differ enough that overloading `pr-batch` would muddy both.
 
 ## Boundaries (what it does NOT do)
 
-- Does not run `verify-pr-fix` itself (Phase A is plan-only).
+- `plan-qa-batch` is plan-only: it produces the plan and goal prompt and does
+  not directly invoke `verify-pr-fix`; that is `qa-batch`'s job.
 - Does not create branches or PRs, and does not merge. (It does use ephemeral
   git worktrees to isolate spec-only "before" repros — §9c — which are discarded
   after the lane.)
@@ -475,6 +479,13 @@ readiness) differ enough that overloading `pr-batch` would muddy both.
 - **Resolver coupling.** Reusing `post-merge-audit-scope` ties `plan-qa-batch` to
   that script's contract (its `--json` shape, and the last-RC default base that
   §3 deliberately overrides with the label query as the authoritative backlog).
+- **Durable skip-counter requires an `agent-coord` schema extension.** The
+  repeated-contention escalation (§6) needs a first-class, compare-and-swap-safe
+  counter field on coordination records. If that field does not exist at Phase A
+  implementation time, escalation runs in degraded mode (current-batch report
+  only, no automated gate). Decide before implementation: add the field to
+  `agent-coord`, use a surrogate such as a dedicated GitHub status/check, or
+  explicitly accept degraded mode for v1.
 - **Mislocated existing specs (separate task).** Three design docs sit under
   public `docs/superpowers/specs/`; by the "`docs/` is public, internal design
   goes to `internal/planning/`" rule they should move. Out of scope for this

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -81,46 +81,61 @@ This is the same selection/interview/dispatch gap that `plan-pr-batch` →
 backlog is defined **only** by terminal labels, so the range can never silently
 drop a PR:
 
-```
+```text
 backlog = (all merged PRs through HEAD)
           − (PRs labeled `qa-verified`)   ← passed QA (§5)
           − (PRs labeled `qa-skipped`)    ← reviewed, nothing to verify (§5)
 ```
 
-Every merged PR ends in exactly one terminal state — `qa-verified` or
-`qa-skipped` — so the unverified set is precisely the PRs with neither label.
-**The authoritative, unbounded label query (§3) runs on every invocation**, so a
-PR merged before the last RC that was never QA'd is never dropped — the RC window
-is only an ordering/prioritization hint, never a filter that removes unlabeled
-PRs. The labels — not the range — guarantee no gaps, and because a `qa-skipped`
-PR is never re-presented, the **backlog** (future work) stays bounded to
-unlabeled PRs only. (The `qa-skipped` _set_ itself grows monotonically with the
-repo's formatting/typo history; that is harmless because it never re-enters the
-backlog, but it is not "bounded.")
+Every merged PR that passes QA or is deliberately skipped ends in exactly one
+terminal state — `qa-verified` or `qa-skipped`. A failing, blocked, or
+tool-stalled PR intentionally carries neither label, so it remains visible for a
+later run. **The authoritative, unbounded label query (§3) runs on every
+invocation**, so a PR merged before the last RC that was never QA'd is never
+dropped — the RC window is only an ordering/prioritization hint, never a filter
+that removes unlabeled PRs. The labels — not the range — guarantee no gaps, and
+because a `qa-skipped` PR is never re-presented, the **backlog** (future work)
+stays bounded to unlabeled PRs only. (The `qa-skipped` _set_ itself grows
+monotonically with the repo's formatting/typo history; that is harmless because
+it never re-enters the backlog, but it is not "bounded.")
 
 ### 3. Scope resolution — label query is authoritative, resolver is an optimization
 
-The authoritative backlog is always the **unbounded, paginated** label query, run
-on every invocation (not just `--full`):
+The authoritative backlog is always the **unbounded, paginated** label query for
+the active target base branch, run on every invocation (not just `--full`):
 
 ```sh
-gh pr list --state merged --search "-label:qa-verified -label:qa-skipped" \
-  --limit 9999   # iterate pages if the repo can exceed the search cap (~1000)
+target_base="${QA_TARGET_BASE:-main}" # e.g. main or the active release branch
+
+gh api --method GET --paginate \
+  -f state=closed -f base="$target_base" -f per_page=100 \
+  /repos/OWNER/REPO/pulls |
+  jq -s '
+    [.[][] | select(.merged_at != null)
+      | select(([.labels[].name] | index("qa-verified")) | not)
+      | select(([.labels[].name] | index("qa-skipped")) | not)]
+  '
 ```
 
-`gh pr list` defaults to `--state open` and `--limit 30` and the search backend
-caps at ~1000 results, so the skill MUST set `--state merged`, a high `--limit`,
-and page explicitly — otherwise the "gap-free" promise silently truncates.
+`gh pr list` defaults to `--state open` and `--limit 30`, and its search backend
+caps around 1000 results. The planner therefore MUST NOT rely on a high
+`--limit` over search to prove "gap-free" coverage. It must page the pull-request
+API (or an equivalent non-search GraphQL connection) until `hasNextPage` /
+`Link: rel="next"` is exhausted, filter `merged_at != null`, and constrain the
+query to the active target base branch so a release sweep does not mix `main`
+and `release/*` PRs.
 
 The read-only resolver
 `.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` is then used
 **only as an optimization** to order/prioritize the common since-RC window, never
 to filter the backlog. Two real constraints when calling it (verified against the
 script): it **hard-fails (`return 1`)** when no `*.rc.*` tag is in head history
-and `--base` is omitted, so `plan-qa-batch` always passes `--base origin/main`
-explicitly and treats any non-zero exit as "optimization unavailable" — the label
-query above remains the unconditional source of truth. `plan-qa-batch` then
-layers QA classification (§4) on the resulting set.
+and `--base` is omitted, so `plan-qa-batch` always passes an explicit
+release-aware `--base` matching the sweep target (`origin/main` for a main sweep,
+or the active release branch for an RC/release sweep). If the resolver returns an
+empty or non-zero optimization for that base, the planner treats the optimization
+as unavailable — the label query above remains the unconditional source of truth.
+`plan-qa-batch` then layers QA classification (§4) on the resulting set.
 
 ### 4. Classify by QA _method_, not include-vs-skip
 
@@ -170,14 +185,15 @@ PR), so it is explicit, not ad hoc:
    at execution time, so the plan is actionable before launch without over-fitting.
 3. **No silent "nothing to verify".** A PR routed to the `qa-skipped` lane is
    surfaced in the interview (§7) with its one-line reason and is labeled only
-   after acknowledgment (developer in an attended run; auto-acknowledged with an
-   audit-trail note in an unattended run — §7) — so the exclusion is deliberate
-   and auditable, never silent.
+   after acknowledgment (an **attended run** has a developer present to confirm;
+   an **unattended run** has no operator and records an auto-acknowledgment audit
+   trail — §7) — so the exclusion is deliberate and auditable, never silent.
 
 ### 5. Dedup and persistence — two terminal labels
 
-Every merged PR reaches exactly one terminal QA state, recorded as a GitHub label
-so the backlog (§2) is a pure query:
+Every merged PR that passes QA or is deliberately skipped reaches exactly one
+terminal QA state, recorded as a GitHub label. Unlabeled PRs are still pending,
+failed, blocked, or tool-stalled, so the backlog (§2) remains a pure query:
 
 - **`qa-verified`** — applied on a **passing** QA run (any method: behavioral
   pass, docs OK, code-check OK).
@@ -186,9 +202,9 @@ so the backlog (§2) is a pure query:
 
 Properties:
 
-- **Dedup** is a single
-  `gh pr list --state merged --search "-label:qa-verified -label:qa-skipped"`
-  query rather than scanning every candidate's comment body.
+- **Dedup** is the paginated pull-request API query from §3 plus client-side
+  label filtering, rather than search-index caps or scanning every candidate's
+  comment body.
 - **GitHub is the persistence.** The plan is a _derived view_ reconstructed from
   the merged set minus the two labels on each run — no local file, no `.context`
   (Conductor-only, non-portable), no tracker issue. Works identically on every
@@ -197,9 +213,11 @@ Properties:
   create a missing label (it errors / no-ops), which would silently break dedup.
   So the writer first ensures the label exists, then adds it — no manual one-time
   setup to forget. Because `qa-batch` lanes run concurrently, the ensure step is
-  **idempotent**: two lanes can race on the same missing label, so a
-  `gh label create` that returns "already exists" is treated as **success**, not a
-  lane failure (equivalently, a single serialized bootstrap before fan-out).
+  **idempotent**: read labels first (`gh label list --json name`), create the
+  missing label if absent, and if a concurrent `gh label create` returns the
+  GitHub 422 validation error, re-read labels and treat it as success only when
+  the expected label is now present. Any other create failure stays loud
+  (equivalently, a single serialized bootstrap before fan-out).
 - **Write-ordering is an invariant, not a description.** `qa-verified` MUST be the
   **final** write: apply it only after `gh pr comment` returns success for the
   evidence comment. If the evidence post fails, the label step is aborted — so a
@@ -219,9 +237,10 @@ QA batches register in the **same `agent-coord` backend**
 rules live in `.agents/workflows/pr-processing.md` and
 `internal/contributor-info/agent-coordination-backend.md`. Per QA lane:
 
-1. `agent-coord doctor` + `agent-coord status` — if a candidate PR has a **live
-   claim** from another (implementation/review) batch, **skip it this round** and
-   report why; QA must not verify a moving target.
+1. `agent-coord doctor` + targeted
+   `agent-coord status --repo OWNER/REPO --target <pr>` per candidate — if a
+   candidate PR has a **live claim** from another (implementation/review) batch,
+   **skip it this round** and report why; QA must not verify a moving target.
 2. `agent-coord claim` the PR's QA lane before starting (compare-and-swap gate;
    `CLAIM_REFUSED` / exit 3 is a hard stop — report holder + heartbeat liveness).
 3. `agent-coord heartbeat` at phase transitions (claimed → reproducing →
@@ -243,13 +262,21 @@ in-progress state.
 
 **Repeated-contention escalation.** A PR skipped for a live claim (point 1) is
 retried next run, but a PR under perpetual edit would be skipped forever and the
-coverage gap would be invisible. After **3** consecutive contention skips the
-planner surfaces it as `blocked — repeated contention` so the maintainer can
-schedule a QA window or override. The skip count needs durable, file-free storage
-across invocations, so it lives on the PR's `agent-coord` coordination record (the
-backend already in use), incremented on each contention skip and cleared when QA
-finally claims the PR — not in a local file (ruled out, §5) and not encodable in a
-terminal label.
+coverage gap would be invisible. The default policy is **3** consecutive
+contention skips before surfacing `blocked — repeated contention`: one skip is
+common during active review, two may be normal during a release day, and three
+means the PR has now missed multiple QA opportunities. The threshold is a
+`qa-batch` parameter, recorded in the handoff, so release managers can tighten or
+relax it for cadence.
+
+The skip count needs durable, file-free storage across invocations. Do **not**
+assume arbitrary mutable metadata exists on current `agent-coord` records. Phase A
+must either add a first-class coordination field / batch-state entry with
+compare-and-swap semantics, or run in degraded mode where repeated-contention
+counts are reported in the current batch output only and are not used for
+automated escalation. A successful QA claim clears the durable count when that
+capability exists; without it, escalation is advisory/UNKNOWN rather than a hard
+gate.
 
 ### 7. The interview
 
@@ -300,7 +327,13 @@ wedge the batch:
 - **(b) Environment-resource contention** — only **one** consumer of the Pro
   renderer / Redis / license / dummy-app DB at a time. Lanes whose env profile
   needs the shared Pro stack **serialize**; docs and pure-read lanes
-  **parallelize** freely.
+  **parallelize** freely. This serialization is separate from per-PR
+  `agent-coord` claims: the `qa-batch` scheduler keeps an in-process resource
+  semaphore for the current batch and, before cross-batch Pro concurrency is
+  enabled, must either acquire an explicit backend resource claim such as
+  `resource:pro-stack` (if the coordination backend supports non-PR targets) or
+  stop with UNKNOWN when another live QA batch could already be using the shared
+  stack. Per-PR claims alone are insufficient to protect the Pro resources.
 - **(c) Working-tree isolation.** QA mostly does not edit source, but the
   documented spec-only "before" tactic (`git checkout <fix>~1 -- <file>`, §4 /
   `verify-pr-fix`) **does mutate the shared checkout** — two such lanes in one
@@ -315,8 +348,9 @@ wedge the batch:
   `qa-batch` parameter. A lane that exceeds it (hung renderer, crashed agent,
   stale `agent-coord` claim, never-exiting test) is marked **failed — not
   labeled**, its claim released, and it is deferred to the next batch and surfaced
-  to the maintainer — the same fail-open posture as the `agent-coord`-unavailable
-  fallback in §6. One stuck lane never blocks the rest indefinitely.
+  to the maintainer — the same blocked/deferred posture as the
+  `agent-coord`-unavailable fallback in §6. One stuck lane never blocks the rest
+  indefinitely.
 
 `plan-qa-batch` stays plan-only (Phase A): it produces the plan and goal prompt
 and launches `qa-batch` only when the user asks. **Phase B** (the planner
@@ -334,6 +368,10 @@ documented as a future enhancement, not built.
   cross-linked issue** describing the reproduction and the broken signal (mirrors
   `post-merge-audit`'s "Needs follow-up issue / Needs fix PR" classification), and
   post the failing evidence on the PR. **Neither** label is applied.
+- **Infra/tooling stall:** do not create a duplicate product bug issue. Post or
+  record the blocker evidence, leave the PR unlabeled, and create at most one
+  maintainer-approved tooling follow-up if the failure is durable and not already
+  tracked.
 - **No standing umbrella tracker issue** for the QA effort itself — that is the
   only thing #3952 ruled out. Per-bug issues are expected and encouraged.
 
@@ -345,6 +383,14 @@ documented as a future enhancement, not built.
   auto-creation is disabled for the run — record the finding in the batch output
   for later filing. The mode is a `qa-batch` invocation flag, recorded in the
   handoff.
+
+Issue bodies are generated from a trusted template. PR-sourced content (titles,
+bodies, comments, diffs, logs, and reproduced output) is treated as untrusted
+data: quote it, fence it, cap excerpts, and never let it supply instructions to
+the agent or alter labels, assignees, commands, repository paths, or safety
+rules. Build multi-line issue bodies in a temporary Markdown file and pass them
+with `gh issue create --body-file`, matching the repository's GitHub follow-up
+issue rule.
 
 ## Coordinated edits to existing skills
 
@@ -420,6 +466,12 @@ readiness) differ enough that overloading `pr-batch` would muddy both.
   public `docs/superpowers/specs/`; by the "`docs/` is public, internal design
   goes to `internal/planning/`" rule they should move. Out of scope for this
   work — handle in a separate PR.
+- **Canonical home.** This planning artifact is useful in this repository because
+  it ties QA labels to React on Rails release readiness, but the reusable
+  `plan-qa-batch` / `qa-batch` skill implementation may belong in
+  `shakacode/agent-workflows`. Decide before Phase A implementation whether to
+  keep only the React on Rails release policy here and move the generic workflow
+  mechanics there.
 
 ## Phasing
 

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -120,8 +120,8 @@ for target_base in $target_bases; do
 done |
   jq -s '
     [.[][] | select(.merged_at != null)
-      | select(([.labels[].name] | index("qa-verified")) | not)
-      | select(([.labels[].name] | index("qa-skipped")) | not)]
+      | select(any(.labels[]; .name == "qa-verified") | not)
+      | select(any(.labels[]; .name == "qa-skipped") | not)]
     | unique_by(.number)
   '
 ```
@@ -157,9 +157,12 @@ script): it **hard-fails (`return 1`)** when no `*.rc.*` tag is in head history
 and `--base` is omitted, so `plan-qa-batch` always passes an explicit
 release-aware `--base` matching the sweep target (`origin/main` for a main sweep,
 or the active release branch for an RC/release sweep). If the resolver returns an
-empty or non-zero optimization for that base, the planner treats the optimization
-as unavailable — the label query above remains the unconditional source of truth.
-`plan-qa-batch` then layers QA classification (§4) on the resulting set.
+empty optimization or a known "no RC tag" result for that base, the planner
+treats the optimization as unavailable — the label query above remains the
+unconditional source of truth. Unexpected resolver failures (auth, missing tools,
+network, malformed JSON, or an unrecognized non-zero exit) are infrastructure
+UNKNOWN and abort before planning. `plan-qa-batch` then layers QA classification
+(§4) on the resulting set.
 
 ### 4. Classify by QA _method_, not include-vs-skip
 
@@ -250,7 +253,9 @@ Properties:
   evidence comment. If the evidence post fails, the label step is aborted — so a
   PR can never carry `qa-verified` without its supporting evidence (no silent
   false positive). A crash between a successful evidence post and the label is
-  survivable: the next run simply re-verifies.
+  survivable: the next run simply re-verifies. `qa-skipped` has no evidence
+  comment; its prerequisite write is the developer acknowledgment, or the
+  unattended auto-acknowledgment audit-trail note (§7).
 - **Failures stay loud.** A failing verification (❌) gets **neither** label and a
   discrete issue (§10); it deliberately remains in the backlog so re-runs keep
   re-verifying until the fix lands, with the open issue as the human signal. (A
@@ -280,12 +285,10 @@ re-edited, and other batches see QA in flight. The **same integration is added t
 **Degraded-backend fallback (exit-code-aware).** The backend doc distinguishes
 exit 3 (`CLAIM_REFUSED`, hard stop) from exit 2 (`UNKNOWN` / degraded). Because QA
 lanes are dependency-sensitive by definition (point 1 — must not verify a moving
-target), an exit-2 `UNKNOWN` status for a PR that **could** carry an invisible
-live implementation claim is treated as **blocked/deferred**, _not_ proceeded on
-advisory public comments. (Advisory-comment fallback is only acceptable for a PR
-with no plausible concurrent claimant.) This matches the canonical rule in
-`agent-coordination-backend.md`; proceeding on UNKNOWN would let QA verify an
-in-progress state.
+target), any exit-2 `UNKNOWN` status for a candidate PR is treated as
+**blocked/deferred**, _not_ proceeded on advisory public comments. This matches
+the canonical rule in `agent-coordination-backend.md`; proceeding on UNKNOWN
+would let QA verify an in-progress state.
 
 **Repeated-contention escalation.** A PR skipped for a live claim (point 1) is
 retried next run, but a PR under perpetual edit would be skipped forever and the
@@ -325,9 +328,12 @@ then ask only for what cannot be inferred:
 3. **Environment availability now** — Redis + Pro license + Pro renderer up?
    Browser available? Candidates whose **actual** env profile (§4b) is
    unavailable are deferred and clearly listed, not silently dropped.
-4. Cap — max items this batch.
-5. Methods/areas to include or exclude.
-6. Concurrency — how many lanes / subagents to plan for.
+4. Cap — max items this batch. Unattended default: the `--cap` invocation value,
+   or unlimited if unset.
+5. Methods/areas to include or exclude. Unattended default: include all methods
+   and areas that have available environments.
+6. Concurrency — how many lanes / subagents to plan for. Unattended default: the
+   configured `qa-batch` concurrency, capped by resource serialization (§9).
 
 ### 8. Output — the QA Batch Plan + goal prompt
 
@@ -360,11 +366,11 @@ wedge the batch:
   semaphore for the current batch and, before cross-batch Pro concurrency is
   enabled, must either acquire an explicit backend resource claim such as
   `resource:pro-stack` (if the coordination backend supports non-PR targets) or
-  stop with UNKNOWN when another live QA batch could already be using the shared
-  stack. Per-PR claims alone are insufficient to protect the Pro resources. The
-  **v1 default** is to stop with UNKNOWN unless the backend resource claim is
-  implemented and verified; proceeding without cross-batch Pro serialization is
-  not allowed.
+  stop with UNKNOWN because another live QA batch could already be using the
+  shared stack and there is no safe cross-machine detection primitive. Per-PR
+  claims alone are insufficient to protect the Pro resources. The **v1 default**
+  is to stop with UNKNOWN unless the backend resource claim is implemented and
+  verified; proceeding without cross-batch Pro serialization is not allowed.
 - **(c) Working-tree isolation.** QA mostly does not edit source, but the
   documented spec-only "before" tactic (`git checkout <fix>~1 -- <file>`, §4 /
   `verify-pr-fix`) **does mutate the shared checkout** — two such lanes in one
@@ -430,9 +436,9 @@ output into it.
 ## Coordinated edits to existing skills
 
 1. **`verify-pr-fix`** — after a passing verification, ensure the label exists
-   (`gh label list` → `gh label create qa-verified` if absent) and add it as the
-   **final** write, only after the evidence comment posts successfully (§5
-   invariant). No other change to its flow.
+   using the paginated label lookup and idempotent create flow from §5, then add
+   it as the **final** write, only after the evidence comment posts successfully
+   (§5 invariant). No other change to its flow.
 2. **`post-merge-audit`** — register `agent-coord` claims/heartbeats for audit
    passes so audits coordinate with implementation and QA batches (§6).
 

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -213,9 +213,11 @@ Properties:
   create a missing label (it errors / no-ops), which would silently break dedup.
   So the writer first ensures the label exists, then adds it — no manual one-time
   setup to forget. Because `qa-batch` lanes run concurrently, the ensure step is
-  **idempotent**: read labels first (`gh label list --json name`), create the
-  missing label if absent, and if a concurrent `gh label create` returns the
-  GitHub 422 validation error, re-read labels and treat it as success only when
+  **idempotent**: read the full label set first (for example,
+  `gh label list --limit 1000 --json name`, or `gh api --paginate` over
+  `/repos/OWNER/REPO/labels` if the repo can exceed that), create the missing
+  label if absent, and if a concurrent `gh label create` returns the GitHub 422
+  validation error, re-read the full label set and treat it as success only when
   the expected label is now present. Any other create failure stays loud
   (equivalently, a single serialized bootstrap before fan-out).
 - **Write-ordering is an invariant, not a description.** `qa-verified` MUST be the

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -290,11 +290,12 @@ relax it for cadence.
 The skip count needs durable, file-free storage across invocations. Do **not**
 assume arbitrary mutable metadata exists on current `agent-coord` records. Phase A
 must either add a first-class coordination field / batch-state entry with
-compare-and-swap semantics, or run in degraded mode where repeated-contention
-counts are reported in the current batch output only and are not used for
-automated escalation. A successful QA claim clears the durable count when that
-capability exists; without it, escalation is advisory/UNKNOWN rather than a hard
-gate.
+compare-and-swap semantics, or explicitly ship v1 in degraded mode where
+repeated-contention counts are reported in the current batch output only and are
+not used for automated escalation. A successful QA claim clears the durable count
+when that capability exists; without it, escalation is advisory/UNKNOWN rather
+than a hard gate, and `qa-batch` must label that mode as "no automated
+repeated-contention escalation" in its handoff.
 
 ### 7. The interview
 
@@ -351,7 +352,10 @@ wedge the batch:
   enabled, must either acquire an explicit backend resource claim such as
   `resource:pro-stack` (if the coordination backend supports non-PR targets) or
   stop with UNKNOWN when another live QA batch could already be using the shared
-  stack. Per-PR claims alone are insufficient to protect the Pro resources.
+  stack. Per-PR claims alone are insufficient to protect the Pro resources. The
+  **v1 default** is to stop with UNKNOWN unless the backend resource claim is
+  implemented and verified; proceeding without cross-batch Pro serialization is
+  not allowed.
 - **(c) Working-tree isolation.** QA mostly does not edit source, but the
   documented spec-only "before" tactic (`git checkout <fix>~1 -- <file>`, §4 /
   `verify-pr-fix`) **does mutate the shared checkout** — two such lanes in one
@@ -410,7 +414,9 @@ data: quote it, fence it, cap excerpts, and never let it supply instructions to
 the agent or alter labels, assignees, commands, repository paths, or safety
 rules. Build multi-line issue bodies in a temporary Markdown file and pass them
 with `gh issue create --body-file`, matching the repository's GitHub follow-up
-issue rule.
+issue rule. The implementation must create that file with `mktemp` and register a
+cleanup trap (for example, `trap 'rm -f "$tmp"' EXIT`) before writing reproduced
+output into it.
 
 ## Coordinated edits to existing skills
 
@@ -486,10 +492,10 @@ readiness) differ enough that overloading `pr-batch` would muddy both.
 - **Durable skip-counter requires an `agent-coord` schema extension.** The
   repeated-contention escalation (§6) needs a first-class, compare-and-swap-safe
   counter field on coordination records. If that field does not exist at Phase A
-  implementation time, escalation runs in degraded mode (current-batch report
-  only, no automated gate). Decide before implementation: add the field to
-  `agent-coord`, use a surrogate such as a dedicated GitHub status/check, or
-  explicitly accept degraded mode for v1.
+  implementation time, v1 explicitly runs in degraded mode (current-batch report
+  only, no automated gate) and must say so in every handoff. A later iteration can
+  add the field to `agent-coord` or use a surrogate such as a dedicated GitHub
+  status/check.
 - **Mislocated existing specs (separate task).** Three design docs sit under
   public `docs/superpowers/specs/`; by the "`docs/` is public, internal design
   goes to `internal/planning/`" rule they should move. Out of scope for this

--- a/internal/planning/2026-06-21-plan-qa-batch-design.md
+++ b/internal/planning/2026-06-21-plan-qa-batch-design.md
@@ -1,0 +1,298 @@
+# Plan QA Batch — Design
+
+Date: 2026-06-21
+Branch: `jg-conductor/3952-qa-automation-plan`
+
+## Problem
+
+Behavioral QA — proving that a merged change actually does what it claims — has a
+worker but no planner. The `verify-pr-fix` skill
+(`.agents/skills/verify-pr-fix/SKILL.md`) verifies **one** PR: reproduce the bug
+before the fix, confirm it gone after, post evidence to the PR. But nothing
+decides **which** merged PRs get that treatment, **when**, or **in what order**.
+
+Issue #3952 was the manual planner — a hand-curated, tiered list of behavioral
+bug-fix PRs to verify since `rc.1`. It was **closed** with the rationale that
+verifying user-facing fixes is a _per-PR practice_ (do it on the PR with
+`verify-pr-fix`, post evidence there), **not a standing umbrella tracking
+issue**. That was the right call about the _tracker_, but it removed the only
+trigger without replacing it: today, whether a merged PR ever gets QA'd depends
+on someone remembering. There is no systematic, gap-free way to ask "what merged
+since the last release that still needs its behavior verified?"
+
+This is the same selection/interview/dispatch gap that `plan-pr-batch` →
+`pr-batch` already fills for _implementation_ work. QA needs the equivalent.
+
+## Goals
+
+1. **Close the trigger gap, gap-free.** Given any point through `HEAD`, surface
+   every merged PR still needing QA, so coverage cannot silently skip a PR.
+2. **Suggest, then interview.** Auto-classify and rank merged PRs, present the
+   suggestions, and interview the developer to confirm scope, priority, cap, and
+   environment availability — the core of the request.
+3. **Route every change to the right QA method.** Behavioral fixes, docs, and
+   other code changes each get an appropriate check; nothing merged is dropped
+   silently.
+4. **Run concurrently and safely.** Split the batch into subagent lanes that run
+   in parallel, coordinated through the **same** `agent-coord` heartbeat the
+   implementation batches use, so QA never collides with in-flight edit work.
+5. **Record findings where they belong.** A passing verification marks the PR; a
+   failing one (or any bug found) opens a discrete, cross-linked issue. No
+   standing umbrella tracker.
+
+## Non-goals
+
+- Not local lint/test/typecheck — that is `verify` (`$verify`).
+- Not process/release-risk auditing (review gates, changelog, cross-PR
+  interactions) — that is `post-merge-audit`. `plan-qa-batch` is the
+  **behavioral** half of release readiness; the two are siblings.
+- Not a code editor — QA workers reproduce and report; they do not fix. A fix is
+  a separate, normally human-authorized follow-up.
+- Not a standing tracking issue (the #3952 lesson).
+
+## Where it fits
+
+| Skill                         | Question it answers                                                                               |
+| ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| `post-merge-audit`            | Process/release risk: review gates clean? changelog present? cross-PR interactions?               |
+| **`plan-qa-batch`** (new)     | **Behavioral: which merged PRs still need their change _proven_, by what method, in what order?** |
+| `qa-batch` (new, slim runner) | Executes the plan: one subagent per QA lane, coordinated and contention-aware                     |
+| `verify-pr-fix`               | The worker for one behavioral PR: reproduce-before / confirm-after                                |
+
+`plan-qa-batch` is to `verify-pr-fix` what `plan-pr-batch` is to `pr-batch`.
+
+## Design
+
+### 1. Trigger and invocation
+
+- **Default (release-gate sweep):** `$plan-qa-batch` with no args resolves
+  "merged through `HEAD`, looking back to the last RC tag." The RC tag is only a
+  _performance bound_ on how far back to scan — see §2.
+- **Override (on-demand):** `$plan-qa-batch <base..head>`, a label/milestone
+  filter, or an explicit PR list.
+- **Idempotent:** re-invoke any time. PRs already carrying `qa-verified` drop
+  out automatically, so the skill always shows exactly what still needs QA.
+
+### 2. Range is always through HEAD — gap-free by construction
+
+`HEAD` (`origin/main` / the release branch) is always the upper bound. A
+start point (commit, PR, tag, RC) is an **optional performance bound**, never the
+correctness boundary, because selection is **per-PR**:
+
+```
+candidates = (all merged PRs through HEAD)
+             − (PRs carrying the `qa-verified` label)
+             − (PRs with genuinely nothing to verify)
+```
+
+Anything left unverified before an arbitrary start point resurfaces on the next
+full sweep. The `qa-verified` label — not the range — guarantees no gaps.
+
+### 3. Scope resolution (reuse, do not duplicate)
+
+Call the existing read-only resolver
+`.agents/skills/post-merge-audit/bin/post-merge-audit-scope --json` to get the
+squash-aware merged-PR set and the last-RC base. One source of truth for "what
+merged since the RC," shared with `post-merge-audit`. `plan-qa-batch` layers QA
+classification (§4) and label dedup (§5) on top of that list.
+
+### 4. Classify by QA _method_, not include-vs-skip
+
+Nothing merged is dropped silently — every PR is routed to the right verification
+method. Each candidate is classified by reading its diff and linked issue:
+
+| Merged change                                      | QA method                                                                                             |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Behavioral fix / feature                           | `verify-pr-fix` — reproduce before/after, post evidence                                               |
+| **Docs**                                           | Read it: does it make sense, are commands/links/examples correct, does it match the code it describes |
+| Refactor / types / config / other code             | "Does it do what it claims, nothing broke" — confirm behavior unchanged + coverage                    |
+| Truly nothing to verify (formatting, comment typo) | Glance + note — the only "excluded" lane, near-empty                                                  |
+
+Each candidate carries **three independent attributes** (deliberately _not_
+collapsed into a single "tier"):
+
+- **(a) QA method** — from the table above.
+- **(b) Environment profile** — read from the actual diff, per PR: spec-only
+  (cheap `git checkout <fix>~1 -- <file>` before/after), OSS dummy app,
+  Pro renderer + Redis + license, or browser/Playwright. This is a property of
+  _the PR_, not of a value tier — an error-path fix and an RSC-cache fix can both
+  need (or both not need) the Pro stack.
+- **(c) Priority** — risk × user-impact, used for ranking.
+
+Ranking is by priority. The environment profile drives lane scheduling (§9) and
+the availability check in the interview (§7) — it does not change a PR's rank.
+
+The skip filter from `verify-pr-fix`'s "When NOT to use" still applies to the
+**behavioral-reproduction** decision (a docs PR does not get a before/after
+repro), but it no longer removes the PR from QA — the PR is routed to the docs or
+code-check method instead.
+
+### 5. Dedup and persistence — one signal
+
+- **`qa-verified` label** on the PR, applied by `verify-pr-fix` on a **passing**
+  run (`gh pr edit <n> --add-label qa-verified`, which works on already-merged
+  PRs). Created once in the repo.
+- **Dedup** is a single `gh pr list --search "… label:qa-verified"` query rather
+  than scanning every candidate's comment body.
+- **GitHub is the persistence.** The plan is a _derived view_ reconstructed from
+  the merged set minus the label on each run — no local file, no `.context`
+  (Conductor-only, non-portable), no tracker issue. Works identically on every
+  platform and machine.
+- **Failures stay loud.** A failing verification gets **no** label — it routes to
+  a discrete issue (§10), never a quiet success marker. (A hidden marker comment
+  to machine-locate the exact evidence comment is intentionally deferred; the
+  label plus the human-readable `verify-pr-fix` comment is enough for v1.)
+
+### 6. Coordination — same heartbeat as the implementation batches
+
+QA batches register in the **same `agent-coord` backend**
+(`shakacode/agent-coordination`) that `pr-batch`/`plan-pr-batch` use; canonical
+rules live in `.agents/workflows/pr-processing.md` and
+`internal/contributor-info/agent-coordination-backend.md`. Per QA lane:
+
+1. `agent-coord doctor` + `agent-coord status` — if a candidate PR has a **live
+   claim** from another (implementation/review) batch, **skip it this round** and
+   report why; QA must not verify a moving target.
+2. `agent-coord claim` the PR's QA lane before starting (compare-and-swap gate;
+   `CLAIM_REFUSED` / exit 3 is a hard stop — report holder + heartbeat liveness).
+3. `agent-coord heartbeat` at phase transitions (claimed → reproducing →
+   verifying → reporting → done).
+
+This is two-way conflict-avoidance: QA will not run on a PR being actively
+re-edited, and other batches see QA in flight. The **same integration is added to
+`post-merge-audit`** so audit passes coordinate too. When the backend is
+unavailable, report private state as `UNKNOWN` and fall back to advisory public
+claim comments, exactly as the implementation batches already do.
+
+### 7. The interview
+
+Present the auto-ranked candidate list plus a collapsed "nothing to verify" list,
+then ask only for what cannot be inferred:
+
+1. Confirm base/range (default: look back to last RC, through `HEAD`).
+2. **Environment availability now** — Redis + Pro license + Pro renderer up?
+   Browser available? Candidates whose **actual** env profile (§4b) is
+   unavailable are deferred and clearly listed, not silently dropped.
+3. Cap — max items this batch.
+4. Methods/areas to include or exclude.
+5. Concurrency — how many lanes / subagents to plan for.
+
+### 8. Output — the QA Batch Plan + goal prompt
+
+`plan-qa-batch` is a **planner** (like `plan-pr-batch`): it does not execute
+unless asked. It emits, to session output:
+
+- A **QA Batch Plan**: ranked, deduped, interviewed candidates, one line each —
+  `#NNNN — title — method — env profile — priority — linked issue — repro tactic`
+  — plus the collapsed excluded list with reasons, the deferred-for-environment
+  list, and the exact `gh`/resolver commands used.
+- A fenced **goal prompt for `qa-batch`** that specifies the concurrent subagent
+  lanes, the `agent-coord` coordination rules, the contention constraints (§9),
+  and the per-PR closeout (label on pass / issue on fail). Sized under the same
+  goal-prompt budget discipline `plan-pr-batch` already enforces.
+
+### 9. Execution — concurrent subagent lanes via `qa-batch`
+
+The `qa-batch` runner dispatches **one subagent per QA lane**, each claiming its
+PR(s), running the routed method, posting evidence, and closing out. Concurrency
+is bounded by **two** constraints — note these are _not_ `pr-batch`'s file-touch
+collision model, which is irrelevant here because QA workers do not edit source:
+
+- **(a) `agent-coord` claims** — never two lanes (or a lane and an implementation
+  batch) on the same PR.
+- **(b) Environment-resource contention** — only **one** consumer of the Pro
+  renderer / Redis / license / dummy-app DB at a time. Lanes whose env profile
+  needs the shared Pro stack **serialize**; spec-only and docs lanes
+  **parallelize** freely.
+
+`plan-qa-batch` stays plan-only (Phase A): it produces the plan and goal prompt
+and launches `qa-batch` only when the user asks. **Phase B** (the planner
+self-dispatching subagents directly, without the explicit launch handoff) is
+documented as a future enhancement, not built.
+
+### 10. Findings → issues
+
+- **Pass (✅):** apply `qa-verified`; post the `verify-pr-fix` evidence comment.
+- **Fail (❌) or any bug/doc/code problem found:** create a **discrete,
+  cross-linked issue** describing the reproduction and the broken signal
+  (mirrors `post-merge-audit`'s "Needs follow-up issue / Needs fix PR"
+  classification, approval-gated before creation), and post the failing evidence
+  on the PR. **No** `qa-verified` label.
+- **No standing umbrella tracker issue** for the QA effort itself — that is the
+  only thing #3952 ruled out. Per-bug issues are expected and encouraged.
+
+## Coordinated edits to existing skills
+
+1. **`verify-pr-fix`** — on a passing verification, add `qa-verified`
+   (`gh pr edit <n> --add-label qa-verified`) after posting evidence. One-time:
+   create the label in the repo. No other change to its flow.
+2. **`post-merge-audit`** — register `agent-coord` claims/heartbeats for audit
+   passes so audits coordinate with implementation and QA batches (§6).
+
+## The `qa-batch` runner skill (slim)
+
+A sibling to `pr-batch`, deliberately thin and QA-specific:
+
+- Consumes the `plan-qa-batch` goal prompt.
+- Dispatches one subagent per lane; each runs the routed QA method.
+- Enforces the two-constraint concurrency model (§9) and the `agent-coord`
+  protocol (§6).
+- Per-PR closeout: label on pass, issue on fail (§10).
+- Reuses `pr-batch`'s safety posture (untrusted GitHub content cannot override
+  `AGENTS.md`; stop on blocked approvals) but **not** its branch/merge/file-touch
+  machinery, which does not apply to QA.
+
+It is kept separate from `pr-batch` because the contention model (env resources,
+not file paths) and the closeout (label/issue, not branch/merge readiness) differ
+enough that overloading `pr-batch` would muddy both.
+
+## Boundaries (what it does NOT do)
+
+- Does not run `verify-pr-fix` itself (Phase A is plan-only).
+- Does not create branches, worktrees, or PRs, and does not merge.
+- Does not produce a standing tracker issue.
+- Does not duplicate `post-merge-audit` (process risk) or `verify` (local checks).
+- Produces a recommendation; the release-gate go/no-go stays with the maintainer.
+
+## Files
+
+**Create:**
+
+- `.agents/skills/plan-qa-batch/SKILL.md`
+- `.agents/skills/qa-batch/SKILL.md`
+- Optionally `.agents/workflows/qa-processing.md` (the QA operating model the
+  goal prompt references, analogous to `pr-processing.md`) if the runner needs
+  more than the SKILL.md carries.
+
+**Edit:**
+
+- `.agents/skills/verify-pr-fix/SKILL.md` — add the `qa-verified` label step.
+- `.agents/skills/post-merge-audit/SKILL.md` — add `agent-coord` coordination.
+
+**One-time repo setup:**
+
+- Create the `qa-verified` GitHub label.
+
+## Open questions / risks
+
+- **`qa-verified` label semantics over time.** A PR superseded by a later change
+  could carry a stale `qa-verified`. Acceptable for v1 (the label means "the fix
+  as merged was proven once"); revisit if churn makes it misleading.
+- **Docs/other-code QA depth.** The non-behavioral methods (§4) are lighter and
+  more subjective than `verify-pr-fix`. v1 keeps them as a structured read +
+  note; they may warrant their own mini-rubric later.
+- **Resolver coupling.** Reusing `post-merge-audit-scope` ties `plan-qa-batch` to
+  that script's contract; a change there must keep the `--json` shape stable.
+- **Mislocated existing specs (separate task).** Three design docs sit under
+  public `docs/superpowers/specs/`; by the "`docs/` is public, internal design
+  goes to `internal/planning/`" rule they should move. Out of scope for this
+  work — handle in a separate PR.
+
+## Phasing
+
+- **Phase A (this design):** `plan-qa-batch` planner + slim `qa-batch` runner +
+  the two coordinated edits + the label. Concurrent subagent lanes, plan-only
+  launch.
+- **Phase B (future):** planner self-dispatch; optional hidden evidence-marker
+  comment if machine-locating the exact evidence becomes necessary; per-method
+  rubrics for docs/other-code QA.


### PR DESCRIPTION
### Summary

Adds an internal design spec (`internal/planning/2026-06-21-plan-qa-batch-design.md`) for a `plan-qa-batch` skill: the missing planner front-end to `verify-pr-fix`, closing the trigger gap left when the manual QA batch issue #3952 was closed. It selects merged PRs still needing behavioral QA through `HEAD` (gap-free via a `qa-verified` label), routes each PR to the right QA method (behavioral/docs/other-code), interviews the developer, and emits a goal prompt for a slim sibling `qa-batch` runner that fans out subagents coordinated through the same `agent-coord` heartbeat the implementation batches use. Docs-only planning artifact — no code or behavior changes; implementation (the two new skills plus coordinated edits to `verify-pr-fix` and `post-merge-audit`) is a follow-up. Relates to #3952.

### Pull Request checklist

- ~[ ] Add/update test to cover these changes~ (design doc only)
- [x] Update documentation
- ~[ ] Update CHANGELOG file~ (internal planning doc, not user-facing)

### Other Information

This is a design/spec for review, not the implementation. Open questions (stale-label semantics, docs-QA depth, resolver coupling) and a separate cleanup of three mislocated specs under public `docs/` are listed at the end of the spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a planning/design document for a batch-based behavioral QA workflow that verifies merged work using label-driven, gap-free backlog prioritization.
  * Describes how candidate work is classified into verification lanes and how evidence is captured for successful outcomes.
  * Covers auditable handling for “nothing to verify” cases, including operator acknowledgement vs unattended auto-acknowledgement.
  * Specifies runner concurrency/safety rules, failure/timeout behavior, and how issues are created and cross-linked for actionable items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->