### PR TITLE
docs: add "React on Rails vs TanStack Start" to the decision guide

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -82,6 +82,7 @@ exclude = [
   '^https://angularjs\.org/?$',            # Connection failed from CI
   '^https://frigade\.com/blog/bundle-size-reduction-with-rsc-and-frigade/?$', # Connection failed from CI
   '^https://tanstack\.com/router',           # Connection failed from CI
+  '^https://tanstack\.com/start',            # Connection failed from CI (tanstack.com blocks/timeouts in CI)
   '^https://tanstack\.com/query/latest/docs/framework/react/guides/ssr$', # Connection failed from CI
   '^https://lodash\.com',                    # Connection reset from CI
   '^https://vite-ruby\.netlify\.app/?$',     # Intermittent connection resets from CI

--- a/docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
+++ b/docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
@@ -1,13 +1,13 @@
 ---
 sidebar_label: 'Decision Guide'
-description: Narrative decision guide for choosing React on Rails vs Hotwire, Inertia, Next.js, Vite, and react-rails.
+description: Narrative decision guide for choosing React on Rails vs Hotwire, Inertia, Next.js, TanStack Start, Vite, and react-rails.
 ---
 
 # Comparing React on Rails to Alternatives
 
 If you are evaluating frontend approaches for a Rails application, the right choice depends on how much of your UI should live in React, how much Rails should keep rendering, and whether server rendering is a requirement from day one.
 
-This page is intentionally practical. It focuses on the tradeoffs teams usually care about when choosing between React on Rails, Hotwire/Turbo, Inertia Rails, a Next.js frontend with a separate Rails backend API, react-rails, and Vite as a build tool.
+This page is intentionally practical. It focuses on the tradeoffs teams usually care about when choosing between React on Rails, Hotwire/Turbo, Inertia Rails, a Next.js frontend with a separate Rails backend API, TanStack Start, react-rails, and Vite as a build tool.
 
 ## Short Version
 
@@ -19,17 +19,20 @@ Choose **Inertia Rails** when you want its controller-to-page-props protocol and
 
 Choose **Next.js + separate Rails backend** when you want a hard frontend/backend boundary and are prepared to run two apps with an explicit API contract between them.
 
+Choose **TanStack Start** when you are greenfield with no existing Rails backend, want a single language across client and server, and are optimizing for raw velocity. If you have, or want, Rails, adopt the TanStack client libraries (Query, Router, Table) on top of Rails instead.
+
 If you are currently on **react-rails**, prefer the migration path to React on Rails rather than starting new work on react-rails.
 
 ## At a Glance
 
-| Option                   | Primary view model                                                  | Best fit                                                                              | What to watch                                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **React on Rails**       | Rails views rendering React components with tight Rails integration | Existing Rails apps, SSR, mixed Rails + React pages, progressive adoption             | More setup than lightweight helper-based integrations                                                                                                 |
-| **Hotwire/Turbo**        | Rails renders HTML, Turbo updates the page                          | Rails-first apps with minimal client-side complexity                                  | Not a React solution, so React ecosystem reuse is limited                                                                                             |
-| **Inertia Rails**        | Controllers return page props to a client-rendered frontend shell   | Teams that want SPA-style page transitions without building a separate JSON API first | Every navigation is a server round-trip; replaces Rails views per-route rather than incremental adoption; review current SSR support in official docs |
-| **Next.js + Rails API**  | Next.js app consumes Rails API responses                            | Teams prioritizing frontend autonomy, edge delivery, or multi-client API reuse        | Two deployables, duplicated auth/session concerns, and stricter API lifecycle management                                                              |
-| **react-rails (legacy)** | Rails views mount React components with helper-based integration    | Existing legacy apps already on react-rails                                           | Maintenance-focused path; plan migration to React on Rails for newer capabilities                                                                     |
+| Option                   | Primary view model                                                  | Best fit                                                                                   | What to watch                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **React on Rails**       | Rails views rendering React components with tight Rails integration | Existing Rails apps, SSR, mixed Rails + React pages, progressive adoption                  | More setup than lightweight helper-based integrations                                                                                                 |
+| **Hotwire/Turbo**        | Rails renders HTML, Turbo updates the page                          | Rails-first apps with minimal client-side complexity                                       | Not a React solution, so React ecosystem reuse is limited                                                                                             |
+| **Inertia Rails**        | Controllers return page props to a client-rendered frontend shell   | Teams that want SPA-style page transitions without building a separate JSON API first      | Every navigation is a server round-trip; replaces Rails views per-route rather than incremental adoption; review current SSR support in official docs |
+| **Next.js + Rails API**  | Next.js app consumes Rails API responses                            | Teams prioritizing frontend autonomy, edge delivery, or multi-client API reuse             | Two deployables, duplicated auth/session concerns, and stricter API lifecycle management                                                              |
+| **TanStack Start**       | Full-stack React framework (client-first; SSR opt-in per route)     | Greenfield React apps with no existing backend; one-language teams optimizing for velocity | Bring-your-own backend (database, ORM, auth, jobs); business logic runs in the JS runtime                                                             |
+| **react-rails (legacy)** | Rails views mount React components with helper-based integration    | Existing legacy apps already on react-rails                                                | Maintenance-focused path; plan migration to React on Rails for newer capabilities                                                                     |
 
 ## React on Rails vs Hotwire/Turbo
 
@@ -109,6 +112,36 @@ Choose React on Rails when your priority is delivering substantial React UI whil
 If this architecture is central to your evaluation, see the dedicated guide: [Next.js with a Separate Rails Backend: Pros and Drawbacks](./nextjs-with-separate-rails-backend.md).
 
 If React Server Components are central to your evaluation, see how the two stacks implement RSC at the architecture level — and the one ownership difference that drives the rest — in [React on Rails Pro and Next.js: RSC Architectures Compared](../../pro/react-server-components/nextjs-comparison.md).
+
+## React on Rails vs TanStack Start
+
+TanStack Start is a full-stack React framework built on TanStack Router and Vite. Unlike the Next.js App Router model, it is client-first: client-side interactivity is the default, and you opt into server-side rendering per route. Server logic lives in colocated **server functions**, and the data layer is bring-your-own — Start ships no ORM or database integration of its own.
+
+That makes this less of an "either/or" than it first looks, because the libraries TanStack publishes do not all play the same role for a Rails team:
+
+- **TanStack Query, Router, and Table are complementary.** They work well in front of a Rails backend, and React on Rails Pro can server-render TanStack Router (see the [TanStack Router guide](../building-features/tanstack-router.md)). Adopting them does not require leaving Rails.
+- **TanStack Start's server functions are the part that overlaps with Rails.** They put business logic, authorization, and data access into TypeScript functions on a Node server — the job Rails already does. If you have, or want, Rails, that is the layer you are choosing between.
+
+**TanStack Start:**
+
+- Pros: one language end to end, type safety across the client/server boundary, fine-grained per-route rendering, and a fast Vite dev loop. A strong fit for greenfield apps with no existing backend and a small team optimizing for velocity.
+- Drawbacks: you still assemble and own the backend — database, ORM, auth, background jobs — from separate libraries, and your business logic shares a runtime with your UI.
+
+**React on Rails:**
+
+- Pros: keep Rails for business logic, persistence, authorization, and jobs, with React — and the TanStack client libraries — as the view layer. React Server Components in React on Rails Pro give the same colocation benefit server functions are known for (server work next to the component, no `/api` round-trip or serializer for that view), except the data comes from Rails: your controller prepares it and passes it as props or streams it as async props.
+- Drawbacks: two languages (Ruby and TypeScript) rather than one, and an untyped JSON boundary between Rails and the client unless you generate types from your API.
+
+Choose TanStack Start when you are greenfield, have no Rails investment, want a single language end to end, and are optimizing for raw velocity.
+
+Choose React on Rails when you want a real backend — Rails — under a modern React frontend, and would rather adopt the TanStack client libraries on top of Rails than move your business logic into JavaScript.
+
+A runnable example of this architecture — React on Rails Pro with TanStack Query, Router, and Table against a Rails backend — is the [React on Rails Pro + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack). React Server Components require React on Rails Pro with the Node renderer.
+
+Official docs:
+
+- [TanStack Start documentation](https://tanstack.com/start/latest)
+- [TanStack Router on React on Rails](../building-features/tanstack-router.md)
 
 ## React on Rails vs react-rails (Legacy Path)
 

--- a/docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
+++ b/docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
@@ -31,7 +31,7 @@ If you are currently on **react-rails**, prefer the migration path to React on R
 | **Hotwire/Turbo**        | Rails renders HTML, Turbo updates the page                          | Rails-first apps with minimal client-side complexity                                       | Not a React solution, so React ecosystem reuse is limited                                                                                             |
 | **Inertia Rails**        | Controllers return page props to a client-rendered frontend shell   | Teams that want SPA-style page transitions without building a separate JSON API first      | Every navigation is a server round-trip; replaces Rails views per-route rather than incremental adoption; review current SSR support in official docs |
 | **Next.js + Rails API**  | Next.js app consumes Rails API responses                            | Teams prioritizing frontend autonomy, edge delivery, or multi-client API reuse             | Two deployables, duplicated auth/session concerns, and stricter API lifecycle management                                                              |
-| **TanStack Start**       | Full-stack React framework (client-first; SSR opt-in per route)     | Greenfield React apps with no existing backend; one-language teams optimizing for velocity | Bring-your-own backend (database, ORM, auth, jobs); business logic runs in the JS runtime                                                             |
+| **TanStack Start**       | Full-stack React framework (SSR-first; selective per-route SSR)     | Greenfield React apps with no existing backend; one-language teams optimizing for velocity | Bring-your-own backend (database, ORM, auth, jobs); business logic runs in the JS runtime                                                             |
 | **react-rails (legacy)** | Rails views mount React components with helper-based integration    | Existing legacy apps already on react-rails                                                | Maintenance-focused path; plan migration to React on Rails for newer capabilities                                                                     |
 
 ## React on Rails vs Hotwire/Turbo
@@ -115,7 +115,7 @@ If React Server Components are central to your evaluation, see how the two stack
 
 ## React on Rails vs TanStack Start
 
-TanStack Start is a full-stack React framework built on TanStack Router and Vite. Unlike the Next.js App Router model, it is client-first: client-side interactivity is the default, and you opt into server-side rendering per route. Server logic lives in colocated **server functions**, and the data layer is bring-your-own — Start ships no ORM or database integration of its own.
+TanStack Start is a full-stack React framework built on TanStack Router and Vite/Nitro. Like Remix, it is SSR-first: routes are server-rendered by default, with fine-grained selective SSR to opt a route out (or SPA mode) where you want it. Server logic lives in colocated **server functions**, and the data layer is bring-your-own — Start ships no ORM or database integration of its own.
 
 That makes this less of an "either/or" than it first looks, because the libraries TanStack publishes do not all play the same role for a Rails team:
 
@@ -129,7 +129,7 @@ That makes this less of an "either/or" than it first looks, because the librarie
 
 **React on Rails:**
 
-- Pros: keep Rails for business logic, persistence, authorization, and jobs, with React — and the TanStack client libraries — as the view layer. React Server Components in React on Rails Pro give the same colocation benefit server functions are known for (server work next to the component, no `/api` round-trip or serializer for that view), except the data comes from Rails: your controller prepares it and passes it as props or streams it as async props.
+- Pros: keep Rails for business logic, persistence, authorization, and jobs, with React — and the TanStack client libraries — as the view layer. React Server Components in React on Rails Pro remove the extra client-side `/api` round-trip for a view: data is prepared in your Rails controller and passed as props (or streamed as async props), and the React component tree renders on the Node renderer. (Start's server functions colocate logic in the same file with end-to-end types; on Rails that logic stays in Rails, across a JSON boundary — see the drawback below.)
 - Drawbacks: two languages (Ruby and TypeScript) rather than one, and an untyped JSON boundary between Rails and the client unless you generate types from your API.
 
 Choose TanStack Start when you are greenfield, have no Rails investment, want a single language end to end, and are optimizing for raw velocity.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1962,7 +1962,7 @@ If you are currently on **react-rails**, prefer the migration path to React on R
 | **Hotwire/Turbo**        | Rails renders HTML, Turbo updates the page                          | Rails-first apps with minimal client-side complexity                                       | Not a React solution, so React ecosystem reuse is limited                                                                                             |
 | **Inertia Rails**        | Controllers return page props to a client-rendered frontend shell   | Teams that want SPA-style page transitions without building a separate JSON API first      | Every navigation is a server round-trip; replaces Rails views per-route rather than incremental adoption; review current SSR support in official docs |
 | **Next.js + Rails API**  | Next.js app consumes Rails API responses                            | Teams prioritizing frontend autonomy, edge delivery, or multi-client API reuse             | Two deployables, duplicated auth/session concerns, and stricter API lifecycle management                                                              |
-| **TanStack Start**       | Full-stack React framework (client-first; SSR opt-in per route)     | Greenfield React apps with no existing backend; one-language teams optimizing for velocity | Bring-your-own backend (database, ORM, auth, jobs); business logic runs in the JS runtime                                                             |
+| **TanStack Start**       | Full-stack React framework (SSR-first; selective per-route SSR)     | Greenfield React apps with no existing backend; one-language teams optimizing for velocity | Bring-your-own backend (database, ORM, auth, jobs); business logic runs in the JS runtime                                                             |
 | **react-rails (legacy)** | Rails views mount React components with helper-based integration    | Existing legacy apps already on react-rails                                                | Maintenance-focused path; plan migration to React on Rails for newer capabilities                                                                     |
 
 ## React on Rails vs Hotwire/Turbo
@@ -2046,7 +2046,7 @@ If React Server Components are central to your evaluation, see how the two stack
 
 ## React on Rails vs TanStack Start
 
-TanStack Start is a full-stack React framework built on TanStack Router and Vite. Unlike the Next.js App Router model, it is client-first: client-side interactivity is the default, and you opt into server-side rendering per route. Server logic lives in colocated **server functions**, and the data layer is bring-your-own — Start ships no ORM or database integration of its own.
+TanStack Start is a full-stack React framework built on TanStack Router and Vite/Nitro. Like Remix, it is SSR-first: routes are server-rendered by default, with fine-grained selective SSR to opt a route out (or SPA mode) where you want it. Server logic lives in colocated **server functions**, and the data layer is bring-your-own — Start ships no ORM or database integration of its own.
 
 That makes this less of an "either/or" than it first looks, because the libraries TanStack publishes do not all play the same role for a Rails team:
 
@@ -2060,7 +2060,7 @@ That makes this less of an "either/or" than it first looks, because the librarie
 
 **React on Rails:**
 
-- Pros: keep Rails for business logic, persistence, authorization, and jobs, with React — and the TanStack client libraries — as the view layer. React Server Components in React on Rails Pro give the same colocation benefit server functions are known for (server work next to the component, no `/api` round-trip or serializer for that view), except the data comes from Rails: your controller prepares it and passes it as props or streams it as async props.
+- Pros: keep Rails for business logic, persistence, authorization, and jobs, with React — and the TanStack client libraries — as the view layer. React Server Components in React on Rails Pro remove the extra client-side `/api` round-trip for a view: data is prepared in your Rails controller and passed as props (or streamed as async props), and the React component tree renders on the Node renderer. (Start's server functions colocate logic in the same file with end-to-end types; on Rails that logic stays in Rails, across a JSON boundary — see the drawback below.)
 - Drawbacks: two languages (Ruby and TypeScript) rather than one, and an untyped JSON boundary between Rails and the client unless you generate types from your API.
 
 Choose TanStack Start when you are greenfield, have no Rails investment, want a single language end to end, and are optimizing for raw velocity.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1938,7 +1938,7 @@ SOURCE: docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
 
 If you are evaluating frontend approaches for a Rails application, the right choice depends on how much of your UI should live in React, how much Rails should keep rendering, and whether server rendering is a requirement from day one.
 
-This page is intentionally practical. It focuses on the tradeoffs teams usually care about when choosing between React on Rails, Hotwire/Turbo, Inertia Rails, a Next.js frontend with a separate Rails backend API, react-rails, and Vite as a build tool.
+This page is intentionally practical. It focuses on the tradeoffs teams usually care about when choosing between React on Rails, Hotwire/Turbo, Inertia Rails, a Next.js frontend with a separate Rails backend API, TanStack Start, react-rails, and Vite as a build tool.
 
 ## Short Version
 
@@ -1950,17 +1950,20 @@ Choose **Inertia Rails** when you want its controller-to-page-props protocol and
 
 Choose **Next.js + separate Rails backend** when you want a hard frontend/backend boundary and are prepared to run two apps with an explicit API contract between them.
 
+Choose **TanStack Start** when you are greenfield with no existing Rails backend, want a single language across client and server, and are optimizing for raw velocity. If you have, or want, Rails, adopt the TanStack client libraries (Query, Router, Table) on top of Rails instead.
+
 If you are currently on **react-rails**, prefer the migration path to React on Rails rather than starting new work on react-rails.
 
 ## At a Glance
 
-| Option                   | Primary view model                                                  | Best fit                                                                              | What to watch                                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **React on Rails**       | Rails views rendering React components with tight Rails integration | Existing Rails apps, SSR, mixed Rails + React pages, progressive adoption             | More setup than lightweight helper-based integrations                                                                                                 |
-| **Hotwire/Turbo**        | Rails renders HTML, Turbo updates the page                          | Rails-first apps with minimal client-side complexity                                  | Not a React solution, so React ecosystem reuse is limited                                                                                             |
-| **Inertia Rails**        | Controllers return page props to a client-rendered frontend shell   | Teams that want SPA-style page transitions without building a separate JSON API first | Every navigation is a server round-trip; replaces Rails views per-route rather than incremental adoption; review current SSR support in official docs |
-| **Next.js + Rails API**  | Next.js app consumes Rails API responses                            | Teams prioritizing frontend autonomy, edge delivery, or multi-client API reuse        | Two deployables, duplicated auth/session concerns, and stricter API lifecycle management                                                              |
-| **react-rails (legacy)** | Rails views mount React components with helper-based integration    | Existing legacy apps already on react-rails                                           | Maintenance-focused path; plan migration to React on Rails for newer capabilities                                                                     |
+| Option                   | Primary view model                                                  | Best fit                                                                                   | What to watch                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **React on Rails**       | Rails views rendering React components with tight Rails integration | Existing Rails apps, SSR, mixed Rails + React pages, progressive adoption                  | More setup than lightweight helper-based integrations                                                                                                 |
+| **Hotwire/Turbo**        | Rails renders HTML, Turbo updates the page                          | Rails-first apps with minimal client-side complexity                                       | Not a React solution, so React ecosystem reuse is limited                                                                                             |
+| **Inertia Rails**        | Controllers return page props to a client-rendered frontend shell   | Teams that want SPA-style page transitions without building a separate JSON API first      | Every navigation is a server round-trip; replaces Rails views per-route rather than incremental adoption; review current SSR support in official docs |
+| **Next.js + Rails API**  | Next.js app consumes Rails API responses                            | Teams prioritizing frontend autonomy, edge delivery, or multi-client API reuse             | Two deployables, duplicated auth/session concerns, and stricter API lifecycle management                                                              |
+| **TanStack Start**       | Full-stack React framework (client-first; SSR opt-in per route)     | Greenfield React apps with no existing backend; one-language teams optimizing for velocity | Bring-your-own backend (database, ORM, auth, jobs); business logic runs in the JS runtime                                                             |
+| **react-rails (legacy)** | Rails views mount React components with helper-based integration    | Existing legacy apps already on react-rails                                                | Maintenance-focused path; plan migration to React on Rails for newer capabilities                                                                     |
 
 ## React on Rails vs Hotwire/Turbo
 
@@ -2040,6 +2043,36 @@ Choose React on Rails when your priority is delivering substantial React UI whil
 If this architecture is central to your evaluation, see the dedicated guide: [Next.js with a Separate Rails Backend: Pros and Drawbacks](./nextjs-with-separate-rails-backend.md).
 
 If React Server Components are central to your evaluation, see how the two stacks implement RSC at the architecture level — and the one ownership difference that drives the rest — in [React on Rails Pro and Next.js: RSC Architectures Compared](../../pro/react-server-components/nextjs-comparison.md).
+
+## React on Rails vs TanStack Start
+
+TanStack Start is a full-stack React framework built on TanStack Router and Vite. Unlike the Next.js App Router model, it is client-first: client-side interactivity is the default, and you opt into server-side rendering per route. Server logic lives in colocated **server functions**, and the data layer is bring-your-own — Start ships no ORM or database integration of its own.
+
+That makes this less of an "either/or" than it first looks, because the libraries TanStack publishes do not all play the same role for a Rails team:
+
+- **TanStack Query, Router, and Table are complementary.** They work well in front of a Rails backend, and React on Rails Pro can server-render TanStack Router (see the [TanStack Router guide](../building-features/tanstack-router.md)). Adopting them does not require leaving Rails.
+- **TanStack Start's server functions are the part that overlaps with Rails.** They put business logic, authorization, and data access into TypeScript functions on a Node server — the job Rails already does. If you have, or want, Rails, that is the layer you are choosing between.
+
+**TanStack Start:**
+
+- Pros: one language end to end, type safety across the client/server boundary, fine-grained per-route rendering, and a fast Vite dev loop. A strong fit for greenfield apps with no existing backend and a small team optimizing for velocity.
+- Drawbacks: you still assemble and own the backend — database, ORM, auth, background jobs — from separate libraries, and your business logic shares a runtime with your UI.
+
+**React on Rails:**
+
+- Pros: keep Rails for business logic, persistence, authorization, and jobs, with React — and the TanStack client libraries — as the view layer. React Server Components in React on Rails Pro give the same colocation benefit server functions are known for (server work next to the component, no `/api` round-trip or serializer for that view), except the data comes from Rails: your controller prepares it and passes it as props or streams it as async props.
+- Drawbacks: two languages (Ruby and TypeScript) rather than one, and an untyped JSON boundary between Rails and the client unless you generate types from your API.
+
+Choose TanStack Start when you are greenfield, have no Rails investment, want a single language end to end, and are optimizing for raw velocity.
+
+Choose React on Rails when you want a real backend — Rails — under a modern React frontend, and would rather adopt the TanStack client libraries on top of Rails than move your business logic into JavaScript.
+
+A runnable example of this architecture — React on Rails Pro with TanStack Query, Router, and Table against a Rails backend — is the [React on Rails Pro + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack). React Server Components require React on Rails Pro with the Node renderer.
+
+Official docs:
+
+- [TanStack Start documentation](https://tanstack.com/start/latest)
+- [TanStack Router on React on Rails](../building-features/tanstack-router.md)
 
 ## React on Rails vs react-rails (Legacy Path)
 


### PR DESCRIPTION
## What

Adds **TanStack Start** to the [alternatives decision guide](https://reactonrails.com/docs/getting-started/comparing-react-on-rails-to-alternatives). It previously covered Hotwire, Inertia, Next.js, Vite, and react-rails — but not TanStack Start, which is now a top-of-mind choice for teams leaving Next.js (it appeared in exactly zero docs before this PR).

Three additions to `comparing-react-on-rails-to-alternatives.md`:

- An **At a Glance** table row
- A **Short Version** entry
- A dedicated **"React on Rails vs TanStack Start"** section

This is the OSS-level decision-guide counterpart to the already-merged RSC architecture comparison (#4158), which covers Next.js.

## Positioning (calibrated to mid-2026)

- **Splits the TanStack suite.** Query/Router/Table are complementary and work in front of a Rails backend (Router SSR is a Pro feature); Start's **server functions** are the part that overlaps with the Rails backend. The message is "embrace the libraries; the framework layer is what you're choosing against."
- **Grounded in Start's current shape.** TanStack Start is client-first (SSR opt-in per route) and ships no ORM/database of its own ("bring your own backend") — so the honest framing is "what's behind your React app," not "Start is bad."
- **Accurate on RSC maturity.** RSC is described as supported in React on Rails Pro with the Node renderer — not "experimental." No claim that TanStack Query data is server-rendered/SEO-crawlable.
- **Fair to Start.** Explicitly concedes greenfield / no-Rails / one-language / velocity-first to TanStack Start.

## Gates

- `npx prettier@3.6.2 --write` ✓
- `node script/generate-llms-full.mjs` ✓ (`llms-full.txt` regenerated)
- `script/check-docs-sidebar` ✓ (no new doc; existing registration unchanged)
- `lychee` ✓ 0 errors (added `tanstack.com/start` to excludes, matching the existing `tanstack.com/router` CI-connectivity exclusion)

## Possible follow-ups (not in this PR)

- A dedicated deep "TanStack Start vs React on Rails Pro" comparison doc paralleling `nextjs-comparison.md`.
- The starter's SSR Query-cache seeding, so "data in first paint" is demonstrably true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TanStack Start to the Rails frontend “comparisons” guidance and short recommendations.
  * Updated the “At a Glance” table with a new TanStack Start row and revised notes.
  * Added a new “React on Rails vs TanStack Start” section covering differences (SSR-first approach, per-route SSR/SPA, server functions) with pros/cons and reference links.

* **Chores**
  * Updated the link-checker configuration to exclude a known TanStack Start connectivity issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->