### PR TITLE
Align create-app AI prompt with Pro default

### DIFF
--- a/prompts.yml
+++ b/prompts.yml
@@ -67,7 +67,7 @@ prompts:
     title: Start a new app
     category: get-started
     doc_route: /docs/getting-started/create-react-on-rails-app
-    prompt: "Set up a new Rails app with React on Rails, using TypeScript and server-side rendering. Follow the official guide at {{doc_url}} and use the exact commands and versions it specifies — don't improvise."
+    prompt: "Set up a new Rails app with the default React on Rails Pro path for React 19.2 feature support. Follow the official guide at {{doc_url}} exactly, use `--standard` only if I explicitly need an open-source-only scaffold, and don't improvise commands or versions."
 
   - id: install-existing
     title: Add to an existing Rails app

--- a/prompts.yml
+++ b/prompts.yml
@@ -67,7 +67,7 @@ prompts:
     title: Start a new app
     category: get-started
     doc_route: /docs/getting-started/create-react-on-rails-app
-    prompt: "Set up a new Rails app using the default React on Rails Pro path (no license required for development) with TypeScript and server-side rendering. Follow the official guide at {{doc_url}} exactly; don't improvise commands or versions. Use --standard only when the user's request explicitly requires an open-source-only scaffold."
+    prompt: "Set up a new Rails app using the default React on Rails Pro path (no token required for development, test, CI/CD, or staging; production requires a paid license) with TypeScript and server-side rendering. Follow the official guide at {{doc_url}} exactly; don't improvise commands or versions. Use --standard only when you intentionally want an open-source-only scaffold."
 
   - id: install-existing
     title: Add to an existing Rails app

--- a/prompts.yml
+++ b/prompts.yml
@@ -67,7 +67,7 @@ prompts:
     title: Start a new app
     category: get-started
     doc_route: /docs/getting-started/create-react-on-rails-app
-    prompt: "Set up a new Rails app using the default React on Rails Pro path with TypeScript and server-side rendering. Follow the official guide at {{doc_url}} exactly; don't improvise commands or versions. Use --standard only when the user's request explicitly requires an open-source-only scaffold."
+    prompt: "Set up a new Rails app using the default React on Rails Pro path (no license required for development) with TypeScript and server-side rendering. Follow the official guide at {{doc_url}} exactly; don't improvise commands or versions. Use --standard only when the user's request explicitly requires an open-source-only scaffold."
 
   - id: install-existing
     title: Add to an existing Rails app

--- a/prompts.yml
+++ b/prompts.yml
@@ -67,7 +67,7 @@ prompts:
     title: Start a new app
     category: get-started
     doc_route: /docs/getting-started/create-react-on-rails-app
-    prompt: "Set up a new Rails app with the default React on Rails Pro path for React 19.2 feature support. Follow the official guide at {{doc_url}} exactly, use `--standard` only if I explicitly need an open-source-only scaffold, and don't improvise commands or versions."
+    prompt: "Set up a new Rails app using the default React on Rails Pro path. Follow the official guide at {{doc_url}} exactly and don't improvise commands or versions. Use --standard only when the user's request explicitly requires an open-source-only scaffold."
 
   - id: install-existing
     title: Add to an existing Rails app

--- a/prompts.yml
+++ b/prompts.yml
@@ -67,7 +67,7 @@ prompts:
     title: Start a new app
     category: get-started
     doc_route: /docs/getting-started/create-react-on-rails-app
-    prompt: "Set up a new Rails app using the default React on Rails Pro path. Follow the official guide at {{doc_url}} exactly and don't improvise commands or versions. Use --standard only when the user's request explicitly requires an open-source-only scaffold."
+    prompt: "Set up a new Rails app using the default React on Rails Pro path with TypeScript and server-side rendering. Follow the official guide at {{doc_url}} exactly; don't improvise commands or versions. Use --standard only when the user's request explicitly requires an open-source-only scaffold."
 
   - id: install-existing
     title: Add to an existing Rails app


### PR DESCRIPTION
## Summary

- Updates the canonical `create-app` AI prompt in `prompts.yml` to match the merged Pro-first docs from #4217.
- Tells agents that the default `npx create-react-on-rails-app my-app` path is React on Rails Pro for React 19.2 feature support.
- Calls out `--standard` only as the explicit open-source-only scaffold escape hatch.

Downstream site context: this unblocks shakacode/reactonrails.com#132 because `reactonrails.com` now generates `prompts.ts`, `prompts.json`, and `prompts/llms.txt` from this upstream source instead of hand-editing generated artifacts.

## Validation

- `.agents/bin/agent-workflow-seam-doctor`
- `git diff --check`
- `script/ci-changes-detector origin/main` (routes `prompts.yml` as uncategorized, so it recommends the broad suite)
- From the downstream site checkout: `REACT_ON_RAILS_REPO=/Users/justin/.codex/worktrees/b187/react_on_rails-upstream npm run sync:docs && npm run prepare:prompts`
- `bin/ci-local --changed --fast` attempted; it installed dependencies and passed docs-sidebar, then failed during RuboCop on pre-existing offenses in `react_on_rails/spike/3313_prism_gemfile_rewriter/*`, outside this one-line prompt change.

## Notes

- No generated `llms-full*.txt` update is included here; this PR changes the prompt catalog source consumed by the docs site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the app creation guidance to default to the React on Rails Pro path.
  * Tightened rules so the open-source-only scaffold is used only when the request explicitly asks for it.
  * Ensures instructions follow the official guide exactly, including commands/versions.
* **Bug Fixes**
  * Reduced setup deviations by preventing improvisation of commands or versions and aligning output more strictly with the guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->