### PR TITLE
Document create-react-on-rails-app RC usage

### DIFF
--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -37,9 +37,10 @@ To try the latest release candidate instead of the latest stable release, use th
 npx create-react-on-rails-app@rc my-app
 ```
 
-When the CLI itself is a prerelease, it pins `react_on_rails` and, for `--pro` or `--rsc`,
-`react_on_rails_pro` to the matching RubyGems prerelease automatically. For example, an npm
-CLI version ending in `-rc.N` maps to a RubyGems version ending in `.rc.N`.
+When the CLI itself is a prerelease, it pins `react_on_rails` to the matching RubyGems prerelease automatically.
+For `--pro` or `--rsc` modes, it also pins `react_on_rails_pro` to the same prerelease.
+For example, an npm CLI version ending in `-rc.N` maps to a RubyGems version ending in `.rc.N`
+(see [Prerelease version formats](../../pro/updating.md#prerelease-versions-ruby-vs-npm-format) for the full mapping table).
 
 ## Options
 

--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -34,7 +34,7 @@ All mode flags support JavaScript (`.jsx`) and TypeScript (`.tsx`) templates.
 To try the latest release candidate instead of the latest stable release, use the npm `rc` tag:
 
 ```bash
-npx create-react-on-rails-app@rc my-app --rsc
+npx create-react-on-rails-app@rc my-app
 ```
 
 When the CLI itself is a prerelease, it pins `react_on_rails` and, for `--pro` or `--rsc`,

--- a/docs/oss/getting-started/create-react-on-rails-app.md
+++ b/docs/oss/getting-started/create-react-on-rails-app.md
@@ -31,6 +31,16 @@ All mode flags support JavaScript (`.jsx`) and TypeScript (`.tsx`) templates.
 `--pro` and `--rsc` require `react_on_rails_pro` to be installable in your environment
 ([Pro setup docs](../../pro/installation.md)).
 
+To try the latest release candidate instead of the latest stable release, use the npm `rc` tag:
+
+```bash
+npx create-react-on-rails-app@rc my-app --rsc
+```
+
+When the CLI itself is a prerelease, it pins `react_on_rails` and, for `--pro` or `--rsc`,
+`react_on_rails_pro` to the matching RubyGems prerelease automatically. For example, an npm
+CLI version ending in `-rc.N` maps to a RubyGems version ending in `.rc.N`.
+
 ## Options
 
 ```bash


### PR DESCRIPTION
## Summary

- Document how to run `create-react-on-rails-app` from the npm `rc` tag.
- Note that prerelease CLI versions pin the matching RubyGems prerelease automatically.

## Validation

- `corepack pnpm exec prettier --check docs/oss/getting-started/create-react-on-rails-app.md`
- `git diff --check origin/main...HEAD`
- `node script/generate-llms-full.mjs --validate`
- Pre-commit hook: trailing newlines, offline markdown links, Prettier
- Pre-push hook: branch lint, online markdown links

## Final confidence

- Rebased onto `origin/main` after #4216 merged, so this docs-only PR now uses the validation-only `llms-full` path instead of carrying generated artifact churn.
- Current head: `37f3e6ee890ba815eddce0d036e1c314b358d760`.
- Addressed and resolved both Claude review threads: the RC quick-start command is flag-free, and the prerelease mapping note now separates OSS vs Pro pinning and links the Pro mapping table.
- Hosted checks on the current head are green: `check-llms-full`, `check-sidebar`, `docs-format-check`, `markdown-format-check`, `markdown-link-check`, CodeQL/Code Quality, `claude-review`, CodeRabbit, and `required-pr-gate`.
- Runtime-heavy jobs were skipped by the docs-only selectors, which is expected for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start guide to install the latest release candidate of `create-react-on-rails-app` via the `rc` tag (e.g., `npx create-react-on-rails-app@rc my-app`).
  * Clarified that prerelease CLI usage automatically pins `react_on_rails` (and `react_on_rails_pro` in `--pro`/`--rsc` modes) to matching RubyGems prereleases.
  * Added an example of the CLI-to-RubyGems prerelease version mapping for `-rc.N` ↔ `.rc.N`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->