### PR TITLE
Document agent workflow CI parity seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,19 @@ see
   `+ci-force-full`, `+ci-stop-hosted`, `+ci-stop-full`, `+ci-skip-hosted [reason]`, `+ci-help`);
   labels `ready-for-hosted-ci` and `force-full-hosted-ci`; human helper `bin/request-hosted-ci`.
   Decision rules are in the **Review Workflow → PR CI Labels** section.
+- **CI parity environment**: no dedicated `act`/local runner image is currently documented.
+  Use `bin/ci-local` and `script/ci-changes-detector origin/main` for local routing, then reproduce
+  CI-only failures from the exact GitHub Actions workflow/job, `runs-on` image, matrix, services,
+  and commands in `.github/workflows/**`; record any runner, service, or secret gap as `UNKNOWN`.
+- **Secret redaction patterns**: redact values for environment variables or log fields whose names
+  contain `SECRET`, `TOKEN`, `KEY`, `PASSWORD`, `CREDENTIAL`, `CERT`, `PASSPHRASE`, `PEM`,
+  `PRIVATE`, `DSN`, or `LICENSE`, plus repo-specific names including `REACT_ON_RAILS_PRO_LICENSE`,
+  `REACT_ON_RAILS_PRO_LICENSE_V2`, `BENCHER_API_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `GITHUB_TOKEN`,
+  `GH_TOKEN`, `NPM_OTP`, `RUBYGEMS_OTP`, `DOCS_DISPATCH_APP_KEY`, `RENDERER_PASSWORD`, and
+  `SECRET_KEY_BASE`. These patterns intentionally favor conservative over-redaction of logs, prompts,
+  and issue comments over preserving non-secret diagnostic text. Repo-specific entries are public
+  identifier names, not values; list them here so agents redact exact aliases even when generic patterns
+  would also match.
 - **Benchmark labels**: `benchmark`, `benchmark-core`, `benchmark-pro`,
   `benchmark-pro-node-renderer`, and `hosted-ci-no-benchmarks` (suppress). Opt-in on PRs.
 - **Follow-up issue prefix**: `Follow-up:`. Default to no new issue; see the **Maintainer


### PR DESCRIPTION
## Summary

- Add the `CI parity environment` seam required by the latest shared `agent-workflows` seam doctor.
- Add explicit secret redaction patterns for CI-parity and `replicate-ci` workflows.
- Document that this repo currently has no dedicated `act`/local runner image, so CI-only reproductions should use exact GitHub Actions job metadata and record runner/service/secret gaps as `UNKNOWN`.

## Rationale

`shakacode/agent-workflows#7` moved the generic workflow logic back into the portable pack. Pressure-testing that pack against this repo showed the latest shared seam doctor now requires `CI parity environment`; without this key, installed shared skills cannot fully resolve this repo's policy.

## Validation

- `.agents/bin/agent-workflow-seam-doctor`
- `/Users/justin/.codex/bin/agent-workflow-seam-doctor --root "$(pwd)" --shared /Users/justin/.codex/worktrees/6517/agent-workflows`
- `/Users/justin/.claude/bin/agent-workflow-seam-doctor --root "$(pwd)" --shared /Users/justin/.codex/worktrees/6517/agent-workflows`
- `agent-workflows-status --host codex` -> `UP_TO_DATE version=0.1.0 revision=d003ad5695d1`
- `agent-workflows-status --host claude` -> `UP_TO_DATE version=0.1.0 revision=d003ad5695d1`
- `bin/ci-local --fast --changed` -> docs-only; docs sidebar check passed; no further CI needed
- pre-commit hook: trailing newlines, offline markdown links, Prettier passed
- pre-push hook: branch Ruby lint skipped, online markdown links passed

## Follow-up

A separate cleanup PR should decide whether to remove generic repo-local `.agents` copies or sync them exactly from `shakacode/agent-workflows`, while keeping RoR-specific policy and the local `stress-test` skill.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified local CI guidance for “CI parity environment” when no dedicated parity runner image is documented, including recommended local routing and handling unknown workflow runner/service details.
  * Expanded instructions for comparing local checks against CI results.
  * Broadened secret redaction guidance by adding additional sensitive keyword patterns and common secret aliases, encouraging conservative redaction to reduce accidental exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->