### PR TITLE
[Pro] Test rejected RSC replacement retry notifications

### DIFF
--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1502,8 +1502,9 @@ describe('RSCRoute successful-version error reset', () => {
       await act(async () => {
         started.deferred.resolve(payload);
         await started.promise;
-        // Flush the timer-scheduled unpin so the next insertion can evict an
-        // actually cold key and record its evicted-success marker.
+        // Unlike peers k-o, flush the timer-scheduled unpin after each resolve;
+        // otherwise the fill loop keeps every entry pinned and never records
+        // the evicted-success marker that the retry assertions depend on.
         await flushMacrotasks();
       });
     };

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1507,9 +1507,12 @@ describe('RSCRoute successful-version error reset', () => {
     };
 
     const rejectLoad = async (started: Awaited<ReturnType<typeof startLoad>>, message: string) => {
+      void started.promise.catch(() => undefined);
       await act(async () => {
         started.deferred.reject(new Error(message));
         await expect(started.promise).rejects.toThrow(message);
+        // evictPromiseIfRejected removes the cached promise via setTimeout(0),
+        // so wait one macrotask before asserting the slot is free.
         await flushMacrotasks();
       });
     };

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1502,6 +1502,8 @@ describe('RSCRoute successful-version error reset', () => {
       await act(async () => {
         started.deferred.resolve(payload);
         await started.promise;
+        // Flush the timer-scheduled unpin so the next insertion can evict an
+        // actually cold key and record its evicted-success marker.
         await flushMacrotasks();
       });
     };

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1469,8 +1469,6 @@ describe('RSCRoute successful-version error reset', () => {
   });
 
   it('p. rejected replacement loads evict their promise and restore the evicted-success marker', async () => {
-    process.env.NODE_ENV = 'production';
-
     type PendingEntry = Deferred & { args: GetServerComponentArgs };
     const pending: PendingEntry[] = [];
     getServerComponent = jest.fn((..._args: [GetServerComponentArgs]) => {
@@ -1504,6 +1502,7 @@ describe('RSCRoute successful-version error reset', () => {
       await act(async () => {
         started.deferred.resolve(payload);
         await started.promise;
+        await flushMacrotasks();
       });
     };
 

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1467,4 +1467,84 @@ describe('RSCRoute successful-version error reset', () => {
     const key = createRSCPayloadKey('Card', { id: 0 });
     await waitFor(() => expect(rscApi.successfulVersions[key]).toBeGreaterThan(0));
   });
+
+  it('p. rejected replacement loads evict their promise and restore the evicted-success marker', async () => {
+    process.env.NODE_ENV = 'production';
+
+    type PendingEntry = Deferred & { args: GetServerComponentArgs };
+    const pending: PendingEntry[] = [];
+    getServerComponent = jest.fn((..._args: [GetServerComponentArgs]) => {
+      const d = makeDeferred();
+      pending.push({ ...d, args: _args[0] });
+      return d.promise;
+    });
+    RSCProvider = createRSCProvider({ getServerComponent });
+
+    let rscApi!: ReturnType<typeof useRSC>;
+    const Probe = () => {
+      rscApi = useRSC();
+      return null;
+    };
+    await renderInAct(
+      <RSCProvider>
+        <Probe />
+      </RSCProvider>,
+    );
+
+    const startLoad = async (id: number) => {
+      let promise!: Promise<React.ReactNode>;
+      await act(async () => {
+        promise = rscApi.getComponent('Card', { id });
+        await Promise.resolve();
+      });
+      return { promise, deferred: findPendingForId(pending, id) };
+    };
+
+    const resolveLoad = async (started: Awaited<ReturnType<typeof startLoad>>, payload: React.ReactNode) => {
+      await act(async () => {
+        started.deferred.resolve(payload);
+        await started.promise;
+      });
+    };
+
+    // Give ids 0..CACHE_CAP a successful payload. Loading the (cap+1)-th key
+    // evicts id 0 and records its "last successful payload was evicted" marker.
+    for (let id = 0; id <= CACHE_CAP; id += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const started = await startLoad(id);
+      // eslint-disable-next-line no-await-in-loop
+      await resolveLoad(started, <span>{`initial ${id}`}</span>);
+    }
+
+    const key = createRSCPayloadKey('Card', { id: 0 });
+    expect(rscApi.successfulVersions[key] ?? 0).toBe(0);
+
+    // Start id 0's replacement load while its evicted-success marker is
+    // present, then churn enough other successful evictions to push that marker
+    // out of the bounded marker LRU before the replacement rejects. The retry
+    // below only notifies routes if the rejection path restores the marker from
+    // the in-flight latch.
+    const failedReplacement = await startLoad(0);
+    for (let id = CACHE_CAP + 1; id <= CACHE_CAP + MARKER_CAP + 2; id += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const started = await startLoad(id);
+      // eslint-disable-next-line no-await-in-loop
+      await resolveLoad(started, <span>{`marker churn ${id}`}</span>);
+    }
+
+    await act(async () => {
+      failedReplacement.deferred.reject(new Error('replacement boom 0'));
+      await expect(failedReplacement.promise).rejects.toThrow('replacement boom 0');
+      await flushMacrotasks();
+    });
+
+    expect(fetchCount(0)).toBe(2);
+    expect(rscApi.successfulVersions[key] ?? 0).toBe(0);
+
+    const retryReplacement = await startLoad(0);
+    expect(fetchCount(0)).toBe(3);
+    await resolveLoad(retryReplacement, <span>replacement after rejection</span>);
+
+    await waitFor(() => expect(rscApi.successfulVersions[key]).toBeGreaterThan(0));
+  });
 });

--- a/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
+++ b/packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx
@@ -1506,6 +1506,14 @@ describe('RSCRoute successful-version error reset', () => {
       });
     };
 
+    const rejectLoad = async (started: Awaited<ReturnType<typeof startLoad>>, message: string) => {
+      await act(async () => {
+        started.deferred.reject(new Error(message));
+        await expect(started.promise).rejects.toThrow(message);
+        await flushMacrotasks();
+      });
+    };
+
     // Give ids 0..CACHE_CAP a successful payload. Loading the (cap+1)-th key
     // evicts id 0 and records its "last successful payload was evicted" marker.
     for (let id = 0; id <= CACHE_CAP; id += 1) {
@@ -1531,11 +1539,7 @@ describe('RSCRoute successful-version error reset', () => {
       await resolveLoad(started, <span>{`marker churn ${id}`}</span>);
     }
 
-    await act(async () => {
-      failedReplacement.deferred.reject(new Error('replacement boom 0'));
-      await expect(failedReplacement.promise).rejects.toThrow('replacement boom 0');
-      await flushMacrotasks();
-    });
+    await rejectLoad(failedReplacement, 'replacement boom 0');
 
     expect(fetchCount(0)).toBe(2);
     expect(rscApi.successfulVersions[key] ?? 0).toBe(0);


### PR DESCRIPTION
## Summary

- Adds a Pro RSCProvider regression test for a `getComponent` replacement load that starts from an evicted-success marker, rejects, and then retries successfully.
- Churns the evicted-success marker LRU while the failing replacement is pending, so the final successful retry only notifies routes if the rejection path restores the marker from the in-flight latch.
- Verifies the rejected replacement promise is evicted by asserting the next same-key `getComponent` performs a fresh fetch.

Closes #4235.

## Test plan

- `script/ci-changes-detector origin/main` -> Pro JavaScript/TypeScript change detected.
- `pnpm --filter react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx --runInBand -t "p\\. rejected replacement loads"` -> pass.
- Mutation proof: temporarily disabled rejected-promise eviction; focused test failed at `fetchCount(0)` (`Expected: 3`, `Received: 2`); source restored.
- Mutation proof: temporarily disabled rejection-path marker restoration; focused test failed with `successfulVersions[key]` still `undefined`; source restored.
- After merging `origin/main`: `pnpm --filter react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx --runInBand` -> 33/33 pass.
- After review follow-up: `pnpm --filter react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx --runInBand -t "p\\. rejected replacement loads"` -> pass.
- After review follow-up: `pnpm --filter react-on-rails-pro exec jest tests/boundedCacheProvider.client.test.tsx --runInBand` -> 33/33 pass.
- `pnpm --filter react-on-rails-pro run type-check` -> pass.
- `pnpm run lint` -> pass.
- `pnpm exec prettier --check packages/react-on-rails-pro/tests/boundedCacheProvider.client.test.tsx` -> pass.
- `git diff --check` -> pass.
- Pre-commit hooks on review follow-up -> pass.
- Pre-push hooks on branch update and review follow-up -> pass.

## PR processing notes

- Changelog: none, test-only.
- Labels: none. This is a focused one-file Pro test addition; standard path-based CI should cover it.
- Review gate: `codex review --uncommitted` initially found that the test did not prove marker restoration; accepted by adding marker-LRU churn while the rejected replacement is pending. Rerun: no actionable correctness issues.
- Review follow-up: addressed the Greptile determinism concern by flushing the provider's timer-scheduled unpin after each resolved setup load in the new regression test. Also removed the new test's unused `NODE_ENV` override, matching Claude's optional observation.
- Full CI: not requested; this is low-risk test-only coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test covering a bounded-cache replacement scenario where a rejected replacement load must not be treated as successful when an eviction marker is present.
  * Verifies the rejected request’s promise is evicted and the corresponding payload is not marked successful.
  * Confirms that retrying the same payload re-fetches and eventually restores the successful state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->