### PR TITLE
Add RSC doctor artifact diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 - **`bin/dev clean` clears generated bundles and caches**: The command stops development processes, reads `config/shakapacker.yml` or `SHAKAPACKER_CONFIG`, removes configured Shakapacker public/private output and cache paths plus common Rails, JavaScript, and renderer bundle caches, and skips unsafe paths outside the app root. [PR 4218](https://github.com/shakacode/react_on_rails/pull/4218) by [justin808](https://github.com/justin808).
 
+- **[Pro]** **Focused RSC doctor artifact diagnostics**: `rake react_on_rails:doctor:rsc` and
+  `Doctor.new(only: ...)` now run the RSC artifact checks directly, reporting missing,
+  stale, invalid, or dev-server-backed RSC bundle and manifest files with rebuild guidance
+  while explaining when Pro path resolution is unavailable. Closes
+  [Issue 4204](https://github.com/shakacode/react_on_rails/issues/4204).
+  [PR 4223](https://github.com/shakacode/react_on_rails/pull/4223) by
+  [justin808](https://github.com/justin808).
+
 #### Fixed
 
 - **[Pro]** **RSC doctor now catches stale install and client-manifest setup failures**:

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -4651,7 +4651,10 @@ module ReactOnRails
     end
 
     def rsc_client_references_manifest_refs(artifact_path)
-      JSON.parse(File.read(artifact_path))["refs"]
+      payload = JSON.parse(File.read(artifact_path))
+      return nil unless payload.is_a?(Hash)
+
+      payload["refs"]
     end
 
     def rsc_client_references_manifest_path

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3497,7 +3497,6 @@ module ReactOnRails
     EXCLUDED_RSC_REGISTRATION_ENTRY_PATH_COMPONENTS = %w[.git log node_modules public spec test tmp vendor].freeze
     RSC_CLIENT_REFERENCES_MANIFEST_ENV = "RSC_MANIFEST_CLIENT_REFERENCES_JSON"
     DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH = "ssr-generated/rsc-client-references.json"
-    RSC_DISCOVERY_WEBPACK_CONFIG_PATH = "config/webpack/rscWebpackConfig.js"
     RSC_DISCOVERY_PRECOMPILE_HOOK_PATH = "bin/shakapacker-precompile-hook"
     RSC_DISCOVERY_WEBPACK_CONFIG_TOKENS = %w[RSC_REFERENCE_DISCOVERY_BUILD RSCReferenceDiscoveryPlugin].freeze
     RSC_DISCOVERY_PRECOMPILE_HOOK_TOKENS = %w[
@@ -4509,7 +4508,9 @@ module ReactOnRails
     end
 
     def rsc_manifest_discovery_supported?
-      file_contains_all?(RSC_DISCOVERY_WEBPACK_CONFIG_PATH, RSC_DISCOVERY_WEBPACK_CONFIG_TOKENS) &&
+      RSC_BUNDLER_CONFIG_PATHS.any? do |config_path|
+        file_contains_all?(config_path, RSC_DISCOVERY_WEBPACK_CONFIG_TOKENS)
+      end &&
         file_contains_all?(RSC_DISCOVERY_PRECOMPILE_HOOK_PATH, RSC_DISCOVERY_PRECOMPILE_HOOK_TOKENS)
     end
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3518,7 +3518,7 @@ module ReactOnRails
 
     def check_rsc_setup
       unless ReactOnRails::Utils.react_on_rails_pro?
-        if rsc_only_check?
+        if rsc_check_explicitly_selected?
           checker.add_info(
             "ℹ️  React Server Components checks skipped — react_on_rails_pro is not installed"
           )
@@ -3545,8 +3545,9 @@ module ReactOnRails
       checker.add_warning("⚠️  RSC setup check encountered an error: #{e.message}")
     end
 
-    def rsc_only_check?
-      check_sections.one? && check_sections.first[:id] == "react_server_components"
+    def rsc_check_explicitly_selected?
+      check_sections.any? { |section| section[:id] == "react_server_components" } &&
+        check_sections != CHECK_SECTIONS
     end
 
     def check_rsc_renderer_mode(pro_config)
@@ -4504,14 +4505,8 @@ module ReactOnRails
       end
     end
 
-    def rsc_client_references_manifest_required?(
-      registration_entry_exists: nil,
-      discovery_supported: nil
-    )
+    def rsc_client_references_manifest_required?(registration_entry_exists:, discovery_supported:)
       return true unless ENV[RSC_CLIENT_REFERENCES_MANIFEST_ENV].to_s.strip.empty?
-
-      registration_entry_exists = rsc_manifest_registration_entry_exists? if registration_entry_exists.nil?
-      discovery_supported = rsc_manifest_discovery_supported? if discovery_supported.nil?
 
       registration_entry_exists && discovery_supported
     end
@@ -4647,6 +4642,9 @@ module ReactOnRails
       end
     rescue JSON::ParserError => e
       checker.add_warning("⚠️  #{label} is not valid JSON: #{e.message}")
+      add_rsc_artifacts_rebuild_guidance
+    rescue StandardError => e
+      checker.add_warning("⚠️  Could not inspect #{label}: #{e.message}")
       add_rsc_artifacts_rebuild_guidance
     end
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3497,6 +3497,13 @@ module ReactOnRails
     EXCLUDED_RSC_REGISTRATION_ENTRY_PATH_COMPONENTS = %w[.git log node_modules public spec test tmp vendor].freeze
     RSC_CLIENT_REFERENCES_MANIFEST_ENV = "RSC_MANIFEST_CLIENT_REFERENCES_JSON"
     DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH = "ssr-generated/rsc-client-references.json"
+    RSC_DISCOVERY_WEBPACK_CONFIG_PATH = "config/webpack/rscWebpackConfig.js"
+    RSC_DISCOVERY_PRECOMPILE_HOOK_PATH = "bin/shakapacker-precompile-hook"
+    RSC_DISCOVERY_WEBPACK_CONFIG_TOKENS = %w[RSC_REFERENCE_DISCOVERY_BUILD RSCReferenceDiscoveryPlugin].freeze
+    RSC_DISCOVERY_PRECOMPILE_HOOK_TOKENS = %w[
+      generate_rsc_manifest_client_references_if_needed
+      RSC_REFERENCE_DISCOVERY_BUILD
+    ].freeze
     # npm registry package names used here must be lowercase; keep this allowlist
     # narrow so names remain safe when reused as Node resolver args and paths.
     PACKAGE_NAME_PATTERN = %r{
@@ -4440,6 +4447,9 @@ module ReactOnRails
 
       refs = rsc_client_references_manifest_refs(artifact_path)
       if refs.is_a?(Array)
+        if rsc_client_references_manifest_stale?(artifact_path)
+          report_stale_rsc_client_references_manifest(artifact_path)
+        end
         checker.add_success("✅ RSC client references manifest includes #{refs.size} refs at #{artifact_path}")
       else
         checker.add_warning("⚠️  RSC client references manifest must contain a refs array: #{artifact_path}")
@@ -4455,6 +4465,13 @@ module ReactOnRails
     def report_missing_rsc_client_references_manifest(artifact_path)
       if rsc_client_references_manifest_required?
         report_missing_rsc_artifact("RSC client references manifest", artifact_path)
+      elsif rsc_manifest_registration_entry_exists? && !rsc_manifest_discovery_supported?
+        checker.add_warning(
+          "⚠️  RSC client references manifest not found at #{artifact_path}, but this app's RSC webpack " \
+          "config or precompile hook does not support manifest discovery yet; resolver will use broad " \
+          "client-reference discovery fallback"
+        )
+        checker.add_info("  💡 Re-run rails g react_on_rails:rsc to update generated configs")
       else
         checker.add_info(
           "  ℹ️  RSC client references manifest not found at #{artifact_path} — " \
@@ -4466,8 +4483,44 @@ module ReactOnRails
     def rsc_client_references_manifest_required?
       return true unless ENV[RSC_CLIENT_REFERENCES_MANIFEST_ENV].to_s.strip.empty?
 
+      rsc_manifest_registration_entry_exists? && rsc_manifest_discovery_supported?
+    end
+
+    def rsc_manifest_registration_entry_exists?
       registration_entry = rsc_manifest_registration_entry
       registration_entry && File.exist?(registration_entry)
+    end
+
+    def rsc_client_references_manifest_stale?(artifact_path)
+      registration_entry = rsc_manifest_registration_entry
+      return false unless registration_entry && File.exist?(registration_entry)
+
+      File.mtime(registration_entry) > File.mtime(artifact_path)
+    rescue StandardError
+      false
+    end
+
+    def report_stale_rsc_client_references_manifest(artifact_path)
+      checker.add_warning(
+        "⚠️  RSC client references manifest is older than the server component registration entry: " \
+        "#{artifact_path}"
+      )
+      checker.add_info("  💡 Re-run bin/shakapacker-precompile-hook before bin/shakapacker")
+    end
+
+    def rsc_manifest_discovery_supported?
+      file_contains_all?(RSC_DISCOVERY_WEBPACK_CONFIG_PATH, RSC_DISCOVERY_WEBPACK_CONFIG_TOKENS) &&
+        file_contains_all?(RSC_DISCOVERY_PRECOMPILE_HOOK_PATH, RSC_DISCOVERY_PRECOMPILE_HOOK_TOKENS)
+    end
+
+    def file_contains_all?(file_path, tokens)
+      resolved_path = File.expand_path(file_path, Dir.pwd)
+      return false unless File.exist?(resolved_path)
+
+      content = File.read(resolved_path)
+      tokens.all? { |token| content.include?(token) }
+    rescue StandardError
+      false
     end
 
     def rsc_manifest_registration_entry

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -4493,11 +4493,12 @@ module ReactOnRails
     end
 
     def rsc_client_references_manifest_required?(
-      registration_entry_exists: rsc_manifest_registration_entry_exists?,
+      registration_entry_exists: nil,
       discovery_supported: nil
     )
       return true unless ENV[RSC_CLIENT_REFERENCES_MANIFEST_ENV].to_s.strip.empty?
 
+      registration_entry_exists = rsc_manifest_registration_entry_exists? if registration_entry_exists.nil?
       discovery_supported = rsc_manifest_discovery_supported? if discovery_supported.nil?
 
       registration_entry_exists && discovery_supported
@@ -4600,7 +4601,7 @@ module ReactOnRails
       end
 
       artifact_path = ReactOnRailsPro::Utils.public_send(method_name)
-      if artifact_path.blank?
+      if artifact_path.to_s.strip.empty?
         checker.add_warning("⚠️  #{label} path could not be resolved")
         return nil
       end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -174,11 +174,13 @@ module ReactOnRails
         raise ArgumentError, "Invalid doctor format #{format.inspect}; expected one of #{OUTPUT_FORMATS.join(', ')}"
       end
 
+      @only_explicitly_set = explicit_check_selection?(only)
       @check_sections = normalize_check_sections(only)
       @checker = SystemChecker.new
       @test_output_path_strategy = :unknown
       @rails_environment_loaded = false
       @rsc_artifacts_rebuild_guidance_added = false
+      @rsc_registration_entry_warning_added = false
     end
 
     def run_diagnosis
@@ -208,6 +210,10 @@ module ReactOnRails
       end
 
       check_ids.uniq.map { |check_id| CHECK_SECTIONS_BY_ID.fetch(check_id) }
+    end
+
+    def explicit_check_selection?(only)
+      Array(only).flat_map { |value| value.to_s.split(/[,\s]+/) }.reject(&:empty?).any?
     end
 
     def print_header
@@ -3546,8 +3552,7 @@ module ReactOnRails
     end
 
     def rsc_check_explicitly_selected?
-      check_sections.any? { |section| section[:id] == "react_server_components" } &&
-        check_sections != CHECK_SECTIONS
+      @only_explicitly_set && check_sections.any? { |section| section[:id] == "react_server_components" }
     end
 
     def check_rsc_renderer_mode(pro_config)
@@ -4551,13 +4556,11 @@ module ReactOnRails
     end
 
     def file_contains_all?(file_path, tokens)
-      resolved_path = File.expand_path(file_path, Dir.pwd)
+      resolved_path = File.expand_path(file_path, doctor_app_root)
       return false unless File.exist?(resolved_path)
 
       content = File.read(resolved_path)
       tokens.all? { |token| content.include?(token) }
-    rescue Errno::ENOENT
-      false
     rescue StandardError => e
       checker.add_warning("⚠️  Could not read #{file_path} during RSC discovery check: #{e.message}")
       false
@@ -4574,16 +4577,23 @@ module ReactOnRails
       configured_path = ENV[RSC_REGISTRATION_ENTRY_PATH_ENV].to_s.strip
       return nil if configured_path.empty?
 
-      resolved_path = File.absolute_path(configured_path, Dir.pwd)
+      resolved_path = File.absolute_path(configured_path, doctor_app_root)
       unless valid_rsc_manifest_registration_entry?(resolved_path)
-        checker.add_warning(
-          "⚠️  #{RSC_REGISTRATION_ENTRY_PATH_ENV}=#{configured_path.inspect} was set but did not pass " \
-          "validation; falling back to default discovery"
-        )
+        warn_invalid_rsc_registration_entry(configured_path)
         return nil
       end
 
       resolved_path
+    end
+
+    def warn_invalid_rsc_registration_entry(configured_path)
+      return if @rsc_registration_entry_warning_added
+
+      checker.add_warning(
+        "⚠️  #{RSC_REGISTRATION_ENTRY_PATH_ENV}=#{configured_path.inspect} was set but did not pass " \
+        "validation; falling back to default discovery"
+      )
+      @rsc_registration_entry_warning_added = true
     end
 
     def default_rsc_manifest_registration_entry
@@ -4592,7 +4602,7 @@ module ReactOnRails
 
       File.expand_path(
         File.join(File.dirname(source_entry_path), "generated", EXPECTED_RSC_REGISTRATION_ENTRY_BASENAME),
-        Dir.pwd
+        doctor_app_root
       )
     rescue StandardError
       nil
@@ -4608,7 +4618,7 @@ module ReactOnRails
 
     def rsc_registration_entry_path_components(path)
       expanded_path = File.expand_path(path.to_s)
-      expanded_root = "#{File.expand_path(Dir.pwd)}#{File::SEPARATOR}"
+      expanded_root = "#{File.expand_path(doctor_app_root)}#{File::SEPARATOR}"
       expanded_path = expanded_path.delete_prefix(expanded_root) if expanded_path.start_with?(expanded_root)
 
       expanded_path.split(File::SEPARATOR).reject(&:empty?)
@@ -4643,6 +4653,8 @@ module ReactOnRails
     rescue JSON::ParserError => e
       checker.add_warning("⚠️  #{label} is not valid JSON: #{e.message}")
       add_rsc_artifacts_rebuild_guidance
+    rescue Errno::EACCES => e
+      checker.add_warning("⚠️  Could not read #{label} (permission denied): #{e.message}")
     rescue StandardError => e
       checker.add_warning("⚠️  Could not inspect #{label}: #{e.message}")
       add_rsc_artifacts_rebuild_guidance
@@ -4659,8 +4671,16 @@ module ReactOnRails
       configured_path = ENV.fetch(RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil).to_s.strip
       File.expand_path(
         configured_path.empty? ? DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH : configured_path,
-        Dir.pwd
+        doctor_app_root
       )
+    end
+
+    def doctor_app_root
+      rails_root = Rails.root if defined?(Rails) && Rails.respond_to?(:root)
+      rails_root = rails_root.to_s
+      rails_root.empty? ? Dir.pwd : rails_root
+    rescue StandardError
+      Dir.pwd
     end
 
     def report_missing_rsc_artifact(label, artifact_path)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3546,7 +3546,7 @@ module ReactOnRails
     end
 
     def rsc_only_check?
-      @check_sections.one? && @check_sections.first[:id] == "react_server_components"
+      check_sections.one? && check_sections.first[:id] == "react_server_components"
     end
 
     def check_rsc_renderer_mode(pro_config)
@@ -4561,7 +4561,10 @@ module ReactOnRails
 
       content = File.read(resolved_path)
       tokens.all? { |token| content.include?(token) }
-    rescue StandardError
+    rescue Errno::ENOENT
+      false
+    rescue StandardError => e
+      checker.add_warning("⚠️  Could not read #{file_path} during RSC discovery check: #{e.message}")
       false
     end
 

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3492,6 +3492,9 @@ module ReactOnRails
     NPM_VIEW_FETCH_TIMEOUT_SECONDS = NPM_VIEW_FETCH_TIMEOUT_MS / 1000.0
     NPM_VIEW_TERMINATION_GRACE_SECONDS = 0.5
     SKIP_NPM_DIST_TAG_CHECK_ENV = "REACT_ON_RAILS_SKIP_NPM_DIST_TAG_CHECK"
+    RSC_REGISTRATION_ENTRY_PATH_ENV = "REACT_ON_RAILS_RSC_REGISTRATION_ENTRY_PATH"
+    EXPECTED_RSC_REGISTRATION_ENTRY_BASENAME = "server-component-registration-entry.js"
+    EXCLUDED_RSC_REGISTRATION_ENTRY_PATH_COMPONENTS = %w[.git log node_modules public spec test tmp vendor].freeze
     RSC_CLIENT_REFERENCES_MANIFEST_ENV = "RSC_MANIFEST_CLIENT_REFERENCES_JSON"
     DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH = "ssr-generated/rsc-client-references.json"
     # npm registry package names used here must be lowercase; keep this allowlist
@@ -4431,7 +4434,7 @@ module ReactOnRails
     def check_rsc_client_references_manifest
       artifact_path = rsc_client_references_manifest_path
       unless File.exist?(artifact_path)
-        report_missing_rsc_artifact("RSC client references manifest", artifact_path)
+        report_missing_rsc_client_references_manifest(artifact_path)
         return
       end
 
@@ -4447,6 +4450,67 @@ module ReactOnRails
       add_rsc_artifacts_rebuild_guidance
     rescue StandardError => e
       checker.add_warning("⚠️  Could not inspect RSC client references manifest: #{e.message}")
+    end
+
+    def report_missing_rsc_client_references_manifest(artifact_path)
+      if rsc_client_references_manifest_required?
+        report_missing_rsc_artifact("RSC client references manifest", artifact_path)
+      else
+        checker.add_info(
+          "  ℹ️  RSC client references manifest not found at #{artifact_path} — " \
+          "resolver will use broad client-reference discovery fallback"
+        )
+      end
+    end
+
+    def rsc_client_references_manifest_required?
+      registration_entry = rsc_manifest_registration_entry
+      registration_entry && File.exist?(registration_entry)
+    end
+
+    def rsc_manifest_registration_entry
+      configured_entry = configured_rsc_manifest_registration_entry
+      return configured_entry if configured_entry
+
+      default_rsc_manifest_registration_entry
+    end
+
+    def configured_rsc_manifest_registration_entry
+      configured_path = ENV[RSC_REGISTRATION_ENTRY_PATH_ENV].to_s.strip
+      return nil if configured_path.empty?
+
+      resolved_path = File.absolute_path(configured_path, Dir.pwd)
+      return nil unless valid_rsc_manifest_registration_entry?(resolved_path)
+
+      resolved_path
+    end
+
+    def default_rsc_manifest_registration_entry
+      source_entry_path = ReactOnRails::PackerUtils.packer_source_entry_path.to_s
+      source_entry_path = "" if source_entry_path == "/"
+
+      File.expand_path(
+        File.join(File.dirname(source_entry_path), "generated", EXPECTED_RSC_REGISTRATION_ENTRY_BASENAME),
+        Dir.pwd
+      )
+    rescue StandardError
+      nil
+    end
+
+    def valid_rsc_manifest_registration_entry?(path)
+      return false unless File.file?(path)
+      return false unless File.basename(path.to_s) == EXPECTED_RSC_REGISTRATION_ENTRY_BASENAME
+
+      path_components = rsc_registration_entry_path_components(path)
+      EXCLUDED_RSC_REGISTRATION_ENTRY_PATH_COMPONENTS.none? { |component| path_components.include?(component) }
+    end
+
+    def rsc_registration_entry_path_components(path)
+      expanded_path = File.expand_path(path.to_s)
+      expanded_root = "#{File.expand_path(Dir.pwd)}#{File::SEPARATOR}"
+      expanded_path = expanded_path.delete_prefix(expanded_root) if expanded_path.start_with?(expanded_root)
+
+      expanded_path.split(File::SEPARATOR).reject(&:empty?)
     end
 
     def rsc_pro_utils_artifact_path(method_name, label)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -178,6 +178,7 @@ module ReactOnRails
       @checker = SystemChecker.new
       @test_output_path_strategy = :unknown
       @rails_environment_loaded = false
+      @rsc_artifacts_rebuild_guidance_added = false
     end
 
     def run_diagnosis
@@ -4553,7 +4554,13 @@ module ReactOnRails
       return nil if configured_path.empty?
 
       resolved_path = File.absolute_path(configured_path, Dir.pwd)
-      return nil unless valid_rsc_manifest_registration_entry?(resolved_path)
+      unless valid_rsc_manifest_registration_entry?(resolved_path)
+        checker.add_warning(
+          "⚠️  #{RSC_REGISTRATION_ENTRY_PATH_ENV}=#{configured_path.inspect} was set but did not pass " \
+          "validation; falling back to default discovery"
+        )
+        return nil
+      end
 
       resolved_path
     end
@@ -4622,8 +4629,11 @@ module ReactOnRails
     end
 
     def rsc_client_references_manifest_path
-      configured_path = ENV.fetch(RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil)
-      File.expand_path(configured_path.presence || DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH)
+      configured_path = ENV.fetch(RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil).to_s.strip
+      File.expand_path(
+        configured_path.empty? ? DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH : configured_path,
+        Dir.pwd
+      )
     end
 
     def report_missing_rsc_artifact(label, artifact_path)

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -4401,6 +4401,11 @@ module ReactOnRails
     end
 
     def check_rsc_artifacts
+      unless defined?(ReactOnRailsPro::Utils)
+        checker.add_info("  ℹ️  RSC artifact checks skipped — upgrade react-on-rails-pro to enable path resolution")
+        return
+      end
+
       check_rsc_bundle_artifact
       check_rsc_server_client_manifest_artifact
       check_rsc_client_references_manifest
@@ -4448,8 +4453,9 @@ module ReactOnRails
       if refs.is_a?(Array)
         if rsc_client_references_manifest_stale?(artifact_path)
           report_stale_rsc_client_references_manifest(artifact_path)
+        else
+          checker.add_success("✅ RSC client references manifest includes #{refs.size} refs at #{artifact_path}")
         end
-        checker.add_success("✅ RSC client references manifest includes #{refs.size} refs at #{artifact_path}")
       else
         checker.add_warning("⚠️  RSC client references manifest must contain a refs array: #{artifact_path}")
         add_rsc_artifacts_rebuild_guidance
@@ -4462,9 +4468,15 @@ module ReactOnRails
     end
 
     def report_missing_rsc_client_references_manifest(artifact_path)
-      if rsc_client_references_manifest_required?
+      registration_entry_exists = rsc_manifest_registration_entry_exists?
+      discovery_supported = registration_entry_exists && rsc_manifest_discovery_supported?
+
+      if rsc_client_references_manifest_required?(
+        registration_entry_exists:,
+        discovery_supported:
+      )
         report_missing_rsc_artifact("RSC client references manifest", artifact_path)
-      elsif rsc_manifest_registration_entry_exists? && !rsc_manifest_discovery_supported?
+      elsif registration_entry_exists && !discovery_supported
         checker.add_warning(
           "⚠️  RSC client references manifest not found at #{artifact_path}, but this app's RSC webpack " \
           "config or precompile hook does not support manifest discovery yet; resolver will use broad " \
@@ -4479,10 +4491,15 @@ module ReactOnRails
       end
     end
 
-    def rsc_client_references_manifest_required?
+    def rsc_client_references_manifest_required?(
+      registration_entry_exists: rsc_manifest_registration_entry_exists?,
+      discovery_supported: nil
+    )
       return true unless ENV[RSC_CLIENT_REFERENCES_MANIFEST_ENV].to_s.strip.empty?
 
-      rsc_manifest_registration_entry_exists? && rsc_manifest_discovery_supported?
+      discovery_supported = rsc_manifest_discovery_supported? if discovery_supported.nil?
+
+      registration_entry_exists && discovery_supported
     end
 
     def rsc_manifest_registration_entry_exists?

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -4464,6 +4464,8 @@ module ReactOnRails
     end
 
     def rsc_client_references_manifest_required?
+      return true unless ENV[RSC_CLIENT_REFERENCES_MANIFEST_ENV].to_s.strip.empty?
+
       registration_entry = rsc_manifest_registration_entry
       registration_entry && File.exist?(registration_entry)
     end

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -164,8 +164,9 @@ module ReactOnRails
       { id: "react_on_rails_pro_setup", title: "React on Rails Pro Setup", method: :check_pro_setup },
       { id: "react_server_components", title: "React Server Components", method: :check_rsc_setup }
     ].freeze
+    CHECK_SECTIONS_BY_ID = CHECK_SECTIONS.to_h { |section| [section[:id], section] }.freeze
 
-    def initialize(verbose: false, fix: false, format: :text)
+    def initialize(verbose: false, fix: false, format: :text, only: nil)
       @verbose = verbose
       @fix = fix
       @format = format.respond_to?(:to_sym) ? format.to_sym : format
@@ -173,6 +174,7 @@ module ReactOnRails
         raise ArgumentError, "Invalid doctor format #{format.inspect}; expected one of #{OUTPUT_FORMATS.join(', ')}"
       end
 
+      @check_sections = normalize_check_sections(only)
       @checker = SystemChecker.new
       @test_output_path_strategy = :unknown
       @rails_environment_loaded = false
@@ -191,7 +193,21 @@ module ReactOnRails
 
     private
 
-    attr_reader :verbose, :fix, :format, :checker
+    attr_reader :verbose, :fix, :format, :checker, :check_sections
+
+    def normalize_check_sections(only)
+      check_ids = Array(only).flat_map { |value| value.to_s.split(/[,\s]+/) }.reject(&:empty?)
+      return CHECK_SECTIONS if check_ids.empty?
+
+      invalid_check_ids = check_ids - CHECK_SECTIONS_BY_ID.keys
+      if invalid_check_ids.any?
+        raise ArgumentError,
+              "Invalid doctor check selector #{invalid_check_ids.join(', ')}; expected one of " \
+              "#{CHECK_SECTIONS_BY_ID.keys.join(', ')}"
+      end
+
+      check_ids.uniq.map { |check_id| CHECK_SECTIONS_BY_ID.fetch(check_id) }
+    end
 
     def print_header
       puts Rainbow("\n#{'=' * 80}").cyan
@@ -212,7 +228,7 @@ module ReactOnRails
     end
 
     def run_all_checks
-      CHECK_SECTIONS.each do |section|
+      check_sections.each do |section|
         initial_message_count = checker.messages.length
         send(section[:method])
 
@@ -238,7 +254,7 @@ module ReactOnRails
     end
 
     def collect_check_results
-      CHECK_SECTIONS.map do |section|
+      check_sections.map do |section|
         initial_message_count = checker.messages.length
         send(section[:method])
 
@@ -3476,6 +3492,8 @@ module ReactOnRails
     NPM_VIEW_FETCH_TIMEOUT_SECONDS = NPM_VIEW_FETCH_TIMEOUT_MS / 1000.0
     NPM_VIEW_TERMINATION_GRACE_SECONDS = 0.5
     SKIP_NPM_DIST_TAG_CHECK_ENV = "REACT_ON_RAILS_SKIP_NPM_DIST_TAG_CHECK"
+    RSC_CLIENT_REFERENCES_MANIFEST_ENV = "RSC_MANIFEST_CLIENT_REFERENCES_JSON"
+    DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH = "ssr-generated/rsc-client-references.json"
     # npm registry package names used here must be lowercase; keep this allowlist
     # narrow so names remain safe when reused as Node resolver args and paths.
     PACKAGE_NAME_PATTERN = %r{
@@ -3505,6 +3523,7 @@ module ReactOnRails
       check_rsc_react_version
       check_rsc_procfile_watcher
       check_rsc_client_manifest
+      check_rsc_artifacts
     rescue StandardError => e
       checker.add_warning("⚠️  RSC setup check encountered an error: #{e.message}")
     end
@@ -4370,6 +4389,121 @@ module ReactOnRails
         "#{RSC_CLIENT_MANIFEST_CLEANUP_PATHS.join(', ')}"
       )
       checker.add_info("  💡 Then rebuild so the Node renderer reads a fresh on-disk React Client Manifest")
+    end
+
+    def check_rsc_artifacts
+      check_rsc_bundle_artifact
+      check_rsc_server_client_manifest_artifact
+      check_rsc_client_references_manifest
+    end
+
+    def check_rsc_bundle_artifact
+      artifact_path = rsc_pro_utils_artifact_path(:rsc_bundle_js_file_path, "RSC bundle")
+      return unless artifact_path
+
+      if manifest_url?(artifact_path)
+        checker.add_warning("⚠️  RSC bundle resolves to a dev-server URL: #{artifact_path}")
+        add_rsc_artifacts_rebuild_guidance
+      elsif File.exist?(artifact_path)
+        checker.add_success("✅ RSC bundle exists at #{artifact_path}")
+      else
+        report_missing_rsc_artifact("RSC bundle", artifact_path)
+      end
+    end
+
+    def check_rsc_server_client_manifest_artifact
+      artifact_path = rsc_pro_utils_artifact_path(
+        :react_server_client_manifest_file_path,
+        "RSC server client manifest"
+      )
+      return unless artifact_path
+
+      if manifest_url?(artifact_path)
+        checker.add_warning("⚠️  RSC server client manifest resolves to a dev-server URL: #{artifact_path}")
+        add_rsc_artifacts_rebuild_guidance
+      elsif File.exist?(artifact_path)
+        report_rsc_json_artifact("RSC server client manifest", artifact_path)
+      else
+        report_missing_rsc_artifact("RSC server client manifest", artifact_path)
+      end
+    end
+
+    def check_rsc_client_references_manifest
+      artifact_path = rsc_client_references_manifest_path
+      unless File.exist?(artifact_path)
+        report_missing_rsc_artifact("RSC client references manifest", artifact_path)
+        return
+      end
+
+      refs = rsc_client_references_manifest_refs(artifact_path)
+      if refs.is_a?(Array)
+        checker.add_success("✅ RSC client references manifest includes #{refs.size} refs at #{artifact_path}")
+      else
+        checker.add_warning("⚠️  RSC client references manifest must contain a refs array: #{artifact_path}")
+        add_rsc_artifacts_rebuild_guidance
+      end
+    rescue JSON::ParserError => e
+      checker.add_warning("⚠️  RSC client references manifest is not valid JSON: #{e.message}")
+      add_rsc_artifacts_rebuild_guidance
+    rescue StandardError => e
+      checker.add_warning("⚠️  Could not inspect RSC client references manifest: #{e.message}")
+    end
+
+    def rsc_pro_utils_artifact_path(method_name, label)
+      unless defined?(ReactOnRailsPro::Utils) && ReactOnRailsPro::Utils.respond_to?(method_name)
+        checker.add_info("  ℹ️  #{label} check skipped — upgrade react-on-rails-pro to enable path resolution")
+        return nil
+      end
+
+      artifact_path = ReactOnRailsPro::Utils.public_send(method_name)
+      if artifact_path.blank?
+        checker.add_warning("⚠️  #{label} path could not be resolved")
+        return nil
+      end
+
+      artifact_path
+    rescue StandardError => e
+      checker.add_warning("⚠️  #{label} path could not be resolved: #{e.message}")
+      nil
+    end
+
+    def report_rsc_json_artifact(label, artifact_path)
+      payload = JSON.parse(File.read(artifact_path))
+      if payload.is_a?(Hash)
+        checker.add_success("✅ #{label} exists at #{artifact_path}")
+      else
+        checker.add_warning("⚠️  #{label} must contain a JSON object: #{artifact_path}")
+        add_rsc_artifacts_rebuild_guidance
+      end
+    rescue JSON::ParserError => e
+      checker.add_warning("⚠️  #{label} is not valid JSON: #{e.message}")
+      add_rsc_artifacts_rebuild_guidance
+    end
+
+    def rsc_client_references_manifest_refs(artifact_path)
+      JSON.parse(File.read(artifact_path))["refs"]
+    end
+
+    def rsc_client_references_manifest_path
+      configured_path = ENV.fetch(RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil)
+      File.expand_path(configured_path.presence || DEFAULT_RSC_CLIENT_REFERENCES_MANIFEST_PATH)
+    end
+
+    def report_missing_rsc_artifact(label, artifact_path)
+      checker.add_warning("⚠️  #{label} not found at #{artifact_path}")
+      add_rsc_artifacts_rebuild_guidance
+    end
+
+    def add_rsc_artifacts_rebuild_guidance
+      return if @rsc_artifacts_rebuild_guidance_added
+
+      checker.add_info("  💡 For RSC development, run: ./bin/dev static")
+      checker.add_info("  💡 Re-run bin/shakapacker-precompile-hook before rebuilding RSC assets")
+      checker.add_info(
+        "  💡 If artifacts look stale after a package or React upgrade, stop the dev server and remove: " \
+        "#{RSC_CLIENT_MANIFEST_CLEANUP_PATHS.join(', ')}"
+      )
+      @rsc_artifacts_rebuild_guidance_added = true
     end
 
     def check_rsc_procfile_watcher

--- a/react_on_rails/lib/react_on_rails/doctor.rb
+++ b/react_on_rails/lib/react_on_rails/doctor.rb
@@ -3517,7 +3517,14 @@ module ReactOnRails
     RSC_CLIENT_MANIFEST_CLEANUP_PATHS = %w[public/packs public/packs-test ssr-generated .node-renderer-bundles].freeze
 
     def check_rsc_setup
-      return unless ReactOnRails::Utils.react_on_rails_pro?
+      unless ReactOnRails::Utils.react_on_rails_pro?
+        if rsc_only_check?
+          checker.add_info(
+            "ℹ️  React Server Components checks skipped — react_on_rails_pro is not installed"
+          )
+        end
+        return
+      end
 
       ensure_rails_environment_loaded
       pro_config = ReactOnRailsPro.configuration
@@ -3536,6 +3543,10 @@ module ReactOnRails
       check_rsc_artifacts
     rescue StandardError => e
       checker.add_warning("⚠️  RSC setup check encountered an error: #{e.message}")
+    end
+
+    def rsc_only_check?
+      @check_sections.one? && @check_sections.first[:id] == "react_server_components"
     end
 
     def check_rsc_renderer_mode(pro_config)
@@ -4476,6 +4487,7 @@ module ReactOnRails
         registration_entry_exists:,
         discovery_supported:
       )
+        report_configured_rsc_client_references_manifest(artifact_path)
         report_missing_rsc_artifact("RSC client references manifest", artifact_path)
       elsif registration_entry_exists && !discovery_supported
         checker.add_warning(
@@ -4502,6 +4514,16 @@ module ReactOnRails
       discovery_supported = rsc_manifest_discovery_supported? if discovery_supported.nil?
 
       registration_entry_exists && discovery_supported
+    end
+
+    def report_configured_rsc_client_references_manifest(artifact_path)
+      configured_path = ENV[RSC_CLIENT_REFERENCES_MANIFEST_ENV].to_s.strip
+      return if configured_path.empty?
+
+      checker.add_warning(
+        "⚠️  #{RSC_CLIENT_REFERENCES_MANIFEST_ENV}=#{configured_path.inspect} requires an existing " \
+        "RSC client references manifest at #{artifact_path}"
+      )
     end
 
     def rsc_manifest_registration_entry_exists?
@@ -4568,7 +4590,7 @@ module ReactOnRails
 
     def default_rsc_manifest_registration_entry
       source_entry_path = ReactOnRails::PackerUtils.packer_source_entry_path.to_s
-      source_entry_path = "" if source_entry_path == "/"
+      return nil if source_entry_path.strip.empty? || source_entry_path == "/"
 
       File.expand_path(
         File.join(File.dirname(source_entry_path), "generated", EXPECTED_RSC_REGISTRATION_ENTRY_BASENAME),

--- a/react_on_rails/lib/tasks/doctor.rake
+++ b/react_on_rails/lib/tasks/doctor.rake
@@ -37,15 +37,30 @@ rescue LoadError
 end
 
 namespace :react_on_rails do
-  desc "Diagnose React on Rails setup and configuration (FORMAT=json for machine-readable output)"
-  task :doctor do
+  rsc_doctor_checks = ["react_server_components"].freeze
+  doctor_options = lambda do |only: nil|
     verbose = ENV["VERBOSE"] == "true"
     fix = ENV["FIX"] == "true"
     # Pass unknown values through so Doctor#initialize fails fast with
     # ArgumentError instead of silently falling back to text output.
     format = ENV["FORMAT"].to_s.empty? ? :text : ENV["FORMAT"].to_sym
+    selected_checks = only || ENV["ONLY"].to_s.split(/[,\s]+/).reject(&:empty?)
+    options = { verbose:, fix:, format: }
+    options[:only] = selected_checks unless selected_checks.empty?
+    options
+  end
 
-    doctor = ReactOnRails::Doctor.new(verbose:, fix:, format:)
+  desc "Diagnose React on Rails setup and configuration (FORMAT=json for machine-readable output)"
+  task :doctor do
+    doctor = ReactOnRails::Doctor.new(**doctor_options.call)
     doctor.run_diagnosis
+  end
+
+  namespace :doctor do
+    desc "Diagnose only React Server Components setup (FORMAT=json for machine-readable output)"
+    task :rsc do
+      doctor = ReactOnRails::Doctor.new(**doctor_options.call(only: rsc_doctor_checks))
+      doctor.run_diagnosis
+    end
   end
 end

--- a/react_on_rails/lib/tasks/doctor.rake
+++ b/react_on_rails/lib/tasks/doctor.rake
@@ -58,7 +58,7 @@ namespace :react_on_rails do
   end
 
   namespace :doctor do
-    desc "Diagnose only React Server Components setup (FORMAT=json for machine-readable output)"
+    desc "Diagnose only React Server Components setup (ONLY is ignored; FORMAT=json for machine-readable output)"
     task :rsc do
       doctor = ReactOnRails::Doctor.new(**doctor_options.call(only: rsc_doctor_checks))
       doctor.run_diagnosis

--- a/react_on_rails/lib/tasks/doctor.rake
+++ b/react_on_rails/lib/tasks/doctor.rake
@@ -38,6 +38,7 @@ end
 
 namespace :react_on_rails do
   rsc_doctor_checks = ["react_server_components"].freeze
+  # Shared by both tasks so ENV option parsing and Doctor initialization stay identical.
   doctor_options = lambda do |only: nil|
     verbose = ENV["VERBOSE"] == "true"
     fix = ENV["FIX"] == "true"

--- a/react_on_rails/spec/lib/react_on_rails/doctor_rake_task_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_rake_task_spec.rb
@@ -53,11 +53,53 @@ RSpec.describe "doctor rake task" do
       ENV.delete("FORMAT")
     end
 
+    it "passes selected checks from ONLY" do
+      doctor_instance = instance_double(ReactOnRails::Doctor, run_diagnosis: nil)
+      allow(ReactOnRails::Doctor).to receive(:new).and_return(doctor_instance)
+
+      ENV["ONLY"] = "react_server_components"
+      Rake::Task["react_on_rails:doctor"].invoke
+
+      expect(ReactOnRails::Doctor).to have_received(:new)
+        .with(verbose: false, fix: false, format: :text, only: ["react_server_components"])
+    ensure
+      ENV.delete("ONLY")
+    end
+
     it "fails fast with ArgumentError when FORMAT is an unrecognized value" do
       ENV["FORMAT"] = "jsno"
 
       expect { Rake::Task["react_on_rails:doctor"].invoke }
         .to raise_error(ArgumentError, /Invalid doctor format/)
+    ensure
+      ENV.delete("FORMAT")
+    end
+  end
+
+  describe "rake react_on_rails:doctor:rsc task" do
+    it "exists" do
+      expect(Rake::Task.task_defined?("react_on_rails:doctor:rsc")).to be true
+    end
+
+    it "invokes doctor with only the React Server Components section" do
+      doctor_instance = instance_double(ReactOnRails::Doctor, run_diagnosis: nil)
+      allow(ReactOnRails::Doctor).to receive(:new).and_return(doctor_instance)
+
+      Rake::Task["react_on_rails:doctor:rsc"].invoke
+
+      expect(ReactOnRails::Doctor).to have_received(:new)
+        .with(verbose: false, fix: false, format: :text, only: ["react_server_components"])
+    end
+
+    it "passes FORMAT=json through the RSC-only task" do
+      doctor_instance = instance_double(ReactOnRails::Doctor, run_diagnosis: nil)
+      allow(ReactOnRails::Doctor).to receive(:new).and_return(doctor_instance)
+
+      ENV["FORMAT"] = "json"
+      Rake::Task["react_on_rails:doctor:rsc"].invoke
+
+      expect(ReactOnRails::Doctor).to have_received(:new)
+        .with(verbose: false, fix: false, format: :json, only: ["react_server_components"])
     ensure
       ENV.delete("FORMAT")
     end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_rake_task_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_rake_task_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe "doctor rake task" do
       expect(Rake::Task.task_defined?("react_on_rails:doctor:rsc")).to be true
     end
 
+    it "documents that ONLY is ignored for the RSC-only task" do
+      expect(File.read(rake_file)).to include("ONLY is ignored")
+    end
+
     it "invokes doctor with only the React Server Components section" do
       doctor_instance = instance_double(ReactOnRails::Doctor, run_diagnosis: nil)
       allow(ReactOnRails::Doctor).to receive(:new).and_return(doctor_instance)
@@ -102,6 +106,19 @@ RSpec.describe "doctor rake task" do
         .with(verbose: false, fix: false, format: :json, only: ["react_server_components"])
     ensure
       ENV.delete("FORMAT")
+    end
+
+    it "ignores ONLY because the task is already scoped to the RSC section" do
+      doctor_instance = instance_double(ReactOnRails::Doctor, run_diagnosis: nil)
+      allow(ReactOnRails::Doctor).to receive(:new).and_return(doctor_instance)
+
+      ENV["ONLY"] = "environment"
+      Rake::Task["react_on_rails:doctor:rsc"].invoke
+
+      expect(ReactOnRails::Doctor).to have_received(:new)
+        .with(verbose: false, fix: false, format: :text, only: ["react_server_components"])
+    ensure
+      ENV.delete("ONLY")
     end
   end
 end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6114,6 +6114,25 @@ RSpec.describe ReactOnRails::Doctor do
       expect(info_messages).to include(a_string_including("broad client-reference discovery fallback"))
     end
 
+    it "warns when a configured RSC registration entry path is invalid" do
+      previous_entry_path = ENV.fetch(described_class::RSC_REGISTRATION_ENTRY_PATH_ENV, nil)
+      ENV[described_class::RSC_REGISTRATION_ENTRY_PATH_ENV] = "missing-registration-entry.js"
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(
+        a_string_including("#{described_class::RSC_REGISTRATION_ENTRY_PATH_ENV}=\"missing-registration-entry.js\"")
+      )
+      expect(warning_messages).to include(a_string_including("falling back to default discovery"))
+    ensure
+      if previous_entry_path.nil?
+        ENV.delete(described_class::RSC_REGISTRATION_ENTRY_PATH_ENV)
+      else
+        ENV[described_class::RSC_REGISTRATION_ENTRY_PATH_ENV] = previous_entry_path
+      end
+    end
+
     it "skips direct artifact checks when Pro path utilities are unavailable" do
       hide_const("ReactOnRailsPro::Utils")
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6092,6 +6092,16 @@ RSpec.describe ReactOnRails::Doctor do
       allow(ReactOnRails::PackerUtils).to receive(:packer_source_entry_path).and_return("app/javascript/packs")
     end
 
+    def write_rsc_discovery_support_files
+      FileUtils.mkdir_p("config/webpack")
+      FileUtils.mkdir_p("bin")
+      File.write("config/webpack/rscWebpackConfig.js", "RSC_REFERENCE_DISCOVERY_BUILD RSCReferenceDiscoveryPlugin")
+      File.write(
+        "bin/shakapacker-precompile-hook",
+        "generate_rsc_manifest_client_references_if_needed RSC_REFERENCE_DISCOVERY_BUILD"
+      )
+    end
+
     it "uses the client-reference discovery fallback when the registration entry is absent" do
       doctor.send(:check_rsc_artifacts)
 
@@ -6103,14 +6113,28 @@ RSpec.describe ReactOnRails::Doctor do
       expect(info_messages).to include(a_string_including("broad client-reference discovery fallback"))
     end
 
-    it "warns when the RSC client references manifest is missing but the registration entry exists" do
+    it "warns when the RSC client references manifest is missing and generated configs support discovery" do
+      FileUtils.mkdir_p("app/javascript/generated")
+      File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
+      write_rsc_discovery_support_files
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+    end
+
+    it "warns with generator guidance when missing manifest discovery support requires broad fallback" do
       FileUtils.mkdir_p("app/javascript/generated")
       File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
 
       doctor.send(:check_rsc_artifacts)
 
       warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
-      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("does not support manifest discovery yet"))
+      expect(warning_messages).to include(a_string_including("broad client-reference discovery fallback"))
+      expect(info_messages).to include(a_string_including("rails g react_on_rails:rsc"))
     end
 
     it "warns when a configured RSC client references manifest is missing" do
@@ -6144,6 +6168,22 @@ RSpec.describe ReactOnRails::Doctor do
       expect(success_messages).to include(a_string_including("RSC server client manifest exists"))
       expect(success_messages).to include(a_string_including("RSC client references manifest includes 0 refs"))
       expect(checker.messages.none? { |msg| msg[:type] == :warning }).to be true
+    end
+
+    it "warns when the RSC client references manifest is older than the registration entry" do
+      FileUtils.mkdir_p("app/javascript/generated")
+      FileUtils.mkdir_p("ssr-generated")
+      File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
+      File.write("ssr-generated/rsc-client-references.json", JSON.generate("refs" => []))
+      File.utime(Time.now - 120, Time.now - 120, "ssr-generated/rsc-client-references.json")
+      File.utime(Time.now, Time.now, "app/javascript/generated/server-component-registration-entry.js")
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("older than the server component registration entry"))
+      expect(info_messages).to include(a_string_including("bin/shakapacker-precompile-hook"))
     end
 
     it "warns when JSON RSC artifacts cannot be parsed or have the wrong shape" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -284,6 +284,55 @@ RSpec.describe ReactOnRails::Doctor do
     end
   end
 
+  describe "selected check sections" do
+    def stub_all_check_sections(doctor)
+      described_class::CHECK_SECTIONS.each do |section|
+        allow(doctor).to receive(section[:method])
+      end
+    end
+
+    it "runs only the selected check in human-readable output" do
+      rsc_doctor = described_class.new(only: "react_server_components")
+      checker = rsc_doctor.instance_variable_get(:@checker)
+      stub_all_check_sections(rsc_doctor)
+      allow(rsc_doctor).to receive(:check_rsc_setup) do
+        checker.messages << { type: :success, content: "RSC-only doctor check ran" }
+      end
+      allow(rsc_doctor).to receive(:exit)
+
+      expect { rsc_doctor.run_diagnosis }
+        .to output(/React Server Components:.*RSC-only doctor check ran/m).to_stdout
+
+      expect(rsc_doctor).to have_received(:check_rsc_setup)
+      expect(rsc_doctor).not_to have_received(:check_environment)
+    end
+
+    it "emits only the selected check in JSON output" do
+      rsc_doctor = described_class.new(format: :json, only: [:react_server_components])
+      checker = rsc_doctor.instance_variable_get(:@checker)
+      stub_all_check_sections(rsc_doctor)
+      allow(rsc_doctor).to receive(:check_rsc_setup) do
+        checker.messages << { type: :warning, content: "RSC artifact missing" }
+      end
+      allow(rsc_doctor).to receive(:exit)
+
+      output = []
+      allow(rsc_doctor).to receive(:puts) { |arg| output << arg.to_s }
+
+      rsc_doctor.run_diagnosis
+
+      report = JSON.parse(output.join("\n"))
+      expect(report["checks"].map { |check| check["id"] }).to eq(["react_server_components"])
+      expect(report["summary"]).to eq("pass" => 0, "warn" => 1, "fail" => 0)
+      expect(report["status"]).to eq("warn")
+    end
+
+    it "rejects unknown check selectors" do
+      expect { described_class.new(only: "missing_section") }
+        .to raise_error(ArgumentError, /Invalid doctor check selector/)
+    end
+  end
+
   describe "#dev_server_label" do
     it "uses the canonical webpack-dev-server spelling for webpack apps" do
       allow(doctor).to receive(:configured_assets_bundler).and_return("webpack")
@@ -6018,6 +6067,67 @@ RSpec.describe ReactOnRails::Doctor do
       success_messages = checker.messages.select { |msg| msg[:type] == :success }.map { |msg| msg[:content] }
       expect(success_messages).to include(a_string_including("RSC client manifest includes 1 client reference"))
       expect(checker.messages.none? { |msg| msg[:type] == :warning }).to be true
+    end
+  end
+
+  describe "check_rsc_artifacts" do
+    let(:doctor) { described_class.new(verbose: false, fix: false) }
+    let(:checker) { doctor.instance_variable_get(:@checker) }
+
+    around do |example|
+      Dir.mktmpdir do |tmpdir|
+        Dir.chdir(tmpdir) { example.run }
+      end
+    end
+
+    before do
+      stub_const("ReactOnRailsPro", Module.new)
+      ReactOnRailsPro.const_set(:Utils, Module.new)
+      ReactOnRailsPro::Utils.define_singleton_method(:rsc_bundle_js_file_path) { nil }
+      ReactOnRailsPro::Utils.define_singleton_method(:react_server_client_manifest_file_path) { nil }
+      allow(ReactOnRailsPro::Utils).to receive_messages(
+        rsc_bundle_js_file_path: File.expand_path("ssr-generated/rsc-bundle.js"),
+        react_server_client_manifest_file_path: File.expand_path("ssr-generated/react-server-client-manifest.json")
+      )
+    end
+
+    it "warns when required RSC build artifacts are missing" do
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("RSC bundle not found"))
+      expect(warning_messages).to include(a_string_including("RSC server client manifest not found"))
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+    end
+
+    it "reports success when the RSC bundle, server manifest, and client references manifest exist" do
+      FileUtils.mkdir_p("ssr-generated")
+      File.write("ssr-generated/rsc-bundle.js", "// RSC bundle")
+      File.write("ssr-generated/react-server-client-manifest.json", JSON.generate("module" => {}))
+      File.write("ssr-generated/rsc-client-references.json", JSON.generate("refs" => []))
+
+      doctor.send(:check_rsc_artifacts)
+
+      success_messages = checker.messages.select { |msg| msg[:type] == :success }.map { |msg| msg[:content] }
+      expect(success_messages).to include(a_string_including("RSC bundle exists"))
+      expect(success_messages).to include(a_string_including("RSC server client manifest exists"))
+      expect(success_messages).to include(a_string_including("RSC client references manifest includes 0 refs"))
+      expect(checker.messages.none? { |msg| msg[:type] == :warning }).to be true
+    end
+
+    it "warns when JSON RSC artifacts cannot be parsed or have the wrong shape" do
+      FileUtils.mkdir_p("ssr-generated")
+      File.write("ssr-generated/rsc-bundle.js", "// RSC bundle")
+      File.write("ssr-generated/react-server-client-manifest.json", "{not-json")
+      File.write("ssr-generated/rsc-client-references.json", JSON.generate("refs" => {}))
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("RSC server client manifest is not valid JSON"))
+      expect(warning_messages).to include(
+        a_string_including("RSC client references manifest must contain a refs array")
+      )
     end
   end
   # rubocop:enable RSpec/VerifiedDoubles

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6114,6 +6114,15 @@ RSpec.describe ReactOnRails::Doctor do
       expect(info_messages).to include(a_string_including("broad client-reference discovery fallback"))
     end
 
+    it "skips direct artifact checks when Pro path utilities are unavailable" do
+      hide_const("ReactOnRailsPro::Utils")
+
+      doctor.send(:check_rsc_artifacts)
+
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      expect(info_messages).to include(a_string_including("RSC artifact checks skipped"))
+    end
+
     it "warns when the RSC client references manifest is missing and generated configs support discovery" do
       FileUtils.mkdir_p("app/javascript/generated")
       File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
@@ -6194,7 +6203,9 @@ RSpec.describe ReactOnRails::Doctor do
 
       warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
       info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      success_messages = checker.messages.select { |msg| msg[:type] == :success }.map { |msg| msg[:content] }
       expect(warning_messages).to include(a_string_including("older than the server component registration entry"))
+      expect(success_messages).not_to include(a_string_including("RSC client references manifest includes"))
       expect(info_messages).to include(a_string_including("bin/shakapacker-precompile-hook"))
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6092,10 +6092,11 @@ RSpec.describe ReactOnRails::Doctor do
       allow(ReactOnRails::PackerUtils).to receive(:packer_source_entry_path).and_return("app/javascript/packs")
     end
 
-    def write_rsc_discovery_support_files
-      FileUtils.mkdir_p("config/webpack")
+    def write_rsc_discovery_support_files(bundler: "webpack")
+      config_dir = "config/#{bundler}"
+      FileUtils.mkdir_p(config_dir)
       FileUtils.mkdir_p("bin")
-      File.write("config/webpack/rscWebpackConfig.js", "RSC_REFERENCE_DISCOVERY_BUILD RSCReferenceDiscoveryPlugin")
+      File.write("#{config_dir}/rscWebpackConfig.js", "RSC_REFERENCE_DISCOVERY_BUILD RSCReferenceDiscoveryPlugin")
       File.write(
         "bin/shakapacker-precompile-hook",
         "generate_rsc_manifest_client_references_if_needed RSC_REFERENCE_DISCOVERY_BUILD"
@@ -6117,6 +6118,17 @@ RSpec.describe ReactOnRails::Doctor do
       FileUtils.mkdir_p("app/javascript/generated")
       File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
       write_rsc_discovery_support_files
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+    end
+
+    it "warns when the Rspack RSC config supports manifest discovery and the manifest is missing" do
+      FileUtils.mkdir_p("app/javascript/generated")
+      File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
+      write_rsc_discovery_support_files(bundler: "rspack")
 
       doctor.send(:check_rsc_artifacts)
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6089,14 +6089,27 @@ RSpec.describe ReactOnRails::Doctor do
         rsc_bundle_js_file_path: File.expand_path("ssr-generated/rsc-bundle.js"),
         react_server_client_manifest_file_path: File.expand_path("ssr-generated/react-server-client-manifest.json")
       )
+      allow(ReactOnRails::PackerUtils).to receive(:packer_source_entry_path).and_return("app/javascript/packs")
     end
 
-    it "warns when required RSC build artifacts are missing" do
+    it "uses the client-reference discovery fallback when the registration entry is absent" do
       doctor.send(:check_rsc_artifacts)
 
       warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
       expect(warning_messages).to include(a_string_including("RSC bundle not found"))
       expect(warning_messages).to include(a_string_including("RSC server client manifest not found"))
+      expect(warning_messages).not_to include(a_string_including("RSC client references manifest not found"))
+      expect(info_messages).to include(a_string_including("broad client-reference discovery fallback"))
+    end
+
+    it "warns when the RSC client references manifest is missing but the registration entry exists" do
+      FileUtils.mkdir_p("app/javascript/generated")
+      File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
     end
 

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6108,6 +6108,7 @@ RSpec.describe ReactOnRails::Doctor do
     end
 
     before do
+      allow(Rails).to receive(:root).and_return(Pathname.new(Dir.pwd))
       stub_const("ReactOnRailsPro", Module.new)
       ReactOnRailsPro.const_set(:Utils, Module.new)
       ReactOnRailsPro::Utils.define_singleton_method(:rsc_bundle_js_file_path) { nil }
@@ -6175,6 +6176,18 @@ RSpec.describe ReactOnRails::Doctor do
       write_rsc_discovery_support_files
 
       doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+    end
+
+    it "resolves relative RSC discovery paths from Rails.root when invoked from a subdirectory" do
+      FileUtils.mkdir_p("app/javascript/generated")
+      File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
+      write_rsc_discovery_support_files
+      FileUtils.mkdir_p("tmp/subdir")
+
+      Dir.chdir("tmp/subdir") { doctor.send(:check_rsc_artifacts) }
 
       warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
@@ -6332,7 +6345,7 @@ RSpec.describe ReactOnRails::Doctor do
       doctor.send(:check_rsc_artifacts)
 
       warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
-      expect(warning_messages).to include(a_string_including("Could not inspect RSC server client manifest"))
+      expect(warning_messages).to include(a_string_including("Could not read RSC server client manifest"))
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
     ensure
       if previous_manifest_path.nil?
@@ -6340,6 +6353,21 @@ RSpec.describe ReactOnRails::Doctor do
       else
         ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = previous_manifest_path
       end
+    end
+
+    it "does not add rebuild guidance when a JSON artifact exists but cannot be read" do
+      FileUtils.mkdir_p("ssr-generated")
+      File.write("ssr-generated/react-server-client-manifest.json", JSON.generate("module" => {}))
+      server_manifest_path = File.expand_path("ssr-generated/react-server-client-manifest.json")
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(server_manifest_path).and_raise(Errno::EACCES, "Permission denied")
+
+      doctor.send(:report_rsc_json_artifact, "RSC server client manifest", server_manifest_path)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("Could not read RSC server client manifest"))
+      expect(info_messages).not_to include(a_string_including("Re-run bin/shakapacker-precompile-hook"))
     end
 
     it "warns clearly when the RSC client references manifest is a JSON array" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6304,6 +6304,21 @@ RSpec.describe ReactOnRails::Doctor do
         a_string_including("RSC client references manifest must contain a refs array")
       )
     end
+
+    it "warns clearly when the RSC client references manifest is a JSON array" do
+      FileUtils.mkdir_p("ssr-generated")
+      File.write("ssr-generated/rsc-bundle.js", "// RSC bundle")
+      File.write("ssr-generated/react-server-client-manifest.json", JSON.generate("module" => {}))
+      File.write("ssr-generated/rsc-client-references.json", JSON.generate([]))
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(
+        a_string_including("RSC client references manifest must contain a refs array")
+      )
+      expect(warning_messages).not_to include(a_string_including("no implicit conversion of String into Integer"))
+    end
   end
   # rubocop:enable RSpec/VerifiedDoubles
 end

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5009,6 +5009,19 @@ RSpec.describe ReactOnRails::Doctor do
         doctor.send(:check_rsc_setup)
         expect(checker.messages.length).to eq(initial_count)
       end
+
+      it "reports a skip reason for the RSC-only doctor" do
+        rsc_only_doctor = described_class.new(verbose: false, fix: false, only: ["react_server_components"])
+        rsc_only_checker = rsc_only_doctor.instance_variable_get(:@checker)
+        allow(rsc_only_doctor).to receive(:puts)
+        allow(rsc_only_doctor).to receive(:exit)
+
+        rsc_only_doctor.send(:check_rsc_setup)
+
+        info_messages = rsc_only_checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+        expect(info_messages).to include(a_string_including("React Server Components checks skipped"))
+        expect(info_messages).to include(a_string_including("react_on_rails_pro is not installed"))
+      end
     end
 
     context "when Pro is installed but RSC is disabled" do
@@ -6153,6 +6166,20 @@ RSpec.describe ReactOnRails::Doctor do
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
     end
 
+    it "does not treat a blank Shakapacker source entry path as ./generated" do
+      allow(ReactOnRails::PackerUtils).to receive(:packer_source_entry_path).and_return("")
+      FileUtils.mkdir_p("generated")
+      File.write("generated/server-component-registration-entry.js", "// wrong default when source_entry_path is blank")
+      write_rsc_discovery_support_files
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      expect(warning_messages).not_to include(a_string_including("RSC client references manifest not found"))
+      expect(info_messages).to include(a_string_including("broad client-reference discovery fallback"))
+    end
+
     it "warns when the Rspack RSC config supports manifest discovery and the manifest is missing" do
       FileUtils.mkdir_p("app/javascript/generated")
       File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
@@ -6187,6 +6214,25 @@ RSpec.describe ReactOnRails::Doctor do
       info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
       expect(info_messages).not_to include(a_string_including("broad client-reference discovery fallback"))
+    ensure
+      if previous_manifest_path.nil?
+        ENV.delete(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV)
+      else
+        ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = previous_manifest_path
+      end
+    end
+
+    it "names the configured RSC client references manifest env var when the path is missing" do
+      previous_manifest_path = ENV.fetch(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil)
+      ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = "true"
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(
+        a_string_including("#{described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV}=\"true\"")
+      )
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
     ensure
       if previous_manifest_path.nil?
         ENV.delete(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV)

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6191,6 +6191,22 @@ RSpec.describe ReactOnRails::Doctor do
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
     end
 
+    it "warns when RSC discovery support files exist but cannot be read" do
+      FileUtils.mkdir_p("app/javascript/generated")
+      File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")
+      write_rsc_discovery_support_files
+      config_path = File.expand_path("config/webpack/rscWebpackConfig.js", Dir.pwd)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(config_path).and_raise(Errno::EACCES, "Permission denied")
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(
+        a_string_including("Could not read config/webpack/rscWebpackConfig.js during RSC discovery check")
+      )
+    end
+
     it "warns with generator guidance when missing manifest discovery support requires broad fallback" do
       FileUtils.mkdir_p("app/javascript/generated")
       File.write("app/javascript/generated/server-component-registration-entry.js", "// registration entry")

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -5022,6 +5022,20 @@ RSpec.describe ReactOnRails::Doctor do
         expect(info_messages).to include(a_string_including("React Server Components checks skipped"))
         expect(info_messages).to include(a_string_including("react_on_rails_pro is not installed"))
       end
+
+      it "reports a skip reason when RSC is part of an explicit mixed selection" do
+        mixed_doctor = described_class.new(verbose: false, fix: false,
+                                           only: %w[environment_prerequisites react_server_components])
+        mixed_checker = mixed_doctor.instance_variable_get(:@checker)
+        allow(mixed_doctor).to receive(:puts)
+        allow(mixed_doctor).to receive(:exit)
+
+        mixed_doctor.send(:check_rsc_setup)
+
+        info_messages = mixed_checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+        expect(info_messages).to include(a_string_including("React Server Components checks skipped"))
+        expect(info_messages).to include(a_string_including("react_on_rails_pro is not installed"))
+      end
     end
 
     context "when Pro is installed but RSC is disabled" do
@@ -6303,6 +6317,29 @@ RSpec.describe ReactOnRails::Doctor do
       expect(warning_messages).to include(
         a_string_including("RSC client references manifest must contain a refs array")
       )
+    end
+
+    it "continues client-reference diagnostics when the server manifest cannot be read" do
+      previous_manifest_path = ENV.fetch(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil)
+      ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = "missing-rsc-client-references.json"
+      FileUtils.mkdir_p("ssr-generated")
+      File.write("ssr-generated/rsc-bundle.js", "// RSC bundle")
+      File.write("ssr-generated/react-server-client-manifest.json", JSON.generate("module" => {}))
+      server_manifest_path = File.expand_path("ssr-generated/react-server-client-manifest.json")
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(server_manifest_path).and_raise(Errno::EACCES, "Permission denied")
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("Could not inspect RSC server client manifest"))
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+    ensure
+      if previous_manifest_path.nil?
+        ENV.delete(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV)
+      else
+        ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = previous_manifest_path
+      end
     end
 
     it "warns clearly when the RSC client references manifest is a JSON array" do

--- a/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
+++ b/react_on_rails/spec/lib/react_on_rails/doctor_spec.rb
@@ -6113,6 +6113,24 @@ RSpec.describe ReactOnRails::Doctor do
       expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
     end
 
+    it "warns when a configured RSC client references manifest is missing" do
+      previous_manifest_path = ENV.fetch(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV, nil)
+      ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = "missing-rsc-client-references.json"
+
+      doctor.send(:check_rsc_artifacts)
+
+      warning_messages = checker.messages.select { |msg| msg[:type] == :warning }.map { |msg| msg[:content] }
+      info_messages = checker.messages.select { |msg| msg[:type] == :info }.map { |msg| msg[:content] }
+      expect(warning_messages).to include(a_string_including("RSC client references manifest not found"))
+      expect(info_messages).not_to include(a_string_including("broad client-reference discovery fallback"))
+    ensure
+      if previous_manifest_path.nil?
+        ENV.delete(described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV)
+      else
+        ENV[described_class::RSC_CLIENT_REFERENCES_MANIFEST_ENV] = previous_manifest_path
+      end
+    end
+
     it "reports success when the RSC bundle, server manifest, and client references manifest exist" do
       FileUtils.mkdir_p("ssr-generated")
       File.write("ssr-generated/rsc-bundle.js", "// RSC bundle")


### PR DESCRIPTION
Fixes #4204

## Why
RSC setup failures need a focused doctor path that can distinguish missing artifacts, stale client-reference manifests, explicit environment overrides, and older generated configs that still need broad fallback discovery.

## What changed
- Adds RSC-focused doctor selection and rake task coverage.
- Checks the RSC bundle, server client manifest, and client references manifest.
- Mirrors generated resolver behavior for default refs, explicit env overrides, stale manifests, webpack/Rspack discovery support, and old-generator fallback guidance.

## Validation
- `bundle exec rspec spec/lib/react_on_rails/doctor_spec.rb spec/lib/react_on_rails/doctor_rake_task_spec.rb --format progress` - 330 examples, 0 failures.
- `BUNDLE_GEMFILE=../Gemfile bundle exec rubocop lib/react_on_rails/doctor.rb spec/lib/react_on_rails/doctor_spec.rb spec/lib/react_on_rails/doctor_rake_task_spec.rb` - no offenses.
- `git diff --check`.
- Branch autoreview clean: no accepted/actionable findings.
- Pre-push hook passed branch Ruby lint and markdown-link selection.

## Notes
Freshness diagnostics are limited to reliable registration-entry/client-references manifest mtimes; broader build metadata freshness remains deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `react_on_rails:doctor:rsc` command for React Server Components diagnosis.
  * Doctor output can now be scoped to specific sections via an `only` selector (including section-only JSON results).

* **Bug Fixes**
  * Enhanced RSC diagnostics with deeper artifact validation (bundle, server/client manifest, `rsc-client-references.json`) and clearer guidance for missing or stale artifacts.
  * Improved messaging when Pro is unavailable and when artifact discovery helpers aren’t supported.

* **Documentation**
  * Updated the changelog with the latest doctor/RSC diagnostics improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->