### PR TITLE
docs: add TanStack Query guide for React on Rails

### DIFF
--- a/docs/oss/building-features/tanstack-query.md
+++ b/docs/oss/building-features/tanstack-query.md
@@ -65,7 +65,7 @@ export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): 
     body: options.json === undefined ? options.body : JSON.stringify(options.json),
   });
 
-  // ...parse JSON, throw ApiError on !response.ok
+  const body = await response.json(); // the starter also handles non-JSON and throws ApiError on !response.ok
   return body as T;
 }
 ```
@@ -174,7 +174,7 @@ const projectsQuery = useQuery({
 
 Because the seed is passed as `initialData` without `initialDataUpdatedAt`, TanStack Query timestamps it at `0`, so the table does one background refetch on mount to confirm freshness — the rows still paint immediately, with no spinner. To treat the seed as fresh for `staleTime` and skip that first refetch, also pass `initialDataUpdatedAt` set to the server's render time.
 
-> **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once.
+> **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once. Note that the `prefetchQuery`/`dehydrate` path needs an awaitable server-render boundary (the Pro [TanStack Router SSR](./tanstack-router.md) path), whereas the props-to-`initialData` seed works in open source.
 
 ## Mutations and Cache Invalidation
 

--- a/docs/oss/building-features/tanstack-query.md
+++ b/docs/oss/building-features/tanstack-query.md
@@ -1,0 +1,219 @@
+# Using TanStack Query
+
+[TanStack Query](https://tanstack.com/query) (formerly React Query) manages **server state in the browser**: caching, request deduplication, background refetching, retries, and cache invalidation. Rails is excellent at server-side data; TanStack Query gives the React side a disciplined way to consume that data without hand-rolling loading flags, retry logic, and ad-hoc caches.
+
+It is the recommended client-side server-state layer for Rails-backed React apps. Rails keeps owning data, routes, auth, sessions, CSRF, validations, mailers, and jobs. TanStack Query does not replace any of that; it consumes the JSON Rails already knows how to produce.
+
+## Support Model
+
+- **Client-side TanStack Query works in open-source React on Rails** with no special integration. It is a standard React library; register a component that mounts `QueryClientProvider` and you are done.
+- **First-paint data seeding** (rendering useful rows in the server HTML, then letting the client reuse them) needs nothing more than React on Rails passing the first screen's data as props. The client adopts it through `useQuery({ initialData })`. This works in OSS and Pro alike.
+- **Full TanStack Router SSR** (server-rendering the route tree and hydrating it) **requires React on Rails Pro**. See [Using TanStack Router](./tanstack-router.md). TanStack Query composes with that boundary but does not depend on it.
+
+This guide mirrors the official [React on Rails + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack) ([live demo](https://starter.reactonrails.com)). Every snippet below is drawn from that app.
+
+## Rails Stays the Source of Truth
+
+A normal Rails controller returns explicit JSON, never raw Active Record:
+
+```ruby
+# app/controllers/api/projects_controller.rb
+module Api
+  class ProjectsController < BaseController
+    def index
+      result = ProjectsQuery.from_params(Current.user.projects, params).result
+
+      render json: {
+        projects: result[:records].map { |project| ProjectSerializer.one(project) },
+        meta: result[:meta]
+      }
+    end
+  end
+end
+```
+
+Filtering, sorting, pagination, and authorization stay in Rails. The React side never reaches past this boundary.
+
+## One CSRF-Aware Fetch Helper
+
+Put the same-origin and CSRF handling in exactly one place so every query and mutation goes through it:
+
+```ts
+// app/javascript/lib/apiFetch.ts
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const headers = new Headers(options.headers);
+  headers.set('Accept', 'application/json');
+  if (options.json !== undefined) headers.set('Content-Type', 'application/json');
+
+  const csrfToken = getCsrfToken(); // reads <meta name="csrf-token">
+  if (csrfToken) headers.set('X-CSRF-Token', csrfToken);
+
+  const response = await fetch(path, {
+    ...options,
+    headers,
+    credentials: 'same-origin',
+    body: options.json === undefined ? options.body : JSON.stringify(options.json),
+  });
+
+  // ...parse JSON, throw ApiError on !response.ok
+  return body as T;
+}
+```
+
+`getCsrfToken()` reads the token Rails already renders into the page via `csrf_meta_tags`. Because requests are same-origin with the CSRF header, Rails session auth keeps working.
+
+## Shared QueryClient Defaults
+
+Create the `QueryClient` from a single factory so SSR and client use identical defaults:
+
+```ts
+// app/javascript/lib/queryClient.ts
+import { QueryClient } from '@tanstack/react-query';
+
+export const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+```
+
+Mount the provider once, and keep the client stable across renders with `useMemo` (or `useState`). Creating `new QueryClient()` inline on every render throws the cache away on each render. See [Mistake 5 in the RSC context & state guide](../migrating/rsc-context-and-state.md) for the failure mode.
+
+```tsx
+const queryClient = useMemo(() => createQueryClient(), []);
+
+return (
+  <QueryClientProvider client={queryClient}>
+    {children}
+    {showDevtools ? <ReactQueryDevtools initialIsOpen={false} /> : null}
+  </QueryClientProvider>
+);
+```
+
+## Reading Server State With Stable Query Keys
+
+Every server-side input belongs in the query key, so the cache entry is unique per filter/sort/page and refetches when any of them change:
+
+```tsx
+const projectsQuery = useQuery({
+  queryKey: ['projects', status, sort, dir, page],
+  queryFn: () => {
+    const params = new URLSearchParams({ sort, dir, page: String(page), per_page: '8' });
+    if (status) params.set('status', status);
+    return apiFetch<ProjectsResponse>(`${api.projectsPath}?${params}`);
+  },
+});
+```
+
+The same query key identifies the same data on the server and the client. That is what lets the server-rendered cache and the client cache line up.
+
+## First Paint Without Spinners
+
+The common failure mode is rendering useful HTML on the server, then immediately showing a spinner and refetching everything on the client. Avoid it by seeding the first screen's data from Rails.
+
+**Rails renders the first page into props** (only on the route that shows the table, using the same query object as the JSON API so the seed equals a later refetch):
+
+```ruby
+# app/controllers/dashboard_controller.rb
+def show
+  @dashboard_props = {
+    api: { projectsPath: api_projects_path },
+    initialProjects: projects_table_initial_load? ? initial_projects : nil,
+    # ...
+  }
+end
+
+# Seed only on the initial full-page load of the table route. Seeding on other
+# routes can let a pre-mount mutation leave a stale seed the table later adopts
+# as fresh (staleTime: 30s). See starter PR #174.
+def projects_table_initial_load?
+  request.path == projects_path
+end
+```
+
+```erb
+<%# app/views/dashboard/show.html.erb %>
+<%= react_component("DashboardApp", props: @dashboard_props, prerender: !Rails.env.test?) %>
+```
+
+**The client adopts the seed as `initialData`** only when its params match the active query key, so the rows render in the initial HTML with no spinner and TanStack Query owns freshness from there:
+
+```tsx
+const { initialProjects } = useDashboardProps();
+
+const initialData =
+  initialProjects &&
+  initialProjects.params.status === status &&
+  initialProjects.params.sort === sort &&
+  initialProjects.params.dir === dir &&
+  initialProjects.params.page === page
+    ? initialProjects.response
+    : undefined;
+
+const projectsQuery = useQuery({
+  queryKey: ['projects', status, sort, dir, page],
+  queryFn: () => apiFetch<ProjectsResponse>(/* ... */),
+  initialData, // first page seeded from Rails; any other filter/sort/page fetches normally
+});
+```
+
+> **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once.
+
+## Mutations and Cache Invalidation
+
+Mutations write through the same `apiFetch` helper, then invalidate or directly update the affected cache entries so the table and metrics refresh once:
+
+```tsx
+const queryClient = useQueryClient();
+
+const mutation = useMutation({
+  mutationFn: (values: ProjectFormValues) =>
+    apiFetch<ProjectResponse>(api.projectsPath, { method: 'POST', json: { project: values } }),
+  onSuccess: ({ project }) => {
+    queryClient.setQueryData(['project', String(project.id)], { project });
+    queryClient.invalidateQueries({ queryKey: ['projects'] });
+    queryClient.invalidateQueries({ queryKey: ['metrics'] });
+  },
+});
+```
+
+This is cleaner than threading "reload this section" callbacks through many components: the cache is the single place that knows what is stale.
+
+## TanStack Query and React Server Components
+
+With React on Rails Pro's [React Server Components](../../pro/react-server-components/index.md), the two split the work:
+
+- **RSC** fetches data for server-rendered, non-interactive pieces. A server component can query a Rails model directly and stream HTML, with no `/api` round-trip and no serializer for that piece.
+- **TanStack Query** owns the interactive "live app" islands: refetching, mutations, optimistic updates, pagination, infinite scroll, background refresh, and cache invalidation.
+
+If you are migrating an existing React Query setup into an RSC app, see [Migrating from React Query / TanStack Query](../migrating/rsc-data-fetching.md#migrating-from-react-query--tanstack-query).
+
+## Why This Fits Rails Apps
+
+- **Less frontend state boilerplate.** Server state ("current user," "projects," "messages," search results) belongs in the query cache, not in Redux or a hand-rolled global store.
+- **Better perceived performance.** The page ships with useful data already present, then stays fresh on the client. You keep the SEO and first-load benefits of server rendering.
+- **Gradual modernization.** Adopt it one React island or one page at a time. No single-page-app rewrite, no framework swap.
+
+## Working Example
+
+The [React on Rails + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack) (Rails 8 + React 19 + React on Rails Pro) implements every pattern above. The relevant files, each marked with a `REFERENCE PATTERN` comment:
+
+- Shared fetch + client: `app/javascript/lib/apiFetch.ts`, `app/javascript/lib/getCsrfToken.ts`, `app/javascript/lib/queryClient.ts`
+- Queries, mutations, provider: `app/javascript/src/Dashboard/ror_components/DashboardApp.tsx`
+- Rails JSON API: `app/controllers/api/projects_controller.rb`
+- SSR seed: `app/controllers/dashboard_controller.rb`, `app/views/dashboard/show.html.erb`
+
+Try it live at [starter.reactonrails.com](https://starter.reactonrails.com).
+
+## References
+
+- [Using TanStack Router](./tanstack-router.md) (the Pro SSR boundary this pairs with)
+- [Migrating from React Query / TanStack Query](../migrating/rsc-data-fetching.md#migrating-from-react-query--tanstack-query)
+- [RSC Context & State](../migrating/rsc-context-and-state.md)
+- [TanStack Query docs](https://tanstack.com/query/latest)
+- [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr)

--- a/docs/oss/building-features/tanstack-query.md
+++ b/docs/oss/building-features/tanstack-query.md
@@ -12,6 +12,12 @@ It is the recommended client-side server-state layer for Rails-backed React apps
 
 This guide mirrors the official [React on Rails + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack) ([live demo](https://starter.reactonrails.com)). Every snippet below is drawn from that app.
 
+## Install
+
+```bash
+pnpm add @tanstack/react-query
+```
+
 ## Rails Stays the Source of Truth
 
 A normal Rails controller returns explicit JSON, never raw Active Record:
@@ -40,6 +46,10 @@ Put the same-origin and CSRF handling in exactly one place so every query and mu
 
 ```ts
 // app/javascript/lib/apiFetch.ts
+import { getCsrfToken } from './getCsrfToken';
+
+type ApiFetchOptions = RequestInit & { json?: unknown };
+
 export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
   const headers = new Headers(options.headers);
   headers.set('Accept', 'application/json');
@@ -82,7 +92,7 @@ export const createQueryClient = () =>
   });
 ```
 
-Mount the provider once, and keep the client stable across renders with `useMemo` (or `useState`). Creating `new QueryClient()` inline on every render throws the cache away on each render. See [Mistake 5 in the RSC context & state guide](../migrating/rsc-context-and-state.md) for the failure mode.
+Mount the provider once, and keep the client stable across renders with `useMemo` (or `useState`). Creating `new QueryClient()` inline on every render throws the cache away on each render. See [Mistake 5 in the RSC context & state guide](../migrating/rsc-context-and-state.md#mistake-5-creating-new-queryclient-on-every-render) for the failure mode.
 
 ```tsx
 const queryClient = useMemo(() => createQueryClient(), []);
@@ -161,6 +171,8 @@ const projectsQuery = useQuery({
   initialData, // first page seeded from Rails; any other filter/sort/page fetches normally
 });
 ```
+
+Because the seed is passed as `initialData` without `initialDataUpdatedAt`, TanStack Query timestamps it at `0`, so the table does one background refetch on mount to confirm freshness — the rows still paint immediately, with no spinner. To treat the seed as fresh for `staleTime` and skip that first refetch, also pass `initialDataUpdatedAt` set to the server's render time.
 
 > **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once.
 

--- a/docs/oss/building-features/tanstack-router.md
+++ b/docs/oss/building-features/tanstack-router.md
@@ -126,3 +126,4 @@ end
 - [Render-Functions Guide](../core-concepts/render-functions.md)
 - [View Helpers API](../api-reference/view-helpers-api.md)
 - [React Router Guide](./react-router.md)
+- [TanStack Query Guide](./tanstack-query.md) (the client-side server-state layer this pairs with)

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -382,6 +382,8 @@ Calling `emit.call` from concurrent fibers is safe: the reactor is single-thread
 
 ## Migrating from React Query / TanStack Query
 
+> **New to TanStack Query on Rails?** This section covers _migrating_ an existing React Query setup into RSC. For a from-scratch guide to the recommended patterns (CSRF-aware fetch, stable query keys, first-paint seeding, and mutations), see [Using TanStack Query](../building-features/tanstack-query.md).
+
 React Query remains valuable in the RSC world for features like polling, optimistic updates, and infinite scrolling. But for simple data display, Server Components replace it entirely.
 
 ### Pattern 1: Simple Replacement (No Client Cache Needed)

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -95,6 +95,7 @@ const sidebars: SidebarsConfig = {
             'building-features/accessibility',
             'building-features/forms',
             'building-features/react-and-redux',
+            'building-features/tanstack-query',
             'building-features/styling-with-tailwind',
             'building-features/i18n',
             'building-features/images',

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -1046,7 +1046,7 @@ bundle exec rails generate react_on_rails:install --rsc
 bundle exec rails generate react_on_rails:rsc
 ```
 
-The RSC generator creates `rscWebpackConfig.js`, adds `RSCWebpackPlugin` to both server and client webpack configs, configures `RSC_BUNDLE_ONLY` handling in `ServerClientOrBoth.js`, and sets up the RSC bundle watcher process. See [React Server Components](./react-server-components/tutorial.md) for more information.
+The RSC generator creates `rscWebpackConfig.js` in the active bundler config directory (`config/webpack/` or `config/rspack/`), adds the RSC bundler plugin to both server and client configs, configures `RSC_BUNDLE_ONLY` handling in `ServerClientOrBoth.js`, and sets up the RSC bundle watcher process. See [React Server Components](./react-server-components/tutorial.md) for more information.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5250,6 +5250,7 @@ end
 - [Render-Functions Guide](../core-concepts/render-functions.md)
 - [View Helpers API](../api-reference/view-helpers-api.md)
 - [React Router Guide](./react-router.md)
+- [TanStack Query Guide](./tanstack-query.md) (the client-side server-state layer this pairs with)
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/building-features/client-side-routing-instant-navigation
@@ -8722,6 +8723,12 @@ It is the recommended client-side server-state layer for Rails-backed React apps
 
 This guide mirrors the official [React on Rails + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack) ([live demo](https://starter.reactonrails.com)). Every snippet below is drawn from that app.
 
+## Install
+
+```bash
+pnpm add @tanstack/react-query
+```
+
 ## Rails Stays the Source of Truth
 
 A normal Rails controller returns explicit JSON, never raw Active Record:
@@ -8750,6 +8757,10 @@ Put the same-origin and CSRF handling in exactly one place so every query and mu
 
 ```ts
 // app/javascript/lib/apiFetch.ts
+import { getCsrfToken } from './getCsrfToken';
+
+type ApiFetchOptions = RequestInit & { json?: unknown };
+
 export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
   const headers = new Headers(options.headers);
   headers.set('Accept', 'application/json');
@@ -8792,7 +8803,7 @@ export const createQueryClient = () =>
   });
 ```
 
-Mount the provider once, and keep the client stable across renders with `useMemo` (or `useState`). Creating `new QueryClient()` inline on every render throws the cache away on each render. See [Mistake 5 in the RSC context & state guide](../migrating/rsc-context-and-state.md) for the failure mode.
+Mount the provider once, and keep the client stable across renders with `useMemo` (or `useState`). Creating `new QueryClient()` inline on every render throws the cache away on each render. See [Mistake 5 in the RSC context & state guide](../migrating/rsc-context-and-state.md#mistake-5-creating-new-queryclient-on-every-render) for the failure mode.
 
 ```tsx
 const queryClient = useMemo(() => createQueryClient(), []);
@@ -8871,6 +8882,8 @@ const projectsQuery = useQuery({
   initialData, // first page seeded from Rails; any other filter/sort/page fetches normally
 });
 ```
+
+Because the seed is passed as `initialData` without `initialDataUpdatedAt`, TanStack Query timestamps it at `0`, so the table does one background refetch on mount to confirm freshness — the rows still paint immediately, with no spinner. To treat the seed as fresh for `staleTime` and skip that first refetch, also pass `initialDataUpdatedAt` set to the server's render time.
 
 > **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once.
 
@@ -19236,7 +19249,7 @@ RSC builds on React on Rails Pro's Node rendering infrastructure. The generator 
 
 In addition to all Pro files:
 
-- `config/webpack/rscWebpackConfig.js` - RSC-specific webpack configuration
+- `config/webpack/rscWebpackConfig.js` or `config/rspack/rscWebpackConfig.js` - RSC-specific bundler configuration
 - `app/javascript/src/HelloServer/` - Example RSC component (replaces HelloWorld)
 - `app/controllers/hello_server_controller.rb` - Controller with streaming support
 - `app/views/hello_server/index.html.erb` - View using `stream_react_component`
@@ -26245,6 +26258,8 @@ Calling `emit.call` from concurrent fibers is safe: the reactor is single-thread
 
 ## Migrating from React Query / TanStack Query
 
+> **New to TanStack Query on Rails?** This section covers _migrating_ an existing React Query setup into RSC. For a from-scratch guide to the recommended patterns (CSRF-aware fetch, stable query keys, first-paint seeding, and mutations), see [Using TanStack Query](../building-features/tanstack-query.md).
+
 React Query remains valuable in the RSC world for features like polling, optimistic updates, and infinite scrolling. But for simple data display, Server Components replace it entirely.
 
 ### Pattern 1: Simple Replacement (No Client Cache Needed)
@@ -27880,6 +27895,7 @@ When something goes wrong during RSC migration, start here. This table maps symp
 | `ReferenceError: fetch is not defined` (or `Headers`, `Request`, `Response`, `AbortController`, `AbortSignal`) | Node renderer VM context missing fetch globals                                               | [Node Renderer VM Context](#node-renderer-vm-context----missing-globals)                      |
 | `ReferenceError: require is not defined`                                                                       | Server bundle or RSC bundle uses `externals` for Node builtins instead of `resolve.fallback` | [Handling Node Builtins](#handling-node-builtins----externals-vs-resolvefallback)             |
 | `ReferenceError: MessageChannel is not defined`                                                                | `react-dom/server.browser` needs `MessageChannel` at load time in VM sandbox                 | [MessageChannel Not Defined](#messagechannel-not-defined)                                     |
+| RSC says a module is missing from the React Client Manifest and the manifest is empty in Rspack `bin/dev`      | Rspack lazy compilation deferred RSC client references before the server renderer read them  | [Empty Client Manifest with Rspack Dev Server](#empty-client-manifest-with-rspack-dev-server) |
 | SSR hangs or times out on large pages                                                                          | Stream backpressure deadlock                                                                 | [Stream Backpressure Deadlock](#stream-backpressure-deadlock)                                 |
 | Rails boot error about version mismatch                                                                        | Gem and npm package at different versions                                                    | [Gem and npm Package Version Mismatch](#gem-and-npm-package-version-mismatch)                 |
 | 422 Unprocessable Entity on form submission                                                                    | Missing CSRF token in fetch request                                                          | [Mutations](rsc-data-fetching.md#mutations-rails-controllers-not-server-actions)              |
@@ -28630,6 +28646,54 @@ class Api::UsersController < ApplicationController
 end
 ```
 
+## Empty Client Manifest with Rspack Dev Server
+
+In RSC apps that use Rspack, normal `bin/dev` dev-server mode must compile RSC client references before the server renderer reads the React Client Manifest. If Rspack lazy compilation is still enabled, the first server render can see an empty manifest and fail with an error like:
+
+```text
+Could not find the module ".../LikeButton.jsx#default" in the React Client Manifest.
+```
+
+Common signs:
+
+- `react-client-manifest.json` contains `"filePathToModuleMetadata": {}`
+- the generated Rspack client bundle mentions `lazy-compilation-proxy`
+- the browser sends `POST /_rspack/lazy/trigger` and Rails returns `404`
+- `bin/dev static` works, but normal `bin/dev` fails
+
+Run the RSC doctor first:
+
+```bash
+bundle exec rails react_on_rails:doctor:rsc
+```
+
+For existing generated apps, update `config/rspack/development.js` so the Rspack dev-server branch disables lazy compilation when an RSC config is present:
+
+```js
+const developmentEnvOnly = (clientWebpackConfig, _serverWebpackConfig, rscWebpackConfig) => {
+  if (process.env.WEBPACK_SERVE) {
+    if (config.assets_bundler === 'rspack') {
+      const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+      clientWebpackConfig.plugins.push(new ReactRefreshRspackPlugin());
+
+      if (rscWebpackConfig) {
+        clientWebpackConfig.lazyCompilation = false;
+      }
+    }
+  }
+};
+```
+
+Also verify that `config/rspack/ServerClientOrBoth.js` passes the RSC config as the third argument to the environment-specific config hook:
+
+```js
+envSpecific(clientConfig, serverConfig, rscConfig);
+```
+
+If it only passes `clientConfig` and `serverConfig`, rerun the RSC generator to refresh both `ServerClientOrBoth.js` and `development.js`.
+
+Fresh generator output includes this guard. If your config has been heavily customized, keep the important behavior: RSC + Rspack + dev-server mode should set `clientWebpackConfig.lazyCompilation = false`.
+
 ## Bundle Analysis Tools
 
 | Tool                                                                                                                          | Purpose                                                          |
@@ -28666,6 +28730,7 @@ end
 | `ReferenceError: require is not defined`                                                                                     | Server or RSC bundle webpack config uses `externals` for Node builtins, generating `require()` calls that fail in VM sandbox                                                                       | Use `resolve.fallback: { path: false, fs: false }` instead of `externals`. See [Handling Node Builtins](#handling-node-builtins----externals-vs-resolvefallback)                                                                                                       |
 | `ReferenceError: MessageChannel is not defined`                                                                              | `react-dom/server.browser` instantiates `MessageChannel` at module load time; VM sandbox lacks this global                                                                                         | Inject a `BannerPlugin` polyfill in the server webpack config. See [MessageChannel Not Defined](#messagechannel-not-defined)                                                                                                                                           |
 | `"global object mismatch"`                                                                                                   | `react-on-rails` and `react-on-rails-pro` resolved from different sources (e.g., npm vs yalc)                                                                                                      | Force consistent resolution with `pnpm.overrides` or `yarn.resolutions`. See [Version Mismatch](#version-mismatch----global-object-mismatch)                                                                                                                           |
+| Missing module in React Client Manifest with empty `filePathToModuleMetadata` in Rspack `bin/dev`                            | Rspack lazy compilation deferred RSC client references before manifest generation                                                                                                                  | Disable Rspack lazy compilation for RSC dev-server mode. See [Empty Client Manifest with Rspack Dev Server](#empty-client-manifest-with-rspack-dev-server)                                                                                                             |
 | SSR hangs indefinitely / request timeout on large RSC payloads                                                               | Stream backpressure deadlock when RSC payload exceeds 16 KB                                                                                                                                        | Update to latest React on Rails Pro. See [Stream Backpressure Deadlock](#stream-backpressure-deadlock)                                                                                                                                                                 |
 | `"The 'react-on-rails' package version does not match the gem version"`                                                      | Gem and npm package installed at different versions                                                                                                                                                | Install the npm package version matching your gem. See [Gem and npm Package Version Mismatch](#gem-and-npm-package-version-mismatch)                                                                                                                                   |
 | `"The 'react-on-rails' package version is not an exact version"`                                                             | Using semver ranges (`^`, `~`, `*`) instead of an exact version in package.json                                                                                                                    | Pin to the exact version without range operators. See [Gem and npm Package Version Mismatch](#gem-and-npm-package-version-mismatch)                                                                                                                                    |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8776,7 +8776,7 @@ export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): 
     body: options.json === undefined ? options.body : JSON.stringify(options.json),
   });
 
-  // ...parse JSON, throw ApiError on !response.ok
+  const body = await response.json(); // the starter also handles non-JSON and throws ApiError on !response.ok
   return body as T;
 }
 ```
@@ -8885,7 +8885,7 @@ const projectsQuery = useQuery({
 
 Because the seed is passed as `initialData` without `initialDataUpdatedAt`, TanStack Query timestamps it at `0`, so the table does one background refetch on mount to confirm freshness — the rows still paint immediately, with no spinner. To treat the seed as fresh for `staleTime` and skip that first refetch, also pass `initialDataUpdatedAt` set to the server's render time.
 
-> **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once.
+> **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once. Note that the `prefetchQuery`/`dehydrate` path needs an awaitable server-render boundary (the Pro [TanStack Router SSR](./tanstack-router.md) path), whereas the props-to-`initialData` seed works in open source.
 
 ## Mutations and Cache Invalidation
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8704,6 +8704,231 @@ export const initialStates = {
 ```
 
 ================================================================================
+PAGE: https://reactonrails.com/docs/building-features/tanstack-query
+SOURCE: docs/oss/building-features/tanstack-query.md
+================================================================================
+
+# Using TanStack Query
+
+[TanStack Query](https://tanstack.com/query) (formerly React Query) manages **server state in the browser**: caching, request deduplication, background refetching, retries, and cache invalidation. Rails is excellent at server-side data; TanStack Query gives the React side a disciplined way to consume that data without hand-rolling loading flags, retry logic, and ad-hoc caches.
+
+It is the recommended client-side server-state layer for Rails-backed React apps. Rails keeps owning data, routes, auth, sessions, CSRF, validations, mailers, and jobs. TanStack Query does not replace any of that; it consumes the JSON Rails already knows how to produce.
+
+## Support Model
+
+- **Client-side TanStack Query works in open-source React on Rails** with no special integration. It is a standard React library; register a component that mounts `QueryClientProvider` and you are done.
+- **First-paint data seeding** (rendering useful rows in the server HTML, then letting the client reuse them) needs nothing more than React on Rails passing the first screen's data as props. The client adopts it through `useQuery({ initialData })`. This works in OSS and Pro alike.
+- **Full TanStack Router SSR** (server-rendering the route tree and hydrating it) **requires React on Rails Pro**. See [Using TanStack Router](./tanstack-router.md). TanStack Query composes with that boundary but does not depend on it.
+
+This guide mirrors the official [React on Rails + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack) ([live demo](https://starter.reactonrails.com)). Every snippet below is drawn from that app.
+
+## Rails Stays the Source of Truth
+
+A normal Rails controller returns explicit JSON, never raw Active Record:
+
+```ruby
+# app/controllers/api/projects_controller.rb
+module Api
+  class ProjectsController < BaseController
+    def index
+      result = ProjectsQuery.from_params(Current.user.projects, params).result
+
+      render json: {
+        projects: result[:records].map { |project| ProjectSerializer.one(project) },
+        meta: result[:meta]
+      }
+    end
+  end
+end
+```
+
+Filtering, sorting, pagination, and authorization stay in Rails. The React side never reaches past this boundary.
+
+## One CSRF-Aware Fetch Helper
+
+Put the same-origin and CSRF handling in exactly one place so every query and mutation goes through it:
+
+```ts
+// app/javascript/lib/apiFetch.ts
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const headers = new Headers(options.headers);
+  headers.set('Accept', 'application/json');
+  if (options.json !== undefined) headers.set('Content-Type', 'application/json');
+
+  const csrfToken = getCsrfToken(); // reads <meta name="csrf-token">
+  if (csrfToken) headers.set('X-CSRF-Token', csrfToken);
+
+  const response = await fetch(path, {
+    ...options,
+    headers,
+    credentials: 'same-origin',
+    body: options.json === undefined ? options.body : JSON.stringify(options.json),
+  });
+
+  // ...parse JSON, throw ApiError on !response.ok
+  return body as T;
+}
+```
+
+`getCsrfToken()` reads the token Rails already renders into the page via `csrf_meta_tags`. Because requests are same-origin with the CSRF header, Rails session auth keeps working.
+
+## Shared QueryClient Defaults
+
+Create the `QueryClient` from a single factory so SSR and client use identical defaults:
+
+```ts
+// app/javascript/lib/queryClient.ts
+import { QueryClient } from '@tanstack/react-query';
+
+export const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+```
+
+Mount the provider once, and keep the client stable across renders with `useMemo` (or `useState`). Creating `new QueryClient()` inline on every render throws the cache away on each render. See [Mistake 5 in the RSC context & state guide](../migrating/rsc-context-and-state.md) for the failure mode.
+
+```tsx
+const queryClient = useMemo(() => createQueryClient(), []);
+
+return (
+  <QueryClientProvider client={queryClient}>
+    {children}
+    {showDevtools ? <ReactQueryDevtools initialIsOpen={false} /> : null}
+  </QueryClientProvider>
+);
+```
+
+## Reading Server State With Stable Query Keys
+
+Every server-side input belongs in the query key, so the cache entry is unique per filter/sort/page and refetches when any of them change:
+
+```tsx
+const projectsQuery = useQuery({
+  queryKey: ['projects', status, sort, dir, page],
+  queryFn: () => {
+    const params = new URLSearchParams({ sort, dir, page: String(page), per_page: '8' });
+    if (status) params.set('status', status);
+    return apiFetch<ProjectsResponse>(`${api.projectsPath}?${params}`);
+  },
+});
+```
+
+The same query key identifies the same data on the server and the client. That is what lets the server-rendered cache and the client cache line up.
+
+## First Paint Without Spinners
+
+The common failure mode is rendering useful HTML on the server, then immediately showing a spinner and refetching everything on the client. Avoid it by seeding the first screen's data from Rails.
+
+**Rails renders the first page into props** (only on the route that shows the table, using the same query object as the JSON API so the seed equals a later refetch):
+
+```ruby
+# app/controllers/dashboard_controller.rb
+def show
+  @dashboard_props = {
+    api: { projectsPath: api_projects_path },
+    initialProjects: projects_table_initial_load? ? initial_projects : nil,
+    # ...
+  }
+end
+
+# Seed only on the initial full-page load of the table route. Seeding on other
+# routes can let a pre-mount mutation leave a stale seed the table later adopts
+# as fresh (staleTime: 30s). See starter PR #174.
+def projects_table_initial_load?
+  request.path == projects_path
+end
+```
+
+```erb
+<%# app/views/dashboard/show.html.erb %>
+<%= react_component("DashboardApp", props: @dashboard_props, prerender: !Rails.env.test?) %>
+```
+
+**The client adopts the seed as `initialData`** only when its params match the active query key, so the rows render in the initial HTML with no spinner and TanStack Query owns freshness from there:
+
+```tsx
+const { initialProjects } = useDashboardProps();
+
+const initialData =
+  initialProjects &&
+  initialProjects.params.status === status &&
+  initialProjects.params.sort === sort &&
+  initialProjects.params.dir === dir &&
+  initialProjects.params.page === page
+    ? initialProjects.response
+    : undefined;
+
+const projectsQuery = useQuery({
+  queryKey: ['projects', status, sort, dir, page],
+  queryFn: () => apiFetch<ProjectsResponse>(/* ... */),
+  initialData, // first page seeded from Rails; any other filter/sort/page fetches normally
+});
+```
+
+> **`initialData` vs `dehydrate`/`HydrationBoundary`.** TanStack Query also ships a server-prefetch pattern: build a `QueryClient`, `prefetchQuery`, `dehydrate` it into the HTML, and wrap the client tree in `HydrationBoundary`. See the [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr). The starter uses the simpler props-to-`initialData` seed because Rails already renders the first page; reach for `dehydrate`/`HydrationBoundary` when you need to seed many queries at once.
+
+## Mutations and Cache Invalidation
+
+Mutations write through the same `apiFetch` helper, then invalidate or directly update the affected cache entries so the table and metrics refresh once:
+
+```tsx
+const queryClient = useQueryClient();
+
+const mutation = useMutation({
+  mutationFn: (values: ProjectFormValues) =>
+    apiFetch<ProjectResponse>(api.projectsPath, { method: 'POST', json: { project: values } }),
+  onSuccess: ({ project }) => {
+    queryClient.setQueryData(['project', String(project.id)], { project });
+    queryClient.invalidateQueries({ queryKey: ['projects'] });
+    queryClient.invalidateQueries({ queryKey: ['metrics'] });
+  },
+});
+```
+
+This is cleaner than threading "reload this section" callbacks through many components: the cache is the single place that knows what is stale.
+
+## TanStack Query and React Server Components
+
+With React on Rails Pro's [React Server Components](../../pro/react-server-components/index.md), the two split the work:
+
+- **RSC** fetches data for server-rendered, non-interactive pieces. A server component can query a Rails model directly and stream HTML, with no `/api` round-trip and no serializer for that piece.
+- **TanStack Query** owns the interactive "live app" islands: refetching, mutations, optimistic updates, pagination, infinite scroll, background refresh, and cache invalidation.
+
+If you are migrating an existing React Query setup into an RSC app, see [Migrating from React Query / TanStack Query](../migrating/rsc-data-fetching.md#migrating-from-react-query--tanstack-query).
+
+## Why This Fits Rails Apps
+
+- **Less frontend state boilerplate.** Server state ("current user," "projects," "messages," search results) belongs in the query cache, not in Redux or a hand-rolled global store.
+- **Better perceived performance.** The page ships with useful data already present, then stays fresh on the client. You keep the SEO and first-load benefits of server rendering.
+- **Gradual modernization.** Adopt it one React island or one page at a time. No single-page-app rewrite, no framework swap.
+
+## Working Example
+
+The [React on Rails + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack) (Rails 8 + React 19 + React on Rails Pro) implements every pattern above. The relevant files, each marked with a `REFERENCE PATTERN` comment:
+
+- Shared fetch + client: `app/javascript/lib/apiFetch.ts`, `app/javascript/lib/getCsrfToken.ts`, `app/javascript/lib/queryClient.ts`
+- Queries, mutations, provider: `app/javascript/src/Dashboard/ror_components/DashboardApp.tsx`
+- Rails JSON API: `app/controllers/api/projects_controller.rb`
+- SSR seed: `app/controllers/dashboard_controller.rb`, `app/views/dashboard/show.html.erb`
+
+Try it live at [starter.reactonrails.com](https://starter.reactonrails.com).
+
+## References
+
+- [Using TanStack Router](./tanstack-router.md) (the Pro SSR boundary this pairs with)
+- [Migrating from React Query / TanStack Query](../migrating/rsc-data-fetching.md#migrating-from-react-query--tanstack-query)
+- [RSC Context & State](../migrating/rsc-context-and-state.md)
+- [TanStack Query docs](https://tanstack.com/query/latest)
+- [TanStack Query SSR guide](https://tanstack.com/query/latest/docs/framework/react/guides/ssr)
+
+================================================================================
 PAGE: https://reactonrails.com/docs/building-features/styling-with-tailwind
 SOURCE: docs/oss/building-features/styling-with-tailwind.md
 ================================================================================


### PR DESCRIPTION
## What

Adds a standalone guide: **[Using TanStack Query](docs/oss/building-features/tanstack-query.md)** (`docs/oss/building-features/tanstack-query.md`).

We already document TanStack Query, but only scattered through the RSC *migration* guides (`rsc-data-fetching.md`, `rsc-context-and-state.md`, `rsc-third-party-libs.md`) framed as "migrating from." There was no peer to [Using TanStack Router](docs/oss/building-features/tanstack-router.md) presenting Query as the recommended client-side server-state layer for Rails-backed React apps. This fills that gap.

## Reconciled to the real starter

Every snippet is drawn from the official [react-on-rails-starter-tanstack](https://github.com/shakacode/react-on-rails-starter-tanstack) (live at [starter.reactonrails.com](https://starter.reactonrails.com)), not idealized pseudo-code. Notably it documents what the starter **actually** does for first paint: Rails renders the first page into props and the client adopts it via `useQuery({ initialData })` (with the stale-seed route guard from starter PR #174), and explains how that differs from TanStack Query's `dehydrate`/`HydrationBoundary` pattern.

Covers: Rails as source of truth (JSON controllers/serializers), one CSRF-aware `apiFetch`, shared `QueryClient` defaults + stable provider, stable query keys, first-paint seeding, mutations with `invalidateQueries`/`setQueryData`, and how Query splits work with RSC.

## Accuracy notes

- Client-side TanStack Query is framed as **OSS-compatible** (no special integration). The `initialData` first-paint seed is just props, also OSS-compatible. Only the full **TanStack Router SSR** boundary is called out as Pro-only (links to the existing Router guide).
- Placed in the **Integrations** sidebar group next to `react-and-redux` (Query is server-state management, the direct analog to Redux).

## Validation

- `node script/generate-llms-full.mjs --check` — passes (regenerated `llms-full.txt`; `llms-full-pro.txt` unchanged, OSS-only page).
- `script/check-docs-sidebar` — passes (page is listed, not orphaned).
- `prettier --check` (3.6.2) — clean. Pre-commit lefthook (prettier/eslint/markdown-links/trailing-newlines) — all green.
- All relative link targets verified to exist.

## Possible follow-ups (not in this PR)

- Inbound cross-links from the RSC/migration and comparison docs to this guide (discoverability).
- A short "Docs" pointer in the starter repo README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Using TanStack Query” guide for Rails-backed React apps, covering CSRF-aware fetching, app-wide QueryClient setup, stable query keys, first-paint loading from Rails-seeded data, and mutation/cache update patterns.
  * Linked the guide from related integration and references sections, and added a migration intro note pointing to the from-scratch approach.
* **Troubleshooting / Pro Documentation**
  * Expanded Rspack dev-server troubleshooting for empty React Client Manifest with lazy compilation, including verification steps and mitigation guidance.
  * Updated the React on Rails Pro RSC generator description to be bundler-agnostic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->