### PR TITLE
docs: cross-link the TanStack Start comparison from the decision guide and Next.js RSC doc

### DIFF
--- a/docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
+++ b/docs/oss/getting-started/comparing-react-on-rails-to-alternatives.md
@@ -136,7 +136,7 @@ Choose TanStack Start when you are greenfield, have no Rails investment, want a 
 
 Choose React on Rails when you want a real backend — Rails — under a modern React frontend, and would rather adopt the TanStack client libraries on top of Rails than move your business logic into JavaScript.
 
-A runnable example of this architecture — React on Rails Pro with TanStack Query, Router, and Table against a Rails backend — is the [React on Rails Pro + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack). React Server Components require React on Rails Pro with the Node renderer.
+A runnable example of this architecture — React on Rails Pro with TanStack Query, Router, and Table against a Rails backend — is the [React on Rails Pro + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack). React Server Components require React on Rails Pro with the Node renderer. For a deeper architecture comparison — where each stack's server tier lives — see [React on Rails Pro and TanStack Start: Two Ways to Own the Full Stack](../../pro/react-server-components/tanstack-start-comparison.md).
 
 Official docs:
 

--- a/docs/pro/react-server-components/nextjs-comparison.md
+++ b/docs/pro/react-server-components/nextjs-comparison.md
@@ -254,3 +254,4 @@ chunk-loading primitives differ.
 - [Rspack Compatibility](./rspack-compatibility.md) — bundler support status and the native `RSCRspackPlugin`
 - [RSC Glossary](./glossary.md) — terminology reference
 - [RSC overview](./index.md) — the full React Server Components documentation set
+- [React on Rails Pro and TanStack Start](./tanstack-start-comparison.md) — the same kind of architecture comparison, for TanStack Start

--- a/llms-full-pro.txt
+++ b/llms-full-pro.txt
@@ -9440,6 +9440,7 @@ chunk-loading primitives differ.
 - [Rspack Compatibility](./rspack-compatibility.md) — bundler support status and the native `RSCRspackPlugin`
 - [RSC Glossary](./glossary.md) — terminology reference
 - [RSC overview](./index.md) — the full React Server Components documentation set
+- [React on Rails Pro and TanStack Start](./tanstack-start-comparison.md) — the same kind of architecture comparison, for TanStack Start
 
 ================================================================================
 PAGE: https://reactonrails.com/docs/pro/react-server-components/tanstack-start-comparison

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2067,7 +2067,7 @@ Choose TanStack Start when you are greenfield, have no Rails investment, want a 
 
 Choose React on Rails when you want a real backend — Rails — under a modern React frontend, and would rather adopt the TanStack client libraries on top of Rails than move your business logic into JavaScript.
 
-A runnable example of this architecture — React on Rails Pro with TanStack Query, Router, and Table against a Rails backend — is the [React on Rails Pro + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack). React Server Components require React on Rails Pro with the Node renderer.
+A runnable example of this architecture — React on Rails Pro with TanStack Query, Router, and Table against a Rails backend — is the [React on Rails Pro + TanStack starter](https://github.com/shakacode/react-on-rails-starter-tanstack). React Server Components require React on Rails Pro with the Node renderer. For a deeper architecture comparison — where each stack's server tier lives — see [React on Rails Pro and TanStack Start: Two Ways to Own the Full Stack](../../pro/react-server-components/tanstack-start-comparison.md).
 
 Official docs:
 


### PR DESCRIPTION
## What

Two cross-links now that the decision-guide section (#4242) and the RoR Pro vs TanStack Start architecture comparison (#4246) are both on `main`:

- The decision guide's **"React on Rails vs TanStack Start"** section now links the deep [architecture comparison](https://reactonrails.com/docs/pro/react-server-components/tanstack-start-comparison) — parallel to how it already links the Next.js RSC comparison.
- The **Next.js RSC comparison** doc's "Related documentation" now links its TanStack Start sibling.

Closes the asymmetry created by #4242 and #4246 landing as separate PRs.

## Gates

- `prettier@3.6.2` ✓ (no reformatting needed)
- `node script/generate-llms-full.mjs` ✓
- `lychee` ✓ 35 OK / 0 errors (the new relative links resolve to the on-`main` docs)

Labels: none (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the React on Rails and TanStack comparison content with an additional link to a deeper architecture overview.
  * Added a new related-docs reference for the React on Rails Pro and TanStack Start comparison.
  * Updated the documentation index so the new comparison page is easier to discover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->