### PR TITLE
Docs: correct create app Rspack default

### DIFF
--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -58,22 +58,22 @@ npx create-react-on-rails-app my-app --webpack
 # Specify package manager
 npx create-react-on-rails-app my-app --package-manager pnpm
 
-# Combine RSC with Webpack
+# RSC already uses Rspack by default; opt into Webpack if needed
 npx create-react-on-rails-app my-app --rsc --webpack
 ```
 
 ### All Options
 
-| Option                       | Description                                                    | Default                  |
-| ---------------------------- | -------------------------------------------------------------- | ------------------------ |
-| `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
-| `--rspack`                   | Use Rspack as the bundler (~20x faster)                        | `true`                   |
-| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                  | `false`                  |
-| `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
-| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
-| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
-| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example               | prompt with mode/`false` |
-| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                | auto-detected            |
+| Option                       | Description                                                           | Default                  |
+| ---------------------------- | --------------------------------------------------------------------- | ------------------------ |
+| `-t, --template <type>`      | `javascript` or `typescript`                                          | `typescript`             |
+| `--rspack`                   | Use Rspack as the bundler (~20x faster, default; pass to be explicit) | `true`                   |
+| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                         | `false`                  |
+| `--standard`                 | Use open-source React on Rails (skip prompt)                          | `false`                  |
+| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)             | `false`                  |
+| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`)        | `false`                  |
+| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example                      | prompt with mode/`false` |
+| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                       | auto-detected            |
 
 When none of `--standard`, `--pro`, or `--rsc` is given, the CLI prompts interactively in TTY environments (default: RSC). In non-TTY environments (CI, pipes, redirected output), standard mode is used automatically.
 When `--tailwind` is omitted, Tailwind is prompted only alongside the mode prompt and disabled otherwise.

--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -58,22 +58,22 @@ npx create-react-on-rails-app my-app --webpack
 # Specify package manager
 npx create-react-on-rails-app my-app --package-manager pnpm
 
-# RSC already uses Rspack by default; opt into Webpack if needed
-npx create-react-on-rails-app my-app --rsc --webpack
+# RSC uses Rspack by default; no bundler flag needed
+npx create-react-on-rails-app my-app --rsc
 ```
 
 ### All Options
 
-| Option                       | Description                                                           | Default                  |
-| ---------------------------- | --------------------------------------------------------------------- | ------------------------ |
-| `-t, --template <type>`      | `javascript` or `typescript`                                          | `typescript`             |
-| `--rspack`                   | Use Rspack as the bundler (~20x faster, default; pass to be explicit) | `true`                   |
-| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                         | `false`                  |
-| `--standard`                 | Use open-source React on Rails (skip prompt)                          | `false`                  |
-| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)             | `false`                  |
-| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`)        | `false`                  |
-| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example                      | prompt with mode/`false` |
-| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                       | auto-detected            |
+| Option                       | Description                                                    | Default                  |
+| ---------------------------- | -------------------------------------------------------------- | ------------------------ |
+| `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
+| `--rspack`                   | Use Rspack as the bundler (~20x faster; Rspack is the default) | `true`                   |
+| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                  | `false`                  |
+| `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
+| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
+| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
+| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example               | prompt with mode/`false` |
+| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                | auto-detected            |
 
 When none of `--standard`, `--pro`, or `--rsc` is given, the CLI prompts interactively in TTY environments (default: RSC). In non-TTY environments (CI, pipes, redirected output), standard mode is used automatically.
 When `--tailwind` is omitted, Tailwind is prompted only alongside the mode prompt and disabled otherwise.

--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -52,14 +52,14 @@ npx create-react-on-rails-app my-app --template javascript
 # Add Tailwind CSS v4 to the generated SSR example
 npx create-react-on-rails-app my-app --tailwind
 
-# Use Rspack for ~20x faster builds
-npx create-react-on-rails-app my-app --rspack
+# Use Webpack instead of the default Rspack bundler
+npx create-react-on-rails-app my-app --webpack
 
 # Specify package manager
 npx create-react-on-rails-app my-app --package-manager pnpm
 
-# Combine RSC with Rspack
-npx create-react-on-rails-app my-app --rspack --rsc
+# Combine RSC with Webpack
+npx create-react-on-rails-app my-app --rsc --webpack
 ```
 
 ### All Options
@@ -67,7 +67,8 @@ npx create-react-on-rails-app my-app --rspack --rsc
 | Option                       | Description                                                    | Default                  |
 | ---------------------------- | -------------------------------------------------------------- | ------------------------ |
 | `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
-| `--rspack`                   | Use Rspack instead of Webpack (~20x faster)                    | `false`                  |
+| `--rspack`                   | Use Rspack as the bundler (~20x faster)                        | `true`                   |
+| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                  | `false`                  |
 | `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
 | `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
 | `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
@@ -89,7 +90,7 @@ The CLI runs these steps automatically:
 After completion, you get:
 
 - A Rails 7+ app with PostgreSQL
-- Shakapacker configured with Webpack (or Rspack) and HMR
+- Shakapacker configured with Rspack by default (or Webpack when requested) and HMR
 - A working HelloWorld React component (TypeScript by default)
 - A generated home page at `/` with links to the example pages, important project files, and Pro/RSC learning resources
 - A teaching-friendly git history that separates Rails creation, gem installation, generator output, and pnpm normalization

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -822,22 +822,22 @@ npx create-react-on-rails-app my-app --webpack
 # Specify package manager
 npx create-react-on-rails-app my-app --package-manager pnpm
 
-# Combine RSC with Webpack
+# RSC already uses Rspack by default; opt into Webpack if needed
 npx create-react-on-rails-app my-app --rsc --webpack
 ```
 
 ### All Options
 
-| Option                       | Description                                                    | Default                  |
-| ---------------------------- | -------------------------------------------------------------- | ------------------------ |
-| `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
-| `--rspack`                   | Use Rspack as the bundler (~20x faster)                        | `true`                   |
-| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                  | `false`                  |
-| `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
-| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
-| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
-| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example               | prompt with mode/`false` |
-| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                | auto-detected            |
+| Option                       | Description                                                           | Default                  |
+| ---------------------------- | --------------------------------------------------------------------- | ------------------------ |
+| `-t, --template <type>`      | `javascript` or `typescript`                                          | `typescript`             |
+| `--rspack`                   | Use Rspack as the bundler (~20x faster, default; pass to be explicit) | `true`                   |
+| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                         | `false`                  |
+| `--standard`                 | Use open-source React on Rails (skip prompt)                          | `false`                  |
+| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)             | `false`                  |
+| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`)        | `false`                  |
+| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example                      | prompt with mode/`false` |
+| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                       | auto-detected            |
 
 When none of `--standard`, `--pro`, or `--rsc` is given, the CLI prompts interactively in TTY environments (default: RSC). In non-TTY environments (CI, pipes, redirected output), standard mode is used automatically.
 When `--tailwind` is omitted, Tailwind is prompted only alongside the mode prompt and disabled otherwise.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -816,14 +816,14 @@ npx create-react-on-rails-app my-app --template javascript
 # Add Tailwind CSS v4 to the generated SSR example
 npx create-react-on-rails-app my-app --tailwind
 
-# Use Rspack for ~20x faster builds
-npx create-react-on-rails-app my-app --rspack
+# Use Webpack instead of the default Rspack bundler
+npx create-react-on-rails-app my-app --webpack
 
 # Specify package manager
 npx create-react-on-rails-app my-app --package-manager pnpm
 
-# Combine RSC with Rspack
-npx create-react-on-rails-app my-app --rspack --rsc
+# Combine RSC with Webpack
+npx create-react-on-rails-app my-app --rsc --webpack
 ```
 
 ### All Options
@@ -831,7 +831,8 @@ npx create-react-on-rails-app my-app --rspack --rsc
 | Option                       | Description                                                    | Default                  |
 | ---------------------------- | -------------------------------------------------------------- | ------------------------ |
 | `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
-| `--rspack`                   | Use Rspack instead of Webpack (~20x faster)                    | `false`                  |
+| `--rspack`                   | Use Rspack as the bundler (~20x faster)                        | `true`                   |
+| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                  | `false`                  |
 | `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
 | `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
 | `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
@@ -853,7 +854,7 @@ The CLI runs these steps automatically:
 After completion, you get:
 
 - A Rails 7+ app with PostgreSQL
-- Shakapacker configured with Webpack (or Rspack) and HMR
+- Shakapacker configured with Rspack by default (or Webpack when requested) and HMR
 - A working HelloWorld React component (TypeScript by default)
 - A generated home page at `/` with links to the example pages, important project files, and Pro/RSC learning resources
 - A teaching-friendly git history that separates Rails creation, gem installation, generator output, and pnpm normalization

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -822,22 +822,22 @@ npx create-react-on-rails-app my-app --webpack
 # Specify package manager
 npx create-react-on-rails-app my-app --package-manager pnpm
 
-# RSC already uses Rspack by default; opt into Webpack if needed
-npx create-react-on-rails-app my-app --rsc --webpack
+# RSC uses Rspack by default; no bundler flag needed
+npx create-react-on-rails-app my-app --rsc
 ```
 
 ### All Options
 
-| Option                       | Description                                                           | Default                  |
-| ---------------------------- | --------------------------------------------------------------------- | ------------------------ |
-| `-t, --template <type>`      | `javascript` or `typescript`                                          | `typescript`             |
-| `--rspack`                   | Use Rspack as the bundler (~20x faster, default; pass to be explicit) | `true`                   |
-| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                         | `false`                  |
-| `--standard`                 | Use open-source React on Rails (skip prompt)                          | `false`                  |
-| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)             | `false`                  |
-| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`)        | `false`                  |
-| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example                      | prompt with mode/`false` |
-| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                       | auto-detected            |
+| Option                       | Description                                                    | Default                  |
+| ---------------------------- | -------------------------------------------------------------- | ------------------------ |
+| `-t, --template <type>`      | `javascript` or `typescript`                                   | `typescript`             |
+| `--rspack`                   | Use Rspack as the bundler (~20x faster; Rspack is the default) | `true`                   |
+| `--webpack`, `--no-rspack`   | Use Webpack instead of Rspack                                  | `false`                  |
+| `--standard`                 | Use open-source React on Rails (skip prompt)                   | `false`                  |
+| `--pro`                      | Enable React on Rails Pro (requires `react_on_rails_pro`)      | `false`                  |
+| `--rsc`                      | Enable React Server Components (requires `react_on_rails_pro`) | `false`                  |
+| `--tailwind`                 | Add Tailwind CSS v4 to the generated SSR example               | prompt with mode/`false` |
+| `-p, --package-manager <pm>` | `npm` or `pnpm`                                                | auto-detected            |
 
 When none of `--standard`, `--pro`, or `--rsc` is given, the CLI prompts interactively in TTY environments (default: RSC). In non-TTY environments (CI, pipes, redirected output), standard mode is used automatically.
 When `--tailwind` is omitted, Tailwind is prompted only alongside the mode prompt and disabled otherwise.


### PR DESCRIPTION
## Why
Refs #4203.

The no-PR audit confirmed that create-react-on-rails-app already covers the requested scaffold flow. A verification pass found one concrete docs mismatch: the getting-started option table still described Rspack as opt-in even though the CLI defaults to Rspack and uses --webpack / --no-rspack for Webpack.

## What changed
- Update the create-react-on-rails-app getting-started examples and option table to show Rspack as the default bundler.
- Refresh llms-full.txt so the docs index matches the edited page.

## Validation
- git diff --check
- /Users/justin/Codex/react_on_rails/node_modules/.bin/prettier --check docs/oss/getting-started/create-react-on-rails-app.md
- node script/generate-llms-full.mjs --check

## Churn / risk
Docs-only follow-up from the #4203 audit. No package source, tests, or dependency files changed.

Final merge authorization was granted in follow-up; merge rationale is recorded below.

## Merge Rationale / Closeout

Merged on 2026-06-25 by Justin Gordon after the docs-only lane reached the merge gate:

- Required PR gate passed on head `cbbda87767afbf2168ea22284588fcfe3bcd5e60`.
- Configured review/check evidence passed: Claude review, CodeRabbit review, CodeQL, check-llms-full, check-sidebar, docs/markdown checks, analyzer checks, and merge ledger.
- Review-thread ledger was clean with no unresolved current-head review threads.
- Changelog classification: `not_user_visible` docs-only change.
- Risk was low: scoped docs plus generated `llms-full.txt`, no package source, dependency, workflow, or lockfile changes.

Final state: merged. Issue #4203 was already closed as completed; this PR was the scoped docs follow-up from the no-PR audit.