### PR TITLE
[codex] Add bin/dev clean and improve dev docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 ### [Unreleased]
 
+#### Added
+
+- **`bin/dev clean` clears generated bundles and caches**: The command stops development processes, reads `config/shakapacker.yml` or `SHAKAPACKER_CONFIG`, removes configured Shakapacker public/private output and cache paths plus common Rails, JavaScript, and renderer bundle caches, and skips unsafe paths outside the app root. [PR 4218](https://github.com/shakacode/react_on_rails/pull/4218) by [justin808](https://github.com/justin808).
+
 #### Fixed
 
 - **[Pro]** **RSC doctor now catches stale install and client-manifest setup failures**:
@@ -40,6 +44,8 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
   and scopes [Issue 4204](https://github.com/shakacode/react_on_rails/issues/4204).
   [PR 4213](https://github.com/shakacode/react_on_rails/pull/4213) by
   [justin808](https://github.com/justin808).
+
+- **Dummy app setup uses native Nokogiri gems on macOS**: The dummy app lockfile now includes Darwin platforms so `bin/setup` installs native Nokogiri gems on Apple Silicon and Intel macOS instead of attempting a source build that can fail with a missing `nokogiri_gumbo.h` header. [PR 4218](https://github.com/shakacode/react_on_rails/pull/4218) by [justin808](https://github.com/justin808).
 
 - **[Pro]** **ScoutApm Node renderer instrumentation no longer depends on Gemfile load order**: Pro now installs `NodeRenderingPool.exec_server_render_js` instrumentation from a Rails engine initializer that runs after `scout_apm.start`, instead of checking `defined?(ScoutApm)` at class load time. Apps without ScoutApm still boot normally, and apps that load `scout_apm` after `react_on_rails_pro` no longer silently skip the Pro Node renderer span. Fixes [Issue 4208](https://github.com/shakacode/react_on_rails/issues/4208). [PR 4210](https://github.com/shakacode/react_on_rails/pull/4210) by [justin808](https://github.com/justin808).
 

--- a/docs/oss/building-features/dev-server-and-testing.md
+++ b/docs/oss/building-features/dev-server-and-testing.md
@@ -21,6 +21,41 @@ Your test setup depends on which testing framework you use. Pick your path:
 
 **The key takeaway:** With [TestHelper properly configured](#test-helper-configuration), all `bin/dev` modes work with all test types. TestHelper auto-compiles test assets when needed, regardless of whether HMR or static mode is running.
 
+## Generated Bundle Files and Cache Cleanup
+
+`bin/dev` commands are intentionally conservative: they start, watch, rebuild, or stop the processes for the selected mode, but they do not wipe every generated bundle directory or bundler cache first. That keeps normal restarts fast, but stale files can survive branch switches, package-version changes, and Shakapacker configuration changes.
+
+The exact output directories come from `config/shakapacker.yml`. The paths below use the defaults shown in this guide.
+
+| Command                              | Generated bundles it uses or writes                                                                        | What it clears automatically                                                                                                                                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bin/dev` (HMR, default)             | Browser bundles are served from webpack-dev-server memory, not from `public/webpack/development/`.         | No generated bundle directories or build caches. Existing disk outputs are left alone.                                                                                                                    |
+| `bin/dev static`                     | Writes development bundles to the development `public_output_path`, usually `public/webpack/development/`. | No output directories or build caches. Watch rebuilds update known outputs but do not remove stale files from old branches.                                                                               |
+| `bin/dev test-watch`                 | Writes test bundles to the test `public_output_path`, usually `public/webpack/test/`.                      | No output directories or build caches. Watch rebuilds update known outputs but do not remove stale files from old branches.                                                                               |
+| TestHelper / `build_test_command`    | Writes test bundles when assets are stale.                                                                 | No output directories or build caches unless your custom `build_test_command` deletes them.                                                                                                               |
+| `bin/dev prod` / `production-assets` | Runs `rails assets:precompile` with production bundler optimizations.                                      | No `public/assets`, `public/webpack/*`, or build-cache cleanup unless your Rails tasks do it.                                                                                                             |
+| `bin/dev kill`                       | Does not build bundles.                                                                                    | Stops known dev processes and removes process/socket files such as Overmind sockets and `tmp/pids/server.pid`; it does not delete bundles, `tmp/cache`, `node_modules/.cache`, or renderer bundle caches. |
+
+If a branch switch or package update leaves confusing asset errors, stop the watchers first, reinstall packages if the lockfile changed, and then clear the generated outputs and caches that apply to your app:
+
+```bash
+bin/dev kill
+
+# If package versions changed, run your package-manager install command first.
+pnpm install
+
+# Adjust these paths if your shakapacker.yml uses different public_output_path values.
+rm -rf public/webpack/development public/webpack/test
+
+# Clear Rails/Shakapacker cache entries that can affect bundle generation.
+rm -rf tmp/cache
+
+# Clear bundler-loader caches when package versions or loader config changed.
+rm -rf node_modules/.cache
+```
+
+For React Server Components or the React on Rails Pro node renderer, also clear the renderer bundle cache you configured with `RENDERER_SERVER_BUNDLE_CACHE_PATH`, such as `tmp/node-renderer-bundles-test-*` in the [RSC testing setup](./testing-configuration.md#rsc-and-node-renderer-system-tests). Some generated renderer templates use `.node-renderer-bundles`; clear that directory too if your launch file still points there.
+
 ## Capybara / Rails System Tests (RSpec and Minitest)
 
 Capybara boots its **own** Puma server for each test run. That server reads `manifest.json` to find asset paths, so assets must exist as files on disk. HMR manifests contain `http://localhost:3035/...` URLs that Capybara's Puma can't serve — but this doesn't matter if TestHelper is configured, because it compiles separate test assets.

--- a/docs/oss/building-features/dev-server-and-testing.md
+++ b/docs/oss/building-features/dev-server-and-testing.md
@@ -23,38 +23,32 @@ Your test setup depends on which testing framework you use. Pick your path:
 
 ## Generated Bundle Files and Cache Cleanup
 
-`bin/dev` commands are intentionally conservative: they start, watch, rebuild, or stop the processes for the selected mode, but they do not wipe every generated bundle directory or bundler cache first. That keeps normal restarts fast, but stale files can survive branch switches, package-version changes, and Shakapacker configuration changes.
+Most `bin/dev` commands are intentionally conservative: they start, watch, rebuild, or stop the processes for the selected mode, but they do not wipe every generated bundle directory or bundler cache first. That keeps normal restarts fast, but stale files can survive branch switches, package-version changes, and Shakapacker configuration changes. Use `bin/dev clean` when you want the cleanup step too.
 
 The exact output directories come from `config/shakapacker.yml`. The paths below use the defaults shown in this guide.
 
-| Command                              | Generated bundles it uses or writes                                                                        | What it clears automatically                                                                                                                                                                              |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bin/dev` (HMR, default)             | Browser bundles are served from webpack-dev-server memory, not from `public/webpack/development/`.         | No generated bundle directories or build caches. Existing disk outputs are left alone.                                                                                                                    |
-| `bin/dev static`                     | Writes development bundles to the development `public_output_path`, usually `public/webpack/development/`. | No output directories or build caches. Watch rebuilds update known outputs but do not remove stale files from old branches.                                                                               |
-| `bin/dev test-watch`                 | Writes test bundles to the test `public_output_path`, usually `public/webpack/test/`.                      | No output directories or build caches. Watch rebuilds update known outputs but do not remove stale files from old branches.                                                                               |
-| TestHelper / `build_test_command`    | Writes test bundles when assets are stale.                                                                 | No output directories or build caches unless your custom `build_test_command` deletes them.                                                                                                               |
-| `bin/dev prod` / `production-assets` | Runs `rails assets:precompile` with production bundler optimizations.                                      | No `public/assets`, `public/webpack/*`, or build-cache cleanup unless your Rails tasks do it.                                                                                                             |
-| `bin/dev kill`                       | Does not build bundles.                                                                                    | Stops known dev processes and removes process/socket files such as Overmind sockets and `tmp/pids/server.pid`; it does not delete bundles, `tmp/cache`, `node_modules/.cache`, or renderer bundle caches. |
+| Command                              | Generated bundles it uses or writes                                                                        | What it clears automatically                                                                                                                                                                                       |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bin/dev` (HMR, default)             | Browser bundles are served from webpack-dev-server memory, not from `public/webpack/development/`.         | No generated bundle directories or build caches. Existing disk outputs are left alone.                                                                                                                             |
+| `bin/dev static`                     | Writes development bundles to the development `public_output_path`, usually `public/webpack/development/`. | No output directories or build caches. Watch rebuilds update known outputs but do not remove stale files from old branches.                                                                                        |
+| `bin/dev test-watch`                 | Writes test bundles to the test `public_output_path`, usually `public/webpack/test/`.                      | No output directories or build caches. Watch rebuilds update known outputs but do not remove stale files from old branches.                                                                                        |
+| TestHelper / `build_test_command`    | Writes test bundles when assets are stale.                                                                 | No output directories or build caches unless your custom `build_test_command` deletes them.                                                                                                                        |
+| `bin/dev prod` / `production-assets` | Runs `rails assets:precompile` with production bundler optimizations.                                      | No `public/assets`, `public/webpack/*`, or build-cache cleanup unless your Rails tasks do it.                                                                                                                      |
+| `bin/dev kill`                       | Does not build bundles.                                                                                    | Stops known dev processes and removes process/socket files such as Overmind sockets and `tmp/pids/server.pid`; it does not delete bundles, `tmp/cache`, `node_modules/.cache`, or renderer bundle caches.          |
+| `bin/dev clean`                      | Does not build bundles.                                                                                    | Runs the `kill` cleanup, reads `config/shakapacker.yml` or `SHAKAPACKER_CONFIG`, removes configured Shakapacker output/cache paths, and clears common build caches. Unsafe paths outside the app root are skipped. |
 
-If a branch switch or package update leaves confusing asset errors, stop the watchers first, reinstall packages if the lockfile changed, and then clear the generated outputs and caches that apply to your app:
+If a branch switch or package update leaves confusing asset errors, stop watchers and clear generated outputs first, then reinstall packages if the lockfile changed before rebuilding:
 
 ```bash
-bin/dev kill
+bin/dev clean
 
 # If package versions changed, run your package-manager install command first.
 pnpm install
-
-# Adjust these paths if your shakapacker.yml uses different public_output_path values.
-rm -rf public/webpack/development public/webpack/test
-
-# Clear Rails/Shakapacker cache entries that can affect bundle generation.
-rm -rf tmp/cache
-
-# Clear bundler-loader caches when package versions or loader config changed.
-rm -rf node_modules/.cache
 ```
 
-For React Server Components or the React on Rails Pro node renderer, also clear the renderer bundle cache you configured with `RENDERER_SERVER_BUNDLE_CACHE_PATH`, such as `tmp/node-renderer-bundles-test-*` in the [RSC testing setup](./testing-configuration.md#rsc-and-node-renderer-system-tests). Some generated renderer templates use `.node-renderer-bundles`; clear that directory too if your launch file still points there.
+`bin/dev clean` derives Shakapacker public and private output paths from the `default`, `development`, `test`, and `production` sections of `shakapacker.yml`, then clears those directories plus configured `cache_path` directories, `public/assets`, `tmp/cache`, `node_modules/.cache`, `.node-renderer-bundles`, and `tmp/node-renderer-bundles-test-*`.
+
+For React Server Components or the React on Rails Pro node renderer, `bin/dev clean` handles the default generated renderer cache paths above and app-local paths configured with `RENDERER_SERVER_BUNDLE_CACHE_PATH`. If that environment variable points outside the app root, the safety guard skips it; clear that external path manually. The [RSC testing setup](./testing-configuration.md#rsc-and-node-renderer-system-tests) explains why each parallel test worker should use its own renderer bundle cache.
 
 ## Capybara / Rails System Tests (RSpec and Minitest)
 

--- a/docs/oss/building-features/dev-server-and-testing.md
+++ b/docs/oss/building-features/dev-server-and-testing.md
@@ -46,7 +46,7 @@ bin/dev clean
 pnpm install
 ```
 
-`bin/dev clean` derives Shakapacker public and private output paths from the `default`, `development`, `test`, and `production` sections of `shakapacker.yml`, then clears those directories plus configured `cache_path` directories, `public/assets`, `tmp/cache`, `node_modules/.cache`, `.node-renderer-bundles`, and `tmp/node-renderer-bundles-test-*`.
+`bin/dev clean` derives Shakapacker public and private output paths from every top-level section in `shakapacker.yml` (including custom sections such as `staging`, plus the standard `default`, `development`, `test`, and `production` sections), then clears those directories plus configured `cache_path` directories, `public/assets`, `tmp/cache`, `node_modules/.cache`, `.node-renderer-bundles`, and `tmp/node-renderer-bundles-test-*`.
 
 For React Server Components or the React on Rails Pro node renderer, `bin/dev clean` handles the default generated renderer cache paths above and app-local paths configured with `RENDERER_SERVER_BUNDLE_CACHE_PATH`. If that environment variable points outside the app root, the safety guard skips it; clear that external path manually. The [RSC testing setup](./testing-configuration.md#rsc-and-node-renderer-system-tests) explains why each parallel test worker should use its own renderer bundle cache.
 

--- a/docs/oss/building-features/dev-server-and-testing.md
+++ b/docs/oss/building-features/dev-server-and-testing.md
@@ -42,8 +42,10 @@ If a branch switch or package update leaves confusing asset errors, stop watcher
 ```bash
 bin/dev clean
 
-# If package versions changed, run your package-manager install command first.
+# If package versions changed, reinstall with your package manager.
 pnpm install
+# or: yarn install
+# or: npm install
 ```
 
 `bin/dev clean` derives Shakapacker public and private output paths from every top-level section in `shakapacker.yml` (including custom sections such as `staging`, plus the standard `default`, `development`, `test`, and `production` sections), then clears those directories plus configured `cache_path` directories, `public/assets`, `tmp/cache`, `node_modules/.cache`, `.node-renderer-bundles`, and `tmp/node-renderer-bundles-test-*`.

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -965,6 +965,8 @@ The doctor will check:
 rm -rf public/webpack/test
 ```
 
+If this started after switching branches or changing package versions, also stop any `bin/dev` watchers and clear the relevant build caches. See [Generated Bundle Files and Cache Cleanup](./dev-server-and-testing.md#generated-bundle-files-and-cache-cleanup) for the command-by-command cleanup behavior.
+
 ### Build command fails
 
 **Problem:** `build_test_command` fails with errors.

--- a/docs/oss/building-features/testing-configuration.md
+++ b/docs/oss/building-features/testing-configuration.md
@@ -965,7 +965,7 @@ The doctor will check:
 rm -rf public/webpack/test
 ```
 
-If this started after switching branches or changing package versions, also stop any `bin/dev` watchers and clear the relevant build caches. See [Generated Bundle Files and Cache Cleanup](./dev-server-and-testing.md#generated-bundle-files-and-cache-cleanup) for the command-by-command cleanup behavior.
+If this started after switching branches or changing package versions, run `bin/dev clean` to stop any `bin/dev` watchers and clear the relevant generated bundles and build caches. See [Generated Bundle Files and Cache Cleanup](./dev-server-and-testing.md#generated-bundle-files-and-cache-cleanup) for the command-by-command cleanup behavior.
 
 ### Build command fails
 

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/dev
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/dev
@@ -83,8 +83,9 @@ if AUTO_OPEN_BROWSER_ONCE && browser_flags.none? { |flag| argv_with_defaults.inc
 end
 
 # Uncomment to run custom precompile tasks before starting the server
-# Only run for server start commands (not kill/help)
-# unless ARGV.include?("kill") || ARGV.include?("-h") || ARGV.include?("--help") || ARGV.include?("help")
+# Only run for server start commands (not kill/clean/help)
+# skip_commands = %w[kill clean help -h --help]
+# unless (ARGV & skip_commands).any?
 #   run_precompile_tasks
 # end
 

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -83,7 +83,7 @@ module ReactOnRails
           puts ""
           kill_processes
           puts ""
-          puts "📖 Reading Shakapacker config: #{display_clean_path(shakapacker_config_path)}"
+          print_shakapacker_config_status
           puts ""
 
           remove_clean_targets(clean_targets)
@@ -459,11 +459,20 @@ module ReactOnRails
           end
         end
 
+        def print_shakapacker_config_status
+          config_path = shakapacker_config_path
+          if File.exist?(config_path)
+            puts "📖 Reading Shakapacker config: #{display_clean_path(config_path)}"
+          else
+            puts "📖 Shakapacker config not found: #{display_clean_path(config_path)}"
+            puts "   • Skipping configured Shakapacker output/cache paths"
+          end
+        end
+
         def safe_clean_path?(path)
-          expanded_path = File.expand_path(path, app_root_path)
-          return false unless path_inside_app_root?(expanded_path)
-          return false if broad_clean_path?(expanded_path)
-          return false unless real_clean_path_inside_app_root?(expanded_path)
+          return false unless path_inside_app_root?(path)
+          return false if broad_clean_path?(path)
+          return false unless real_clean_path_inside_app_root?(path)
 
           true
         end
@@ -482,9 +491,13 @@ module ReactOnRails
         end
 
         def real_app_root_path
-          File.realpath(app_root_path)
+          root_path = app_root_path
+          return @real_app_root_path if @real_app_root_path_for == root_path
+
+          @real_app_root_path_for = root_path
+          @real_app_root_path = File.realpath(root_path)
         rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
-          app_root_path
+          @real_app_root_path = root_path
         end
 
         def broad_clean_path?(path)
@@ -497,11 +510,10 @@ module ReactOnRails
         end
 
         def display_clean_path(path)
-          expanded_path = File.expand_path(path, app_root_path)
           root_prefix = "#{app_root_path}/"
-          return expanded_path.delete_prefix(root_prefix) if expanded_path.start_with?(root_prefix)
+          return path.delete_prefix(root_prefix) if path.start_with?(root_prefix)
 
-          expanded_path
+          path
         end
 
         def app_root_path

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -487,7 +487,7 @@ module ReactOnRails
 
           real_path = File.realpath(path)
           path_inside_real_app_root?(real_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
           false
         end
 
@@ -495,7 +495,7 @@ module ReactOnRails
           link_target = File.readlink(path)
           resolved_path = File.expand_path(link_target, File.dirname(path))
           path_inside_real_app_root?(resolved_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
           false
         end
 
@@ -509,7 +509,7 @@ module ReactOnRails
 
           @real_app_root_path_for = root_path
           @real_app_root_path = File.realpath(root_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EACCES
           @real_app_root_path = root_path
         end
 

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -28,6 +28,7 @@ module ReactOnRails
 
       HELP_FLAGS = ["-h", "--help"].freeze
       TEST_WATCH_MODES = %w[auto full client-only].freeze
+      CLEAN_SHAKAPACKER_ENVIRONMENTS = %w[development test production].freeze
       OPEN_BROWSER_WAIT_TIMEOUT = 60
       OPEN_BROWSER_POLL_INTERVAL = 0.5
       DOCS_BASE_URL = "https://reactonrails.com/docs"
@@ -75,6 +76,20 @@ module ReactOnRails
           ].any?
 
           print_kill_summary(killed_any)
+        end
+
+        def clean_generated_assets_and_caches
+          puts "🧹 Cleaning generated bundles and caches..."
+          puts ""
+          kill_processes
+          puts ""
+          puts "📖 Reading Shakapacker config: #{display_clean_path(shakapacker_config_path)}"
+          puts ""
+
+          remove_clean_targets(clean_targets)
+
+          puts ""
+          puts "✅ Generated bundles and caches cleaned"
         end
 
         # Fallback port list for the port-scan kill path. Uses the base-port
@@ -296,12 +311,12 @@ module ReactOnRails
 
           options = parse_cli_options(args)
 
-          # Run precompile hook once before starting any mode (except kill/help)
+          # Run precompile hook once before starting any mode (except kill/clean/help)
           # Then set environment variable to prevent duplicate execution in spawned processes.
           # Note: We always set SHAKAPACKER_SKIP_PRECOMPILE_HOOK=true (even when no hook is configured)
           # to provide a consistent signal that bin/dev is managing the precompile lifecycle.
           # This allows custom scripts to detect bin/dev's presence and adjust behavior accordingly.
-          unless %w[kill help].include?(command) || help_requested
+          unless %w[kill clean help].include?(command) || help_requested
             run_precompile_hook_if_present
             ENV["SHAKAPACKER_SKIP_PRECOMPILE_HOOK"] = "true"
           end
@@ -321,6 +336,8 @@ module ReactOnRails
                                                          open_browser_once: options[:open_browser_once])
           when "kill"
             kill_processes
+          when "clean"
+            clean_generated_assets_and_caches
           when "help"
             show_help
           when "test-watch"
@@ -339,6 +356,161 @@ module ReactOnRails
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
         private
+
+        def clean_targets
+          deduplicate_clean_targets(
+            shakapacker_clean_targets +
+              common_clean_targets +
+              renderer_bundle_cache_targets
+          )
+        end
+
+        def shakapacker_clean_targets
+          shakapacker_sections_for_cleanup.flat_map do |environment, section|
+            public_output_path = shakapacker_public_output_path(section)
+            private_output_path = section["private_output_path"].to_s.strip
+            cache_path = section["cache_path"].to_s.strip
+            targets = [
+              clean_target(public_output_path, "Shakapacker #{environment} public output")
+            ]
+            unless private_output_path.empty?
+              targets << clean_target(private_output_path, "Shakapacker #{environment} private output")
+            end
+            targets << clean_target(cache_path, "Shakapacker #{environment} cache") unless cache_path.empty?
+            targets
+          end
+        end
+
+        def shakapacker_sections_for_cleanup
+          config = parsed_shakapacker_config
+          return [] unless config
+
+          default_section = stringify_config_keys(shakapacker_section(config, "default"))
+          environment_names = ["default"] | (config.keys.map(&:to_s) - ["default"]) | CLEAN_SHAKAPACKER_ENVIRONMENTS
+          environment_names.map do |environment|
+            section = default_section.merge(stringify_config_keys(shakapacker_section(config, environment)))
+            [environment, section]
+          end
+        end
+
+        def shakapacker_public_output_path(section)
+          public_root_path = section["public_root_path"].to_s.strip
+          public_root_path = "public" if public_root_path.empty?
+
+          public_output_path = section["public_output_path"].to_s.strip
+          public_output_path = "packs" if public_output_path.empty?
+
+          return public_output_path if File.absolute_path?(public_output_path)
+
+          File.join(public_root_path, public_output_path)
+        end
+
+        def common_clean_targets
+          [
+            clean_target("public/assets", "Rails compiled assets"),
+            clean_target("tmp/cache", "Rails/Shakapacker cache"),
+            clean_target("node_modules/.cache", "JavaScript bundler cache"),
+            clean_target(".node-renderer-bundles", "node renderer bundle cache")
+          ]
+        end
+
+        def renderer_bundle_cache_targets
+          targets = []
+          renderer_cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH", "").to_s.strip
+          unless renderer_cache_path.empty?
+            targets << clean_target(renderer_cache_path, "configured node renderer bundle cache")
+          end
+
+          Dir.glob(File.join(app_root_path, "tmp/node-renderer-bundles-test-*")).each do |path|
+            targets << clean_target(path, "test node renderer bundle cache")
+          end
+
+          targets
+        end
+
+        def clean_target(path, label)
+          { path: File.expand_path(path, app_root_path), label: }
+        end
+
+        def deduplicate_clean_targets(targets)
+          targets.each_with_object({}) do |target, deduplicated|
+            deduplicated[target[:path]] ||= target
+          end.values
+        end
+
+        def remove_clean_targets(targets)
+          targets.each do |target|
+            path = target.fetch(:path)
+            label = target.fetch(:label)
+            display_path = display_clean_path(path)
+
+            unless safe_clean_path?(path)
+              puts "⚠️  Skipping unsafe cleanup path: #{display_path} (#{label})"
+              next
+            end
+
+            unless File.exist?(path) || File.symlink?(path)
+              puts "   • #{display_path} (not present)"
+              next
+            end
+
+            FileUtils.rm_rf(path)
+            puts "   ✓ Removed #{display_path} (#{label})"
+          end
+        end
+
+        def safe_clean_path?(path)
+          expanded_path = File.expand_path(path, app_root_path)
+          return false unless path_inside_app_root?(expanded_path)
+          return false if broad_clean_path?(expanded_path)
+          return false unless real_clean_path_inside_app_root?(expanded_path)
+
+          true
+        end
+
+        def path_inside_app_root?(path)
+          path.start_with?("#{app_root_path}/")
+        end
+
+        def real_clean_path_inside_app_root?(path)
+          return true unless File.exist?(path) || File.symlink?(path)
+
+          real_path = File.realpath(path)
+          real_path.start_with?("#{real_app_root_path}/")
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+          false
+        end
+
+        def real_app_root_path
+          File.realpath(app_root_path)
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+          app_root_path
+        end
+
+        def broad_clean_path?(path)
+          [
+            app_root_path,
+            File.join(app_root_path, "public"),
+            File.join(app_root_path, "tmp"),
+            File.join(app_root_path, "node_modules")
+          ].include?(path)
+        end
+
+        def display_clean_path(path)
+          expanded_path = File.expand_path(path, app_root_path)
+          root_prefix = "#{app_root_path}/"
+          return expanded_path.delete_prefix(root_prefix) if expanded_path.start_with?(root_prefix)
+
+          expanded_path
+        end
+
+        def app_root_path
+          File.expand_path(shakapacker_config_base_dir)
+        end
+
+        def stringify_config_keys(hash)
+          hash.transform_keys(&:to_s)
+        end
 
         # Extract the command from args, skipping flag values
         # For example, in ["--route", "hello_world"], "hello_world" is a flag value, not a command
@@ -634,6 +806,7 @@ module ReactOnRails
                                   #{Rainbow('→ Uses:').yellow} bin/shakapacker --watch (RAILS_ENV=test)
 
               #{Rainbow('kill').red.bold}                #{Rainbow('Kill all development processes for a clean start').white}
+              #{Rainbow('clean').red.bold}               #{Rainbow('Kill dev processes and remove generated bundles/caches').white}
               #{Rainbow('help').blue.bold}                #{Rainbow('Show this help message').white}
           COMMANDS
         end

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -465,8 +465,11 @@ module ReactOnRails
 
         def print_shakapacker_config_status
           config_path = shakapacker_config_path
-          if File.exist?(config_path)
+          if parsed_shakapacker_config
             puts "📖 Reading Shakapacker config: #{display_clean_path(config_path)}"
+          elsif File.exist?(config_path)
+            puts "📖 Could not parse Shakapacker config: #{display_clean_path(config_path)}"
+            puts "   • Skipping configured Shakapacker output/cache paths"
           else
             puts "📖 Shakapacker config not found: #{display_clean_path(config_path)}"
             puts "   • Skipping configured Shakapacker output/cache paths"

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -455,7 +455,11 @@ module ReactOnRails
             end
 
             FileUtils.rm_rf(path)
-            puts "   ✓ Removed #{display_path} (#{label})"
+            if File.exist?(path) || File.symlink?(path)
+              puts "⚠️  Partially removed #{display_path} - some files could not be deleted (#{label})"
+            else
+              puts "   ✓ Removed #{display_path} (#{label})"
+            end
           end
         end
 
@@ -509,7 +513,7 @@ module ReactOnRails
 
           @real_app_root_path_for = root_path
           @real_app_root_path = File.realpath(root_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EACCES
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
           @real_app_root_path = root_path
         end
 

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -86,10 +86,14 @@ module ReactOnRails
           print_shakapacker_config_status
           puts ""
 
-          remove_clean_targets(clean_targets)
+          clean_finished_without_warnings = remove_clean_targets(clean_targets)
 
           puts ""
-          puts "✅ Generated bundles and caches cleaned"
+          if clean_finished_without_warnings
+            puts "✅ Generated bundles and caches cleaned"
+          else
+            puts "⚠️  Cleanup completed with warnings"
+          end
         end
 
         # Fallback port list for the port-scan kill path. Uses the base-port
@@ -416,7 +420,7 @@ module ReactOnRails
 
         def renderer_bundle_cache_targets
           targets = []
-          renderer_cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH", "").to_s.strip
+          renderer_cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH", "").strip
           unless renderer_cache_path.empty?
             targets << clean_target(renderer_cache_path, "configured node renderer bundle cache")
           end
@@ -439,12 +443,15 @@ module ReactOnRails
         end
 
         def remove_clean_targets(targets)
+          all_targets_clean = true
+
           targets.each do |target|
             path = target.fetch(:path)
             label = target.fetch(:label)
             display_path = display_clean_path(path)
 
             unless safe_clean_path?(path)
+              all_targets_clean = false
               puts "⚠️  Skipping unsafe cleanup path: #{display_path} (#{label})"
               next
             end
@@ -456,11 +463,14 @@ module ReactOnRails
 
             FileUtils.rm_rf(path)
             if File.exist?(path) || File.symlink?(path)
+              all_targets_clean = false
               puts "⚠️  Partially removed #{display_path} - some files could not be deleted (#{label})"
             else
               puts "   ✓ Removed #{display_path} (#{label})"
             end
           end
+
+          all_targets_clean
         end
 
         def print_shakapacker_config_status
@@ -499,9 +509,12 @@ module ReactOnRails
         end
 
         def broken_symlink_target_inside_app_root?(path)
+          parent_real_path = File.realpath(File.dirname(path))
+          return false unless parent_real_path == real_app_root_path || path_inside_real_app_root?(parent_real_path)
+
           link_target = File.readlink(path)
           resolved_path = File.expand_path(link_target, File.dirname(path))
-          path_inside_real_app_root?(resolved_path)
+          path_inside_app_root?(resolved_path) || path_inside_real_app_root?(resolved_path)
         rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
           false
         end

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -483,11 +483,24 @@ module ReactOnRails
 
         def real_clean_path_inside_app_root?(path)
           return true unless File.exist?(path) || File.symlink?(path)
+          return broken_symlink_target_inside_app_root?(path) if File.symlink?(path) && !File.exist?(path)
 
           real_path = File.realpath(path)
-          real_path.start_with?("#{real_app_root_path}/")
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR
+          path_inside_real_app_root?(real_path)
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL
           false
+        end
+
+        def broken_symlink_target_inside_app_root?(path)
+          link_target = File.readlink(path)
+          resolved_path = File.expand_path(link_target, File.dirname(path))
+          path_inside_real_app_root?(resolved_path)
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL
+          false
+        end
+
+        def path_inside_real_app_root?(path)
+          path.start_with?("#{real_app_root_path}/")
         end
 
         def real_app_root_path
@@ -517,7 +530,11 @@ module ReactOnRails
         end
 
         def app_root_path
-          File.expand_path(shakapacker_config_base_dir)
+          base_dir = shakapacker_config_base_dir
+          return @app_root_path if @app_root_path_base_dir == base_dir
+
+          @app_root_path_base_dir = base_dir
+          @app_root_path = File.expand_path(base_dir)
         end
 
         def stringify_config_keys(hash)

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -504,7 +504,7 @@ module ReactOnRails
 
           real_path = File.realpath(path)
           path_inside_real_app_root?(real_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES, Errno::EPERM
           false
         end
 
@@ -515,7 +515,7 @@ module ReactOnRails
           link_target = File.readlink(path)
           resolved_path = File.expand_path(link_target, File.dirname(path))
           path_inside_app_root?(resolved_path) || path_inside_real_app_root?(resolved_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES, Errno::EPERM
           false
         end
 
@@ -529,7 +529,7 @@ module ReactOnRails
 
           @real_app_root_path_for = root_path
           @real_app_root_path = File.realpath(root_path)
-        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES
+        rescue Errno::ENOENT, Errno::ELOOP, Errno::ENOTDIR, Errno::EINVAL, Errno::EACCES, Errno::EPERM
           @real_app_root_path = root_path
         end
 

--- a/react_on_rails/lib/react_on_rails/dev/server_manager.rb
+++ b/react_on_rails/lib/react_on_rails/dev/server_manager.rb
@@ -30,6 +30,9 @@ module ReactOnRails
       TEST_WATCH_MODES = %w[auto full client-only].freeze
       OPEN_BROWSER_WAIT_TIMEOUT = 60
       OPEN_BROWSER_POLL_INTERVAL = 0.5
+      DOCS_BASE_URL = "https://reactonrails.com/docs"
+      DEV_SERVER_AND_TESTING_DOCS_URL = "#{DOCS_BASE_URL}/building-features/dev-server-and-testing/".freeze
+      TESTING_CONFIGURATION_DOCS_URL = "#{DOCS_BASE_URL}/building-features/testing-configuration/".freeze
 
       class << self
         def start(mode = :development, procfile = nil, verbose: false, route: nil, rails_env: nil,
@@ -1819,12 +1822,16 @@ module ReactOnRails
             #{Rainbow('•').red} #{Rainbow('"Assets not loading"').white} #{Rainbow('→ Verify Procfile.dev is present and check server logs').white}
 
             #{Rainbow('📖 DOCUMENTATION:').cyan.bold}
-            #{Rainbow('•').yellow} #{Rainbow('Testing & dev server guide:').white} #{Rainbow('docs/oss/building-features/dev-server-and-testing.md').green}
-            #{Rainbow('•').yellow} #{Rainbow('Testing configuration:').white} #{Rainbow('docs/oss/building-features/testing-configuration.md').green}
-            #{Rainbow('•').yellow} #{Rainbow('Full docs:').white} #{Rainbow('https://reactonrails.com/docs/').cyan.underline}
+            #{documentation_link('Dev server modes & testing:', DEV_SERVER_AND_TESTING_DOCS_URL)}
+            #{documentation_link('Test asset configuration:', TESTING_CONFIGURATION_DOCS_URL)}
+            #{documentation_link('Full documentation:', "#{DOCS_BASE_URL}/")}
           TROUBLESHOOTING
         end
         # rubocop:enable Metrics/AbcSize
+
+        def documentation_link(label, url)
+          "#{Rainbow('•').yellow} #{Rainbow(label).white} #{Rainbow(url).cyan.underline}"
+        end
       end
     end
   end

--- a/react_on_rails/spec/dummy/Gemfile.lock
+++ b/react_on_rails/spec/dummy/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
@@ -344,6 +346,7 @@ GEM
     sqlite3 (2.9.4)
       mini_portile2 (~> 2.8.0)
     sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
     sqlite3 (2.9.4-x86_64-linux-gnu)
     steep (1.9.4)
       activesupport (>= 5.1)
@@ -399,6 +402,7 @@ GEM
 PLATFORMS
   arm64-darwin
   ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1535,12 +1535,16 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
         production:
           public_output_path: webpack/production
+
+        staging:
+          public_output_path: webpack/staging
       YAML
       create_clean_test_dirs(
         "public/packs",
         "public/webpack/development",
         "public/webpack/test",
         "public/webpack/production",
+        "public/webpack/staging",
         "ssr-generated",
         "tmp/shakapacker",
         "tmp/shakapacker-test",
@@ -1557,11 +1561,13 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(described_class).to have_received(:kill_processes)
         expect(output).to include("config/shakapacker.yml")
         expect(output).to include("public/webpack/development")
+        expect(output).to include("public/webpack/staging")
         expect(output).to include("tmp/shakapacker-test")
         expect(File).not_to exist("public/packs")
         expect(File).not_to exist("public/webpack/development")
         expect(File).not_to exist("public/webpack/test")
         expect(File).not_to exist("public/webpack/production")
+        expect(File).not_to exist("public/webpack/staging")
         expect(File).not_to exist("ssr-generated")
         expect(File).not_to exist("tmp/shakapacker")
         expect(File).not_to exist("tmp/shakapacker-test")
@@ -1606,6 +1612,25 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       aggregate_failures do
         expect(output).to include("Removed public/broken-packs")
         expect(File).not_to be_symlink("public/broken-packs")
+      end
+    end
+
+    it "skips cleanup targets when realpath is blocked by permissions" do
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: public
+          public_output_path: restricted-packs
+      YAML
+      create_clean_test_dirs("public/restricted-packs")
+      restricted_path = File.expand_path("public/restricted-packs", Dir.pwd)
+      allow(File).to receive(:realpath).and_call_original
+      allow(File).to receive(:realpath).with(restricted_path).and_raise(Errno::EACCES)
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Skipping unsafe cleanup path: public/restricted-packs")
+        expect(File).to exist("public/restricted-packs")
       end
     end
 

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1563,6 +1563,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(output).to include("public/webpack/development")
         expect(output).to include("public/webpack/staging")
         expect(output).to include("tmp/shakapacker-test")
+        expect(output).to include("Generated bundles and caches cleaned")
         expect(File).not_to exist("public/packs")
         expect(File).not_to exist("public/webpack/development")
         expect(File).not_to exist("public/webpack/test")
@@ -1635,6 +1636,31 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "removes broken symlink cleanup targets when the app root path is a symlink" do
+      Dir.mktmpdir("react-on-rails-real-root") do |real_root|
+        symlink_root = clean_test_outside_path("symlink-root")
+        File.symlink(real_root, symlink_root)
+
+        Dir.chdir(symlink_root) do
+          allow(Rails).to receive(:root).and_return(Pathname.new(symlink_root))
+          write_clean_test_shakapacker_config(<<~YAML)
+            default:
+              public_root_path: public
+              public_output_path: broken-packs
+          YAML
+          FileUtils.mkdir_p("public")
+          File.symlink("../tmp/deleted-packs", "public/broken-packs")
+
+          output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+          aggregate_failures do
+            expect(output).to include("Removed public/broken-packs")
+            expect(File).not_to be_symlink("public/broken-packs")
+          end
+        end
+      end
+    end
+
     it "skips cleanup targets when realpath is blocked by permissions" do
       write_clean_test_shakapacker_config(<<~YAML)
         default:
@@ -1650,6 +1676,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
       aggregate_failures do
         expect(output).to include("Skipping unsafe cleanup path: public/restricted-packs")
+        expect(output).to include("Cleanup completed with warnings")
         expect(File).to exist("public/restricted-packs")
       end
     end
@@ -1669,6 +1696,8 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
       aggregate_failures do
         expect(output).to include("Partially removed public/partial-packs")
+        expect(output).to include("Cleanup completed with warnings")
+        expect(output).not_to include("Generated bundles and caches cleaned")
         expect(File).to exist("public/partial-packs")
       end
     end
@@ -1711,6 +1740,7 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(File).to exist(File.join(outside_renderer_cache, "keep.txt"))
         expect(File).to exist("public")
         expect(output).to include("Skipping unsafe cleanup path")
+        expect(output).to include("Cleanup completed with warnings")
       end
     end
   end

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1634,6 +1634,25 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "warns when a cleanup target remains after removal" do
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: public
+          public_output_path: partial-packs
+      YAML
+      create_clean_test_dirs("public/partial-packs")
+      partial_path = File.expand_path("public/partial-packs", Dir.pwd)
+      allow(FileUtils).to receive(:rm_rf).and_call_original
+      allow(FileUtils).to receive(:rm_rf).with(partial_path)
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Partially removed public/partial-packs")
+        expect(File).to exist("public/partial-packs")
+      end
+    end
+
     it "skips shakapacker.yml paths that resolve outside the app root or to broad root directories" do
       outside_packs = clean_test_outside_path("outside-packs")
       outside_cache = clean_test_outside_path("outside-cache")

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1689,6 +1689,16 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "links to the published documentation for dev server and testing guidance" do
+      output = capture_stdout { described_class.show_help }
+
+      aggregate_failures do
+        expect(output).to match(%r{https://reactonrails.com/docs/building-features/dev-server-and-testing/})
+        expect(output).to match(%r{https://reactonrails.com/docs/building-features/testing-configuration/})
+        expect(output).to match(%r{https://reactonrails.com/docs/})
+      end
+    end
+
     context "when Shakapacker config uses live reload instead of HMR" do
       include_context "with clean port env"
 

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1681,6 +1681,47 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "skips cleanup targets when realpath is blocked by operation permissions" do
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: public
+          public_output_path: restricted-packs
+      YAML
+      create_clean_test_dirs("public/restricted-packs")
+      restricted_path = File.expand_path("public/restricted-packs", Dir.pwd)
+      allow(File).to receive(:realpath).and_call_original
+      allow(File).to receive(:realpath).with(restricted_path).and_raise(Errno::EPERM)
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Skipping unsafe cleanup path: public/restricted-packs")
+        expect(output).to include("Cleanup completed with warnings")
+        expect(File).to exist("public/restricted-packs")
+      end
+    end
+
+    it "skips broken symlink cleanup targets when readlink is blocked by operation permissions" do
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: public
+          public_output_path: blocked-link
+      YAML
+      FileUtils.mkdir_p("public")
+      File.symlink("../tmp/deleted-packs", "public/blocked-link")
+      blocked_path = File.expand_path("public/blocked-link", Dir.pwd)
+      allow(File).to receive(:readlink).and_call_original
+      allow(File).to receive(:readlink).with(blocked_path).and_raise(Errno::EPERM)
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Skipping unsafe cleanup path: public/blocked-link")
+        expect(output).to include("Cleanup completed with warnings")
+        expect(File).to be_symlink("public/blocked-link")
+      end
+    end
+
     it "warns when a cleanup target remains after removal" do
       write_clean_test_shakapacker_config(<<~YAML)
         default:

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1592,6 +1592,23 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "removes broken symlink cleanup targets when the link target stays inside the app root" do
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: public
+          public_output_path: broken-packs
+      YAML
+      FileUtils.mkdir_p("public")
+      File.symlink(File.expand_path("tmp/deleted-packs", Dir.pwd), "public/broken-packs")
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Removed public/broken-packs")
+        expect(File).not_to be_symlink("public/broken-packs")
+      end
+    end
+
     it "skips shakapacker.yml paths that resolve outside the app root or to broad root directories" do
       outside_packs = clean_test_outside_path("outside-packs")
       outside_cache = clean_test_outside_path("outside-cache")

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1483,11 +1483,15 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     around do |example|
       original_renderer_cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH", nil)
       Dir.mktmpdir("react-on-rails-clean") do |tmpdir|
-        Dir.chdir(tmpdir) do
-          example.run
+        Dir.mktmpdir("react-on-rails-clean-outside") do |outside_tmpdir|
+          @clean_test_outside_root = outside_tmpdir
+          Dir.chdir(tmpdir) do
+            example.run
+          end
         end
       end
     ensure
+      @clean_test_outside_root = nil
       if original_renderer_cache_path.nil?
         ENV.delete("RENDERER_SERVER_BUNDLE_CACHE_PATH")
       else
@@ -1507,6 +1511,10 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
 
     def create_clean_test_dirs(*paths)
       paths.each { |path| FileUtils.mkdir_p(path) }
+    end
+
+    def clean_test_outside_path(*parts)
+      File.join(@clean_test_outside_root, *parts)
     end
 
     it "removes bundle outputs and cache paths derived from shakapacker.yml" do
@@ -1565,21 +1573,44 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "reports missing shakapacker.yml and still removes common caches" do
+      create_clean_test_dirs(
+        "tmp/cache",
+        "node_modules/.cache",
+        ".node-renderer-bundles"
+      )
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Shakapacker config not found: config/shakapacker.yml")
+        expect(output).to include("Skipping configured Shakapacker output/cache paths")
+        expect(output).not_to include("Reading Shakapacker config")
+        expect(File).not_to exist("tmp/cache")
+        expect(File).not_to exist("node_modules/.cache")
+        expect(File).not_to exist(".node-renderer-bundles")
+      end
+    end
+
     it "skips shakapacker.yml paths that resolve outside the app root or to broad root directories" do
-      ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] = "../outside-renderer-cache"
-      FileUtils.mkdir_p("../outside-packs")
-      FileUtils.mkdir_p("../outside-webpack/development")
-      FileUtils.mkdir_p("../outside-renderer-cache")
+      outside_packs = clean_test_outside_path("outside-packs")
+      outside_cache = clean_test_outside_path("outside-cache")
+      outside_webpack = clean_test_outside_path("outside-webpack")
+      outside_renderer_cache = clean_test_outside_path("outside-renderer-cache")
+      ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] = outside_renderer_cache
+      FileUtils.mkdir_p(outside_packs)
+      FileUtils.mkdir_p(File.join(outside_webpack, "development"))
+      FileUtils.mkdir_p(outside_renderer_cache)
       FileUtils.mkdir_p("public")
-      File.write("../outside-packs/keep.txt", "keep")
-      File.write("../outside-webpack/development/keep.txt", "keep")
-      File.write("../outside-renderer-cache/keep.txt", "keep")
-      File.symlink(File.expand_path("../outside-webpack", Dir.pwd), "public/webpack")
+      File.write(File.join(outside_packs, "keep.txt"), "keep")
+      File.write(File.join(outside_webpack, "development", "keep.txt"), "keep")
+      File.write(File.join(outside_renderer_cache, "keep.txt"), "keep")
+      File.symlink(outside_webpack, "public/webpack")
       write_clean_test_shakapacker_config(<<~YAML)
         default:
-          public_root_path: ..
+          public_root_path: #{@clean_test_outside_root}
           public_output_path: outside-packs
-          cache_path: ../outside-cache
+          cache_path: #{outside_cache}
 
         test:
           public_root_path: public
@@ -1594,9 +1625,9 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       output = capture_stdout { described_class.clean_generated_assets_and_caches }
 
       aggregate_failures do
-        expect(File).to exist("../outside-packs/keep.txt")
-        expect(File).to exist("../outside-webpack/development/keep.txt")
-        expect(File).to exist("../outside-renderer-cache/keep.txt")
+        expect(File).to exist(File.join(outside_packs, "keep.txt"))
+        expect(File).to exist(File.join(outside_webpack, "development", "keep.txt"))
+        expect(File).to exist(File.join(outside_renderer_cache, "keep.txt"))
         expect(File).to exist("public")
         expect(output).to include("Skipping unsafe cleanup path")
       end

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1598,6 +1598,26 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
       end
     end
 
+    it "reports invalid shakapacker.yml and still removes common caches" do
+      write_clean_test_shakapacker_config("<% if %>")
+      create_clean_test_dirs(
+        "tmp/cache",
+        "node_modules/.cache",
+        ".node-renderer-bundles"
+      )
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(output).to include("Could not parse Shakapacker config: config/shakapacker.yml")
+        expect(output).to include("Skipping configured Shakapacker output/cache paths")
+        expect(output).not_to include("Reading Shakapacker config")
+        expect(File).not_to exist("tmp/cache")
+        expect(File).not_to exist("node_modules/.cache")
+        expect(File).not_to exist(".node-renderer-bundles")
+      end
+    end
+
     it "removes broken symlink cleanup targets when the link target stays inside the app root" do
       write_clean_test_shakapacker_config(<<~YAML)
         default:

--- a/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
+++ b/react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb
@@ -1479,6 +1479,130 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
     end
   end
 
+  describe ".clean_generated_assets_and_caches" do
+    around do |example|
+      original_renderer_cache_path = ENV.fetch("RENDERER_SERVER_BUNDLE_CACHE_PATH", nil)
+      Dir.mktmpdir("react-on-rails-clean") do |tmpdir|
+        Dir.chdir(tmpdir) do
+          example.run
+        end
+      end
+    ensure
+      if original_renderer_cache_path.nil?
+        ENV.delete("RENDERER_SERVER_BUNDLE_CACHE_PATH")
+      else
+        ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] = original_renderer_cache_path
+      end
+    end
+
+    before do
+      allow(Rails).to receive(:root).and_return(Pathname.new(Dir.pwd))
+      allow(described_class).to receive(:kill_processes)
+    end
+
+    def write_clean_test_shakapacker_config(content)
+      FileUtils.mkdir_p("config")
+      File.write("config/shakapacker.yml", content)
+    end
+
+    def create_clean_test_dirs(*paths)
+      paths.each { |path| FileUtils.mkdir_p(path) }
+    end
+
+    it "removes bundle outputs and cache paths derived from shakapacker.yml" do
+      ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] = "tmp/custom-renderer-cache"
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: public
+          public_output_path: packs
+          private_output_path: ssr-generated
+          cache_path: tmp/shakapacker
+
+        development:
+          public_output_path: webpack/development
+
+        test:
+          public_output_path: webpack/test
+          cache_path: tmp/shakapacker-test
+
+        production:
+          public_output_path: webpack/production
+      YAML
+      create_clean_test_dirs(
+        "public/packs",
+        "public/webpack/development",
+        "public/webpack/test",
+        "public/webpack/production",
+        "ssr-generated",
+        "tmp/shakapacker",
+        "tmp/shakapacker-test",
+        "tmp/cache",
+        "node_modules/.cache",
+        ".node-renderer-bundles",
+        "tmp/custom-renderer-cache",
+        "tmp/node-renderer-bundles-test-0"
+      )
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(described_class).to have_received(:kill_processes)
+        expect(output).to include("config/shakapacker.yml")
+        expect(output).to include("public/webpack/development")
+        expect(output).to include("tmp/shakapacker-test")
+        expect(File).not_to exist("public/packs")
+        expect(File).not_to exist("public/webpack/development")
+        expect(File).not_to exist("public/webpack/test")
+        expect(File).not_to exist("public/webpack/production")
+        expect(File).not_to exist("ssr-generated")
+        expect(File).not_to exist("tmp/shakapacker")
+        expect(File).not_to exist("tmp/shakapacker-test")
+        expect(File).not_to exist("tmp/cache")
+        expect(File).not_to exist("node_modules/.cache")
+        expect(File).not_to exist(".node-renderer-bundles")
+        expect(File).not_to exist("tmp/custom-renderer-cache")
+        expect(File).not_to exist("tmp/node-renderer-bundles-test-0")
+      end
+    end
+
+    it "skips shakapacker.yml paths that resolve outside the app root or to broad root directories" do
+      ENV["RENDERER_SERVER_BUNDLE_CACHE_PATH"] = "../outside-renderer-cache"
+      FileUtils.mkdir_p("../outside-packs")
+      FileUtils.mkdir_p("../outside-webpack/development")
+      FileUtils.mkdir_p("../outside-renderer-cache")
+      FileUtils.mkdir_p("public")
+      File.write("../outside-packs/keep.txt", "keep")
+      File.write("../outside-webpack/development/keep.txt", "keep")
+      File.write("../outside-renderer-cache/keep.txt", "keep")
+      File.symlink(File.expand_path("../outside-webpack", Dir.pwd), "public/webpack")
+      write_clean_test_shakapacker_config(<<~YAML)
+        default:
+          public_root_path: ..
+          public_output_path: outside-packs
+          cache_path: ../outside-cache
+
+        test:
+          public_root_path: public
+          public_output_path: .
+          cache_path: tmp
+
+        development:
+          public_root_path: public
+          public_output_path: webpack/development
+      YAML
+
+      output = capture_stdout { described_class.clean_generated_assets_and_caches }
+
+      aggregate_failures do
+        expect(File).to exist("../outside-packs/keep.txt")
+        expect(File).to exist("../outside-webpack/development/keep.txt")
+        expect(File).to exist("../outside-renderer-cache/keep.txt")
+        expect(File).to exist("public")
+        expect(output).to include("Skipping unsafe cleanup path")
+      end
+    end
+  end
+
   describe ".kill_port_processes" do
     it "kills processes on specified ports" do
       allow(Open3).to receive(:capture2).with("lsof", "-ti", ":3000", err: File::NULL).and_return(["1234", nil])
@@ -1687,6 +1811,12 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(output).to match(%r{bin/dev test-watch})
         expect(output).to match(%r{bin/dev static})
       end
+    end
+
+    it "documents the clean command" do
+      output = capture_stdout { described_class.show_help }
+
+      expect(output).to match(%r{clean\s+Kill dev processes and remove generated bundles/caches})
     end
 
     it "links to the published documentation for dev server and testing guidance" do
@@ -2189,6 +2319,15 @@ RSpec.describe ReactOnRails::Dev::ServerManager do
         expect(Open3).not_to receive(:capture3)
 
         described_class.run_from_command_line(["kill"])
+
+        expect(ENV.fetch("SHAKAPACKER_SKIP_PRECOMPILE_HOOK", nil)).to be_nil
+      end
+
+      it "does not run hook or set environment variable for clean command" do
+        expect(Open3).not_to receive(:capture3)
+        expect(described_class).to receive(:clean_generated_assets_and_caches)
+
+        described_class.run_from_command_line(["clean"])
 
         expect(ENV.fetch("SHAKAPACKER_SKIP_PRECOMPILE_HOOK", nil)).to be_nil
       end


### PR DESCRIPTION
## Summary

- Add `bin/dev clean` to kill dev processes, read `config/shakapacker.yml` or `SHAKAPACKER_CONFIG`, and remove configured Shakapacker public/private output paths, configured cache paths, Rails/JS build caches, and renderer bundle caches.
- Keep cleanup guarded to app-local paths, including realpath checks for existing symlinked targets, broken symlink target checks, permission-denied skips, and partial-removal warnings, while avoiding broad roots such as the app root, `public`, `tmp`, and `node_modules`.
- Document command-by-command bundle/cache cleanup behavior, update the generated `bin/dev` hook comments, and cross-link stale test asset troubleshooting to `bin/dev clean`.
- Fix local `bin/setup` on macOS by adding Darwin platforms to the dummy app lockfile so Bundler installs native Nokogiri gems instead of source-compiling Nokogiri.

## Validation

- `script/ci-changes-detector origin/main` (recommends broad hosted jobs because Ruby core, RSpec, dummy app, and generators changed)
- `cd react_on_rails && mise x ruby@3.4.6 -- bundle exec rspec spec/react_on_rails/dev/server_manager_spec.rb` (230 examples, 0 failures)
- `mise x ruby@3.4.6 -- bundle exec rubocop --no-parallel --format simple react_on_rails/lib/react_on_rails/dev/server_manager.rb react_on_rails/spec/react_on_rails/dev/server_manager_spec.rb react_on_rails/lib/generators/react_on_rails/templates/base/base/bin/dev` (3 files inspected, no offenses)
- `pnpm start format.listDifferent`
- `pnpm exec prettier --check docs/oss/building-features/dev-server-and-testing.md`
- `git diff --check` and `git diff --cached --check`
- `lychee --config .lychee.toml docs/oss/building-features/dev-server-and-testing.md docs/oss/building-features/testing-configuration.md` (21 total, 20 OK, 1 excluded)
- `cd react_on_rails/spec/dummy && mise x ruby@3.4.6 -- bundle install`
- `cd react_on_rails/spec/dummy && mise x ruby@3.4.6 -- bundle info nokogiri` (confirmed `nokogiri-1.19.1-arm64-darwin`)
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)
- Pre-commit hooks: trailing newlines, offline Markdown links, Prettier, autofix, RuboCop
- Pre-push hooks: branch RuboCop, online Markdown links

## Notes

The change detector recommends broad hosted jobs for final confidence because this PR touches `server_manager.rb`, generator template comments, RSpec coverage, docs, changelog, and the dummy app lockfile. Local validation was focused on the changed behavior, documentation, formatting, links, and the macOS Nokogiri install failure path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `bin/dev clean` to stop dev processes and remove generated bundle outputs and common build/cache files, including renderer bundle caches, with safeguards to prevent deleting unsafe paths.
  * Updated `bin/dev` help text to document the new `clean` command and link to relevant troubleshooting guidance.
* **Bug Fixes**
  * Improved macOS `bin/setup` so native Nokogiri gems install via the dummy app lockfile on both Apple Silicon and Intel.
* **Documentation**
  * Expanded guidance on generated bundle/cache cleanup and added troubleshooting steps for stale assets after branch or package changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->