### PR TITLE
Release train: release-forward-port re-homes changelog to [Unreleased]

### DIFF
--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -972,6 +972,9 @@ class ReleaseForwardPort
     end
 
     apply_changelog_reconciliation(target, result)
+  rescue ChangelogReconciler::ReconcileError => e
+    # Map the reconciler's own error onto the shared GitError exit path.
+    raise GitError, e.message
   end
 
   def apply_changelog_reconciliation(target, result)
@@ -1266,14 +1269,25 @@ end
 # but is reimplemented self-contained here so this script has no rake dependency.
 # rubocop:disable Metrics/ClassLength
 class ChangelogReconciler
+  # Raised for changelog structures the reconciler cannot operate on (e.g. a target
+  # with no [Unreleased] section). Kept local so the reconciler does not depend on
+  # ReleaseForwardPort's error types; the caller maps it to the same exit status.
+  class ReconcileError < StandardError; end
+
   UNRELEASED = "Unreleased"
   DEFAULT_HEADING = "#### Changed"
   CHANGELOG_FILE = "CHANGELOG.md"
   SECTION_HEADER = /^### \[([^\]]+)\].*$/
   BLOCK_HEADING = /^####+\s+/
   PRERELEASE_SUFFIX = /\.(?:test|beta|alpha|rc|pre)(?:\.\d+)?\z/i
-  # A changelog entry cites its PR as a /pull/NNNN compare/issue link or as the
-  # "PR NNNN" / "#NNNN" shorthand. Any of these is enough to de-duplicate by PR.
+  # An entry's OWN PR is, by changelog convention, the "[PR NNNN](...) by [author]"
+  # trailer at the end. Many entries also reference OTHER PRs mid-text ("Follow-up
+  # to [PR 4227]... [PR 4234] by [author]"), so this trailer anchor is matched first
+  # to avoid de-duplicating on a referenced PR instead of the entry's own.
+  PR_TRAILER_PATTERN = /\[PR\s*#?(\d+)\]\([^)]*\)\s*by\b/i
+  # Fallbacks when there is no "... by [author]" trailer: a /pull/NNNN link, the
+  # "PR NNNN" / "#NNNN" shorthand. The LAST occurrence wins, since the entry's own
+  # PR conventionally comes after any PRs it references.
   PR_REFERENCE_PATTERNS = [
     %r{/pull/(\d+)\b},
     /\bPR\s*\[?#?(\d+)\b/i,
@@ -1307,7 +1321,7 @@ class ChangelogReconciler
     target = parse_sections(@target_changelog)
     source = parse_sections(@source_changelog)
 
-    base_version = release_base_version(source, target)
+    base_version = source_release_base_version(source)
     removed_sections = stray_rc_sections(target, base_version)
 
     target_entries = section_entries(find_unreleased(target))
@@ -1387,7 +1401,7 @@ class ChangelogReconciler
   def rebuild_changelog(target, entries, removed_sections)
     sections = target[:sections].reject { |section| removed_sections.include?(section) }
     unreleased = sections.find { |section| section[:version] == UNRELEASED }
-    raise ReleaseForwardPort::GitError, "target #{CHANGELOG_FILE} has no ### [#{UNRELEASED}] section" unless unreleased
+    raise ReconcileError, "target #{CHANGELOG_FILE} has no ### [#{UNRELEASED}] section" unless unreleased
 
     unreleased = unreleased.dup
     unreleased[:body] = render_unreleased_body(entries)
@@ -1426,9 +1440,14 @@ class ChangelogReconciler
   end
 
   def collect_pr_number(text)
+    trailer = text.scan(PR_TRAILER_PATTERN).last
+    return trailer.first.to_i if trailer
+
+    # No "... by [author]" trailer: take the last match of the first pattern that
+    # matches at all (last-ref-wins).
     PR_REFERENCE_PATTERNS.each do |pattern|
-      match = text.match(pattern)
-      return match[1].to_i if match
+      last = text.scan(pattern).last
+      return last.first.to_i if last
     end
     nil
   end
@@ -1437,8 +1456,14 @@ class ChangelogReconciler
     text.to_s.gsub(/\s+/, " ").strip
   end
 
-  def release_base_version(source, target)
-    highest_prerelease_base(source) || highest_prerelease_base(target)
+  # The active release line is defined by the SOURCE branch's prerelease sections.
+  # We must NOT fall back to the target's RC base: if the source has no prerelease
+  # sections, there is nothing to re-home and no basis to claim a target RC section
+  # belongs to this line, so the run is a clean no-op (handled by the empty-base
+  # guards in prerelease_sections / stray_rc_sections). Forward-porting from a
+  # non-prerelease ref such as release/16.6.0 must not reach into main's RC base.
+  def source_release_base_version(source)
+    highest_prerelease_base(source)
   end
 
   def highest_prerelease_base(parsed)
@@ -1447,23 +1472,26 @@ class ChangelogReconciler
 
       section[:version].sub(PRERELEASE_SUFFIX, "")
     end.uniq
+    highest_version(bases)
+  end
+
+  # Order version strings, tolerating a malformed base that Gem::Version rejects
+  # (only the parse is rescued, not the surrounding section scan).
+  def highest_version(bases)
     bases.max_by { |base| Gem::Version.new(base) }
   rescue ArgumentError
     bases.max
   end
 
-  # Sections on the TARGET that a cherry-pick introduced: any prerelease-headed
-  # section whose base matches the active release line. These are the residue the
+  # Sections on the TARGET that a cherry-pick introduced: prerelease-headed
+  # sections whose base matches the active release line. These are the residue the
   # reconciliation must drop so entries live only under [Unreleased] on main.
   def stray_rc_sections(target, base_version)
-    return [] unless base_version
-
-    target[:sections].select do |section|
-      section[:version].match?(PRERELEASE_SUFFIX) &&
-        section[:version].sub(PRERELEASE_SUFFIX, "") == base_version
-    end
+    prerelease_sections(target, base_version)
   end
 
+  # Prerelease (rc.N / beta.N / ...) sections in `parsed` whose base equals
+  # base_version. Empty base (source had no prerelease sections) selects nothing.
   def prerelease_sections(parsed, base_version)
     return [] unless base_version
 

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -8,6 +8,7 @@ require "digest"
 # rubocop:disable Metrics/ClassLength
 class ReleaseForwardPort
   VERSION_FILE = "react_on_rails/lib/react_on_rails/version.rb"
+  CHANGELOG_FILE = "CHANGELOG.md"
   # Project convention is `X.Y.Z.rc.N`, but a release branch can still contain a
   # bare `X.Y.Z.rc` bump. Treat both as release-only version bumps.
   RC_VERSION_BUMP_SUBJECT = /
@@ -52,7 +53,8 @@ class ReleaseForwardPort
     @options = {
       dry_run: false,
       ack_manual: [],
-      target: "main"
+      target: "main",
+      changelog: false
     }
     @parser = build_parser
   end
@@ -67,6 +69,8 @@ class ReleaseForwardPort
     verify_ref!(target, label: "target")
     normalize_acknowledged_manual_shas!
     ensure_local_target_branch!(target) unless @options[:dry_run]
+
+    return run_changelog_reconciliation(source, target) if @options[:changelog]
 
     commits = source_only_commits(source, target)
     equiv_commits = patch_equivalent_candidates(source, target)
@@ -145,6 +149,7 @@ class ReleaseForwardPort
       parser.on("--dry-run", "Print the plan without checking out or cherry-picking") do
         @options[:dry_run] = true
       end
+      add_changelog_option(parser)
       add_ack_manual_option(parser)
       parser.on("-h", "--help", "Show this help") do
         puts parser
@@ -157,11 +162,30 @@ class ReleaseForwardPort
     <<~BANNER
       Usage: script/release-forward-port --source release/X.Y.Z [--target main] [--dry-run]
              script/release-forward-port release/X.Y.Z [main] [--dry-run]
+             script/release-forward-port --source release/X.Y.Z --changelog [--target main] [--dry-run]
 
-      Forward-port commits that are on a release branch but not on the target branch.
-      The helper cherry-picks with -x, skips commits already forward-ported with -x
+      Default mode forward-ports commits that are on a release branch but not on the target
+      branch. The helper cherry-picks with -x, skips commits already forward-ported with -x
       evidence or patches present in the target tree, and excludes RC version bump commits.
+
+      --changelog mode runs a separate CHANGELOG.md reconciliation pass instead of the
+      cherry-pick loop: it collapses every release-branch entry (each rc.N section plus
+      [Unreleased]) into the target's [Unreleased] section, de-duplicates by PR number against
+      the target's existing entries, and drops any RC-header section a prior cherry-pick left
+      on the target. The default cherry-pick behavior is unchanged for callers that omit the flag.
     BANNER
+  end
+
+  def add_changelog_option(parser)
+    parser.on(
+      "--changelog",
+      "Re-home release-branch CHANGELOG.md entries (rc.N + [Unreleased]) into the target's",
+      "[Unreleased] section instead of cherry-picking commits. De-duplicates by PR number",
+      "against existing target entries and drops stray RC-header sections on the target.",
+      "Compose with --dry-run to preview the [Unreleased] additions and removals."
+    ) do
+      @options[:changelog] = true
+    end
   end
 
   def add_ack_manual_option(parser)
@@ -929,6 +953,122 @@ class ReleaseForwardPort
     git("checkout", target)
   end
 
+  # --changelog mode entry point. Reads CHANGELOG.md from both refs, reconciles
+  # the release-branch entries into the target's [Unreleased] section, and either
+  # previews the change (--dry-run) or rewrites the working-tree CHANGELOG.md on
+  # the checked-out target branch.
+  def run_changelog_reconciliation(source, target)
+    source_changelog = changelog_at(source, label: "source")
+    target_changelog = changelog_at(target, label: "target")
+
+    reconciler = ChangelogReconciler.new(source_changelog:, target_changelog:)
+    result = reconciler.reconcile
+
+    print_changelog_reconciliation_plan(source, target, result)
+
+    if @options[:dry_run]
+      puts "\nDRY RUN: CHANGELOG.md was not modified and no branch was checked out."
+      return 0
+    end
+
+    apply_changelog_reconciliation(target, result)
+  end
+
+  def apply_changelog_reconciliation(target, result)
+    unless result.changed?
+      puts "\nNothing to reconcile; #{CHANGELOG_FILE} on #{target} already has every release-branch entry."
+      return 0
+    end
+
+    ensure_clean_worktree!
+    checkout_target!(target)
+    # Write UTF-8 explicitly so the ⚠️-carrying changelog round-trips byte-for-byte
+    # under a C/POSIX-locale runner where the default external encoding is US-ASCII.
+    File.write(changelog_path, result.reconciled_changelog, encoding: Encoding::UTF_8)
+    puts "\nReconciled #{result.added_entries.length} entr#{result.added_entries.length == 1 ? 'y' : 'ies'} " \
+         "into #{CHANGELOG_FILE} [Unreleased] on #{target}."
+    puts "Review and commit #{CHANGELOG_FILE} (this mode does not commit)."
+    0
+  end
+
+  def print_changelog_reconciliation_plan(source, target, result)
+    puts "Release forward-port CHANGELOG.md reconciliation plan"
+    puts "  source: #{source}"
+    puts "  target: #{target}"
+    puts
+
+    print_changelog_added_entries(result)
+    print_changelog_removed_sections(result)
+    print_changelog_already_present(result)
+
+    puts
+    puts changelog_reconciliation_summary(result)
+  end
+
+  def print_changelog_added_entries(result)
+    if result.added_entries.empty?
+      puts "No new release-branch entries to add under [Unreleased]."
+      return
+    end
+
+    puts "Entries to ADD under [Unreleased]:"
+    result.added_entries.each { |entry| puts indent_changelog_entry("+", entry) }
+  end
+
+  def print_changelog_removed_sections(result)
+    return if result.removed_sections.empty?
+
+    puts
+    puts "RC-header sections to DROP from the target (cherry-pick residue):"
+    result.removed_sections.each { |version| puts "  - ### [#{version}]" }
+  end
+
+  def print_changelog_already_present(result)
+    return if result.skipped_entries.empty?
+
+    puts
+    puts "Entries already present on the target (skipped, de-duplicated by PR number):"
+    result.skipped_entries.each { |entry| puts indent_changelog_entry("=", entry) }
+  end
+
+  def indent_changelog_entry(marker, entry)
+    first, *rest = entry.text.lines
+    pr = entry.pr_number ? " (PR ##{entry.pr_number})" : ""
+    lines = ["  #{marker} #{first.to_s.rstrip}#{pr}"]
+    rest.each { |line| lines << "      #{line.rstrip}" }
+    lines.join("\n")
+  end
+
+  def changelog_reconciliation_summary(result)
+    parts = [
+      "#{changelog_count(result.added_entries.length, 'entry', 'entries')} to add",
+      "#{changelog_count(result.skipped_entries.length, 'entry', 'entries')} already present"
+    ]
+    parts << "#{changelog_count(result.removed_sections.length, 'RC section', 'RC sections')} to drop" if
+      result.removed_sections.any?
+    "Summary: #{parts.join(', ')}."
+  end
+
+  def changelog_count(count, singular, plural)
+    "#{count} #{count == 1 ? singular : plural}"
+  end
+
+  def changelog_at(ref, label:)
+    # CHANGELOG.md is authored as UTF-8 (it contains characters like the ⚠️
+    # breaking-change marker). Open3 tags git's stdout with the process external
+    # encoding, which is US-ASCII under a C/POSIX-locale CI runner; matching a
+    # regex against those bytes then raises "invalid byte sequence in US-ASCII".
+    # Re-tag the bytes as UTF-8 so parsing is locale-independent.
+    git("show", "#{ref}:#{CHANGELOG_FILE}").dup.force_encoding(Encoding::UTF_8)
+  rescue GitError => e
+    raise GitError, "unable to read #{CHANGELOG_FILE} at #{label} ref #{ref.inspect}: #{e.message}"
+  end
+
+  def changelog_path
+    git_toplevel = git("rev-parse", "--show-toplevel").strip
+    File.join(git_toplevel, CHANGELOG_FILE)
+  end
+
   def apply_plan(plan)
     unless actionable_plan?(plan)
       puts "\nNothing to cherry-pick."
@@ -1107,6 +1247,372 @@ class ReleaseForwardPort
     message << stderr.strip unless stderr.strip.empty?
     message << stdout.strip unless stdout.strip.empty?
     message.join(": ")
+  end
+end
+# rubocop:enable Metrics/ClassLength
+
+# Re-homes release-branch CHANGELOG.md entries into the target's [Unreleased]
+# section. On a release branch a fix's entry lives under an RC header
+# (### [17.0.0.rc.1]); on main it belongs under ### [Unreleased]. A plain
+# cherry-pick -x of the fix commit drags the RC-header context and either
+# conflicts or lands the entry in the wrong section. This reconciler is the
+# changelog restructure half of the forward-port: it collapses every entry from
+# the release branch's rc.N sections plus its own [Unreleased] into the target's
+# [Unreleased], de-duplicated by PR number against the target's existing entries,
+# and drops any RC-header section a prior pick left on the target.
+#
+# The parsing approach intentionally mirrors react_on_rails/rakelib/update_changelog.rake
+# (parse_changelog_sections / changelog_section_blocks / consolidate_changelog_blocks)
+# but is reimplemented self-contained here so this script has no rake dependency.
+# rubocop:disable Metrics/ClassLength
+class ChangelogReconciler
+  UNRELEASED = "Unreleased"
+  DEFAULT_HEADING = "#### Changed"
+  CHANGELOG_FILE = "CHANGELOG.md"
+  SECTION_HEADER = /^### \[([^\]]+)\].*$/
+  BLOCK_HEADING = /^####+\s+/
+  PRERELEASE_SUFFIX = /\.(?:test|beta|alpha|rc|pre)(?:\.\d+)?\z/i
+  # A changelog entry cites its PR as a /pull/NNNN compare/issue link or as the
+  # "PR NNNN" / "#NNNN" shorthand. Any of these is enough to de-duplicate by PR.
+  PR_REFERENCE_PATTERNS = [
+    %r{/pull/(\d+)\b},
+    /\bPR\s*\[?#?(\d+)\b/i,
+    %r{(?<![\w/])#(\d+)\b}
+  ].freeze
+
+  Entry = Struct.new(:text, :pr_number, :heading, keyword_init: true)
+
+  Result = Struct.new(
+    :reconciled_changelog,
+    :added_entries,
+    :skipped_entries,
+    :removed_sections,
+    :original_changelog,
+    keyword_init: true
+  ) do
+    # Semantic change only: adding at least one entry or dropping at least one
+    # stray RC section. Skipped (already-present) entries do not count, so the
+    # reconciler never reformats the target's existing [Unreleased] for nothing.
+    def changed?
+      added_entries.any? || removed_sections.any?
+    end
+  end
+
+  def initialize(source_changelog:, target_changelog:)
+    @source_changelog = source_changelog
+    @target_changelog = target_changelog
+  end
+
+  def reconcile
+    target = parse_sections(@target_changelog)
+    source = parse_sections(@source_changelog)
+
+    base_version = release_base_version(source, target)
+    removed_sections = stray_rc_sections(target, base_version)
+
+    target_entries = section_entries(find_unreleased(target))
+    seen_pr_numbers = target_entries.filter_map(&:pr_number).to_set
+    target_entry_texts = target_entries.to_set { |entry| normalize_text(entry.text) }
+
+    added, skipped = partition_source_entries(
+      collect_source_entries(source, base_version),
+      seen_pr_numbers,
+      target_entry_texts
+    )
+
+    # Only re-render when there is a real change; otherwise return the target
+    # changelog byte-for-byte so a no-op run never reflows existing entries.
+    reconciled = if added.any? || removed_sections.any?
+                   rebuild_changelog(target, target_entries + added, removed_sections)
+                 else
+                   @target_changelog
+                 end
+
+    Result.new(
+      reconciled_changelog: reconciled,
+      added_entries: added,
+      skipped_entries: skipped,
+      removed_sections: removed_sections.map { |section| section[:version] },
+      original_changelog: @target_changelog
+    )
+  end
+
+  private
+
+  # Collapse every release-branch source section that belongs in main's
+  # [Unreleased]: the branch's own [Unreleased] first (so it wins "first seen"
+  # ordering), then each rc.N / prerelease section for the active base version.
+  def collect_source_entries(source, base_version)
+    sections = [find_unreleased(source)].compact
+    sections += prerelease_sections(source, base_version)
+    blocks = sections.flat_map { |section| section_blocks(section[:body]) }
+    entries_from_blocks(consolidate_blocks(blocks))
+  end
+
+  # Split the collapsed source entries into those to add to main's [Unreleased]
+  # and those already present. De-duplication rules (matching update_changelog.rake
+  # deduplicate_block_entries semantics):
+  #   - Against the TARGET: skip when the PR number already appears on main, OR
+  #     the entry text already appears on main (PR-number match catches reworded
+  #     entries the release branch and main phrase differently).
+  #   - Within the source itself: skip only exact text duplicates, so two distinct
+  #     entries that share one (new) PR number both carry over.
+  def partition_source_entries(entries, seen_pr_numbers, target_entry_texts)
+    added = []
+    skipped = []
+    added_texts = Set.new
+
+    entries.each do |entry|
+      normalized = normalize_text(entry.text)
+      if entry_present_on_target?(entry, seen_pr_numbers, target_entry_texts) || added_texts.include?(normalized)
+        skipped << entry
+      else
+        added_texts << normalized
+        added << entry
+      end
+    end
+
+    [added, skipped]
+  end
+
+  def entry_present_on_target?(entry, seen_pr_numbers, target_entry_texts)
+    return true if entry.pr_number && seen_pr_numbers.include?(entry.pr_number)
+
+    target_entry_texts.include?(normalize_text(entry.text))
+  end
+
+  # Rebuild the target changelog: rewrite [Unreleased]'s body from the merged
+  # entry list (grouped under their #### headings) and drop the stray RC-header
+  # sections a prior cherry-pick introduced.
+  def rebuild_changelog(target, entries, removed_sections)
+    sections = target[:sections].reject { |section| removed_sections.include?(section) }
+    unreleased = sections.find { |section| section[:version] == UNRELEASED }
+    raise ReleaseForwardPort::GitError, "target #{CHANGELOG_FILE} has no ### [#{UNRELEASED}] section" unless unreleased
+
+    unreleased = unreleased.dup
+    unreleased[:body] = render_unreleased_body(entries)
+    sections = sections.map { |section| section[:version] == UNRELEASED ? unreleased : section }
+
+    render_sections(target[:prefix], sections)
+  end
+
+  def render_unreleased_body(entries)
+    return "\n" if entries.empty?
+
+    blocks = consolidate_blocks(blocks_from_entries(entries))
+    "\n#{blocks.join("\n\n").strip}\n\n"
+  end
+
+  # Group entries back under their #### headings (Added / Changed / Fixed / ...),
+  # preserving first-seen heading order, so the rebuilt body keeps the keepachangelog
+  # structure rather than a flat bullet list. Every entry carries its owning heading
+  # from the parsing pass; a defensive default covers any heading-less entry.
+  def blocks_from_entries(entries)
+    blocks = []
+    index_by_heading = {}
+
+    entries.each do |entry|
+      heading = entry.heading || DEFAULT_HEADING
+      if index_by_heading.key?(heading)
+        blocks[index_by_heading[heading]] << "\n#{entry.text}"
+      else
+        index_by_heading[heading] = blocks.length
+        # Blank line after the #### heading matches the CHANGELOG.md house style.
+        blocks << "#{heading}\n\n#{entry.text}"
+      end
+    end
+
+    blocks
+  end
+
+  def collect_pr_number(text)
+    PR_REFERENCE_PATTERNS.each do |pattern|
+      match = text.match(pattern)
+      return match[1].to_i if match
+    end
+    nil
+  end
+
+  def normalize_text(text)
+    text.to_s.gsub(/\s+/, " ").strip
+  end
+
+  def release_base_version(source, target)
+    highest_prerelease_base(source) || highest_prerelease_base(target)
+  end
+
+  def highest_prerelease_base(parsed)
+    bases = parsed[:sections].filter_map do |section|
+      next unless section[:version].match?(PRERELEASE_SUFFIX)
+
+      section[:version].sub(PRERELEASE_SUFFIX, "")
+    end.uniq
+    bases.max_by { |base| Gem::Version.new(base) }
+  rescue ArgumentError
+    bases.max
+  end
+
+  # Sections on the TARGET that a cherry-pick introduced: any prerelease-headed
+  # section whose base matches the active release line. These are the residue the
+  # reconciliation must drop so entries live only under [Unreleased] on main.
+  def stray_rc_sections(target, base_version)
+    return [] unless base_version
+
+    target[:sections].select do |section|
+      section[:version].match?(PRERELEASE_SUFFIX) &&
+        section[:version].sub(PRERELEASE_SUFFIX, "") == base_version
+    end
+  end
+
+  def prerelease_sections(parsed, base_version)
+    return [] unless base_version
+
+    parsed[:sections].select do |section|
+      section[:version].match?(PRERELEASE_SUFFIX) &&
+        section[:version].sub(PRERELEASE_SUFFIX, "") == base_version
+    end
+  end
+
+  def find_unreleased(parsed)
+    parsed[:sections].find { |section| section[:version] == UNRELEASED }
+  end
+
+  # --- Self-contained changelog parsing (mirrors update_changelog.rake) ---
+
+  def parse_sections(changelog)
+    lines = changelog.lines
+    headers = []
+    lines.each_with_index do |line, index|
+      match = line.match(SECTION_HEADER)
+      headers << { index:, version: match[1], header: line } if match
+    end
+
+    return { prefix: changelog, sections: [] } if headers.empty?
+
+    prefix = lines[0...headers.first[:index]].join
+    sections = headers.each_with_index.map do |header, position|
+      section_end = position + 1 < headers.length ? headers[position + 1][:index] : lines.length
+      {
+        version: header[:version],
+        header: header[:header],
+        body: lines[(header[:index] + 1)...section_end].join
+      }
+    end
+
+    { prefix:, sections: }
+  end
+
+  def render_sections(prefix, sections)
+    "#{prefix}#{sections.map { |section| "#{section[:header]}#{section[:body]}" }.join}"
+  end
+
+  def section_blocks(section_body)
+    block_lines = []
+    blocks = []
+
+    section_body.lines.each do |line|
+      normalized = line.rstrip
+      if normalized.match?(BLOCK_HEADING) && !block_lines.empty?
+        blocks << normalize_block(block_lines)
+        block_lines = [normalized]
+      else
+        block_lines << normalized
+      end
+    end
+
+    blocks << normalize_block(block_lines) unless block_lines.empty?
+    blocks.reject(&:empty?)
+  end
+
+  def normalize_block(lines)
+    normalized = lines.map(&:rstrip)
+    normalized.shift while normalized.first == ""
+    normalized.pop while normalized.last == ""
+    normalized.join("\n")
+  end
+
+  def normalize_heading_key(line)
+    normalized = line.to_s.strip
+    level = normalized[/\A(#+)/, 1] || ""
+    text = normalized.sub(/\A#+\s+/, "")
+                     .gsub(/\A(?:⚠️|⚠)\s*/, "")
+                     .downcase
+                     .gsub(/\s+/, " ")
+    "#{level} #{text}".strip
+  end
+
+  # Merge blocks that share a heading into one, in first-seen order.
+  def consolidate_blocks(blocks)
+    consolidated = []
+    heading_indices = {}
+
+    blocks.each do |block|
+      cleaned = block.strip
+      next if cleaned.empty?
+
+      heading_match = cleaned.lines.first.to_s.rstrip.match(/\A(####+\s+.+)/)
+      if heading_match
+        merge_heading_block(consolidated, heading_indices, cleaned, heading_match[1])
+      else
+        consolidated << cleaned
+      end
+    end
+
+    consolidated
+  end
+
+  def merge_heading_block(consolidated, heading_indices, cleaned, heading_line)
+    key = normalize_heading_key(heading_line)
+    if heading_indices.key?(key)
+      index = heading_indices[key]
+      tail = cleaned.lines.drop(1).join.gsub(/\A\n+/, "").rstrip
+      consolidated[index] = "#{consolidated[index].rstrip}\n#{tail}" unless tail.empty?
+    else
+      heading_indices[key] = consolidated.length
+      consolidated << cleaned
+    end
+  end
+
+  # Turn consolidated #### blocks into individual Entry structs, carrying the
+  # owning heading on each entry so they can be regrouped after de-duplication.
+  def entries_from_blocks(blocks)
+    blocks.flat_map { |block| block_to_entries(block) }
+  end
+
+  def section_entries(section)
+    return [] unless section
+
+    entries_from_blocks(consolidate_blocks(section_blocks(section[:body])))
+  end
+
+  def block_to_entries(block)
+    lines = block.lines
+    heading = lines.first.to_s.rstrip
+    return [] unless heading.match?(BLOCK_HEADING)
+
+    split_entries(lines.drop(1)).map do |text|
+      Entry.new(text:, pr_number: collect_pr_number(text), heading:)
+    end
+  end
+
+  # Group body lines into logical entries: a top-level "- " bullet starts a new
+  # entry; nested bullets and continuation lines belong to the current entry.
+  def split_entries(body_lines)
+    entries = []
+    current = nil
+
+    body_lines.each do |line|
+      stripped = line.rstrip
+      if stripped.start_with?("- ")
+        entries << current if current
+        current = stripped.dup
+      elsif current
+        current << "\n#{stripped}"
+      end
+    end
+
+    entries << current if current
+    entries.map(&:strip).reject(&:empty?)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/script/release-forward-port
+++ b/script/release-forward-port
@@ -72,6 +72,22 @@ class ReleaseForwardPort
 
     return run_changelog_reconciliation(source, target) if @options[:changelog]
 
+    # This final expression is the process exit status.
+    run_cherry_pick_forward_port(source, target)
+  rescue OptionParser::ParseError, UsageError => e
+    warn "ERROR: #{e.message}"
+    warn @parser
+    2
+  rescue GitError => e
+    warn "ERROR: #{e.message}"
+    1
+  end
+
+  private
+
+  # Default mode: cherry-pick -x the source-only commits onto the target. Called
+  # within run's begin block, so its UsageError/GitError raises are caught there.
+  def run_cherry_pick_forward_port(source, target)
     commits = source_only_commits(source, target)
     equiv_commits = patch_equivalent_candidates(source, target)
     target_version = version_at(target)
@@ -93,18 +109,8 @@ class ReleaseForwardPort
 
     ensure_clean_worktree!
     checkout_target!(target)
-    # This final expression is the process exit status.
     apply_plan(plan)
-  rescue OptionParser::ParseError, UsageError => e
-    warn "ERROR: #{e.message}"
-    warn @parser
-    2
-  rescue GitError => e
-    warn "ERROR: #{e.message}"
-    1
   end
-
-  private
 
   def finish_no_action_plan(plan, target)
     if acknowledged_manual_entries?(plan)

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -1,0 +1,743 @@
+#!/usr/bin/env bash
+# Test harness for `script/release-forward-port --changelog` (the CHANGELOG.md
+# re-homing mode). Mirrors the structure of script/ci-changes-detector-test.bash:
+# each case runs in an isolated mktemp git repo subshell, so the real repo's
+# branches, remote, and working tree are never touched. Requires bash and git.
+# Run with `bash script/release-forward-port-test.bash`.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORWARD_PORT="$SCRIPT_DIR/release-forward-port"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+CURRENT_TEST=""
+FAILURES=()
+
+fail() {
+  local message="$1"
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  FAILURES+=("$CURRENT_TEST: $message")
+  # When invoked from inside a run_test subshell, also persist the message so
+  # the outer summary can show the specific assertion rather than a generic
+  # "subshell exited" line.
+  if [ -n "${SUBSHELL_FAILURES_FILE:-}" ]; then
+    printf '%s\n' "$CURRENT_TEST: $message" >> "$SUBSHELL_FAILURES_FILE"
+  fi
+  echo "  FAIL: $message" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      fail "$label: expected to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-output}"
+  case "$haystack" in
+    *"$needle"*)
+      fail "$label: expected NOT to contain '$needle', got '$haystack'"
+      return 1
+      ;;
+    *) ;;
+  esac
+}
+
+run_test() {
+  local test_fn="$1"
+  CURRENT_TEST="$test_fn"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "-> $test_fn"
+
+  local tmpdir before_failed had_errexit=false subshell_failures
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/release-forward-port-test.XXXXXX")"
+  subshell_failures="$tmpdir/failures.log"
+  : > "$subshell_failures"
+  before_failed="$TESTS_FAILED"
+
+  case "$-" in
+    *e*) had_errexit=true ;;
+  esac
+
+  set +e
+  (
+    set -euo pipefail
+    SUBSHELL_FAILURES_FILE="$subshell_failures"
+    export SUBSHELL_FAILURES_FILE
+    cd "$tmpdir" || exit 1
+    "$test_fn"
+  )
+  local rc=$?
+  if [ "$had_errexit" = true ]; then
+    set -e
+  fi
+
+  # Ingest detailed failure messages recorded inside the subshell so the final
+  # summary reflects the actual assertion text instead of a generic exit code.
+  if [ -s "$subshell_failures" ]; then
+    while IFS= read -r failure_line; do
+      [ -n "$failure_line" ] || continue
+      TESTS_FAILED=$((TESTS_FAILED + 1))
+      FAILURES+=("$failure_line")
+    done < "$subshell_failures"
+  fi
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -ne 0 ] && [ "$TESTS_FAILED" -eq "$before_failed" ]; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("$CURRENT_TEST: subshell exited $rc (see stderr above for details)")
+    echo "  FAIL: subshell exited $rc" >&2
+  fi
+}
+
+# Initialize a git repo with `main` checked out. Callers then write CHANGELOG.md
+# fixtures and commit them on main and a release/X.Y.Z branch.
+init_repo() {
+  git init -q -b main
+  git config user.email test@example.com
+  git config user.name "Forward Port Test"
+}
+
+commit_all() {
+  local message="$1"
+  git add -A
+  git commit -q -m "$message"
+}
+
+# Write CHANGELOG.md on main, commit, branch release/17.0.0, write the release
+# CHANGELOG.md, commit, and return to main. Two heredocs are passed by file path.
+seed_main_and_release() {
+  local main_changelog="$1"
+  local release_changelog="$2"
+  local release_branch="${3:-release/17.0.0}"
+
+  cp "$main_changelog" CHANGELOG.md
+  commit_all "main changelog"
+
+  git checkout -q -b "$release_branch"
+  cp "$release_changelog" CHANGELOG.md
+  commit_all "release changelog"
+
+  git checkout -q main
+}
+
+run_changelog() {
+  local source="${1:-release/17.0.0}"
+  shift || true
+  ruby "$FORWARD_PORT" --source "$source" --target main --changelog "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures: small helpers that emit CHANGELOG.md bodies to a path.
+# ---------------------------------------------------------------------------
+
+pr_link() {
+  local number="$1"
+  printf '[PR %s](https://github.com/shakacode/react_on_rails/pull/%s)' "$number" "$number"
+}
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+# rc.0 + rc.1 + branch [Unreleased] all collapse into main's [Unreleased]; a PR
+# already present on main is de-duplicated; a stray rc section on main is dropped.
+test_collapses_rc_sections_and_branch_unreleased_into_main_unreleased() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Existing main fix**: already here. $(pr_link 100) by [a](https://github.com/a).
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **rc0 leftover**: a prior pick stamped this onto main. $(pr_link 50) by [a](https://github.com/a).
+
+### [16.6.0] - 2026-04-09
+
+#### Added
+
+- **Old stable**: shipped. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Branch unreleased fix**: newest on the branch. $(pr_link 300) by [a](https://github.com/a).
+
+### [17.0.0.rc.1] - 2026-06-02
+
+#### Added
+
+- **rc1 feature**: added in rc1. $(pr_link 200) by [a](https://github.com/a).
+
+#### Fixed
+
+- **Existing main fix**: already here. $(pr_link 100) by [a](https://github.com/a).
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **rc0 leftover**: a prior pick stamped this onto main. $(pr_link 50) by [a](https://github.com/a).
+
+### [16.6.0] - 2026-04-09
+
+#### Added
+
+- **Old stable**: shipped. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog)"
+  assert_contains "$out" "Summary: 3 entries to add, 1 entry already present, 1 RC section to drop." "summary"
+  assert_contains "$out" "### [17.0.0.rc.0]" "drop section listing"
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  # All three branch entries land under Unreleased.
+  assert_contains "$changelog" "Branch unreleased fix" "rehomed branch unreleased"
+  assert_contains "$changelog" "rc1 feature" "rehomed rc1"
+  assert_contains "$changelog" "rc0 leftover" "rehomed rc0"
+  # Existing main entry stays exactly once (deduped by PR number).
+  local occurrences
+  occurrences="$(grep -c "Existing main fix" CHANGELOG.md)"
+  [ "$occurrences" -eq 1 ] || fail "expected 1 'Existing main fix', got $occurrences"
+  # The stray rc.0 SECTION header is gone from main.
+  assert_not_contains "$changelog" "### [17.0.0.rc.0]" "rc0 header dropped"
+  # The unrelated stable section is preserved.
+  assert_contains "$changelog" "### [16.6.0]" "stable section kept"
+}
+
+# --dry-run previews the additions and removals but never writes CHANGELOG.md.
+test_dry_run_previews_without_writing() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Main fix**: here. $(pr_link 100) by [a](https://github.com/a).
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **Stray rc section**: on main. $(pr_link 50) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **New branch entry**: from rc0. $(pr_link 200) by [a](https://github.com/a).
+
+- **Stray rc section**: on main. $(pr_link 50) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local before out after
+  before="$(cat CHANGELOG.md)"
+  out="$(run_changelog release/17.0.0 --dry-run)"
+  after="$(cat CHANGELOG.md)"
+
+  assert_contains "$out" "Entries to ADD under [Unreleased]:" "dry-run add header"
+  assert_contains "$out" "New branch entry" "dry-run shows addition"
+  assert_contains "$out" "RC-header sections to DROP" "dry-run drop header"
+  assert_contains "$out" "### [17.0.0.rc.0]" "dry-run drop listing"
+  assert_contains "$out" "DRY RUN: CHANGELOG.md was not modified" "dry-run notice"
+  [ "$before" = "$after" ] || fail "dry-run must not modify CHANGELOG.md"
+}
+
+# De-duplication is by PR number even when the entry prose differs between the
+# release branch and main (e.g. main reworded the same PR's entry).
+test_dedupes_by_pr_number_even_with_different_prose() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Reworded on main**: main's phrasing of the fix. $(pr_link 222) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.1] - 2026-06-02
+
+#### Fixed
+
+- **Original branch wording**: the branch phrasing of the same fix. $(pr_link 222) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog)"
+  assert_contains "$out" "0 entries to add" "nothing added (PR deduped)"
+  assert_contains "$out" "1 entry already present" "deduped entry counted"
+
+  # main keeps only its own wording; the branch wording is not appended.
+  assert_contains "$(cat CHANGELOG.md)" "Reworded on main" "main wording kept"
+  assert_not_contains "$(cat CHANGELOG.md)" "Original branch wording" "branch wording skipped"
+}
+
+# Multiple distinct entries that share one PR number are all carried over (the
+# dedup key is "PR already on main", not "PR seen once"); two entries from the
+# same new PR both land.
+test_multiple_entries_same_new_pr_all_carry_over() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Pre-existing**: main entry. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **First change from PR**: part one. $(pr_link 500) by [a](https://github.com/a).
+
+#### Fixed
+
+- **Second change from PR**: part two. $(pr_link 500) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog)"
+  # Both entries from PR 500 are new to main; both must be added.
+  assert_contains "$out" "First change from PR" "first PR-500 entry"
+  assert_contains "$out" "Second change from PR" "second PR-500 entry"
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "First change from PR" "first added"
+  assert_contains "$changelog" "Second change from PR" "second added"
+}
+
+# Entries regroup under their #### headings (Added / Changed / Fixed), with the
+# target's existing entries kept first within each heading, and the blank-line
+# house style preserved.
+test_entries_regroup_under_headings_in_order() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Added
+
+- **Main added**: first. $(pr_link 10) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **Branch added**: second. $(pr_link 20) by [a](https://github.com/a).
+
+#### Fixed
+
+- **Branch fixed**: a fix. $(pr_link 30) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+  run_changelog >/dev/null
+
+  # The two Added entries share one #### Added block, main's first.
+  local added_block
+  added_block="$(awk '/^#### Added$/{flag=1} /^#### Fixed$/{flag=0} flag' CHANGELOG.md)"
+  assert_contains "$added_block" "Main added" "main added present"
+  assert_contains "$added_block" "Branch added" "branch added merged into same block"
+  # Order: main's entry precedes the branch's within the merged block.
+  case "$added_block" in
+    *"Main added"*"Branch added"*) ;;
+    *) fail "expected 'Main added' before 'Branch added' in merged Added block" ;;
+  esac
+  # A separate #### Fixed block exists for the fix.
+  assert_contains "$(cat CHANGELOG.md)" "#### Fixed" "fixed heading present"
+  # Blank line after each heading (house style): "#### Added" then empty line.
+  assert_contains "$(cat CHANGELOG.md)" "$(printf '#### Added\n\n- ')" "blank line after heading"
+}
+
+# Idempotency: running the reconciliation twice leaves the changelog unchanged
+# on the second run (everything is already present).
+test_second_run_is_noop() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Main**: x. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **Branch**: y. $(pr_link 2) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  run_changelog >/dev/null
+  commit_all "apply reconciliation"
+  local after_first
+  after_first="$(cat CHANGELOG.md)"
+
+  local out
+  out="$(run_changelog)"
+  assert_contains "$out" "0 entries to add" "second run adds nothing"
+  assert_contains "$out" "Nothing to reconcile" "second run is a no-op"
+  [ "$after_first" = "$(cat CHANGELOG.md)" ] || fail "second run must not change CHANGELOG.md"
+}
+
+# An empty branch [Unreleased] with no matching rc sections (e.g. nothing to
+# forward-port yet) is a clean no-op, not an error.
+test_no_release_entries_is_clean_noop() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Main**: x. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [16.6.0] - 2026-04-09
+
+#### Added
+
+- **Old stable**: shipped. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local before out after
+  before="$(cat CHANGELOG.md)"
+  out="$(run_changelog)"
+  after="$(cat CHANGELOG.md)"
+  assert_contains "$out" "0 entries to add" "no entries to add"
+  assert_contains "$out" "Nothing to reconcile" "clean no-op"
+  [ "$before" = "$after" ] || fail "no-op run must not modify CHANGELOG.md"
+}
+
+# Multi-line entries (continuation/detail lines and nested bullets) are carried
+# over intact, not truncated to the first line.
+test_multiline_entry_preserved() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **[Pro]** **Multi-line feature**: summary line.
+  A second descriptive line with more detail.
+  $(pr_link 250) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+  run_changelog >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "Multi-line feature" "summary preserved"
+  assert_contains "$changelog" "A second descriptive line with more detail." "continuation preserved"
+  assert_contains "$changelog" "/pull/250" "pr link preserved"
+}
+
+# The "#NNNN" shorthand (no /pull/ URL) is recognized for de-duplication.
+test_hash_shorthand_pr_reference_dedupes() {
+  init_repo
+
+  cat > main.md <<'EOF'
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Main shorthand entry**: fixed in #321.
+EOF
+
+  cat > release.md <<'EOF'
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Fixed
+
+- **Branch shorthand entry**: same fix, also #321.
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog)"
+  assert_contains "$out" "0 entries to add" "shorthand PR deduped"
+  assert_not_contains "$(cat CHANGELOG.md)" "Branch shorthand entry" "branch shorthand skipped"
+}
+
+# Default (no --changelog) mode is unaffected: a dry-run with no eligible commits
+# still prints the cherry-pick plan, NOT the changelog reconciliation plan.
+test_default_mode_unchanged_without_flag() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+EOF
+  cp main.md CHANGELOG.md
+  # A real version.rb so the default cherry-pick mode's version-drift guard has
+  # something to read (keeps stderr clean); this mode is unrelated to --changelog.
+  mkdir -p react_on_rails/lib/react_on_rails
+  printf 'module ReactOnRails\n  VERSION = "17.0.0"\nend\n' \
+    > react_on_rails/lib/react_on_rails/version.rb
+  commit_all "init"
+  git checkout -q -b release/17.0.0
+  # No new commits on the branch beyond main, so the plan is empty.
+  git checkout -q main
+
+  local out
+  out="$(ruby "$FORWARD_PORT" --source release/17.0.0 --target main --dry-run)"
+  assert_contains "$out" "Release forward-port plan" "cherry-pick plan header"
+  assert_not_contains "$out" "CHANGELOG.md reconciliation plan" "no reconciliation in default mode"
+  assert_contains "$out" "DRY RUN: no branches were checked out" "default dry-run notice"
+}
+
+# An empty main [Unreleased] (header only, no entries yet) receives the
+# forward-ported entries with correct heading + blank-line formatting.
+test_empty_main_unreleased_receives_entries() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [16.6.0] - 2026-04-09
+
+#### Added
+
+- **Old stable**: shipped. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **Branch entry**: new. $(pr_link 9) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+  run_changelog >/dev/null
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "$(printf '### [Unreleased]\n\n#### Added\n\n- **Branch entry**')" "entry under empty unreleased"
+  assert_contains "$changelog" "### [16.6.0]" "stable section kept"
+}
+
+# A target with no ### [Unreleased] section is a clear error (the forward-port
+# train always reconciles into [Unreleased]; a target without it is a misconfig).
+test_target_without_unreleased_errors_clearly() {
+  init_repo
+
+  printf '# Change Log\n\n### [16.6.0] - 2026-04-09\n\n#### Added\n\n- x.\n' > CHANGELOG.md
+  commit_all "init main without unreleased"
+  git checkout -q -b release/17.0.0
+  printf '# Change Log\n\n### [Unreleased]\n\n### [17.0.0.rc.0] - 2026-05-30\n\n#### Added\n\n- new. ' > CHANGELOG.md
+  printf '[PR 9](https://github.com/shakacode/react_on_rails/pull/9).\n' >> CHANGELOG.md
+  commit_all "release branch"
+  git checkout -q main
+
+  local out rc
+  set +e
+  out="$(ruby "$FORWARD_PORT" --source release/17.0.0 --target main --changelog 2>&1)"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "expected non-zero exit when target lacks [Unreleased]"
+  assert_contains "$out" "has no ### [Unreleased] section" "missing unreleased error"
+}
+
+# UTF-8 content (e.g. the ⚠️ breaking-change marker) must parse and round-trip
+# even when Ruby's default external encoding is US-ASCII (a C/POSIX-locale CI
+# runner). Regression for the "invalid byte sequence in US-ASCII" failure.
+test_utf8_changelog_parses_and_round_trips_under_ascii_locale() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### ⚠️ Breaking Changes
+
+- **Existing breaking change**: ⚠️ already on main. $(pr_link 100) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Added
+
+- **New ✨ feature**: emoji prose. $(pr_link 200) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  # Force a US-ASCII external encoding to reproduce the C-locale CI runner.
+  local out
+  out="$(LC_ALL=C LANG=C run_changelog)"
+  assert_contains "$out" "New ✨ feature" "emoji entry added"
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "⚠️ Breaking Changes" "warning marker preserved"
+  assert_contains "$changelog" "New ✨ feature" "new emoji entry written"
+  # The file must remain valid UTF-8 after the rewrite.
+  ruby -e 'exit(File.read("CHANGELOG.md", encoding: "UTF-8").valid_encoding? ? 0 : 1)' \
+    || fail "rewritten CHANGELOG.md is not valid UTF-8"
+}
+
+# A missing CHANGELOG.md at the source ref is a clear, non-crashing error.
+test_missing_source_changelog_errors_clearly() {
+  init_repo
+
+  printf '# Change Log\n\n### [Unreleased]\n' > CHANGELOG.md
+  commit_all "init main"
+  git checkout -q -b release/17.0.0
+  git rm -q CHANGELOG.md
+  commit_all "remove changelog on release branch"
+  git checkout -q main
+
+  local out rc
+  set +e
+  out="$(ruby "$FORWARD_PORT" --source release/17.0.0 --target main --changelog 2>&1)"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "expected non-zero exit for missing source CHANGELOG.md"
+  assert_contains "$out" "unable to read CHANGELOG.md" "missing changelog error"
+}
+
+run_test test_collapses_rc_sections_and_branch_unreleased_into_main_unreleased
+run_test test_dry_run_previews_without_writing
+run_test test_dedupes_by_pr_number_even_with_different_prose
+run_test test_multiple_entries_same_new_pr_all_carry_over
+run_test test_entries_regroup_under_headings_in_order
+run_test test_second_run_is_noop
+run_test test_no_release_entries_is_clean_noop
+run_test test_multiline_entry_preserved
+run_test test_hash_shorthand_pr_reference_dedupes
+run_test test_empty_main_unreleased_receives_entries
+run_test test_target_without_unreleased_errors_clearly
+run_test test_utf8_changelog_parses_and_round_trips_under_ascii_locale
+run_test test_default_mode_unchanged_without_flag
+run_test test_missing_source_changelog_errors_clearly
+
+echo
+echo "Release forward-port changelog tests: $TESTS_RUN run, $TESTS_FAILED failed"
+
+if [ "$TESTS_FAILED" -ne 0 ]; then
+  printf '\nFailures:\n' >&2
+  printf '  - %s\n' "${FAILURES[@]}" >&2
+  exit 1
+fi

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -654,6 +654,108 @@ test_target_without_unreleased_errors_clearly() {
   assert_contains "$out" "has no ### [Unreleased] section" "missing unreleased error"
 }
 
+# A SOURCE with no prerelease sections (e.g. forward-porting from release/16.6.0,
+# a patch line) must NOT reach into the TARGET's RC base: a stray rc section on
+# main belonging to an unrelated line must be left untouched. The branch's own
+# [Unreleased] backport still re-homes. Regression for the target-RC-fallback bug.
+test_non_prerelease_source_does_not_touch_target_rc_section() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Main fix**: here. $(pr_link 100) by [a](https://github.com/a).
+
+### [17.0.0.rc.5] - 2026-06-16
+
+#### Added
+
+- **Stray rc5 on main**: belongs to the 17.0.0 line, not 16.6.0. $(pr_link 50) by [a](https://github.com/a).
+
+### [16.6.0] - 2026-04-09
+
+#### Added
+
+- **Old stable**: shipped. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Backport on 16.6 branch**: no rc sections here. $(pr_link 900) by [a](https://github.com/a).
+
+### [16.6.0] - 2026-04-09
+
+#### Added
+
+- **Old stable**: shipped. $(pr_link 1) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md "release/16.6.0"
+
+  local out
+  out="$(run_changelog release/16.6.0)"
+  # The branch [Unreleased] backport is still re-homed ...
+  assert_contains "$out" "Backport on 16.6 branch" "backport re-homed"
+  # ... but the unrelated 17.0.0 RC section is NOT dropped.
+  assert_not_contains "$out" "RC-header sections to DROP" "no RC drop for non-prerelease source"
+
+  local changelog
+  changelog="$(cat CHANGELOG.md)"
+  assert_contains "$changelog" "### [17.0.0.rc.5]" "stray rc5 section preserved"
+  assert_contains "$changelog" "Stray rc5 on main" "stray rc5 entry preserved"
+  assert_contains "$changelog" "Backport on 16.6 branch" "backport written under unreleased"
+}
+
+# De-duplication keys on the entry's OWN PR (the "[PR NNNN](...) by [author]"
+# trailer), not on a PR it merely references. An entry that references PR 4227 but
+# is itself PR 4234 must dedupe against main's PR 4234, and must NOT dedupe against
+# a main entry that is PR 4227.
+test_dedupes_on_own_pr_trailer_not_referenced_pr() {
+  init_repo
+
+  cat > main.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+#### Fixed
+
+- **Already on main as 4234**: main's copy. [PR 4234](https://github.com/shakacode/react_on_rails/pull/4234) by [a](https://github.com/a).
+EOF
+
+  cat > release.md <<EOF
+# Change Log
+
+### [Unreleased]
+
+### [17.0.0.rc.0] - 2026-05-30
+
+#### Fixed
+
+- **Branch copy of 4234**: references [PR 4227](https://github.com/shakacode/react_on_rails/pull/4227) but is itself [PR 4234](https://github.com/shakacode/react_on_rails/pull/4234) by [a](https://github.com/a).
+- **Genuinely new, references 4227**: follow-up to [PR 4227](https://github.com/shakacode/react_on_rails/pull/4227), itself [PR 4250](https://github.com/shakacode/react_on_rails/pull/4250) by [a](https://github.com/a).
+EOF
+
+  seed_main_and_release main.md release.md
+
+  local out
+  out="$(run_changelog)"
+  # The 4234 branch entry is deduped (own PR matches main's 4234) ...
+  assert_not_contains "$(cat CHANGELOG.md)" "Branch copy of 4234" "own-PR 4234 deduped"
+  # ... while the 4250 entry (which only REFERENCES 4227) is added, not deduped.
+  assert_contains "$(cat CHANGELOG.md)" "Genuinely new, references 4227" "referenced-PR not treated as own"
+  assert_contains "$out" "1 entry to add" "exactly one new entry"
+}
+
 # UTF-8 content (e.g. the ⚠️ breaking-change marker) must parse and round-trip
 # even when Ruby's default external encoding is US-ASCII (a C/POSIX-locale CI
 # runner). Regression for the "invalid byte sequence in US-ASCII" failure.
@@ -729,6 +831,8 @@ run_test test_multiline_entry_preserved
 run_test test_hash_shorthand_pr_reference_dedupes
 run_test test_empty_main_unreleased_receives_entries
 run_test test_target_without_unreleased_errors_clearly
+run_test test_non_prerelease_source_does_not_touch_target_rc_section
+run_test test_dedupes_on_own_pr_trailer_not_referenced_pr
 run_test test_utf8_changelog_parses_and_round_trips_under_ascii_locale
 run_test test_default_mode_unchanged_without_flag
 run_test test_missing_source_changelog_errors_clearly

--- a/script/release-forward-port-test.bash
+++ b/script/release-forward-port-test.bash
@@ -2,8 +2,9 @@
 # Test harness for `script/release-forward-port --changelog` (the CHANGELOG.md
 # re-homing mode). Mirrors the structure of script/ci-changes-detector-test.bash:
 # each case runs in an isolated mktemp git repo subshell, so the real repo's
-# branches, remote, and working tree are never touched. Requires bash and git.
-# Run with `bash script/release-forward-port-test.bash`.
+# branches, remote, and working tree are never touched. Requires bash, git, and
+# ruby (each case runs `ruby` on the script under test). Run with
+# `bash script/release-forward-port-test.bash`.
 
 set -uo pipefail
 


### PR DESCRIPTION
## What & why

PR 3 of 4 in the **release-train automation** series (design spec in #4255).

When forward-porting release-branch fixes to `main`, their changelog entries live under an RC header (`### [17.0.0.rc.1]`) on the release branch but belong under `### [Unreleased]` on `main`. A plain `cherry-pick -x` (the current behavior) drags the RC-header context and tends to conflict or land the entry in the wrong section. This adds a dedicated changelog-reconciliation mode that **re-homes** those entries into `main`'s `[Unreleased]`.

## Changes

- `script/release-forward-port`: new `--changelog` flag. When set, runs reconciliation **instead of** the cherry-pick loop; omitting it leaves the default `cherry-pick -x` path byte-identical for existing callers.
  - Collapses every release-branch entry (each `rc.N` section **plus** the branch's own `[Unreleased]`) into the target's `[Unreleased]`.
  - De-duplicates against the target **by PR number** (catches reworded entries) and by exact text; distinct entries sharing one new PR both carry over.
  - Drops any stray RC-header section a prior cherry-pick left on the target; regroups under `####` headings.
  - `--changelog --dry-run` previews the exact ADD/DROP/skip plan and writes nothing; a no-op run returns the target changelog byte-for-byte.
  - Self-contained `ChangelogReconciler` class — no `update_changelog.rake` dependency (kept disjoint from PR 2).
- `script/release-forward-port-test.bash`: new harness (14 cases, throwaway `mktemp` repos).

## Validation

- `bash script/release-forward-port-test.bash`: `14 run, 0 failed` (also validated apply against a copy of the real `CHANGELOG.md`).
- `bundle exec rubocop script/release-forward-port`: `no offenses detected`.
- `shellcheck -x script/release-forward-port-test.bash`: clean.
- Existing regression spec `release_forward_port_script_spec.rb`: `44 examples, 0 failures` (default cherry-pick path unchanged).

Two bugs found + fixed during validation: a US-ASCII/UTF-8 locale crash on `⚠️` in the changelog (now forces UTF-8, regression-tested), and a within-source dedup that wrongly dropped a second distinct entry sharing one new PR.

## Notes

- No changelog entry: release automation tooling (no-entry category).
- Follow-up (out of scope): the new `*-test.bash` harness isn't yet in CI's hardcoded shellcheck/test list (`.github/workflows/git-diff-base-tests.yml`); wiring it in is a one-line addition for a later PR.

Confidence note: high. Default behavior provably unchanged (regression spec green, new logic gated behind `--changelog`); new path covered by 14 cases incl. a real-CHANGELOG apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--changelog` mode to forward-port releases that reconciles `CHANGELOG.md` into the target branch’s **Unreleased** section, with a reconciliation preview (and `--dry-run` option).
  * Collapses prerelease/RC changelog content into **Unreleased**, re-groups entries under consistent **Added/Fixed/Changed** headings, and deduplicates entries while preserving entry formatting.

* **Bug Fixes**
  * Improved changelog parsing and rewriting robustness, including UTF-8-safe handling under restrictive locale settings.

* **Tests**
  * Added end-to-end integration coverage for reconciliation behavior, idempotency/no-op runs, and clear errors for missing/invalid `CHANGELOG.md` or missing **Unreleased** section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->