### PR TITLE
Improve Pro renderer password guidance for unset envs

### DIFF
--- a/packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts
@@ -196,21 +196,20 @@ function normalizedRuntimeEnvs() {
     .map((value) => value.toLowerCase());
 }
 
-function runtimeEnvsAllowDevelopmentDefaults() {
-  const runtimeEnvs = normalizedRuntimeEnvs();
+function runtimeEnvsAllowDevelopmentDefaults(runtimeEnvs = normalizedRuntimeEnvs()) {
   // Fail closed: every present runtime env must be development/test before we allow
   // missing-password defaults. Any production-like value, or no env at all, still
   // requires an explicit password.
   return runtimeEnvs.length > 0 && runtimeEnvs.every((value) => value === 'development' || value === 'test');
 }
 
-function unsetRuntimeEnvPasswordGuidance() {
-  if (normalizedRuntimeEnvs().length > 0) {
+function unsetRuntimeEnvPasswordGuidance(runtimeEnvs: string[]) {
+  if (runtimeEnvs.length > 0) {
     return '';
   }
 
   return (
-    '\n\nBoth NODE_ENV and RAILS_ENV are unset. For a local Rails development shell, either set them explicitly:\n\n' +
+    '\n\nBoth RAILS_ENV and NODE_ENV are unset. For a local Rails development shell, either set them explicitly:\n\n' +
     '  export RAILS_ENV=development NODE_ENV=development\n\n' +
     'or configure RENDERER_PASSWORD. Deployed/shared environments should set explicit envs and RENDERER_PASSWORD.'
   );
@@ -363,7 +362,8 @@ const KNOWN_WEAK_PASSWORDS = new Set(
 const MIN_PASSWORD_LENGTH = 16;
 
 function validatePasswordForProduction(aConfig: Config): string | null {
-  const isProductionLike = !runtimeEnvsAllowDevelopmentDefaults();
+  const runtimeEnvs = normalizedRuntimeEnvs();
+  const isProductionLike = !runtimeEnvsAllowDevelopmentDefaults(runtimeEnvs);
 
   if (!aConfig.password || aConfig.password.trim() === '') {
     if (isProductionLike) {
@@ -373,7 +373,7 @@ function validatePasswordForProduction(aConfig: Config): string | null {
         `\n\n` +
         `In development and test environments, the renderer password is optional and no authentication\n` +
         `is required. In all other environments, you must explicitly configure a password to secure\n` +
-        `communication between Rails and the Node Renderer.${unsetRuntimeEnvPasswordGuidance()}\n\n` +
+        `communication between Rails and the Node Renderer.${unsetRuntimeEnvPasswordGuidance(runtimeEnvs)}\n\n` +
         `To secure the renderer, set the RENDERER_PASSWORD environment variable:\n\n` +
         `  export RENDERER_PASSWORD="your-secure-password"\n\n` +
         `Or pass it in the config object:\n\n` +
@@ -381,7 +381,7 @@ function validatePasswordForProduction(aConfig: Config): string | null {
         `Environment matrix:\n` +
         `  development — password optional (no authentication)\n` +
         `  test        — password optional (no authentication)\n` +
-        `  (neither set) — treated as production-like; RENDERER_PASSWORD required\n` +
+        `  (both unset) — treated as production-like; RENDERER_PASSWORD required\n` +
         `  all other environments (staging, production, qa, preview, etc.) — RENDERER_PASSWORD required`
       );
     }

--- a/packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts
@@ -198,9 +198,22 @@ function normalizedRuntimeEnvs() {
 
 function runtimeEnvsAllowDevelopmentDefaults() {
   const runtimeEnvs = normalizedRuntimeEnvs();
-  // Rails defaults an unset environment to development, so the fully unset case
-  // should not make fresh development shells fail closed.
-  return runtimeEnvs.every((value) => value === 'development' || value === 'test');
+  // Fail closed: every present runtime env must be development/test before we allow
+  // missing-password defaults. Any production-like value, or no env at all, still
+  // requires an explicit password.
+  return runtimeEnvs.length > 0 && runtimeEnvs.every((value) => value === 'development' || value === 'test');
+}
+
+function unsetRuntimeEnvPasswordGuidance() {
+  if (normalizedRuntimeEnvs().length > 0) {
+    return '';
+  }
+
+  return (
+    '\n\nBoth NODE_ENV and RAILS_ENV are unset. For a local Rails development shell, either set them explicitly:\n\n' +
+    '  export RAILS_ENV=development NODE_ENV=development\n\n' +
+    'or configure RENDERER_PASSWORD. Deployed/shared environments should set explicit envs and RENDERER_PASSWORD.'
+  );
 }
 
 // Intentionally checks only NODE_ENV, not both NODE_ENV and RAILS_ENV like
@@ -355,21 +368,21 @@ function validatePasswordForProduction(aConfig: Config): string | null {
   if (!aConfig.password || aConfig.password.trim() === '') {
     if (isProductionLike) {
       return (
-        'RENDERER_PASSWORD must be set in production-like environments ' +
+        `RENDERER_PASSWORD must be set in production-like environments ` +
         `(NODE_ENV: "${env.NODE_ENV ?? '(not set)'}", RAILS_ENV: "${env.RAILS_ENV ?? '(not set)'}").` +
-        '\n\n' +
-        'In development and test environments, the renderer password is optional and no authentication\n' +
-        'is required. In all other environments, you must explicitly configure a password to secure\n' +
-        'communication between Rails and the Node Renderer.\n\n' +
-        'To fix this, set the RENDERER_PASSWORD environment variable:\n\n' +
-        '  export RENDERER_PASSWORD="your-secure-password"\n\n' +
-        'Or pass it in the config object:\n\n' +
-        '  reactOnRailsProNodeRenderer({ password: process.env.RENDERER_PASSWORD });\n\n' +
-        'Environment matrix:\n' +
-        '  development — password optional (no authentication)\n' +
-        '  test        — password optional (no authentication)\n' +
-        '  (neither set) — password optional; Rails defaults unset env to development\n' +
-        '  all other environments (staging, production, qa, preview, etc.) — RENDERER_PASSWORD required'
+        `\n\n` +
+        `In development and test environments, the renderer password is optional and no authentication\n` +
+        `is required. In all other environments, you must explicitly configure a password to secure\n` +
+        `communication between Rails and the Node Renderer.${unsetRuntimeEnvPasswordGuidance()}\n\n` +
+        `To secure the renderer, set the RENDERER_PASSWORD environment variable:\n\n` +
+        `  export RENDERER_PASSWORD="your-secure-password"\n\n` +
+        `Or pass it in the config object:\n\n` +
+        `  reactOnRailsProNodeRenderer({ password: process.env.RENDERER_PASSWORD });\n\n` +
+        `Environment matrix:\n` +
+        `  development — password optional (no authentication)\n` +
+        `  test        — password optional (no authentication)\n` +
+        `  (neither set) — treated as production-like; RENDERER_PASSWORD required\n` +
+        `  all other environments (staging, production, qa, preview, etc.) — RENDERER_PASSWORD required`
       );
     }
     return null;

--- a/packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts
+++ b/packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts
@@ -198,10 +198,9 @@ function normalizedRuntimeEnvs() {
 
 function runtimeEnvsAllowDevelopmentDefaults() {
   const runtimeEnvs = normalizedRuntimeEnvs();
-  // Fail closed: every present runtime env must be development/test before we allow
-  // missing-password defaults. Any production-like value, or no env at all, still
-  // requires an explicit password.
-  return runtimeEnvs.length > 0 && runtimeEnvs.every((value) => value === 'development' || value === 'test');
+  // Rails defaults an unset environment to development, so the fully unset case
+  // should not make fresh development shells fail closed.
+  return runtimeEnvs.every((value) => value === 'development' || value === 'test');
 }
 
 // Intentionally checks only NODE_ENV, not both NODE_ENV and RAILS_ENV like
@@ -369,7 +368,7 @@ function validatePasswordForProduction(aConfig: Config): string | null {
         'Environment matrix:\n' +
         '  development — password optional (no authentication)\n' +
         '  test        — password optional (no authentication)\n' +
-        '  (neither set) — treated as production-like; RENDERER_PASSWORD required\n' +
+        '  (neither set) — password optional; Rails defaults unset env to development\n' +
         '  all other environments (staging, production, qa, preview, etc.) — RENDERER_PASSWORD required'
       );
     }

--- a/packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts
@@ -343,19 +343,14 @@ describe('configBuilder', () => {
       expect(() => buildConfig()).not.toThrow();
     });
 
-    it('throws when neither NODE_ENV nor RAILS_ENV is set (fail-closed)', () => {
+    it('does not throw when neither NODE_ENV nor RAILS_ENV is set', () => {
       delete process.env.NODE_ENV;
       delete process.env.RAILS_ENV;
       delete process.env.RENDERER_PASSWORD;
-      const processExit = mockProcessExit();
 
-      const { buildConfig, error } = loadConfigBuilderWithMockedLogger();
+      const { buildConfig } = loadConfigBuilderWithMockedLogger();
 
-      expect(() => buildConfig()).toThrow('process.exit: 1');
-      expect(processExit).toHaveBeenCalledWith(1);
-      expect(error).toHaveBeenCalledWith(
-        expect.stringContaining('(neither set) — treated as production-like; RENDERER_PASSWORD required'),
-      );
+      expect(() => buildConfig()).not.toThrow();
     });
 
     it('does not throw when password is set after module import', () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts
@@ -343,14 +343,22 @@ describe('configBuilder', () => {
       expect(() => buildConfig()).not.toThrow();
     });
 
-    it('does not throw when neither NODE_ENV nor RAILS_ENV is set', () => {
+    it('throws with local dev guidance when neither NODE_ENV nor RAILS_ENV is set', () => {
       delete process.env.NODE_ENV;
       delete process.env.RAILS_ENV;
       delete process.env.RENDERER_PASSWORD;
+      const processExit = mockProcessExit();
 
-      const { buildConfig } = loadConfigBuilderWithMockedLogger();
+      const { buildConfig, error } = loadConfigBuilderWithMockedLogger();
 
-      expect(() => buildConfig()).not.toThrow();
+      expect(() => buildConfig()).toThrow('process.exit: 1');
+      expect(processExit).toHaveBeenCalledWith(1);
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining('export RAILS_ENV=development NODE_ENV=development'),
+      );
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining('(neither set) — treated as production-like; RENDERER_PASSWORD required'),
+      );
     });
 
     it('does not throw when password is set after module import', () => {

--- a/packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts
+++ b/packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts
@@ -357,7 +357,7 @@ describe('configBuilder', () => {
         expect.stringContaining('export RAILS_ENV=development NODE_ENV=development'),
       );
       expect(error).toHaveBeenCalledWith(
-        expect.stringContaining('(neither set) — treated as production-like; RENDERER_PASSWORD required'),
+        expect.stringContaining('(both unset) — treated as production-like; RENDERER_PASSWORD required'),
       );
     });
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -610,7 +610,6 @@ module ReactOnRailsPro
 
         or configure RENDERER_PASSWORD. Deployed/shared environments should set explicit
         envs and RENDERER_PASSWORD.
-
       GUIDANCE
     end
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -552,9 +552,9 @@ module ReactOnRailsPro
 
       runtime_envs = [ENV.fetch("RAILS_ENV", nil), ENV.fetch("NODE_ENV", nil)].compact_blank.map(&:downcase)
       allowed_envs = %w[development test].freeze
-      # Rails defaults an unset environment to development, so the fully unset
-      # case should not make fresh development shells fail closed.
-      is_production_like = !runtime_envs.all? { |env| allowed_envs.include?(env) }
+      # Fail closed when both envs are unset; the error below gives fresh dev shells
+      # the explicit development-env command.
+      is_production_like = !(runtime_envs.any? && runtime_envs.all? { |env| allowed_envs.include?(env) })
 
       if renderer_password.blank?
         return unless is_production_like
@@ -566,8 +566,9 @@ module ReactOnRailsPro
           In development and test environments, the renderer password is optional and no authentication
           is required. In all other environments, you must explicitly configure a password to secure
           communication between Rails and the Node Renderer.
+          #{unset_renderer_env_guidance(runtime_envs)}
 
-          To fix this, set the RENDERER_PASSWORD environment variable:
+          To secure the renderer, set the RENDERER_PASSWORD environment variable:
 
             export RENDERER_PASSWORD="your-secure-password"
 
@@ -588,7 +589,7 @@ module ReactOnRailsPro
 
           Environment matrix (both RAILS_ENV and NODE_ENV are checked):
             development/test — password optional when every set env is development or test
-            (both unset)     — password optional; Rails defaults unset env to development
+            (both unset)     — treated as production-like; RENDERER_PASSWORD required
             staging          — RENDERER_PASSWORD required
             production       — RENDERER_PASSWORD required
             (mixed envs)     — RENDERER_PASSWORD required (e.g. NODE_ENV=production + RAILS_ENV=development)
@@ -596,6 +597,21 @@ module ReactOnRailsPro
       end
 
       warn_if_renderer_password_weak
+    end
+
+    def unset_renderer_env_guidance(runtime_envs)
+      return unless runtime_envs.empty?
+
+      <<~GUIDANCE
+
+        Both RAILS_ENV and NODE_ENV are unset. For a local Rails development shell,
+        either set them explicitly:
+
+          export RAILS_ENV=development NODE_ENV=development
+
+        or configure RENDERER_PASSWORD. Deployed/shared environments should set explicit
+        envs and RENDERER_PASSWORD.
+      GUIDANCE
     end
 
     def warn_if_renderer_password_weak

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -567,7 +567,6 @@ module ReactOnRailsPro
           is required. In all other environments, you must explicitly configure a password to secure
           communication between Rails and the Node Renderer.
           #{unset_renderer_env_guidance(runtime_envs)}
-
           To secure the renderer, set the RENDERER_PASSWORD environment variable:
 
             export RENDERER_PASSWORD="your-secure-password"
@@ -600,7 +599,7 @@ module ReactOnRailsPro
     end
 
     def unset_renderer_env_guidance(runtime_envs)
-      return unless runtime_envs.empty?
+      return "" unless runtime_envs.empty?
 
       <<~GUIDANCE
 
@@ -611,6 +610,7 @@ module ReactOnRailsPro
 
         or configure RENDERER_PASSWORD. Deployed/shared environments should set explicit
         envs and RENDERER_PASSWORD.
+
       GUIDANCE
     end
 

--- a/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
+++ b/react_on_rails_pro/lib/react_on_rails_pro/configuration.rb
@@ -552,7 +552,9 @@ module ReactOnRailsPro
 
       runtime_envs = [ENV.fetch("RAILS_ENV", nil), ENV.fetch("NODE_ENV", nil)].compact_blank.map(&:downcase)
       allowed_envs = %w[development test].freeze
-      is_production_like = !(runtime_envs.any? && runtime_envs.all? { |e| allowed_envs.include?(e) })
+      # Rails defaults an unset environment to development, so the fully unset
+      # case should not make fresh development shells fail closed.
+      is_production_like = !runtime_envs.all? { |env| allowed_envs.include?(env) }
 
       if renderer_password.blank?
         return unless is_production_like
@@ -586,7 +588,7 @@ module ReactOnRailsPro
 
           Environment matrix (both RAILS_ENV and NODE_ENV are checked):
             development/test — password optional when every set env is development or test
-            (both unset)     — treated as production-like; RENDERER_PASSWORD required
+            (both unset)     — password optional; Rails defaults unset env to development
             staging          — RENDERER_PASSWORD required
             production       — RENDERER_PASSWORD required
             (mixed envs)     — RENDERER_PASSWORD required (e.g. NODE_ENV=production + RAILS_ENV=development)

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -459,17 +459,6 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
           end.to raise_error(ReactOnRailsPro::Error, /RENDERER_PASSWORD must be set/)
         end
 
-        it "raises when RAILS_ENV is unset (fail-closed, matching Node-side behavior)" do
-          allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
-
-          expect do
-            ReactOnRailsPro.configure do |config|
-              config.server_renderer = "NodeRenderer"
-              config.renderer_url = "https://localhost:3800"
-            end
-          end.to raise_error(ReactOnRailsPro::Error, /RENDERER_PASSWORD must be set/)
-        end
-
         it "raises when NODE_ENV is production even if RAILS_ENV is development" do
           allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return("development")
           allow(ENV).to receive(:fetch).with("NODE_ENV", nil).and_return("production")
@@ -624,6 +613,17 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
         it "does not raise when RAILS_ENV is unset and NODE_ENV is development" do
           allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
           allow(ENV).to receive(:fetch).with("NODE_ENV", nil).and_return("development")
+
+          expect do
+            ReactOnRailsPro.configure do |config|
+              config.server_renderer = "NodeRenderer"
+              config.renderer_url = "https://localhost:3800"
+            end
+          end.not_to raise_error
+        end
+
+        it "does not raise when both RAILS_ENV and NODE_ENV are unset" do
+          allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
 
           expect do
             ReactOnRailsPro.configure do |config|

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -469,7 +469,7 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
             end
           end.to raise_error(ReactOnRailsPro::Error) { |error|
             expect(error.message).to include("export RAILS_ENV=development NODE_ENV=development")
-            expect(error.message).to include("(both unset)     — treated as production-like")
+            expect(error.message).to include("(both unset)").and include("treated as production-like")
           }
         end
 

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -459,6 +459,20 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
           end.to raise_error(ReactOnRailsPro::Error, /RENDERER_PASSWORD must be set/)
         end
 
+        it "raises with local dev guidance when RAILS_ENV and NODE_ENV are unset" do
+          allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
+
+          expect do
+            ReactOnRailsPro.configure do |config|
+              config.server_renderer = "NodeRenderer"
+              config.renderer_url = "https://localhost:3800"
+            end
+          end.to raise_error(ReactOnRailsPro::Error) { |error|
+            expect(error.message).to include("export RAILS_ENV=development NODE_ENV=development")
+            expect(error.message).to include("(both unset)     — treated as production-like")
+          }
+        end
+
         it "raises when NODE_ENV is production even if RAILS_ENV is development" do
           allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return("development")
           allow(ENV).to receive(:fetch).with("NODE_ENV", nil).and_return("production")
@@ -613,17 +627,6 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
         it "does not raise when RAILS_ENV is unset and NODE_ENV is development" do
           allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
           allow(ENV).to receive(:fetch).with("NODE_ENV", nil).and_return("development")
-
-          expect do
-            ReactOnRailsPro.configure do |config|
-              config.server_renderer = "NodeRenderer"
-              config.renderer_url = "https://localhost:3800"
-            end
-          end.not_to raise_error
-        end
-
-        it "does not raise when both RAILS_ENV and NODE_ENV are unset" do
-          allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
 
           expect do
             ReactOnRailsPro.configure do |config|

--- a/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
+++ b/react_on_rails_pro/spec/react_on_rails_pro/configuration_spec.rb
@@ -461,6 +461,7 @@ module ReactOnRailsPro # rubocop:disable Metrics/ModuleLength
 
         it "raises with local dev guidance when RAILS_ENV and NODE_ENV are unset" do
           allow(ENV).to receive(:fetch).with("RAILS_ENV", nil).and_return(nil)
+          allow(ENV).to receive(:fetch).with("NODE_ENV", nil).and_return(nil)
 
           expect do
             ReactOnRailsPro.configure do |config|


### PR DESCRIPTION
## Why

Fixes #4201.

Fresh Pro development shells can have both `RAILS_ENV` and `NODE_ENV` unset. The safer contract is still to fail closed when the renderer password is missing, but the previous diagnostics did not lead with the common local-development fix.

## What changed

- Preserve fail-closed renderer password validation when both `RAILS_ENV` and `NODE_ENV` are unset.
- Add explicit local-development guidance to both Ruby and Node renderer errors: `export RAILS_ENV=development NODE_ENV=development`.
- Keep password-optional behavior for explicit development/test envs and password-required behavior for production-like or mixed envs.
- Align the Ruby configuration guard and Node renderer config builder matrix/tests.

## QA evidence

- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 RUBYOPT="-EUTF-8" bundle exec rspec spec/react_on_rails_pro/configuration_spec.rb`
  - 86 examples, 0 failures
- `pnpm exec jest tests/configBuilder.test.ts --runInBand`
  - PASS, 39 tests
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop --ignore-parent-exclusion lib/react_on_rails_pro/configuration.rb spec/react_on_rails_pro/configuration_spec.rb`
  - no offenses
- `pnpm exec prettier --check packages/react-on-rails-pro-node-renderer/src/shared/configBuilder.ts packages/react-on-rails-pro-node-renderer/tests/configBuilder.test.ts`
  - all matched Prettier style
- `pnpm --filter react-on-rails-pro-node-renderer type-check`
  - passed
- `git diff --check`
  - clean
- Pre-push hook
  - branch Ruby lint passed; no Markdown files required link checking

## Review-fix note

Initial head treated both envs unset as development-like. Review identified the production-misconfiguration risk, so current head `1538e4a0a` keeps fail-closed behavior and fixes the issue via clearer guidance instead.

## Churn notes

The first attempted node-renderer package test used the package script in a way that ran a broader suite and hit an unrelated missing generated dummy SSR bundle plus existing stream timeouts. The focused `configBuilder.test.ts` Jest command above is the intended validation for this PR and passed.

## Batch context

This PR is part of batch `pro-rsc-observability-20260625-b3`. Batch merge authority is `none`; do not merge from this batch handoff.

## Codex Merge Rationale

Merged externally at `bc6b10c5b370432821ce2f53d508f609859769c6` after the current head `1538e4a0ae56ac1ba54bdd8d25f7a8ed18939331` satisfied the batch merge gate.

Reasons this was merge-safe:

- The final implementation preserves the fail-closed renderer-password contract when both `RAILS_ENV` and `NODE_ENV` are unset, while adding actionable local-development guidance in both Ruby and Node renderer errors.
- Focused Ruby and TypeScript tests covered the unset-env matrix and the Ruby/Node behavior parity.
- Required CI was ready, full hosted check rows had no remaining non-success entries at closeout, review threads were resolved, and `script/pr-merge-ledger 4211 --strict --changelog-classification not_user_visible --finding-dispositions /tmp/pr4211-dispositions.XXXXXX.json` reported `complete_allowed: true` with no violations or UNKNOWN fields.
- Changelog classification is `not_user_visible` because this is diagnostic/error-guidance behavior for a Pro misconfiguration path, not a public API or release-note-level feature change.

Residual risk: only the Pro renderer-password diagnostic path changed; no runtime authentication bypass is introduced because both-unset environments still require `RENDERER_PASSWORD` unless development/test is explicit.
