### PR TITLE
docs: cross-link the TanStack Query guide from related pages

### DIFF
--- a/docs/oss/building-features/tanstack-router.md
+++ b/docs/oss/building-features/tanstack-router.md
@@ -126,3 +126,4 @@ end
 - [Render-Functions Guide](../core-concepts/render-functions.md)
 - [View Helpers API](../api-reference/view-helpers-api.md)
 - [React Router Guide](./react-router.md)
+- [TanStack Query Guide](./tanstack-query.md) (the client-side server-state layer this pairs with)

--- a/docs/oss/migrating/rsc-data-fetching.md
+++ b/docs/oss/migrating/rsc-data-fetching.md
@@ -382,6 +382,8 @@ Calling `emit.call` from concurrent fibers is safe: the reactor is single-thread
 
 ## Migrating from React Query / TanStack Query
 
+> **New to TanStack Query on Rails?** This section covers _migrating_ an existing React Query setup into RSC. For a from-scratch guide to the recommended patterns (CSRF-aware fetch, stable query keys, first-paint seeding, and mutations), see [Using TanStack Query](../building-features/tanstack-query.md).
+
 React Query remains valuable in the RSC world for features like polling, optimistic updates, and infinite scrolling. But for simple data display, Server Components replace it entirely.
 
 ### Pattern 1: Simple Replacement (No Client Cache Needed)


### PR DESCRIPTION
## What

Makes the new **[Using TanStack Query](https://github.com/shakacode/react_on_rails/pull/4237)** guide discoverable by linking to it from the two most relevant existing pages:

- **`rsc-data-fetching.md`** — a callout at the *"Migrating from React Query / TanStack Query"* section steers readers who want the from-scratch patterns (not migration) to the guide.
- **`tanstack-router.md`** — adds the Query guide to its References (the Router/Query pair).

## Stacked on #4237

> **Base branch is `jg/docs-tanstack-query-guide`** (PR #4237), because the link targets only exist once that PR's `tanstack-query.md` lands. The link-check would fail against `main`. After #4237 merges, I'll retarget this to `main` and rebase.

## Validation

- Content-only edits (no `sidebars.ts`), so `check-llms-full` runs in `--validate` mode; no `llms-full` regeneration needed (the daily bot refreshes it).
- Pre-commit lefthook (prettier/markdown-links/trailing-newlines) — green. 3 insertions, 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
