### PR TITLE
Harden PR security preflight against non-UTF-8 locales

### DIFF
--- a/.agents/skills/pr-batch/bin/pr-security-preflight
+++ b/.agents/skills/pr-batch/bin/pr-security-preflight
@@ -82,6 +82,10 @@ def run_gh(*args)
     stdout, stderr, status = Open3.capture3("gh", *args)
   end
 
+  # Force UTF-8 so non-ASCII gh output (issue bodies, author names) survives LANG=C.
+  stdout = stdout.force_encoding("UTF-8").scrub
+  stderr = stderr.force_encoding("UTF-8").scrub
+
   return stdout if status.success?
 
   output = [stderr, stdout].reject { |text| text.to_s.empty? }.join("\n")

--- a/.agents/skills/pr-batch/bin/pr-security-preflight-test.rb
+++ b/.agents/skills/pr-batch/bin/pr-security-preflight-test.rb
@@ -298,6 +298,23 @@ class PrSecurityPreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLe
     end
   end
 
+  def test_non_ascii_gh_output_does_not_crash_under_ascii_locale
+    with_fake_gh("non-ascii-issue") do |env, trust_config_path, _log_path|
+      out, status = run_script(
+        env.merge("LANG" => "C", "LC_ALL" => "C"),
+        "--repo",
+        "owner/repo",
+        "--trust-config",
+        trust_config_path,
+        "123"
+      )
+
+      refute_includes out, "invalid byte sequence"
+      assert status.success?, out
+      assert_includes out, "SECURITY_PREFLIGHT_OK"
+    end
+  end
+
   private
 
   def trust_coderabbit(trust_config_path)
@@ -374,6 +391,10 @@ class PrSecurityPreflightTest < Minitest::Test # rubocop:disable Metrics/ClassLe
         elif [ "$mode" = "reaction-only-participant" ] || [ "$mode" = "trusted-hidden-participant" ] || [ "$mode" = "trusted-bot-participant" ] || [ "$mode" = "human-bot-basename-participant" ]; then
           cat <<'JSON'
       {"number":123,"title":"Test issue","html_url":"https://github.com/owner/repo/issues/123","body":"Document GITHUB_TOKEN use.","user":{"login":"issue-author"}}
+      JSON
+        elif [ "$mode" = "non-ascii-issue" ]; then
+          cat <<'JSON'
+      {"number":123,"title":"Tëst issué — café","html_url":"https://github.com/owner/repo/issues/123","body":"Café au lait notes — déjà vu 🚀 friendly documentation update","user":{"login":"justin808"}}
       JSON
         else
           cat <<'JSON'


### PR DESCRIPTION
## Problem

`.agents/skills/pr-batch/bin/pr-security-preflight` runs in the PR-batch
security preflight. `run_gh` returns raw `gh` stdout, so `JSON.parse(run_gh(...))`
of issue/PR payloads crashes under a non-UTF-8 locale (`LANG=C` / `LC_ALL=C`,
common in CI and headless agent shells) with `invalid byte sequence in US-ASCII`
whenever an issue body or author display name contains non-ASCII bytes — very
common in real GitHub data.

Reproduced under `LANG=C` with a non-ASCII issue body:
`pr-security-preflight:106 … JSON.parse … Encoding::InvalidByteSequenceError`.

## Fix

Force UTF-8 + `scrub` on `stdout`/`stderr` once, right after `Open3.capture3` —
protects every downstream `JSON.parse`, `match?`, and `.strip`. Adds a
`non-ascii-issue` fixture and a `LANG=C` regression test (fails before the fix,
passes after).

## Context

Same bug class as the vendored seam-doctor fix (#4191) and the shared-pack fixes
in shakacode/agent-workflows#1 and #3. This file has diverged from the upstream
pack (RoR-specific hardening in #4148 / #4151 / #4170), so the fix is applied
directly to RoR's copy rather than vendored.

## Testing

- `ruby .agents/skills/pr-batch/bin/pr-security-preflight-test.rb` → 21 runs, 0
  failures (adds the `LANG=C` case).
- `bundle exec rubocop` on both files → no offenses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of GitHub output so non-ASCII characters no longer cause parsing or display errors.
  * Prevented “invalid byte sequence” failures in environments using an ASCII locale.
* **Tests**
  * Added coverage for non-ASCII GitHub responses to verify the check still completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->