### PR TITLE
[codex] Clarify agent workflow update source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@ React on Rails is a Ruby gem + npm package that integrates React with Ruby on Ra
   [`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows).
   Use that repo's `agent-workflows-status` and `upgrade-agent-workflows`
   helpers to keep installed Codex or Claude homes current.
+- When updating reusable agent workflows, skills, commands, or prompt
+  templates, first consider whether the change belongs in
+  `shakacode/agent-workflows` rather than this repo; keep local edits focused on
+  React on Rails-specific policy, seams, or overrides.
 - `.agents/skills/`: repo-local skill copies/overrides plus repo-specific skills;
   `.claude/skills` is a symlink here so Claude Code exposes the same workflows as
   slash commands in this checkout.


### PR DESCRIPTION
## Summary

- Clarifies that reusable agent workflow, skill, command, and prompt-template updates should be considered for `shakacode/agent-workflows` first.
- Keeps this repo focused on React on Rails-specific agent policy, seams, and overrides.

## Validation

- `git diff --check`
- `script/ci-changes-detector origin/main` -> documentation-only changes; recommended CI jobs: none
- `pnpm exec prettier --check AGENTS.md`
- pre-commit hook: trailing-newlines, markdown-links, prettier
- pre-push hook: branch-lint, online markdown-links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for updating shared agent workflows, encouraging changes to be checked against the canonical shared repository first.
  * Clarified that local updates should stay focused on project-specific policies, seams, and overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->