### PR TITLE
Fix llms-full update workflow auth path

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           bash script/ci-required-hosted-gate-test.bash
 
+      - name: Fetch workflow dispatch base
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git fetch --no-tags --depth=50 origin main:refs/remotes/origin/main
+
       - name: Select hosted CI mode
         id: hosted-ci
         uses: ./.github/actions/hosted-ci-selectors

--- a/.github/workflows/update-llms-full.yml
+++ b/.github/workflows/update-llms-full.yml
@@ -1,7 +1,9 @@
 name: Update llms-full.txt
 
 permissions:
-  contents: read
+  actions: write # needed for `gh workflow run` in "Dispatch generated PR checks"
+  contents: write
+  pull-requests: write
 
 on:
   schedule:
@@ -35,21 +37,27 @@ jobs:
       - name: Regenerate llms-full references
         run: node script/generate-llms-full.mjs
 
-      - name: Create docs bot token
-        id: docs-bot-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
-        with:
-          app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.DOCS_DISPATCH_APP_KEY }}
-          owner: shakacode
-          repositories: react_on_rails
-          permission-contents: write
-          permission-pull-requests: write
+      - name: Detect generated changes
+        id: generated-changes
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- llms-full.txt llms-full-pro.txt &&
+            [ -z "$(git status --porcelain -- llms-full.txt llms-full-pro.txt)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No llms-full reference changes detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Generated llms-full reference changes detected:"
+            git status --short -- llms-full.txt llms-full-pro.txt
+          fi
 
       - name: Create pull request for generated updates
+        if: steps.generated-changes.outputs.changed == 'true'
+        id: create-pull-request
         uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
-          token: ${{ steps.docs-bot-token.outputs.token }}
+          token: ${{ github.token }}
           branch: docs/update-llms-full
           delete-branch: true
           title: Regenerate llms-full references
@@ -62,8 +70,27 @@ jobs:
             - `bash script/generate-llms-full-test.bash`
             - `node script/generate-llms-full.mjs`
 
-            Expected generated PR check:
-            - `node script/generate-llms-full.mjs --check`
+            Expected generated PR checks:
+            - `ci-required / required-pr-gate`
+            - `Validate llms-full.txt / check-llms-full`
           add-paths: |
             llms-full.txt
             llms-full-pro.txt
+
+      - name: Dispatch generated PR checks
+        if: steps.create-pull-request.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          dispatch_failed=false
+          for workflow in ci-required.yml check-llms-full.yml; do
+            if ! gh workflow run "$workflow" --ref docs/update-llms-full; then
+              dispatch_failed=true
+            fi
+          done
+
+          if [ "$dispatch_failed" = "true" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- replace the missing docs App write-token path in `update-llms-full.yml` with the repo `GITHUB_TOKEN`
- detect generated `llms-full*` diffs before trying to open a PR, so clean runs no-op cleanly
- explicitly dispatch `ci-required` and `check-llms-full` on the generated branch after the workflow creates/updates `docs/update-llms-full`
- fetch `origin/main` for `ci-required` workflow-dispatch runs so branch-dispatched required gates have a real diff base

Refs #4219.

## Why
The first post-merge manual run of `Update llms-full.txt` failed before PR creation because `reactonrails-docs-dispatch` is not installed on `shakacode/react_on_rails` and only has `contents: write`, while the workflow requested a token for this repo with pull-request write access.

## Verification
- `ruby -e "require 'yaml'; %w[.github/workflows/update-llms-full.yml .github/workflows/ci-required.yml].each { |f| YAML.safe_load_file(f, permitted_classes: [], aliases: false); puts f }"`
- `actionlint .github/workflows/update-llms-full.yml .github/workflows/ci-required.yml`
- `bash script/generate-llms-full-test.bash`
- `node script/generate-llms-full.mjs --validate`
- `bash script/ci-required-hosted-gate-test.bash`
- `corepack pnpm start format.listDifferent`
- `corepack pnpm run lint`
- `git diff --check origin/main...HEAD`

`bundle exec rubocop` was run and still fails only on existing `react_on_rails/spike/3313_prism_gemfile_rewriter/*` offenses unrelated to this YAML-only change. `yamllint` is not installed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automated documentation update flow so regeneration PRs are only created when generated reference files actually differ.
  * Enhanced CI check orchestration to dispatch and run the relevant required validations after updates.
* **Bug Fixes**
  * Improved required CI baseline handling for manual workflow dispatch runs to reduce false failures during gating/change detection.
  * Updated the reference update automation to use the standard workflow token for pull request creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->