### PR TITLE
Fix RSC Rspack dev manifest generation

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -150,6 +150,7 @@ exclude = [
   # ============================================================================
   # EXTERNAL DOC PAGES WITH CI CONNECTIVITY FAILURES
   # ============================================================================
+  '^https://loadable-components\.com/docs/server-side-rendering/?(#.*)?$', # Connection timeout from link checks
   '^https://vite\.dev(/.*)?$', # Connection failed from CI
   '^https://tanstack\.com/query/latest/docs/framework/react/guides/ssr$',  # Connection failed from CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ After a release, run `/update-changelog` in Claude Code to analyze commits, writ
 
 #### Fixed
 
+- **[Pro]** **Generated RSC + Rspack apps render in normal `bin/dev`**:
+  RSC + Rspack generator output now disables Rspack lazy compilation while the
+  dev server is running, so discovered client references are compiled before
+  the React Client Manifest is read during server rendering. Fresh generated
+  apps no longer fail `/hello_server` with an empty `react-client-manifest.json`
+  in normal HMR mode. Fixes Issue 4226.
+  [PR 4227](https://github.com/shakacode/react_on_rails/pull/4227) by
+  [ihabadham](https://github.com/ihabadham).
+
 - **[Pro]** **RSC doctor now catches stale install and client-manifest setup failures**:
   The doctor now validates installed `react-on-rails-rsc` peer requirements
   against `react` and `react-dom`, warns when the installed RSC package is

--- a/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/development.js.tt
+++ b/react_on_rails/lib/generators/react_on_rails/templates/base/base/config/webpack/development.js.tt
@@ -1,6 +1,8 @@
 <%= add_documentation_reference(config[:message], "// https://github.com/shakacode/react-on-rails-demo-ssr-hmr/blob/master/config/webpack/development.js") %>
 
 const { devServer, inliningCss, config } = require('shakapacker');
+const { existsSync } = require('fs');
+const { resolve } = require('path');
 
 const serverClientOrBoth = require('./ServerClientOrBoth');
 
@@ -12,6 +14,11 @@ const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig) => {
       // Rspack uses @rspack/plugin-react-refresh for React Fast Refresh
       const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
       clientWebpackConfig.plugins.push(new ReactRefreshRspackPlugin());
+
+      if (existsSync(resolve(__dirname, 'rscWebpackConfig.js'))) {
+        // RSC client references must be compiled before the server render reads the client manifest.
+        clientWebpackConfig.lazyCompilation = false;
+      }
     } else {
       // Webpack uses @pmmmwh/react-refresh-webpack-plugin
       const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');

--- a/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
+++ b/react_on_rails/spec/react_on_rails/generators/install_generator_spec.rb
@@ -3134,6 +3134,13 @@ describe InstallGenerator, type: :generator do
           expect(content).to include("rscConfig")
         end
       end
+
+      it "disables Rspack lazy compilation while serving RSC apps" do
+        assert_file "config/rspack/development.js" do |content|
+          expect(content).to include("existsSync(resolve(__dirname, 'rscWebpackConfig.js'))")
+          expect(content).to include("clientWebpackConfig.lazyCompilation = false")
+        end
+      end
     end
 
     it "installs both RSC and Rspack dependencies" do


### PR DESCRIPTION
## Summary

Fixes #4226.

Fresh RSC + Rspack apps generated by `react_on_rails:install --rsc --rspack` failed in normal `bin/dev` mode because the Rspack dev-server client manifest could stay empty while lazy compilation deferred the discovered RSC client reference modules.

This updates the generated Rspack development config to disable `lazyCompilation` only for RSC apps while the dev server is serving. React Fast Refresh / HMR stays enabled; only Rspack lazy compilation is disabled for this RSC dev-server path.

## Implementation

- Detect generated RSC apps by checking for `config/rspack/rscWebpackConfig.js`.
- In Rspack dev-server mode (`WEBPACK_SERVE`), set `clientWebpackConfig.lazyCompilation = false` for those RSC apps.
- Add generator coverage so `--rsc --rspack` output includes the guard and assignment.
- Add the changelog entry after the PR number was assigned.
- Exclude an existing flaky Loadable Components docs URL from lychee because it times out during link checks and otherwise blocks changelog pushes unrelated to that old link.

## Verification

- `git fetch --prune origin main`
- `.agents/bin/agent-workflow-seam-doctor`
- `(cd react_on_rails && bundle exec rspec spec/react_on_rails/generators/install_generator_spec.rb -e 'disables Rspack lazy compilation while serving RSC apps')`
- Generated a fresh app at `/tmp/ror-rsc-rspack-fixed-20260627` from this branch plus `react_on_rails_rsc` main:
  - `rails new ... --skip-git --skip-bundle --skip-jbuilder --skip-system-test --skip-bootsnap`
  - added local path gems for `react_on_rails` and `react_on_rails_pro`
  - `bundle install`
  - `bundle exec rails generate react_on_rails:install --rsc --rspack`
  - installed `react-on-rails-rsc` from local main
  - `bundle exec rails db:prepare`
- Ran normal dev-server mode:
  - `REACT_ON_RAILS_BASE_PORT=5810 mise x ruby@3.3.7 node@22.16.0 -- bin/dev --no-open-browser`
- Verified `http://localhost:5810/hello_server` returns `200 OK`.
- Verified `http://localhost:5811/packs/react-client-manifest.json` contains the generated `LikeButton.jsx` client reference and a non-empty chunk list.
- Verified with Playwright that `/hello_server` renders and the Like button increments from `0 likes` to `1 like`.
- Verified HMR still works by editing the generated `LikeButton.jsx`; Playwright observed the button update live to `💚 Love`, and the console reported the hot update for `./app/javascript/src/HelloServer/components/LikeButton.jsx`.
- Verified logs do not contain `lazy-compilation-proxy`, `/_rspack/lazy/trigger`, `Could not find the module`, or `React Client Manifest` errors. The only browser console error during the main run was the app's missing favicon.
- Commit hooks passed.
- Pre-push hooks passed, including online lychee on `CHANGELOG.md`:
  - `1013 Total`, `276 OK`, `0 Errors`, `737 Excluded`

Artifacts are under `tmp/experiments/20260627T011345Z-rsc-rspack-disable-lazy-fix/` in the local checkout.

## CI

This is generator-sensitive and should get hosted CI before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-time handling for RSC apps using Rspack so the client bundle is built eagerly when needed, helping server rendering reliably access the client manifest.
* **Tests**
  * Added an RSpec check to ensure Rspack lazy compilation is disabled in the RSC + Rspack development flow.
* **Chores**
  * Updated link-checker exclusions for specific documentation URLs that were timing out in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->