### PR TITLE
Make llms-full updates bot-managed

### DIFF
--- a/.github/workflows/check-llms-full.yml
+++ b/.github/workflows/check-llms-full.yml
@@ -1,4 +1,4 @@
-name: Check llms-full.txt
+name: Validate llms-full.txt
 
 permissions:
   contents: read
@@ -55,5 +55,5 @@ jobs:
       - name: Test llms-full generator validation
         run: bash script/generate-llms-full-test.bash
 
-      - name: Check llms-full.txt is current and docs URLs resolve
-        run: node script/generate-llms-full.mjs --check
+      - name: Validate llms-full generation inputs
+        run: node script/generate-llms-full.mjs --validate

--- a/.github/workflows/check-llms-full.yml
+++ b/.github/workflows/check-llms-full.yml
@@ -71,7 +71,10 @@ jobs:
             mode=check
           else
             if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "$BASE_SHA"
+              git fetch --no-tags --depth=1 origin "$BASE_SHA" || {
+                echo "::error::Could not fetch base SHA $BASE_SHA; unable to determine llms-full mode" >&2
+                exit 1
+              }
             fi
 
             if git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \

--- a/.github/workflows/check-llms-full.yml
+++ b/.github/workflows/check-llms-full.yml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Read runtime versions
@@ -55,5 +56,44 @@ jobs:
       - name: Test llms-full generator validation
         run: bash script/generate-llms-full-test.bash
 
-      - name: Validate llms-full generation inputs
-        run: node script/generate-llms-full.mjs --validate
+      - name: Determine llms-full validation mode
+        id: llms-full-mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          mode=validate
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            mode=check
+          elif [ -z "$BASE_SHA" ] || [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            mode=check
+          else
+            if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "$BASE_SHA"
+            fi
+
+            if git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+              llms-full.txt \
+              llms-full-pro.txt \
+              llms.txt \
+              docs/sidebars.ts \
+              docs/llms-full-preamble.md \
+              docs/.llms-exclusions \
+              docs/.llms-known-redirects \
+              script/generate-llms-full.mjs \
+              script/generate-llms-full-test.bash \
+              .github/workflows/check-llms-full.yml | grep -q .; then
+              mode=check
+            fi
+          fi
+
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "llms-full validation mode: --$mode"
+
+      - name: Validate llms-full references
+        env:
+          LLMS_FULL_MODE: ${{ steps.llms-full-mode.outputs.mode }}
+        run: node script/generate-llms-full.mjs "--${LLMS_FULL_MODE}"

--- a/.github/workflows/check-llms-full.yml
+++ b/.github/workflows/check-llms-full.yml
@@ -41,7 +41,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Read runtime versions
@@ -96,4 +95,18 @@ jobs:
       - name: Validate llms-full references
         env:
           LLMS_FULL_MODE: ${{ steps.llms-full-mode.outputs.mode }}
-        run: node script/generate-llms-full.mjs "--${LLMS_FULL_MODE}"
+        run: |
+          set -euo pipefail
+
+          case "$LLMS_FULL_MODE" in
+            check)
+              node script/generate-llms-full.mjs --check
+              ;;
+            validate)
+              node script/generate-llms-full.mjs --validate
+              ;;
+            *)
+              echo "Unexpected llms-full validation mode: $LLMS_FULL_MODE" >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -6,7 +6,11 @@ permissions:
 on:
   push:
     branches: [main]
-    paths: ['docs/**']
+    paths:
+      - 'docs/**'
+      - 'llms.txt'
+      - 'llms-full.txt'
+      - 'llms-full-pro.txt'
 
 jobs:
   notify-docs-site:
@@ -20,7 +24,7 @@ jobs:
           owner: shakacode
           repositories: reactonrails.com
 
-      - uses: peter-evans/repository-dispatch@v3
+      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/reactonrails.com

--- a/.github/workflows/update-llms-full.yml
+++ b/.github/workflows/update-llms-full.yml
@@ -1,0 +1,50 @@
+name: Update llms-full.txt
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-llms-full:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Read runtime versions
+        id: tool-versions
+        uses: ./.github/actions/read-tool-versions
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.tool-versions.outputs.node-version }}
+
+      - name: Test llms-full generator validation
+        run: bash script/generate-llms-full-test.bash
+
+      - name: Regenerate llms-full references
+        run: node script/generate-llms-full.mjs
+
+      - name: Create pull request for generated updates
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: docs/update-llms-full
+          delete-branch: true
+          title: Regenerate llms-full references
+          commit-message: Regenerate llms-full references
+          body: |
+            Regenerates the machine-readable docs reference files from the current docs source.
+
+            Validation:
+            - `bash script/generate-llms-full-test.bash`
+            - `node script/generate-llms-full.mjs`
+          add-paths: |
+            llms-full.txt
+            llms-full-pro.txt

--- a/.github/workflows/update-llms-full.yml
+++ b/.github/workflows/update-llms-full.yml
@@ -1,13 +1,16 @@
 name: Update llms-full.txt
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   schedule:
     - cron: '17 4 * * *'
   workflow_dispatch:
+
+concurrency:
+  group: update-llms-full
+  cancel-in-progress: false
 
 jobs:
   update-llms-full:
@@ -32,19 +35,35 @@ jobs:
       - name: Regenerate llms-full references
         run: node script/generate-llms-full.mjs
 
-      - name: Create pull request for generated updates
-        uses: peter-evans/create-pull-request@v7
+      - name: Create docs bot token
+        id: docs-bot-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
+          app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.DOCS_DISPATCH_APP_KEY }}
+          owner: shakacode
+          repositories: react_on_rails
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Create pull request for generated updates
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
+        with:
+          token: ${{ steps.docs-bot-token.outputs.token }}
           branch: docs/update-llms-full
           delete-branch: true
           title: Regenerate llms-full references
           commit-message: Regenerate llms-full references
           body: |
             Regenerates the machine-readable docs reference files from the current docs source.
+            Source-doc changes may land before this generated-reference PR is merged; merge this PR to refresh the hosted llms-full endpoints.
 
-            Validation:
+            Validation performed by this workflow:
             - `bash script/generate-llms-full-test.bash`
             - `node script/generate-llms-full.mjs`
+
+            Expected generated PR check:
+            - `node script/generate-llms-full.mjs --check`
           add-paths: |
             llms-full.txt
             llms-full-pro.txt

--- a/.github/workflows/update-llms-full.yml
+++ b/.github/workflows/update-llms-full.yml
@@ -16,7 +16,7 @@ jobs:
   update-llms-full:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/read-tool-versions
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ steps.tool-versions.outputs.node-version }}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -127,4 +127,3 @@ rules:
       - pro-test-package-and-gem.yml:225
       - pro-test-package-and-gem.yml:324
       - shakaperf-release-gates.yml:56
-      - trigger-docs-site.yml:23

--- a/script/generate-llms-full-test.bash
+++ b/script/generate-llms-full-test.bash
@@ -193,6 +193,28 @@ test_complete_sidebar_top_level_sections_pass_check() {
   node script/generate-llms-full.mjs --check >/dev/null
 }
 
+test_validate_mode_allows_stale_generated_outputs() {
+  write_fixture
+  cat >> docs/oss/getting-started/quick-start.md <<'MD'
+
+New source-only docs content.
+MD
+
+  node script/generate-llms-full.mjs --validate >/dev/null
+
+  local out rc
+  set +e
+  out="$(node script/generate-llms-full.mjs --check 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    fail "expected --check to fail after source docs changed without regenerating llms-full.txt"
+    return 1
+  fi
+  assert_contains "$out" "llms-full.txt is stale"
+}
+
 test_missing_sidebar_top_level_section_fails_check() {
   write_fixture
   awk '!/^- Core Concepts: /' llms.txt > llms.txt.next
@@ -327,6 +349,7 @@ test_svg_diagram_embeds_become_text_descriptions() {
 }
 
 run_test test_complete_sidebar_top_level_sections_pass_check
+run_test test_validate_mode_allows_stale_generated_outputs
 run_test test_svg_diagram_embeds_become_text_descriptions
 run_test test_split_produces_oss_and_pro_files
 run_test test_missing_sidebar_top_level_section_fails_check

--- a/script/generate-llms-full.mjs
+++ b/script/generate-llms-full.mjs
@@ -14,6 +14,7 @@
  * Usage:
  *   node script/generate-llms-full.mjs           # regenerate both llms-full files
  *   node script/generate-llms-full.mjs --check   # CI mode: fail on drift
+ *   node script/generate-llms-full.mjs --validate # CI mode: validate without drift check or writes
  *
  * Doc ID rules mirror script/check-docs-sidebar:
  *   docs/oss/getting-started/quick-start.md → getting-started/quick-start
@@ -42,6 +43,12 @@ const SITE_DOCS_URL = 'https://reactonrails.com/docs';
 const SPLIT_THRESHOLD_KIB = 2048;
 
 const checkMode = process.argv.includes('--check');
+const validateMode = process.argv.includes('--validate');
+
+if (checkMode && validateMode) {
+  console.error('✗ Use either --check or --validate, not both.');
+  process.exit(1);
+}
 
 function fail(message) {
   console.error(`✗ ${message}`);
@@ -487,6 +494,11 @@ if (checkMode) {
       fail(`${label} is stale. Run \`node script/generate-llms-full.mjs\` and commit the result.`);
     }
   }
+} else if (validateMode) {
+  // Validation-only mode intentionally does not compare or write the generated
+  // aggregate files. Docs PRs should prove the generator still works and the
+  // URLs/sidebar map are valid without forcing large generated diffs into every
+  // source-doc change. Scheduled automation keeps the committed references fresh.
 } else if (process.exitCode === 1) {
   console.error('✗ Not writing llms-full files while URL validation is failing; fix the URLs above first.');
 } else {
@@ -499,8 +511,14 @@ if (process.exitCode !== 1) {
   const summary = outputs
     .map(({ label, ids, sizeKib }) => `${label} ${sizeKib.toFixed(0)} KiB (${ids.length} pages)`)
     .join(', ');
+  let action = 'generated';
+  if (checkMode) {
+    action = 'are current';
+  } else if (validateMode) {
+    action = 'validated';
+  }
   console.log(
-    `✓ llms-full files ${checkMode ? 'are current' : 'generated'}: ${summary} ` +
+    `✓ llms-full files ${action}: ${summary} ` +
       `(split threshold ${SPLIT_THRESHOLD_KIB} KiB); ${validatedUrlCount} docs URLs and ` +
       `${validatedSidebarSectionCount} sidebar top-level sections validated.`,
   );


### PR DESCRIPTION
## Summary
- add `--validate` mode to `script/generate-llms-full.mjs` so source-doc-only PRs can validate generator inputs without committing the giant generated references
- keep drift enforcement for generated artifacts, generator/config inputs, and manual runs by switching `check-llms-full` between `--validate` and `--check` based on changed paths
- add a daily/manual bot-managed workflow that regenerates `llms-full.txt` and `llms-full-pro.txt`, opens a generated PR with a scoped GitHub App token, and relies on that PR CI to prove generated files are current
- update the docs-site dispatch trigger so root `llms*` artifact changes rebuild the hosted site, and pin the write-capable third-party actions touched here

## Confidence / merge notes
- Current head: `ede67378a8b3245f306590797991871e7af59606`.
- The accepted process tradeoff is explicit: ordinary source-doc merges may rebuild docs before the daily/generated `llms-full*` PR lands, so hosted `llms-full*` can lag briefly. This keeps generated artifacts out of normal docs PRs; generator/config/root-artifact changes still run `--check` and cannot silently drift.
- The motivating stale-base replay is PR #4214: once this lands, that docs-only PR should rerun on the validation-only path instead of carrying `llms-full.txt`.
- Post-merge workflow exercise is tracked in #4219.
- Hosted CI was requested on the current head with `+ci-run-hosted`; merge waits for current-head required checks/reviews.

## Workflow Change Audit
- Secret references: reuses existing `DOCS_DISPATCH_APP_ID` and `DOCS_DISPATCH_APP_KEY`. The new update workflow requests an installation token for `shakacode/react_on_rails`; #4219 verifies that the App installation has the needed repo permissions.
- Permissions: `check-llms-full.yml` remains `contents: read`; `update-llms-full.yml` reduces the default `GITHUB_TOKEN` to `contents: read` and uses the scoped App token for write operations; `trigger-docs-site.yml` remains `contents: read`.
- Triggers: `check-llms-full.yml` still covers docs/generator/root-artifact changes; `update-llms-full.yml` runs daily/manual with non-canceling concurrency; `trigger-docs-site.yml` now includes `llms.txt`, `llms-full.txt`, and `llms-full-pro.txt`.
- Third-party actions: `peter-evans/create-pull-request` is pinned to verified v7.0.6 SHA `67ccf781d68cd99b580ae25a5c18a1cc84ffff1f`; `peter-evans/repository-dispatch` is pinned to verified v3.0.0 SHA `ff45666b9427631e3450c54a1bcbee4d9ff4d7c0`.

## Verification
- `bash script/generate-llms-full-test.bash`
- `node script/generate-llms-full.mjs --validate`
- `node script/generate-llms-full.mjs --check`
- local mode simulation against `origin/main` returns `check` for this PR because it changes generator/workflow inputs
- `actionlint .github/workflows/check-llms-full.yml .github/workflows/update-llms-full.yml .github/workflows/trigger-docs-site.yml`
- Ruby YAML parse for `.github/workflows/*.{yml,yaml}`
- `corepack pnpm run lint`
- `corepack pnpm start format.listDifferent`
- `script/ci-changes-detector origin/main`
- `git diff --check`
- `codex review --base origin/main` found no actionable regressions after the workflow fixes
- Claude local review found the stale-window tradeoff and generated-PR wording issue; the wording was fixed and the stale-window tradeoff is documented above plus tracked in #4219
- post-rebase: `bash script/generate-llms-full-test.bash && node script/generate-llms-full.mjs --validate && node script/generate-llms-full.mjs --check`
- post-rebase: `actionlint .github/workflows/check-llms-full.yml .github/workflows/update-llms-full.yml .github/workflows/trigger-docs-site.yml`
- post-rebase: `git diff --check origin/main...HEAD`
- Pre-commit hook: trailing newlines and Prettier
- Pre-push hook: branch lint and markdown link check

`yamllint` and local `zizmor` are not installed in this environment, so those were left to GitHub Actions. `bundle exec rubocop` was run earlier and fails on pre-existing offenses under `react_on_rails/spike/3313_prism_gemfile_rewriter/*`; this branch does not touch Ruby files.
## Hosted CI closeout
- Current-head hosted checks on `ede67378a8b3245f306590797991871e7af59606` passed across the full visible matrix, including `check-llms-full`, `actionlint`, `zizmor`, CodeQL, package/gem tests, integration tests, Playwright, Pro package/integration jobs, and `required-pr-gate`.
- The first `rspec-dummy-app-node-renderer` attempt failed before checkout during `Initialize containers`; the targeted rerun on the same head reached the test steps and passed in 3m50s, so I treated the first attempt as runner/container infrastructure.
- The remaining red `claude-review` check is an automation credential failure, not a review finding: the job reports `Claude review result: is_error=true total_cost_usd=0 num_turns=1` and asks to rotate `CLAUDE_CODE_OAUTH_TOKEN`. A local Claude review pass was run instead and its actionable wording finding was fixed; no unresolved review threads remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new automated workflow to regenerate `llms-full.txt` / `llms-full-pro.txt` and open an update pull request.
  * Introduced `llms-full` **`--validate`** mode to validate references without rewriting outputs.
* **Bug Fixes**
  * Improved `llms-full` CI validation logic to choose the correct mode based on event context and detect stale references.
  * Updated docs-site rebuild triggers to run when `llms-full*` files change.
* **Tests / CI**
  * Added a regression test to confirm `--validate` accepts stale outputs while `--check` fails.
  * Adjusted workflow naming and tightened workflow/action configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Final merge confidence
- Final head: `71cf6af33cf25e2c4c0812e542e3713f4836885d`.
- Current-head checks are green across required and visible hosted CI: `check-llms-full`, `actionlint`, `zizmor`, CodeQL, Claude, CodeRabbit, lint/build, package/gem tests, Playwright, Pro package/integration jobs, and `required-pr-gate`.
- Current-head review threads are resolved. Optional post-review suggestions about generated PR labels and workflow-list documentation were answered in-thread; #4219 remains the follow-up to exercise the generated PR workflow and tune process details after the first real run.